### PR TITLE
[Enterprise Search] Replace `EuiThemeProvider` with `KibanaThemeProvider`

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -16,8 +16,10 @@ import { Store } from 'redux';
 import { I18nProvider } from '@kbn/i18n-react';
 
 import { AppMountParameters, CoreStart } from '../../../../../src/core/public';
-import { EuiThemeProvider } from '../../../../../src/plugins/kibana_react/common';
-import { KibanaContextProvider } from '../../../../../src/plugins/kibana_react/public';
+import {
+  KibanaContextProvider,
+  KibanaThemeProvider,
+} from '../../../../../src/plugins/kibana_react/public';
 import { InitialAppData } from '../../common/types';
 import { PluginsStart, ClientConfigType, ClientData } from '../plugin';
 
@@ -70,7 +72,7 @@ export const renderApp = (
 
   ReactDOM.render(
     <I18nProvider>
-      <EuiThemeProvider>
+      <KibanaThemeProvider theme$={params.theme$}>
         <KibanaContextProvider services={{ ...core, ...plugins }}>
           <Provider store={store}>
             <Router history={params.history}>
@@ -79,7 +81,7 @@ export const renderApp = (
             </Router>
           </Provider>
         </KibanaContextProvider>
-      </EuiThemeProvider>
+      </KibanaThemeProvider>
     </I18nProvider>,
     params.element
   );


### PR DESCRIPTION
In pursuit of https://github.com/elastic/kibana/issues/118866

## Summary

Replaces `EuiThemeProvider` with `KibanaThemeProvider`