### PR TITLE
[App Search, Crawler] Optional domain validation

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
@@ -37,6 +37,7 @@ import { getDomainWithProtocol } from './utils';
 const DEFAULT_VALUES: AddDomainLogicValues = {
   addDomainFormInputValue: 'https://',
   entryPointValue: '/',
+  canIgnoreValidationFailure: false,
   displayValidation: false,
   domainValidationResult: {
     steps: {
@@ -47,6 +48,7 @@ const DEFAULT_VALUES: AddDomainLogicValues = {
     },
   },
   allowSubmit: false,
+  ignoreValidationFailure: false,
   isValidationLoading: false,
   hasBlockingFailure: false,
   hasValidationCompleted: false,
@@ -190,6 +192,31 @@ describe('AddDomainLogic', () => {
             networkConnectivity: { state: '' },
           },
         });
+      });
+    });
+
+    describe('setIgnoreValidationFailure', () => {
+      beforeEach(() => {
+        mount({
+          addDomainFormInputValue: 'https://elastic.co',
+          entryPointValue: '/customers',
+          hasValidationCompleted: true,
+          errors: ['first error', 'second error'],
+          domainValidationResult: {
+            steps: {
+              contentVerification: { state: 'loading' },
+              indexingRestrictions: { state: 'loading' },
+              initialValidation: { state: 'loading' },
+              networkConnectivity: { state: 'loading' },
+            },
+          },
+        });
+
+        AddDomainLogic.actions.setIgnoreValidationFailure(true);
+      });
+
+      it('should set the input value', () => {
+        expect(AddDomainLogic.values.ignoreValidationFailure).toEqual(true);
       });
     });
 
@@ -663,6 +690,32 @@ describe('AddDomainLogic', () => {
       });
     });
 
