### PR TITLE
[logging] Adds a global deprecation warning about log format change.

### DIFF
--- a/src/core/server/config/deprecation/core_deprecations.test.ts
+++ b/src/core/server/config/deprecation/core_deprecations.test.ts
@@ -22,17 +22,17 @@ describe('core deprecations', () => {
     it('logs a warning if CONFIG_PATH environ variable is set', () => {
       process.env.CONFIG_PATH = 'somepath';
       const { messages } = applyCoreDeprecations();
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "Environment variable \\"CONFIG_PATH\\" is deprecated. It has been replaced with \\"KBN_PATH_CONF\\" pointing to a config folder",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          'Environment variable "CONFIG_PATH" is deprecated. It has been replaced with "KBN_PATH_CONF" pointing to a config folder',
+        ])
+      );
     });
 
     it('does not log a warning if CONFIG_PATH environ variable is unset', () => {
       delete process.env.CONFIG_PATH;
       const { messages } = applyCoreDeprecations();
-      expect(messages).toHaveLength(0);
+      expect(messages).toHaveLength(1);
     });
   });
 
@@ -40,17 +40,17 @@ describe('core deprecations', () => {
     it('logs a warning if KIBANA_PATH_CONF environ variable is set', () => {
       process.env.KIBANA_PATH_CONF = 'somepath';
       const { messages } = applyCoreDeprecations();
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "Environment variable \\"KIBANA_PATH_CONF\\" is deprecated. It has been replaced with \\"KBN_PATH_CONF\\" pointing to a config folder",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          'Environment variable "KIBANA_PATH_CONF" is deprecated. It has been replaced with "KBN_PATH_CONF" pointing to a config folder',
+        ])
+      );
     });
 
     it('does not log a warning if KIBANA_PATH_CONF environ variable is unset', () => {
       delete process.env.KIBANA_PATH_CONF;
       const { messages } = applyCoreDeprecations();
-      expect(messages).toHaveLength(0);
+      expect(messages).toHaveLength(1);
     });
   });
 
@@ -58,17 +58,17 @@ describe('core deprecations', () => {
     it('logs a warning if DATA_PATH environ variable is set', () => {
       process.env.DATA_PATH = 'somepath';
       const { messages } = applyCoreDeprecations();
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "Environment variable \\"DATA_PATH\\" will be removed.  It has been replaced with kibana.yml setting \\"path.data\\"",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          'Environment variable "DATA_PATH" will be removed.  It has been replaced with kibana.yml setting "path.data"',
+        ])
+      );
     });
 
     it('does not log a warning if DATA_PATH environ variable is unset', () => {
       delete process.env.DATA_PATH;
       const { messages } = applyCoreDeprecations();
-      expect(messages).toHaveLength(0);
+      expect(messages).toHaveLength(1);
     });
   });
 
@@ -78,11 +78,11 @@ describe('core deprecations', () => {
         server: { xsrf: { whitelist: ['/path'] } },
       });
       expect(migrated.server.xsrf.allowlist).toEqual(['/path']);
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "Setting \\"server.xsrf.whitelist\\" has been replaced by \\"server.xsrf.allowlist\\"",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          'Setting "server.xsrf.whitelist" has been replaced by "server.xsrf.allowlist"',
+        ])
+      );
     });
   });
 
@@ -97,18 +97,18 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         server: { cors: true },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"server.cors\\" is deprecated and has been replaced by \\"server.cors.enabled\\"",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"server.cors" is deprecated and has been replaced by "server.cors.enabled"',
+        ])
+      );
     });
     it('does not log deprecation message when server.cors.enabled set', () => {
       const { migrated, messages } = applyCoreDeprecations({
         server: { cors: { enabled: true } },
       });
       expect(migrated.server.cors).toEqual({ enabled: true });
-      expect(messages.length).toBe(0);
+      expect(messages.length).toBe(1);
     });
   });
 
