### PR TITLE
[7.16] [Security Solution][Endpoint] add a few delays to one of the FTR Policy tests that integrates with Fleet (#119304)

### DIFF
--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
@@ -533,12 +533,16 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         // Fleet has its  own form inputs, like description. When those are updated, the changes
         // are also dispatched to the embedded endpoint Policy form. Update to the Endpoint Policy
         // form after that should preserve the changes done on the Fleet form
+        // NOTE: A few delays were added below due to sporadic failures of this test case (see #100236)
+        const sleep = (ms = 100) => new Promise((resolve) => setTimeout(resolve, ms));
 
         // Wait for the endpoint form to load and then update the policy description
         await testSubjects.existOrFail('endpointIntegrationPolicyForm');
+        await sleep(); // Allow forms to sync
         await pageObjects.ingestManagerCreatePackagePolicy.setPackagePolicyDescription(
           'protect everything'
         );
+        await sleep(); // Allow forms to sync
 
         const winDnsEventingCheckbox = await testSubjects.find('policyWindowsEvent_dns');
         await pageObjects.ingestManagerCreatePackagePolicy.scrollToCenterOfWindow(


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Security Solution][Endpoint] add a few delays to one of the FTR Policy tests that integrates with Fleet (#119304)