### PR TITLE
[Cases] Refreshing all signals indices in test

### DIFF
--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
@@ -665,8 +665,7 @@ export default ({ getService }: FtrProviderContext): void => {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/117971
-      describe.skip('esArchiver', () => {
+      describe('esArchiver', () => {
         const defaultSignalsIndex = '.siem-signals-default-000001';
 
         beforeEach(async () => {
@@ -725,6 +724,7 @@ export default ({ getService }: FtrProviderContext): void => {
           });
 
           await es.indices.refresh({ index: defaultSignalsIndex });
+          await es.indices.refresh({ index: signalsIndex2 });
 
           let signals = await getSignals();
           // There should be no change in their status since syncing is disabled
@@ -748,6 +748,7 @@ export default ({ getService }: FtrProviderContext): void => {
           })) as CasesResponse;
 
           await es.indices.refresh({ index: defaultSignalsIndex });
+          await es.indices.refresh({ index: signalsIndex2 });
 
           signals = await getSignals();
 
@@ -773,6 +774,7 @@ export default ({ getService }: FtrProviderContext): void => {
             },
           });
           await es.indices.refresh({ index: defaultSignalsIndex });
+          await es.indices.refresh({ index: signalsIndex2 });
 
           signals = await getSignals();
 


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/117971

This PR fixes an issues where one of the signals indices wasn't being refreshed and was causing inconsistent results when querying the index to determine the alert's status. Now we're refreshing all indices involved in the test.