### PR TITLE
[test] Surfacing deprecations with rich context from ES warning header

### DIFF
--- a/packages/kbn-dev-utils/src/tooling_log/tooling_log_text_writer.ts
+++ b/packages/kbn-dev-utils/src/tooling_log/tooling_log_text_writer.ts
@@ -95,9 +95,7 @@ export class ToolingLogTextWriter implements Writer {
       if (msg.type === 'write') {
         const txt = format(msg.args[0], ...msg.args.slice(1));
         // Ensure that Elasticsearch deprecation log messages from Kibana aren't ignored
-        if (/\[deprecation\]\[elasticsearch\]/.test(txt)) {
-          return true;
-        } else {
+        if (!/\[deprecation\]\[elasticsearch\]/.test(txt)) {
           return false;
         }
       } else {

--- a/packages/kbn-dev-utils/src/tooling_log/tooling_log_text_writer.ts
+++ b/packages/kbn-dev-utils/src/tooling_log/tooling_log_text_writer.ts
@@ -91,8 +91,18 @@ export class ToolingLogTextWriter implements Writer {
       return false;
     }
 
-    if (this.ignoreSources && msg.source && this.ignoreSources.includes(msg.source)) {
-      return false;
+    if (
+      this.ignoreSources &&
+      msg.source &&
+      this.ignoreSources.includes(msg.source) &&
+      msg.type === 'write'
+    ) {
+      const txt = format(msg.args[0], ...msg.args.slice(1));
+      if (/\] \[error\]\[/.test(txt)) {
+        return true;
+      } else {
+        return false;
+      }
     }
 
     const prefix = has(MSG_PREFIXES, msg.type) ? MSG_PREFIXES[msg.type] : '';

--- a/packages/kbn-dev-utils/src/tooling_log/tooling_log_text_writer.ts
+++ b/packages/kbn-dev-utils/src/tooling_log/tooling_log_text_writer.ts
@@ -91,15 +91,15 @@ export class ToolingLogTextWriter implements Writer {
       return false;
     }
 
-    if (
-      this.ignoreSources &&
-      msg.source &&
-      this.ignoreSources.includes(msg.source) &&
-      msg.type === 'write'
-    ) {
-      const txt = format(msg.args[0], ...msg.args.slice(1));
-      if (/\] \[error\]\[/.test(txt)) {
-        return true;
+    if (this.ignoreSources && msg.source && this.ignoreSources.includes(msg.source)) {
+      if (msg.type === 'write') {
+        const txt = format(msg.args[0], ...msg.args.slice(1));
+        // Ensure that Elasticsearch deprecation log messages from Kibana aren't ignored
+        if (/\[deprecation\]\[elasticsearch\]/.test(txt)) {
+          return true;
+        } else {
+          return false;
+        }
       } else {
         return false;
       }

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -6642,9 +6642,7 @@ class ToolingLogTextWriter {
       if (msg.type === 'write') {
         const txt = (0, _util.format)(msg.args[0], ...msg.args.slice(1)); // Ensure that Elasticsearch deprecation log messages from Kibana aren't ignored
 
-        if (/\[deprecation\]\[elasticsearch\]/.test(txt)) {
-          return true;
-        } else {
+        if (!/\[deprecation\]\[elasticsearch\]/.test(txt)) {
           return false;
         }
       } else {

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -6639,7 +6639,17 @@ class ToolingLogTextWriter {
     }
 
     if (this.ignoreSources && msg.source && this.ignoreSources.includes(msg.source)) {
-      return false;
+      if (msg.type === 'write') {
+        const txt = (0, _util.format)(msg.args[0], ...msg.args.slice(1)); // Ensure that Elasticsearch deprecation log messages from Kibana aren't ignored
+
+        if (/\[deprecation\]\[elasticsearch\]/.test(txt)) {
+          return true;
+        } else {
+          return false;
+        }
+      } else {
+        return false;
+      }
     }
 
     const prefix = has(MSG_PREFIXES, msg.type) ? MSG_PREFIXES[msg.type] : '';

--- a/src/core/server/elasticsearch/client/configure_client.test.ts
+++ b/src/core/server/elasticsearch/client/configure_client.test.ts
@@ -500,5 +500,152 @@ describe('configureClient', () => {
         `);
       });
     });
+
+    describe('deprecation warnings from response headers', () => {
+      it('does not log when no deprecation warning header is returned', () => {
+        const client = configureClient(createFakeConfig(), { logger, type: 'test', scoped: false });
+
+        const response = createResponseWithBody({
+          seq_no_primary_term: true,
+          query: {
+            term: { user: 'kimchy' },
+          },
+        });
+        client.diagnostic.emit('response', new errors.ResponseError(response), response);
+
+        expect(loggingSystemMock.collect(logger).warn).toEqual([]);
+        expect(loggingSystemMock.collect(logger).error).toEqual([]);
+      });
+
+      it('logs error when the client receives an Elasticsearch error response for a deprecated request originating from a user', () => {
+        const client = configureClient(createFakeConfig(), { logger, type: 'test', scoped: false });
+
+        const response = createApiResponse({
+          statusCode: 400,
+          warnings: ['GET /_path is deprecated'],
+          params: {
+            method: 'GET',
+            path: '/_path',
+            querystring: { hello: 'dolly' },
+          },
+          body: {
+            error: {
+              type: 'illegal_argument_exception',
+              reason: 'request [/_path] contains unrecognized parameter: [name]',
+            },
+          },
+        });
+        client.diagnostic.emit('response', new errors.ResponseError(response), response);
+
+        expect(loggingSystemMock.collect(logger).warn).toEqual([]);
+        expect(loggingSystemMock.collect(logger).error[0][0]).toMatch(
+          'ES DEPRECATION: GET /_path is deprecated'
+        );
+        expect(loggingSystemMock.collect(logger).error[0][0]).toMatch('Origin:user');
+        expect(loggingSystemMock.collect(logger).error[0][0]).toMatch(/Stack trace:\n.*at/);
+        expect(loggingSystemMock.collect(logger).error[0][0]).toMatch(
+          /Query:\n.*400\n.*GET \/_path\?hello\=dolly \[illegal_argument_exception\]: request \[\/_path\] contains unrecognized parameter: \[name\]/
+        );
+      });
+
+      it('logs warning when the client receives an Elasticsearch error response for a deprecated request originating from kibana', () => {
+        const client = configureClient(createFakeConfig(), { logger, type: 'test', scoped: false });
+
+        const response = createApiResponse({
+          statusCode: 400,
+          warnings: ['GET /_path is deprecated'],
+          // Set the request header to indicate to Elasticsearch that this is a request over which users have no control
+          requestOptions: { headers: { 'x-elastic-product-origin': 'kibana' } },
+          params: {
+            method: 'GET',
+            path: '/_path',
+            querystring: { hello: 'dolly' },
+          },
+          body: {
+            error: {
+              type: 'illegal_argument_exception',
+              reason: 'request [/_path] contains unrecognized parameter: [name]',
+            },
+          },
+        });
+        client.diagnostic.emit('response', new errors.ResponseError(response), response);
+
+        expect(loggingSystemMock.collect(logger).error).toEqual([]);
+        expect(loggingSystemMock.collect(logger).warn[0][0]).toMatch(
+          'ES DEPRECATION: GET /_path is deprecated'
+        );
+        expect(loggingSystemMock.collect(logger).warn[0][0]).toMatch('Origin:kibana');
+        expect(loggingSystemMock.collect(logger).warn[0][0]).toMatch(/Stack trace:\n.*at/);
+        expect(loggingSystemMock.collect(logger).warn[0][0]).toMatch(
+          /Query:\n.*400\n.*GET \/_path\?hello\=dolly \[illegal_argument_exception\]: request \[\/_path\] contains unrecognized parameter: \[name\]/
+        );
+      });
+
+      it('logs error when the client receives an Elasticsearch success response for a deprecated request originating from a user', () => {
+        const client = configureClient(createFakeConfig(), { logger, type: 'test', scoped: false });
+
+        const response = createApiResponse({
+          statusCode: 200,
+          warnings: ['GET /_path is deprecated'],
+          params: {
+            method: 'GET',
+            path: '/_path',
+            querystring: { hello: 'dolly' },
+          },
+          body: {
+            hits: [
+              {
+                _source: 'may the source be with you',
+              },
+            ],
+          },
+        });
+        client.diagnostic.emit('response', null, response);
+
+        expect(loggingSystemMock.collect(logger).warn).toEqual([]);
+        expect(loggingSystemMock.collect(logger).error[0][0]).toMatch(
+          'ES DEPRECATION: GET /_path is deprecated'
+        );
+        expect(loggingSystemMock.collect(logger).error[0][0]).toMatch('Origin:user');
+        expect(loggingSystemMock.collect(logger).error[0][0]).toMatch(/Stack trace:\n.*at/);
+        expect(loggingSystemMock.collect(logger).error[0][0]).toMatch(
+          /Query:\n.*200\n.*GET \/_path\?hello\=dolly/
+        );
+      });
+
+      it('logs warning when the client receives an Elasticsearch success response for a deprecated request originating from kibana', () => {
+        const client = configureClient(createFakeConfig(), { logger, type: 'test', scoped: false });
+
+        const response = createApiResponse({
+          statusCode: 200,
+          warnings: ['GET /_path is deprecated'],
+          // Set the request header to indicate to Elasticsearch that this is a request over which users have no control
+          requestOptions: { headers: { 'x-elastic-product-origin': 'kibana' } },
+          params: {
+            method: 'GET',
+            path: '/_path',
+            querystring: { hello: 'dolly' },
+          },
+          body: {
+            hits: [
+              {
+                _source: 'may the source be with you',
+              },
+            ],
+          },
+        });
+        client.diagnostic.emit('response', null, response);
+
+        expect(loggingSystemMock.collect(logger).error).toEqual([]);
+        expect(loggingSystemMock.collect(logger).warn[0][0]).toMatch(
+          'ES DEPRECATION: GET /_path is deprecated'
+        );
+        expect(loggingSystemMock.collect(logger).warn[0][0]).toMatch('Origin:kibana');
+        expect(loggingSystemMock.collect(logger).warn[0][0]).toMatch(/Stack trace:\n.*at/);
+        expect(loggingSystemMock.collect(logger).warn[0][0]).toMatch(
+          /Query:\n.*200\n.*GET \/_path\?hello\=dolly/
+        );
+      });
+    });
   });
 });

--- a/src/core/server/elasticsearch/client/configure_client.ts
+++ b/src/core/server/elasticsearch/client/configure_client.ts
@@ -163,7 +163,7 @@ const addLogging = ({ client, type, logger }: { client: Client; type: string; lo
         const stackTrace = new Error().stack?.split('\n').slice(5).join('\n');
 
         if (requestOrigin === 'kibana') {
-          deprecationLogger.info(
+          deprecationLogger.warn(
             `ES DEPRECATION: ${event.warnings}\nOrigin:${requestOrigin}\nStack trace:\n${stackTrace}\nQuery:\n${queryMessage}`
           );
         } else {

--- a/src/core/server/elasticsearch/client/configure_client.ts
+++ b/src/core/server/elasticsearch/client/configure_client.ts
@@ -144,7 +144,7 @@ const addLogging = ({ client, type, logger }: { client: Client; type: string; lo
 
       queryLogger.debug(queryMessage, meta);
 
-      if (event.headers.warning ?? false) {
+      if (event.headers!.warning ?? false) {
         // Plugins can explicitly mark requests as originating from a user by
         // removing the `'x-elastic-product-origin': 'kibana'` header that's
         // added by default. User requests will be shown to users in the
@@ -153,8 +153,10 @@ const addLogging = ({ client, type, logger }: { client: Client; type: string; lo
         // Kibana requests will be hidden from the upgrade assistant UI and are
         // only logged to help developers maintain their plugins
         const requestOrigin =
-          (event.meta.request.params.headers != null &&
-            (event.meta.request.params.headers['x-elastic-product-origin'] as unknown as string)) ??
+          (event.meta.request.options.headers != null &&
+            (event.meta.request.options.headers[
+              'x-elastic-product-origin'
+            ] as unknown as string)) ??
           'user';
 
         const stackTrace = new Error().stack?.split('\n').slice(5).join('\n');
@@ -162,14 +164,16 @@ const addLogging = ({ client, type, logger }: { client: Client; type: string; lo
         // Construct a JSON logMeta payload to make it easier for CI tools to consume
         const logMeta = {
           deprecation: {
-            message: event.headers.warning ?? 'placeholder',
+            message: event.headers!.warning ?? 'placeholder',
             requestOrigin,
             query: queryMessage,
             stack: stackTrace,
           },
         };
-        deprecationLogger.debug(
-          `ES DEPRECATION: ${event.headers.warning}\nOrigin:${requestOrigin}\nStack trace:\n${stackTrace}\nQuery:\n${queryMessage}`,
+        deprecationLogger.error(
+          `ES DEPRECATION: ${
+            event.headers!.warning
+          }\nOrigin:${requestOrigin}\nStack trace:\n${stackTrace}\nQuery:\n${queryMessage}`,
           logMeta as unknown as LogMeta
         );
       }

--- a/src/core/server/elasticsearch/client/configure_client.ts
+++ b/src/core/server/elasticsearch/client/configure_client.ts
@@ -14,7 +14,8 @@ import type {
   TransportRequestParams,
   TransportRequestOptions,
 } from '@elastic/elasticsearch/lib/Transport';
-import { Logger } from '../../logging';
+
+import { Logger, LogMeta } from '../../logging';
 import { parseClientOptions, ElasticsearchClientConfig } from './client_config';
 
 const noop = () => undefined;
@@ -47,7 +48,7 @@ export const configureClient = (
   }
 
   const client = new Client({ ...clientOptions, Transport: KibanaTransport });
-  addLogging(client, logger.get('query', type));
+  addLogging({ client, logger, type });
 
   // --------------------------------------------------------------------------------- //
   // Hack to disable the "Product check" only in the scoped clients while we           //
@@ -119,7 +120,9 @@ export function getRequestDebugMeta(event: RequestEvent): {
   };
 }
 
-const addLogging = (client: Client, logger: Logger) => {
+const addLogging = ({ client, type, logger }: { client: Client; type: string; logger: Logger }) => {
+  const queryLogger = logger.get('query', type);
+  const deprecationLogger = logger.get('deprecation', type);
   client.on('response', (error, event) => {
     if (event) {
       const opaqueId = event.meta.request.options.opaqueId;
@@ -128,14 +131,47 @@ const addLogging = (client: Client, logger: Logger) => {
             http: { request: { id: event.meta.request.options.opaqueId } },
           }
         : undefined; // do not clutter logs if opaqueId is not present
+      let queryMessage = '';
       if (error) {
         if (error instanceof errors.ResponseError) {
-          logger.debug(`${getResponseMessage(event)} ${getErrorMessage(error)}`, meta);
+          queryMessage = `${getResponseMessage(event)} ${getErrorMessage(error)}`;
         } else {
-          logger.debug(getErrorMessage(error), meta);
+          queryMessage = getErrorMessage(error);
         }
       } else {
-        logger.debug(getResponseMessage(event), meta);
+        queryMessage = getResponseMessage(event);
+      }
+
+      queryLogger.debug(queryMessage, meta);
+
+      if (event.headers.warning ?? false) {
+        // Plugins can explicitly mark requests as originating from a user by
+        // removing the `'x-elastic-product-origin': 'kibana'` header that's
+        // added by default. User requests will be shown to users in the
+        // upgrade assistant UI as an action item that has to be addressed
+        // before they upgrade.
+        // Kibana requests will be hidden from the upgrade assistant UI and are
+        // only logged to help developers maintain their plugins
+        const requestOrigin =
+          (event.meta.request.params.headers != null &&
+            (event.meta.request.params.headers['x-elastic-product-origin'] as unknown as string)) ??
+          'user';
+
+        const stackTrace = new Error().stack?.split('\n').slice(5).join('\n');
+
+        // Construct a JSON logMeta payload to make it easier for CI tools to consume
+        const logMeta = {
+          deprecation: {
+            message: event.headers.warning ?? 'placeholder',
+            requestOrigin,
+            query: queryMessage,
+            stack: stackTrace,
+          },
+        };
+        deprecationLogger.debug(
+          `ES DEPRECATION: ${event.headers.warning}\nOrigin:${requestOrigin}\nStack trace:\n${stackTrace}\nQuery:\n${queryMessage}`,
+          logMeta as unknown as LogMeta
+        );
       }
     }
   });

--- a/src/core/server/logging/logging_config.ts
+++ b/src/core/server/logging/logging_config.ts
@@ -65,7 +65,13 @@ export const config = {
       defaultValue: new Map<string, AppenderConfigType>(),
     }),
     loggers: schema.arrayOf(loggerSchema, {
-      defaultValue: [],
+      defaultValue: [
+        {
+          name: 'elasticsearch.deprecation',
+          level: 'off',
+          appenders: [],
+        },
+      ],
     }),
     root: schema.object(
       {

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -962,7 +962,6 @@ export class SavedObjectsRepository {
       esOptions,
       {
         ignore: [404],
-        headers: { 'x-elastic-product-origin': 'make deprecation' },
       }
     );
     if (statusCode === 404) {

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -962,6 +962,7 @@ export class SavedObjectsRepository {
       esOptions,
       {
         ignore: [404],
+        headers: { 'x-elastic-product-origin': 'make deprecation' },
       }
     );
     if (statusCode === 404) {

--- a/src/core/test_helpers/kbn_server.ts
+++ b/src/core/test_helpers/kbn_server.ts
@@ -105,6 +105,9 @@ export function createRootWithCorePlugins(settings = {}, cliArgs: Partial<CliArg
       username: kibanaServerTestUser.username,
       password: kibanaServerTestUser.password,
     },
+    logging: {
+      loggers: [{ name: 'elasticsearch.deprecation', level: 'all' }],
+    },
     // createRootWithSettings sets default value to "true", so undefined should be threatened as "true".
     ...(cliArgs.oss === false
       ? {

--- a/test/api_integration/apis/saved_objects/find.ts
+++ b/test/api_integration/apis/saved_objects/find.ts
@@ -15,7 +15,7 @@ export default function ({ getService }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const SPACE_ID = 'ftr-so-find';
 
-  describe('find', () => {
+  describe.only('find', () => {
     before(async () => {
       await kibanaServer.spaces.create({ id: SPACE_ID, name: SPACE_ID });
       await kibanaServer.importExport.load(

--- a/test/api_integration/apis/saved_objects/find.ts
+++ b/test/api_integration/apis/saved_objects/find.ts
@@ -15,7 +15,7 @@ export default function ({ getService }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const SPACE_ID = 'ftr-so-find';
 
-  describe.only('find', () => {
+  describe('find', () => {
     before(async () => {
       await kibanaServer.spaces.create({ id: SPACE_ID, name: SPACE_ID });
       await kibanaServer.importExport.load(

--- a/test/common/config.js
+++ b/test/common/config.js
@@ -53,6 +53,8 @@ export default function () {
         `--plugin-path=${path.join(__dirname, 'fixtures', 'plugins', 'newsfeed')}`,
         `--newsfeed.service.urlRoot=${servers.kibana.protocol}://${servers.kibana.hostname}:${servers.kibana.port}`,
         `--newsfeed.service.pathTemplate=/api/_newsfeed-FTS-external-service-simulators/kibana/v{VERSION}.json`,
+        '--logging.loggers[0].name=elasticsearch.deprecation',
+        '--logging.loggers[0].level=all',
       ],
     },
     services,


### PR DESCRIPTION
## Summary

Backport https://github.com/elastic/kibana/pull/120044/ on 7.16 since I couldn't see any deprecation logs on main to verify that it works.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
