### PR TITLE
[File upload] Rename geo-shape field to geometry

### DIFF
--- a/x-pack/plugins/file_upload/public/components/json_upload_and_parse.tsx
+++ b/x-pack/plugins/file_upload/public/components/json_upload_and_parse.tsx
@@ -105,7 +105,7 @@ export class JsonUploadAndParse extends Component<FileUploadComponentProps, Stat
     } as unknown as Settings;
     const mappings = {
       properties: {
-        coordinates: {
+        geometry: {
           type: this.state.geoFieldType,
         },
       },

--- a/x-pack/plugins/file_upload/public/importer/geojson_importer/geojson_importer.test.js
+++ b/x-pack/plugins/file_upload/public/importer/geojson_importer/geojson_importer.test.js
@@ -225,7 +225,7 @@ describe('toEsDoc', () => {
   test('should convert feature to geo_point ES document', () => {
     const esDoc = toEsDoc(FEATURE_COLLECTION.features[0], ES_FIELD_TYPES.GEO_POINT);
     expect(esDoc).toEqual({
-      coordinates: [-112.0372, 46.608058],
+      geometry: [-112.0372, 46.608058],
       population: 200,
     });
   });
@@ -233,7 +233,7 @@ describe('toEsDoc', () => {
   test('should convert feature to geo_shape ES document', () => {
     const esDoc = toEsDoc(FEATURE_COLLECTION.features[0], ES_FIELD_TYPES.GEO_SHAPE);
     expect(esDoc).toEqual({
-      coordinates: {
+      geometry: {
         type: 'Point',
         coordinates: [-112.0372, 46.608058],
       },
@@ -244,7 +244,7 @@ describe('toEsDoc', () => {
   test('should convert GeometryCollection feature to geo_shape ES document', () => {
     const esDoc = toEsDoc(GEOMETRY_COLLECTION_FEATURE, ES_FIELD_TYPES.GEO_SHAPE);
     expect(esDoc).toEqual({
-      coordinates: {
+      geometry: {
         type: 'GeometryCollection',
         geometries: [
           {

--- a/x-pack/plugins/file_upload/public/importer/geojson_importer/geojson_importer.ts
+++ b/x-pack/plugins/file_upload/public/importer/geojson_importer/geojson_importer.ts
@@ -375,7 +375,7 @@ export function toEsDoc(
 ) {
   const properties = feature.properties ? feature.properties : {};
   return {
-    coordinates:
+    geometry:
       geoFieldType === ES_FIELD_TYPES.GEO_SHAPE
         ? feature.geometry
         : (feature.geometry as Point).coordinates,


### PR DESCRIPTION
## Summary

part of https://github.com/elastic/kibana/issues/94333

The GeoJson file upload indexes point&shape data with the name `coordinates`. This is really confusing, especially when indexing with GeoJson

e.g.: calling a geo-field `coordinates` is just weird.
![image](https://user-images.githubusercontent.com/1833023/144123879-14dae8ff-4668-416f-98db-4ae150b3ecab.png)

Renames this to `geometry`, which is more conventional. e.g. GDAL uses this as its default shape-field-name too.

with this PR
![image](https://user-images.githubusercontent.com/1833023/144127913-4096fb9a-c2ee-428a-9f81-c37191fe63c9.png)
