### PR TITLE
[UA] Filter out elastic products deprecation logs

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecation_logs/es_deprecation_logs.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecation_logs/es_deprecation_logs.test.tsx
@@ -212,7 +212,11 @@ describe('ES deprecation logs', () => {
         DEPRECATION_LOGS_ORIGIN_FIELD,
         ...APPS_WITH_DEPRECATION_LOGS,
       ].forEach((param) => {
-        expect(decodedUrl).toContain(param);
+        try {
+          expect(decodedUrl).toContain(param);
+        } catch (e) {
+          throw new Error(`Expected [${param}] not found in ${decodedUrl}`);
+        }
       });
     });
   });

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecation_logs/es_deprecation_logs.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecation_logs/es_deprecation_logs.test.tsx
@@ -16,6 +16,8 @@ import {
   DEPRECATION_LOGS_INDEX,
   DEPRECATION_LOGS_SOURCE_ID,
   DEPRECATION_LOGS_COUNT_POLL_INTERVAL_MS,
+  APPS_WITH_DEPRECATION_LOGS,
+  DEPRECATION_LOGS_ORIGIN_FIELD,
 } from '../../../common/constants';
 
 // Once the logs team register the kibana locators in their app, we should be able
@@ -171,9 +173,15 @@ describe('ES deprecation logs', () => {
       component.update();
 
       expect(exists('viewObserveLogs')).toBe(true);
-      expect(find('viewObserveLogs').props().href).toBe(
-        `/app/logs/stream?sourceId=${DEPRECATION_LOGS_SOURCE_ID}&logPosition=(end:now,start:'${MOCKED_TIME}')`
+      const sourceId = DEPRECATION_LOGS_SOURCE_ID;
+      const logPosition = `(end:now,start:'${MOCKED_TIME}')`;
+      const logFilter = encodeURI(
+        `(language:kuery,query:'not ${DEPRECATION_LOGS_ORIGIN_FIELD} : (${APPS_WITH_DEPRECATION_LOGS.join(
+          ' or '
+        )})')`
       );
+      const queryParams = `sourceId=${sourceId}&logPosition=${logPosition}&logFilter=${logFilter}`;
+      expect(find('viewObserveLogs').props().href).toBe(`/app/logs/stream?${queryParams}`);
     });
 
     test(`Doesn't show observability app link if infra app is not available`, async () => {
@@ -197,7 +205,13 @@ describe('ES deprecation logs', () => {
 
       const decodedUrl = decodeURIComponent(find('viewDiscoverLogs').props().href);
       expect(decodedUrl).toContain('discoverUrl');
-      ['"language":"kuery"', '"query":"@timestamp+>'].forEach((param) => {
+      [
+        '"language":"kuery"',
+        '"query":"@timestamp+>',
+        'filters=',
+        DEPRECATION_LOGS_ORIGIN_FIELD,
+        ...APPS_WITH_DEPRECATION_LOGS,
+      ].forEach((param) => {
         expect(decodedUrl).toContain(param);
       });
     });

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/app_context.mock.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/app_context.mock.ts
@@ -22,10 +22,29 @@ import { breadcrumbService } from '../../../public/application/lib/breadcrumbs';
 import { dataPluginMock } from '../../../../../../src/plugins/data/public/mocks';
 import { cloudMock } from '../../../../../../x-pack/plugins/cloud/public/mocks';
 
+const data = dataPluginMock.createStartContract();
+const dataViews = { ...data.dataViews };
+const findDataView = (id: string) =>
+  Promise.resolve([
+    {
+      id,
+      title: id,
+      getFieldByName: jest.fn((name: string) => ({
+        name,
+      })),
+    },
+  ]);
+
 const servicesMock = {
   api: apiService,
   breadcrumbs: breadcrumbService,
-  data: dataPluginMock.createStartContract(),
+  data: {
+    ...data,
+    dataViews: {
+      ...dataViews,
+      find: findDataView,
+    },
+  },
 };
 
 // We'll mock these values to avoid testing the locators themselves.

--- a/x-pack/plugins/upgrade_assistant/common/constants.ts
+++ b/x-pack/plugins/upgrade_assistant/common/constants.ts
@@ -47,7 +47,17 @@ export const SYSTEM_INDICES_MIGRATION_POLL_INTERVAL_MS = 15000;
  * We want to filter those out for our users so they only see deprecation logs
  * that _they_ are generating.
  */
-export const APPS_WITH_DEPRECATION_LOGS = ['1.6', '1.7'];
+export const APPS_WITH_DEPRECATION_LOGS = [
+  'kibana',
+  'cloud',
+  'logstash',
+  'beats',
+  'fleet',
+  'ml',
+  'security',
+  'observability',
+  'enterprise-search',
+];
 
 // The field that will indicate which elastic product generated the deprecation log
-export const DEPRECATION_LOGS_ORIGIN_FIELD = 'ecs.version';
+export const DEPRECATION_LOGS_ORIGIN_FIELD = 'elastic_product_origin';

--- a/x-pack/plugins/upgrade_assistant/common/constants.ts
+++ b/x-pack/plugins/upgrade_assistant/common/constants.ts
@@ -41,3 +41,13 @@ export const CLUSTER_UPGRADE_STATUS_POLL_INTERVAL_MS = 45000;
 export const CLOUD_BACKUP_STATUS_POLL_INTERVAL_MS = 60000;
 export const DEPRECATION_LOGS_COUNT_POLL_INTERVAL_MS = 15000;
 export const SYSTEM_INDICES_MIGRATION_POLL_INTERVAL_MS = 15000;
+
+/**
+ * List of Elastic apps that potentially can generate deprecation logs.
+ * We want to filter those out for our users so they only see deprecation logs
+ * that _they_ are generating.
+ */
+export const APPS_WITH_DEPRECATION_LOGS = ['1.6', '1.7'];
+
+// The field that will indicate which elastic product generated the deprecation log
+export const DEPRECATION_LOGS_ORIGIN_FIELD = 'ecs.version';

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/external_links.test.ts
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/external_links.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getDeprecationIndexPatternId } from './external_links';
+import { getDeprecationDataView } from './external_links';
 
 import { DEPRECATION_LOGS_INDEX_PATTERN } from '../../../../../common/constants';
 import { dataPluginMock, Start } from '../../../../../../../../src/plugins/data/public/mocks';
@@ -17,14 +17,14 @@ describe('External Links', () => {
     dataService = dataPluginMock.createStartContract();
   });
 
-  describe('getDeprecationIndexPatternId', () => {
-    it('creates new index pattern if doesnt exist', async () => {
+  describe('getDeprecationDataView', () => {
+    it('creates new data view if doesnt exist', async () => {
       dataService.dataViews.find = jest.fn().mockResolvedValue([]);
       dataService.dataViews.createAndSave = jest.fn().mockResolvedValue({ id: '123-456' });
 
-      const indexPatternId = await getDeprecationIndexPatternId(dataService);
+      const dataViewId = (await getDeprecationDataView(dataService)).id;
 
-      expect(indexPatternId).toBe('123-456');
+      expect(dataViewId).toBe('123-456');
       // prettier-ignore
       expect(dataService.dataViews.createAndSave).toHaveBeenCalledWith({
         title: DEPRECATION_LOGS_INDEX_PATTERN,
@@ -32,7 +32,7 @@ describe('External Links', () => {
       }, false, true);
     });
 
-    it('uses existing index pattern if it already exists', async () => {
+    it('uses existing data view if it already exists', async () => {
       dataService.dataViews.find = jest.fn().mockResolvedValue([
         {
           id: '123-456',
@@ -40,9 +40,9 @@ describe('External Links', () => {
         },
       ]);
 
-      const indexPatternId = await getDeprecationIndexPatternId(dataService);
+      const dataViewId = await (await getDeprecationDataView(dataService)).id;
 
-      expect(indexPatternId).toBe('123-456');
+      expect(dataViewId).toBe('123-456');
       expect(dataService.dataViews.find).toHaveBeenCalledWith(DEPRECATION_LOGS_INDEX_PATTERN);
     });
   });

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/external_links.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/external_links.tsx
@@ -7,11 +7,16 @@
 
 import { encode } from 'rison-node';
 import React, { FunctionComponent, useState, useEffect } from 'react';
+import { buildPhrasesFilter, PhraseFilter } from '@kbn/es-query';
 
 import { FormattedMessage } from '@kbn/i18n/react';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { EuiLink, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiPanel, EuiText } from '@elastic/eui';
 
+import {
+  APPS_WITH_DEPRECATION_LOGS,
+  DEPRECATION_LOGS_ORIGIN_FIELD,
+} from '../../../../../common/constants';
 import { DataPublicPluginStart } from '../../../../shared_imports';
 import { useAppContext } from '../../../app_context';
 import {
@@ -29,32 +34,32 @@ interface Props {
   checkpoint: string;
 }
 
-export const getDeprecationIndexPatternId = async (dataService: DataPublicPluginStart) => {
+export const getDeprecationDataView = async (dataService: DataPublicPluginStart) => {
   const results = await dataService.dataViews.find(DEPRECATION_LOGS_INDEX_PATTERN);
   // Since the find might return also results with wildcard matchers we need to find the
   // index pattern that has an exact match with our title.
-  const deprecationIndexPattern = results.find(
+  const deprecationDataView = results.find(
     (result) => result.title === DEPRECATION_LOGS_INDEX_PATTERN
   );
 
-  if (deprecationIndexPattern) {
-    return deprecationIndexPattern.id;
+  if (deprecationDataView) {
+    return deprecationDataView;
   } else {
-    // When creating the index pattern, we need to be careful when creating an indexPattern
+    // When creating the data view, we need to be careful when creating a data view
     // for an index that doesnt exist. Since the deprecation logs data stream is only created
     // when a deprecation log is indexed it could be possible that it might not exist at the
     // time we need to render the DiscoveryAppLink.
-    // So in order to avoid those errors we need to make sure that the indexPattern is created
+    // So in order to avoid those errors we need to make sure that the data view is created
     // with allowNoIndex and that we skip fetching fields to from the source index.
     const override = false;
     const skipFetchFields = true;
     // prettier-ignore
-    const newIndexPattern = await dataService.dataViews.createAndSave({
+    const newDataView = await dataService.dataViews.createAndSave({
       title: DEPRECATION_LOGS_INDEX_PATTERN,
       allowNoIndex: true,
     }, override, skipFetchFields);
 
-    return newIndexPattern.id;
+    return newDataView;
   }
 };
 
@@ -68,19 +73,29 @@ const DiscoverAppLink: FunctionComponent<Props> = ({ checkpoint }) => {
 
   useEffect(() => {
     const getDiscoveryUrl = async () => {
-      const indexPatternId = await getDeprecationIndexPatternId(dataService);
       const locator = share.url.locators.get('DISCOVER_APP_LOCATOR');
-
       if (!locator) {
         return;
       }
 
-      const url = await locator.getUrl({
-        indexPatternId,
+      const dataView = await getDeprecationDataView(dataService);
+      const field = dataView.getFieldByName(DEPRECATION_LOGS_ORIGIN_FIELD);
+
+      let filters: PhraseFilter[] = [];
+
+      if (field !== undefined) {
+        const filter = buildPhrasesFilter(field!, [...APPS_WITH_DEPRECATION_LOGS], dataView);
+        filter.meta.negate = true;
+        filters = [filter];
+      }
+
+      const url = await locator?.getUrl({
+        indexPatternId: dataView.id,
         query: {
           language: 'kuery',
           query: `@timestamp > "${checkpoint}"`,
         },
+        filters,
       });
 
       setDiscoveryUrl(url);
@@ -88,6 +103,10 @@ const DiscoverAppLink: FunctionComponent<Props> = ({ checkpoint }) => {
 
     getDiscoveryUrl();
   }, [dataService, checkpoint, share.url.locators]);
+
+  if (discoveryUrl === undefined) {
+    return null;
+  }
 
   return (
     // eslint-disable-next-line @elastic/eui/href-or-on-click
@@ -112,11 +131,19 @@ const ObservabilityAppLink: FunctionComponent<Props> = ({ checkpoint }) => {
       core: { http },
     },
   } = useAppContext();
-  const logStreamUrl = http?.basePath?.prepend(
-    `/app/logs/stream?sourceId=${DEPRECATION_LOGS_SOURCE_ID}&logPosition=(end:now,start:${encode(
-      checkpoint
-    )})`
+
+  // Ideally we don't want to hardcode the path to the Log Stream app and use the UrlService.locator instead.
+  // Issue opened: https://github.com/elastic/kibana/issues/104855
+  const streamAppPath = '/app/logs/stream';
+
+  const sourceId = DEPRECATION_LOGS_SOURCE_ID;
+  const logPosition = `(end:now,start:${encode(checkpoint)})`;
+  const logFilter = encodeURI(
+    `(language:kuery,query:'not ecs.version : (${APPS_WITH_DEPRECATION_LOGS.join(' or ')})')`
   );
+  const queryParams = `sourceId=${sourceId}&logPosition=${logPosition}&logFilter=${logFilter}`;
+
+  const logStreamUrl = http?.basePath?.prepend(`${streamAppPath}?${queryParams}`);
 
   return (
     // eslint-disable-next-line @elastic/eui/href-or-on-click

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/external_links.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/external_links.tsx
@@ -139,7 +139,9 @@ const ObservabilityAppLink: FunctionComponent<Props> = ({ checkpoint }) => {
   const sourceId = DEPRECATION_LOGS_SOURCE_ID;
   const logPosition = `(end:now,start:${encode(checkpoint)})`;
   const logFilter = encodeURI(
-    `(language:kuery,query:'not ecs.version : (${APPS_WITH_DEPRECATION_LOGS.join(' or ')})')`
+    `(language:kuery,query:'not ${DEPRECATION_LOGS_ORIGIN_FIELD} : (${APPS_WITH_DEPRECATION_LOGS.join(
+      ' or '
+    )})')`
   );
   const queryParams = `sourceId=${sourceId}&logPosition=${logPosition}&logFilter=${logFilter}`;
 

--- a/x-pack/plugins/upgrade_assistant/server/routes/deprecation_logging.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/deprecation_logging.ts
@@ -6,7 +6,11 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { API_BASE_PATH } from '../../common/constants';
+import {
+  API_BASE_PATH,
+  APPS_WITH_DEPRECATION_LOGS,
+  DEPRECATION_LOGS_ORIGIN_FIELD,
+} from '../../common/constants';
 
 import {
   getDeprecationLoggingStatus,
@@ -108,9 +112,18 @@ export function registerDeprecationLoggingRoutes({
             index: DEPRECATION_LOGS_INDEX,
             body: {
               query: {
-                range: {
-                  '@timestamp': {
-                    gte: request.query.from,
+                bool: {
+                  must: {
+                    range: {
+                      '@timestamp': {
+                        gte: request.query.from,
+                      },
+                    },
+                  },
+                  must_not: {
+                    terms: {
+                      [DEPRECATION_LOGS_ORIGIN_FIELD]: [...APPS_WITH_DEPRECATION_LOGS],
+                    },
                   },
                 },
               },

--- a/x-pack/test/api_integration/apis/upgrade_assistant/es_deprecation_logs.helpers.ts
+++ b/x-pack/test/api_integration/apis/upgrade_assistant/es_deprecation_logs.helpers.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Chance from 'chance';
+
+import {
+  DEPRECATION_LOGS_INDEX,
+  DEPRECATION_LOGS_ORIGIN_FIELD,
+} from '../../../../plugins/upgrade_assistant/common/constants';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+const chance = new Chance();
+const CHARS_POOL = 'abcdefghijklmnopqrstuvwxyz';
+const getRandomString = () => `${chance.string({ pool: CHARS_POOL })}-${Date.now()}`;
+
+const deprecationMock = {
+  'event.dataset': 'deprecation.elasticsearch',
+  '@timestamp': '2021-12-06T16:28:11,104Z',
+  'log.level': 'CRITICAL',
+  'log.logger':
+    'org.elasticsearch.deprecation.rest.action.admin.indices.RestGetIndexTemplateAction',
+  'elasticsearch.cluster.name': 'es-test-cluster',
+  'elasticsearch.cluster.uuid': 'PBE1syg4ToKCA0DcD2nKEw',
+  'elasticsearch.node.id': '_0gaVTs5TIO_JWuFl9URJA',
+  'elasticsearch.node.name': 'node-01',
+  message:
+    '[types removal] Specifying include_type_name in get index template requests is deprecated.',
+  'data_stream.type': 'logs',
+  'data_stream.dataset': 'deprecation.elasticsearch',
+  'data_stream.namespace': 'default',
+  'ecs.version': '1.7',
+  'elasticsearch.event.category': 'types',
+  'event.code': 'get_index_template_include_type_name',
+  'elasticsearch.http.request.x_opaque_id': 'd17e37e2-d41f-49cc-8186-35bcdcd99770',
+};
+
+export const initHelpers = (getService: FtrProviderContext['getService']) => {
+  const es = getService('es');
+
+  const createDeprecationLog = async (isElasticProduct = false) => {
+    const id = getRandomString();
+
+    const body = {
+      ...deprecationMock,
+    };
+
+    if (isElasticProduct) {
+      (body as any)[DEPRECATION_LOGS_ORIGIN_FIELD] = 'kibana';
+    }
+
+    await es.index({
+      id,
+      index: DEPRECATION_LOGS_INDEX,
+      op_type: 'create',
+      refresh: true,
+      body,
+    });
+
+    return id;
+  };
+
+  const deleteDeprecationLogs = async (docIds: string[]) => {
+    return await es.deleteByQuery({
+      index: DEPRECATION_LOGS_INDEX,
+      refresh: true,
+      body: {
+        query: {
+          ids: { values: docIds },
+        },
+      },
+    });
+  };
+
+  return {
+    createDeprecationLog,
+    deleteDeprecationLogs,
+  };
+};

--- a/x-pack/test/api_integration/apis/upgrade_assistant/es_deprecation_logs.ts
+++ b/x-pack/test/api_integration/apis/upgrade_assistant/es_deprecation_logs.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import expect from '@kbn/expect';
+import moment from 'moment-timezone';
+
+import {
+  DEPRECATION_LOGS_INDEX,
+  DEPRECATION_LOGS_ORIGIN_FIELD,
+  APPS_WITH_DEPRECATION_LOGS,
+  API_BASE_PATH,
+} from '../../../../plugins/upgrade_assistant/common/constants';
+import { FtrProviderContext } from '../../ftr_provider_context';
+import { initHelpers } from './es_deprecation_logs.helpers';
+
+export default function ({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const supertest = getService('supertest');
+
+  const { createDeprecationLog, deleteDeprecationLogs } = initHelpers(getService);
+
+  describe('Elasticsearch deprecation logs', () => {
+    describe('GET /api/upgrade_assistant/deprecation_logging', () => {
+      describe('/count', () => {
+        it('should filter out the deprecation from Elastic products', async () => {
+          // We add a custom deprecation to make sure our filter is working
+          // and make sure that the count of deprecation without filter is greater
+          // than the total of deprecations
+          const doc1 = await createDeprecationLog();
+          const doc2 = await createDeprecationLog(true); // Create Elastic Product deprecation
+          const checkpoint = moment('2000-01-01').toISOString();
+
+          const allDeprecations = (
+            await es.search({
+              index: DEPRECATION_LOGS_INDEX,
+              size: 10000,
+            })
+          ).body.hits.hits;
+
+          const nonElasticProductDeprecations = allDeprecations.filter(
+            (deprecation) =>
+              !APPS_WITH_DEPRECATION_LOGS.includes(
+                (deprecation._source as any)[DEPRECATION_LOGS_ORIGIN_FIELD]
+              )
+          );
+
+          const { body: apiRequestResponse } = await supertest
+            .get(`${API_BASE_PATH}/deprecation_logging/count`)
+            .query({
+              from: checkpoint,
+            })
+            .set('kbn-xsrf', 'xxx')
+            .expect(200);
+
+          expect(nonElasticProductDeprecations.length).be.below(allDeprecations.length);
+          expect(apiRequestResponse.count).be(nonElasticProductDeprecations.length);
+
+          await deleteDeprecationLogs([doc1, doc2]);
+        });
+      });
+    });
+  });
+}

--- a/x-pack/test/api_integration/apis/upgrade_assistant/index.ts
+++ b/x-pack/test/api_integration/apis/upgrade_assistant/index.ts
@@ -13,5 +13,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./cloud_backup_status'));
     loadTestFile(require.resolve('./privileges'));
     loadTestFile(require.resolve('./es_deprecations'));
+    loadTestFile(require.resolve('./es_deprecation_logs'));
   });
 }


### PR DESCRIPTION
This PR adds the filters to not display deprecation logs coming from Elastic products in Upgrade Assistant.

This is a draft which currently points to `7.16`. But this work will later target `main` and `7.17`.

Fixes https://github.com/elastic/kibana/issues/120152

<img width="1574" alt="Screenshot 2021-12-03 at 17 19 24" src="https://user-images.githubusercontent.com/2854616/144645671-4286d764-e87d-4eef-9df0-7a9f48203b30.png">

