### PR TITLE
[Security Solution] Add alerts-as-data index names as alias to signals indices

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/__snapshots__/get_signals_template.test.ts.snap
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/__snapshots__/get_signals_template.test.ts.snap
@@ -610,10 +610,15 @@ Object {
     "test-index-*",
   ],
   "template": Object {
+    "aliases": Object {
+      ".alerts-security.alerts-space-id": Object {
+        "is_write_index": false,
+      },
+    },
     "mappings": Object {
       "_meta": Object {
         "aliases_version": 1,
-        "version": 57,
+        "version": 67,
       },
       "dynamic": false,
       "properties": Object {
@@ -6348,6 +6353,6 @@ Object {
       },
     },
   },
-  "version": 57,
+  "version": 67,
 }
 `;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/create_index_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/create_index_route.ts
@@ -97,7 +97,7 @@ export const createDetectionIndex = async (
   if (await templateNeedsUpdate({ alias: index, esClient })) {
     await esClient.indices.putIndexTemplate({
       name: index,
-      body: getSignalsTemplate(index, spaceId, aadIndexAliasName) as Record<string, unknown>,
+      body: getSignalsTemplate(index, aadIndexAliasName) as Record<string, unknown>,
     });
   }
   // Check if the old legacy siem signals template exists and remove it

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/create_preview_index_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/create_preview_index_route.ts
@@ -62,6 +62,7 @@ export const createPreviewIndex = async (
 ) => {
   const esClient = context.core.elasticsearch.client.asCurrentUser;
   const index = siemClient.getPreviewIndex();
+  const spaceId = context.securitySolution.getSpaceId();
 
   const indexExists = await getIndexExists(esClient, index);
 
@@ -70,10 +71,13 @@ export const createPreviewIndex = async (
     await setPolicy(esClient, index, previewPolicy);
   }
 
+  const ruleDataService = context.securitySolution.getRuleDataService();
+  const aadIndexAliasName = ruleDataService.getResourceName(`security.alerts-${spaceId}`);
+
   if (await templateNeedsUpdate({ alias: index, esClient })) {
     await esClient.indices.putIndexTemplate({
       name: index,
-      body: getSignalsTemplate(index) as Record<string, unknown>,
+      body: getSignalsTemplate(index, aadIndexAliasName) as Record<string, unknown>,
     });
   }
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/get_signals_template.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/get_signals_template.test.ts
@@ -9,11 +9,7 @@ import { createBackwardsCompatibilityMapping, getSignalsTemplate } from './get_s
 
 describe('get_signals_template', () => {
   test('it should set the lifecycle "name" and "rollover_alias" to be the name of the index passed in', () => {
-    const template = getSignalsTemplate(
-      'test-index',
-      'space-id',
-      '.alerts-security.alerts-space-id'
-    );
+    const template = getSignalsTemplate('test-index', '.alerts-security.alerts-space-id');
     expect(template.template.settings).toEqual({
       index: {
         lifecycle: {
@@ -28,38 +24,22 @@ describe('get_signals_template', () => {
   });
 
   test('it should set have the index patterns with an ending glob in it', () => {
-    const template = getSignalsTemplate(
-      'test-index',
-      'space-id',
-      '.alerts-security.alerts-space-id'
-    );
+    const template = getSignalsTemplate('test-index', '.alerts-security.alerts-space-id');
     expect(template.index_patterns).toEqual(['test-index-*']);
   });
 
   test('it should have a mappings section which is an object type', () => {
-    const template = getSignalsTemplate(
-      'test-index',
-      'space-id',
-      '.alerts-security.alerts-space-id'
-    );
+    const template = getSignalsTemplate('test-index', '.alerts-security.alerts-space-id');
     expect(typeof template.template.mappings).toEqual('object');
   });
 
   test('it should have a signals section which is an object type', () => {
-    const template = getSignalsTemplate(
-      'test-index',
-      'space-id',
-      '.alerts-security.alerts-space-id'
-    );
+    const template = getSignalsTemplate('test-index', '.alerts-security.alerts-space-id');
     expect(typeof template.template.mappings.properties.signal).toEqual('object');
   });
 
   test('it should have a "total_fields" section that is at least 10k in size', () => {
-    const template = getSignalsTemplate(
-      'test-index',
-      'space-id',
-      '.alerts-security.alerts-space-id'
-    );
+    const template = getSignalsTemplate('test-index', '.alerts-security.alerts-space-id');
     expect(template.template.settings.mapping.total_fields.limit).toBeGreaterThanOrEqual(10000);
   });
 
@@ -82,11 +62,7 @@ describe('get_signals_template', () => {
   // Instead you have to use "keyword". This test was first introduced when ECS 1.10 came out and data_stream.* values which had
   // "constant_keyword" fields and we needed to change those to be "keyword" instead.
   test('it should NOT have any "constant_keyword" and instead those should be replaced with regular "keyword" in the mapping', () => {
-    const template = getSignalsTemplate(
-      'test-index',
-      'space-id',
-      '.alerts-security.alerts-space-id'
-    );
+    const template = getSignalsTemplate('test-index', '.alerts-security.alerts-space-id');
 
     // Small recursive function to find any values of "constant_keyword" and mark which fields it was found on and then error on those fields
     // The matchers from jest such as jest.toMatchObject do not support recursion, so I have to write it here:
@@ -117,11 +93,7 @@ describe('get_signals_template', () => {
   });
 
   test('it should match snapshot', () => {
-    const template = getSignalsTemplate(
-      'test-index',
-      'space-id',
-      '.alerts-security.alerts-space-id'
-    );
+    const template = getSignalsTemplate('test-index', '.alerts-security.alerts-space-id');
     expect(template).toMatchSnapshot();
   });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/get_signals_template.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/get_signals_template.ts
@@ -33,7 +33,7 @@ import signalExtraFields from './signal_extra_fields.json';
   incremented by 10 in order to add "room" for the aforementioned patch
   release
 */
-export const SIGNALS_TEMPLATE_VERSION = 57;
+export const SIGNALS_TEMPLATE_VERSION = 67;
 /**
   @constant
   @type {number}
@@ -59,16 +59,16 @@ export const SIGNALS_FIELD_ALIASES_VERSION = 1;
 export const MIN_EQL_RULE_INDEX_VERSION = 2;
 export const ALIAS_VERSION_FIELD = 'aliases_version';
 
-export const getSignalsTemplate = (index: string, spaceId?: string, aadIndexAliasName?: string) => {
+export const getSignalsTemplate = (index: string, aadIndexAliasName: string) => {
   const fieldAliases = createSignalsFieldAliases();
   const template = {
     index_patterns: [`${index}-*`],
     template: {
-      // aliases: {
-      //   [aadIndexAliasName]: {
-      //     is_write_index: false,
-      //   },
-      // },
+      aliases: {
+        [aadIndexAliasName]: {
+          is_write_index: false,
+        },
+      },
       settings: {
         index: {
           lifecycle: {
@@ -142,7 +142,7 @@ const properties = {
 export const backwardsCompatibilityMappings = [
   {
     minVersion: 0,
-    // Version 45 shipped with 7.14
+    // Version 45 shipped with 7.14. 7.15+ have both the host.os.name.caseless field and the field aliases
     maxVersion: 45,
     mapping: {
       runtime: {


### PR DESCRIPTION
## Summary

Re-adds the index alias to `.siem-signals` index template and updates the `SIGNALS_TEMPLATE_VERSION`. Updating the version will cause the `create_index_route` to be called, applying the alias to existing indices as well as rolling over the index after updating the template.