### PR TITLE
[Workplace Search] Remove unused parameter

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -338,8 +338,6 @@ export const GITHUB_LINK_TITLE = i18n.translate(
 
 export const CUSTOM_SERVICE_TYPE = 'custom';
 
-export const WORKPLACE_SEARCH_URL_PREFIX = '/app/enterprise_search/workplace_search';
-
 export const DOCUMENTATION_LINK_TITLE = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.sources.documentation',
   {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -313,7 +313,6 @@ describe('AddSourceLogic', () => {
         expect(http.get).toHaveBeenCalledWith('/internal/workplace_search/sources/create', {
           query: {
             ...params,
-            kibana_host: '',
           },
         });
 
@@ -352,7 +351,6 @@ describe('AddSourceLogic', () => {
         expect(http.get).toHaveBeenCalledWith('/internal/workplace_search/sources/create', {
           query: {
             ...params,
-            kibana_host: '',
           },
         });
 
@@ -435,7 +433,6 @@ describe('AddSourceLogic', () => {
 
           const query = {
             index_permissions: false,
-            kibana_host: '',
           };
 
           expect(clearFlashMessages).toHaveBeenCalled();
@@ -459,7 +456,6 @@ describe('AddSourceLogic', () => {
 
           const query = {
             index_permissions: true,
-            kibana_host: '',
             subdomain: 'subdomain',
           };
 
@@ -489,9 +485,7 @@ describe('AddSourceLogic', () => {
           expect(http.get).toHaveBeenCalledWith(
             '/internal/workplace_search/org/sources/github/reauth_prepare',
             {
-              query: {
-                kibana_host: '',
-              },
+              query: {},
             }
           );
           await nextTick();
@@ -653,16 +647,12 @@ describe('AddSourceLogic', () => {
       });
 
       it('getSourceConnectData', () => {
-        const query = {
-          kibana_host: '',
-        };
-
         AddSourceLogic.actions.getSourceConnectData('github', jest.fn());
 
         expect(http.get).toHaveBeenCalledWith(
           '/internal/workplace_search/account/sources/github/prepare',
           {
-            query,
+            query: {},
           }
         );
       });
@@ -673,9 +663,7 @@ describe('AddSourceLogic', () => {
         expect(http.get).toHaveBeenCalledWith(
           '/internal/workplace_search/account/sources/123/reauth_prepare',
           {
-            query: {
-              kibana_host: '',
-            },
+            query: {},
           }
         );
       });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -21,7 +21,7 @@ import {
 import { HttpLogic } from '../../../../../shared/http';
 import { KibanaLogic } from '../../../../../shared/kibana';
 import { AppLogic } from '../../../../app_logic';
-import { CUSTOM_SERVICE_TYPE, WORKPLACE_SEARCH_URL_PREFIX } from '../../../../constants';
+import { CUSTOM_SERVICE_TYPE } from '../../../../constants';
 import {
   SOURCES_PATH,
   ADD_GITHUB_PATH,
@@ -162,15 +162,6 @@ interface PreContentSourceResponse {
   serviceType: string;
   githubOrganizations: string[];
 }
-
-/**
- * Workplace Search needs to know the host for the redirect. As of yet, we do not
- * have access to this in Kibana. We parse it from the browser and pass it as a param.
- */
-const {
-  location: { href },
-} = window;
-const kibanaHost = href.substr(0, href.indexOf(WORKPLACE_SEARCH_URL_PREFIX));
 
 export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceActions>>({
   path: ['enterprise_search', 'workplace_search', 'add_source_logic'],
@@ -407,9 +398,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         ? `/internal/workplace_search/org/sources/${serviceType}/prepare`
         : `/internal/workplace_search/account/sources/${serviceType}/prepare`;
 
-      const query = {
-        kibana_host: kibanaHost,
-      } as HttpFetchQuery;
+      const query = {} as HttpFetchQuery;
 
       if (isOrganization) query.index_permissions = indexPermissions;
       if (subdomain) query.subdomain = subdomain;
@@ -430,9 +419,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         ? `/internal/workplace_search/org/sources/${sourceId}/reauth_prepare`
         : `/internal/workplace_search/account/sources/${sourceId}/reauth_prepare`;
 
-      const query = {
-        kibana_host: kibanaHost,
-      } as HttpFetchQuery;
+      const query = {} as HttpFetchQuery;
 
       try {
         const response = await HttpLogic.values.http.get<SourceConnectData>(route, { query });
@@ -507,7 +494,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       const { http } = HttpLogic.values;
       const { navigateToUrl } = KibanaLogic.values;
       const { setAddedSource } = SourcesLogic.actions;
-      const query = { ...params, kibana_host: kibanaHost };
+      const query = { ...params };
       const route = '/internal/workplace_search/sources/create';
 
       /**

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -241,9 +241,6 @@ export function registerAccountSourceReauthPrepareRoute({
         params: schema.object({
           id: schema.string(),
         }),
-        query: schema.object({
-          kibana_host: schema.string(),
-        }),
       },
     },
     enterpriseSearchRequestHandler.createRequest({
@@ -303,7 +300,6 @@ export function registerAccountPrepareSourcesRoute({
           serviceType: schema.string(),
         }),
         query: schema.object({
-          kibana_host: schema.string(),
           subdomain: schema.maybe(schema.string()),
         }),
       },
@@ -585,9 +581,6 @@ export function registerOrgSourceReauthPrepareRoute({
         params: schema.object({
           id: schema.string(),
         }),
-        query: schema.object({
-          kibana_host: schema.string(),
-        }),
       },
     },
     enterpriseSearchRequestHandler.createRequest({
@@ -647,7 +640,6 @@ export function registerOrgPrepareSourcesRoute({
           serviceType: schema.string(),
         }),
         query: schema.object({
-          kibana_host: schema.string(),
           index_permissions: schema.boolean(),
           subdomain: schema.maybe(schema.string()),
         }),
@@ -920,7 +912,6 @@ export function registerOauthConnectorParamsRoute({
       path: '/internal/workplace_search/sources/create',
       validate: {
         query: schema.object({
-          kibana_host: schema.string(),
           code: schema.maybe(schema.string()),
           session_state: schema.maybe(schema.string()),
           authuser: schema.maybe(schema.string()),


### PR DESCRIPTION
## Summary

Stop sending the `kibana_host` parameter since it's not used by Enterprise Search.

Related: https://github.com/elastic/enterprise-search-team/issues/913

- [x] tested locally

