### PR TITLE
chore(NA): splits types from code on @kbn/apm-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -558,6 +558,7 @@
     "@types/kbn__ace": "link:bazel-bin/packages/kbn-ace/npm_module_types",
     "@types/kbn__alerts": "link:bazel-bin/packages/kbn-alerts/npm_module_types",
     "@types/kbn__analytics": "link:bazel-bin/packages/kbn-analytics/npm_module_types",
+    "@types/kbn__apm-utils": "link:bazel-bin/packages/kbn-apm-utils/npm_module_types",
     "@types/kbn__i18n": "link:bazel-bin/packages/kbn-i18n/npm_module_types",
     "@types/kbn__i18n-react": "link:bazel-bin/packages/kbn-i18n-react/npm_module_types",
     "@types/license-checker": "15.0.0",

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -80,6 +80,7 @@ filegroup(
       "//packages/kbn-ace:build_types",
       "//packages/kbn-alerts:build_types",
       "//packages/kbn-analytics:build_types",
+      "//packages/kbn-apm-utils:build_types",
       "//packages/kbn-i18n:build_types",
       "//packages/kbn-i18n-react:build_types",
   ],

--- a/packages/kbn-apm-utils/BUILD.bazel
+++ b/packages/kbn-apm-utils/BUILD.bazel
@@ -1,9 +1,10 @@
-load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
-load("//src/dev/bazel:index.bzl", "jsts_transpiler")
+load("@npm//@bazel/typescript:index.bzl", "ts_config")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types", "ts_project")
 
 PKG_BASE_NAME = "kbn-apm-utils"
 PKG_REQUIRE_NAME = "@kbn/apm-utils"
+TYPES_PKG_REQUIRE_NAME = "@types/kbn__apm-utils"
 
 SOURCE_FILES = glob([
   "src/index.ts",
@@ -61,7 +62,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
+  deps = RUNTIME_DEPS + [":target_node"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )
@@ -77,6 +78,23 @@ filegroup(
   name = "build",
   srcs = [
     ":npm_module",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+pkg_npm_types(
+  name = "npm_module_types",
+  srcs = SRCS,
+  deps = [":tsc_types"],
+  package_name = TYPES_PKG_REQUIRE_NAME,
+  tsconfig = ":tsconfig",
+  visibility = ["//visibility:public"],
+)
+
+filegroup(
+  name = "build_types",
+  srcs = [
+    ":npm_module_types",
   ],
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-apm-utils/package.json
+++ b/packages/kbn-apm-utils/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@kbn/apm-utils",
   "main": "./target_node/index.js",
-  "types": "./target_types/index.d.ts",
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -5817,6 +5817,10 @@
   version "0.0.0"
   uid ""
 
+"@types/kbn__apm-utils@link:bazel-bin/packages/kbn-apm-utils/npm_module_types":
+  version "0.0.0"
+  uid ""
+
 "@types/kbn__i18n-react@link:bazel-bin/packages/kbn-i18n-react/npm_module_types":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
This PR is a step forward on #104519

It splits the the types build from the code transpilation.