### PR TITLE
[8.0] [Kibana react] Added flag to Monaco to not always capture scroll (#119577)

### DIFF
--- a/src/plugins/kibana_react/public/code_editor/__snapshots__/code_editor.test.tsx.snap
+++ b/src/plugins/kibana_react/public/code_editor/__snapshots__/code_editor.test.tsx.snap
@@ -199,6 +199,7 @@ exports[`<CodeEditor /> is rendered 1`] = `
           "renderLineHighlight": "none",
           "scrollBeyondLastLine": false,
           "scrollbar": Object {
+            "alwaysConsumeMouseWheel": false,
             "useShadows": false,
           },
           "wordBasedSuggestions": false,

--- a/src/plugins/kibana_react/public/code_editor/code_editor.tsx
+++ b/src/plugins/kibana_react/public/code_editor/code_editor.tsx
@@ -397,6 +397,10 @@ export const CodeEditor: React.FC<Props> = ({
           },
           scrollbar: {
             useShadows: false,
+            // Scroll events are handled only when there is scrollable content. When there is scrollable content, the
+            // editor should scroll to the bottom then break out of that scroll context and continue scrolling on any
+            // outer scrollbars.
+            alwaysConsumeMouseWheel: false,
           },
           wordBasedSuggestions: false,
           wordWrap: 'on',


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Kibana react] Added flag to Monaco to not always capture scroll (#119577)