@@ -117,18 +117,18 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         server: { host: '0' },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "Support for setting server.host to \\"0\\" in kibana.yml is deprecated and will be removed in Kibana version 8.0.0. Instead use \\"0.0.0.0\\" to bind to all interfaces.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          'Support for setting server.host to "0" in kibana.yml is deprecated and will be removed in Kibana version 8.0.0. Instead use "0.0.0.0" to bind to all interfaces.',
+        ])
+      );
     });
     it('does not log a warning if server.host is not set to "0"', () => {
       const { migrated, messages } = applyCoreDeprecations({
         server: { host: '0.0.0.0' },
       });
       expect(migrated.server.host).toEqual('0.0.0.0');
-      expect(messages.length).toBe(0);
+      expect(messages.length).toBe(1);
     });
   });
 
@@ -139,13 +139,14 @@ describe('core deprecations', () => {
           basePath: 'foo',
         },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "You should set server.basePath along with server.rewriteBasePath. Starting in 7.0, Kibana will expect that all requests start with server.basePath rather than expecting you to rewrite the requests in your reverse proxy. Set server.rewriteBasePath to false to preserve the current behavior and silence this warning.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          'You should set server.basePath along with server.rewriteBasePath. Starting in 7.0, Kibana will expect that all requests start with server.basePath rather than expecting you to rewrite the requests in your reverse proxy. Set server.rewriteBasePath to false to preserve the current behavior and silence this warning.',
+        ])
+      );
       expect(levels).toMatchInlineSnapshot(`
         Array [
+          "warning",
           "warning",
         ]
       `);
@@ -155,7 +156,7 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         server: {},
       });
-      expect(messages).toHaveLength(0);
+      expect(messages).toHaveLength(1);
     });
 
     it('does not log a warning if both server.basePath and server.rewriteBasePath are set', () => {
@@ -165,7 +166,7 @@ describe('core deprecations', () => {
           rewriteBasePath: true,
         },
       });
-      expect(messages).toHaveLength(0);
+      expect(messages).toHaveLength(1);
     });
   });
 
@@ -178,11 +179,11 @@ describe('core deprecations', () => {
           },
         };
         const { messages } = applyCoreDeprecations(settings);
-        expect(messages).toMatchInlineSnapshot(`
-            Array [
-              "csp.rules no longer supports the {nonce} syntax. Replacing with 'self' in script-src",
-            ]
-        `);
+        expect(messages).toEqual(
+          expect.arrayContaining([
+            "csp.rules no longer supports the {nonce} syntax. Replacing with 'self' in script-src",
+          ])
+        );
       });
 
       it('replaces a nonce', () => {
@@ -244,11 +245,11 @@ describe('core deprecations', () => {
         const { messages } = applyCoreDeprecations({
           csp: { rules: [`script-src 'unsafe-eval'`] },
         });
-        expect(messages).toMatchInlineSnapshot(`
-              Array [
-                "csp.rules must contain the 'self' source. Automatically adding to script-src.",
-              ]
-        `);
+        expect(messages).toEqual(
+          expect.arrayContaining([
+            "csp.rules must contain the 'self' source. Automatically adding to script-src.",
+          ])
+        );
       });
 
       it('adds self', () => {
@@ -270,11 +271,11 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { events: { ops: '*' } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.events.ops\\" has been deprecated and will be removed in 8.0. To access ops data moving forward, please enable debug logs for the \\"metrics.ops\\" context in your logging configuration.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.events.ops" has been deprecated and will be removed in 8.0. To access ops data moving forward, please enable debug logs for the "metrics.ops" context in your logging configuration.',
+        ])
+      );
     });
   });
 
@@ -283,11 +284,11 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { events: { request: '*' } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.events.request\\" has been deprecated and will be removed in 8.0. To access request data moving forward, please enable debug logs for the \\"http.server.response\\" context in your logging configuration.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.events.request" has been deprecated and will be removed in 8.0. To access request data moving forward, please enable debug logs for the "http.server.response" context in your logging configuration.',
+        ])
+      );
     });
   });
 