+    describe('canIgnoreValidationFailure', () => {
+      it('is true when any steps have blocking failures', () => {
+        mount({
+          hasValidationCompleted: true,
+          domainValidationResult: {
+            steps: {
+              contentVerification: { state: 'invalid', blockingFailure: true },
+              indexingRestrictions: { state: 'valid' },
+              initialValidation: { state: 'valid' },
+              networkConnectivity: { state: 'valid' },
+            },
+          },
+        });
+
+        expect(AddDomainLogic.values.canIgnoreValidationFailure).toEqual(true);
+      });
+
+      it('is false when validation has not completed', () => {
+        mount({
+          hasValidationCompleted: false,
+        });
+
+        expect(AddDomainLogic.values.canIgnoreValidationFailure).toEqual(false);
+      });
+    });
+
     describe('allowSubmit', () => {
       it('is true when a user has validated all steps and has no failures', () => {
         mount({
@@ -672,6 +725,22 @@ describe('AddDomainLogic', () => {
               indexingRestrictions: { state: 'valid' },
               initialValidation: { state: 'valid' },
               networkConnectivity: { state: 'valid' },
+            },
+          },
+        });
+
+        expect(AddDomainLogic.values.allowSubmit).toEqual(true);
+      });
+
+      it('is true when a user ignores validation failure', () => {
+        mount({
+          ignoreValidationFailure: true,
+          domainValidationResult: {
+            steps: {
+              contentVerification: { state: 'valid' },
+              indexingRestrictions: { state: 'valid' },
+              initialValidation: { state: 'invalid' },
+              networkConnectivity: { state: 'invalid' },
             },
           },
         });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_validation.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_validation.test.tsx
@@ -5,16 +5,22 @@
  * 2.0.
  */
 
-import { setMockValues } from '../../../../../__mocks__/kea_logic';
+import { setMockActions, setMockValues } from '../../../../../__mocks__/kea_logic';
 
 import React from 'react';
 
 import { shallow } from 'enzyme';
 
+import { EuiCheckbox } from '@elastic/eui';
+
 import { AddDomainValidation } from './add_domain_validation';
 import { ValidationStepPanel } from './validation_step_panel';
 
 describe('AddDomainValidation', () => {
+  const actions = {
+    setIgnoreValidationFailure: jest.fn(),
+  };
+
   it('contains four validation steps', () => {
     setMockValues({
       addDomainFormInputValue: 'https://elastic.co',
@@ -31,5 +37,30 @@ describe('AddDomainValidation', () => {
     const wrapper = shallow(<AddDomainValidation />);
 
     expect(wrapper.find(ValidationStepPanel)).toHaveLength(4);
+  });
+
+  it('can ignore validation failure', () => {
+    setMockValues({
+      canIgnoreValidationFailure: true,
+      ignoreValidationFailure: false,
+      addDomainFormInputValue: 'https://elastic.co',
+      domainValidationResult: {
+        steps: {
+          contentVerification: { state: 'invalid', blockingFailure: true },
+          indexingRestrictions: { state: 'valid' },
+          initialValidation: { state: 'valid' },
+          networkConnectivity: { state: 'valid' },
+        },
+      },
+    });
+    setMockActions(actions);
+
+    const wrapper = shallow(<AddDomainValidation />);
+    wrapper
+      .find(EuiCheckbox)
+      .first()
+      .simulate('change', { target: { checked: true } });
+
+    expect(actions.setIgnoreValidationFailure).toHaveBeenCalledWith(true);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_validation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_validation.tsx
@@ -7,9 +7,17 @@
 
 import React from 'react';
 
-import { useValues } from 'kea';
+import { useActions, useValues } from 'kea';
 
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiCheckbox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
@@ -17,7 +25,13 @@ import { AddDomainLogic } from './add_domain_logic';
 import { ValidationStepPanel } from './validation_step_panel';
 
 export const AddDomainValidation: React.FC = () => {
-  const { addDomainFormInputValue, domainValidationResult } = useValues(AddDomainLogic);
+  const {
+    addDomainFormInputValue,
+    canIgnoreValidationFailure,
+    domainValidationResult,
+    ignoreValidationFailure,
+  } = useValues(AddDomainLogic);
+  const { setIgnoreValidationFailure } = useActions(AddDomainLogic);
 
   return (
     <>
@@ -77,6 +91,39 @@ export const AddDomainValidation: React.FC = () => {
             )}
           />
         </EuiFlexItem>
+        {canIgnoreValidationFailure && (
+          <EuiFlexItem>
+            <EuiPanel hasShadow={false}>
+              <EuiCheckbox
+                id={`crawler_domain_${addDomainFormInputValue}`}
+                label={
+                  <>
+                    <EuiText size="s">
+                      {i18n.translate(
+                        'xpack.enterpriseSearch.appSearch.crawler.addDomainForm.ignoreValidationTitle',
+                        {
+                          defaultMessage: 'Ignore validation failures and continue',
+                        }
+                      )}
+                    </EuiText>
+                    <EuiSpacer size="s" />
+                    <EuiText color="subdued" size="xs">
+                      {i18n.translate(
+                        'xpack.enterpriseSearch.appSearch.crawler.addDomainForm.ignoreValidationDescription',
+                        {
+                          defaultMessage:
+                            'The web crawler will be unable to index any content on this domain until the errors above are addressed.',
+                        }
+                      )}
+                    </EuiText>
+                  </>
+                }
+                checked={ignoreValidationFailure}
+                onChange={(e) => setIgnoreValidationFailure(e.target.checked)}
+              />
+            </EuiPanel>
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
     </>
   );


### PR DESCRIPTION
## Summary

> When a user attempts to add a domain, but validation fails, they don't have any options for moving forward. There may be cases in which the user wants to add a domain they know will fail a crawl because they plan to make changes on their end later on.

Domain validation should be skippable by checking a checkbox if "Indexing Restrictions" and/or "Content Verification" fail.

### Validation can be skipped

<img width="811" alt="CleanShot 2021-12-01 at 12 50 57@2x" src="https://user-images.githubusercontent.com/809707/144229908-97f82097-ceb2-4f5e-ab31-74c9f12fa502.png">


### Validation cannot be skipped

<img width="811" alt="CleanShot 2021-12-01 at 12 52 07@2x" src="https://user-images.githubusercontent.com/809707/144229933-c6065878-1fcf-44c9-925d-fa93cf828ea8.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)