### PR TITLE
[Fleet] Renable skipped test for limited packages

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
@@ -214,7 +214,7 @@ export default function (providerContext: FtrProviderContext) {
           package: {
             name: 'endpoint',
             title: 'Endpoint',
-            version: '0.13.0',
+            version: '1.3.0-dev.0',
           },
         })
         .expect(200);
@@ -232,7 +232,7 @@ export default function (providerContext: FtrProviderContext) {
           package: {
             name: 'endpoint',
             title: 'Endpoint',
-            version: '0.13.0',
+            version: '1.3.0-dev.0',
           },
         })
         .expect(400);

--- a/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
@@ -199,8 +199,7 @@ export default function (providerContext: FtrProviderContext) {
         .expect(400);
     });
 
-    // https://github.com/elastic/kibana/issues/118257
-    it.skip('should not allow multiple limited packages on the same agent policy', async function () {
+    it('should not allow multiple limited packages on the same agent policy', async function () {
       await supertest
         .post(`/api/fleet/package_policies`)
         .set('kbn-xsrf', 'xxxx')


### PR DESCRIPTION
## Summary

Resolves #118257. Re-enable a test that was skipped due to #117107.

This test was passing locally and I couldn't figure out exactly why it errored on CI, but errors showed these messages:
```
[00:20:34]             │ proc [kibana] [2021-12-02T22:01:04.785+00:00][ERROR][plugins.securitySolution] This rule is attempting to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, however no index matching: ["logs-endpoint.alerts-*"] was found. This warning will continue to appear until a matching index is created or this rule is de-activated. If you have recently enrolled agents enabled with Endpoint Security through Fleet, this warning should stop once an alert is sent from an agent. name: "Endpoint Security" id: "54359441-53bb-11ec-93a1-a12f0883393c" rule id: "9a1a2dae-0b5f-4c3d-8305-a268d404c306" space ID: "default"
...
[00:20:44]             │ proc [kibana] [2021-12-02T22:01:14.932+00:00][WARN ][plugins.fleet] Failure to install package [endpoint]: [ResponseError: illegal_argument_exception: [illegal_argument_exception] Reason: updating component template [logs-endpoint.alerts@settings] results in invalid composable template [logs-endpoint.alerts] after templates are merged]
```

I suspect that the latest Endpoint package (or perhaps even the Security Rules package?) got installed by another test suite before this one ran. As part of this test, we try to install a very old version of the Endpoint package that may be conflicting with what has already been installed. Updating the package version used in this test seems to resolve these errors.

Manual backport: #120294