### PR TITLE
[Metrics UI] Stabilize home page tests

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_time_controls.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_time_controls.tsx
@@ -58,6 +58,7 @@ export const WaffleTimeControls = withTheme(({ interval }: Props) => {
           delay="long"
           display="inlineBlock"
           position="top"
+          data-test-subj="waffleDatePickerIntervalTooltip"
         >
           <EuiDatePicker
             dateFormat="L LTS"

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -167,8 +167,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/106650
-    describe.skip('Saved Views', () => {
+    describe('Saved Views', () => {
       before(() => esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs'));
       after(() => esArchiver.unload('x-pack/test/functional/es_archives/infra/metrics_and_logs'));
       it('should have save and load controls', async () => {

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -35,8 +35,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/119763
-    describe.skip('with metrics present', () => {
+    describe('with metrics present', () => {
       before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs');
         await pageObjects.common.navigateToApp('infraOps');

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -23,8 +23,16 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       const datePickerInput = await find.byCssSelector(
         `${testSubjSelector('waffleDatePicker')} .euiDatePicker.euiFieldText`
       );
+
+      // explicitly focus to trigger tooltip
+      await datePickerInput.focus();
+
       await datePickerInput.clearValueWithKeyboard();
-      await datePickerInput.type([time, browser.keys.RETURN]);
+      await datePickerInput.type(time);
+
+      // dismiss the tooltip, which won't be hidden because blur doesn't happen reliably
+      await testSubjects.click('waffleDatePickerIntervalTooltip');
+
       await this.waitForLoading();
     },
 

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -23,7 +23,7 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       const datePickerInput = await find.byCssSelector(
         `${testSubjSelector('waffleDatePicker')} .euiDatePicker.euiFieldText`
       );
-      await datePickerInput.clearValueWithKeyboard({ charByChar: true });
+      await datePickerInput.clearValueWithKeyboard();
       await datePickerInput.type([time, browser.keys.RETURN]);
       await this.waitForLoading();
     },
@@ -111,7 +111,7 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
 
     async clearSearchTerm() {
       const input = await testSubjects.find('infraSearchField');
-      await input.clearValueWithKeyboard({ charByChar: true });
+      await input.clearValueWithKeyboard();
       return input;
     },
 

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -105,7 +105,16 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
 
     async enterSearchTerm(query: string) {
       const input = await this.clearSearchTerm();
-      await input.type([query, browser.keys.RETURN]);
+      await input.type(query);
+
+      // wait for input value to echo the input before submitting
+      // this ensures the React state has caught up with the events
+      await retry.try(async () => {
+        const value = await input.getAttribute('value');
+        expect(value).to.eql(query);
+      });
+
+      await input.type(browser.keys.RETURN);
       await this.waitForLoading();
     },
 

--- a/x-pack/test/functional/page_objects/infra_saved_views.ts
+++ b/x-pack/test/functional/page_objects/infra_saved_views.ts
@@ -10,6 +10,7 @@ import { Key } from 'selenium-webdriver';
 import { FtrProviderContext } from '../ftr_provider_context';
 
 export function InfraSavedViewsProvider({ getService }: FtrProviderContext) {
+  const retry = getService('retry');
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
 
@@ -74,8 +75,10 @@ export function InfraSavedViewsProvider({ getService }: FtrProviderContext) {
     },
 
     async ensureViewIsLoaded(name: string) {
-      const subject = await testSubjects.find('savedViews-openPopover');
-      expect(await subject.getVisibleText()).to.be(name);
+      await retry.try(async () => {
+        const subject = await testSubjects.find('savedViews-openPopover');
+        expect(await subject.getVisibleText()).to.be(name);
+      });
     },
 
     async ensureViewIsLoadable(name: string) {


### PR DESCRIPTION
## :memo: Summary

This attempts to stabilize two failing Metrics UI inventory page tests.

closes #106650
closes #119763

## :female_detective: Review notes

- **Saved Views** failure: Two problems occurred here:
  - The view selector button didn't show the expected saved view name. The button label was only read once without retries, so I suspect it might have been read before the side-effect hook that updates the label had a chance to run. This adds a retry around the assertion.
  - The date picker is wrapped with a `<EuiTooltip>` that relies on the focus and blur events to be triggered reliably. But for some reason the `blur` event is not fired in many cases which causes the tooltip to stay open and cover up a menu item that needs to be visible for a later test case. The workaround tries to make sure the tooltip opens and closes more reliably. This might break or be superfluous once the recent date picker changes in EUI 41.2.0 are brought into Kibana.
- **Filter** failure: The return key press after entering the filter text might have been triggered too quickly, which means the React component's state has not yet caught up with the input changes by the time the submission happens. That means the KQL compilation in submission might reject the incomplete KQL query and abort. This change makes sure the input fields value echoes back the key presses (meaning the React state change has propagated) before submitting.
- The date picker was changed `charByChar` with every change triggering a submission. This slowed down the test significantly without apparent necessity. I changed the page object to apply the changes in one go, which seems to work and is a lot faster. If this turns out to have other downsides I can revert the change.