### PR TITLE
[8.0] [Enterprise Search] Remove `external_id` from UI code (#120143)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/reindex_job/reindex_job_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/reindex_job/reindex_job_logic.test.ts
@@ -25,13 +25,13 @@ describe('ReindexJobLogic', () => {
     fieldCoercionErrors: {
       some_erroring_field: [
         {
-          external_id: 'document-1',
+          id: 'document-1',
           error: "Value 'some text' cannot be parsed as a number",
         },
       ],
       another_erroring_field: [
         {
-          external_id: 'document-2',
+          id: 'document-2',
           error: "Value '123' cannot be parsed as a date",
         },
       ],

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.test.tsx
@@ -22,11 +22,11 @@ describe('SchemaErrorsAccordion', () => {
     fieldCoercionErrors: {
       id: [
         {
-          external_id: 'foo',
+          id: 'foo',
           error: 'this is an error',
         },
         {
-          external_id: 'bar',
+          id: 'bar',
           error: 'this is another error',
         },
       ],

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
@@ -36,7 +36,7 @@ import './schema_errors_accordion.scss';
 interface Props {
   fieldCoercionErrors: FieldCoercionErrors;
   schema: Schema;
-  generateViewPath?(externalId: string): string;
+  generateViewPath?(id: string): string;
 }
 
 export const SchemaErrorsAccordion: React.FC<Props> = ({
@@ -89,7 +89,7 @@ export const SchemaErrorsAccordion: React.FC<Props> = ({
             </EuiTableHeader>
             <EuiTableBody>
               {errors.map((error) => {
-                const { external_id: id, error: errorMessage } = error;
+                const { id, error: errorMessage } = error;
                 return (
                   <EuiTableRow key={`schemaErrorDocument-${fieldName}-${id}`}>
                     <EuiTableRowCell truncateText>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/types.ts
@@ -58,7 +58,7 @@ export interface IndexJob extends IIndexingStatus {
 }
 
 export interface FieldCoercionError {
-  external_id: string;
+  id: string;
   error: string;
 }
 export type FieldCoercionErrors = Record<string, FieldCoercionError[]>;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/__mocks__/content_sources.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/__mocks__/content_sources.mock.ts
@@ -370,7 +370,7 @@ export const exampleResult = {
       myLink: 'http://foo',
       otherTitle: 'foo',
       content_source_id: '60e85e7ea2564c265a88a4f0',
-      external_id: 'doc-60e85eb7a2564c937a88a4f3',
+      id: 'doc-60e85eb7a2564c937a88a4f3',
       last_updated: '2021-07-09T14:35:35+00:00',
       updated_at: '2021-07-09T14:35:35+00:00',
       source: 'custom',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
@@ -257,7 +257,7 @@ export type CustomAPIFieldValue =
 export interface Result {
   content_source_id: string;
   last_updated: string;
-  external_id: string;
+  id: string;
   updated_at: string;
   source: string;
   [key: string]: CustomAPIFieldValue;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.ts
@@ -123,6 +123,7 @@ export const defaultSearchResultConfig = {
 export const DisplaySettingsLogic = kea<
   MakeLogicType<DisplaySettingsValues, DisplaySettingsActions>
 >({
+  path: ['enterprise_search', 'workplace_search', 'display_settings_logic'],
   actions: {
     onInitializeDisplaySettings: (displaySettingsProps: DisplaySettingsInitialData) =>
       displaySettingsProps,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
@@ -67,7 +67,7 @@ describe('SchemaLogic', () => {
 
   const fieldCoercionErrors = [
     {
-      external_id: '123',
+      id: '123',
       error: 'error',
     },
   ] as any;


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Enterprise Search] Remove `external_id` from UI code (#120143)