### PR TITLE
[Security Solution] endpoint metadata transform stats API

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -7,7 +7,6 @@
 
 import type { TransformConfigSchema } from './transforms/types';
 import { ENABLE_CASE_CONNECTOR } from '../../cases/common';
-import { METADATA_TRANSFORMS_PATTERN } from './endpoint/constants';
 
 /**
  * as const
@@ -361,8 +360,6 @@ export const showAllOthersBucket: string[] = [
  * than use it from here.
  */
 export const ELASTIC_NAME = 'estc' as const;
-
-export const METADATA_TRANSFORM_STATS_URL = `/api/transform/transforms/${METADATA_TRANSFORMS_PATTERN}/_stats`;
 
 export const RISKY_HOSTS_INDEX_PREFIX = 'ml_host_risk_score_latest_' as const;
 

--- a/x-pack/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/constants.ts
@@ -44,6 +44,7 @@ export const LIMITED_CONCURRENCY_ENDPOINT_COUNT = 100;
 export const BASE_ENDPOINT_ROUTE = '/api/endpoint';
 export const HOST_METADATA_LIST_ROUTE = `${BASE_ENDPOINT_ROUTE}/metadata`;
 export const HOST_METADATA_GET_ROUTE = `${BASE_ENDPOINT_ROUTE}/metadata/{id}`;
+export const METADATA_TRANSFORMS_STATUS_ROUTE = `${BASE_ENDPOINT_ROUTE}/metadata/transforms`;
 
 export const TRUSTED_APPS_GET_API = `${BASE_ENDPOINT_ROUTE}/trusted_apps/{id}`;
 export const TRUSTED_APPS_LIST_API = `${BASE_ENDPOINT_ROUTE}/trusted_apps`;
@@ -68,3 +69,6 @@ export const failedFleetActionErrorCode = '424';
 
 export const ENDPOINT_DEFAULT_PAGE = 0;
 export const ENDPOINT_DEFAULT_PAGE_SIZE = 10;
+
+export const FORBIDDEN_MESSAGE =
+  'You do not have permission to perform this action or license level does not allow for this action';

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/mocks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/mocks.ts
@@ -24,12 +24,13 @@ import {
   ENDPOINT_ACTION_LOG_ROUTE,
   HOST_METADATA_GET_ROUTE,
   HOST_METADATA_LIST_ROUTE,
+  METADATA_TRANSFORMS_STATUS_ROUTE,
 } from '../../../../common/endpoint/constants';
 import {
   pendingActionsHttpMock,
   PendingActionsHttpMockInterface,
 } from '../../../common/lib/endpoint_pending_actions/mocks';
