### PR TITLE
[Uptime] Setup synthetics index template

### DIFF
--- a/x-pack/plugins/uptime/common/constants/rest_api.ts
+++ b/x-pack/plugins/uptime/common/constants/rest_api.ts
@@ -35,4 +35,7 @@ export enum API_URLS {
   DELETE_RULE = '/api/alerting/rule/',
   RULES_FIND = '/api/alerting/rules/_find',
   CONNECTOR_TYPES = '/api/actions/connector_types',
+
+  // Service end points
+  INDEX_TEMPLATES = '/api/uptime/service/index_templates',
 }

--- a/x-pack/plugins/uptime/public/pages/overview.tsx
+++ b/x-pack/plugins/uptime/public/pages/overview.tsx
@@ -10,12 +10,14 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { useBreadcrumbs } from '../hooks/use_breadcrumbs';
-import { useTrackPageview } from '../../../observability/public';
+import { useFetcher, useTrackPageview } from '../../../observability/public';
 import { MonitorList } from '../components/overview/monitor_list/monitor_list_container';
 import { StatusPanel } from '../components/overview/status_panel';
 import { QueryBar } from '../components/overview/query_bar/query_bar';
 import { MONITORING_OVERVIEW_LABEL } from '../routes';
 import { FilterGroup } from '../components/overview/filter_group/filter_group';
