### PR TITLE
[SecuritySolution] Hide sourcerer when no data

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/sourcerer/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/sourcerer/index.test.tsx
@@ -7,12 +7,7 @@
 
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
-import {
-  initDataView,
-  initialSourcererState,
-  initSourcererScope,
-  SourcererScopeName,
-} from '../../store/sourcerer/model';
+import { initialSourcererState, SourcererScopeName } from '../../store/sourcerer/model';
 import { Sourcerer } from './index';
 import { sourcererActions, sourcererModel } from '../../store/sourcerer';
 import {

--- a/x-pack/plugins/security_solution/public/common/components/sourcerer/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/sourcerer/index.test.tsx
@@ -7,7 +7,12 @@
 
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
-import { SourcererScopeName } from '../../store/sourcerer/model';
+import {
+  initDataView,
+  initialSourcererState,
+  initSourcererScope,
+  SourcererScopeName,
+} from '../../store/sourcerer/model';
 import { Sourcerer } from './index';
 import { sourcererActions, sourcererModel } from '../../store/sourcerer';
 import {
@@ -781,5 +786,31 @@ describe('Sourcerer integration tests', () => {
         selectedPatterns: ['fakebeat-*'],
       })
     );
+  });
+});
+
+describe('No indices exists', () => {
+  const mockNoIndicesState = {
+    ...mockGlobalState,
+    sourcerer: {
+      ...initialSourcererState,
+    },
+  };
+
+  const { storage } = createSecuritySolutionStorageMock();
+
+  beforeEach(() => {
+    store = createStore(mockNoIndicesState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+  test('No render the sourcerer', () => {
+    const wrapper = mount(
+      <TestProviders store={store}>
+        <Sourcerer {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(wrapper.find(`[data-test-subj="sourcerer-trigger"]`).exists()).toEqual(false);
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/sourcerer/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/sourcerer/index.test.tsx
@@ -789,7 +789,7 @@ describe('Sourcerer integration tests', () => {
   });
 });
 
-describe('No indices exists', () => {
+describe('No data', () => {
   const mockNoIndicesState = {
     ...mockGlobalState,
     sourcerer: {
@@ -804,7 +804,7 @@ describe('No indices exists', () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
   });
-  test('No render the sourcerer', () => {
+  test('Hide sourcerer', () => {
     const wrapper = mount(
       <TestProviders store={store}>
         <Sourcerer {...defaultProps} />

--- a/x-pack/plugins/security_solution/public/common/components/sourcerer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/sourcerer/index.tsx
@@ -27,6 +27,7 @@ import * as i18n from './translations';
 import { sourcererActions, sourcererModel, sourcererSelectors } from '../../store/sourcerer';
 import { useDeepEqualSelector } from '../../hooks/use_selector';
 import { SourcererScopeName } from '../../store/sourcerer/model';
+import { checkIfIndicesExist } from '../../store/sourcerer/helpers';
 import { usePickIndexPatterns } from './use_pick_index_patterns';
 import {
   FormRow,
@@ -54,7 +55,13 @@ export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }
     kibanaDataViews,
     signalIndexName,
     sourcererScope: { selectedDataViewId, selectedPatterns, loading },
+    sourcererDataView,
   } = useDeepEqualSelector((state) => sourcererScopeSelector(state, scopeId));
+  console.log('sourcererDataView---', sourcererDataView);
+  const indicesExist = useMemo(
+    () => checkIfIndicesExist({ scopeId, signalIndexName, sourcererDataView }),
+    [scopeId, signalIndexName, sourcererDataView]
+  );
 
   const [isOnlyDetectionAlertsChecked, setIsOnlyDetectionAlertsChecked] = useState(
     isTimelineSourcerer && selectedPatterns.join() === signalIndexName
@@ -203,7 +210,7 @@ export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }
     setExpandAdvancedOptions((prevState) => !prevState);
   }, []);
 
-  return (
+  return indicesExist ? (
     <EuiPopover
       data-test-subj={isTimelineSourcerer ? 'timeline-sourcerer-popover' : 'sourcerer-popover'}
       button={buttonWithTooptip}
@@ -312,6 +319,6 @@ export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }
         </EuiForm>
       </PopoverContent>
     </EuiPopover>
-  );
+  ) : null;
 });
 Sourcerer.displayName = 'Sourcerer';

--- a/x-pack/plugins/security_solution/public/common/components/sourcerer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/sourcerer/index.tsx
@@ -57,7 +57,6 @@ export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }
     sourcererScope: { selectedDataViewId, selectedPatterns, loading },
     sourcererDataView,
   } = useDeepEqualSelector((state) => sourcererScopeSelector(state, scopeId));
-  console.log('sourcererDataView---', sourcererDataView);
   const indicesExist = useMemo(
     () => checkIfIndicesExist({ scopeId, signalIndexName, sourcererDataView }),
     [scopeId, signalIndexName, sourcererDataView]

--- a/x-pack/plugins/security_solution/public/common/containers/sourcerer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/sourcerer/index.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../../../common/constants';
 import { TimelineId } from '../../../../common';
 import { useDeepEqualSelector } from '../../hooks/use_selector';
-import { getScopePatternListSelection } from '../../store/sourcerer/helpers';
+import { checkIfIndicesExist, getScopePatternListSelection } from '../../store/sourcerer/helpers';
 import { useAppToasts } from '../../hooks/use_app_toasts';
 import { postSourcererDataView } from './api';
 import { useDataView } from '../source/use_data_view';
@@ -273,6 +273,11 @@ export const useSourcererDataView = (
     [scopeSelectedPatterns]
   );
 
+  const indicesExist = useMemo(
+    () => checkIfIndicesExist({ scopeId, signalIndexName, sourcererDataView: selectedDataView }),
+    [scopeId, signalIndexName, selectedDataView]
+  );
+
   return useMemo(
     () => ({
       browserFields: selectedDataView.browserFields,
@@ -282,12 +287,7 @@ export const useSourcererDataView = (
         fields: selectedDataView.indexFields,
         title: selectedPatterns.join(','),
       },
-      indicesExist:
-        scopeId === SourcererScopeName.detections
-          ? selectedDataView.patternList.includes(`${signalIndexName}`)
-          : scopeId === SourcererScopeName.default
-          ? selectedDataView.patternList.filter((i) => i !== signalIndexName).length > 0
-          : selectedDataView.patternList.length > 0,
+      indicesExist,
       loading: loading || selectedDataView.loading,
       runtimeMappings: selectedDataView.runtimeMappings,
       // all active & inactive patterns in DATA_VIEW
@@ -295,7 +295,18 @@ export const useSourcererDataView = (
       // selected patterns in DATA_VIEW
       selectedPatterns: selectedPatterns.sort(),
     }),
-    [loading, selectedPatterns, signalIndexName, scopeId, selectedDataView]
+    [
+      selectedDataView.browserFields,
+      selectedDataView.id,
+      selectedDataView.docValueFields,
+      selectedDataView.indexFields,
+      selectedDataView.loading,
+      selectedDataView.runtimeMappings,
+      selectedDataView.title,
+      selectedPatterns,
+      indicesExist,
+      loading,
+    ]
   );
 };
 

--- a/x-pack/plugins/security_solution/public/common/store/sourcerer/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/store/sourcerer/helpers.ts
@@ -8,6 +8,7 @@
 import { isEmpty } from 'lodash';
 import { SourcererDataView, SourcererModel, SourcererScopeById, SourcererScopeName } from './model';
 import { SelectedDataViewPayload } from './actions';
+import { sourcererModel } from '../model';
 
 export const getScopePatternListSelection = (
   theDataView: SourcererDataView | undefined,
@@ -94,3 +95,19 @@ export const validateSelectedPatterns = (
     },
   };
 };
+
+interface CheckIfIndicesExistParams {
+  scopeId: sourcererModel.SourcererScopeName;
+  signalIndexName: string | null;
+  sourcererDataView: sourcererModel.SourcererDataView;
+}
+export const checkIfIndicesExist = ({
+  scopeId,
+  signalIndexName,
+  sourcererDataView,
+}: CheckIfIndicesExistParams) =>
+  scopeId === SourcererScopeName.detections
+    ? sourcererDataView.patternList.includes(`${signalIndexName}`)
+    : scopeId === SourcererScopeName.default
+    ? sourcererDataView.patternList.filter((i) => i !== signalIndexName).length > 0
+    : sourcererDataView.patternList.length > 0;


### PR DESCRIPTION
## Summary
Before Adding data: No data view dropdown
<img width="1680" alt="Screenshot 2021-11-30 at 12 45 25" src="https://user-images.githubusercontent.com/6295984/144049696-1fd897ed-db9f-493a-852e-8f1f235a9295.png">

After adding data: Data view appears
<img width="1663" alt="Screenshot 2021-11-30 at 12 51 17" src="https://user-images.githubusercontent.com/6295984/144050604-9b113866-80e2-45df-ab1a-0912a9ceeeba.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
