### PR TITLE
fix(NA): @kbn/utils build on windows native environment

### DIFF
--- a/packages/kbn-utils/BUILD.bazel
+++ b/packages/kbn-utils/BUILD.bazel
@@ -32,6 +32,7 @@ RUNTIME_DEPS = [
 
 TYPES_DEPS = [
   "//packages/kbn-config-schema",
+  "//packages/kbn-dev-utils",
   "@npm//load-json-file",
   "@npm//tslib",
   "@npm//@types/jest",

--- a/packages/kbn-utils/BUILD.bazel
+++ b/packages/kbn-utils/BUILD.bazel
@@ -32,7 +32,6 @@ RUNTIME_DEPS = [
 
 TYPES_DEPS = [
   "//packages/kbn-config-schema",
-  "//packages/kbn-dev-utils",
   "@npm//load-json-file",
   "@npm//tslib",
   "@npm//@types/jest",

--- a/packages/kbn-utils/src/path/index.test.ts
+++ b/packages/kbn-utils/src/path/index.test.ts
@@ -7,10 +7,17 @@
  */
 
 import { accessSync, constants } from 'fs';
-import { createAbsolutePathSerializer } from '@kbn/dev-utils';
 import { getConfigPath, getDataPath, getLogsPath, getConfigDirectory } from './';
+import { REPO_ROOT } from '../repo_root';
 
-expect.addSnapshotSerializer(createAbsolutePathSerializer());
+expect.addSnapshotSerializer(
+  ((rootPath: string = REPO_ROOT, replacement = '<absolute path>') => {
+    return {
+      test: (value: any) => typeof value === 'string' && value.startsWith(rootPath),
+      serialize: (value: string) => value.replace(rootPath, replacement).replace(/\\/g, '/'),
+    };
+  })()
+);
 
 describe('Default path finder', () => {
   it('should expose a path to the config directory', () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/120304

With our migration into the types rule on Bazel that splits types from code bundles we no longer import transient type dependencies. That resulted in a missing declaration for a dependency on the native Windows environment as the build layouts dependencies differently on Windows vs Unix based OS. In order to quickly solve that I removed the dependency for `@kbn/utils` on `@kbn/dev-utils` as it will introduce a circular dep.