### PR TITLE
[Security Solution][Detections] Fix 409 conflict error happening when user enables a rule

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/perform_bulk_action_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/perform_bulk_action_route.ts
@@ -89,8 +89,6 @@ export const performBulkActionRoute = (
                   await enableRule({
                     rule,
                     rulesClient,
-                    ruleStatusClient,
-                    spaceId: context.securitySolution.getSpaceId(),
                   });
                 }
               })

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/enable_rule.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/enable_rule.ts
@@ -7,15 +7,11 @@
 
 import { SanitizedAlert } from '../../../../../alerting/common';
 import { RulesClient } from '../../../../../alerting/server';
-import { RuleExecutionStatus } from '../../../../common/detection_engine/schemas/common/schemas';
-import { IRuleExecutionLogClient } from '../rule_execution_log/types';
 import { RuleParams } from '../schemas/rule_schemas';
 
 interface EnableRuleArgs {
   rule: SanitizedAlert<RuleParams>;
   rulesClient: RulesClient;
-  ruleStatusClient: IRuleExecutionLogClient;
-  spaceId: string;
 }
 
 /**
@@ -23,21 +19,7 @@ interface EnableRuleArgs {
  *
  * @param rule - rule to enable
  * @param rulesClient - Alerts client
- * @param ruleStatusClient - ExecLog client
  */
-export const enableRule = async ({
-  rule,
-  rulesClient,
-  ruleStatusClient,
-  spaceId,
-}: EnableRuleArgs) => {
+export const enableRule = async ({ rule, rulesClient }: EnableRuleArgs) => {
   await rulesClient.enable({ id: rule.id });
-
-  await ruleStatusClient.logStatusChange({
-    ruleId: rule.id,
-    ruleName: rule.name,
-    ruleType: rule.alertTypeId,
-    spaceId,
-    newStatus: RuleExecutionStatus['going to run'],
-  });
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/patch_rules.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/patch_rules.ts
@@ -222,7 +222,7 @@ export const patchRules = async ({
   if (rule.enabled && enabled === false) {
     await rulesClient.disable({ id: rule.id });
   } else if (!rule.enabled && enabled === true) {
-    await enableRule({ rule, rulesClient, ruleStatusClient, spaceId });
+    await enableRule({ rule, rulesClient });
   } else {
     // enabled is null or undefined and we do not touch the rule
   }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/update_rules.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/update_rules.ts
@@ -104,7 +104,7 @@ export const updateRules = async ({
   if (existingRule.enabled && enabled === false) {
     await rulesClient.disable({ id: existingRule.id });
   } else if (!existingRule.enabled && enabled === true) {
-    await enableRule({ rule: existingRule, rulesClient, ruleStatusClient, spaceId });
+    await enableRule({ rule: existingRule, rulesClient });
   }
   return { ...update, enabled };
 };


### PR DESCRIPTION
**Tickets:** https://github.com/elastic/kibana/issues/119334, https://github.com/elastic/kibana/issues/119596

## Summary

With this PR, we do not update rule execution status to `going to run` for a rule immediately when the user enables this rule. Instead, the rule executor now does this as soon as the rule starts.

This should fix the 409 conflict error that has been happening due to a race condition between the route handler and the executor both changing the status to `going to run` at almost the same time.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
