### PR TITLE
[8.0] [Fleet] Add base Fleet authz logic and API (#119199)

### DIFF
--- a/x-pack/plugins/fleet/common/authz.ts
+++ b/x-pack/plugins/fleet/common/authz.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface FleetAuthz {
+  fleet: {
+    all: boolean;
+    setup: boolean;
+    readEnrollmentTokens: boolean;
+  };
+
+  integrations: {
+    readPackageInfo: boolean;
+    readInstalledPackages: boolean;
+    installPackages: boolean;
+    upgradePackages: boolean;
+    removePackages: boolean;
+
+    readPackageSettings: boolean;
+    writePackageSettings: boolean;
+
+    readIntegrationPolicies: boolean;
+    writeIntegrationPolicies: boolean;
+  };
+}
+
+interface CalculateParams {
+  fleet: {
+    all: boolean;
+    setup: boolean;
+  };
+
+  integrations: {
+    all: boolean;
+    read: boolean;
+  };
+}
+
+export const calculateAuthz = ({ fleet, integrations }: CalculateParams): FleetAuthz => ({
+  fleet: {
+    all: fleet.all && (integrations.all || integrations.read),
+
+    // These are currently used by Fleet Server setup
+    setup: fleet.all || fleet.setup,
+    readEnrollmentTokens: fleet.all || fleet.setup,
+  },
+
+  integrations: {
+    readPackageInfo: fleet.all || fleet.setup || integrations.all || integrations.read,
+    readInstalledPackages: integrations.all || integrations.read,
+    installPackages: fleet.all && integrations.all,
+    upgradePackages: fleet.all && integrations.all,
+    removePackages: fleet.all && integrations.all,
+
+    readPackageSettings: fleet.all && integrations.all,
+    writePackageSettings: fleet.all && integrations.all,
+
+    readIntegrationPolicies: fleet.all && integrations.all,
+    writeIntegrationPolicies: fleet.all && integrations.all,
+  },
+});

--- a/x-pack/plugins/fleet/common/index.ts
+++ b/x-pack/plugins/fleet/common/index.ts
@@ -11,3 +11,5 @@
 export * from './constants';
 export * from './services';
 export * from './types';
+export type { FleetAuthz } from './authz';
+export { calculateAuthz } from './authz';

--- a/x-pack/plugins/fleet/public/mock/fleet_start_services.tsx
+++ b/x-pack/plugins/fleet/public/mock/fleet_start_services.tsx
@@ -14,6 +14,8 @@ import type { IStorage } from '../../../../../src/plugins/kibana_utils/public';
 import { Storage } from '../../../../../src/plugins/kibana_utils/public';
 import { setHttpClient } from '../hooks/use_request';
 
+import type { FleetAuthz } from '../../common';
+
 import { createStartDepsMock } from './plugin_dependencies';
 import type { MockedFleetStartServices } from './types';
 
@@ -26,6 +28,25 @@ const createMockStore = (): MockedKeys<IStorage> => {
     removeItem: jest.fn().mockImplementation((key: string) => delete store[key]),
     clear: jest.fn().mockImplementation(() => (store = {})),
   };
+};
+
+const fleetAuthzMock: FleetAuthz = {
+  fleet: {
+    all: true,
+    setup: true,
+    readEnrollmentTokens: true,
+  },
+  integrations: {
+    readPackageInfo: true,
+    readInstalledPackages: true,
+    installPackages: true,
+    upgradePackages: true,
+    removePackages: true,
+    readPackageSettings: true,
+    writePackageSettings: true,
+    readIntegrationPolicies: true,
+    writeIntegrationPolicies: true,
+  },
 };
 
 const configureStartServices = (services: MockedFleetStartServices): void => {
@@ -52,6 +73,7 @@ export const createStartServices = (basePath: string = '/mock'): MockedFleetStar
     ...coreMock.createStart({ basePath }),
     ...createStartDepsMock(),
     storage: new Storage(createMockStore()) as jest.Mocked<Storage>,
+    authz: fleetAuthzMock,
   };
 
   configureStartServices(startServices);

--- a/x-pack/plugins/fleet/public/mock/plugin_interfaces.ts
+++ b/x-pack/plugins/fleet/public/mock/plugin_interfaces.ts
@@ -14,5 +14,23 @@ export const createStartMock = (extensionsStorage: UIExtensionsStorage = {}): Mo
   return {
     isInitialized: jest.fn().mockResolvedValue(true),
     registerExtension: createExtensionRegistrationCallback(extensionsStorage),
+    authz: {
+      fleet: {
+        all: true,
+        setup: true,
+        readEnrollmentTokens: true,
+      },
+      integrations: {
+        readPackageInfo: true,
+        readInstalledPackages: true,
+        installPackages: true,
+        upgradePackages: true,
+        removePackages: true,
+        readPackageSettings: true,
+        writePackageSettings: true,
+        readIntegrationPolicies: true,
+        writeIntegrationPolicies: true,
+      },
+    },
   };
 };

