### PR TITLE
[Visualize] Fixes wrong display of split warning callout

### DIFF
--- a/src/plugins/visualize/public/application/components/visualize_editor_common.test.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_editor_common.test.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { shallowWithIntl, mountWithIntl } from '@kbn/test/jest';
 import { VisualizeEditorCommon } from './visualize_editor_common';
 import { VisualizeEditorVisInstance } from '../types';
+import { SplitChartWarning } from './split_chart_warning';
 
 const mockGetLegacyUrlConflict = jest.fn();
 const mockRedirectLegacyUrl = jest.fn(() => Promise.resolve());
@@ -114,5 +115,87 @@ describe('VisualizeEditorCommon', () => {
       '#/edit/alias_id?_g=test',
       'TSVB visualization'
     );
+  });
+
+  it('should display a warning callout for new heatmap implementation with split aggs', async () => {
+    const wrapper = shallowWithIntl(
+      <VisualizeEditorCommon
+        appState={null}
+        hasUnsavedChanges={false}
+        setHasUnsavedChanges={() => {}}
+        hasUnappliedChanges={false}
+        isEmbeddableRendered={false}
+        onAppLeave={() => {}}
+        visEditorRef={React.createRef()}
+        visInstance={
+          {
+            savedVis: {
+              id: 'test',
+              sharingSavedObjectProps: {
+                outcome: 'conflict',
+                aliasTargetId: 'alias_id',
+              },
+            },
+            vis: {
+              type: {
+                title: 'Heatmap',
+                name: 'heatmap',
+              },
+              data: {
+                aggs: {
+                  aggs: [
+                    {
+                      schema: 'split',
+                    },
+                  ],
+                },
+              },
+            },
+          } as unknown as VisualizeEditorVisInstance
+        }
+      />
+    );
+    expect(wrapper.find(SplitChartWarning).length).toBe(1);
+  });
+
+  it('should not display a warning callout for XY charts with split aggs', async () => {
+    const wrapper = shallowWithIntl(
+      <VisualizeEditorCommon
+        appState={null}
+        hasUnsavedChanges={false}
+        setHasUnsavedChanges={() => {}}
+        hasUnappliedChanges={false}
+        isEmbeddableRendered={false}
+        onAppLeave={() => {}}
+        visEditorRef={React.createRef()}
+        visInstance={
+          {
+            savedVis: {
+              id: 'test',
+              sharingSavedObjectProps: {
+                outcome: 'conflict',
+                aliasTargetId: 'alias_id',
+              },
+            },
+            vis: {
+              type: {
+                title: 'XY',
+                name: 'line',
+              },
+              data: {
+                aggs: {
+                  aggs: [
+                    {
+                      schema: 'split',
+                    },
+                  ],
+                },
+              },
+            },
+          } as unknown as VisualizeEditorVisInstance
+        }
+      />
+    );
+    expect(wrapper.find(SplitChartWarning).length).toBe(0);
   });
 });

--- a/src/plugins/visualize/public/application/components/visualize_editor_common.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_editor_common.tsx
@@ -134,7 +134,9 @@ export const VisualizeEditorCommon = ({
         />
       )}
       {visInstance?.vis?.type?.stage === 'experimental' && <ExperimentalVisInfo />}
-      {!hasHeatmapLegacyhartsEnabled && isSplitChart && <SplitChartWarning />}
+      {!hasHeatmapLegacyhartsEnabled &&
+        isSplitChart &&
+        visInstance?.vis.type.name === 'heatmap' && <SplitChartWarning />}
       {visInstance?.vis?.type?.getInfoMessage?.(visInstance.vis)}
       {getLegacyUrlConflictCallout()}
       {visInstance && (


### PR DESCRIPTION
## Summary

The new heatmap implementation doesn't allow small multiples. For this reason we added a notification to all these heatmaps that have been created with the split chart aggregation and are using the new implementation. I had forgotten to check by the vis type (`heatmap`) and it was been displayed to all other visualizations (pie, xy) if they were using the split charts bucket. 

This PR fixes it.

**Before**
![image](https://user-images.githubusercontent.com/17003240/144402264-101068b9-c4e8-42f0-8ef8-82502a6f67fe.png)
**After**:
![image](https://user-images.githubusercontent.com/17003240/144402327-b383caff-d2f2-4e32-8adc-3224bab2941e.png)


### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios