### PR TITLE
[Security Solution][Endpoint] Remove (don't register) Endpoint Trusted Apps specific APIs

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/index.ts
@@ -11,7 +11,14 @@ import { KbnClient } from '@kbn/test';
 import pMap from 'p-map';
 import { basename } from 'path';
 import { AxiosResponse } from 'axios';
-import { TRUSTED_APPS_CREATE_API, TRUSTED_APPS_LIST_API } from '../../../common/endpoint/constants';
+import {
+  ENDPOINT_TRUSTED_APPS_LIST_DESCRIPTION,
+  ENDPOINT_TRUSTED_APPS_LIST_ID,
+  ENDPOINT_TRUSTED_APPS_LIST_NAME,
+  EXCEPTION_LIST_ITEM_URL,
+  EXCEPTION_LIST_URL,
+} from '@kbn/securitysolution-list-constants';
+import { CreateExceptionListSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { TrustedApp } from '../../../common/endpoint/types';
 import { TrustedAppGenerator } from '../../../common/endpoint/data_generators/trusted_app_generator';
 import { indexFleetEndpointPolicy } from '../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
@@ -21,6 +28,7 @@ import {
   PACKAGE_POLICY_API_ROUTES,
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
 } from '../../../../fleet/common';
+import { newTrustedAppToCreateExceptionListItem } from '../../../public/management/pages/trusted_apps/service/mappers';
 
 const defaultLogger = new ToolingLog({ level: 'info', writeTo: process.stdout });
 const separator = '----------------------------------------';
@@ -76,17 +84,14 @@ export const run: (options?: RunOptions) => Promise<TrustedApp[]> = async ({
     url: kibana,
   });
 
-  // touch the Trusted Apps List so it can be created
-  // and
   // setup fleet with endpoint integrations
+  // and
+  // and ensure the trusted apps list is created
   logger.info('setting up Fleet with endpoint and creating trusted apps list');
   const [installedEndpointPackage] = await Promise.all([
     setupFleetForEndpoint(kbnClient).then((response) => response.endpointPackage),
 
-    kbnClient.request({
-      method: 'GET',
-      path: TRUSTED_APPS_LIST_API,
-    }),
+    ensureCreateEndpointTrustedAppsList(kbnClient),
   ]);
 
   // Setup a list of real endpoint policies and return a method to randomly select one
@@ -125,8 +130,8 @@ export const run: (options?: RunOptions) => Promise<TrustedApp[]> = async ({
       return kbnClient
         .request<TrustedApp>({
           method: 'POST',
-          path: TRUSTED_APPS_CREATE_API,
-          body,
+          path: EXCEPTION_LIST_ITEM_URL,
+          body: newTrustedAppToCreateExceptionListItem(body),
         })
         .then(({ data }) => {
           logger.write(data.id);
@@ -175,4 +180,30 @@ const fetchEndpointPolicies = (
       kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`,
     },
   });
+};
+
+const ensureCreateEndpointTrustedAppsList = async (kbn: KbnClient) => {
+  const newListDefinition: CreateExceptionListSchema = {
+    description: ENDPOINT_TRUSTED_APPS_LIST_DESCRIPTION,
+    list_id: ENDPOINT_TRUSTED_APPS_LIST_ID,
+    meta: undefined,
+    name: ENDPOINT_TRUSTED_APPS_LIST_NAME,
+    os_types: [],
+    tags: [],
+    type: 'endpoint',
+    namespace_type: 'agnostic',
+  };
+
+  await kbn
+    .request({
+      method: 'POST',
+      path: EXCEPTION_LIST_URL,
+      body: newListDefinition,
+    })
+    .catch((e) => {
+      // Ignore if list was already created
+      if (e.response.status !== 409) {
+        throw e;
+      }
+    });
 };

--- a/x-pack/plugins/security_solution/server/endpoint/routes/trusted_apps/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/trusted_apps/index.ts
@@ -5,95 +5,96 @@
  * 2.0.
  */
 
-import {
-  DeleteTrustedAppsRequestSchema,
-  GetOneTrustedAppRequestSchema,
-  GetTrustedAppsRequestSchema,
-  PostTrustedAppCreateRequestSchema,
-  PutTrustedAppUpdateRequestSchema,
-  GetTrustedAppsSummaryRequestSchema,
-} from '../../../../common/endpoint/schema/trusted_apps';
-import {
-  TRUSTED_APPS_CREATE_API,
-  TRUSTED_APPS_DELETE_API,
-  TRUSTED_APPS_GET_API,
-  TRUSTED_APPS_LIST_API,
-  TRUSTED_APPS_UPDATE_API,
-  TRUSTED_APPS_SUMMARY_API,
-} from '../../../../common/endpoint/constants';
-
-import {
-  getTrustedAppsCreateRouteHandler,
-  getTrustedAppsDeleteRouteHandler,
-  getTrustedAppsGetOneHandler,
-  getTrustedAppsListRouteHandler,
-  getTrustedAppsSummaryRouteHandler,
-  getTrustedAppsUpdateRouteHandler,
-} from './handlers';
+// import {
+//   DeleteTrustedAppsRequestSchema,
+//   GetOneTrustedAppRequestSchema,
+//   GetTrustedAppsRequestSchema,
+//   PostTrustedAppCreateRequestSchema,
+//   PutTrustedAppUpdateRequestSchema,
+//   GetTrustedAppsSummaryRequestSchema,
+// } from '../../../../common/endpoint/schema/trusted_apps';
+// import {
+//   TRUSTED_APPS_CREATE_API,
+//   TRUSTED_APPS_DELETE_API,
+//   TRUSTED_APPS_GET_API,
+//   TRUSTED_APPS_LIST_API,
+//   TRUSTED_APPS_UPDATE_API,
+//   TRUSTED_APPS_SUMMARY_API,
+// } from '../../../../common/endpoint/constants';
+//
+// import {
+//   getTrustedAppsCreateRouteHandler,
+//   getTrustedAppsDeleteRouteHandler,
+//   getTrustedAppsGetOneHandler,
+//   getTrustedAppsListRouteHandler,
+//   getTrustedAppsSummaryRouteHandler,
+//   getTrustedAppsUpdateRouteHandler,
+// } from './handlers';
 import { SecuritySolutionPluginRouter } from '../../../types';
 import { EndpointAppContext } from '../../types';
 
 export const registerTrustedAppsRoutes = (
-  router: SecuritySolutionPluginRouter,
-  endpointAppContext: EndpointAppContext
+  _router: SecuritySolutionPluginRouter,
+  _endpointAppContext: EndpointAppContext
 ) => {
-  // DELETE one
-  router.delete(
-    {
-      path: TRUSTED_APPS_DELETE_API,
-      validate: DeleteTrustedAppsRequestSchema,
-      options: { authRequired: true },
-    },
-    getTrustedAppsDeleteRouteHandler(endpointAppContext)
-  );
-
-  // GET one
-  router.get(
-    {
-      path: TRUSTED_APPS_GET_API,
-      validate: GetOneTrustedAppRequestSchema,
-      options: { authRequired: true },
-    },
-    getTrustedAppsGetOneHandler(endpointAppContext)
-  );
-
-  // GET list
-  router.get(
-    {
-      path: TRUSTED_APPS_LIST_API,
-      validate: GetTrustedAppsRequestSchema,
-      options: { authRequired: true },
-    },
-    getTrustedAppsListRouteHandler(endpointAppContext)
-  );
-
-  // CREATE
-  router.post(
-    {
-      path: TRUSTED_APPS_CREATE_API,
-      validate: PostTrustedAppCreateRequestSchema,
-      options: { authRequired: true },
-    },
-    getTrustedAppsCreateRouteHandler(endpointAppContext)
-  );
-
-  // PUT
-  router.put(
-    {
-      path: TRUSTED_APPS_UPDATE_API,
-      validate: PutTrustedAppUpdateRequestSchema,
-      options: { authRequired: true },
-    },
-    getTrustedAppsUpdateRouteHandler(endpointAppContext)
-  );
-
-  // SUMMARY
-  router.get(
-    {
-      path: TRUSTED_APPS_SUMMARY_API,
-      validate: GetTrustedAppsSummaryRequestSchema,
-      options: { authRequired: true },
-    },
-    getTrustedAppsSummaryRouteHandler(endpointAppContext)
-  );
+  // FIXME: DELETE all trusted apps api related modules (#2148)
+  // // DELETE one
+  // router.delete(
+  //   {
+  //     path: TRUSTED_APPS_DELETE_API,
+  //     validate: DeleteTrustedAppsRequestSchema,
+  //     options: { authRequired: true },
+  //   },
+  //   getTrustedAppsDeleteRouteHandler(endpointAppContext)
+  // );
+  //
+  // // GET one
+  // router.get(
+  //   {
+  //     path: TRUSTED_APPS_GET_API,
+  //     validate: GetOneTrustedAppRequestSchema,
+  //     options: { authRequired: true },
+  //   },
+  //   getTrustedAppsGetOneHandler(endpointAppContext)
+  // );
+  //
+  // // GET list
+  // router.get(
+  //   {
+  //     path: TRUSTED_APPS_LIST_API,
+  //     validate: GetTrustedAppsRequestSchema,
+  //     options: { authRequired: true },
+  //   },
+  //   getTrustedAppsListRouteHandler(endpointAppContext)
+  // );
+  //
+  // // CREATE
+  // router.post(
+  //   {
+  //     path: TRUSTED_APPS_CREATE_API,
+  //     validate: PostTrustedAppCreateRequestSchema,
+  //     options: { authRequired: true },
+  //   },
+  //   getTrustedAppsCreateRouteHandler(endpointAppContext)
+  // );
+  //
+  // // PUT
+  // router.put(
+  //   {
+  //     path: TRUSTED_APPS_UPDATE_API,
+  //     validate: PutTrustedAppUpdateRequestSchema,
+  //     options: { authRequired: true },
+  //   },
+  //   getTrustedAppsUpdateRouteHandler(endpointAppContext)
+  // );
+  //
+  // // SUMMARY
+  // router.get(
+  //   {
+  //     path: TRUSTED_APPS_SUMMARY_API,
+  //     validate: GetTrustedAppsSummaryRequestSchema,
+  //     options: { authRequired: true },
+  //   },
+  //   getTrustedAppsSummaryRouteHandler(endpointAppContext)
+  // );
 };


### PR DESCRIPTION
## Summary

PR #118801 we moved trusted application UI functionality to use the Exception Lists APIs, similar to how all other Endpoint exceptions are currently implemented. This PR un-register the Trusted Apps specific APIs so that they are not exposed with v8.0. 

> Note: this is just a quick stop gap until we have time to completely remove all of the code associated with this API. Not registering the API ensure that it is not available with 8.0 since we are approaching its FF date.

In addition, the Trusted Apps test data loading script was adjusted to use the Exceptions Lists APIs.

