### PR TITLE
[ML] Functional tests - stabilize index data visualizer tests

### DIFF
--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
@@ -15,7 +15,8 @@ import {
   sampleLogTestData,
 } from './index_test_data';
 
-export default function ({ getService }: FtrProviderContext) {
+export default function ({ getPageObject, getService }: FtrProviderContext) {
+  const headerPage = getPageObject('header');
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
 
@@ -42,6 +43,7 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.dataVisualizerIndexBased.clickUseFullDataButton(
         testData.expected.totalDocCountFormatted
       );
+      await headerPage.waitUntilLoadingHasFinished();
 
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} displays elements in the doc count panel correctly`
@@ -166,8 +168,7 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.securityUI.loginAsMlPowerUser();
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/118472
-    describe.skip('with farequote', function () {
+    describe('with farequote', function () {
       // Run tests on full farequote index.
       it(`${farequoteDataViewTestData.suiteTitle} loads the data visualizer selector page`, async () => {
         // Start navigation from the base of the ML app.


### PR DESCRIPTION
## Summary

This PR stabilizes and re-enabled the index data visualizer tests by waiting for global loading to finish before validating row content.

Closes #118472
