### PR TITLE
[8.0] Fix globalsearchg functional tests (#120333)

### DIFF
--- a/x-pack/plugins/global_search/server/routes/integration_tests/get_searchable_types.test.ts
+++ b/x-pack/plugins/global_search/server/routes/integration_tests/get_searchable_types.test.ts
@@ -46,7 +46,7 @@ describe('GET /internal/global_search/searchable_types', () => {
 
   it('calls the handler context with correct parameters', async () => {
     await supertest(httpSetup.server.listener)
-      .post('/internal/global_search/searchable_types')
+      .get('/internal/global_search/searchable_types')
       .expect(200);
 
     expect(globalSearchHandlerContext.getSearchableTypes).toHaveBeenCalledTimes(1);
@@ -56,7 +56,7 @@ describe('GET /internal/global_search/searchable_types', () => {
     globalSearchHandlerContext.getSearchableTypes.mockResolvedValue(['type-a', 'type-b']);
 
     const response = await supertest(httpSetup.server.listener)
-      .post('/internal/global_search/searchable_types')
+      .get('/internal/global_search/searchable_types')
       .expect(200);
 
     expect(response.body).toEqual({
@@ -68,8 +68,8 @@ describe('GET /internal/global_search/searchable_types', () => {
     globalSearchHandlerContext.getSearchableTypes.mockRejectedValue(new Error());
 
     const response = await supertest(httpSetup.server.listener)
-      .post('/internal/global_search/searchable_types')
-      .expect(200);
+      .get('/internal/global_search/searchable_types')
+      .expect(500);
 
     expect(response.body).toEqual(
       expect.objectContaining({


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix globalsearchg functional tests (#120333)