### PR TITLE
Upgrade to EUI v40.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^8.0.0-canary.35",
     "@elastic/ems-client": "8.0.0",
-    "@elastic/eui": "40.1.0",
+    "@elastic/eui": "40.1.1",
     "@elastic/filesaver": "1.1.2",
     "@elastic/maki": "6.3.0",
     "@elastic/node-crypto": "1.2.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -75,6 +75,6 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.0.0': ['Elastic License 2.0'],
-  '@elastic/eui@40.1.0': ['SSPL-1.0 OR Elastic License 2.0'],
+  '@elastic/eui@40.1.1': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1594,10 +1594,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@40.1.0":
-  version "40.1.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-40.1.0.tgz#d5ad63e9ed4ae482037a637e9b3f2598712c9e94"
-  integrity sha512-xlmbu4ZjdKtpgkQZ6GNMWCyyjSJaNFPMj97pLs11UEag2L1W0IwISlGF9+K45Qp4KLatR6iphwiyLFGmqGOOTA==
+"@elastic/eui@40.1.1":
+  version "40.1.1"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-40.1.1.tgz#98b744d61dccf4b3c8ba5fdf7255f872908cf7e8"
+  integrity sha512-Zi5yhyT7/e/TiuFpYrmlhghnGIUfRRsx/0AqyrTa85ys4f4XGOuF0YusM/p1kJzzBY3O1Dmd8vTs8lwNRJ+WfA==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
## Summary

`eui@40.1.0` ⏩ `eui@40.1.1`

## [`40.1.1`](https://github.com/elastic/eui/tree/v40.1.1)

**Note: this release is a backport containing changes originally made after `42.0.0`**
 
**Bug fixes**

- Fixed unremoved event listener memory leak in `EuiPopover` ([#5437](https://github.com/elastic/eui/pull/5437))