+import { apiService } from '../state/api/utils';
+import { API_URLS } from '../../common/constants';
 
 const EuiFlexItemStyled = styled(EuiFlexItem)`
   && {
@@ -34,6 +36,10 @@ export const OverviewPageComponent = () => {
   useTrackPageview({ app: 'uptime', path: 'overview', delay: 15000 });
 
   useBreadcrumbs([{ text: MONITORING_OVERVIEW_LABEL }]); // No extra breadcrumbs on overview
+
+  useFetcher(() => {
+    return apiService.get(API_URLS.INDEX_TEMPLATES);
+  }, []);
 
   return (
     <>

--- a/x-pack/plugins/uptime/public/pages/overview.tsx
+++ b/x-pack/plugins/uptime/public/pages/overview.tsx
@@ -10,14 +10,12 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { useBreadcrumbs } from '../hooks/use_breadcrumbs';
-import { useFetcher, useTrackPageview } from '../../../observability/public';
+import { useTrackPageview } from '../../../observability/public';
 import { MonitorList } from '../components/overview/monitor_list/monitor_list_container';
 import { StatusPanel } from '../components/overview/status_panel';
 import { QueryBar } from '../components/overview/query_bar/query_bar';
 import { MONITORING_OVERVIEW_LABEL } from '../routes';
 import { FilterGroup } from '../components/overview/filter_group/filter_group';
-import { apiService } from '../state/api/utils';
-import { API_URLS } from '../../common/constants';
 
 const EuiFlexItemStyled = styled(EuiFlexItem)`
   && {
@@ -36,10 +34,6 @@ export const OverviewPageComponent = () => {
   useTrackPageview({ app: 'uptime', path: 'overview', delay: 15000 });
 
   useBreadcrumbs([{ text: MONITORING_OVERVIEW_LABEL }]); // No extra breadcrumbs on overview
-
-  useFetcher(() => {
-    return apiService.get(API_URLS.INDEX_TEMPLATES);
-  }, []);
 
   return (
     <>

--- a/x-pack/plugins/uptime/server/lib/adapters/framework/adapter_types.ts
+++ b/x-pack/plugins/uptime/server/lib/adapters/framework/adapter_types.ts
@@ -24,6 +24,7 @@ import { UptimeESClient } from '../../lib';
 import type { UptimeRouter } from '../../../types';
 import { SecurityPluginStart } from '../../../../../security/server';
 import { CloudSetup } from '../../../../../cloud/server';
+import { FleetStartContract } from '../../../../../fleet/server';
 import { UptimeConfig } from '../../../../common/config';
 
 export type UMElasticsearchQueryFn<P, R = any> = (
@@ -41,7 +42,8 @@ export type UMSavedObjectsQueryFn<T = any, P = undefined> = (
 export interface UptimeCoreSetup {
   router: UptimeRouter;
   config: UptimeConfig;
-  cloud: CloudSetup;
+  cloud?: CloudSetup;
+  fleet: FleetStartContract;
   security: SecurityPluginStart;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
 }
@@ -59,6 +61,7 @@ export interface UptimeCorePluginsSetup {
 
 export interface UptimeCorePluginsStart {
   security: SecurityPluginStart;
+  fleet: FleetStartContract;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
 }
 

--- a/x-pack/plugins/uptime/server/rest_api/index.ts
+++ b/x-pack/plugins/uptime/server/rest_api/index.ts
@@ -27,6 +27,7 @@ import { createGetIndexStatusRoute } from './index_state';
 import { createNetworkEventsRoute } from './network_events';
 import { createJourneyFailedStepsRoute } from './pings/journeys';
 import { createLastSuccessfulStepRoute } from './synthetics/last_successful_step';
+import { installIndexTemplatesRoute } from './synthetics_service/install_index_templates';
 
 export * from './types';
 export { createRouteWithAuth } from './create_route_with_auth';
@@ -51,4 +52,5 @@ export const restApiRoutes: UMRestApiRouteFactory[] = [
   createJourneyFailedStepsRoute,
   createLastSuccessfulStepRoute,
   createJourneyScreenshotBlocksRoute,
+  installIndexTemplatesRoute,
 ];

--- a/x-pack/plugins/uptime/server/rest_api/synthetics_service/install_index_templates.ts
+++ b/x-pack/plugins/uptime/server/rest_api/synthetics_service/install_index_templates.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { ElasticsearchClient, SavedObjectsClientContract } from 'kibana/server';
+import { UMRestApiRouteFactory } from '../types';
+import { API_URLS } from '../../../common/constants';
+import { UptimeCoreSetup } from '../../lib/adapters';
+
+export const installIndexTemplates: UMRestApiRouteFactory = () => ({
+  method: 'GET',
+  path: API_URLS.INDEX_TEMPLATES,
+  validate: {},
+  handler: async ({ server, request, savedObjectsClient, uptimeEsClient }): Promise<any> => {
+    return installSyntheticsIndexTemplates({
+      server,
+      savedObjectsClient,
+      esClient: uptimeEsClient.baseESClient,
+    });
+  },
+});
+
+export async function installSyntheticsIndexTemplates({
+  esClient,
+  server,
+  savedObjectsClient,
+}: {
+  server: UptimeCoreSetup;
+  esClient: ElasticsearchClient;
+  savedObjectsClient: SavedObjectsClientContract;
+}) {
+  // no need to add error handling here since fleetSetupCompleted is already wrapped in try/catch and will log
+  // warning if setup fails to complete
+  await server.fleet.fleetSetupCompleted();
+
+  return await server.fleet.packageService.ensureInstalledPackage({
+    esClient,
+    savedObjectsClient,
+    pkgName: 'synthetics',
+  });
+}

--- a/x-pack/plugins/uptime/server/rest_api/synthetics_service/install_index_templates.ts
+++ b/x-pack/plugins/uptime/server/rest_api/synthetics_service/install_index_templates.ts
@@ -9,7 +9,7 @@ import { UMRestApiRouteFactory } from '../types';
 import { API_URLS } from '../../../common/constants';
 import { UptimeCoreSetup } from '../../lib/adapters';
 
-export const installIndexTemplates: UMRestApiRouteFactory = () => ({
+export const installIndexTemplatesRoute: UMRestApiRouteFactory = () => ({
   method: 'GET',
   path: API_URLS.INDEX_TEMPLATES,
   validate: {},


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/uptime/issues/405

This PR adds the functionality in uptime plugin, where if synthetics service is enabled, it will install index templates for the synthetics.

### Testing
Start elasticsearch from scratch with kibana and start kibana, make sure to enable synthetics service configs
 with flags

```
#xpack.uptime.unsafe.service.enabled: true
#xpack.uptime.unsafe.service.password: test
#xpack.uptime.unsafe.service.manifestUrl: https://test.com
#xpack.uptime.unsafe.service.username: test
#xpack.uptime.unsafe.service.hosts: ["test.com"]
```


once kibana is started check if synthetics index templates are installed

![image](https://user-images.githubusercontent.com/3505601/143448512-bd963760-6cc2-4cdc-ad82-e42e806fe27a.png)

