### PR TITLE
[Security Solution][Detections] Improves Table UI: do not show dash when tags field is empty

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
@@ -189,7 +189,7 @@ export const getColumns = ({
       align: 'center',
       render: (tags: Rule['tags']) => {
         if (tags.length === 0) {
-          return getEmptyTagValue();
+          return null;
         }
 
         const renderItem = (tag: string, i: number) => (


### PR DESCRIPTION
## Summary

On rules table, when field tags is empty, do not display dash, as it can be confusing. There is no 'Tags' title for a column to hint user about displayed dash.

#### Before
<img width="1281" alt="Screenshot 2021-11-25 at 12 44 55" src="https://user-images.githubusercontent.com/92328789/143444273-e4980782-20dc-42e0-8ef2-b4963dc9b2c3.png">

### After
<img width="1283" alt="Screenshot 2021-11-25 at 12 44 21" src="https://user-images.githubusercontent.com/92328789/143444231-e5c38ed9-a547-45ac-bfb7-7df6d8a3a1d5.png">

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
