### PR TITLE
[118684] Add ability for case owner selection in flyout

### DIFF
--- a/x-pack/plugins/cases/common/constants.ts
+++ b/x-pack/plugins/cases/common/constants.ts
@@ -80,20 +80,7 @@ export const SUPPORTED_CONNECTORS = [
 export const MAX_ALERTS_PER_SUB_CASE = 5000;
 export const MAX_GENERATED_ALERTS_PER_SUB_CASE = 50;
 
-/**
- * This must be the same value that the security solution plugin uses to define the case kind when it registers the
- * feature for the 7.13 migration only.
- *
- * This variable is being also used by test files and mocks.
- */
 export const SECURITY_SOLUTION_OWNER = 'securitySolution';
-
-/**
- * This must be the same value that the observability plugin uses to define the case kind when it registers the
- * feature for the 7.13 migration only.
- *
- * This variable is being also used by test files and mocks.
- */
 export const OBSERVABILITY_OWNER = 'observability';
 
 export const OWNER_INFO = {

--- a/x-pack/plugins/cases/common/constants.ts
+++ b/x-pack/plugins/cases/common/constants.ts
@@ -89,6 +89,25 @@ export const MAX_GENERATED_ALERTS_PER_SUB_CASE = 50;
 export const SECURITY_SOLUTION_OWNER = 'securitySolution';
 
 /**
+ * This must be the same value that the observability plugin uses to define the case kind when it registers the
+ * feature for the 7.13 migration only.
+ *
+ * This variable is being also used by test files and mocks.
+ */
+export const OBSERVABILITY_OWNER = 'observability';
+
+export const OWNER_INFO = {
+  [SECURITY_SOLUTION_OWNER]: {
+    label: 'Security',
+    iconType: 'logoSecurity',
+  },
+  [OBSERVABILITY_OWNER]: {
+    label: 'Observability',
+    iconType: 'logoObservability',
+  },
+};
+
+/**
  * This flag governs enabling the case as a connector feature. It is disabled by default as the feature is not complete.
  */
 export const ENABLE_CASE_CONNECTOR = false;

--- a/x-pack/plugins/cases/common/index.ts
+++ b/x-pack/plugins/cases/common/index.ts
@@ -15,12 +15,7 @@
 // For example, constants below could eventually be in a "kbn-cases-constants" instead.
 // See: https://docs.elastic.dev/kibana-dev-docs/key-concepts/platform-intro#public-plugin-api
 
-export {
-  CASES_URL,
-  OBSERVABILITY_OWNER,
-  SECURITY_SOLUTION_OWNER,
-  ENABLE_CASE_CONNECTOR,
-} from './constants';
+export { CASES_URL, SECURITY_SOLUTION_OWNER, ENABLE_CASE_CONNECTOR } from './constants';
 
 export { CommentType, CaseStatuses, getCasesFromAlertsUrl, throwErrors } from './api';
 

--- a/x-pack/plugins/cases/common/index.ts
+++ b/x-pack/plugins/cases/common/index.ts
@@ -15,7 +15,12 @@
 // For example, constants below could eventually be in a "kbn-cases-constants" instead.
 // See: https://docs.elastic.dev/kibana-dev-docs/key-concepts/platform-intro#public-plugin-api
 
-export { CASES_URL, SECURITY_SOLUTION_OWNER, ENABLE_CASE_CONNECTOR } from './constants';
+export {
+  CASES_URL,
+  OBSERVABILITY_OWNER,
+  SECURITY_SOLUTION_OWNER,
+  ENABLE_CASE_CONNECTOR,
+} from './constants';
 
 export { CommentType, CaseStatuses, getCasesFromAlertsUrl, throwErrors } from './api';
 

--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -10,13 +10,19 @@ import React from 'react';
 import { euiDarkVars } from '@kbn/ui-shared-deps-src/theme';
 import { I18nProvider } from '@kbn/i18n-react';
 import { ThemeProvider } from 'styled-components';
+
 import { DEFAULT_FEATURES, SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { CasesFeatures } from '../../../common/ui/types';
 import { CasesProvider } from '../../components/cases_context';
 import { createKibanaContextProviderMock } from '../lib/kibana/kibana_react.mock';
 import { FieldHook } from '../shared_imports';
 
-type Props = { children: React.ReactNode } & Partial<CasesContextValue>;
+interface Props {
+  children: React.ReactNode;
+  userCanCrud?: boolean;
+  features?: CasesFeatures;
+  owner?: string[];
+}
 
 window.scrollTo = jest.fn();
 const MockKibanaContextProvider = createKibanaContextProviderMock();

--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -14,42 +14,32 @@ import { DEFAULT_FEATURES, SECURITY_SOLUTION_OWNER } from '../../../common/const
 import { CasesFeatures } from '../../../common/ui/types';
 import { CasesProvider } from '../../components/cases_context';
 import { createKibanaContextProviderMock } from '../lib/kibana/kibana_react.mock';
-import { FieldHook } from '../shared_imports';
 
+import { FieldHook } from '../shared_imports';
 interface Props {
   children: React.ReactNode;
-  userCanCrud?: boolean;
-  features?: CasesFeatures;
+  caseConfig?: Partial<CasesContextValue>;
 }
 
 window.scrollTo = jest.fn();
 const MockKibanaContextProvider = createKibanaContextProviderMock();
 
-/** A utility for wrapping children in the providers required to run most tests */
-const TestProvidersComponent: React.FC<Props> = ({
-  children,
-  userCanCrud = true,
-  features = {},
-}) => {
-  /**
-   * The empty object at the beginning avoids the mutation
-   * of the DEFAULT_FEATURES object
-   */
-  const featuresOptions = merge({}, DEFAULT_FEATURES, features);
-  return (
-    <I18nProvider>
-      <MockKibanaContextProvider>
-        <ThemeProvider theme={() => ({ eui: euiDarkVars, darkMode: true })}>
-          <CasesProvider
-            value={{ owner: [SECURITY_SOLUTION_OWNER], userCanCrud, features: featuresOptions }}
-          >
-            {children}
-          </CasesProvider>
-        </ThemeProvider>
-      </MockKibanaContextProvider>
-    </I18nProvider>
-  );
+const defaultCaseConfig = {
+  userCanCrud: true,
+  owner: [SECURITY_SOLUTION_OWNER],
+  features: DEFAULT_FEATURES,
 };
+
+/** A utility for wrapping children in the providers required to run most tests */
+const TestProvidersComponent: React.FC<Props> = ({ children, caseConfig }) => (
+  <I18nProvider>
+    <MockKibanaContextProvider>
+      <ThemeProvider theme={() => ({ eui: euiDarkVars, darkMode: true })}>
+        <CasesProvider value={merge(defaultCaseConfig, caseConfig)}>{children}</CasesProvider>
+      </ThemeProvider>
+    </MockKibanaContextProvider>
+  </I18nProvider>
+);
 
 export const TestProviders = React.memo(TestProvidersComponent);
 

--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -15,38 +15,36 @@ import { CasesFeatures } from '../../../common/ui/types';
 import { CasesProvider } from '../../components/cases_context';
 import { createKibanaContextProviderMock } from '../lib/kibana/kibana_react.mock';
 import { FieldHook } from '../shared_imports';
-interface Props {
-  children: React.ReactNode;
-  caseConfig?: Partial<CasesContextValue>;
-}
+
+type Props = { children: React.ReactNode } & Partial<CasesContextValue>;
 
 window.scrollTo = jest.fn();
 const MockKibanaContextProvider = createKibanaContextProviderMock();
 
-const defaultCaseConfig = {
-  userCanCrud: true,
-  owner: [SECURITY_SOLUTION_OWNER],
-  features: DEFAULT_FEATURES,
-};
-
 /** A utility for wrapping children in the providers required to run most tests */
-const TestProvidersComponent: React.FC<Props> = ({ children, caseConfig = {} }) => (
-  <I18nProvider>
-    <MockKibanaContextProvider>
-      <ThemeProvider theme={() => ({ eui: euiDarkVars, darkMode: true })}>
-        <CasesProvider
-          value={{
-            ...defaultCaseConfig,
-            ...caseConfig,
-            features: merge({}, DEFAULT_FEATURES, caseConfig.features),
-          }}
-        >
-          {children}
-        </CasesProvider>
-      </ThemeProvider>
-    </MockKibanaContextProvider>
-  </I18nProvider>
-);
+const TestProvidersComponent: React.FC<Props> = ({
+  children,
+  features,
+  owner = [SECURITY_SOLUTION_OWNER],
+  userCanCrud = true,
+}) => {
+  /**
+   * The empty object at the beginning avoids the mutation
+   * of the DEFAULT_FEATURES object
+   */
+  const featuresOptions = merge({}, DEFAULT_FEATURES, features);
+  return (
+    <I18nProvider>
+      <MockKibanaContextProvider>
+        <ThemeProvider theme={() => ({ eui: euiDarkVars, darkMode: true })}>
+          <CasesProvider value={{ features: featuresOptions, owner, userCanCrud }}>
+            {children}
+          </CasesProvider>
+        </ThemeProvider>
+      </MockKibanaContextProvider>
+    </I18nProvider>
+  );
+};
 
 export const TestProviders = React.memo(TestProvidersComponent);
 

--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -14,7 +14,6 @@ import { DEFAULT_FEATURES, SECURITY_SOLUTION_OWNER } from '../../../common/const
 import { CasesFeatures } from '../../../common/ui/types';
 import { CasesProvider } from '../../components/cases_context';
 import { createKibanaContextProviderMock } from '../lib/kibana/kibana_react.mock';
-
 import { FieldHook } from '../shared_imports';
 interface Props {
   children: React.ReactNode;

--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { merge } from 'lodash';
 import React from 'react';
 import { euiDarkVars } from '@kbn/ui-shared-deps-src/theme';
 import { I18nProvider } from '@kbn/i18n-react';
@@ -29,11 +30,19 @@ const defaultCaseConfig = {
 };
 
 /** A utility for wrapping children in the providers required to run most tests */
-const TestProvidersComponent: React.FC<Props> = ({ children, caseConfig }) => (
+const TestProvidersComponent: React.FC<Props> = ({ children, caseConfig = {} }) => (
   <I18nProvider>
     <MockKibanaContextProvider>
       <ThemeProvider theme={() => ({ eui: euiDarkVars, darkMode: true })}>
-        <CasesProvider value={{ ...defaultCaseConfig, ...caseConfig }}>{children}</CasesProvider>
+        <CasesProvider
+          value={{
+            ...defaultCaseConfig,
+            ...caseConfig,
+            features: merge({}, DEFAULT_FEATURES, caseConfig.features),
+          }}
+        >
+          {children}
+        </CasesProvider>
       </ThemeProvider>
     </MockKibanaContextProvider>
   </I18nProvider>

--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { merge } from 'lodash';
 import { euiDarkVars } from '@kbn/ui-shared-deps-src/theme';
 import { I18nProvider } from '@kbn/i18n-react';
 import { ThemeProvider } from 'styled-components';
@@ -34,7 +33,7 @@ const TestProvidersComponent: React.FC<Props> = ({ children, caseConfig }) => (
   <I18nProvider>
     <MockKibanaContextProvider>
       <ThemeProvider theme={() => ({ eui: euiDarkVars, darkMode: true })}>
-        <CasesProvider value={merge(defaultCaseConfig, caseConfig)}>{children}</CasesProvider>
+        <CasesProvider value={{ ...defaultCaseConfig, ...caseConfig }}>{children}</CasesProvider>
       </ThemeProvider>
     </MockKibanaContextProvider>
   </I18nProvider>

--- a/x-pack/plugins/cases/public/common/translations.ts
+++ b/x-pack/plugins/cases/public/common/translations.ts
@@ -63,6 +63,13 @@ export const SOLUTION_REQUIRED = i18n.translate(
   }
 );
 
+export const ARIA_KEYPAD_LEGEND = i18n.translate(
+  'xpack.cases.createCase.ariaKeypadSolutionSelection',
+  {
+    defaultMessage: 'Single solution select',
+  }
+);
+
 export const COMMENT_REQUIRED = i18n.translate('xpack.cases.caseView.commentFieldRequiredError', {
   defaultMessage: 'A comment is required.',
 });

--- a/x-pack/plugins/cases/public/common/translations.ts
+++ b/x-pack/plugins/cases/public/common/translations.ts
@@ -56,10 +56,10 @@ export const DESCRIPTION_REQUIRED = i18n.translate(
   }
 );
 
-export const SELECTION_REQUIRED = i18n.translate(
-  'xpack.cases.createCase.selectionFieldRequiredError',
+export const SOLUTION_REQUIRED = i18n.translate(
+  'xpack.cases.createCase.solutionFieldRequiredError',
   {
-    defaultMessage: 'A selection is required',
+    defaultMessage: 'A solution is required',
   }
 );
 
@@ -115,8 +115,8 @@ export const TAGS = i18n.translate('xpack.cases.caseView.tags', {
   defaultMessage: 'Tags',
 });
 
-export const CASE_TYPE = i18n.translate('xpack.cases.caseView.caseType', {
-  defaultMessage: 'Case Type',
+export const SOLUTION = i18n.translate('xpack.cases.caseView.solution', {
+  defaultMessage: 'Solution',
 });
 
 export const ACTIONS = i18n.translate('xpack.cases.allCases.actions', {

--- a/x-pack/plugins/cases/public/common/translations.ts
+++ b/x-pack/plugins/cases/public/common/translations.ts
@@ -56,6 +56,13 @@ export const DESCRIPTION_REQUIRED = i18n.translate(
   }
 );
 
+export const SELECTION_REQUIRED = i18n.translate(
+  'xpack.cases.createCase.selectionFieldRequiredError',
+  {
+    defaultMessage: 'A selection is required',
+  }
+);
+
 export const COMMENT_REQUIRED = i18n.translate('xpack.cases.caseView.commentFieldRequiredError', {
   defaultMessage: 'A comment is required.',
 });
@@ -106,6 +113,10 @@ export const TO = i18n.translate('xpack.cases.caseView.to', {
 
 export const TAGS = i18n.translate('xpack.cases.caseView.tags', {
   defaultMessage: 'Tags',
+});
+
+export const CASE_TYPE = i18n.translate('xpack.cases.caseView.caseType', {
+  defaultMessage: 'Case Type',
 });
 
 export const ACTIONS = i18n.translate('xpack.cases.allCases.actions', {

--- a/x-pack/plugins/cases/public/components/app/routes.test.tsx
+++ b/x-pack/plugins/cases/public/components/app/routes.test.tsx
@@ -41,7 +41,7 @@ const renderWithRouter = (
   userCanCrud = true
 ) => {
   return render(
-    <TestProviders userCanCrud>
+    <TestProviders userCanCrud={userCanCrud}>
       <MemoryRouter initialEntries={initialEntries}>
         <CasesRoutes useFetchAlertData={(alertIds) => [false, {}]} />
       </MemoryRouter>

--- a/x-pack/plugins/cases/public/components/app/routes.test.tsx
+++ b/x-pack/plugins/cases/public/components/app/routes.test.tsx
@@ -41,7 +41,7 @@ const renderWithRouter = (
   userCanCrud = true
 ) => {
   return render(
-    <TestProviders caseConfig={{ userCanCrud }}>
+    <TestProviders userCanCrud>
       <MemoryRouter initialEntries={initialEntries}>
         <CasesRoutes useFetchAlertData={(alertIds) => [false, {}]} />
       </MemoryRouter>

--- a/x-pack/plugins/cases/public/components/app/routes.test.tsx
+++ b/x-pack/plugins/cases/public/components/app/routes.test.tsx
@@ -41,7 +41,7 @@ const renderWithRouter = (
   userCanCrud = true
 ) => {
   return render(
-    <TestProviders userCanCrud={userCanCrud}>
+    <TestProviders caseConfig={{ userCanCrud }}>
       <MemoryRouter initialEntries={initialEntries}>
         <CasesRoutes useFetchAlertData={(alertIds) => [false, {}]} />
       </MemoryRouter>

--- a/x-pack/plugins/cases/public/components/app/use_available_owners.test.ts
+++ b/x-pack/plugins/cases/public/components/app/use_available_owners.test.ts
@@ -60,18 +60,21 @@ describe('useKibanaMock', () => {
 
     expect(result.current).toEqual(['securitySolution', 'observability']);
   });
+
   it('returns no owner types if user has access to none', () => {
     mockKibana({});
     const { result } = renderHook(useAvailableCasesOwners);
 
     expect(result.current).toEqual([]);
   });
+
   it('returns only the permission it should have with CRUD as default', () => {
     mockKibana(hasSecurityAsCrud);
     const { result } = renderHook(useAvailableCasesOwners);
 
     expect(result.current).toEqual(['securitySolution']);
   });
+
   it('returns only the permission it should have with READ as default', () => {
     mockKibana(hasObservabilityAsRead);
     const { result } = renderHook(() => useAvailableCasesOwners('read'));

--- a/x-pack/plugins/cases/public/components/app/use_available_owners.test.ts
+++ b/x-pack/plugins/cases/public/components/app/use_available_owners.test.ts
@@ -6,7 +6,8 @@
  */
 
 import { renderHook } from '@testing-library/react-hooks';
-import { OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER } from '../../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../../common';
+import { OBSERVABILITY_OWNER } from '../../../common/constants';
 
 import { useKibana } from '../../common/lib/kibana';
 import { useAvailableCasesOwners } from './use_available_owners';

--- a/x-pack/plugins/cases/public/components/app/use_available_owners.test.ts
+++ b/x-pack/plugins/cases/public/components/app/use_available_owners.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useKibana } from '../../common/lib/kibana';
+import { useAvailableCasesOwners } from './use_available_owners';
+
+jest.mock('../../common/lib/kibana');
+
+const useKibanaMock = useKibana as jest.MockedFunction<typeof useKibana>;
+
+const hasAll = {
+  securitySolutionCases: {
+    crud_cases: true,
+    read_cases: true,
+  },
+  observabilityCases: {
+    crud_cases: true,
+    read_cases: true,
+  },
+};
+
+const hasSecurityAsCrud = {
+  securitySolutionCases: {
+    crud_cases: true,
+  },
+  observabilityCases: {
+    read_cases: true,
+  },
+};
+
+const hasObservabilityAsRead = {
+  observabilityCases: {
+    read_cases: true,
+  },
+  securitySolutionCases: {
+    crud_cases: true,
+  },
+};
+
+const mockKibana = (permissionType: unknown = hasAll) => {
+  useKibanaMock.mockReturnValue({
+    services: {
+      application: {
+        capabilities: permissionType,
+      },
+    },
+  } as unknown as ReturnType<typeof useKibana>);
+};
+
+describe('useKibanaMock', () => {
+  it('returns all available owner types if user has access to all', () => {
+    mockKibana();
+    const { result } = renderHook(useAvailableCasesOwners);
+
+    expect(result.current).toEqual(['securitySolution', 'observability']);
+  });
+  it('returns no owner types if user has access to none', () => {
+    mockKibana({});
+    const { result } = renderHook(useAvailableCasesOwners);
+
+    expect(result.current).toEqual([]);
+  });
+  it('returns only the permission it should have with CRUD as default', () => {
+    mockKibana(hasSecurityAsCrud);
+    const { result } = renderHook(useAvailableCasesOwners);
+
+    expect(result.current).toEqual(['securitySolution']);
+  });
+  it('returns only the permission it should have with READ as default', () => {
+    mockKibana(hasObservabilityAsRead);
+    const { result } = renderHook(() => useAvailableCasesOwners('read'));
+
+    expect(result.current).toEqual(['observability']);
+  });
+});

--- a/x-pack/plugins/cases/public/components/app/use_available_owners.ts
+++ b/x-pack/plugins/cases/public/components/app/use_available_owners.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { ApplicationStart } from 'kibana/public';
 import { useKibana } from '../../common/lib/kibana';
 
 /**
@@ -18,7 +17,7 @@ import { useKibana } from '../../common/lib/kibana';
  **/
 
 export const useAvailableCasesOwners = (level: 'crud' | 'read' = 'crud'): string[] => {
-  const { capabilities } = useKibana().services.application as ApplicationStart;
+  const { capabilities } = useKibana().services.application;
   const capabilityName = `${level}_cases`;
   return Object.entries(capabilities).reduce(
     (availableOwners: string[], [featureId, capability]) => {

--- a/x-pack/plugins/cases/public/components/app/use_available_owners.ts
+++ b/x-pack/plugins/cases/public/components/app/use_available_owners.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ApplicationStart } from 'kibana/public';
+import { useKibana } from '../../common/lib/kibana';
+
+/**
+ *
+ * @param level : 'crud' | 'read' (default: 'crud')
+ *
+ * `securitySolution` owner uses cases capability feature id: 'securitySolutionCases'; //owner
+ * `observability` owner uses cases capability feature id: 'observabilityCases';
+ * both solutions use `crud_cases` and `read_cases` capability names
+ **/
+
+export const useAvailableCasesOwners = (level: 'crud' | 'read' = 'crud'): string[] => {
+  const { capabilities } = useKibana().services.application as ApplicationStart;
+  const capabilityName = `${level}_cases`;
+  return Object.entries(capabilities).reduce(
+    (availableOwners: string[], [featureId, capability]) => {
+      if (featureId.endsWith('Cases') && !!capability[capabilityName]) {
+        availableOwners.push(featureId.replace('Cases', ''));
+      }
+      return availableOwners;
+    },
+    []
+  );
+};

--- a/x-pack/plugins/cases/public/components/app/use_readonly_header.test.tsx
+++ b/x-pack/plugins/cases/public/components/app/use_readonly_header.test.tsx
@@ -33,7 +33,7 @@ describe('CaseContainerComponent', () => {
 
   it('displays the readonly glasses badge read permissions but not write', () => {
     renderHook(() => useReadonlyHeader(), {
-      wrapper: ({ children }) => <TestProviders userCanCrud>{children}</TestProviders>,
+      wrapper: ({ children }) => <TestProviders userCanCrud={false}>{children}</TestProviders>,
     });
 
     expect(mockedSetBadge).toBeCalledTimes(1);

--- a/x-pack/plugins/cases/public/components/app/use_readonly_header.test.tsx
+++ b/x-pack/plugins/cases/public/components/app/use_readonly_header.test.tsx
@@ -33,7 +33,9 @@ describe('CaseContainerComponent', () => {
 
   it('displays the readonly glasses badge read permissions but not write', () => {
     renderHook(() => useReadonlyHeader(), {
-      wrapper: ({ children }) => <TestProviders userCanCrud={false}>{children}</TestProviders>,
+      wrapper: ({ children }) => (
+        <TestProviders caseConfig={{ userCanCrud: false }}>{children}</TestProviders>
+      ),
     });
 
     expect(mockedSetBadge).toBeCalledTimes(1);

--- a/x-pack/plugins/cases/public/components/app/use_readonly_header.test.tsx
+++ b/x-pack/plugins/cases/public/components/app/use_readonly_header.test.tsx
@@ -33,9 +33,7 @@ describe('CaseContainerComponent', () => {
 
   it('displays the readonly glasses badge read permissions but not write', () => {
     renderHook(() => useReadonlyHeader(), {
-      wrapper: ({ children }) => (
-        <TestProviders caseConfig={{ userCanCrud: false }}>{children}</TestProviders>
-      ),
+      wrapper: ({ children }) => <TestProviders userCanCrud>{children}</TestProviders>,
     });
 
     expect(mockedSetBadge).toBeCalledTimes(1);

--- a/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
@@ -118,7 +118,7 @@ describe('CaseActionBar', () => {
 
   it('should not show the sync alerts toggle when alerting is disabled', () => {
     const { queryByText } = render(
-      <TestProviders caseConfig={{ features: { alerts: { sync: false } } }}>
+      <TestProviders features={{ alerts: { sync: false } }}>
         <CaseActionBar {...defaultProps} />
       </TestProviders>
     );

--- a/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
@@ -118,7 +118,7 @@ describe('CaseActionBar', () => {
 
   it('should not show the sync alerts toggle when alerting is disabled', () => {
     const { queryByText } = render(
-      <TestProviders features={{ alerts: { sync: false } }}>
+      <TestProviders caseConfig={{ features: { alerts: { sync: false } } }}>
         <CaseActionBar {...defaultProps} />
       </TestProviders>
     );

--- a/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
@@ -191,7 +191,7 @@ describe('ConfigureCases', () => {
     test('it disables correctly when the user cannot crud', () => {
       const newWrapper = mount(<ConfigureCases />, {
         wrappingComponent: TestProviders,
-        wrappingComponentProps: { caseConfig: { userCanCrud: false } },
+        wrappingComponentProps: { userCanCrud: false },
       });
 
       expect(newWrapper.find('button[data-test-subj="dropdown-connectors"]').prop('disabled')).toBe(

--- a/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
@@ -191,7 +191,7 @@ describe('ConfigureCases', () => {
     test('it disables correctly when the user cannot crud', () => {
       const newWrapper = mount(<ConfigureCases />, {
         wrappingComponent: TestProviders,
-        wrappingComponentProps: { userCanCrud: false },
+        wrappingComponentProps: { caseConfig: { userCanCrud: false } },
       });
 
       expect(newWrapper.find('button[data-test-subj="dropdown-connectors"]').prop('disabled')).toBe(

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
@@ -33,7 +33,7 @@ describe('Case Owner Selection', () => {
   };
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   it('renders', () => {

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import { act } from '@testing-library/react';
+
+import { useForm, Form, FormHook } from '../../common/shared_imports';
+import { CaseOwnerSelection } from './case_owner_selection';
+import { schema, FormProps } from './schema';
+
+// const useAvailableCasesOwners = jest.fn(() => ['securitySolution']);
+
+jest.mock('../app/use_available_owners', () => ({
+  useAvailableCasesOwners: () => ['securitySolution', 'observability'],
+}));
+
+describe('Description', () => {
+  let globalForm: FormHook;
+
+  const MockHookWrapperComponent: React.FC = ({ children }) => {
+    const { form } = useForm<FormProps>({
+      defaultValue: { selectedOwner: '' },
+      schema: {
+        selectedOwner: schema.selectedOwner,
+      },
+    });
+
+    globalForm = form;
+
+    return <Form form={form}>{children}</Form>;
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders', async () => {
+    const wrapper = mount(
+      <MockHookWrapperComponent>
+        <CaseOwnerSelection isLoading={false} />
+      </MockHookWrapperComponent>
+    );
+
+    expect(wrapper.find(`[data-test-subj="caseOwnerSelection"]`).exists()).toBeTruthy();
+  });
+
+  it.skip('it changes the selection', async () => {
+    const wrapper = mount(
+      <MockHookWrapperComponent>
+        <CaseOwnerSelection isLoading={false} />
+      </MockHookWrapperComponent>
+    );
+
+    await act(async () => {
+      wrapper.find(`[data-test-subj="observabilityRadioButton"] input`).simulate('click');
+    });
+
+    expect(globalForm.getFormData()).toEqual({ selectedOwner: 'observability' });
+  });
+});

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
@@ -65,7 +65,7 @@ describe('Case Owner Selection', () => {
     ).toBeTruthy();
   });
 
-  it('defaults to first available Solution', async () => {
+  it('defaults to security Solution', async () => {
     const wrapper = mount(
       <MockHookWrapperComponent>
         <CaseOwnerSelection
@@ -77,10 +77,10 @@ describe('Case Owner Selection', () => {
 
     expect(
       wrapper.find(`[data-test-subj="observabilityRadioButton"] input`).first().props().checked
-    ).toBeTruthy();
+    ).toBeFalsy();
     expect(
       wrapper.find(`[data-test-subj="securitySolutionRadioButton"] input`).first().props().checked
-    ).toBeFalsy();
+    ).toBeTruthy();
   });
 
   it('it changes the selection', async () => {

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
@@ -13,13 +13,10 @@ import { useForm, Form, FormHook } from '../../common/shared_imports';
 import { CaseOwnerSelection } from './case_owner_selection';
 import { schema, FormProps } from './schema';
 
-// const useAvailableCasesOwners = jest.fn(() => ['securitySolution']);
+const OBSERVABILITY = 'observability';
+const SECURITY_SOLUTION = 'securitySolution';
 
-jest.mock('../app/use_available_owners', () => ({
-  useAvailableCasesOwners: () => ['securitySolution', 'observability'],
-}));
-
-describe('Description', () => {
+describe('Case Owner Selection', () => {
   let globalForm: FormHook;
 
   const MockHookWrapperComponent: React.FC = ({ children }) => {
@@ -39,25 +36,46 @@ describe('Description', () => {
     jest.resetAllMocks();
   });
 
-  it('renders', async () => {
+  it('renders', () => {
     const wrapper = mount(
       <MockHookWrapperComponent>
-        <CaseOwnerSelection isLoading={false} />
+        <CaseOwnerSelection availableOwners={[SECURITY_SOLUTION]} isLoading={false} />
       </MockHookWrapperComponent>
     );
 
     expect(wrapper.find(`[data-test-subj="caseOwnerSelection"]`).exists()).toBeTruthy();
   });
 
+  it.each([
+    [OBSERVABILITY, SECURITY_SOLUTION],
+    [SECURITY_SOLUTION, OBSERVABILITY],
+  ])('disables %s button if user only has %j', (disabledButton, permission) => {
+    const wrapper = mount(
+      <MockHookWrapperComponent>
+        <CaseOwnerSelection availableOwners={[permission]} isLoading={false} />
+      </MockHookWrapperComponent>
+    );
+
+    expect(
+      wrapper.find(`[data-test-subj="${disabledButton}RadioButton"] input`).first().props().disabled
+    ).toBeTruthy();
+    expect(
+      wrapper.find(`[data-test-subj="${permission}RadioButton"] input`).first().props().disabled
+    ).toBeFalsy();
+  });
+
   it.skip('it changes the selection', async () => {
     const wrapper = mount(
       <MockHookWrapperComponent>
-        <CaseOwnerSelection isLoading={false} />
+        <CaseOwnerSelection
+          availableOwners={[OBSERVABILITY, SECURITY_SOLUTION]}
+          isLoading={false}
+        />
       </MockHookWrapperComponent>
     );
 
     await act(async () => {
-      wrapper.find(`[data-test-subj="observabilityRadioButton"] input`).simulate('click');
+      wrapper.find(`[data-test-subj="observabilityRadioButton"]`).first().simulate('click');
     });
 
     expect(globalForm.getFormData()).toEqual({ selectedOwner: 'observability' });

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
-import { act } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 
 import { useForm, Form, FormHook } from '../../common/shared_imports';
 import { CaseOwnerSelection } from './case_owner_selection';
@@ -64,7 +64,7 @@ describe('Case Owner Selection', () => {
     ).toBeFalsy();
   });
 
-  it.skip('it changes the selection', async () => {
+  it('it changes the selection', async () => {
     const wrapper = mount(
       <MockHookWrapperComponent>
         <CaseOwnerSelection
@@ -75,9 +75,41 @@ describe('Case Owner Selection', () => {
     );
 
     await act(async () => {
-      wrapper.find(`[data-test-subj="observabilityRadioButton"]`).first().simulate('click');
+      wrapper
+        .find(`[data-test-subj="observabilityRadioButton"] input`)
+        .first()
+        .simulate('change', 'observability');
+    });
+
+    await waitFor(() => {
+      wrapper.update();
+      expect(
+        wrapper.find(`[data-test-subj="observabilityRadioButton"] input`).first().props().checked
+      ).toBeTruthy();
+      expect(
+        wrapper.find(`[data-test-subj="securitySolutionRadioButton"] input`).first().props().checked
+      ).toBeFalsy();
     });
 
     expect(globalForm.getFormData()).toEqual({ selectedOwner: 'observability' });
+
+    await act(async () => {
+      wrapper
+        .find(`[data-test-subj="securitySolutionRadioButton"] input`)
+        .first()
+        .simulate('change', 'securitySolution');
+    });
+
+    await waitFor(() => {
+      wrapper.update();
+      expect(
+        wrapper.find(`[data-test-subj="securitySolutionRadioButton"] input`).first().props().checked
+      ).toBeTruthy();
+      expect(
+        wrapper.find(`[data-test-subj="observabilityRadioButton"] input`).first().props().checked
+      ).toBeFalsy();
+    });
+
+    expect(globalForm.getFormData()).toEqual({ selectedOwner: 'securitySolution' });
   });
 });

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.test.tsx
@@ -9,12 +9,10 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { act, waitFor } from '@testing-library/react';
 
+import { OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER } from '../../../common';
 import { useForm, Form, FormHook } from '../../common/shared_imports';
 import { CaseOwnerSelection } from './case_owner_selection';
 import { schema, FormProps } from './schema';
-
-const OBSERVABILITY = 'observability';
-const SECURITY_SOLUTION = 'securitySolution';
 
 describe('Case Owner Selection', () => {
   let globalForm: FormHook;
@@ -39,7 +37,7 @@ describe('Case Owner Selection', () => {
   it('renders', () => {
     const wrapper = mount(
       <MockHookWrapperComponent>
-        <CaseOwnerSelection availableOwners={[SECURITY_SOLUTION]} isLoading={false} />
+        <CaseOwnerSelection availableOwners={[SECURITY_SOLUTION_OWNER]} isLoading={false} />
       </MockHookWrapperComponent>
     );
 
@@ -47,8 +45,8 @@ describe('Case Owner Selection', () => {
   });
 
   it.each([
-    [OBSERVABILITY, SECURITY_SOLUTION],
-    [SECURITY_SOLUTION, OBSERVABILITY],
+    [OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER],
+    [SECURITY_SOLUTION_OWNER, OBSERVABILITY_OWNER],
   ])('disables %s button if user only has %j', (disabledButton, permission) => {
     const wrapper = mount(
       <MockHookWrapperComponent>
@@ -62,13 +60,34 @@ describe('Case Owner Selection', () => {
     expect(
       wrapper.find(`[data-test-subj="${permission}RadioButton"] input`).first().props().disabled
     ).toBeFalsy();
+    expect(
+      wrapper.find(`[data-test-subj="${permission}RadioButton"] input`).first().props().checked
+    ).toBeTruthy();
+  });
+
+  it('defaults to first available Solution', async () => {
+    const wrapper = mount(
+      <MockHookWrapperComponent>
+        <CaseOwnerSelection
+          availableOwners={[OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER]}
+          isLoading={false}
+        />
+      </MockHookWrapperComponent>
+    );
+
+    expect(
+      wrapper.find(`[data-test-subj="observabilityRadioButton"] input`).first().props().checked
+    ).toBeTruthy();
+    expect(
+      wrapper.find(`[data-test-subj="securitySolutionRadioButton"] input`).first().props().checked
+    ).toBeFalsy();
   });
 
   it('it changes the selection', async () => {
     const wrapper = mount(
       <MockHookWrapperComponent>
         <CaseOwnerSelection
-          availableOwners={[OBSERVABILITY, SECURITY_SOLUTION]}
+          availableOwners={[OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER]}
           isLoading={false}
         />
       </MockHookWrapperComponent>
@@ -78,7 +97,7 @@ describe('Case Owner Selection', () => {
       wrapper
         .find(`[data-test-subj="observabilityRadioButton"] input`)
         .first()
-        .simulate('change', 'observability');
+        .simulate('change', OBSERVABILITY_OWNER);
     });
 
     await waitFor(() => {
@@ -91,13 +110,13 @@ describe('Case Owner Selection', () => {
       ).toBeFalsy();
     });
 
-    expect(globalForm.getFormData()).toEqual({ selectedOwner: 'observability' });
+    expect(globalForm.getFormData()).toEqual({ selectedOwner: OBSERVABILITY_OWNER });
 
     await act(async () => {
       wrapper
         .find(`[data-test-subj="securitySolutionRadioButton"] input`)
         .first()
-        .simulate('change', 'securitySolution');
+        .simulate('change', SECURITY_SOLUTION_OWNER);
     });
 
     await waitFor(() => {
@@ -110,6 +129,6 @@ describe('Case Owner Selection', () => {
       ).toBeFalsy();
     });
 
-    expect(globalForm.getFormData()).toEqual({ selectedOwner: 'securitySolution' });
+    expect(globalForm.getFormData()).toEqual({ selectedOwner: SECURITY_SOLUTION_OWNER });
   });
 });

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
@@ -40,7 +40,8 @@ const FullWidthKeyPadMenu = euiStyled(EuiKeyPadMenu)`
 `;
 
 const FullWidthKeyPadItem = euiStyled(EuiKeyPadMenuItem)`
-  width: 100%
+
+  width: 100%;
 `;
 
 const CaseOwnerSelectionComponent: React.FC<Props> = ({ availableOwners, isLoading }) => {
@@ -58,10 +59,16 @@ function MenuSelection({
   field,
   isLoading = false,
 }: MenuSelectionProps): JSX.Element {
-  const radioGroupName = useGeneratedHtmlId({ prefix: 'caseOwnerRadioGroup' });
   const { errorMessage, isInvalid } = getFieldValidityAndErrorMessage(field);
+  const radioGroupName = useGeneratedHtmlId({ prefix: 'caseOwnerRadioGroup' });
 
   const onChange = useCallback((val: string) => field.setValue(val), [field]);
+
+  React.useEffect(() => {
+    if (availableOwners.length === 1) {
+      onChange(availableOwners[0]);
+    }
+  }, [availableOwners, onChange]);
 
   return (
     <EuiFormRow

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
@@ -8,6 +8,8 @@
 import React, { memo, useCallback } from 'react';
 
 import {
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiFormRow,
   EuiIcon,
   EuiKeyPadMenu,
@@ -15,15 +17,17 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 
+import { euiStyled } from '../../../../../../src/plugins/kibana_react/common';
 import { FieldHook, getFieldValidityAndErrorMessage, UseField } from '../../common/shared_imports';
-import { useAvailableCasesOwners } from '../app/use_available_owners';
 
 interface MenuSelectionProps {
   field: FieldHook<string>;
   isLoading: boolean;
+  availableOwners: string[];
 }
 
 interface Props {
+  availableOwners: string[];
   isLoading: boolean;
 }
 
@@ -31,12 +35,29 @@ const SECURITY_SOLUTION = 'securitySolution';
 const OBSERVABILITY = 'observability';
 const FIELD_NAME = 'selectedOwner';
 
-const CaseOwnerSelectionComponent: React.FC<Props> = ({ isLoading }) => {
-  return <UseField path={FIELD_NAME} component={MenuSelection} componentProps={{ isLoading }} />;
+const FullWidthKeyPadMenu = euiStyled(EuiKeyPadMenu)`
+  width: 100%;
+`;
+
+const FullWidthKeyPadItem = euiStyled(EuiKeyPadMenuItem)`
+  width: 100%
+`;
+
+const CaseOwnerSelectionComponent: React.FC<Props> = ({ availableOwners, isLoading }) => {
+  return (
+    <UseField
+      path={FIELD_NAME}
+      component={MenuSelection}
+      componentProps={{ availableOwners, isLoading }}
+    />
+  );
 };
 
-function MenuSelection({ field, isLoading = false }: MenuSelectionProps): JSX.Element {
-  const availableOwners = useAvailableCasesOwners();
+function MenuSelection({
+  availableOwners,
+  field,
+  isLoading = false,
+}: MenuSelectionProps): JSX.Element {
   const radioGroupName = useGeneratedHtmlId({ prefix: 'caseOwnerRadioGroup' });
   const { errorMessage, isInvalid } = getFieldValidityAndErrorMessage(field);
 
@@ -52,32 +73,38 @@ function MenuSelection({ field, isLoading = false }: MenuSelectionProps): JSX.El
       label={field.label}
       labelAppend={field.labelAppend}
     >
-      <EuiKeyPadMenu checkable={{ ariaLegend: 'Single select as radios' }}>
-        <EuiKeyPadMenuItem
-          data-test-subj="securityRadioButton"
-          onChange={onChange}
-          checkable="single"
-          name={radioGroupName}
-          id={SECURITY_SOLUTION}
-          label="Security"
-          isSelected={field.value === SECURITY_SOLUTION}
-          isDisabled={isLoading || !availableOwners.includes(SECURITY_SOLUTION)}
-        >
-          <EuiIcon type="logoSecurity" size="xl" />
-        </EuiKeyPadMenuItem>
-        <EuiKeyPadMenuItem
-          data-test-subj="observabilityRadioButton"
-          onChange={onChange}
-          checkable="single"
-          name={radioGroupName}
-          id={OBSERVABILITY}
-          label="Observability"
-          isSelected={field.value === OBSERVABILITY}
-          isDisabled={isLoading || !availableOwners.includes(OBSERVABILITY)}
-        >
-          <EuiIcon type="logoObservability" size="xl" />
-        </EuiKeyPadMenuItem>
-      </EuiKeyPadMenu>
+      <FullWidthKeyPadMenu checkable={{ ariaLegend: 'Single case type select' }}>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <FullWidthKeyPadItem
+              data-test-subj="securitySolutionRadioButton"
+              onChange={onChange}
+              checkable="single"
+              name={radioGroupName}
+              id={SECURITY_SOLUTION}
+              label="Security"
+              isSelected={field.value === SECURITY_SOLUTION}
+              isDisabled={isLoading || !availableOwners.includes(SECURITY_SOLUTION)}
+            >
+              <EuiIcon type="logoSecurity" size="xl" />
+            </FullWidthKeyPadItem>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <FullWidthKeyPadItem
+              data-test-subj="observabilityRadioButton"
+              onChange={onChange}
+              checkable="single"
+              name={radioGroupName}
+              id={OBSERVABILITY}
+              label="Observability"
+              isSelected={field.value === OBSERVABILITY}
+              isDisabled={isLoading || !availableOwners.includes(OBSERVABILITY)}
+            >
+              <EuiIcon type="logoObservability" size="xl" />
+            </FullWidthKeyPadItem>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </FullWidthKeyPadMenu>
     </EuiFormRow>
   );
 }

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useEffect } from 'react';
 
 import {
   EuiFlexGroup,
@@ -64,7 +64,7 @@ function MenuSelection({
 
   const onChange = useCallback((val: string) => field.setValue(val), [field]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (availableOwners.length === 1) {
       onChange(availableOwners[0]);
     }

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useCallback } from 'react';
+
+import {
+  EuiFormRow,
+  EuiIcon,
+  EuiKeyPadMenu,
+  EuiKeyPadMenuItem,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+
+import { FieldHook, getFieldValidityAndErrorMessage, UseField } from '../../common/shared_imports';
+import { useAvailableCasesOwners } from '../app/use_available_owners';
+
+interface MenuSelectionProps {
+  field: FieldHook<string>;
+  isLoading: boolean;
+}
+
+interface Props {
+  isLoading: boolean;
+}
+
+const SECURITY_SOLUTION = 'securitySolution';
+const OBSERVABILITY = 'observability';
+const FIELD_NAME = 'selectedOwner';
+
+const CaseOwnerSelectionComponent: React.FC<Props> = ({ isLoading }) => {
+  return <UseField path={FIELD_NAME} component={MenuSelection} componentProps={{ isLoading }} />;
+};
+
+function MenuSelection({ field, isLoading = false }: MenuSelectionProps): JSX.Element {
+  const availableOwners = useAvailableCasesOwners();
+  const radioGroupName = useGeneratedHtmlId({ prefix: 'caseOwnerRadioGroup' });
+  const { errorMessage, isInvalid } = getFieldValidityAndErrorMessage(field);
+
+  const onChange = useCallback((val: string) => field.setValue(val), [field]);
+
+  return (
+    <EuiFormRow
+      data-test-subj="caseOwnerSelection"
+      fullWidth
+      isInvalid={isInvalid}
+      error={errorMessage}
+      helpText={field.helpText}
+      label={field.label}
+      labelAppend={field.labelAppend}
+    >
+      <EuiKeyPadMenu checkable={{ ariaLegend: 'Single select as radios' }}>
+        <EuiKeyPadMenuItem
+          data-test-subj="securityRadioButton"
+          onChange={onChange}
+          checkable="single"
+          name={radioGroupName}
+          id={SECURITY_SOLUTION}
+          label="Security"
+          isSelected={field.value === SECURITY_SOLUTION}
+          isDisabled={isLoading || !availableOwners.includes(SECURITY_SOLUTION)}
+        >
+          <EuiIcon type="logoSecurity" size="xl" />
+        </EuiKeyPadMenuItem>
+        <EuiKeyPadMenuItem
+          data-test-subj="observabilityRadioButton"
+          onChange={onChange}
+          checkable="single"
+          name={radioGroupName}
+          id={OBSERVABILITY}
+          label="Observability"
+          isSelected={field.value === OBSERVABILITY}
+          isDisabled={isLoading || !availableOwners.includes(OBSERVABILITY)}
+        >
+          <EuiIcon type="logoObservability" size="xl" />
+        </EuiKeyPadMenuItem>
+      </EuiKeyPadMenu>
+    </EuiFormRow>
+  );
+}
+
+CaseOwnerSelectionComponent.displayName = 'CaseOwnerSelectionComponent';
+
+export const CaseOwnerSelection = memo(CaseOwnerSelectionComponent);

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
@@ -18,7 +18,11 @@ import {
 } from '@elastic/eui';
 
 import { euiStyled } from '../../../../../../src/plugins/kibana_react/common';
+import { OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER } from '../../../common';
+import { OWNER_INFO } from '../../../common/constants';
+
 import { FieldHook, getFieldValidityAndErrorMessage, UseField } from '../../common/shared_imports';
+import * as i18n from './translations';
 
 interface MenuSelectionProps {
   field: FieldHook<string>;
@@ -31,8 +35,8 @@ interface Props {
   isLoading: boolean;
 }
 
-const SECURITY_SOLUTION = 'securitySolution';
-const OBSERVABILITY = 'observability';
+const DEFAULT_SELECTABLE_OWNERS = [SECURITY_SOLUTION_OWNER, OBSERVABILITY_OWNER] as const;
+
 const FIELD_NAME = 'selectedOwner';
 
 const FullWidthKeyPadMenu = euiStyled(EuiKeyPadMenu)`
@@ -54,21 +58,21 @@ const CaseOwnerSelectionComponent: React.FC<Props> = ({ availableOwners, isLoadi
   );
 };
 
-function MenuSelection({
+const MenuSelection = ({
   availableOwners,
   field,
   isLoading = false,
-}: MenuSelectionProps): JSX.Element {
+}: MenuSelectionProps): JSX.Element => {
   const { errorMessage, isInvalid } = getFieldValidityAndErrorMessage(field);
   const radioGroupName = useGeneratedHtmlId({ prefix: 'caseOwnerRadioGroup' });
 
   const onChange = useCallback((val: string) => field.setValue(val), [field]);
 
   useEffect(() => {
-    if (availableOwners.length === 1) {
+    if (!field.value) {
       onChange(availableOwners[0]);
     }
-  }, [availableOwners, onChange]);
+  }, [availableOwners, field.value, onChange]);
 
   return (
     <EuiFormRow
@@ -80,41 +84,29 @@ function MenuSelection({
       label={field.label}
       labelAppend={field.labelAppend}
     >
-      <FullWidthKeyPadMenu checkable={{ ariaLegend: 'Single case type select' }}>
+      <FullWidthKeyPadMenu checkable={{ ariaLegend: i18n.ARIA_KEYPAD_LEGEND }}>
         <EuiFlexGroup>
-          <EuiFlexItem>
-            <FullWidthKeyPadItem
-              data-test-subj="securitySolutionRadioButton"
-              onChange={onChange}
-              checkable="single"
-              name={radioGroupName}
-              id={SECURITY_SOLUTION}
-              label="Security"
-              isSelected={field.value === SECURITY_SOLUTION}
-              isDisabled={isLoading || !availableOwners.includes(SECURITY_SOLUTION)}
-            >
-              <EuiIcon type="logoSecurity" size="xl" />
-            </FullWidthKeyPadItem>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <FullWidthKeyPadItem
-              data-test-subj="observabilityRadioButton"
-              onChange={onChange}
-              checkable="single"
-              name={radioGroupName}
-              id={OBSERVABILITY}
-              label="Observability"
-              isSelected={field.value === OBSERVABILITY}
-              isDisabled={isLoading || !availableOwners.includes(OBSERVABILITY)}
-            >
-              <EuiIcon type="logoObservability" size="xl" />
-            </FullWidthKeyPadItem>
-          </EuiFlexItem>
+          {DEFAULT_SELECTABLE_OWNERS.map((owner) => (
+            <EuiFlexItem>
+              <FullWidthKeyPadItem
+                data-test-subj={`${owner}RadioButton`}
+                onChange={onChange}
+                checkable="single"
+                name={radioGroupName}
+                id={owner}
+                label={OWNER_INFO[owner].label}
+                isSelected={field.value === owner}
+                isDisabled={isLoading || !availableOwners.includes(owner)}
+              >
+                <EuiIcon type={OWNER_INFO[owner].iconType} size="xl" />
+              </FullWidthKeyPadItem>
+            </EuiFlexItem>
+          ))}
         </EuiFlexGroup>
       </FullWidthKeyPadMenu>
     </EuiFormRow>
   );
-}
+};
 
 CaseOwnerSelectionComponent.displayName = 'CaseOwnerSelectionComponent';
 

--- a/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
+++ b/x-pack/plugins/cases/public/components/create/case_owner_selection.tsx
@@ -70,7 +70,11 @@ const MenuSelection = ({
 
   useEffect(() => {
     if (!field.value) {
-      onChange(availableOwners[0]);
+      const securitySolutionIndex = availableOwners.findIndex(
+        (value) => value === SECURITY_SOLUTION_OWNER
+      );
+      const defaultSelectedSolution = securitySolutionIndex === -1 ? 0 : securitySolutionIndex;
+      onChange(availableOwners[defaultSelectedSolution]);
     }
   }, [availableOwners, field.value, onChange]);
 
@@ -87,7 +91,7 @@ const MenuSelection = ({
       <FullWidthKeyPadMenu checkable={{ ariaLegend: i18n.ARIA_KEYPAD_LEGEND }}>
         <EuiFlexGroup>
           {DEFAULT_SELECTABLE_OWNERS.map((owner) => (
-            <EuiFlexItem>
+            <EuiFlexItem key={owner}>
               <FullWidthKeyPadItem
                 data-test-subj={`${owner}RadioButton`}
                 onChange={onChange}

--- a/x-pack/plugins/cases/public/components/create/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.test.tsx
@@ -17,13 +17,8 @@ import { schema, FormProps } from './schema';
 import { CreateCaseForm, CreateCaseFormProps } from './form';
 import { useCaseConfigure } from '../../containers/configure/use_configure';
 import { useCaseConfigureResponse } from '../configure_cases/__mock__';
-import { CaseContextConfig, TestProviders } from '../../common/mock';
+import { TestProviders } from '../../common/mock';
 import { CasesContextValue } from '../../containers/types';
-
-interface MockWrapper {
-  children: React.ReactNode;
-  owner?: string[];
-}
 
 jest.mock('../../containers/use_get_tags');
 jest.mock('../../containers/configure/use_connectors');

--- a/x-pack/plugins/cases/public/components/create/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.test.tsx
@@ -18,7 +18,6 @@ import { CreateCaseForm, CreateCaseFormProps } from './form';
 import { useCaseConfigure } from '../../containers/configure/use_configure';
 import { useCaseConfigureResponse } from '../configure_cases/__mock__';
 import { TestProviders } from '../../common/mock';
-import { CasesContextValue } from '../../containers/types';
 
 jest.mock('../../containers/use_get_tags');
 jest.mock('../../containers/configure/use_connectors');
@@ -48,9 +47,9 @@ const casesFormProps: CreateCaseFormProps = {
 
 describe('CreateCaseForm', () => {
   let globalForm: FormHook;
-  const MockHookWrapperComponent: React.FC<Partial<CasesContextValue>> = ({
+  const MockHookWrapperComponent: React.FC<{ testProviderProps?: unknown }> = ({
     children,
-    ...props
+    testProviderProps = {},
   }) => {
     const { form } = useForm<FormProps>({
       defaultValue: initialCaseValue,
@@ -61,7 +60,7 @@ describe('CreateCaseForm', () => {
     globalForm = form;
 
     return (
-      <TestProviders {...props}>
+      <TestProviders {...testProviderProps}>
         <Form form={form}>{children}</Form>
       </TestProviders>
     );
@@ -106,12 +105,12 @@ describe('CreateCaseForm', () => {
     expect(wrapper.find(`[data-test-subj="caseDescription"]`).exists()).toBeTruthy();
     expect(wrapper.find(`[data-test-subj="caseSyncAlerts"]`).exists()).toBeTruthy();
     expect(wrapper.find(`[data-test-subj="caseConnectors"]`).exists()).toBeTruthy();
-    expect(wrapper.find(`[data-test-subj="caseOwnerSelection"]`).exists()).toBeFalsy();
+    expect(wrapper.find(`[data-test-subj="caseOwnerSelector"]`).exists()).toBeFalsy();
   });
 
   it('renders all form fields including case selection if has permissions and no owner', async () => {
     const wrapper = mount(
-      <MockHookWrapperComponent owner={[]}>
+      <MockHookWrapperComponent testProviderProps={{ owner: [] }}>
         <CreateCaseForm {...casesFormProps} />
       </MockHookWrapperComponent>
     );
@@ -121,12 +120,12 @@ describe('CreateCaseForm', () => {
     expect(wrapper.find(`[data-test-subj="caseDescription"]`).exists()).toBeTruthy();
     expect(wrapper.find(`[data-test-subj="caseSyncAlerts"]`).exists()).toBeTruthy();
     expect(wrapper.find(`[data-test-subj="caseConnectors"]`).exists()).toBeTruthy();
-    expect(wrapper.find(`[data-test-subj="caseOwnerSelection"]`).exists()).toBeTruthy();
+    expect(wrapper.find(`[data-test-subj="caseOwnerSelector"]`).exists()).toBeTruthy();
   });
 
   it('hides the sync alerts toggle', () => {
     const { queryByText } = render(
-      <MockHookWrapperComponent features={{ alerts: { sync: false } }}>
+      <MockHookWrapperComponent testProviderProps={{ features: { alerts: { sync: false } } }}>
         <CreateCaseForm {...casesFormProps} />
       </MockHookWrapperComponent>
     );

--- a/x-pack/plugins/cases/public/components/create/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.test.tsx
@@ -61,7 +61,7 @@ describe('CreateCaseForm', () => {
     globalForm = form;
 
     return (
-      <TestProviders caseConfig={{ ...props }}>
+      <TestProviders {...props}>
         <Form form={form}>{children}</Form>
       </TestProviders>
     );

--- a/x-pack/plugins/cases/public/components/create/form.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.tsx
@@ -168,12 +168,7 @@ export const CreateCaseForm: React.FC<CreateCaseFormProps> = React.memo(
     timelineIntegration,
   }) => (
     <CasesTimelineIntegrationProvider timelineIntegration={timelineIntegration}>
-      <FormContext
-        afterCaseCreated={afterCaseCreated}
-        caseType={caseType}
-        hideConnectorServiceNowSir={hideConnectorServiceNowSir}
-        onSuccess={onSuccess}
-      >
+      <FormContext afterCaseCreated={afterCaseCreated} caseType={caseType} onSuccess={onSuccess}>
         <CreateCaseFormFields
           connectors={empty}
           isLoadingConnectors={false}

--- a/x-pack/plugins/cases/public/components/create/form.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.tsx
@@ -57,7 +57,6 @@ export interface CreateCaseFormFieldsProps {
   isLoadingConnectors: boolean;
   hideConnectorServiceNowSir: boolean;
   withSteps: boolean;
-  showCaseOwnerSelection?: boolean;
 }
 export interface CreateCaseFormProps
   extends Pick<Partial<CreateCaseFormFieldsProps>, 'hideConnectorServiceNowSir' | 'withSteps'> {
@@ -70,13 +69,7 @@ export interface CreateCaseFormProps
 
 const empty: ActionConnector[] = [];
 export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.memo(
-  ({
-    connectors,
-    isLoadingConnectors,
-    hideConnectorServiceNowSir,
-    showCaseOwnerSelection = false,
-    withSteps,
-  }) => {
+  ({ connectors, isLoadingConnectors, hideConnectorServiceNowSir, withSteps }) => {
     const { isSubmitting } = useFormContext();
     const { isSyncAlertsEnabled } = useCasesFeatures();
 

--- a/x-pack/plugins/cases/public/components/create/form.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.tsx
@@ -31,7 +31,7 @@ import { UsePostComment } from '../../containers/use_post_comment';
 import { SubmitCaseButton } from './submit_button';
 import { FormContext } from './form_context';
 import { useCasesFeatures } from '../cases_context/use_cases_features';
-import { CaseOwnerSelection } from './case_owner_selection';
+import { CreateCaseOwnerSelector } from './owner_selector';
 import { useCasesContext } from '../cases_context/use_cases_context';
 import { useAvailableCasesOwners } from '../app/use_available_owners';
 
@@ -88,7 +88,10 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
             </Container>
             {canShowCaseSolutionSelection && (
               <Container big>
-                <CaseOwnerSelection availableOwners={availableOwners} isLoading={isSubmitting} />
+                <CreateCaseOwnerSelector
+                  availableOwners={availableOwners}
+                  isLoading={isSubmitting}
+                />
               </Container>
             )}
             <Container big>

--- a/x-pack/plugins/cases/public/components/create/form.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.tsx
@@ -31,6 +31,7 @@ import { UsePostComment } from '../../containers/use_post_comment';
 import { SubmitCaseButton } from './submit_button';
 import { FormContext } from './form_context';
 import { useCasesFeatures } from '../cases_context/use_cases_features';
+import { CaseOwnerSelection } from './case_owner_selection';
 
 interface ContainerProps {
   big?: boolean;
@@ -54,6 +55,7 @@ export interface CreateCaseFormFieldsProps {
   isLoadingConnectors: boolean;
   hideConnectorServiceNowSir: boolean;
   withSteps: boolean;
+  showCaseOwnerSelection?: boolean;
 }
 export interface CreateCaseFormProps
   extends Pick<Partial<CreateCaseFormFieldsProps>, 'hideConnectorServiceNowSir' | 'withSteps'> {
@@ -66,7 +68,13 @@ export interface CreateCaseFormProps
 
 const empty: ActionConnector[] = [];
 export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.memo(
-  ({ connectors, isLoadingConnectors, hideConnectorServiceNowSir, withSteps }) => {
+  ({
+    connectors,
+    isLoadingConnectors,
+    hideConnectorServiceNowSir,
+    showCaseOwnerSelection = false,
+    withSteps,
+  }) => {
     const { isSubmitting } = useFormContext();
     const { isSyncAlertsEnabled } = useCasesFeatures();
 
@@ -79,13 +87,18 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
             <Container>
               <Tags isLoading={isSubmitting} />
             </Container>
+            {showCaseOwnerSelection && (
+              <Container big>
+                <CaseOwnerSelection isLoading={isSubmitting} />
+              </Container>
+            )}
             <Container big>
               <Description isLoading={isSubmitting} />
             </Container>
           </>
         ),
       }),
-      [isSubmitting]
+      [isSubmitting, showCaseOwnerSelection]
     );
 
     const secondStep = useMemo(

--- a/x-pack/plugins/cases/public/components/create/form.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.tsx
@@ -75,7 +75,7 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
 
     const { owner } = useCasesContext();
     const availableOwners = useAvailableCasesOwners();
-    const canShowCaseTypeSelection = !owner.length && availableOwners.length;
+    const canShowCaseSolutionSelection = !owner.length && availableOwners.length;
 
     const firstStep = useMemo(
       () => ({
@@ -86,7 +86,7 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
             <Container>
               <Tags isLoading={isSubmitting} />
             </Container>
-            {canShowCaseTypeSelection && (
+            {canShowCaseSolutionSelection && (
               <Container big>
                 <CaseOwnerSelection availableOwners={availableOwners} isLoading={isSubmitting} />
               </Container>
@@ -97,7 +97,7 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
           </>
         ),
       }),
-      [isSubmitting, canShowCaseTypeSelection, availableOwners]
+      [isSubmitting, canShowCaseSolutionSelection, availableOwners]
     );
 
     const secondStep = useMemo(

--- a/x-pack/plugins/cases/public/components/create/form.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.tsx
@@ -32,6 +32,8 @@ import { SubmitCaseButton } from './submit_button';
 import { FormContext } from './form_context';
 import { useCasesFeatures } from '../cases_context/use_cases_features';
 import { CaseOwnerSelection } from './case_owner_selection';
+import { useCasesContext } from '../cases_context/use_cases_context';
+import { useAvailableCasesOwners } from '../app/use_available_owners';
 
 interface ContainerProps {
   big?: boolean;
@@ -78,6 +80,10 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
     const { isSubmitting } = useFormContext();
     const { isSyncAlertsEnabled } = useCasesFeatures();
 
+    const { owner } = useCasesContext();
+    const availableOwners = useAvailableCasesOwners();
+    const canShowCaseTypeSelection = !owner.length && availableOwners.length;
+
     const firstStep = useMemo(
       () => ({
         title: i18n.STEP_ONE_TITLE,
@@ -87,9 +93,9 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
             <Container>
               <Tags isLoading={isSubmitting} />
             </Container>
-            {showCaseOwnerSelection && (
+            {canShowCaseTypeSelection && (
               <Container big>
-                <CaseOwnerSelection isLoading={isSubmitting} />
+                <CaseOwnerSelection availableOwners={availableOwners} isLoading={isSubmitting} />
               </Container>
             )}
             <Container big>
@@ -98,7 +104,7 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
           </>
         ),
       }),
-      [isSubmitting, showCaseOwnerSelection]
+      [isSubmitting, canShowCaseTypeSelection, availableOwners]
     );
 
     const secondStep = useMemo(

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -249,7 +249,7 @@ describe('Create case', () => {
       });
 
       const wrapper = mount(
-        <TestProviders features={{ alerts: { sync: false } }}>
+        <TestProviders caseConfig={{ features: { alerts: { sync: false } } }}>
           <FormContext onSuccess={onFormSubmitSuccess}>
             <CreateCaseFormFields {...defaultCreateCaseForm} />
             <SubmitCaseButton />

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -249,7 +249,7 @@ describe('Create case', () => {
       });
 
       const wrapper = mount(
-        <TestProviders caseConfig={{ features: { alerts: { sync: false } } }}>
+        <TestProviders features={{ alerts: { sync: false } }}>
           <FormContext onSuccess={onFormSubmitSuccess}>
             <CreateCaseFormFields {...defaultCreateCaseForm} />
             <SubmitCaseButton />

--- a/x-pack/plugins/cases/public/components/create/form_context.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.tsx
@@ -63,9 +63,7 @@ export const FormContext: React.FC<Props> = ({
       isValid
     ) => {
       if (isValid) {
-        const selectedOwner = dataWithoutConnectorId.selectedOwner;
-        delete dataWithoutConnectorId.selectedOwner;
-
+        const { selectedOwner, ...userFormData } = dataWithoutConnectorId;
         const caseConnector = getConnectorById(dataConnectorId, connectors);
 
         const connectorToUpdate = caseConnector
@@ -73,7 +71,7 @@ export const FormContext: React.FC<Props> = ({
           : getNoneConnector();
 
         const updatedCase = await postCase({
-          ...dataWithoutConnectorId,
+          ...userFormData,
           type: caseType,
           connector: connectorToUpdate,
           settings: { syncAlerts },

--- a/x-pack/plugins/cases/public/components/create/form_context.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.tsx
@@ -34,7 +34,6 @@ interface Props {
   afterCaseCreated?: (theCase: Case, postComment: UsePostComment['postComment']) => Promise<void>;
   caseType?: CaseType;
   children?: JSX.Element | JSX.Element[];
-  hideConnectorServiceNowSir?: boolean;
   onSuccess?: (theCase: Case) => Promise<void>;
 }
 
@@ -42,7 +41,6 @@ export const FormContext: React.FC<Props> = ({
   afterCaseCreated,
   caseType = CaseType.individual,
   children,
-  hideConnectorServiceNowSir,
   onSuccess,
 }) => {
   const { connectors, loading: isLoadingConnectors } = useConnectors();

--- a/x-pack/plugins/cases/public/components/create/form_context.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.tsx
@@ -27,7 +27,7 @@ const initialCaseValue: FormProps = {
   connectorId: 'none',
   fields: null,
   syncAlerts: true,
-  selectedOwner: '',
+  selectedOwner: null,
 };
 
 interface Props {

--- a/x-pack/plugins/cases/public/components/create/form_context.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.tsx
@@ -27,6 +27,7 @@ const initialCaseValue: FormProps = {
   connectorId: 'none',
   fields: null,
   syncAlerts: true,
+  selectedOwner: '',
 };
 
 interface Props {
@@ -62,6 +63,9 @@ export const FormContext: React.FC<Props> = ({
       isValid
     ) => {
       if (isValid) {
+        const selectedOwner = dataWithoutConnectorId.selectedOwner;
+        delete dataWithoutConnectorId.selectedOwner;
+
         const caseConnector = getConnectorById(dataConnectorId, connectors);
 
         const connectorToUpdate = caseConnector
@@ -73,7 +77,7 @@ export const FormContext: React.FC<Props> = ({
           type: caseType,
           connector: connectorToUpdate,
           settings: { syncAlerts },
-          owner: owner[0],
+          owner: selectedOwner ?? owner[0],
         });
 
         if (afterCaseCreated && updatedCase) {

--- a/x-pack/plugins/cases/public/components/create/owner_selector.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/owner_selector.test.tsx
@@ -9,9 +9,10 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { act, waitFor } from '@testing-library/react';
 
-import { OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER } from '../../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../../common';
+import { OBSERVABILITY_OWNER } from '../../../common/constants';
 import { useForm, Form, FormHook } from '../../common/shared_imports';
-import { CaseOwnerSelection } from './case_owner_selection';
+import { CreateCaseOwnerSelector } from './owner_selector';
 import { schema, FormProps } from './schema';
 
 describe('Case Owner Selection', () => {
@@ -37,11 +38,11 @@ describe('Case Owner Selection', () => {
   it('renders', () => {
     const wrapper = mount(
       <MockHookWrapperComponent>
-        <CaseOwnerSelection availableOwners={[SECURITY_SOLUTION_OWNER]} isLoading={false} />
+        <CreateCaseOwnerSelector availableOwners={[SECURITY_SOLUTION_OWNER]} isLoading={false} />
       </MockHookWrapperComponent>
     );
 
-    expect(wrapper.find(`[data-test-subj="caseOwnerSelection"]`).exists()).toBeTruthy();
+    expect(wrapper.find(`[data-test-subj="caseOwnerSelector"]`).exists()).toBeTruthy();
   });
 
   it.each([
@@ -50,7 +51,7 @@ describe('Case Owner Selection', () => {
   ])('disables %s button if user only has %j', (disabledButton, permission) => {
     const wrapper = mount(
       <MockHookWrapperComponent>
-        <CaseOwnerSelection availableOwners={[permission]} isLoading={false} />
+        <CreateCaseOwnerSelector availableOwners={[permission]} isLoading={false} />
       </MockHookWrapperComponent>
     );
 
@@ -68,7 +69,7 @@ describe('Case Owner Selection', () => {
   it('defaults to security Solution', async () => {
     const wrapper = mount(
       <MockHookWrapperComponent>
-        <CaseOwnerSelection
+        <CreateCaseOwnerSelector
           availableOwners={[OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER]}
           isLoading={false}
         />
@@ -86,7 +87,7 @@ describe('Case Owner Selection', () => {
   it('it changes the selection', async () => {
     const wrapper = mount(
       <MockHookWrapperComponent>
-        <CaseOwnerSelection
+        <CreateCaseOwnerSelector
           availableOwners={[OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER]}
           isLoading={false}
         />

--- a/x-pack/plugins/cases/public/components/create/owner_selector.tsx
+++ b/x-pack/plugins/cases/public/components/create/owner_selector.tsx
@@ -18,13 +18,13 @@ import {
 } from '@elastic/eui';
 
 import { euiStyled } from '../../../../../../src/plugins/kibana_react/common';
-import { OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER } from '../../../common';
-import { OWNER_INFO } from '../../../common/constants';
+import { SECURITY_SOLUTION_OWNER } from '../../../common';
+import { OBSERVABILITY_OWNER, OWNER_INFO } from '../../../common/constants';
 
 import { FieldHook, getFieldValidityAndErrorMessage, UseField } from '../../common/shared_imports';
 import * as i18n from './translations';
 
-interface MenuSelectionProps {
+interface OwnerSelectorProps {
   field: FieldHook<string>;
   isLoading: boolean;
   availableOwners: string[];
@@ -48,21 +48,11 @@ const FullWidthKeyPadItem = euiStyled(EuiKeyPadMenuItem)`
   width: 100%;
 `;
 
-const CaseOwnerSelectionComponent: React.FC<Props> = ({ availableOwners, isLoading }) => {
-  return (
-    <UseField
-      path={FIELD_NAME}
-      component={MenuSelection}
-      componentProps={{ availableOwners, isLoading }}
-    />
-  );
-};
-
-const MenuSelection = ({
+const OwnerSelector = ({
   availableOwners,
   field,
   isLoading = false,
-}: MenuSelectionProps): JSX.Element => {
+}: OwnerSelectorProps): JSX.Element => {
   const { errorMessage, isInvalid } = getFieldValidityAndErrorMessage(field);
   const radioGroupName = useGeneratedHtmlId({ prefix: 'caseOwnerRadioGroup' });
 
@@ -70,17 +60,17 @@ const MenuSelection = ({
 
   useEffect(() => {
     if (!field.value) {
-      const securitySolutionIndex = availableOwners.findIndex(
-        (value) => value === SECURITY_SOLUTION_OWNER
+      onChange(
+        availableOwners.includes(SECURITY_SOLUTION_OWNER)
+          ? SECURITY_SOLUTION_OWNER
+          : availableOwners[0]
       );
-      const defaultSelectedSolution = securitySolutionIndex === -1 ? 0 : securitySolutionIndex;
-      onChange(availableOwners[defaultSelectedSolution]);
     }
   }, [availableOwners, field.value, onChange]);
 
   return (
     <EuiFormRow
-      data-test-subj="caseOwnerSelection"
+      data-test-subj="caseOwnerSelector"
       fullWidth
       isInvalid={isInvalid}
       error={errorMessage}
@@ -112,6 +102,16 @@ const MenuSelection = ({
   );
 };
 
-CaseOwnerSelectionComponent.displayName = 'CaseOwnerSelectionComponent';
+const CaseOwnerSelector: React.FC<Props> = ({ availableOwners, isLoading }) => {
+  return (
+    <UseField
+      path={FIELD_NAME}
+      component={OwnerSelector}
+      componentProps={{ availableOwners, isLoading }}
+    />
+  );
+};
 
-export const CaseOwnerSelection = memo(CaseOwnerSelectionComponent);
+CaseOwnerSelector.displayName = 'CaseOwnerSelectionComponent';
+
+export const CreateCaseOwnerSelector = memo(CaseOwnerSelector);

--- a/x-pack/plugins/cases/public/components/create/schema.tsx
+++ b/x-pack/plugins/cases/public/components/create/schema.tsx
@@ -36,7 +36,7 @@ export type FormProps = Omit<CasePostRequest, 'connector' | 'settings' | 'owner'
   connectorId: string;
   fields: ConnectorTypeFields['fields'];
   syncAlerts: boolean;
-  selectedOwner?: string;
+  selectedOwner?: string | null;
 };
 
 export const schema: FormSchema<FormProps> = {

--- a/x-pack/plugins/cases/public/components/create/schema.tsx
+++ b/x-pack/plugins/cases/public/components/create/schema.tsx
@@ -36,6 +36,7 @@ export type FormProps = Omit<CasePostRequest, 'connector' | 'settings' | 'owner'
   connectorId: string;
   fields: ConnectorTypeFields['fields'];
   syncAlerts: boolean;
+  selectedOwner?: string;
 };
 
 export const schema: FormSchema<FormProps> = {
@@ -59,6 +60,15 @@ export const schema: FormSchema<FormProps> = {
     validations: [
       {
         validator: emptyField(i18n.DESCRIPTION_REQUIRED),
+      },
+    ],
+  },
+  selectedOwner: {
+    label: i18n.CASE_TYPE,
+    type: FIELD_TYPES.RADIO_GROUP,
+    validations: [
+      {
+        validator: emptyField(i18n.SELECTION_REQUIRED),
       },
     ],
   },

--- a/x-pack/plugins/cases/public/components/create/schema.tsx
+++ b/x-pack/plugins/cases/public/components/create/schema.tsx
@@ -64,11 +64,11 @@ export const schema: FormSchema<FormProps> = {
     ],
   },
   selectedOwner: {
-    label: i18n.CASE_TYPE,
+    label: i18n.SOLUTION,
     type: FIELD_TYPES.RADIO_GROUP,
     validations: [
       {
-        validator: emptyField(i18n.SELECTION_REQUIRED),
+        validator: emptyField(i18n.SOLUTION_REQUIRED),
       },
     ],
   },

--- a/x-pack/plugins/cases/public/components/recent_cases/no_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/no_cases/index.test.tsx
@@ -27,7 +27,7 @@ describe('NoCases', () => {
 
   it('displays a message without a link to create a case when the user does not have write permissions', () => {
     const wrapper = mount(
-      <TestProviders userCanCrud={false}>
+      <TestProviders caseConfig={{ userCanCrud: false }}>
         <NoCases />
       </TestProviders>
     );

--- a/x-pack/plugins/cases/public/components/recent_cases/no_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/no_cases/index.test.tsx
@@ -27,7 +27,7 @@ describe('NoCases', () => {
 
   it('displays a message without a link to create a case when the user does not have write permissions', () => {
     const wrapper = mount(
-      <TestProviders caseConfig={{ userCanCrud: false }}>
+      <TestProviders userCanCrud>
         <NoCases />
       </TestProviders>
     );

--- a/x-pack/plugins/cases/public/components/recent_cases/no_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/no_cases/index.test.tsx
@@ -27,7 +27,7 @@ describe('NoCases', () => {
 
   it('displays a message without a link to create a case when the user does not have write permissions', () => {
     const wrapper = mount(
-      <TestProviders userCanCrud>
+      <TestProviders userCanCrud={false}>
         <NoCases />
       </TestProviders>
     );


### PR DESCRIPTION
## Summary

OSQuery would like the ability to add data to a case from outside security or observability. To implement this a new hook is created- useAvailableCaseOwners, that grabs the current owner permissions of the current user.

Add ability for case owner selection in flyout
Provide a selection to a user in flyout to choose an owner for a new case. This is based on permissions of the current user.

In addition :
useAvailableOwners hook is added, along with tests, to check permissions of the current user
test_providers is updated to use an easily configureable `caseConfig` to override the default context.

## Local testing
To be able to easily test this. in 
`x-pack/plugins/cases/public/components/create/form.tsx`

change line 89 from
`{canShowCaseTypeSelection && (` to `{!canShowCaseTypeSelection && (`


and line 140 from
`{withSteps ? (` to `{!withSteps ? (`

This will enable you to see flyout version of the form which is also permissioned to show the new case type field from anywhere you could create a new case before

![recording(6)](https://user-images.githubusercontent.com/28942857/144540890-4cd34064-73f8-4145-bbe6-4c23b0418e50.gif)


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

- [X] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

