### PR TITLE
[Lens] allow visualization errors dependant on activeData

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/add_layer.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/add_layer.tsx
@@ -23,7 +23,7 @@ interface AddLayerButtonProps {
   visualization: Visualization;
   visualizationState: unknown;
   onAddLayerClick: (layerType: LayerType) => void;
-  layersMeta: Pick<FramePublicAPI, 'datasourceLayers' | 'activeData'>;
+  layersMeta: FramePublicAPI;
 }
 
 export function getLayerType(visualization: Visualization, state: unknown, layerId: string) {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/state_helpers.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/state_helpers.ts
@@ -187,7 +187,7 @@ export const validateDatasourceAndVisualization = (
   currentDatasourceState: unknown | null,
   currentVisualization: Visualization | null,
   currentVisualizationState: unknown | undefined,
-  frameAPI: Pick<FramePublicAPI, 'datasourceLayers'>
+  frameAPI: FramePublicAPI
 ): ErrorMessage[] | undefined => {
   const layersGroups = currentVisualizationState
     ? currentVisualization
@@ -210,7 +210,7 @@ export const validateDatasourceAndVisualization = (
     : undefined;
 
   const visualizationValidationErrors = currentVisualizationState
-    ? currentVisualization?.getErrorMessages(currentVisualizationState, frameAPI.datasourceLayers)
+    ? currentVisualization?.getErrorMessages(currentVisualizationState, frameAPI)
     : undefined;
 
   if (datasourceValidationErrors?.length || visualizationValidationErrors?.length) {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -53,7 +53,6 @@ import {
   selectIsFullscreenDatasource,
   selectSearchSessionId,
   selectActiveDatasourceId,
-  selectActiveData,
   selectDatasourceStates,
 } from '../../state_management';
 
@@ -185,7 +184,6 @@ export function SuggestionPanel({
 }: SuggestionPanelProps) {
   const dispatchLens = useLensDispatch();
   const activeDatasourceId = useLensSelector(selectActiveDatasourceId);
-  const activeData = useLensSelector(selectActiveData);
   const datasourceStates = useLensSelector(selectDatasourceStates);
   const existsStagedPreview = useLensSelector((state) => Boolean(state.lens.stagedPreview));
   const currentVisualization = useLensSelector(selectCurrentVisualization);
@@ -215,7 +213,7 @@ export function SuggestionPanel({
             ? visualizationMap[currentVisualization.activeId]
             : undefined,
           visualizationState: currentVisualization.state,
-          activeData,
+          activeData: frame.activeData,
         })
           .filter(
             ({
@@ -273,14 +271,15 @@ export function SuggestionPanel({
       currentStateExpression: newStateExpression,
       currentStateError: validationErrors,
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    frame,
     currentDatasourceStates,
     currentVisualization.state,
     currentVisualization.activeId,
     activeDatasourceId,
     datasourceMap,
     visualizationMap,
+    missingIndexPatterns.length,
   ]);
 
   const context: ExecutionContextSearch = useLensSelector(selectExecutionContextSearch);

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -132,7 +132,6 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   const activeDatasourceId = useLensSelector(selectActiveDatasourceId);
   const datasourceStates = useLensSelector(selectDatasourceStates);
 
-  const { datasourceLayers } = framePublicAPI;
   const [localState, setLocalState] = useState<WorkspaceState>({
     expressionBuildError: undefined,
     expandError: false,
@@ -175,8 +174,14 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
         visualization.state,
         framePublicAPI
       ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [activeVisualization, visualization.state, activeDatasourceId, datasourceMap, datasourceStates]
+    [
+      framePublicAPI,
+      activeVisualization,
+      visualization.state,
+      activeDatasourceId,
+      datasourceMap,
+      datasourceStates,
+    ]
   );
 
   const expression = useMemo(() => {
@@ -187,7 +192,7 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
           visualizationState: visualization.state,
           datasourceMap,
           datasourceStates,
-          datasourceLayers,
+          datasourceLayers: framePublicAPI.datasourceLayers,
         });
 
         if (ast) {
@@ -199,7 +204,10 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
           return null;
         }
       } catch (e) {
-        const buildMessages = activeVisualization?.getErrorMessages(visualization.state);
+        const buildMessages = activeVisualization?.getErrorMessages(
+          visualization.state,
+          framePublicAPI
+        );
         const defaultMessage = {
           shortMessage: i18n.translate('xpack.lens.editorFrame.buildExpressionError', {
             defaultMessage: 'An unexpected error occurred while preparing the chart',
@@ -214,11 +222,11 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
       }
     }
   }, [
+    framePublicAPI,
     activeVisualization,
     visualization.state,
     datasourceMap,
     datasourceStates,
-    datasourceLayers,
     configurationValidationError?.length,
     missingRefsErrors.length,
   ]);
@@ -592,6 +600,8 @@ export const VisualizationWrapper = ({
     );
   }
 
+  console.log(localState)
+
   if (localState.expressionBuildError?.length) {
     const firstError = localState.expressionBuildError[0];
     return (
@@ -617,6 +627,7 @@ export const VisualizationWrapper = ({
       </EuiFlexGroup>
     );
   }
+  
 
   return (
     <div className="lnsExpressionRenderer">

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -55,7 +55,7 @@ export const makeConfigureStore = (
     middleware.push(
       createLogger({
         // @ts-ignore
-        predicate: () => window.ELASTIC_LENS_LOGGER,
+        // predicate: () => window.ELASTIC_LENS_LOGGER,
       })
     );
   }

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -435,7 +435,7 @@ export interface OperationMetadata {
 
 export interface VisualizationConfigProps<T = unknown> {
   layerId: string;
-  frame: Pick<FramePublicAPI, 'datasourceLayers' | 'activeData'>;
+  frame: FramePublicAPI;
   state: T;
 }
 
@@ -499,7 +499,7 @@ interface VisualizationDimensionChangeProps<T> {
   layerId: string;
   columnId: string;
   prevState: T;
-  frame: Pick<FramePublicAPI, 'datasourceLayers' | 'activeData'>;
+  frame: FramePublicAPI;
 }
 
 /**
@@ -657,7 +657,7 @@ export interface Visualization<T = unknown> {
   /** Retrieve a list of supported layer types with initialization data */
   getSupportedLayers: (
     state?: T,
-    frame?: Pick<FramePublicAPI, 'datasourceLayers' | 'activeData'>
+    frame?: FramePublicAPI
   ) => Array<{
     type: LayerType;
     label: string;
@@ -752,7 +752,7 @@ export interface Visualization<T = unknown> {
    */
   getErrorMessages: (
     state: T,
-    datasourceLayers?: Record<string, DatasourcePublicAPI>
+    frame?: FramePublicAPI
   ) =>
     | Array<{
         shortMessage: string;

--- a/x-pack/plugins/lens/public/xy_visualization/visualization.test.ts
+++ b/x-pack/plugins/lens/public/xy_visualization/visualization.test.ts
@@ -1460,7 +1460,7 @@ describe('xy_visualization', () => {
               },
             ],
           },
-          frame.datasourceLayers
+          frame
         )
       ).toEqual([
         {
@@ -1516,7 +1516,7 @@ describe('xy_visualization', () => {
               },
             ],
           },
-          datasourceLayers
+          { ...frame, datasourceLayers }
         )
       ).toEqual([
         {
@@ -1572,7 +1572,7 @@ describe('xy_visualization', () => {
               },
             ],
           },
-          datasourceLayers
+          { ...frame, datasourceLayers }
         )
       ).toEqual([
         {

--- a/x-pack/plugins/lens/public/xy_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/visualization.tsx
@@ -608,12 +608,20 @@ export const getXyVisualization = ({
     toExpression(state, layers, paletteService, attributes),
   toPreviewExpression: (state, layers) => toPreviewExpression(state, layers, paletteService),
 
-  getErrorMessages(state, datasourceLayers) {
+  getErrorMessages(state, frame) {
+    const { datasourceLayers } = frame || {};
     // Data error handling below here
     const hasNoAccessors = ({ accessors }: XYLayerConfig) =>
       accessors == null || accessors.length === 0;
     const hasNoSplitAccessor = ({ splitAccessor, seriesType }: XYLayerConfig) =>
       seriesType.includes('percentage') && splitAccessor == null;
+    if (
+      frame?.activeData?.['5c14c18d-f01c-4a4b-bd25-e67b04ad33a1']?.rows?.[0]?.[
+        '29c8b6ae-3452-4d8b-9ebd-61f0808878b8X0'
+      ] == 1
+    ) {
+      return [{ shortMessage: 'what', longMessage: 'omg static value 1' }];
+    }
 
     const errors: Array<{
       shortMessage: string;


### PR DESCRIPTION
## Summary

Needed to show an error for gauges min>max and min=== max. We want to make involved dimensions highlighted.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
