### PR TITLE
[Alerting] Be more explicit with which events we want

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/event_log.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/event_log.ts
@@ -490,8 +490,11 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
             });
           });
 
-          const startEvent = events[0];
-          const executeEvent = events[1];
+          const executeEvents = getEventsByAction(events, 'execute');
+          const executeStartEvents = getEventsByAction(events, 'execute-start');
+
+          const startEvent = executeStartEvents[0];
+          const executeEvent = executeEvents[0];
 
           expect(startEvent).to.be.ok();
           expect(executeEvent).to.be.ok();


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/116561

I think this test is flaky because we aren't guaranteeing the actual event log order in our `getEventLog` test function so we need to be more explicit about which events we want