### PR TITLE
[Lens][WIP] reject date histogram for empty pie

### DIFF
--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
@@ -22,7 +22,6 @@ function shouldReject({
   table,
   keptLayerIds,
   state,
-  emptyConfiguration,
 }: SuggestionRequest<PieVisualizationState>) {
   // usecase for dropping a field - state doesn't exist yet and subVisualizationId doesn't exist
   const emptyConfiguration =

--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
@@ -25,7 +25,11 @@ function shouldReject({
   emptyConfiguration,
 }: SuggestionRequest<PieVisualizationState>) {
   // usecase for dropping a field - state doesn't exist yet and subVisualizationId doesn't exist
-  console.log(table, state, emptyConfiguration);
+  const emptyConfiguration =
+    state?.shape &&
+    isPartitionShape(state.shape) &&
+    state?.layers?.[0]?.metric === undefined &&
+    state?.layers?.[0]?.groups.length === 0;
   if (emptyConfiguration) {
     return hasIntervalScale(table.columns);
   }
@@ -75,14 +79,8 @@ export function suggestions({
 }: SuggestionRequest<PieVisualizationState>): Array<
   VisualizationSuggestion<PieVisualizationState>
 > {
-   console.log('empty');
-  const emptyConfiguration =
-    state?.shape &&
-    isPartitionShape(state.shape) &&
-    state?.layers?.[0]?.metric === undefined &&
-    state?.layers?.[0]?.groups.length === 0;
 
-  if (shouldReject({ table, state, keptLayerIds, emptyConfiguration })) {
+  if (shouldReject({ table, state, keptLayerIds })) {
     return [];
   }
   const [groups, metrics] = partition(table.columns, (col) => col.operation.isBucketed);

--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
@@ -24,17 +24,15 @@ function shouldReject({
   state,
 }: SuggestionRequest<PieVisualizationState>) {
   // usecase for dropping a field - state doesn't exist yet and subVisualizationId doesn't exist
-  const emptyConfiguration =
-    state?.shape &&
-    isPartitionShape(state.shape) &&
+  const isPartitionChart = state?.shape && isPartitionShape(state.shape)
+  const isEmptyPartition =
+    isPartitionLike &&
     state?.layers?.[0]?.metric === undefined &&
     state?.layers?.[0]?.groups.length === 0;
-  if (emptyConfiguration) {
-    return hasIntervalScale(table.columns);
-  }
+
   // Histograms are not good for pi. But we should not reject them on switching between partition charts.
   const shouldRejectIntervals =
-    state?.shape && isPartitionShape(state.shape) ? false : hasIntervalScale(table.columns);
+    isPartitionChart || isEmptyPartition ? false : hasIntervalScale(table.columns);
 
   return (
     keptLayerIds.length > 1 ||

--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
@@ -18,21 +18,17 @@ function hasIntervalScale(columns: TableSuggestionColumn[]) {
   return columns.some((col) => col.operation.scale === 'interval');
 }
 
-function shouldReject({
-  table,
-  keptLayerIds,
-  state,
-}: SuggestionRequest<PieVisualizationState>) {
+function shouldReject({ table, keptLayerIds, state }: SuggestionRequest<PieVisualizationState>) {
   // usecase for dropping a field - state doesn't exist yet and subVisualizationId doesn't exist
-  const isPartitionChart = state?.shape && isPartitionShape(state.shape)
+  const isPartitionChart = state?.shape && isPartitionShape(state.shape);
   const isEmptyPartition =
-    isPartitionLike &&
+    isPartitionChart &&
     state?.layers?.[0]?.metric === undefined &&
     state?.layers?.[0]?.groups.length === 0;
 
   // Histograms are not good for pi. But we should not reject them on switching between partition charts.
   const shouldRejectIntervals =
-    isPartitionChart || isEmptyPartition ? false : hasIntervalScale(table.columns);
+    isPartitionChart && !isEmptyPartition ? false : hasIntervalScale(table.columns);
 
   return (
     keptLayerIds.length > 1 ||
@@ -76,7 +72,6 @@ export function suggestions({
 }: SuggestionRequest<PieVisualizationState>): Array<
   VisualizationSuggestion<PieVisualizationState>
 > {
-
   if (shouldReject({ table, state, keptLayerIds })) {
     return [];
   }

--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
@@ -37,8 +37,7 @@ function shouldReject({
     keptLayerIds.length > 1 ||
     (keptLayerIds.length && table.layerId !== keptLayerIds[0]) ||
     table.changeType === 'reorder' ||
-    shouldRejectIntervals ||
-    table.columns.some((col) => col.operation.isStaticValue)
+    shouldRejectIntervals
   );
 }
 

--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
@@ -18,7 +18,16 @@ function hasIntervalScale(columns: TableSuggestionColumn[]) {
   return columns.some((col) => col.operation.scale === 'interval');
 }
 
-function shouldReject({ table, keptLayerIds, state }: SuggestionRequest<PieVisualizationState>) {
+function shouldReject({
+  table,
+  keptLayerIds,
+  state,
+  subVisualizationId,
+}: SuggestionRequest<PieVisualizationState>) {
+  // usecase for dropping a field - state doesn't exist yet and subVisualizationId doesn't exist
+  if (!subVisualizationId && !state) {
+    return hasIntervalScale(table.columns);
+  }
   // Histograms are not good for pi. But we should not reject them on switching between partition charts.
   const shouldRejectIntervals =
     state?.shape && isPartitionShape(state.shape) ? false : hasIntervalScale(table.columns);
@@ -65,7 +74,7 @@ export function suggestions({
 }: SuggestionRequest<PieVisualizationState>): Array<
   VisualizationSuggestion<PieVisualizationState>
 > {
-  if (shouldReject({ table, state, keptLayerIds })) {
+  if (shouldReject({ table, state, keptLayerIds, subVisualizationId })) {
     return [];
   }
 
@@ -78,12 +87,13 @@ export function suggestions({
   const incompleteConfiguration = metrics.length === 0 || groups.length === 0;
   const metricColumnId = metrics.length > 0 ? metrics[0].columnId : undefined;
 
-  if (incompleteConfiguration && state && !subVisualizationId) {
-    // reject incomplete configurations if the sub visualization isn't specifically requested
-    // this allows to switch chart types via switcher with incomplete configurations, but won't
-    // cause incomplete suggestions getting auto applied on dropped fields
-    return [];
-  }
+  // we need to comment it because now we want to support incompleteConfigurations
+  // if (incompleteConfiguration && state && !subVisualizationId) {
+  //   // reject incomplete configurations if the sub visualization isn't specifically requested
+  //   // this allows to switch chart types via switcher with incomplete configurations, but won't
+  //   // cause incomplete suggestions getting auto applied on dropped fields
+  //   return [];
+  // }
 
   const results: Array<VisualizationSuggestion<PieVisualizationState>> = [];
 

--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
@@ -75,9 +75,7 @@ export function suggestions({
 }: SuggestionRequest<PieVisualizationState>): Array<
   VisualizationSuggestion<PieVisualizationState>
 > {
-  const [groups, metrics] = partition(table.columns, (col) => col.operation.isBucketed);
-
-  console.log('empty');
+   console.log('empty');
   const emptyConfiguration =
     state?.shape &&
     isPartitionShape(state.shape) &&
@@ -87,6 +85,8 @@ export function suggestions({
   if (shouldReject({ table, state, keptLayerIds, emptyConfiguration })) {
     return [];
   }
+  const [groups, metrics] = partition(table.columns, (col) => col.operation.isBucketed);
+
   if (metrics.length > 1 || groups.length > maximumGroupLength) {
     return [];
   }


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
