### PR TITLE
[7.16] [APM] Bug: Navigating between trace samples by pagination moves the viewport up to the top of the page (#119233)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_details/distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/distribution/index.tsx
@@ -36,6 +36,7 @@ import { useWaterfallFetcher } from '../use_waterfall_fetcher';
 import { WaterfallWithSummary } from '../waterfall_with_summary';
 
 import { useTransactionDistributionChartData } from './use_transaction_distribution_chart_data';
+import { HeightRetainer } from '../../../shared/HeightRetainer';
 
 // Enforce min height so it's consistent across all tabs on the same level
 // to prevent "flickering" behavior
@@ -105,115 +106,120 @@ export function TransactionDistribution({
     useTransactionDistributionChartData();
 
   return (
-    <div data-test-subj="apmTransactionDistributionTabContent">
-      <EuiFlexGroup style={{ minHeight: MIN_TAB_TITLE_HEIGHT }}>
-        <EuiFlexItem style={{ flexDirection: 'row', alignItems: 'center' }}>
-          <EuiTitle size="xs">
-            <h5 data-test-subj="apmTransactionDistributionChartTitle">
-              {i18n.translate(
-                'xpack.apm.transactionDetails.distribution.panelTitle',
-                {
-                  defaultMessage: 'Latency distribution',
-                }
-              )}
-            </h5>
-          </EuiTitle>
-        </EuiFlexItem>
-        {hasData && !selection && (
-          <EuiFlexItem>
-            <EuiFlexGroup justifyContent="flexEnd" gutterSize="xs">
-              <EuiFlexItem
-                grow={false}
-                style={{ flexDirection: 'row', alignItems: 'center' }}
-              >
-                <EuiIcon type="iInCircle" title={emptySelectionText} size="s" />
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-                style={{ flexDirection: 'row', alignItems: 'center' }}
-              >
-                <EuiText size="xs">{emptySelectionText}</EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
+    <HeightRetainer>
+      <div data-test-subj="apmTransactionDistributionTabContent">
+        <EuiFlexGroup style={{ minHeight: MIN_TAB_TITLE_HEIGHT }}>
+          <EuiFlexItem style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <EuiTitle size="xs">
+              <h5 data-test-subj="apmTransactionDistributionChartTitle">
+                {i18n.translate(
+                  'xpack.apm.transactionDetails.distribution.panelTitle',
+                  {
+                    defaultMessage: 'Latency distribution',
+                  }
+                )}
+              </h5>
+            </EuiTitle>
           </EuiFlexItem>
-        )}
-        {hasData && selection && (
-          <EuiFlexItem grow={false}>
-            <EuiBadge
-              iconType="cross"
-              iconSide="left"
-              onClick={onTrackedClearSelection}
-              onClickAriaLabel={clearSelectionAriaLabel}
-              iconOnClick={onTrackedClearSelection}
-              iconOnClickAriaLabel={clearSelectionAriaLabel}
-              data-test-sub="apmTransactionDetailsDistributionClearSelectionBadge"
-            >
-              {i18n.translate(
-                'xpack.apm.transactionDetails.distribution.selectionText',
-                {
-                  defaultMessage: `Selection: {formattedSelection}`,
-                  values: {
-                    formattedSelection: getFormattedSelection(selection),
-                  },
-                }
-              )}
-            </EuiBadge>
-          </EuiFlexItem>
-        )}
-      </EuiFlexGroup>
+          {hasData && !selection && (
+            <EuiFlexItem>
+              <EuiFlexGroup justifyContent="flexEnd" gutterSize="xs">
+                <EuiFlexItem
+                  grow={false}
+                  style={{ flexDirection: 'row', alignItems: 'center' }}
+                >
+                  <EuiIcon
+                    type="iInCircle"
+                    title={emptySelectionText}
+                    size="s"
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                  style={{ flexDirection: 'row', alignItems: 'center' }}
+                >
+                  <EuiText size="xs">{emptySelectionText}</EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          )}
+          {hasData && selection && (
+            <EuiFlexItem grow={false}>
+              <EuiBadge
+                iconType="cross"
+                iconSide="left"
+                onClick={onTrackedClearSelection}
+                onClickAriaLabel={clearSelectionAriaLabel}
+                iconOnClick={onTrackedClearSelection}
+                iconOnClickAriaLabel={clearSelectionAriaLabel}
+                data-test-sub="apmTransactionDetailsDistributionClearSelectionBadge"
+              >
+                {i18n.translate(
+                  'xpack.apm.transactionDetails.distribution.selectionText',
+                  {
+                    defaultMessage: `Selection: {formattedSelection}`,
+                    values: {
+                      formattedSelection: getFormattedSelection(selection),
+                    },
+                  }
+                )}
+              </EuiBadge>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
 
-      <EuiText color="subdued" size="xs">
-        <FormattedMessage
-          id="xpack.apm.transactionDetails.tabs.transactionDistributionChartDescription"
-          defaultMessage="Log-log plot for latency (x) by transactions (y) with overlapping bands for {allTransactions} and {failedTransactions}."
-          values={{
-            allTransactions: (
-              <span style={{ color: transactionColors.ALL_TRANSACTIONS }}>
-                <FormattedMessage
-                  id="xpack.apm.transactionDetails.tabs.transactionDistributionChartAllTransactions"
-                  defaultMessage="all transactions"
-                />
-              </span>
-            ),
-            failedTransactions: (
-              <span
-                style={{ color: transactionColors.ALL_FAILED_TRANSACTIONS }}
-              >
-                <FormattedMessage
-                  id="xpack.apm.transactionDetails.tabs.transactionDistributionChartFailedTransactions"
-                  defaultMessage="failed transactions"
-                />
-              </span>
-            ),
-          }}
+        <EuiText color="subdued" size="xs">
+          <FormattedMessage
+            id="xpack.apm.transactionDetails.tabs.transactionDistributionChartDescription"
+            defaultMessage="Log-log plot for latency (x) by transactions (y) with overlapping bands for {allTransactions} and {failedTransactions}."
+            values={{
+              allTransactions: (
+                <span style={{ color: transactionColors.ALL_TRANSACTIONS }}>
+                  <FormattedMessage
+                    id="xpack.apm.transactionDetails.tabs.transactionDistributionChartAllTransactions"
+                    defaultMessage="all transactions"
+                  />
+                </span>
+              ),
+              failedTransactions: (
+                <span
+                  style={{ color: transactionColors.ALL_FAILED_TRANSACTIONS }}
+                >
+                  <FormattedMessage
+                    id="xpack.apm.transactionDetails.tabs.transactionDistributionChartFailedTransactions"
+                    defaultMessage="failed transactions"
+                  />
+                </span>
+              ),
+            }}
+          />
+        </EuiText>
+
+        <EuiSpacer size="s" />
+
+        <TransactionDistributionChart
+          data={chartData}
+          markerCurrentTransaction={markerCurrentTransaction}
+          markerPercentile={DEFAULT_PERCENTILE_THRESHOLD}
+          markerValue={percentileThresholdValue ?? 0}
+          onChartSelection={onTrackedChartSelection as BrushEndListener}
+          hasData={hasData}
+          palette={[
+            transactionColors.ALL_TRANSACTIONS,
+            transactionColors.ALL_FAILED_TRANSACTIONS,
+          ]}
+          selection={selection}
+          status={status}
         />
-      </EuiText>
 
-      <EuiSpacer size="s" />
-
-      <TransactionDistributionChart
-        data={chartData}
-        markerCurrentTransaction={markerCurrentTransaction}
-        markerPercentile={DEFAULT_PERCENTILE_THRESHOLD}
-        markerValue={percentileThresholdValue ?? 0}
-        onChartSelection={onTrackedChartSelection as BrushEndListener}
-        hasData={hasData}
-        palette={[
-          transactionColors.ALL_TRANSACTIONS,
-          transactionColors.ALL_FAILED_TRANSACTIONS,
-        ]}
-        selection={selection}
-        status={status}
-      />
-
-      <EuiSpacer size="s" />
-
-      <WaterfallWithSummary
-        urlParams={urlParams}
-        waterfall={waterfall}
-        isLoading={waterfallStatus === FETCH_STATUS.LOADING}
-        traceSamples={traceSamples}
-      />
-    </div>
+        <EuiSpacer size="s" />
+        <WaterfallWithSummary
+          urlParams={urlParams}
+          waterfall={waterfall}
+          isLoading={waterfallStatus === FETCH_STATUS.LOADING}
+          traceSamples={traceSamples}
+        />
+      </div>
+    </HeightRetainer>
   );
 }

--- a/x-pack/plugins/apm/public/components/app/transaction_details/transaction_details_tabs.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/transaction_details_tabs.tsx
@@ -18,7 +18,6 @@ import { useApmParams } from '../../../hooks/use_apm_params';
 import { useTransactionTraceSamplesFetcher } from '../../../hooks/use_transaction_trace_samples_fetcher';
 
 import { maybe } from '../../../../common/utils/maybe';
-import { HeightRetainer } from '../../shared/HeightRetainer';
 import { fromQuery, push, toQuery } from '../../shared/Links/url_helpers';
 
 import { failedTransactionsCorrelationsTab } from './failed_transactions_correlations_tab';
@@ -131,20 +130,18 @@ export function TransactionDetailsTabs() {
         ))}
       </EuiTabs>
       <EuiSpacer size="m" />
-      <HeightRetainer>
-        <EuiPanel hasBorder={true}>
-          <TabContent
-            {...{
-              clearChartSelection,
-              onFilter,
-              sampleRangeFrom,
-              sampleRangeTo,
-              selectSampleFromChartSelection,
-              traceSamples,
-            }}
-          />
-        </EuiPanel>
-      </HeightRetainer>
+      <EuiPanel hasBorder={true}>
+        <TabContent
+          {...{
+            clearChartSelection,
+            onFilter,
+            sampleRangeFrom,
+            sampleRangeTo,
+            selectSampleFromChartSelection,
+            traceSamples,
+          }}
+        />
+      </EuiPanel>
     </>
   );
 }

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/index.tsx
@@ -12,7 +12,6 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { euiStyled } from '../../../../../../../../../../src/plugins/kibana_react/common';
 import { Timeline } from '../../../../../shared/charts/Timeline';
