### PR TITLE
[Maps] remove getIndexPatternsService from server.kibana_server_services

### DIFF
--- a/x-pack/plugins/maps/server/kibana_server_services.ts
+++ b/x-pack/plugins/maps/server/kibana_server_services.ts
@@ -17,7 +17,8 @@ export function setStartServices(core: CoreStart, plugins: StartDeps) {
 
 export const getSavedObjectClient = (extraTypes?: string[]) => {
   return coreStart.savedObjects.createInternalRepository(extraTypes);
-}
+};
 
-export const getIndexPatternsServiceFactory = () => pluginsStart.data.indexPatterns.indexPatternsServiceFactory;
+export const getIndexPatternsServiceFactory = () =>
+  pluginsStart.data.indexPatterns.indexPatternsServiceFactory;
 export const getElasticsearch = () => coreStart.elasticsearch;

--- a/x-pack/plugins/maps/server/kibana_server_services.ts
+++ b/x-pack/plugins/maps/server/kibana_server_services.ts
@@ -5,32 +5,19 @@
  * 2.0.
  */
 
-import { ElasticsearchClient, ISavedObjectsRepository } from 'kibana/server';
-import { SavedObjectsClient } from '../../../../src/core/server';
-import {
-  IndexPatternsCommonService,
-  IndexPatternsServiceStart,
-} from '../../../../src/plugins/data/server';
+import { CoreStart } from '../../../../src/core/server';
+import { StartDeps } from './plugin';
 
-let internalRepository: ISavedObjectsRepository;
-export const setInternalRepository = (
-  createInternalRepository: (extraTypes?: string[]) => ISavedObjectsRepository
-) => {
-  internalRepository = createInternalRepository();
-};
-export const getInternalRepository = () => internalRepository;
+let coreStart: CoreStart;
+let pluginsStart: StartDeps;
+export function setStartServices(core: CoreStart, plugins: StartDeps) {
+  coreStart = core;
+  pluginsStart = plugins;
+}
 
-let esClient: ElasticsearchClient;
-let indexPatternsService: IndexPatternsCommonService;
-export const setIndexPatternsService = async (
-  indexPatternsServiceFactory: IndexPatternsServiceStart['indexPatternsServiceFactory'],
-  elasticsearchClient: ElasticsearchClient
-) => {
-  esClient = elasticsearchClient;
-  indexPatternsService = await indexPatternsServiceFactory(
-    new SavedObjectsClient(getInternalRepository()),
-    elasticsearchClient
-  );
-};
-export const getIndexPatternsService = () => indexPatternsService;
-export const getESClient = () => esClient;
+export const getSavedObjectClient = (extraTypes?: string[]) => {
+  return coreStart.savedObjects.createInternalRepository(extraTypes);
+}
+
+export const getIndexPatternsServiceFactory = () => pluginsStart.data.indexPatterns.indexPatternsServiceFactory;
+export const getElasticsearch = () => coreStart.elasticsearch;

--- a/x-pack/plugins/maps/server/maps_telemetry/maps_telemetry.test.js
+++ b/x-pack/plugins/maps/server/maps_telemetry/maps_telemetry.test.js
@@ -54,18 +54,30 @@ jest.mock('../kibana_server_services', () => {
     },
   };
   return {
-    getIndexPatternsService() {
+    getSavedObjectClient: () => {
+      return {}
+    },
+    getElasticsearch: () => {
       return {
-        async get(x) {
-          return x === testAggIndexPatternId ? testAggIndexPattern : testIndexPatterns[x];
-        },
-        async getIds() {
-          return Object.values(testIndexPatterns).map((x) => x.id);
-        },
-        async getFieldsForIndexPattern(x) {
-          return x.fields;
-        },
-      };
+        client: {
+          asInternalUser: {}
+        }
+      }
+    },
+    getIndexPatternsServiceFactory() {
+      return function() {
+        return {
+          async get(x) {
+            return x === testAggIndexPatternId ? testAggIndexPattern : testIndexPatterns[x];
+          },
+          async getIds() {
+            return Object.values(testIndexPatterns).map((x) => x.id);
+          },
+          async getFieldsForIndexPattern(x) {
+            return x.fields;
+          },
+        };
+      }
     },
   };
 });

--- a/x-pack/plugins/maps/server/maps_telemetry/maps_telemetry.test.js
+++ b/x-pack/plugins/maps/server/maps_telemetry/maps_telemetry.test.js
@@ -55,17 +55,17 @@ jest.mock('../kibana_server_services', () => {
   };
   return {
     getSavedObjectClient: () => {
-      return {}
+      return {};
     },
     getElasticsearch: () => {
       return {
         client: {
-          asInternalUser: {}
-        }
-      }
+          asInternalUser: {},
+        },
+      };
     },
     getIndexPatternsServiceFactory() {
-      return function() {
+      return function () {
         return {
           async get(x) {
             return x === testAggIndexPatternId ? testAggIndexPattern : testIndexPatterns[x];
@@ -77,7 +77,7 @@ jest.mock('../kibana_server_services', () => {
             return x.fields;
           },
         };
-      }
+      };
     },
   };
 });

