### PR TITLE
[DOCS] Fix link and add redirect for removed security page

### DIFF
--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -15,6 +15,10 @@ Refer to {ref}/snapshot-restore.html[Snapshot and Restore].
 == Tutorial: Snapshot and Restore
 Refer to {ref}/snapshot-restore.html[Snapshot and Restore].
 
+[role="exclude",id="configuring-tls-communication"]
+== Encrypt communications in {kib}
+Refer to <<using-kibana-with-security,Configure security in {kib}>>.
+
 [role="exclude",id="configuring-tls"]
 == Encrypt TLS communications in {kib}
 Refer to {ref}/security-basic-setup-https.html#encrypt-kibana-http[Encrypt HTTP client communications for {kib}].

--- a/docs/user/security/securing-communications/elasticsearch-mutual-tls.asciidoc
+++ b/docs/user/security/securing-communications/elasticsearch-mutual-tls.asciidoc
@@ -33,7 +33,7 @@ configures {kib} to authenticate with {es} using a
 needs to map the client certificate's distinguished name (DN) to the appropriate
 `kibana_system` role.
 
-NOTE: Using a PKI realm is a gold feature. For a comparison of the Elastic
+NOTE: Using a PKI realm is a subscription feature. For a comparison of the Elastic
 license levels, see https://www.elastic.co/subscriptions[the subscription page].
 
 [discrete]

--- a/docs/user/security/securing-communications/elasticsearch-mutual-tls.asciidoc
+++ b/docs/user/security/securing-communications/elasticsearch-mutual-tls.asciidoc
@@ -33,8 +33,7 @@ configures {kib} to authenticate with {es} using a
 needs to map the client certificate's distinguished name (DN) to the appropriate
 `kibana_system` role.
 
-NOTE: Using a PKI realm is a subscription feature. For a comparison of the Elastic
-license levels, see https://www.elastic.co/subscriptions[the subscription page].
+NOTE: Using a PKI realm is a https://www.elastic.co/subscriptions[subscription feature].
 
 [discrete]
 ==== Configure {kib} and {es} to use mutual TLS authentication


### PR DESCRIPTION
Updates a link and adds a redirect for a page that was removed in #106996.

Redirect preview: https://kibana_119966.docs-preview.app.elstc.co/guide/en/kibana/master/configuring-tls-communication.html

Closes #119916.