-import { METADATA_TRANSFORM_STATS_URL, TRANSFORM_STATES } from '../../../../common/constants';
+import { TRANSFORM_STATES } from '../../../../common/constants';
 import { TransformStatsResponse } from './types';
 import {
   fleetGetAgentPolicyListHttpMock,
@@ -162,7 +163,7 @@ export const failedTransformStateMock = {
 export const transformsHttpMocks = httpHandlerMockFactory<TransformHttpMocksInterface>([
   {
     id: 'metadataTransformStats',
-    path: METADATA_TRANSFORM_STATS_URL,
+    path: METADATA_TRANSFORMS_STATUS_ROUTE,
     method: 'get',
     handler: () => failedTransformStateMock,
   },

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.ts
@@ -10,7 +10,6 @@ import { CoreStart, HttpStart } from 'kibana/public';
 import { Dispatch } from 'redux';
 import semverGte from 'semver/functions/gte';
 import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '../../../../../../fleet/common';
-import { METADATA_TRANSFORM_STATS_URL } from '../../../../../common/constants';
 import {
   BASE_POLICY_RESPONSE_ROUTE,
   ENDPOINT_ACTION_LOG_ROUTE,
@@ -18,6 +17,7 @@ import {
   HOST_METADATA_LIST_ROUTE,
   metadataCurrentIndexPattern,
   METADATA_UNITED_INDEX,
+  METADATA_TRANSFORMS_STATUS_ROUTE,
 } from '../../../../../common/endpoint/constants';
 import {
   ActivityLog,
@@ -783,7 +783,7 @@ export async function handleLoadMetadataTransformStats(http: HttpStart, store: E
 
   try {
     const transformStatsResponse: TransformStatsResponse = await http.get(
-      METADATA_TRANSFORM_STATS_URL
+      METADATA_TRANSFORMS_STATUS_ROUTE
     );
 
     dispatch({

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/mock_endpoint_result_list.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/mock_endpoint_result_list.ts
@@ -32,8 +32,8 @@ import { pendingActionsResponseMock } from '../../../../common/lib/endpoint_pend
 import {
   ACTION_STATUS_ROUTE,
   HOST_METADATA_LIST_ROUTE,
+  METADATA_TRANSFORMS_STATUS_ROUTE,
 } from '../../../../../common/endpoint/constants';
-import { METADATA_TRANSFORM_STATS_URL } from '../../../../../common/constants';
 import { TransformStats, TransformStatsResponse } from '../types';
 
 const generator = new EndpointDocGenerator('seed');
@@ -162,7 +162,7 @@ const endpointListApiPathHandlerMocks = ({
       return pendingActionsResponseMock();
     },
 
-    [METADATA_TRANSFORM_STATS_URL]: (): TransformStatsResponse => ({
+    [METADATA_TRANSFORMS_STATUS_ROUTE]: (): TransformStatsResponse => ({
       count: transforms.length,
       transforms,
     }),

--- a/x-pack/plugins/security_solution/server/endpoint/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/mocks.ts
@@ -40,6 +40,8 @@ import { createCasesClientMock } from '../../../cases/server/client/mocks';
 import { requestContextFactoryMock } from '../request_context_factory.mock';
 import { EndpointMetadataService } from './services/metadata';
 import { createFleetAuthzMock } from '../../../fleet/common';
+import { createMockClients } from '../lib/detection_engine/routes/__mocks__/request_context';
+import type { EndpointAuthz } from '../../common/endpoint/types/authz';
 
 /**
  * Creates a mocked EndpointAppContext.
@@ -181,9 +183,13 @@ export const createMockMetadataRequestContext = (): jest.Mocked<MetadataRequestC
 
 export function createRouteHandlerContext(
   dataClient: jest.Mocked<IScopedClusterClient>,
-  savedObjectsClient: jest.Mocked<SavedObjectsClientContract>
+  savedObjectsClient: jest.Mocked<SavedObjectsClientContract>,
+  overrides: { endpointAuthz?: Partial<EndpointAuthz> } = {}
 ) {
-  const context = requestContextMock.create() as jest.Mocked<SecuritySolutionRequestHandlerContext>;
+  const context = requestContextMock.create(
+    createMockClients(),
+    overrides
+  ) as jest.Mocked<SecuritySolutionRequestHandlerContext>;
   context.core.elasticsearch.client = dataClient;
   context.core.savedObjects.client = savedObjectsClient;
   return context;

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.ts
@@ -18,6 +18,7 @@ import {
   ISOLATE_HOST_ROUTE,
   UNISOLATE_HOST_ROUTE,
   failedFleetActionErrorCode,
+  FORBIDDEN_MESSAGE,
 } from '../../../../common/endpoint/constants';
 import { AGENT_ACTIONS_INDEX } from '../../../../../fleet/common';
 import {
@@ -105,8 +106,7 @@ export const isolationRequestHandler = function (
     if ((!canIsolateHost && isolate) || (!canUnIsolateHost && !isolate)) {
       return res.forbidden({
         body: {
-          message:
-            'You do not have permission to perform this action or license level does not allow for this action',
+          message: FORBIDDEN_MESSAGE,
         },
       });
     }

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/index.ts
@@ -9,11 +9,17 @@ import { schema } from '@kbn/config-schema';
 
 import { HostStatus } from '../../../../common/endpoint/types';
 import { EndpointAppContext } from '../../types';
-import { getLogger, getMetadataRequestHandler, getMetadataListRequestHandler } from './handlers';
+import {
+  getLogger,
+  getMetadataRequestHandler,
+  getMetadataListRequestHandler,
+  getMetadataTransformStatsHandler,
+} from './handlers';
 import type { SecuritySolutionPluginRouter } from '../../../types';
 import {
   HOST_METADATA_GET_ROUTE,
   HOST_METADATA_LIST_ROUTE,
+  METADATA_TRANSFORMS_STATUS_ROUTE,
 } from '../../../../common/endpoint/constants';
 import { GetMetadataListRequestSchema } from '../../../../common/endpoint/schema/metadata';
 
@@ -59,5 +65,14 @@ export function registerEndpointRoutes(
       options: { authRequired: true, tags: ['access:securitySolution'] },
     },
     getMetadataRequestHandler(endpointAppContext, logger)
+  );
+
+  router.get(
+    {
+      path: METADATA_TRANSFORMS_STATUS_ROUTE,
+      validate: false,
+      options: { authRequired: true, tags: ['access:securitySolution'] },
+    },
+    getMetadataTransformStatsHandler(logger)
   );
 }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
@@ -31,8 +31,9 @@ import type {
   SecuritySolutionRequestHandlerContext,
 } from '../../../../types';
 import { getEndpointAuthzInitialStateMock } from '../../../../../common/endpoint/service/authz';
+import { EndpointAuthz } from '../../../../../common/endpoint/types/authz';
 
-const createMockClients = () => {
+export const createMockClients = () => {
   const core = coreMock.createRequestHandlerContext();
   const license = licensingMock.createLicenseMock();
 
@@ -67,11 +68,12 @@ type SecuritySolutionRequestHandlerContextMock =
   };
 
 const createRequestContextMock = (
-  clients: MockClients = createMockClients()
+  clients: MockClients = createMockClients(),
+  overrides: { endpointAuthz?: Partial<EndpointAuthz> } = {}
 ): SecuritySolutionRequestHandlerContextMock => {
   return {
     core: clients.core,
-    securitySolution: createSecuritySolutionRequestContextMock(clients),
+    securitySolution: createSecuritySolutionRequestContextMock(clients, overrides),
     actions: {
       getActionsClient: jest.fn(() => clients.actionsClient),
     } as unknown as jest.Mocked<ActionsApiRequestHandlerContext>,
@@ -87,14 +89,15 @@ const createRequestContextMock = (
 };
 
 const createSecuritySolutionRequestContextMock = (
-  clients: MockClients
+  clients: MockClients,
+  overrides: { endpointAuthz?: Partial<EndpointAuthz> } = {}
 ): jest.Mocked<SecuritySolutionApiRequestHandlerContext> => {
   const core = clients.core;
   const kibanaRequest = requestMock.create();
 
   return {
     core,
-    endpointAuthz: getEndpointAuthzInitialStateMock(),
+    endpointAuthz: getEndpointAuthzInitialStateMock(overrides.endpointAuthz),
     getConfig: jest.fn(() => clients.config),
     getFrameworkRequest: jest.fn(() => {
       return {

--- a/x-pack/test/security_solution_endpoint_api_int/apis/data_stream_helper.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/data_stream_helper.ts
@@ -119,10 +119,12 @@ export async function startTransform(
   const transformsResponse = await client.transform.getTransform({
     transform_id: `${transformId}*`,
   });
-  return transformsResponse.transforms.map((transform) => {
-    const t = transform as unknown as { id: string };
-    return client.transform.startTransform({ transform_id: t.id });
-  });
+  return Promise.all(
+    transformsResponse.transforms.map((transform) => {
+      const t = transform as unknown as { id: string };
+      return client.transform.startTransform({ transform_id: t.id });
+    })
+  );
 }
 
 export function bulkIndex(

--- a/x-pack/test/security_solution_endpoint_api_int/apis/metadata.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/metadata.ts
@@ -7,6 +7,7 @@
 
 import uuid from 'uuid';
 import expect from '@kbn/expect';
+import { TransformGetTransformStatsTransformStats } from '@elastic/elasticsearch/lib/api/types';
 import { FtrProviderContext } from '../ftr_provider_context';
 import {
   deleteAllDocsFromMetadataCurrentIndex,
@@ -24,10 +25,13 @@ import {
   HOST_METADATA_LIST_ROUTE,
   METADATA_UNITED_INDEX,
   METADATA_UNITED_TRANSFORM,
+  METADATA_TRANSFORMS_STATUS_ROUTE,
+  metadataTransformPrefix,
 } from '../../../plugins/security_solution/common/endpoint/constants';
 import { AGENTS_INDEX } from '../../../plugins/fleet/common';
 import { generateAgentDocs, generateMetadataDocs } from './metadata.fixtures';
 import { indexFleetEndpointPolicy } from '../../../plugins/security_solution/common/endpoint/data_loaders/index_fleet_endpoint_policy';
+import { TRANSFORM_STATES } from '../../../plugins/security_solution/common/constants';
 
 export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
@@ -71,7 +75,6 @@ export default function ({ getService }: FtrProviderContext) {
           await deleteAllDocsFromFleetAgents(getService);
           await deleteAllDocsFromMetadataDatastream(getService);
           await deleteAllDocsFromMetadataCurrentIndex(getService);
-          await stopTransform(getService, `${METADATA_UNITED_TRANSFORM}*`);
           await deleteAllDocsFromIndex(getService, METADATA_UNITED_INDEX);
         });
 
@@ -502,6 +505,63 @@ export default function ({ getService }: FtrProviderContext) {
             expect(body.pageSize).to.eql(10);
           });
         });
+      });
+    });
+
+    describe('get metadata transforms', () => {
+      it('should respond forbidden if no fleet access', async () => {
+        await getService('supertestWithoutAuth')
+          .get(METADATA_TRANSFORMS_STATUS_ROUTE)
+          .set('kbn-xsrf', 'xxx')
+          .expect(401);
+      });
+
+      it('correctly returns stopped transform stats', async () => {
+        await stopTransform(getService, `${metadataTransformPrefix}*`);
+        await stopTransform(getService, `${METADATA_UNITED_TRANSFORM}*`);
+
+        const { body } = await supertest
+          .get(METADATA_TRANSFORMS_STATUS_ROUTE)
+          .set('kbn-xsrf', 'xxx')
+          .expect(200);
+
+        expect(body.count).to.eql(2);
+
+        const transforms: TransformGetTransformStatsTransformStats[] = body.transforms.sort(
+          (
+            a: TransformGetTransformStatsTransformStats,
+            b: TransformGetTransformStatsTransformStats
+          ) => a.id > b.id
+        );
+
+        expect(transforms[0].id).to.contain(metadataTransformPrefix);
+        expect(transforms[0].state).to.eql(TRANSFORM_STATES.STOPPED);
+        expect(transforms[1].id).to.contain(METADATA_UNITED_TRANSFORM);
+        expect(transforms[1].state).to.eql(TRANSFORM_STATES.STOPPED);
+
+        await startTransform(getService, metadataTransformPrefix);
+        await startTransform(getService, METADATA_UNITED_TRANSFORM);
+      });
+
+      it('correctly returns started transform stats', async () => {
+        const { body } = await supertest
+          .get(METADATA_TRANSFORMS_STATUS_ROUTE)
+          .set('kbn-xsrf', 'xxx')
+          .expect(200);
+
+        expect(body.count).to.eql(2);
+
+        const transforms: TransformGetTransformStatsTransformStats[] = body.transforms.sort(
+          (
+            a: TransformGetTransformStatsTransformStats,
+            b: TransformGetTransformStatsTransformStats
+          ) => a.id > b.id
+        );
+
+        expect(transforms[0].id).to.contain(metadataTransformPrefix);
+        expect(transforms[0].state).to.eql(TRANSFORM_STATES.STARTED);
+        expect(transforms[1].id).to.contain(METADATA_UNITED_TRANSFORM);
+        expect(transforms[1].state).to.eql(TRANSFORM_STATES.STARTED);
       });
     });
   });


### PR DESCRIPTION
## Summary

Add new endpoint metadata transform stats API that explicitly checks for fleet permissions and switch endpoints transform warning banner to use new endpoint.


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