-import { HeightRetainer } from '../../../../../shared/HeightRetainer';
 import { fromQuery, toQuery } from '../../../../../shared/Links/url_helpers';
 import { getAgentMarks } from '../Marks/get_agent_marks';
 import { getErrorMarks } from '../Marks/get_error_marks';
@@ -76,62 +75,60 @@ export function Waterfall({ waterfall, waterfallItemId }: Props) {
   };
 
   return (
-    <HeightRetainer>
-      <Container>
-        {waterfall.apiResponse.exceedsMax && (
-          <EuiCallOut
-            color="warning"
-            size="s"
-            iconType="alert"
-            title={i18n.translate('xpack.apm.waterfall.exceedsMax', {
-              defaultMessage:
-                'Number of items in this trace exceed what is displayed',
-            })}
-          />
-        )}
-        <div>
-          <div style={{ display: 'flex' }}>
-            <EuiButtonEmpty
-              style={{ zIndex: 3, position: 'absolute' }}
-              iconType={isAccordionOpen ? 'fold' : 'unfold'}
-              onClick={() => {
-                setIsAccordionOpen((isOpen) => !isOpen);
-              }}
-            />
-            <Timeline
-              marks={[...agentMarks, ...errorMarks]}
-              xMax={duration}
-              height={waterfallHeight}
-              margins={timelineMargins}
-            />
-          </div>
-          <WaterfallItemsContainer>
-            {!waterfall.entryWaterfallTransaction ? null : (
-              <AccordionWaterfall
-                // used to recreate the entire tree when `isAccordionOpen` changes, collapsing or expanding all elements.
-                key={`accordion_state_${isAccordionOpen}`}
-                isOpen={isAccordionOpen}
-                item={waterfall.entryWaterfallTransaction}
-                level={0}
-                setMaxLevel={setMaxLevel}
-                waterfallItemId={waterfallItemId}
-                duration={duration}
-                waterfall={waterfall}
-                timelineMargins={timelineMargins}
-                onClickWaterfallItem={(item: IWaterfallItem) =>
-                  toggleFlyout({ history, item })
-                }
-              />
-            )}
-          </WaterfallItemsContainer>
-        </div>
-
-        <WaterfallFlyout
-          waterfallItemId={waterfallItemId}
-          waterfall={waterfall}
-          toggleFlyout={toggleFlyout}
+    <Container>
+      {waterfall.apiResponse.exceedsMax && (
+        <EuiCallOut
+          color="warning"
+          size="s"
+          iconType="alert"
+          title={i18n.translate('xpack.apm.waterfall.exceedsMax', {
+            defaultMessage:
+              'Number of items in this trace exceed what is displayed',
+          })}
         />
-      </Container>
-    </HeightRetainer>
+      )}
+      <div>
+        <div style={{ display: 'flex' }}>
+          <EuiButtonEmpty
+            style={{ zIndex: 3, position: 'absolute' }}
+            iconType={isAccordionOpen ? 'fold' : 'unfold'}
+            onClick={() => {
+              setIsAccordionOpen((isOpen) => !isOpen);
+            }}
+          />
+          <Timeline
+            marks={[...agentMarks, ...errorMarks]}
+            xMax={duration}
+            height={waterfallHeight}
+            margins={timelineMargins}
+          />
+        </div>
+        <WaterfallItemsContainer>
+          {!waterfall.entryWaterfallTransaction ? null : (
+            <AccordionWaterfall
+              // used to recreate the entire tree when `isAccordionOpen` changes, collapsing or expanding all elements.
+              key={`accordion_state_${isAccordionOpen}`}
+              isOpen={isAccordionOpen}
+              item={waterfall.entryWaterfallTransaction}
+              level={0}
+              setMaxLevel={setMaxLevel}
+              waterfallItemId={waterfallItemId}
+              duration={duration}
+              waterfall={waterfall}
+              timelineMargins={timelineMargins}
+              onClickWaterfallItem={(item: IWaterfallItem) =>
+                toggleFlyout({ history, item })
+              }
+            />
+          )}
+        </WaterfallItemsContainer>
+      </div>
+
+      <WaterfallFlyout
+        waterfallItemId={waterfallItemId}
+        waterfall={waterfall}
+        toggleFlyout={toggleFlyout}
+      />
+    </Container>
   );
 }


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [APM] Bug: Navigating between trace samples by pagination moves the viewport up to the top of the page (#119233)