--- a/x-pack/plugins/maps/server/maps_telemetry/maps_telemetry.ts
+++ b/x-pack/plugins/maps/server/maps_telemetry/maps_telemetry.ts
@@ -22,7 +22,11 @@ import {
   LayerDescriptor,
 } from '../../common/descriptor_types';
 import { MapSavedObject, MapSavedObjectAttributes } from '../../common/map_saved_object_type';
-import { getElasticsearch, getIndexPatternsServiceFactory, getSavedObjectClient } from '../kibana_server_services';
+import {
+  getElasticsearch,
+  getIndexPatternsServiceFactory,
+  getSavedObjectClient,
+} from '../kibana_server_services';
 import { injectReferences } from '././../../common/migrations/references';
 import {
   getBaseMapsPerCluster,
@@ -42,7 +46,7 @@ async function getIndexPatternsService() {
   const factory = getIndexPatternsServiceFactory();
   return factory(
     new SavedObjectsClient(getSavedObjectClient()),
-    getElasticsearch().client.asInternalUser,
+    getElasticsearch().client.asInternalUser
   );
 }
 

--- a/x-pack/plugins/maps/server/maps_telemetry/maps_telemetry.ts
+++ b/x-pack/plugins/maps/server/maps_telemetry/maps_telemetry.ts
@@ -22,7 +22,7 @@ import {
   LayerDescriptor,
 } from '../../common/descriptor_types';
 import { MapSavedObject, MapSavedObjectAttributes } from '../../common/map_saved_object_type';
-import { getIndexPatternsService, getInternalRepository } from '../kibana_server_services';
+import { getElasticsearch, getIndexPatternsServiceFactory, getSavedObjectClient } from '../kibana_server_services';
 import { injectReferences } from '././../../common/migrations/references';
 import {
   getBaseMapsPerCluster,
@@ -36,6 +36,15 @@ import {
   TELEMETRY_SCALING_OPTION_COUNTS_PER_CLUSTER,
   TELEMETRY_TERM_JOIN_COUNTS_PER_CLUSTER,
 } from './util';
+import { SavedObjectsClient } from '../../../../../src/core/server';
+
+async function getIndexPatternsService() {
+  const factory = getIndexPatternsServiceFactory();
+  return factory(
+    new SavedObjectsClient(getSavedObjectClient()),
+    getElasticsearch().client.asInternalUser,
+  );
+}
 
 interface IStats {
   [key: string]: {
@@ -302,7 +311,7 @@ export async function execTransformOverMultipleSavedObjectPages<T>(
   savedObjectType: string,
   transform: (savedObjects: Array<SavedObject<T>>) => void
 ) {
-  const savedObjectsClient = getInternalRepository();
+  const savedObjectsClient = getSavedObjectClient();
 
   let currentPage = 1;
   // Seed values

--- a/x-pack/plugins/maps/server/plugin.ts
+++ b/x-pack/plugins/maps/server/plugin.ts
@@ -25,8 +25,7 @@ import { registerMapsUsageCollector } from './maps_telemetry/collectors/register
 import { APP_ID, APP_ICON, MAP_SAVED_OBJECT_TYPE, getFullPath } from '../common/constants';
 import { mapSavedObjects, mapsTelemetrySavedObjects } from './saved_objects';
 import { MapsXPackConfig } from '../config';
-// @ts-ignore
-import { setIndexPatternsService, setInternalRepository } from './kibana_server_services';
+import { setStartServices } from './kibana_server_services';
 import { UsageCollectionSetup } from '../../../../src/plugins/usage_collection/server';
 import { emsBoundariesSpecProvider } from './tutorials/ems';
 // @ts-ignore
@@ -160,7 +159,6 @@ export class MapsPlugin implements Plugin {
     );
   }
 
-  // @ts-ignore
   setup(core: CoreSetup, plugins: SetupDeps) {
     const { usageCollection, home, licensing, features, mapsEms, customIntegrations } = plugins;
     const mapsEmsConfig = mapsEms.config;
@@ -230,12 +228,7 @@ export class MapsPlugin implements Plugin {
     };
   }
 
-  // @ts-ignore
   start(core: CoreStart, plugins: StartDeps) {
-    setInternalRepository(core.savedObjects.createInternalRepository);
-    setIndexPatternsService(
-      plugins.data.indexPatterns.indexPatternsServiceFactory,
-      core.elasticsearch.client.asInternalUser
-    );
+    setStartServices(core, plugins);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/119651

https://github.com/elastic/kibana/pull/118480 has merged. This PR highlighted that the current way of getting an indexPatternService in maps/server plugin is error prone. indexPatternService usage requires care as to the elasticsearch client (interanl vs user)and whether request is needed (read vs write).

To prevent misuse of a shared indexPatternService, this PR updates kiana_server_services to replace getIndexPatternsService with getters for the parts needed to create indexPatternService. Then consumers of getIndexPatternsService can create their own instances as needed to avoid problems outlined above