### PR TITLE
chore(NA): use internal pkg_npm on @kbn/babel-code-parser

### DIFF
--- a/packages/kbn-babel-code-parser/BUILD.bazel
+++ b/packages/kbn-babel-code-parser/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
-load("//src/dev/bazel:index.bzl", "jsts_transpiler")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm")
 
 PKG_BASE_NAME = "kbn-babel-code-parser"
 PKG_REQUIRE_NAME = "@kbn/babel-code-parser"


### PR DESCRIPTION
This PR is a step forward on #104519

It changes the package build to use the internal macro for `pkg_npm`