### PR TITLE
Tech debt/substitute legacy request

### DIFF
--- a/src/core/server/http/auth_headers_storage.ts
+++ b/src/core/server/http/auth_headers_storage.ts
@@ -5,8 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
-import { KibanaRequest, ensureRawRequest, LegacyRequest } from './router';
+import { Request } from '@hapi/hapi';
+import { KibanaRequest, ensureRawRequest } from './router';
 import { AuthHeaders } from './lifecycle/auth';
 
 /**
@@ -19,8 +19,8 @@ export type GetAuthHeaders = (request: KibanaRequest) => AuthHeaders | undefined
 
 /** @internal */
 export class AuthHeadersStorage {
-  private authHeadersCache = new WeakMap<LegacyRequest, AuthHeaders>();
-  public set = (request: KibanaRequest | LegacyRequest, headers: AuthHeaders) => {
+  private authHeadersCache = new WeakMap<Request, AuthHeaders>();
+  public set = (request: KibanaRequest | Request, headers: AuthHeaders) => {
     this.authHeadersCache.set(ensureRawRequest(request), headers);
   };
   public get: GetAuthHeaders = (request) => {

--- a/src/core/server/http/auth_state_storage.ts
+++ b/src/core/server/http/auth_state_storage.ts
@@ -5,8 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
-import { ensureRawRequest, KibanaRequest, LegacyRequest } from './router';
+import { Request } from '@hapi/hapi';
+import { ensureRawRequest, KibanaRequest } from './router';
 
 /**
  * Status indicating an outcome of the authentication.
@@ -45,12 +45,12 @@ export type IsAuthenticated = (request: KibanaRequest) => boolean;
 
 /** @internal */
 export class AuthStateStorage {
-  private readonly storage = new WeakMap<LegacyRequest, unknown>();
+  private readonly storage = new WeakMap<Request, unknown>();
   constructor(private readonly canBeAuthenticated: () => boolean) {}
-  public set = (request: KibanaRequest | LegacyRequest, state: unknown) => {
+  public set = (request: KibanaRequest | Request, state: unknown) => {
     this.storage.set(ensureRawRequest(request), state);
   };
-  public get = <T = unknown>(request: KibanaRequest | LegacyRequest) => {
+  public get = <T = unknown>(request: KibanaRequest | Request) => {
     const key = ensureRawRequest(request);
     const state = this.storage.get(key) as T;
     const status: AuthStatus = this.storage.has(key)

--- a/src/core/server/http/base_path_service.ts
+++ b/src/core/server/http/base_path_service.ts
@@ -7,8 +7,8 @@
  */
 
 import { modifyUrl } from '@kbn/std';
-
-import { ensureRawRequest, KibanaRequest, LegacyRequest } from './router';
+import { Request } from '@hapi/hapi';
+import { ensureRawRequest, KibanaRequest } from './router';
 
 /**
  * Access or manipulate the Kibana base path
@@ -16,7 +16,7 @@ import { ensureRawRequest, KibanaRequest, LegacyRequest } from './router';
  * @public
  */
 export class BasePath {
-  private readonly basePathCache = new WeakMap<LegacyRequest, string>();
+  private readonly basePathCache = new WeakMap<Request, string>();
 
   /**
    * returns the server's basePath

--- a/src/core/server/http/router/index.ts
+++ b/src/core/server/http/router/index.ts
@@ -23,7 +23,6 @@ export type {
   KibanaRequestRouteOptions,
   KibanaRouteOptions,
   KibanaRequestState,
-  LegacyRequest,
 } from './request';
 export { isSafeMethod, validBodyOutput } from './route';
 export type {

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -78,13 +78,6 @@ export interface KibanaRequestEvents {
 }
 
 /**
- * @deprecated
- * `hapi` request object, supported during migration process only for backward compatibility.
- * @public
- */
-export interface LegacyRequest extends Request {} // eslint-disable-line @typescript-eslint/no-empty-interface
-
-/**
  * Kibana specific abstraction for an incoming request.
  * @public
  */

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -312,7 +312,7 @@ export class KibanaRequest<
  * Returns underlying Hapi Request
  * @internal
  */
-export const ensureRawRequest = (request: KibanaRequest | LegacyRequest) =>
+export const ensureRawRequest = (request: KibanaRequest | Request) =>
   isKibanaRequest(request) ? request[requestSymbol] : request;
 
 /**
@@ -323,7 +323,7 @@ export function isKibanaRequest(request: unknown): request is KibanaRequest {
   return request instanceof KibanaRequest;
 }
 
-function isRequest(request: any): request is LegacyRequest {
+function isRequest(request: any): request is Request {
   try {
     return request.raw.req && typeof request.raw.req === 'object';
   } catch {
@@ -332,9 +332,9 @@ function isRequest(request: any): request is LegacyRequest {
 }
 
 /**
- * Checks if an incoming request either KibanaRequest or Legacy.Request
+ * Checks if an incoming request either KibanaRequest or Hapi.Request
  * @internal
  */
-export function isRealRequest(request: unknown): request is KibanaRequest | LegacyRequest {
+export function isRealRequest(request: unknown): request is KibanaRequest | Request {
   return isKibanaRequest(request) || isRequest(request);
 }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/119867

This PR handles the remaining usages of `LegacyRequest` in core http by substituting `LegacyRequest` with `Hapi.Request` and removes the type from the `http` interface.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios (Tests did not need to be updated)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) (No changes)
