### PR TITLE
[Exploratory View] Add a tooltip to the report metric badge [Closes #117447]

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/report_metric_options.test.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/report_metric_options.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { mockAppIndexPattern, mockIndexPattern, mockUxSeries, render } from '../rtl_helpers';
 import { getDefaultConfigs } from '../configurations/default_configs';
 import { PERCENTILE } from '../configurations/constants';
@@ -53,5 +54,22 @@ describe('ReportMetricOptions', function () {
     );
 
     expect(await screen.findByText('Page load time')).toBeInTheDocument();
+  });
+
+  it('should include a tooltip for the report metric', async function () {
+    mockAppIndexPattern({ loading: false });
+    const { getByText, findByText } = render(
+      <ReportMetricOptions
+        seriesId={0}
+        seriesConfig={{ ...dataViewSeries }}
+        series={{ ...mockUxSeries }}
+      />
+    );
+
+    userEvent.hover(getByText('Page load time'));
+
+    // The tooltip from EUI takes 250ms to appear, so we must
+    // use a `find*` query to asynchronously poll for it.
+    expect(await findByText('Report metric')).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/report_metric_options.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/report_metric_options.tsx
@@ -128,18 +128,20 @@ export function ReportMetricOptions({ seriesId, series, seriesConfig }: Props) {
       )}
       {series.selectedMetricField &&
         (indexPattern ? (
-          <EuiBadge
-            iconType="cross"
-            iconSide="right"
-            iconOnClick={() => onChange(undefined)}
-            iconOnClickAriaLabel={REMOVE_REPORT_METRIC_LABEL}
-          >
-            {
-              seriesConfig?.metricOptions?.find(
-                (option) => option.id === series.selectedMetricField
-              )?.label
-            }
-          </EuiBadge>
+          <EuiToolTip position="top" content={REPORT_METRIC_TOOLTIP}>
+            <EuiBadge
+              iconType="cross"
+              iconSide="right"
+              iconOnClick={() => onChange(undefined)}
+              iconOnClickAriaLabel={REMOVE_REPORT_METRIC_LABEL}
+            >
+              {
+                seriesConfig?.metricOptions?.find(
+                  (option) => option.id === series.selectedMetricField
+                )?.label
+              }
+            </EuiBadge>
+          </EuiToolTip>
         ) : (
           <EuiLoadingSpinner />
         ))}
@@ -169,3 +171,10 @@ const NO_PERMISSIONS = i18n.translate('xpack.observability.expView.seriesEditor.
   defaultMessage:
     "Unable to create Index Pattern. You don't have the required permission, please contact your admin.",
 });
+
+const REPORT_METRIC_TOOLTIP = i18n.translate(
+  'xpack.observability.expView.seriesEditor.reportMetricTooltip',
+  {
+    defaultMessage: 'Report metric',
+  }
+);


### PR DESCRIPTION
## Summary

This PR closes #117447 by adding a tooltip to the report metric badge.

You can see the result on the gif below.

![tooltipmetric](https://user-images.githubusercontent.com/6868147/144031499-9e16b38d-41ef-4985-9186-93ba20ca95da.gif)

### How to test it

1. Access the `Uptime` app and go into the monitors screen, for example
2. On the top right corner, access the exploratory view by clicking `Explore data`
3. Hover over the report metric type


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release note

Add missing tooltip to the report metric badge in Exploratory View.