### PR TITLE
[saved objects] Updates import docs to make it clearer which versions are supported.

### DIFF
--- a/docs/api/saved-objects/import.asciidoc
+++ b/docs/api/saved-objects/import.asciidoc
@@ -14,7 +14,7 @@ Saved objects can only be imported into the same version, a newer minor on the s
 | 6.7.x | 6.8.x | Yes
 | 6.x.x | 7.x.x | Yes
 | 7.x.x | 8.x.x | Yes
-| 7.1.0| 7.15.x | Yes
+| 7.1.x | 7.15.x | Yes
 | 7.x.x | 6.x.x | No
 | 7.15.x | 7.1.x | No
 | 6.x.x | 8.x.x | No

--- a/docs/api/saved-objects/import.asciidoc
+++ b/docs/api/saved-objects/import.asciidoc
@@ -11,11 +11,13 @@ Saved objects can only be imported into the same version, a newer minor on the s
 
 |=======
 | Exporting version | Importing version | Compatible?
-| 6.7.0 | 6.8.1 | Yes
-| 6.8.1 | 7.3.0 | Yes
-| 7.3.0 | 7.11.1 | Yes
-| 7.11.1 | 7.6.0 | No
-| 6.8.1 | 8.0.0 | No
+| 6.7.x | 6.8.x | Yes
+| 6.x.x | 7.x.x | Yes
+| 7.x.x | 8.x.x | Yes
+| 7.1.0| 7.15.x | Yes
+| 7.x.x | 6.x.x | No
+| 7.15.x | 7.1.x | No
+| 6.x.x | 8.x.x | No
 |=======
 
 [[saved-objects-api-import-request]]


### PR DESCRIPTION
Replaces https://github.com/elastic/kibana/pull/119027

---

Original PR description from @jalogisch:

## Summary

After the need to re-read the compatibility list and the text above multiple times to understand if something specific is possible or not, this updated list should make it clear directly. 

This should be sent to `7.16` and `8.0` branch too.


### For maintainers

Documentation only