@@ -296,11 +297,11 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { events: { response: '*' } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.events.response\\" has been deprecated and will be removed in 8.0. To access response data moving forward, please enable debug logs for the \\"http.server.response\\" context in your logging configuration.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.events.response" has been deprecated and will be removed in 8.0. To access response data moving forward, please enable debug logs for the "http.server.response" context in your logging configuration.',
+        ])
+      );
     });
   });
 
@@ -309,11 +310,11 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { timezone: 'GMT' },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.timezone\\" has been deprecated and will be removed in 8.0. To set the timezone moving forward, please add a timezone date modifier to the log pattern in your logging configuration.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.timezone" has been deprecated and will be removed in 8.0. To set the timezone moving forward, please add a timezone date modifier to the log pattern in your logging configuration.',
+        ])
+      );
     });
   });
 
@@ -322,21 +323,21 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { dest: 'stdout' },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.dest\\" has been deprecated and will be removed in 8.0. To set the destination moving forward, you can use the \\"console\\" appender in your logging configuration or define a custom one.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.dest" has been deprecated and will be removed in 8.0. To set the destination moving forward, you can use the "console" appender in your logging configuration or define a custom one.',
+        ])
+      );
     });
     it('warns when dest path is given', () => {
       const { messages } = applyCoreDeprecations({
         logging: { dest: '/log-log.txt' },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.dest\\" has been deprecated and will be removed in 8.0. To set the destination moving forward, you can use the \\"console\\" appender in your logging configuration or define a custom one.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.dest" has been deprecated and will be removed in 8.0. To set the destination moving forward, you can use the "console" appender in your logging configuration or define a custom one.',
+        ])
+      );
     });
   });
 
@@ -345,31 +346,31 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { quiet: true },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.quiet\\" has been deprecated and will be removed in 8.0. Moving forward, you can use \\"logging.root.level:error\\" in your logging configuration. ",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.quiet" has been deprecated and will be removed in 8.0. Moving forward, you can use "logging.root.level:error" in your logging configuration.',
+        ])
+      );
     });
     it('warns when silent is used', () => {
       const { messages } = applyCoreDeprecations({
         logging: { silent: true },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.silent\\" has been deprecated and will be removed in 8.0. Moving forward, you can use \\"logging.root.level:off\\" in your logging configuration. ",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.silent" has been deprecated and will be removed in 8.0. Moving forward, you can use "logging.root.level:off" in your logging configuration.',
+        ])
+      );
     });
     it('warns when verbose is used', () => {
       const { messages } = applyCoreDeprecations({
         logging: { verbose: true },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.verbose\\" has been deprecated and will be removed in 8.0. Moving forward, you can use \\"logging.root.level:all\\" in your logging configuration. ",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.verbose" has been deprecated and will be removed in 8.0. Moving forward, you can use "logging.root.level:all" in your logging configuration.',
+        ])
+      );
     });
   });
 
@@ -378,11 +379,11 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { json: true },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.json\\" has been deprecated and will be removed in 8.0. To specify log message format moving forward, you can configure the \\"appender.layout\\" property for every custom appender in your logging configuration. There is currently no default layout for custom appenders and each one must be declared explicitly.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.json" has been deprecated and will be removed in 8.0. To specify log message format moving forward, you can configure the "appender.layout" property for every custom appender in your logging configuration. There is currently no default layout for custom appenders and each one must be declared explicitly.',
+        ])
+      );
     });
   });
 
