### PR TITLE
[8.0] [DOCS] Fixes configure settings docs in 8.x (#119918)

### DIFF
--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -21,7 +21,7 @@ configuration using `${MY_ENV_VAR}` syntax.
 |===
 
 | `console.ui.enabled:`
-Toggling this causes the server to regenerate assets on the next startup,
+| Toggling this causes the server to regenerate assets on the next startup,
 which may cause a delay before pages start being served.
 Set to `false` to disable Console. *Default: `true`*
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fixes configure settings docs in 8.x (#119918)