### PR TITLE
[Canvas] Fixed layer controls visibility.

### DIFF
--- a/x-pack/plugins/canvas/public/components/sidebar/sidebar_content/sidebar_content.component.tsx
+++ b/x-pack/plugins/canvas/public/components/sidebar/sidebar_content/sidebar_content.component.tsx
@@ -65,7 +65,7 @@ const SingleElementSidebar: React.FC<{ selectedElementId: string | null }> = ({
   selectedElementId,
 }) => (
   <Fragment>
-    <SidebarHeader title={strings.getSingleElementSidebarTitle()} />
+    <SidebarHeader title={strings.getSingleElementSidebarTitle()} showLayerControls />
     <ElementSettings selectedElementId={selectedElementId} />
   </Fragment>
 );

--- a/x-pack/plugins/canvas/public/components/sidebar_header/sidebar_header.tsx
+++ b/x-pack/plugins/canvas/public/components/sidebar_header/sidebar_header.tsx
@@ -48,6 +48,7 @@ const createHandlers = function <T>(
 
 interface Props {
   title: string;
+  showLayerControls?: boolean;
 }
 
 export const SidebarHeader: React.FC<Props> = (props) => {


### PR DESCRIPTION
## Fixed visibility of layer controls at the Canvas workpad sidebar. (Regression)
This bug has been introduced at this PR: https://github.com/elastic/kibana/pull/111672.

## Screenshots
### Before:
![Screenshot 2021-11-30 at 15 20 25](https://user-images.githubusercontent.com/22456368/144054779-723e5ba0-4c61-4056-b3ac-3d8b188f1e40.png)

### After:
![Screenshot 2021-11-30 at 15 19 47](https://user-images.githubusercontent.com/22456368/144054686-d277a81d-decc-409e-be0b-6b84b6b68ab2.png)
