### PR TITLE
[8.0] remove link for last breadcrumb element of SOM and SOT sections (#119425)

### DIFF
--- a/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
@@ -63,7 +63,6 @@ const SavedObjectsTablePage = ({
         text: i18n.translate('savedObjectsManagement.breadcrumb.index', {
           defaultMessage: 'Saved objects',
         }),
-        href: '/',
       },
     ]);
   }, [setBreadcrumbs]);

--- a/x-pack/plugins/saved_objects_tagging/public/management/tag_management_page.tsx
+++ b/x-pack/plugins/saved_objects_tagging/public/management/tag_management_page.tsx
@@ -122,7 +122,6 @@ export const TagManagementPage: FC<TagManagementPageParams> = ({
         text: i18n.translate('xpack.savedObjectsTagging.management.breadcrumb.index', {
           defaultMessage: 'Tags',
         }),
-        href: '/',
       },
     ]);
   }, [setBreadcrumbs]);


### PR DESCRIPTION
Backports the following commits to 8.0:
 - remove link for last breadcrumb element of SOM and SOT sections (#119425)