### PR TITLE
[Security Solutions] Removes tech debt of exporting all from linter rule for lists plugin

### DIFF
--- a/x-pack/plugins/lists/public/index.ts
+++ b/x-pack/plugins/lists/public/index.ts
@@ -5,10 +5,8 @@
  * 2.0.
  */
 
-// TODO: https://github.com/elastic/kibana/issues/110903
-/* eslint-disable @kbn/eslint/no_export_all */
-
-export * from './shared_exports';
+export { getExceptionBuilderComponentLazy } from './exceptions/components/builder/index';
+export type { OnChangeProps } from './exceptions/components/builder/index';
 
 import type { PluginInitializerContext } from '../../../../src/core/public';
 

--- a/x-pack/plugins/security/common/licensing/index.mock.ts
+++ b/x-pack/plugins/security/common/licensing/index.mock.ts
@@ -7,10 +7,8 @@
 
 import { of } from 'rxjs';
 
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { LICENSE_TYPE } from '../../../licensing/server';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import type { LicenseType } from '../../../licensing/server';
+import type { LicenseType } from '../../../licensing/common/types';
+import { LICENSE_TYPE } from '../../../licensing/common/types';
 import type { SecurityLicenseFeatures } from './license_features';
 import type { SecurityLicense } from './license_service';
 

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
@@ -38,8 +38,7 @@ import {
   isThresholdRule,
 } from '../../../../../common/detection_engine/utils';
 import { Status } from '../../../../../common/detection_engine/schemas/common/schemas';
-import { ExceptionBuilder } from '../../../../../public/shared_imports';
-
+import { getExceptionBuilderComponentLazy } from '../../../../../../lists/public';
 import * as i18nCommon from '../../../translations';
 import * as i18n from './translations';
 import * as sharedI18n from '../translations';
