### PR TITLE
Upgrade to EUI v39.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^7.16.0-canary.7",
     "@elastic/ems-client": "7.16.0",
-    "@elastic/eui": "39.1.2",
+    "@elastic/eui": "39.1.3",
     "@elastic/filesaver": "1.1.2",
     "@elastic/good": "^9.0.1-kibana3",
     "@elastic/maki": "6.3.0",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -75,6 +75,6 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@7.16.0': ['Elastic License 2.0'],
-  '@elastic/eui@39.1.2': ['SSPL-1.0 OR Elastic License 2.0'],
+  '@elastic/eui@39.1.3': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,10 +1595,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@39.1.2":
-  version "39.1.2"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-39.1.2.tgz#8eb1684a7a406bc13b8514a366d450e964dbf56f"
-  integrity sha512-R3MqXcLOYMe/nlm+KG0TGrAjTCmpuwNkh7iKGUxVXZIRkzkgp2wyGmoX1qZnKTogN3OSEf7kKEq1JeivPYWBOA==
+"@elastic/eui@39.1.3":
+  version "39.1.3"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-39.1.3.tgz#4cabdbf4d5942f8a0114363d97d72408d57ec872"
+  integrity sha512-jXRMZj6s/Pi6D9FgcX2za6iP3k2OOXs+4CrU24SCPwmBJkwjdI3qQVPIV/Vq5rZ6GaM798PLGRm9aAyXNcVjsw==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
## Summary

`eui@39.1.2` ⏩ `eui@39.1.3`

## [`39.1.3`](https://github.com/elastic/eui/tree/v39.1.3)

**Note: this release is a backport containing changes originally made after `42.0.0`**
 
**Bug fixes**

- Fixed unremoved event listener memory leak in `EuiPopover` ([#5437](https://github.com/elastic/eui/pull/5437))