@@ -391,44 +392,44 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { rotate: { enabled: true } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.rotate\\" and sub-options have been deprecated and will be removed in 8.0. Moving forward, you can enable log rotation using the \\"rolling-file\\" appender for a logger in your logging configuration.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.rotate" and sub-options have been deprecated and will be removed in 8.0. Moving forward, you can enable log rotation using the "rolling-file" appender for a logger in your logging configuration.',
+        ])
+      );
     });
 
     it('warns when logging.rotate polling configurations are used', () => {
       const { messages } = applyCoreDeprecations({
         logging: { rotate: { enabled: true, usePolling: true, pollingInterval: 5000 } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.rotate\\" and sub-options have been deprecated and will be removed in 8.0. Moving forward, you can enable log rotation using the \\"rolling-file\\" appender for a logger in your logging configuration.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.rotate" and sub-options have been deprecated and will be removed in 8.0. Moving forward, you can enable log rotation using the "rolling-file" appender for a logger in your logging configuration.',
+        ])
+      );
     });
 
     it('warns when logging.rotate.everyBytes configurations are used', () => {
       const { messages } = applyCoreDeprecations({
         logging: { rotate: { enabled: true, everyBytes: 1048576 } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.rotate\\" and sub-options have been deprecated and will be removed in 8.0. Moving forward, you can enable log rotation using the \\"rolling-file\\" appender for a logger in your logging configuration.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.rotate" and sub-options have been deprecated and will be removed in 8.0. Moving forward, you can enable log rotation using the "rolling-file" appender for a logger in your logging configuration.',
+        ])
+      );
     });
 
     it('warns when logging.rotate.keepFiles is used', () => {
       const { messages } = applyCoreDeprecations({
         logging: { rotate: { enabled: true, keepFiles: 1024 } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.rotate\\" and sub-options have been deprecated and will be removed in 8.0. Moving forward, you can enable log rotation using the \\"rolling-file\\" appender for a logger in your logging configuration.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.rotate" and sub-options have been deprecated and will be removed in 8.0. Moving forward, you can enable log rotation using the "rolling-file" appender for a logger in your logging configuration.',
+        ])
+      );
     });
   });
 
@@ -437,11 +438,11 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { events: { log: ['info'] } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.events.log\\" has been deprecated and will be removed in 8.0. Moving forward, log levels can be customized on a per-logger basis using the new logging configuration.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.events.log" has been deprecated and will be removed in 8.0. Moving forward, log levels can be customized on a per-logger basis using the new logging configuration.',
+        ])
+      );
     });
   });
 
@@ -450,11 +451,11 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { events: { error: ['some error'] } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.events.error\\" has been deprecated and will be removed in 8.0. Moving forward, you can use \\"logging.root.level: error\\" in your logging configuration.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          '"logging.events.error" has been deprecated and will be removed in 8.0. Moving forward, you can use "logging.root.level: error" in your logging configuration.',
+        ])
+      );
     });
   });
 
