### PR TITLE
change ownership of `advanced_settings` to core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,6 @@
 
 # Vis Editors
 /x-pack/plugins/lens/ @elastic/kibana-vis-editors
-/src/plugins/advanced_settings/ @elastic/kibana-vis-editors
 /src/plugins/charts/ @elastic/kibana-vis-editors
 /src/plugins/vis_default_editor/ @elastic/kibana-vis-editors
 /src/plugins/vis_types/metric/ @elastic/kibana-vis-editors
@@ -263,6 +262,7 @@
 /src/plugins/home/server/*.ts @elastic/kibana-core
 /src/plugins/home/server/services/ @elastic/kibana-core
 /src/plugins/kibana_overview/ @elastic/kibana-core
+/src/plugins/advanced_settings/ @elastic/kibana-core
 /x-pack/plugins/global_search_bar/ @elastic/kibana-core
 #CC# /src/core/server/csp/ @elastic/kibana-core
 #CC# /src/plugins/saved_objects/ @elastic/kibana-core


### PR DESCRIPTION
## Summary

We agreed on this a while back, but never made it official.

Changing ownership of the `advanced_settings` plugin from @elastic/kibana-vis-editors to @elastic/kibana-core 


