### PR TITLE
[8.0] chore(NA): use internal pkg_npm on @kbn/babel-preset (#120123)

### DIFF
--- a/packages/kbn-babel-preset/BUILD.bazel
+++ b/packages/kbn-babel-preset/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//src/dev/bazel:index.bzl", "pkg_npm")
 
 PKG_BASE_NAME = "kbn-babel-preset"
 PKG_REQUIRE_NAME = "@kbn/babel-preset"
@@ -24,7 +25,7 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md",
 ]
 
-DEPS = [
+RUNTIME_DEPS = [
   "@npm//@babel/plugin-proposal-class-properties",
   "@npm//@babel/plugin-proposal-export-namespace-from",
   "@npm//@babel/plugin-proposal-nullish-coalescing-operator",
@@ -46,7 +47,7 @@ js_library(
   srcs = NPM_MODULE_EXTRA_FILES + [
     ":srcs",
   ],
-  deps = DEPS,
+  deps = RUNTIME_DEPS,
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-ui-shared-deps-src/BUILD.bazel
+++ b/packages/kbn-ui-shared-deps-src/BUILD.bazel
@@ -45,7 +45,6 @@ TYPES_DEPS = [
   "//packages/elastic-datemath:npm_module_types",
   "//packages/elastic-safer-lodash-set",
   "//packages/kbn-analytics:npm_module_types",
-  "//packages/kbn-babel-preset",
   "//packages/kbn-i18n:npm_module_types",
   "//packages/kbn-i18n-react:npm_module_types",
   "//packages/kbn-monaco",


### PR DESCRIPTION
Backports the following commits to 8.0:
 - chore(NA): use internal pkg_npm on @kbn/babel-preset (#120123)