### PR TITLE
Fix order of Lens tests

### DIFF
--- a/x-pack/test/functional/apps/lens/index.ts
+++ b/x-pack/test/functional/apps/lens/index.ts
@@ -48,6 +48,16 @@ export default function ({ getService, loadTestFile, getPageObjects }: FtrProvid
     });
 
     describe('', function () {
+      this.tags(['ciGroup16', 'skipFirefox']);
+
+      loadTestFile(require.resolve('./add_to_dashboard'));
+      loadTestFile(require.resolve('./table_dashboard'));
+      loadTestFile(require.resolve('./table'));
+      loadTestFile(require.resolve('./runtime_fields'));
+      loadTestFile(require.resolve('./dashboard'));
+    });
+
+    describe('', function () {
       this.tags(['ciGroup4', 'skipFirefox']);
 
       loadTestFile(require.resolve('./colors'));
@@ -65,16 +75,6 @@ export default function ({ getService, loadTestFile, getPageObjects }: FtrProvid
       loadTestFile(require.resolve('./lens_reporting'));
       // has to be last one in the suite because it overrides saved objects
       loadTestFile(require.resolve('./rollup'));
-    });
-
-    describe('', function () {
-      this.tags(['ciGroup16', 'skipFirefox']);
-
-      loadTestFile(require.resolve('./add_to_dashboard'));
-      loadTestFile(require.resolve('./table_dashboard'));
-      loadTestFile(require.resolve('./table'));
-      loadTestFile(require.resolve('./runtime_fields'));
-      loadTestFile(require.resolve('./dashboard'));
     });
   });
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/120390
Fixes https://github.com/elastic/kibana/issues/120391
Fixes https://github.com/elastic/kibana/issues/120393
Fixes https://github.com/elastic/kibana/issues/120394

The above test suites were failing in the cloud tests because they are not running separated by CI groups, but one after the other. As the tests of ci group 16 were running after the rollup test suite which is overriding saved objects, they were failing. This PR makes sure the tests are in the right order if ran in series.