### PR TITLE
[8.0] [SecuritySolution][CTI] Fix preview matrix histogram query (#116328)

### DIFF
--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/__mocks__/index.ts
@@ -2098,8 +2098,8 @@ export const formattedPreviewStrategyResponse = {
       JSON.stringify(
         {
           index: ['.siem-preview-signals-default'],
-          allowNoIndices: true,
-          ignoreUnavailable: true,
+          allow_no_indices: true,
+          ignore_unavailable: true,
           track_total_hits: true,
           body: {
             aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/preview/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/preview/__mocks__/index.ts
@@ -18,8 +18,8 @@ export const mockOptions = {
 
 export const expectedDsl = {
   index: ['.siem-preview-signals-default'],
-  allowNoIndices: true,
-  ignoreUnavailable: true,
+  allow_no_indices: true,
+  ignore_unavailable: true,
   track_total_hits: true,
   body: {
     aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/preview/query.preview_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/preview/query.preview_histogram.dsl.ts
@@ -65,8 +65,8 @@ export const buildPreviewHistogramQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
-    ignoreUnavailable: true,
+    allow_no_indices: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       aggregations: getHistogramAggregation(),


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [SecuritySolution][CTI] Fix preview matrix histogram query (#116328)