### PR TITLE
[ML] Disabling delete data view for data frame analytics and transforms wizards

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/action_delete/delete_action_modal.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/action_delete/delete_action_modal.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiConfirmModal,
@@ -28,6 +28,7 @@ export const DeleteActionModal: FC<DeleteAction> = ({
   toggleDeleteIndex,
   toggleDeleteIndexPattern,
   userCanDeleteIndex,
+  userCanDeleteDataView,
 }) => {
   if (item === undefined) {
     return null;
@@ -85,6 +86,7 @@ export const DeleteActionModal: FC<DeleteAction> = ({
               })}
               checked={deleteIndexPattern}
               onChange={toggleDeleteIndexPattern}
+              disabled={userCanDeleteDataView === false}
             />
           )}
         </EuiFlexItem>

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/action_delete/delete_action_modal.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/action_delete/delete_action_modal.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FC, useMemo } from 'react';
+import React, { FC } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiConfirmModal,

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/action_delete/use_delete_action.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/action_delete/use_delete_action.tsx
@@ -42,11 +42,13 @@ export const useDeleteAction = (canDeleteDataFrameAnalytics: boolean) => {
   const [deleteTargetIndex, setDeleteTargetIndex] = useState<boolean>(true);
   const [deleteIndexPattern, setDeleteIndexPattern] = useState<boolean>(true);
   const [userCanDeleteIndex, setUserCanDeleteIndex] = useState<boolean>(false);
+  const [userCanDeleteDataView, setUserCanDeleteDataView] = useState<boolean>(false);
   const [indexPatternExists, setIndexPatternExists] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const {
     data: { dataViews },
+    application: { capabilities },
   } = useMlKibana().services;
 
   const indexName = item?.config.dest.index ?? '';
@@ -82,6 +84,14 @@ export const useDeleteAction = (canDeleteDataFrameAnalytics: boolean) => {
       const userCanDelete = await canDeleteIndex(indexName, toastNotificationService);
       if (userCanDelete) {
         setUserCanDeleteIndex(true);
+      }
+
+      const canDeleteDataView =
+        capabilities.savedObjectsManagement.delete === true ||
+        capabilities.indexPatterns.save === true;
+      setUserCanDeleteDataView(canDeleteDataView);
+      if (canDeleteDataView === false) {
+        setDeleteIndexPattern(false);
       }
     } catch (e) {
       const error = extractErrorMessage(e);
@@ -180,5 +190,6 @@ export const useDeleteAction = (canDeleteDataFrameAnalytics: boolean) => {
     toggleDeleteIndex,
     toggleDeleteIndexPattern,
     userCanDeleteIndex,
+    userCanDeleteDataView,
   };
 };

--- a/x-pack/plugins/transform/public/app/hooks/use_delete_transform.tsx
+++ b/x-pack/plugins/transform/public/app/hooks/use_delete_transform.tsx
@@ -25,6 +25,7 @@ export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
     http,
     savedObjects,
     ml: { extractErrorMessage },
+    application: { capabilities },
   } = useAppDependencies();
   const toastNotifications = useToastNotifications();
 
@@ -32,6 +33,7 @@ export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
   const [deleteIndexPattern, setDeleteIndexPattern] = useState<boolean>(true);
   const [userCanDeleteIndex, setUserCanDeleteIndex] = useState<boolean>(false);
   const [indexPatternExists, setIndexPatternExists] = useState<boolean>(false);
+  const [userCanDeleteDataView, setUserCanDeleteDataView] = useState<boolean>(false);
 
   const toggleDeleteIndex = useCallback(
     () => setDeleteDestIndex(!deleteDestIndex),
@@ -70,6 +72,13 @@ export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
       if (userCanDelete) {
         setUserCanDeleteIndex(true);
       }
+      const canDeleteDataView =
+        capabilities.savedObjectsManagement.delete === true ||
+        capabilities.indexPatterns.save === true;
+      setUserCanDeleteDataView(canDeleteDataView);
+      if (canDeleteDataView === false) {
+        setDeleteIndexPattern(false);
+      }
     } catch (e) {
       toastNotifications.addDanger(
         i18n.translate(
@@ -80,7 +89,7 @@ export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
         )
       );
     }
-  }, [http, toastNotifications]);
+  }, [http, toastNotifications, capabilities]);
 
   useEffect(() => {
     checkUserIndexPermission();
@@ -99,6 +108,7 @@ export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
 
   return {
     userCanDeleteIndex,
+    userCanDeleteDataView,
     deleteDestIndex,
     indexPatternExists,
     deleteIndexPattern,

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/action_delete/delete_action_modal.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/action_delete/delete_action_modal.tsx
@@ -75,6 +75,7 @@ export const DeleteActionModal: FC<DeleteAction> = ({
               )}
               checked={deleteIndexPattern}
               onChange={toggleDeleteIndexPattern}
+              disabled={userCanDeleteDataView === false}
             />
           }
         </EuiFlexItem>

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/action_delete/delete_action_modal.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/action_delete/delete_action_modal.tsx
@@ -29,6 +29,7 @@ export const DeleteActionModal: FC<DeleteAction> = ({
   toggleDeleteIndex,
   toggleDeleteIndexPattern,
   userCanDeleteIndex,
+  userCanDeleteDataView,
 }) => {
   const isBulkAction = items.length > 1;
 
@@ -114,6 +115,7 @@ export const DeleteActionModal: FC<DeleteAction> = ({
               )}
               checked={deleteIndexPattern}
               onChange={toggleDeleteIndexPattern}
+              disabled={userCanDeleteDataView === false}
             />
           </EuiFlexItem>
         )}

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/action_delete/use_delete_action.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/action_delete/use_delete_action.tsx
@@ -38,6 +38,7 @@ export const useDeleteAction = (forceDisable: boolean) => {
 
   const {
     userCanDeleteIndex,
+    userCanDeleteDataView,
     deleteDestIndex,
     indexPatternExists,
     deleteIndexPattern,
@@ -50,7 +51,7 @@ export const useDeleteAction = (forceDisable: boolean) => {
 
     const shouldDeleteDestIndex = userCanDeleteIndex && deleteDestIndex;
     const shouldDeleteDestIndexPattern =
-      userCanDeleteIndex && indexPatternExists && deleteIndexPattern;
+      userCanDeleteIndex && userCanDeleteDataView && indexPatternExists && deleteIndexPattern;
     // if we are deleting multiple transforms, then force delete all if at least one item has failed
     // else, force delete only when the item user picks has failed
     const forceDelete = isBulkAction
@@ -113,5 +114,6 @@ export const useDeleteAction = (forceDisable: boolean) => {
     toggleDeleteIndex,
     toggleDeleteIndexPattern,
     userCanDeleteIndex,
+    userCanDeleteDataView,
   };
 };


### PR DESCRIPTION
If the user does not have permission to delete data views, the option is disabled.

Related to https://github.com/elastic/kibana/pull/117690

**Transforms**
One transform:
![image](https://user-images.githubusercontent.com/22172091/143455068-a9e6a4e2-853e-4cca-bbf6-72a22912ce0b.png)

Bulk delete:
![image](https://user-images.githubusercontent.com/22172091/143455110-d5ea9ca4-1591-457e-99f8-8b79ab790fdc.png)


**Data frame analytics**
![image](https://user-images.githubusercontent.com/22172091/143455157-906f337b-338f-4847-aa3c-6cf27eb6145d.png)