@@ -463,22 +464,29 @@ describe('core deprecations', () => {
       const { messages } = applyCoreDeprecations({
         logging: { filter: { cookie: 'none' } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.filter\\" has been deprecated and will be removed in 8.0.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining(['"logging.filter" has been deprecated and will be removed in 8.0.'])
+      );
     });
 
     it('warns when filter.authorization is used', () => {
       const { messages } = applyCoreDeprecations({
         logging: { filter: { authorization: 'none' } },
       });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"logging.filter\\" has been deprecated and will be removed in 8.0.",
-        ]
-      `);
+      expect(messages).toEqual(
+        expect.arrayContaining(['"logging.filter" has been deprecated and will be removed in 8.0.'])
+      );
+    });
+  });
+
+  describe('log format', () => {
+    it('always logs a deprecation warning', () => {
+      const { messages } = applyCoreDeprecations();
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          'Starting in 8.0, the Kibana logging format will be changing. This may affect you if you are doing any special handling of your Kibana logs, such as ingesting logs into Elasticsearch for further analysis. If you are using the new logging configuration, you are already receiving logs in both old and new formats, and the old format will simply be going away. If you are not yet using the new logging configuration, the log format will change upon upgrade to 8.0. Beginning in 8.0, the format of JSON logs will be ECS-compatible JSON, and the default pattern log format will be configurable with our new logging system. Please refer to the documentation for more information about the new logging format.',
+        ])
+      );
     });
   });
 });

--- a/src/core/server/config/deprecation/core_deprecations.ts
+++ b/src/core/server/config/deprecation/core_deprecations.ts
@@ -382,7 +382,7 @@ const quietLoggingDeprecation: ConfigDeprecation = (
       message: i18n.translate('core.deprecations.loggingQuiet.deprecationMessage', {
         defaultMessage:
           '"logging.quiet" has been deprecated and will be removed ' +
-          'in 8.0. Moving forward, you can use "logging.root.level:error" in your logging configuration. ',
+          'in 8.0. Moving forward, you can use "logging.root.level:error" in your logging configuration.',
       }),
       correctiveActions: {
         manualSteps: [
@@ -413,7 +413,7 @@ const silentLoggingDeprecation: ConfigDeprecation = (
       message: i18n.translate('core.deprecations.loggingSilent.deprecationMessage', {
         defaultMessage:
           '"logging.silent" has been deprecated and will be removed ' +
-          'in 8.0. Moving forward, you can use "logging.root.level:off" in your logging configuration. ',
+          'in 8.0. Moving forward, you can use "logging.root.level:off" in your logging configuration.',
       }),
       correctiveActions: {
         manualSteps: [
@@ -444,7 +444,7 @@ const verboseLoggingDeprecation: ConfigDeprecation = (
       message: i18n.translate('core.deprecations.loggingVerbose.deprecationMessage', {
         defaultMessage:
           '"logging.verbose" has been deprecated and will be removed ' +
-          'in 8.0. Moving forward, you can use "logging.root.level:all" in your logging configuration. ',
+          'in 8.0. Moving forward, you can use "logging.root.level:all" in your logging configuration.',
       }),
       correctiveActions: {
         manualSteps: [
@@ -613,6 +613,50 @@ const logFilterDeprecation: ConfigDeprecation = (
   }
 };
 
+const logFormatDeprecation: ConfigDeprecation = (
+  settings,
+  fromPath,
+  addDeprecation,
+  { branch }
+) => {
+  addDeprecation({
+    configPath: 'logging',
+    level: 'warning',
+    documentationUrl: `https://www.elastic.co/guide/en/kibana/${branch}/logging-configuration-migration.html`,
+    title: i18n.translate('core.deprecations.loggingFormat.deprecationTitle', {
+      defaultMessage: `Kibana's logging format is changing in 8.0`,
+    }),
+    message: i18n.translate('core.deprecations.loggingFormat.deprecationMessage', {
+      defaultMessage:
+        'Starting in 8.0, the Kibana logging format will be changing. ' +
+        'This may affect you if you are doing any special handling of your Kibana logs, ' +
+        'such as ingesting logs into Elasticsearch for further analysis. ' +
+        'If you are using the new logging configuration, you are already receiving logs in both ' +
+        'old and new formats, and the old format will simply be going away. ' +
+        'If you are not yet using the new logging configuration, the log format will change ' +
+        'upon upgrade to 8.0. Beginning in 8.0, the format of JSON logs will be ECS-compatible JSON, ' +
+        'and the default pattern log format will be configurable with our new logging system. ' +
+        'Please refer to the documentation for more information about the new logging format.',
+    }),
+    correctiveActions: {
+      manualSteps: [
+        i18n.translate('core.deprecations.loggingFormat.manualSteps1', {
+          defaultMessage: `Determine whether your infrastructure is relying on Kibana's legacy log format.`,
+        }),
+        i18n.translate('core.deprecations.loggingFormat.manualSteps2', {
+          defaultMessage: `Learn more about our new logging system by checking out the documentation.`,
+        }),
+        i18n.translate('core.deprecations.loggingFormat.manualSteps3', {
+          defaultMessage: `Learn more about ECS at https://www.elastic.co/guide/en/ecs/8.0/ecs-reference.html.`,
+        }),
+        i18n.translate('core.deprecations.loggingFormat.manualSteps4', {
+          defaultMessage: `Update your ingest tooling to use the new logging format.`,
+        }),
+      ],
+    },
+  });
+};
+
 export const coreDeprecationProvider: ConfigDeprecationProvider = ({
   unusedFromRoot,
   renameFromRoot,
@@ -674,4 +718,5 @@ export const coreDeprecationProvider: ConfigDeprecationProvider = ({
   logEventsLogDeprecation,
   logEventsErrorDeprecation,
   logFilterDeprecation,
+  logFormatDeprecation,
 ];

--- a/src/core/server/config/integration_tests/config_deprecation.test.ts
+++ b/src/core/server/config/integration_tests/config_deprecation.test.ts
@@ -30,11 +30,11 @@ describe('configuration deprecations', () => {
     await root.setup();
 
     const logs = loggingSystemMock.collect(mockLoggingSystem);
-    expect(logs.warn.flat()).toMatchInlineSnapshot(`
-      Array [
-        "\\"logging.silent\\" has been deprecated and will be removed in 8.0. Moving forward, you can use \\"logging.root.level:off\\" in your logging configuration. ",
-      ]
-    `);
+    expect(logs.warn.flat()).toEqual(
+      expect.arrayContaining([
+        '"logging.silent" has been deprecated and will be removed in 8.0. Moving forward, you can use "logging.root.level:off" in your logging configuration.',
+      ])
+    );
   });
 
   it('should log deprecation warnings for core deprecations', async () => {
@@ -49,12 +49,12 @@ describe('configuration deprecations', () => {
     await root.setup();
 
     const logs = loggingSystemMock.collect(mockLoggingSystem);
-    expect(logs.warn.flat()).toMatchInlineSnapshot(`
-      Array [
-        "You no longer need to configure \\"optimize.lazy\\".",
-        "You no longer need to configure \\"optimize.lazyPort\\".",
-        "\\"logging.silent\\" has been deprecated and will be removed in 8.0. Moving forward, you can use \\"logging.root.level:off\\" in your logging configuration. ",
-      ]
-    `);
+    expect(logs.warn.flat()).toEqual(
+      expect.arrayContaining([
+        'You no longer need to configure "optimize.lazy".',
+        'You no longer need to configure "optimize.lazyPort".',
+        '"logging.silent" has been deprecated and will be removed in 8.0. Moving forward, you can use "logging.root.level:off" in your logging configuration.',
+      ])
+    );
   });
 });


### PR DESCRIPTION
After running into an issue where [the RPM package created deprecation warnings in 7.16 due to the way it configured logging](https://github.com/elastic/kibana/issues/111263), we decided we would [skip the deprecation](https://github.com/elastic/kibana/pull/120273) in the RPM package service description.

When we introduced the new logging system in 7.13, we were not worried about awareness of the new logging format, because:
- folks would need to "opt in" by changing their logging configuration in order to see the new format
- by explicitly deprecating the old logging configs, we were forcing users to refer to the docs and learn about the new format
- Upgrade Assistant would make this process easier for users

However, we've now created a scenario where a user could upgrade to 8.0 with zero warning about the new logging format in the Upgrade Assistant (they would only know about this by referring to the breaking changes docs).

So we decided that the safest approach would be to create a deprecation for _all_ users, and register it at the `warning` level. This way, everyone will be explicitly warned about the change in the Upgrade Assistant, but won't be blocked on upgrading.

![Screen Shot 2021-12-02 at 2 13 12 PM](https://user-images.githubusercontent.com/1608770/144514667-78870442-d6a3-46cd-9961-23dfdac3116e.png)


