### PR TITLE
[DOCS] Fix typo in snapshot warning

### DIFF
--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -58,7 +58,7 @@ The upgrade path from 6.8 to 7.0 is *not* supported.
 [[upgrade-before-you-begin]]
 === Before you begin
 
-WARNING: {kib} automatically runs upgrade migrations when required. To roll back to an earlier version in case of an upgrade failure, you **must** have a {ref}/snapshot-restore.html[backup snapshot] available. This snapshot must include the `kibana` feature state or all `kibana*` indices. For more information see <<upgrade-migrations, upgrade migrations>>.
+WARNING: {kib} automatically runs upgrade migrations when required. To roll back to an earlier version in case of an upgrade failure, you **must** have a {ref}/snapshot-restore.html[backup snapshot] available. This snapshot must include the `kibana` feature state or all `.kibana*` indices. For more information see <<upgrade-migrations, upgrade migrations>>.
 
 Before you upgrade {kib}:
 


### PR DESCRIPTION
Fixes a typo I introduced in https://github.com/elastic/kibana/pull/114836. 😨 

This doesn't require a forward-port due to changes in https://github.com/elastic/kibana/pull/120174.