### PR TITLE
[DOCS] Fixes Lens typo

### DIFF
--- a/docs/user/dashboard/lens.asciidoc
+++ b/docs/user/dashboard/lens.asciidoc
@@ -249,7 +249,7 @@ In the legend, click the field, then choose one of the following options:
 [[configure-the-visualization-components]]
 ==== Configure the visualization components
 
-Each visualiztion type comes with a set of components that you access from the editor toolbar.
+Each visualization type comes with a set of components that you access from the editor toolbar.
 
 The following component menus are available:
 


### PR DESCRIPTION
## Summary

Corrects `visualiztion` to `visualization`.