@@ -475,7 +474,7 @@ export const AddExceptionModal = memo(function AddExceptionModal({
                   <EuiSpacer size="l" />
                 </>
               )}
-              {ExceptionBuilder.getExceptionBuilderComponentLazy({
+              {getExceptionBuilderComponentLazy({
                 allowLargeValueLists:
                   !isEqlRule(maybeRule?.type) && !isThresholdRule(maybeRule?.type),
                 httpService: http,

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.test.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../../../../common/detection_engine/schemas/response/rules_schema.mocks';
 import { useRuleAsync } from '../../../../detections/containers/detection_engine/rules/use_rule_async';
 import { getMockTheme } from '../../../lib/kibana/kibana_react.mock';
-import { ExceptionBuilder } from '../../../../shared_imports';
+import { getExceptionBuilderComponentLazy } from '../../../../../../lists/public';
 
 const mockTheme = getMockTheme({
   eui: {
@@ -44,39 +44,31 @@ jest.mock('../../../containers/source');
 jest.mock('../use_fetch_or_create_rule_exception_list');
 jest.mock('../../../../detections/containers/detection_engine/alerts/use_signal_index');
 jest.mock('../../../../detections/containers/detection_engine/rules/use_rule_async');
-jest.mock('../../../../shared_imports', () => {
-  const originalModule = jest.requireActual('../../../../shared_imports');
-  const emptyComp = <span data-test-subj="edit-exception-modal-builder" />;
-  return {
-    ...originalModule,
-    ExceptionBuilder: {
-      getExceptionBuilderComponentLazy: () => emptyComp,
-    },
-  };
-});
+jest.mock('../../../../../../lists/public');
+
+const mockGetExceptionBuilderComponentLazy = getExceptionBuilderComponentLazy as jest.Mock<
+  ReturnType<typeof getExceptionBuilderComponentLazy>
+>;
+const mockUseSignalIndex = useSignalIndex as jest.Mock<Partial<ReturnType<typeof useSignalIndex>>>;
+const mockUseAddOrUpdateException = useAddOrUpdateException as jest.Mock<
+  ReturnType<typeof useAddOrUpdateException>
+>;
+const mockUseFetchIndex = useFetchIndex as jest.Mock;
+const mockUseCurrentUser = useCurrentUser as jest.Mock<Partial<ReturnType<typeof useCurrentUser>>>;
+const mockUseRuleAsync = useRuleAsync as jest.Mock;
 
 describe('When the edit exception modal is opened', () => {
   const ruleName = 'test rule';
 
-  let ExceptionBuilderComponent: jest.SpyInstance<
-    ReturnType<typeof ExceptionBuilder.getExceptionBuilderComponentLazy>
-  >;
-
   beforeEach(() => {
     const emptyComp = <span data-test-subj="edit-exception-modal-builder" />;
-    ExceptionBuilderComponent = jest
-      .spyOn(ExceptionBuilder, 'getExceptionBuilderComponentLazy')
-      .mockReturnValue(emptyComp);
-
-    (useSignalIndex as jest.Mock).mockReturnValue({
+    mockGetExceptionBuilderComponentLazy.mockReturnValue(emptyComp);
+    mockUseSignalIndex.mockReturnValue({
       loading: false,
       signalIndexName: 'test-signal',
     });
-    (useAddOrUpdateException as jest.Mock).mockImplementation(() => [
-      { isLoading: false },
-      jest.fn(),
-    ]);
-    (useFetchIndex as jest.Mock).mockImplementation(() => [
+    mockUseAddOrUpdateException.mockImplementation(() => [{ isLoading: false }, jest.fn()]);
+    mockUseFetchIndex.mockImplementation(() => [
       false,
       {
         indexPatterns: createStubIndexPattern({
@@ -96,8 +88,8 @@ describe('When the edit exception modal is opened', () => {
         }),
       },
     ]);
-    (useCurrentUser as jest.Mock).mockReturnValue({ username: 'test-username' });
-    (useRuleAsync as jest.Mock).mockImplementation(() => ({
+    mockUseCurrentUser.mockReturnValue({ username: 'test-username' });
+    mockUseRuleAsync.mockImplementation(() => ({
       rule: getRulesSchemaMock(),
     }));
   });
@@ -109,7 +101,7 @@ describe('When the edit exception modal is opened', () => {
 
   describe('when the modal is loading', () => {
     it('renders the loading spinner', async () => {
-      (useFetchIndex as jest.Mock).mockImplementation(() => [
+      mockUseFetchIndex.mockImplementation(() => [
         true,
         {
           indexPatterns: stubIndexPattern,
@@ -157,7 +149,7 @@ describe('When the edit exception modal is opened', () => {
             />
           </ThemeProvider>
         );
-        const callProps = ExceptionBuilderComponent.mock.calls[0][0];
+        const callProps = mockGetExceptionBuilderComponentLazy.mock.calls[0][0];
         await waitFor(() => {
           callProps.onChange({ exceptionItems: [...callProps.exceptionListItems] });
         });
@@ -202,7 +194,7 @@ describe('When the edit exception modal is opened', () => {
             />
           </ThemeProvider>
         );
-        const callProps = ExceptionBuilderComponent.mock.calls[0][0];
+        const callProps = mockGetExceptionBuilderComponentLazy.mock.calls[0][0];
         await waitFor(() => {
           callProps.onChange({ exceptionItems: [...callProps.exceptionListItems] });
         });
@@ -255,7 +247,7 @@ describe('When the edit exception modal is opened', () => {
           />
         </ThemeProvider>
       );
-      const callProps = ExceptionBuilderComponent.mock.calls[0][0];
+      const callProps = (getExceptionBuilderComponentLazy as jest.Mock).mock.calls[0][0];
       await waitFor(() => {
         callProps.onChange({ exceptionItems: [...callProps.exceptionListItems] });
       });
@@ -299,7 +291,7 @@ describe('When the edit exception modal is opened', () => {
           />
         </ThemeProvider>
       );
-      const callProps = ExceptionBuilderComponent.mock.calls[0][0];
+      const callProps = mockGetExceptionBuilderComponentLazy.mock.calls[0][0];
       await waitFor(() => {
         callProps.onChange({ exceptionItems: [...callProps.exceptionListItems] });
       });
@@ -344,7 +336,7 @@ describe('When the edit exception modal is opened', () => {
           />
         </ThemeProvider>
       );
-      const callProps = ExceptionBuilderComponent.mock.calls[0][0];
+      const callProps = mockGetExceptionBuilderComponentLazy.mock.calls[0][0];
       await waitFor(() => {
         callProps.onChange({ exceptionItems: [...callProps.exceptionListItems] });
       });
@@ -380,7 +372,7 @@ describe('When the edit exception modal is opened', () => {
         />
       </ThemeProvider>
     );
-    const callProps = ExceptionBuilderComponent.mock.calls[0][0];
+    const callProps = mockGetExceptionBuilderComponentLazy.mock.calls[0][0];
     await waitFor(() => callProps.onChange({ exceptionItems: [], errorExists: true }));
 
     expect(

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
@@ -37,7 +37,7 @@ import {
 import { useFetchIndex } from '../../../containers/source';
 import { useSignalIndex } from '../../../../detections/containers/detection_engine/alerts/use_signal_index';
 import { useRuleAsync } from '../../../../detections/containers/detection_engine/rules/use_rule_async';
-import { ExceptionBuilder } from '../../../../../public/shared_imports';
+import { getExceptionBuilderComponentLazy } from '../../../../../../lists/public';
 
 import * as i18n from './translations';
 import * as sharedI18n from '../translations';
@@ -344,7 +344,7 @@ export const EditExceptionModal = memo(function EditExceptionModal({
                   <EuiSpacer />
                 </>
               )}
-              {ExceptionBuilder.getExceptionBuilderComponentLazy({
+              {getExceptionBuilderComponentLazy({
                 allowLargeValueLists:
                   !isEqlRule(maybeRule?.type) && !isThresholdRule(maybeRule?.type),
                 httpService: http,

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
@@ -30,8 +30,8 @@ import { Loader } from '../../../../../../common/components/loader';
 import { useKibana } from '../../../../../../common/lib/kibana';
 import { useFetchIndex } from '../../../../../../common/containers/source';
 import { AppAction } from '../../../../../../common/store/actions';
-import { ExceptionBuilder } from '../../../../../../shared_imports';
-
+import { getExceptionBuilderComponentLazy } from '../../../../../../../../lists/public';
+import type { OnChangeProps } from '../../../../../../../../lists/public';
 import { useEventFiltersSelector } from '../../hooks';
 import { getFormEntryStateMutable, getHasNameError, getNewComment } from '../../../store/selector';
 import { NAME_LABEL, NAME_ERROR, NAME_PLACEHOLDER, OS_LABEL, RULE_NAME } from './translations';
@@ -67,7 +67,7 @@ export const EventFiltersForm: React.FC<EventFiltersFormProps> = memo(
     );
 
     const handleOnBuilderChange = useCallback(
-      (arg: ExceptionBuilder.OnChangeProps) => {
+      (arg: OnChangeProps) => {
         dispatch({
           type: 'eventFiltersChangeForm',
           payload: {
@@ -121,7 +121,7 @@ export const EventFiltersForm: React.FC<EventFiltersFormProps> = memo(
 
     const exceptionBuilderComponentMemo = useMemo(
       () =>
-        ExceptionBuilder.getExceptionBuilderComponentLazy({
+        getExceptionBuilderComponentLazy({
           allowLargeValueLists: false,
           httpService: http,
           autocompleteService: data.autocomplete,

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -10,7 +10,7 @@ import reduceReducers from 'reduce-reducers';
 import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 import { pluck } from 'rxjs/operators';
 import { AnyAction, Reducer } from 'redux';
-import {
+import type {
   PluginSetup,
   PluginStart,
   SetupPlugins,

--- a/x-pack/plugins/security_solution/public/shared_imports.ts
+++ b/x-pack/plugins/security_solution/public/shared_imports.ts
@@ -30,5 +30,3 @@ export {
 export { Field, SelectField } from '../../../../src/plugins/es_ui_shared/static/forms/components';
 export { fieldValidators } from '../../../../src/plugins/es_ui_shared/static/forms/helpers';
 export type { ERROR_CODE } from '../../../../src/plugins/es_ui_shared/static/forms/helpers/field_validators/types';
-
-export { ExceptionBuilder } from '../../lists/public';

--- a/x-pack/plugins/security_solution/public/types.ts
+++ b/x-pack/plugins/security_solution/public/types.ts
@@ -5,43 +5,43 @@
  * 2.0.
  */
 
-import { CoreStart } from '../../../../src/core/public';
-import { HomePublicPluginSetup } from '../../../../src/plugins/home/public';
+import type { CoreStart } from '../../../../src/core/public';
+import type { HomePublicPluginSetup } from '../../../../src/plugins/home/public';
 import type { DataPublicPluginStart } from '../../../../src/plugins/data/public';
-import { EmbeddableStart } from '../../../../src/plugins/embeddable/public';
-import { LensPublicStart } from '../../../plugins/lens/public';
-import { NewsfeedPublicPluginStart } from '../../../../src/plugins/newsfeed/public';
-import { Start as InspectorStart } from '../../../../src/plugins/inspector/public';
-import { UiActionsStart } from '../../../../src/plugins/ui_actions/public';
-import { UsageCollectionSetup } from '../../../../src/plugins/usage_collection/public';
-import { Storage } from '../../../../src/plugins/kibana_utils/public';
-import { FleetStart } from '../../fleet/public';
-import { PluginStart as ListsPluginStart } from '../../lists/public';
-import { SpacesPluginStart } from '../../spaces/public';
-import {
+import type { EmbeddableStart } from '../../../../src/plugins/embeddable/public';
+import type { LensPublicStart } from '../../../plugins/lens/public';
+import type { NewsfeedPublicPluginStart } from '../../../../src/plugins/newsfeed/public';
+import type { Start as InspectorStart } from '../../../../src/plugins/inspector/public';
+import type { UiActionsStart } from '../../../../src/plugins/ui_actions/public';
+import type { UsageCollectionSetup } from '../../../../src/plugins/usage_collection/public';
+import type { Storage } from '../../../../src/plugins/kibana_utils/public';
+import type { FleetStart } from '../../fleet/public';
+import type { PluginStart as ListsPluginStart } from '../../lists/public';
+import type { SpacesPluginStart } from '../../spaces/public';
+import type {
   TriggersAndActionsUIPublicPluginSetup as TriggersActionsSetup,
   TriggersAndActionsUIPublicPluginStart as TriggersActionsStart,
 } from '../../triggers_actions_ui/public';
-import { CasesUiStart } from '../../cases/public';
-import { SecurityPluginSetup } from '../../security/public';
-import { TimelinesUIStart } from '../../timelines/public';
-import { ResolverPluginSetup } from './resolver/types';
-import { Inspect } from '../common/search_strategy';
-import { MlPluginSetup, MlPluginStart } from '../../ml/public';
+import type { CasesUiStart } from '../../cases/public';
+import type { SecurityPluginSetup } from '../../security/public';
+import type { TimelinesUIStart } from '../../timelines/public';
+import type { ResolverPluginSetup } from './resolver/types';
+import type { Inspect } from '../common/search_strategy';
+import type { MlPluginSetup, MlPluginStart } from '../../ml/public';
 
-import { Detections } from './detections';
-import { Cases } from './cases';
-import { Exceptions } from './exceptions';
-import { Hosts } from './hosts';
-import { Network } from './network';
-import { Overview } from './overview';
-import { Rules } from './rules';
-import { Timelines } from './timelines';
-import { Management } from './management';
-import { Ueba } from './ueba';
-import { LicensingPluginStart, LicensingPluginSetup } from '../../licensing/public';
-import { DashboardStart } from '../../../../src/plugins/dashboard/public';
-import { IndexPatternFieldEditorStart } from '../../../../src/plugins/data_view_field_editor/public';
+import type { Detections } from './detections';
+import type { Cases } from './cases';
+import type { Exceptions } from './exceptions';
+import type { Hosts } from './hosts';
+import type { Network } from './network';
+import type { Overview } from './overview';
+import type { Rules } from './rules';
+import type { Timelines } from './timelines';
+import type { Management } from './management';
+import type { Ueba } from './ueba';
+import type { LicensingPluginStart, LicensingPluginSetup } from '../../licensing/public';
+import type { DashboardStart } from '../../../../src/plugins/dashboard/public';
+import type { IndexPatternFieldEditorStart } from '../../../../src/plugins/data_view_field_editor/public';
 
 export interface SetupPlugins {
   home?: HomePublicPluginSetup;


### PR DESCRIPTION
## Summary

See: https://github.com/elastic/kibana/issues/110903

This removes the `export *` from:
* lists plugin

This also adds `import type` and `export type` in a few areas and fixes the `LicenseType` by changing it from `server` to using the version from `common` to remove the restricted paths. This extra addition prevents more memory leaks when we run jest.
