### PR TITLE
[8.0][Fleet] Renable skipped test for limited packages

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
@@ -214,7 +214,7 @@ export default function (providerContext: FtrProviderContext) {
           package: {
             name: 'endpoint',
             title: 'Endpoint',
-            version: '0.13.0',
+            version: '1.3.0-dev.0',
           },
         })
         .expect(200);
@@ -232,7 +232,7 @@ export default function (providerContext: FtrProviderContext) {
           package: {
             name: 'endpoint',
             title: 'Endpoint',
-            version: '0.13.0',
+            version: '1.3.0-dev.0',
           },
         })
         .expect(400);

--- a/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
@@ -199,8 +199,7 @@ export default function (providerContext: FtrProviderContext) {
         .expect(400);
     });
 
-    // https://github.com/elastic/kibana/issues/118257
-    it.skip('should not allow multiple limited packages on the same agent policy', async function () {
+    it('should not allow multiple limited packages on the same agent policy', async function () {
       await supertest
         .post(`/api/fleet/package_policies`)
         .set('kbn-xsrf', 'xxxx')


### PR DESCRIPTION
## Summary

Manual backport for #120293 to test against 8.0 branch.
