### PR TITLE
[SecuritySolution] Fix styling issue for data views

### DIFF
--- a/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -9,16 +9,18 @@
 import {
   EuiBadge,
   EuiButton,
-  EuiBadgeGroup,
   EuiButtonEmpty,
   EuiInMemoryTable,
   EuiPageHeader,
   EuiSpacer,
+  EuiFlexItem,
+  EuiFlexGroup,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { RouteComponentProps, withRouter, useLocation } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
+import styled from 'styled-components';
 import { reactRouterNavigate, useKibana } from '../../../../../plugins/kibana_react/public';
 import { IndexPatternManagmentContext } from '../../types';
 import { IndexPatternTableItem } from '../types';
@@ -58,6 +60,10 @@ const securityDataView = i18n.translate(
 );
 
 const securitySolution = 'security-solution';
+
+const StyledFlexItem = styled(EuiFlexItem)`
+  justify-content: center;
+`;
 
 interface Props extends RouteComponentProps {
   canSave: boolean;
@@ -120,19 +126,24 @@ export const IndexPatternTable = ({
         }
       ) => (
         <>
-          <EuiButtonEmpty size="s" {...reactRouterNavigate(history, `patterns/${index.id}`)}>
-            {name}
-          </EuiButtonEmpty>
-          &emsp;
-          <EuiBadgeGroup gutterSize="s">
+          <EuiFlexGroup gutterSize="s" wrap>
+            <StyledFlexItem grow={false}>
+              <EuiButtonEmpty size="s" {...reactRouterNavigate(history, `patterns/${index.id}`)}>
+                {name}
+              </EuiButtonEmpty>
+            </StyledFlexItem>
             {index.id && index.id.indexOf(securitySolution) === 0 && (
-              <EuiBadge>{securityDataView}</EuiBadge>
+              <StyledFlexItem grow={false}>
+                <EuiBadge>{securityDataView}</EuiBadge>
+              </StyledFlexItem>
             )}
             {index.tags &&
               index.tags.map(({ key: tagKey, name: tagName }) => (
-                <EuiBadge key={tagKey}>{tagName}</EuiBadge>
+                <StyledFlexItem grow={false} key={tagKey}>
+                  <EuiBadge>{tagName}</EuiBadge>
+                </StyledFlexItem>
               ))}
-          </EuiBadgeGroup>
+          </EuiFlexGroup>
         </>
       ),
       dataType: 'string' as const,

--- a/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
+import { css } from '@emotion/react';
 import {
   EuiBadge,
   EuiButton,
@@ -20,7 +20,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { RouteComponentProps, withRouter, useLocation } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import styled from 'styled-components';
 import { reactRouterNavigate, useKibana } from '../../../../../plugins/kibana_react/public';
 import { IndexPatternManagmentContext } from '../../types';
 import { IndexPatternTableItem } from '../types';
@@ -61,7 +60,7 @@ const securityDataView = i18n.translate(
 
 const securitySolution = 'security-solution';
 
-const StyledFlexItem = styled(EuiFlexItem)`
+const flexItemStyles = css`
   justify-content: center;
 `;
 
@@ -127,21 +126,21 @@ export const IndexPatternTable = ({
       ) => (
         <>
           <EuiFlexGroup gutterSize="s" wrap>
-            <StyledFlexItem grow={false}>
+            <EuiFlexItem grow={false} css={flexItemStyles}>
               <EuiButtonEmpty size="s" {...reactRouterNavigate(history, `patterns/${index.id}`)}>
                 {name}
               </EuiButtonEmpty>
-            </StyledFlexItem>
+            </EuiFlexItem>
             {index.id && index.id.indexOf(securitySolution) === 0 && (
-              <StyledFlexItem grow={false}>
+              <EuiFlexItem grow={false} css={flexItemStyles}>
                 <EuiBadge>{securityDataView}</EuiBadge>
-              </StyledFlexItem>
+              </EuiFlexItem>
             )}
             {index.tags &&
               index.tags.map(({ key: tagKey, name: tagName }) => (
-                <StyledFlexItem grow={false} key={tagKey}>
+                <EuiFlexItem grow={false} css={flexItemStyles} key={tagKey}>
                   <EuiBadge>{tagName}</EuiBadge>
-                </StyledFlexItem>
+                </EuiFlexItem>
               ))}
           </EuiFlexGroup>
         </>


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/119922
This pr is for fixing the styling issue after this change: https://github.com/elastic/kibana/pull/115176

Before:
<img width="1380" alt="Screen Shot 2021-11-29 at 5 24 16 PM" src="https://user-images.githubusercontent.com/6935300/143963503-43e5e1e0-adcf-4583-aac7-eeeb6091e03f.png">

After:
<img width="1314" alt="Screenshot 2021-11-30 at 14 51 04" src="https://user-images.githubusercontent.com/6295984/144070192-a672d491-3404-43fe-91bf-018626af8b78.png">
<img width="1408" alt="Screenshot 2021-11-30 at 14 50 56" src="https://user-images.githubusercontent.com/6295984/144070195-2500ff11-8c5d-458c-8b69-5fa086563e4a.png">
<img width="1661" alt="Screenshot 2021-11-30 at 14 50 44" src="https://user-images.githubusercontent.com/6295984/144070198-9474bde7-cdee-42fb-b0f1-19433adf703a.png">
