### PR TITLE
[7.16] [APM][Fleet] deprecation warning is not showing up (#119381)

### DIFF
--- a/x-pack/plugins/apm/server/deprecations/deprecations.test.ts
+++ b/x-pack/plugins/apm/server/deprecations/deprecations.test.ts
@@ -48,7 +48,13 @@ describe('getDeprecations', () => {
         cloudSetup: { isCloudEnabled: true } as unknown as CloudSetup,
         fleet: {
           start: () => ({
-            agentPolicyService: { get: () => ({ id: 'foo' } as AgentPolicy) },
+            agentPolicyService: {
+              get: () =>
+                ({
+                  id: 'foo',
+                  package_policies: [{ package: { name: 'apm' } }],
+                } as AgentPolicy),
+            },
           }),
         } as unknown as APMRouteHandlerResources['plugins']['fleet'],
       });

--- a/x-pack/plugins/apm/server/deprecations/index.ts
+++ b/x-pack/plugins/apm/server/deprecations/index.ts
@@ -9,7 +9,7 @@ import { GetDeprecationsContext, DeprecationsDetails } from 'src/core/server';
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
 import { CloudSetup } from '../../../cloud/server';
-import { getCloudAgentPolicy } from '../lib/fleet/get_cloud_apm_package_policy';
+import { getCloudAgentPolicy, getApmPackagePolicy } from '../lib/fleet/get_cloud_apm_package_policy';
 import { APMRouteHandlerResources } from '../';
 
 export function getDeprecations({
@@ -36,10 +36,12 @@ export function getDeprecations({
     });
 
     const isCloudEnabled = !!cloudSetup?.isCloudEnabled;
+    const hasAPMPackagePolicy = !isEmpty(getApmPackagePolicy(cloudAgentPolicy));
 
-    const hasCloudAgentPolicy = !isEmpty(cloudAgentPolicy);
+    // TODO: remove when docs support "main"
+    const docBranch = branch === 'main' ? 'master' : branch;
 
-    if (isCloudEnabled && !hasCloudAgentPolicy) {
+    if (isCloudEnabled && !hasAPMPackagePolicy) {
       deprecations.push({
         title: i18n.translate('xpack.apm.deprecations.legacyModeTitle', {
           defaultMessage: 'APM Server running in legacy mode',
@@ -48,7 +50,7 @@ export function getDeprecations({
           defaultMessage:
             'Running the APM Server binary directly is considered a legacy option and is deprecated since 7.16. Switch to APM Server managed by an Elastic Agent instead. Read our documentation to learn more.',
         }),
-        documentationUrl: `https://www.elastic.co/guide/en/apm/server/${branch}/apm-integration.html`,
+        documentationUrl: `https://www.elastic.co/guide/en/apm/server/${docBranch}/apm-integration.html`,
         level: 'warning',
         correctiveActions: {
           manualSteps: [

--- a/x-pack/plugins/apm/server/deprecations/index.ts
+++ b/x-pack/plugins/apm/server/deprecations/index.ts
@@ -9,7 +9,10 @@ import { GetDeprecationsContext, DeprecationsDetails } from 'src/core/server';
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
 import { CloudSetup } from '../../../cloud/server';
-import { getCloudAgentPolicy, getApmPackagePolicy } from '../lib/fleet/get_cloud_apm_package_policy';
+import {
+  getCloudAgentPolicy,
+  getApmPackagePolicy,
+} from '../lib/fleet/get_cloud_apm_package_policy';
 import { APMRouteHandlerResources } from '../';
 
 export function getDeprecations({


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [APM][Fleet] deprecation warning is not showing up (#119381)