### PR TITLE
[ML] Update the `i18n` import

### DIFF
--- a/x-pack/plugins/ml/public/application/trained_models/models_management/force_stop_dialog.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/force_stop_dialog.tsx
@@ -7,7 +7,7 @@
 
 import React, { FC } from 'react';
 import { EuiConfirmModal } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import type { OverlayStart } from 'kibana/public';
 import type { ModelItem } from './models_list';
 import { toMountPoint } from '../../../../../../../src/plugins/kibana_react/public';


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/pull/118563 caused the `main` branch to break because of lacking changes from  https://github.com/elastic/kibana/pull/119256. 

This PR updates the `i18n` import accordingly. 