### PR TITLE
Removes core/server from mocks

### DIFF
--- a/x-pack/plugins/security_solution/server/client/jest.config.js
+++ b/x-pack/plugins/security_solution/server/client/jest.config.js
@@ -15,7 +15,6 @@ module.exports = {
   collectCoverageFrom: ['<rootDir>/x-pack/plugins/security_solution/server/client/**/*.{ts,tsx}'],
   // See: https://github.com/elastic/kibana/issues/117255, the moduleNameMapper creates mocks to avoid memory leaks from kibana core.
   moduleNameMapper: {
-    'core/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/core.mock.ts',
     'task_manager/server$':
       '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/task_manager.mock.ts',
     'alerting/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/alert.mock.ts',

--- a/x-pack/plugins/security_solution/server/endpoint/jest.config.js
+++ b/x-pack/plugins/security_solution/server/endpoint/jest.config.js
@@ -15,7 +15,6 @@ module.exports = {
   collectCoverageFrom: ['<rootDir>/x-pack/plugins/security_solution/server/endpoint/**/*.{ts,tsx}'],
   // See: https://github.com/elastic/kibana/issues/117255, the moduleNameMapper creates mocks to avoid memory leaks from kibana core.
   moduleNameMapper: {
-    'core/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/core.mock.ts',
     'task_manager/server$':
       '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/task_manager.mock.ts',
     'alerting/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/alert.mock.ts',

--- a/x-pack/plugins/security_solution/server/fleet_integration/jest.config.js
+++ b/x-pack/plugins/security_solution/server/fleet_integration/jest.config.js
@@ -17,7 +17,6 @@ module.exports = {
   ],
   // See: https://github.com/elastic/kibana/issues/117255, the moduleNameMapper creates mocks to avoid memory leaks from kibana core.
   moduleNameMapper: {
-    'core/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/core.mock.ts',
     'task_manager/server$':
       '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/task_manager.mock.ts',
     'alerting/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/alert.mock.ts',

--- a/x-pack/plugins/security_solution/server/jest.config.js
+++ b/x-pack/plugins/security_solution/server/jest.config.js
@@ -17,7 +17,6 @@ module.exports = {
   collectCoverageFrom: ['<rootDir>/x-pack/plugins/security_solution/server/**/*.{ts,tsx}'],
   // See: https://github.com/elastic/kibana/issues/117255, the moduleNameMapper creates mocks to avoid memory leaks from kibana core.
   moduleNameMapper: {
-    'core/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/core.mock.ts',
     'task_manager/server$':
       '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/task_manager.mock.ts',
     'alerting/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/alert.mock.ts',

--- a/x-pack/plugins/security_solution/server/lib/jest.config.js
+++ b/x-pack/plugins/security_solution/server/lib/jest.config.js
@@ -15,7 +15,6 @@ module.exports = {
   collectCoverageFrom: ['<rootDir>/x-pack/plugins/security_solution/server/lib/**/*.{ts,tsx}'],
   // See: https://github.com/elastic/kibana/issues/117255, the moduleNameMapper creates mocks to avoid memory leaks from kibana core.
   moduleNameMapper: {
-    'core/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/core.mock.ts',
     'task_manager/server$':
       '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/task_manager.mock.ts',
     'alerting/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/alert.mock.ts',

--- a/x-pack/plugins/security_solution/server/search_strategy/jest.config.js
+++ b/x-pack/plugins/security_solution/server/search_strategy/jest.config.js
@@ -17,7 +17,6 @@ module.exports = {
   ],
   // See: https://github.com/elastic/kibana/issues/117255, the moduleNameMapper creates mocks to avoid memory leaks from kibana core.
   moduleNameMapper: {
-    'core/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/core.mock.ts',
     'task_manager/server$':
       '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/task_manager.mock.ts',
     'alerting/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/alert.mock.ts',

--- a/x-pack/plugins/security_solution/server/usage/jest.config.js
+++ b/x-pack/plugins/security_solution/server/usage/jest.config.js
@@ -15,7 +15,6 @@ module.exports = {
   collectCoverageFrom: ['<rootDir>/x-pack/plugins/security_solution/server/usage/**/*.{ts,tsx}'],
   // See: https://github.com/elastic/kibana/issues/117255, the moduleNameMapper creates mocks to avoid memory leaks from kibana core.
   moduleNameMapper: {
-    'core/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/core.mock.ts',
     'task_manager/server$':
       '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/task_manager.mock.ts',
     'alerting/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/alert.mock.ts',

--- a/x-pack/plugins/security_solution/server/utils/jest.config.js
+++ b/x-pack/plugins/security_solution/server/utils/jest.config.js
@@ -15,7 +15,6 @@ module.exports = {
   collectCoverageFrom: ['<rootDir>/x-pack/plugins/security_solution/server/utils/**/*.{ts,tsx}'],
   // See: https://github.com/elastic/kibana/issues/117255, the moduleNameMapper creates mocks to avoid memory leaks from kibana core.
   moduleNameMapper: {
-    'core/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/core.mock.ts',
     'task_manager/server$':
       '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/task_manager.mock.ts',
     'alerting/server$': '<rootDir>/x-pack/plugins/security_solution/server/__mocks__/alert.mock.ts',


### PR DESCRIPTION
## Summary

OOM happens with:

```sh
node --max-old-space-size=1000 ./node_modules/.bin/jest --runInBand --logHeapUsage --no-cache --config x-pack/plugins/security_solution/jest.config.dev.js x-pack/plugins/security_solution/server
```

Where if I keep this mock such as in `main` I can run at 600 megs without OOM's:

```sh
node --max-old-space-size=600 ./node_modules/.bin/jest --runInBand --logHeapUsage --no-cache --config x-pack/plugins/security_solution/jest.config.dev.js x-pack/plugins/security_solution/server
```

