### PR TITLE
[APM] Disable telemetry in agent config endpoint

### DIFF
--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/route.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/route.ts
@@ -186,7 +186,7 @@ const agentConfigurationSearchRoute = createApmServerRoute({
   params: t.type({
     body: searchParamsRt,
   }),
-  options: { tags: ['access:apm'] },
+  options: { tags: ['access:apm'], disableTelemetry: true },
   handler: async (resources) => {
     const { params, logger } = resources;
 


### PR DESCRIPTION
For some clusters the agent config search endpoint receives a lot of traffic. To avoid causing excessive load we should disable telemetry for this API.