### PR TITLE
[RAC] Fixes terminology and splits tests to new case

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
@@ -107,10 +107,8 @@ function AlertsPage() {
       // Note that the API uses the semantics of 'alerts' instead of 'rules'
       const { alertExecutionStatus, ruleMutedStatus, ruleEnabledStatus } = response;
       if (alertExecutionStatus && ruleMutedStatus && ruleEnabledStatus) {
-        const total = Object.entries(alertExecutionStatus).reduce((acc, [key, value]) => {
-          if (key !== 'error') {
-            acc = acc + value;
-          }
+        const total = Object.values(alertExecutionStatus).reduce((acc, value) => {
+          acc = acc + value;
           return acc;
         }, 0);
         const { error } = alertExecutionStatus;

--- a/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
@@ -107,13 +107,10 @@ function AlertsPage() {
       // Note that the API uses the semantics of 'alerts' instead of 'rules'
       const { alertExecutionStatus, ruleMutedStatus, ruleEnabledStatus } = response;
       if (alertExecutionStatus && ruleMutedStatus && ruleEnabledStatus) {
-        const total = Object.values(alertExecutionStatus).reduce((acc, value) => {
-          acc = acc + value;
-          return acc;
-        }, 0);
-        const { error } = alertExecutionStatus;
-        const { muted } = ruleMutedStatus;
+        const total = Object.values(alertExecutionStatus).reduce((acc, value) => acc + value, 0);
         const { disabled } = ruleEnabledStatus;
+        const { muted } = ruleMutedStatus;
+        const { error } = alertExecutionStatus;
         setRuleStats({
           ...ruleStats,
           total,

--- a/x-pack/test/functional/services/observability/alerts/common.ts
+++ b/x-pack/test/functional/services/observability/alerts/common.ts
@@ -271,7 +271,7 @@ export function ObservabilityAlertsCommonProvider({
     return actionsOverflowButtons[index] || null;
   };
 
-  const getAlertStatValue = async (testSubj: string) => {
+  const getRuleStatValue = async (testSubj: string) => {
     const stat = await testSubjects.find(testSubj);
     const title = await stat.findByCssSelector('.euiStat__title');
     const count = await title.getVisibleText();
@@ -317,6 +317,6 @@ export function ObservabilityAlertsCommonProvider({
     viewRuleDetailsButtonClick,
     viewRuleDetailsLinkClick,
     getAlertsFlyoutViewRuleDetailsLinkOrFail,
-    getAlertStatValue,
+    getRuleStatValue,
   };
 }

--- a/x-pack/test/observability_functional/apps/observability/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/alerts/index.ts
@@ -7,13 +7,6 @@
 
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
-import { ObjectRemover } from '../../../../functional_with_es_ssl/lib/object_remover';
-import {
-  createAlert,
-  disableAlert,
-  muteAlert,
-} from '../../../../functional_with_es_ssl/lib/alert_api_actions';
-import { generateUniqueKey } from '../../../../functional_with_es_ssl/lib/get_test_data';
 
 async function asyncForEach<T>(array: T[], callback: (item: T, index: number) => void) {
   for (let index = 0; index < array.length; index++) {
@@ -28,8 +21,6 @@ const TOTAL_ALERTS_CELL_COUNT = 165;
 export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const find = getService('find');
-  const supertest = getService('supertest');
-  const objectRemover = new ObjectRemover(supertest);
 
   describe('Observability alerts', function () {
     this.tags('includeFirefox');
@@ -243,65 +234,6 @@ export default ({ getService }: FtrProviderContext) => {
           await actionsButton.click();
           await observability.alerts.common.viewRuleDetailsButtonClick();
           expect(await find.existsByCssSelector('[title="Rules and Connectors"]')).to.eql(true);
-        });
-      });
-
-      describe('Stat counters', () => {
-        beforeEach(async () => {
-          const uniqueKey = generateUniqueKey();
-
-          const alertToDisable = await createAlert({
-            supertest,
-            objectRemover,
-            overwrites: { name: 'b', tags: [uniqueKey] },
-          });
-          await createAlert({
-            supertest,
-            objectRemover,
-            overwrites: { name: 'c', tags: [uniqueKey] },
-          });
-          await createAlert({
-            supertest,
-            objectRemover,
-            overwrites: { name: 'a', tags: [uniqueKey] },
-          });
-          await createAlert({
-            supertest,
-            objectRemover,
-            overwrites: { name: 'd', tags: [uniqueKey] },
-          });
-          await createAlert({
-            supertest,
-            objectRemover,
-            overwrites: { name: 'e', tags: [uniqueKey] },
-          });
-          const alertToMute = await createAlert({
-            supertest,
-            objectRemover,
-            overwrites: { name: 'f', tags: [uniqueKey] },
-          });
-
-          await disableAlert({ supertest, alertId: alertToDisable.id });
-          await muteAlert({ supertest, alertId: alertToMute.id });
-
-          await observability.alerts.common.navigateToTimeWithData();
-        });
-
-        afterEach(async () => {
-          await objectRemover.removeAll();
-        });
-
-        it('Exist and display expected values', async () => {
-          const subjToValueMap: { [key: string]: number } = {
-            statRuleCount: 6,
-            statDisabled: 1,
-            statMuted: 1,
-            statErrors: 0,
-          };
-          await asyncForEach(Object.keys(subjToValueMap), async (subject: string) => {
-            const value = await observability.alerts.common.getAlertStatValue(subject);
-            expect(value).to.be(subjToValueMap[subject]);
-          });
         });
       });
     });

--- a/x-pack/test/observability_functional/apps/observability/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/alerts/index.ts
@@ -7,12 +7,7 @@
 
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
-
-async function asyncForEach<T>(array: T[], callback: (item: T, index: number) => void) {
-  for (let index = 0; index < array.length; index++) {
-    await callback(array[index], index);
-  }
-}
+import { asyncForEach } from '../helpers';
 
 const ACTIVE_ALERTS_CELL_COUNT = 78;
 const RECOVERED_ALERTS_CELL_COUNT = 120;

--- a/x-pack/test/observability_functional/apps/observability/alerts/rule_stats.ts
+++ b/x-pack/test/observability_functional/apps/observability/alerts/rule_stats.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { ObjectRemover } from '../../../../functional_with_es_ssl/lib/object_remover';
+import {
+  createAlert as createRule,
+  disableAlert as disableRule,
+  muteAlert as muteRule,
+} from '../../../../functional_with_es_ssl/lib/alert_api_actions';
+import { generateUniqueKey } from '../../../../functional_with_es_ssl/lib/get_test_data';
+
+async function asyncForEach<T>(array: T[], callback: (item: T, index: number) => void) {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index);
+  }
+}
+
+export default ({ getService }: FtrProviderContext) => {
+  const esArchiver = getService('esArchiver');
+  const supertest = getService('supertest');
+  const objectRemover = new ObjectRemover(supertest);
+
+  describe('Observability rules', function () {
+    this.tags('includeFirefox');
+
+    const testSubjects = getService('testSubjects');
+    const retry = getService('retry');
+    const observability = getService('observability');
+
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/observability/alerts');
+      const setup = async () => {
+        await observability.alerts.common.setKibanaTimeZoneToUTC();
+        await observability.alerts.common.navigateToTimeWithData();
+      };
+      await setup();
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/observability/alerts');
+    });
+
+    describe('With no data', () => {
+      it('Shows the no data screen', async () => {
+        await observability.alerts.common.getNoDataPageOrFail();
+      });
+    });
+
+    describe('Stat counters', () => {
+      beforeEach(async () => {
+        const uniqueKey = generateUniqueKey();
+
+        const ruleToDisable = await createRule({
+          supertest,
+          objectRemover,
+          overwrites: { name: 'b', tags: [uniqueKey] },
+        });
+        await createRule({
+          supertest,
+          objectRemover,
+          overwrites: { name: 'c', tags: [uniqueKey] },
+        });
+        await createRule({
+          supertest,
+          objectRemover,
+          overwrites: { name: 'a', tags: [uniqueKey] },
+        });
+        await createRule({
+          supertest,
+          objectRemover,
+          overwrites: { name: 'd', tags: [uniqueKey] },
+        });
+        await createRule({
+          supertest,
+          objectRemover,
+          overwrites: { name: 'e', tags: [uniqueKey] },
+        });
+        const ruleToMute = await createRule({
+          supertest,
+          objectRemover,
+          overwrites: { name: 'f', tags: [uniqueKey] },
+        });
+
+        await disableRule({ supertest, alertId: ruleToDisable.id });
+        await muteRule({ supertest, alertId: ruleToMute.id });
+
+        await observability.alerts.common.navigateToTimeWithData();
+      });
+
+      afterEach(async () => {
+        await objectRemover.removeAll();
+      });
+
+      it('Exist and display expected values', async () => {
+        const subjToValueMap: { [key: string]: number } = {
+          statRuleCount: 6,
+          statDisabled: 1,
+          statMuted: 1,
+          statErrors: 0,
+        };
+        await asyncForEach(Object.keys(subjToValueMap), async (subject: string) => {
+          const value = await observability.alerts.common.getRuleStatValue(subject);
+          expect(value).to.be(subjToValueMap[subject]);
+        });
+      });
+    });
+  });
+};

--- a/x-pack/test/observability_functional/apps/observability/alerts/rule_stats.ts
+++ b/x-pack/test/observability_functional/apps/observability/alerts/rule_stats.ts
@@ -14,12 +14,7 @@ import {
   muteAlert as muteRule,
 } from '../../../../functional_with_es_ssl/lib/alert_api_actions';
 import { generateUniqueKey } from '../../../../functional_with_es_ssl/lib/get_test_data';
-
-async function asyncForEach<T>(array: T[], callback: (item: T, index: number) => void) {
-  for (let index = 0; index < array.length; index++) {
-    await callback(array[index], index);
-  }
-}
+import { asyncForEach } from '../helpers';
 
 export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
@@ -29,8 +24,6 @@ export default ({ getService }: FtrProviderContext) => {
   describe('Observability rules', function () {
     this.tags('includeFirefox');
 
-    const testSubjects = getService('testSubjects');
-    const retry = getService('retry');
     const observability = getService('observability');
 
     before(async () => {

--- a/x-pack/test/observability_functional/apps/observability/helpers.ts
+++ b/x-pack/test/observability_functional/apps/observability/helpers.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export async function asyncForEach<T>(array: T[], callback: (item: T, index: number) => void) {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index);
+  }
+}

--- a/x-pack/test/observability_functional/apps/observability/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/index.ts
@@ -10,15 +10,18 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('ObservabilityApp', function () {
     this.tags('ciGroup6');
-    loadTestFile(require.resolve('./feature_controls'));
-    loadTestFile(require.resolve('./exploratory_view'));
+
     loadTestFile(require.resolve('./alerts'));
-    loadTestFile(require.resolve('./alerts/alert_disclaimer'));
-    loadTestFile(require.resolve('./alerts/workflow_status'));
-    loadTestFile(require.resolve('./alerts/pagination'));
     loadTestFile(require.resolve('./alerts/add_to_case'));
-    loadTestFile(require.resolve('./alerts/state_synchronization'));
+    loadTestFile(require.resolve('./alerts/alert_disclaimer'));
     loadTestFile(require.resolve('./alerts/bulk_actions'));
+    loadTestFile(require.resolve('./alerts/pagination'));
+    loadTestFile(require.resolve('./alerts/rule_stats'));
+    loadTestFile(require.resolve('./alerts/state_synchronization'));
     loadTestFile(require.resolve('./alerts/table_storage'));
+    loadTestFile(require.resolve('./alerts/workflow_status'));
+
+    loadTestFile(require.resolve('./exploratory_view'));
+    loadTestFile(require.resolve('./feature_controls'));
   });
 }


### PR DESCRIPTION
## Summary

This PR is a follow up to #119750 to address additional feedback by @mgiota:
- Splits rule stat tests to a new test case
- Renames methods and vars that use the alerting service **Alert** semantics to **Rule**
- Includes erroring rules in the total count


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
