### PR TITLE
[7.16] [es-query] Fix logic for detecting scripted phrase fields (#119511)

### DIFF
--- a/packages/kbn-es-query/src/filters/build_filters/phrase_filter.test.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/phrase_filter.test.ts
@@ -5,16 +5,19 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
+import { set } from 'lodash';
 import {
   buildInlineScriptForPhraseFilter,
   buildPhraseFilter,
   getPhraseFilterField,
   PhraseFilter,
+  isPhraseFilter,
+  isScriptedPhraseFilter,
 } from './phrase_filter';
 import { fields, getField } from '../stubs';
 import { DataViewBase } from '../../es_query';
 import { estypes } from '@elastic/elasticsearch';
+import { Filter } from './types';
 
 describe('Phrase filter builder', () => {
   let indexPattern: DataViewBase;
@@ -151,16 +154,36 @@ describe('buildInlineScriptForPhraseFilter', () => {
   });
 });
 
-describe('getPhraseFilterField', function () {
+describe('getPhraseFilterField', function() {
   const indexPattern: DataViewBase = {
     fields,
     title: 'dataView',
   };
 
   it('should return the name of the field a phrase query is targeting', () => {
-    const field = indexPattern.fields.find((patternField) => patternField.name === 'extension');
+    const field = indexPattern.fields.find(patternField => patternField.name === 'extension');
     const filter = buildPhraseFilter(field!, 'jpg', indexPattern);
     const result = getPhraseFilterField(filter as PhraseFilter);
     expect(result).toBe('extension');
+  });
+});
+
+describe('isPhraseFilter', () => {
+  it('should return true if the filter is a phrases filter false otherwise', () => {
+    const filter: Filter = set({ meta: {} }, 'query.match_phrase', {}) as Filter;
+    const unknownFilter = {} as Filter;
+
+    expect(isPhraseFilter(filter)).toBe(true);
+    expect(isPhraseFilter(unknownFilter)).toBe(false);
+  });
+});
+
+describe('isScriptedPhraseFilter', () => {
+  it('should return true if the filter is a phrases filter false otherwise', () => {
+    const filter: Filter = set({ meta: {} }, 'query.script.script.params.value', {}) as Filter;
+    const unknownFilter = {} as Filter;
+
+    expect(isScriptedPhraseFilter(filter)).toBe(true);
+    expect(isPhraseFilter(unknownFilter)).toBe(false);
   });
 });

--- a/packages/kbn-es-query/src/filters/build_filters/phrase_filter.test.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/phrase_filter.test.ts
@@ -154,14 +154,14 @@ describe('buildInlineScriptForPhraseFilter', () => {
   });
 });
 
-describe('getPhraseFilterField', function() {
+describe('getPhraseFilterField', function () {
   const indexPattern: DataViewBase = {
     fields,
     title: 'dataView',
   };
 
   it('should return the name of the field a phrase query is targeting', () => {
-    const field = indexPattern.fields.find(patternField => patternField.name === 'extension');
+    const field = indexPattern.fields.find((patternField) => patternField.name === 'extension');
     const filter = buildPhraseFilter(field!, 'jpg', indexPattern);
     const result = getPhraseFilterField(filter as PhraseFilter);
     expect(result).toBe('extension');

--- a/packages/kbn-es-query/src/filters/build_filters/phrase_filter.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/phrase_filter.ts
@@ -31,8 +31,10 @@ export type PhraseFilter = Filter & {
 
 export type ScriptedPhraseFilter = Filter & {
   meta: PhraseFilterMeta;
-  script: {
-    script: estypes.InlineScript;
+  query: {
+    script: {
+      script: estypes.InlineScript;
+    };
   };
 };
 
@@ -58,7 +60,7 @@ export const isPhraseFilter = (filter: Filter): filter is PhraseFilter => {
  * @public
  */
 export const isScriptedPhraseFilter = (filter: Filter): filter is ScriptedPhraseFilter =>
-  has(filter, 'script.script.params.value');
+  has(filter, 'query.script.script.params.value');
 
 /** @internal */
 export const getPhraseFilterField = (filter: PhraseFilter) => {
@@ -77,7 +79,7 @@ export const getPhraseFilterValue = (
     const queryValue = Object.values(queryConfig)[0];
     return isPlainObject(queryValue) ? queryValue.query : queryValue;
   } else {
-    return filter.script.script.params?.value;
+    return filter.query?.script?.script?.params?.value;
   }
 };
 

--- a/src/plugins/data/public/query/filter_manager/lib/generate_filters.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/generate_filters.ts
@@ -40,7 +40,9 @@ function getExistingFilter(
     }
 
     if (isScriptedPhraseFilter(filter)) {
-      return filter.meta.field === fieldName && filter.script.script.params?.value === value;
+      return (
+        filter.meta.field === fieldName && filter.query?.script?.script?.params?.value === value
+      );
     }
   }) as any;
 }

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.ts
@@ -20,7 +20,7 @@ import {
 import { FilterValueFormatter } from '../../../../../common';
 
 const getScriptedPhraseValue = (filter: PhraseFilter) =>
-  get(filter, ['script', 'script', 'params', 'value']);
+  get(filter, ['query', 'script', 'script', 'params', 'value']);
 
 const getFormattedValueFn = (value: any) => {
   return (formatter?: FilterValueFormatter) => {

--- a/src/plugins/input_control_vis/public/control/filter_manager/phrase_filter_manager.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/phrase_filter_manager.ts
@@ -97,8 +97,8 @@ export class PhraseFilterManager extends FilterManager {
     }
 
     // scripted field filter
-    if (_.has(kbnFilter, 'script')) {
-      return _.get(kbnFilter, 'script.script.params.value');
+    if (_.has(kbnFilter, 'query.script')) {
+      return _.get(kbnFilter, 'query.script.script.params.value');
     }
 
     // single phrase filter


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [es-query] Fix logic for detecting scripted phrase fields (#119511)