### PR TITLE
[DOCS] Fix description of monitoring.cluster_alerts.allowedSpaces

### DIFF
--- a/docs/settings/spaces-settings.asciidoc
+++ b/docs/settings/spaces-settings.asciidoc
@@ -14,9 +14,6 @@ configure this setting lower than the `index.max_result_window` in {es}.
 The default is `1000`.
 
 `monitoring.cluster_alerts.allowedSpaces` {ess-icon}:: 
-Specifies the spaces where cluster alerts are automatically generated. 
-You must specify all spaces where you want to generate alerts, including the default space. 
-When the default space is unspecified, {kib} is unable to generate an alert for the default space.
-{es} clusters that run on {es} services are all containers. To send monitoring data 
-from your self-managed {es} installation to {es} services, set to `false`. 
-The default is `true`.
+Specifies the spaces where cluster Stack Monitoring alerts can be created.
+You must specify all spaces where you want to generate alerts, including the default space.
+The default is `[ "default" ]`


### PR DESCRIPTION
## Summary

Proposed fix of the description of `monitoring.cluster_alerts.allowedSpaces`.
I also might suggest to move it to the Monitoring documentation page instead of the Spaces.

Once we define the description, we should amend also https://www.elastic.co/guide/en/cloud/current/ec-manage-kibana-settings.html

### For maintainers

- [ ] Check the description.
- [ ] Agree/disagree about the location of the documentation.