### PR TITLE
[Workplace Search] Promote the Synchronize CTA (#2178)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -544,6 +544,7 @@ export const Overview: React.FC = () => {
         </EuiFlexItem>
         <EuiFlexItem grow={7}>
           <EuiFlexGroup gutterSize="m" direction="column">
+            {showSyncTriggerCallout && syncTriggerCallout}
             <EuiFlexItem>{groups.length > 0 && groupsSummary}</EuiFlexItem>
             {details.length > 0 && <EuiFlexItem>{detailsSummary}</EuiFlexItem>}
             {!custom && serviceTypeSupportsPermissions && (
@@ -587,7 +588,6 @@ export const Overview: React.FC = () => {
                 )}
               </>
             )}
-            {showSyncTriggerCallout && syncTriggerCallout}
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>


### PR DESCRIPTION
## Summary

Moves the CTA for synchronising data sources in Workplace Search up, per [this issue](https://github.com/elastic/workplace-search-team/issues/2178).


<img width="1358" alt="Screenshot 2021-11-29 at 16 43 22" src="https://user-images.githubusercontent.com/94373878/143899411-8f86e18b-b50a-4aa3-8748-c8b3e41be6e4.png">

### Checklist

Delete any items that are not applicable to this PR.
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
