### PR TITLE
[8.0] chore(NA): splits types from code on @kbn/config (#120267)

### DIFF
--- a/package.json
+++ b/package.json
@@ -559,6 +559,7 @@
     "@types/kbn__apm-config-loader": "link:bazel-bin/packages/kbn-apm-config-loader/npm_module_types",
     "@types/kbn__apm-utils": "link:bazel-bin/packages/kbn-apm-utils/npm_module_types",
     "@types/kbn__cli-dev-mode": "link:bazel-bin/packages/kbn-cli-dev-mode/npm_module_types",
+    "@types/kbn__config": "link:bazel-bin/packages/kbn-config/npm_module_types",
     "@types/kbn__i18n": "link:bazel-bin/packages/kbn-i18n/npm_module_types",
     "@types/kbn__i18n-react": "link:bazel-bin/packages/kbn-i18n-react/npm_module_types",
     "@types/license-checker": "15.0.0",

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -82,6 +82,7 @@ filegroup(
       "//packages/kbn-apm-config-loader:build_types",
       "//packages/kbn-apm-utils:build_types",
       "//packages/kbn-cli-dev-mode:build_types",
+      "//packages/kbn-config:build_types",
       "//packages/kbn-i18n:build_types",
       "//packages/kbn-i18n-react:build_types",
   ],

--- a/packages/kbn-cli-dev-mode/BUILD.bazel
+++ b/packages/kbn-cli-dev-mode/BUILD.bazel
@@ -48,7 +48,7 @@ RUNTIME_DEPS = [
 ]
 
 TYPES_DEPS = [
-  "//packages/kbn-config",
+  "//packages/kbn-config:npm_module_types",
   "//packages/kbn-config-schema",
   "//packages/kbn-dev-utils",
   "//packages/kbn-logging",

--- a/packages/kbn-config/BUILD.bazel
+++ b/packages/kbn-config/BUILD.bazel
@@ -1,9 +1,10 @@
-load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
-load("//src/dev/bazel:index.bzl", "jsts_transpiler")
+load("@npm//@bazel/typescript:index.bzl", "ts_config")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types", "ts_project")
 
 PKG_BASE_NAME = "kbn-config"
 PKG_REQUIRE_NAME = "@kbn/config"
+TYPES_PKG_REQUIRE_NAME = "@types/kbn__config"
 
 SOURCE_FILES = glob(
   [
@@ -91,7 +92,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
+  deps = RUNTIME_DEPS + [":target_node"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )
@@ -107,6 +108,23 @@ filegroup(
   name = "build",
   srcs = [
     ":npm_module",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+pkg_npm_types(
+  name = "npm_module_types",
+  srcs = SRCS,
+  deps = [":tsc_types"],
+  package_name = TYPES_PKG_REQUIRE_NAME,
+  tsconfig = ":tsconfig",
+  visibility = ["//visibility:public"],
+)
+
+filegroup(
+  name = "build_types",
+  srcs = [
+    ":npm_module_types",
   ],
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-config/package.json
+++ b/packages/kbn-config/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@kbn/config",
   "main": "./target_node/index.js",
-  "types": "./target_types/index.d.ts",
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true

--- a/packages/kbn-docs-utils/BUILD.bazel
+++ b/packages/kbn-docs-utils/BUILD.bazel
@@ -36,7 +36,7 @@ RUNTIME_DEPS = [
 ]
 
 TYPES_DEPS = [
-  "//packages/kbn-config",
+  "//packages/kbn-config:npm_module_types",
   "//packages/kbn-dev-utils",
   "//packages/kbn-utils",
   "@npm//ts-morph",

--- a/packages/kbn-optimizer/BUILD.bazel
+++ b/packages/kbn-optimizer/BUILD.bazel
@@ -46,6 +46,7 @@ RUNTIME_DEPS = [
   "@npm//execa",
   "@npm//jest-diff",
   "@npm//json-stable-stringify",
+  "@npm//js-yaml",
   "@npm//lmdb-store",
   "@npm//loader-utils",
   "@npm//node-sass",
@@ -62,7 +63,7 @@ RUNTIME_DEPS = [
 ]
 
 TYPES_DEPS = [
-  "//packages/kbn-config",
+  "//packages/kbn-config:npm_module_types",
   "//packages/kbn-config-schema",
   "//packages/kbn-dev-utils",
   "//packages/kbn-std",
@@ -83,6 +84,7 @@ TYPES_DEPS = [
   "@npm//@types/compression-webpack-plugin",
   "@npm//@types/jest",
   "@npm//@types/json-stable-stringify",
+  "@npm//@types/js-yaml",
   "@npm//@types/loader-utils",
   "@npm//@types/node",
   "@npm//@types/normalize-path",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5802,6 +5802,10 @@
   version "0.0.0"
   uid ""
 
+"@types/kbn__config@link:bazel-bin/packages/kbn-config/npm_module_types":
+  version "0.0.0"
+  uid ""
+
 "@types/kbn__i18n-react@link:bazel-bin/packages/kbn-i18n-react/npm_module_types":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
Backports the following commits to 8.0:
 - chore(NA): splits types from code on @kbn/config (#120267)