### PR TITLE
[Security Solution][CTI] Unskips "Displays enrichment matched.* fields on the timeline" test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/cti_enrichments.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/cti_enrichments.spec.ts
@@ -55,11 +55,13 @@ describe('CTI Enrichment', () => {
     goToRuleDetails();
   });
 
-  it.skip('Displays enrichment matched.* fields on the timeline', () => {
+  it('Displays enrichment matched.* fields on the timeline', () => {
     const expectedFields = {
       'threat.enrichments.matched.atomic': getNewThreatIndicatorRule().atomic,
-      'threat.enrichments.matched.type': 'indicator_match_rule',
+      'threat.enrichments.matched.type': getNewThreatIndicatorRule().matchedType,
       'threat.enrichments.matched.field': getNewThreatIndicatorRule().indicatorMappingField,
+      'threat.enrichments.matched.id': getNewThreatIndicatorRule().matchedId,
+      'threat.enrichments.matched.index': getNewThreatIndicatorRule().matchedIndex,
     };
     const fields = Object.keys(expectedFields) as Array<keyof typeof expectedFields>;
 

--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -80,6 +80,9 @@ export interface ThreatIndicatorRule extends CustomRule {
   threatIndicatorPath: string;
   type?: string;
   atomic?: string;
+  matchedType?: string;
+  matchedId?: string;
+  matchedIndex?: string;
 }
 
 export interface MachineLearningRule {
@@ -407,6 +410,9 @@ export const getNewThreatIndicatorRule = (): ThreatIndicatorRule => ({
   timeline: getIndicatorMatchTimelineTemplate(),
   maxSignals: 100,
   threatIndicatorPath: 'threat.indicator',
+  matchedType: 'indicator_match_rule',
+  matchedId: '84cf452c1e0375c3d4412cb550bd1783358468a3b3b777da4829d72c7d6fb74f',
+  matchedIndex: 'logs-ti_abusech.malware',
 });
 
 export const duplicatedRuleName = `${getNewThreatIndicatorRule().name} [Duplicate]`;


### PR DESCRIPTION
## Summary

This PR is part of the work we are doing in order to bring to life all the skipped tests to merge the rule registry changes: #116460

As the issue https://github.com/elastic/kibana/issues/119633 has been fixed, now we can unskip the test.

In this PR apart from unskipping the tests we are adding also the new matched fields.
