### PR TITLE
[Alerting] Add mock timers to prevent potential delays when fetching new Date

### DIFF
--- a/x-pack/plugins/task_manager/server/task_pool.test.ts
+++ b/x-pack/plugins/task_manager/server/task_pool.test.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import sinon from 'sinon';
 import { of, Subject } from 'rxjs';
 import { TaskPool, TaskPoolRunResult } from './task_pool';
@@ -18,6 +17,15 @@ import uuid from 'uuid';
 import { TaskRunningStage } from './task_running';
 
 describe('TaskPool', () => {
+  beforeEach(() => {
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(new Date(2021, 12, 30));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test('occupiedWorkers are a sum of running tasks', async () => {
     const pool = new TaskPool({
       maxWorkers$: of(200),


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/89015

I'm not able to reproduce this in the flaky test runner but after looking into the code and error message:
```
Expected: "Cancelling task TaskType \"shooooo\" as it expired at 2021-10-13T18:26:36.948Z after running for 05m 30s (with timeout set at 5m)."
Received: "Cancelling task TaskType \"shooooo\" as it expired at 2021-10-13T18:26:36.948Z after running for 05m 31s (with timeout set at 5m)."
```

I think the issue is potential timing issues when not properly mocking `new Date()`, as the `new Date()` used in the test and the `new Date()` in the actual file might slightly differ at times so this PR adds more control over this to ensure they aren't out of sync.