### PR TITLE
[APM] Fix bug in documentation on `span.destination` metrics

### DIFF
--- a/x-pack/plugins/apm/dev_docs/apm_queries.md
+++ b/x-pack/plugins/apm/dev_docs/apm_queries.md
@@ -461,6 +461,7 @@ GET apm-*-metric-*,metrics-apm*/_search?terminate_after=1000
       "aggs": {
         "throughput": {
           "rate": {
+            "field": "span.destination.service.response_time.count",
             "unit": "minute"
           }
         }


### PR DESCRIPTION
`field` is required in rate agg for `span.destination` metrics