### PR TITLE
[DOCS] Updates security section of intro doc

### DIFF
--- a/docs/user/introduction.asciidoc
+++ b/docs/user/introduction.asciidoc
@@ -169,7 +169,7 @@ them in bulk operations.
 === Secure {kib}
 
 {kib} offers a range of security features for you to control who has access to what.
-{ref}/configuring-stack-security.html[Security is enabled automatically] when you enroll {kib} with an {es} cluster.
+{ref}/configuring-stack-security.html[Security is enabled automatically] when you enroll {kib} with a secured {es} cluster.
 For a description of all available configuration options,
 refer to <<security-settings-kb,Security settings in {kib}>>.
 

--- a/docs/user/introduction.asciidoc
+++ b/docs/user/introduction.asciidoc
@@ -169,9 +169,8 @@ them in bulk operations.
 === Secure {kib}
 
 {kib} offers a range of security features for you to control who has access to what.
-The security features are automatically turned on when
-{ref}/security-minimal-setup.html[security is enabled in
-{es}]. For a description of all available configuration options,
+{ref}/configuring-stack-security.html[Security is enabled automatically] when you enroll {kib} with an {es} cluster.
+For a description of all available configuration options,
 refer to <<security-settings-kb,Security settings in {kib}>>.
 
 [float]


### PR DESCRIPTION
## Summary

This PR updates the security section of the intro doc to indicate that security is on by default.

Preview:
[https://kibana_120036.docs-preview.app.elstc.co/guide/en/kibana/master/introduction.html](https://kibana_120036.docs-preview.app.elstc.co/guide/en/kibana/master/introduction.html)