### PR TITLE
[Workplace Search] fix overview page spacing

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -257,6 +257,7 @@ export const Overview: React.FC = () => {
 
   const groupsSummary = (
     <>
+      <EuiSpacer />
       <EuiTitle size="xs">
         <h5>{GROUP_ACCESS_TITLE}</h5>
       </EuiTitle>
@@ -479,7 +480,6 @@ export const Overview: React.FC = () => {
 
   const syncTriggerCallout = (
     <EuiFlexItem>
-      <EuiSpacer />
       <EuiTitle size="xs">
         <h5>{SOURCE_SYNCHRONIZATION_TITLE}</h5>
       </EuiTitle>


### PR DESCRIPTION
## Summary

This PR fixes the spacing for the right column on the source overview page. I found a missing `<EuiSpacer />` in the `groupsSummary` area and an extra `<EuiSpacer />` in the `syncTriggerCallout` area.

| before | after |
|-|-|
| <img width="1462" alt="Screenshot 2021-12-02 at 2 19 50 pm" src="https://user-images.githubusercontent.com/7115017/144441503-e925e017-ce6e-47dc-9156-b5e628f72cbb.png"> | <img width="1463" alt="Screenshot 2021-12-02 at 2 18 17 pm" src="https://user-images.githubusercontent.com/7115017/144441487-3c92222b-38db-48c8-8551-c3e6c0446c69.png"> |

### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
