### PR TITLE
[Devtools] Compress mappings response size for autocomplete

### DIFF
--- a/src/plugins/console/public/lib/mappings/mappings.js
+++ b/src/plugins/console/public/lib/mappings/mappings.js
@@ -250,7 +250,10 @@ function retrieveSettings(settingsKey, settingsToRetrieve) {
 
   // Fetch autocomplete info if setting is set to true, and if user has made changes.
   if (settingsToRetrieve[settingsKey] === true) {
-    return es.send('GET', settingKeyToPathMap[settingsKey], null, true);
+    // Appending pretty=false here to compress the response size for autocomplete.
+    const path = `${settingKeyToPathMap[settingsKey]}?pretty=false`;
+
+    return es.send('GET', path, null, true);
   } else {
     const settingsPromise = new $.Deferred();
     if (settingsToRetrieve[settingsKey] === false) {

--- a/src/plugins/console/public/lib/mappings/mappings.js
+++ b/src/plugins/console/public/lib/mappings/mappings.js
@@ -250,7 +250,7 @@ function retrieveSettings(settingsKey, settingsToRetrieve) {
 
   // Fetch autocomplete info if setting is set to true, and if user has made changes.
   if (settingsToRetrieve[settingsKey] === true) {
-    // Appending pretty=false here to compress the response size for autocomplete.
+    // Use pretty=false in these request in order to compress the response by removing whitespace
     const path = `${settingKeyToPathMap[settingsKey]}?pretty=false`;
 
     return es.send('GET', path, null, true);


### PR DESCRIPTION
Resolve: [#119220](https://github.com/elastic/kibana/issues/119220)

[Edit by @cjcenizal] Did some benchmarking by installing all of the sample data and comparing the payload size without compression (2.2kb) and with compression (2kb). This shows a payload size reduction of 9%, keeping in mind that this isn't a great benchmark with such a small mappings size and a small sample size (since whitespace will change depending on the shape of the mappings).