--- a/x-pack/plugins/fleet/server/mocks/index.ts
+++ b/x-pack/plugins/fleet/server/mocks/index.ts
@@ -20,6 +20,7 @@ import type { PackagePolicyServiceInterface } from '../services/package_policy';
 import type { AgentPolicyServiceInterface, AgentService } from '../services';
 import type { FleetAppContext } from '../plugin';
 import { createMockTelemetryEventsSender } from '../telemetry/__mocks__';
+import type { FleetAuthz } from '../../common';
 
 // Export all mocks from artifacts
 export * from '../services/artifacts/mocks';
@@ -119,4 +120,26 @@ export const createMockAgentService = (): jest.Mocked<AgentService> => {
     getAgent: jest.fn(),
     listAgents: jest.fn(),
   };
+};
+
+/**
+ * Creates mock `authz` object
+ */
+export const fleetAuthzMock: FleetAuthz = {
+  fleet: {
+    all: true,
+    setup: true,
+    readEnrollmentTokens: true,
+  },
+  integrations: {
+    readPackageInfo: true,
+    readInstalledPackages: true,
+    installPackages: true,
+    upgradePackages: true,
+    removePackages: true,
+    readPackageSettings: true,
+    writePackageSettings: true,
+    readIntegrationPolicies: true,
+    writeIntegrationPolicies: true,
+  },
 };

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.test.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.test.ts
@@ -9,7 +9,7 @@ import { httpServerMock, savedObjectsClientMock } from 'src/core/server/mocks';
 
 import type { PostFleetSetupResponse } from '../../../common';
 import { RegistryError } from '../../errors';
-import { createAppContextStartContractMock, xpackMocks } from '../../mocks';
+import { createAppContextStartContractMock, xpackMocks, fleetAuthzMock } from '../../mocks';
 import { appContextService } from '../../services/app_context';
 import { setupFleet } from '../../services/setup';
 import type { FleetRequestHandlerContext } from '../../types';
@@ -34,6 +34,7 @@ describe('FleetSetupHandler', () => {
     context = {
       ...xpackMocks.createRequestHandlerContext(),
       fleet: {
+        authz: fleetAuthzMock,
         epm: {
           internalSoClient: savedObjectsClientMock.create(),
         },

--- a/x-pack/plugins/fleet/server/types/request_context.ts
+++ b/x-pack/plugins/fleet/server/types/request_context.ts
@@ -13,10 +13,12 @@ import type {
   SavedObjectsClientContract,
   IRouter,
 } from '../../../../../src/core/server';
+import type { FleetAuthz } from '../../common/authz';
 
 /** @internal */
 export interface FleetRequestHandlerContext extends RequestHandlerContext {
   fleet: {
+    authz: FleetAuthz;
     epm: {
       /**
        * Saved Objects client configured to use kibana_system privileges instead of end-user privileges. Should only be

--- a/x-pack/plugins/fleet/storybook/context/index.tsx
+++ b/x-pack/plugins/fleet/storybook/context/index.tsx
@@ -69,6 +69,24 @@ export const StorybookContext: React.FC<{ storyContext?: StoryContext }> = ({
       notifications: getNotifications(),
       share: getShare(),
       uiSettings: getUiSettings(),
+      authz: {
+        fleet: {
+          all: true,
+          setup: true,
+          readEnrollmentTokens: true,
+        },
+        integrations: {
+          readPackageInfo: true,
+          readInstalledPackages: true,
+          installPackages: true,
+          upgradePackages: true,
+          removePackages: true,
+          readPackageSettings: true,
+          writePackageSettings: true,
+          readIntegrationPolicies: true,
+          writeIntegrationPolicies: true,
+        },
+      },
     }),
     [isCloudEnabled]
   );

--- a/x-pack/plugins/security_solution/server/endpoint/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/mocks.ts
@@ -17,6 +17,7 @@ import {
   createMockAgentPolicyService,
   createMockAgentService,
   createArtifactsClientMock,
+  fleetAuthzMock,
 } from '../../../fleet/server/mocks';
 import { createMockConfig } from '../lib/detection_engine/routes/__mocks__';
 import {
@@ -153,6 +154,9 @@ export const createMockPackageService = (): jest.Mocked<PackageService> => {
  */
 export const createMockFleetStartContract = (indexPattern: string): FleetStartContract => {
   return {
+    authz: {
+      fromRequest: jest.fn().mockResolvedValue(fleetAuthzMock),
+    },
     fleetSetupCompleted: jest.fn().mockResolvedValue(undefined),
     esIndexPatternService: {
       getESIndexPattern: jest.fn().mockResolvedValue(indexPattern),


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Fleet] Add base Fleet authz logic and API (#119199)