### PR TITLE
[ML] Functional tests - add retry to Fleet package install and removal

### DIFF
--- a/x-pack/test/functional/services/ml/test_resources.ts
+++ b/x-pack/test/functional/services/ml/test_resources.ts
@@ -476,10 +476,12 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
       const version = await this.getFleetPackageVersion(packageName);
       const packageWithVersion = `${packageName}-${version}`;
 
-      await supertest
-        .post(`/api/fleet/epm/packages/${packageWithVersion}`)
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+      await retry.tryForTime(30 * 1000, async () => {
+        await supertest
+          .post(`/api/fleet/epm/packages/${packageWithVersion}`)
+          .set(COMMON_REQUEST_HEADERS)
+          .expect(200);
+      });
 
       log.debug(` > Installed`);
       return packageWithVersion;
@@ -488,10 +490,12 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
     async removeFleetPackage(packageWithVersion: string) {
       log.debug(`Removing Fleet package '${packageWithVersion}'`);
 
-      await supertest
-        .delete(`/api/fleet/epm/packages/${packageWithVersion}`)
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+      await retry.tryForTime(30 * 1000, async () => {
+        await supertest
+          .delete(`/api/fleet/epm/packages/${packageWithVersion}`)
+          .set(COMMON_REQUEST_HEADERS)
+          .expect(200);
+      });
 
       log.debug(` > Removed`);
     },


### PR DESCRIPTION
## Summary

This PR stabilizes the module test setup and teardown by adding retries to the Fleet package install and removal service methods.

We've seen some short-living connection issues to the package repository during test execution, which should be fixed by the retry.

Closes #102282
