### PR TITLE
[DO NOT MERGE][Unified observability] POC Embedded dashboard

### DIFF
--- a/x-pack/plugins/observability/kibana.json
+++ b/x-pack/plugins/observability/kibana.json
@@ -6,23 +6,14 @@
   },
   "version": "8.0.0",
   "kibanaVersion": "kibana",
-  "configPath": [
-    "xpack",
-    "observability"
-  ],
-  "optionalPlugins": [
-    "discover",
-    "embeddable",
-    "home",
-    "lens",
-    "licensing",
-    "spaces",
-    "usageCollection"
-  ],
+  "configPath": ["xpack", "observability"],
+  "optionalPlugins": ["discover", "home", "lens", "licensing", "spaces", "usageCollection"],
   "requiredPlugins": [
     "alerting",
     "cases",
     "data",
+    "dashboard",
+    "embeddable",
     "features",
     "inspector",
     "ruleRegistry",

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/utils/observability_index_patterns.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/utils/observability_index_patterns.ts
@@ -44,8 +44,8 @@ const appToPatternMap: Record<AppDataType, string> = {
   synthetics: '(synthetics-data-view)*',
   apm: 'apm-*',
   ux: '(rum-data-view)*',
-  infra_logs: '',
-  infra_metrics: '',
+  infra_logs: 'logs-*,filebeat-*',
+  infra_metrics: 'metrics-*,metricbeat-*',
   mobile: '(mobile-data-view)*',
 };
 
@@ -136,6 +136,9 @@ export class ObservabilityIndexPatterns {
       case 'mobile':
         const resultApm = await getDataHandler('apm')?.hasData();
         return resultApm?.indices.transaction;
+      case 'infra_metrics':
+      case 'infra_logs':
+        return ' '; // FIXME: metrics app should provide this
     }
   }
 

--- a/x-pack/plugins/observability/public/pages/overview/dashboard/index.ts
+++ b/x-pack/plugins/observability/public/pages/overview/dashboard/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './overview_dashboard';

--- a/x-pack/plugins/observability/public/pages/overview/dashboard/overview_dashboard.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/dashboard/overview_dashboard.tsx
@@ -5,23 +5,58 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
 import { RefreshInterval, TimeRange } from '../../../../../../../src/plugins/data/common';
 import { ViewMode } from '../../../../../../../src/plugins/embeddable/public';
 import { ObservabilityPublicPluginsStart } from '../../..';
+import { ObservabilityIndexPatterns } from '../../../components/shared/exploratory_view/utils/observability_index_patterns';
+import { cpuPanel, logRatePanel } from '../panels';
 
 interface OverviewDashboardProps {
   timeRange: TimeRange;
   refreshConfig: RefreshInterval;
 }
 
+// FIXME
+type DashboardPanels = any;
+
 export function OverviewDashboard(props: OverviewDashboardProps) {
   const { timeRange, refreshConfig } = props;
   const { services } = useKibana<ObservabilityPublicPluginsStart>();
 
+  const observabilityDataViews = useMemo(
+    () => new ObservabilityIndexPatterns(services.data),
+    [services]
+  );
+
+  const [panels, setPanels] = useState<DashboardPanels>(undefined);
+
+  useEffect(() => {
+    (async () => {
+      const panelList = await Promise.all([
+        logRatePanel(observabilityDataViews, 1, { x: 0, y: 0, w: 20, h: 20 }),
+        cpuPanel(observabilityDataViews, 2, { x: 20, y: 0, w: 20, h: 20 }),
+      ]);
+
+      setPanels(
+        panelList.reduce<DashboardPanels>((obj, panel, i) => {
+          const id = i + 1;
+
+          obj[id] = panel;
+          return obj;
+        }, {})
+      );
+    })();
+  }, [observabilityDataViews]);
+
   const DashboardContainerByValueRenderer =
     services.dashboard.getDashboardContainerByValueRenderer();
+
+  // FIXME Do a spinner
+  if (!panels) {
+    return null;
+  }
 
   return (
     <DashboardContainerByValueRenderer
@@ -42,7 +77,7 @@ export function OverviewDashboard(props: OverviewDashboardProps) {
         },
         filters: [],
 
-        panels: {},
+        panels,
       }}
     />
   );

--- a/x-pack/plugins/observability/public/pages/overview/dashboard/overview_dashboard.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/dashboard/overview_dashboard.tsx
@@ -6,7 +6,44 @@
  */
 
 import React from 'react';
+import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
+import { RefreshInterval, TimeRange } from '../../../../../../../src/plugins/data/common';
+import { ViewMode } from '../../../../../../../src/plugins/embeddable/public';
+import { ObservabilityPublicPluginsStart } from '../../..';
 
-export function OverviewDashboard() {
-  return <div>Dashboard goes here</div>;
+interface OverviewDashboardProps {
+  timeRange: TimeRange;
+  refreshConfig: RefreshInterval;
+}
+
+export function OverviewDashboard(props: OverviewDashboardProps) {
+  const { timeRange, refreshConfig } = props;
+  const { services } = useKibana<ObservabilityPublicPluginsStart>();
+
+  const DashboardContainerByValueRenderer =
+    services.dashboard.getDashboardContainerByValueRenderer();
+
+  return (
+    <DashboardContainerByValueRenderer
+      input={{
+        id: '',
+        title: 'Observability Overview',
+
+        viewMode: ViewMode.VIEW,
+        isFullScreenMode: false,
+        useMargins: false,
+
+        timeRange,
+        refreshConfig,
+
+        query: {
+          query: '',
+          language: 'lucene',
+        },
+        filters: [],
+
+        panels: {},
+      }}
+    />
+  );
 }

--- a/x-pack/plugins/observability/public/pages/overview/dashboard/overview_dashboard.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/dashboard/overview_dashboard.tsx
@@ -11,7 +11,7 @@ import { RefreshInterval, TimeRange } from '../../../../../../../src/plugins/dat
 import { ViewMode } from '../../../../../../../src/plugins/embeddable/public';
 import { ObservabilityPublicPluginsStart } from '../../..';
 import { ObservabilityIndexPatterns } from '../../../components/shared/exploratory_view/utils/observability_index_patterns';
-import { cpuPanel, logRatePanel } from '../panels';
+import { cpuPanel, logRatePanel, logStreamPanel } from '../panels';
 
 interface OverviewDashboardProps {
   timeRange: TimeRange;
@@ -37,6 +37,7 @@ export function OverviewDashboard(props: OverviewDashboardProps) {
       const panelList = await Promise.all([
         logRatePanel(observabilityDataViews, 1, { x: 0, y: 0, w: 20, h: 20 }),
         cpuPanel(observabilityDataViews, 2, { x: 20, y: 0, w: 20, h: 20 }),
+        logStreamPanel(observabilityDataViews, 3, { x: 0, y: 20, w: 40, h: 20 }),
       ]);
 
       setPanels(
@@ -66,7 +67,7 @@ export function OverviewDashboard(props: OverviewDashboardProps) {
 
         viewMode: ViewMode.VIEW,
         isFullScreenMode: false,
-        useMargins: false,
+        useMargins: true,
 
         timeRange,
         refreshConfig,

--- a/x-pack/plugins/observability/public/pages/overview/dashboard/overview_dashboard.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/dashboard/overview_dashboard.tsx
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+export function OverviewDashboard() {
+  return <div>Dashboard goes here</div>;
+}

--- a/x-pack/plugins/observability/public/pages/overview/overview_page.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/overview_page.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 import { i18n } from '@kbn/i18n';
-import React from 'react';
-import { useTrackPageview } from '../..';
+import React, { useState, useEffect } from 'react';
+import { useKibana } from '../../../../../../src/plugins/kibana_react/public';
+import { ObservabilityPublicPluginsStart, useTrackPageview } from '../..';
 import { DatePicker } from '../../components/shared/date_picker';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
 import { useHasData } from '../../hooks/use_has_data';
@@ -16,12 +17,98 @@ import { RouteParams } from '../../routes';
 import { getNoDataConfig } from '../../utils/no_data_config';
 import { OverviewDashboard } from './dashboard';
 import { LoadingObservability } from './loading_observability';
+import { DataView } from '../../../../../../src/plugins/data/common';
 
 interface Props {
   routeParams: RouteParams<'/overview'>;
 }
 
+function getLensAttributes(defaultDataView: DataView, color: string) {
+  const dataLayer = {
+    columnOrder: ['col1', 'col2'],
+    columns: {
+      col2: {
+        dataType: 'number',
+        isBucketed: false,
+        label: 'Count of records',
+        operationType: 'count',
+        scale: 'ratio',
+        sourceField: 'Records',
+      },
+      col1: {
+        dataType: 'date',
+        isBucketed: true,
+        label: '@timestamp',
+        operationType: 'date_histogram',
+        params: { interval: 'auto' },
+        scale: 'interval',
+        sourceField: '@timestamp',
+      },
+    },
+  };
+
+  const xyConfig = {
+    axisTitlesVisibilitySettings: { x: true, yLeft: true, yRight: true },
+    fittingFunction: 'None',
+    gridlinesVisibilitySettings: { x: true, yLeft: true, yRight: true },
+    layers: [
+      {
+        accessors: ['col2'],
+        layerId: 'layer1',
+        layerType: 'data',
+        seriesType: 'bar_stacked',
+        xAccessor: 'col1',
+        yConfig: [{ forAccessor: 'col2', color }],
+      },
+    ],
+    legend: { isVisible: true, position: 'right' },
+    preferredSeriesType: 'bar_stacked',
+    tickLabelsVisibilitySettings: { x: true, yLeft: true, yRight: true },
+    valueLabels: 'hide',
+  };
+
+  return {
+    visualizationType: 'lnsXY',
+    title: 'Log rate',
+    references: [
+      {
+        id: defaultDataView.id!,
+        name: 'indexpattern-datasource-current-indexpattern',
+        type: 'index-pattern',
+      },
+      {
+        id: defaultDataView.id!,
+        name: 'indexpattern-datasource-layer-layer1',
+        type: 'index-pattern',
+      },
+    ],
+    state: {
+      datasourceStates: {
+        indexpattern: {
+          layers: {
+            layer1: dataLayer,
+          },
+        },
+      },
+      filters: [],
+      query: { language: 'kuery', query: '' },
+      visualization: xyConfig,
+    },
+  };
+}
+
 export function OverviewPage({ routeParams }: Props) {
+  const { services } = useKibana<ObservabilityPublicPluginsStart>();
+
+  const [defaultDataView, setDefaultDataView] = useState<DataView | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const dw = await services.data.dataViews.getDefault();
+      setDefaultDataView(dw);
+    })();
+  }, [services]);
+
   useTrackPageview({ app: 'observability-overview', path: 'overview' });
   useTrackPageview({ app: 'observability-overview', path: 'overview', delay: 15000 });
   useBreadcrumbs([
@@ -79,6 +166,49 @@ export function OverviewPage({ routeParams }: Props) {
           refreshConfig={{ pause: refreshPaused, value: refreshInterval }}
         />
       )}
+      {/* {hasData && defaultDataView ? (
+        <DashboardContainerByValueRenderer
+          input={{
+            id: 'random-id',
+            title: 'Observability overview',
+
+            viewMode: ViewMode.VIEW,
+            isFullScreenMode: false,
+            useMargins: false,
+
+            timeRange: relativeTime,
+            refreshConfig: {
+              pause: refreshPaused,
+              value: refreshInterval,
+            },
+
+            query: {
+              query: '',
+              language: 'lucene',
+            },
+            filters: [],
+
+            panels: {
+              '1': {
+                gridData: {
+                  w: 20,
+                  h: 20,
+                  x: 0,
+                  y: 0,
+                  i: '1',
+                },
+                type: 'lens',
+                explicitInput: {
+                  id: '1',
+                  attributes: getLensAttributes(defaultDataView, 'red'),
+                },
+              },
+            },
+          }}
+        />
+      ) : (
+        <div>No data</div>
+      )} */}
     </ObservabilityPageTemplate>
   );
 }

--- a/x-pack/plugins/observability/public/pages/overview/overview_page.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/overview_page.tsx
@@ -36,7 +36,7 @@ export function OverviewPage({ routeParams }: Props) {
 
   const { relativeStart, relativeEnd } = useTimeRange();
 
-  const relativeTime = { start: relativeStart, end: relativeEnd };
+  const relativeTime = { from: relativeStart, to: relativeEnd };
 
   const { hasAnyData, isAllRequestsComplete } = useHasData();
 
@@ -63,8 +63,8 @@ export function OverviewPage({ routeParams }: Props) {
               pageTitle: overviewPageTitle,
               rightSideItems: [
                 <DatePicker
-                  rangeFrom={relativeTime.start}
-                  rangeTo={relativeTime.end}
+                  rangeFrom={relativeTime.from}
+                  rangeTo={relativeTime.to}
                   refreshInterval={refreshInterval}
                   refreshPaused={refreshPaused}
                 />,
@@ -73,7 +73,12 @@ export function OverviewPage({ routeParams }: Props) {
           : undefined
       }
     >
-      {hasData && <OverviewDashboard />}
+      {hasData && (
+        <OverviewDashboard
+          timeRange={relativeTime}
+          refreshConfig={{ pause: refreshPaused, value: refreshInterval }}
+        />
+      )}
     </ObservabilityPageTemplate>
   );
 }

--- a/x-pack/plugins/observability/public/pages/overview/overview_page.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/overview_page.tsx
@@ -14,6 +14,7 @@ import { usePluginContext } from '../../hooks/use_plugin_context';
 import { useTimeRange } from '../../hooks/use_time_range';
 import { RouteParams } from '../../routes';
 import { getNoDataConfig } from '../../utils/no_data_config';
+import { OverviewDashboard } from './dashboard';
 import { LoadingObservability } from './loading_observability';
 
 interface Props {
@@ -72,7 +73,7 @@ export function OverviewPage({ routeParams }: Props) {
           : undefined
       }
     >
-      {hasData && <div>New observability content goes here</div>}
+      {hasData && <OverviewDashboard />}
     </ObservabilityPageTemplate>
   );
 }

--- a/x-pack/plugins/observability/public/pages/overview/panels/cpu_panel.ts
+++ b/x-pack/plugins/observability/public/pages/overview/panels/cpu_panel.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ObsPanel } from './types';
+
+export const cpuPanel: ObsPanel = async (observabilityDataViews, id, coordinates) => {
+  const dataView = await observabilityDataViews.getIndexPattern('infra_metrics');
+
+  return {
+    gridData: {
+      ...coordinates,
+      i: id.toString(),
+    },
+    type: 'lens',
+    explicitInput: {
+      id: id.toString(),
+      attributes: getLensAttributes(dataView),
+    },
+  };
+};
+
+function getLensAttributes(dataView: DataView) {
+  return {
+    title: 'CPU by Host',
+    description: '',
+    visualizationType: 'lnsXY',
+    state: {
+      visualization: {
+        legend: {
+          isVisible: true,
+          position: 'right',
+          isInside: true,
+        },
+        valueLabels: 'hide',
+        fittingFunction: 'None',
+        curveType: 'LINEAR',
+        xTitle: '',
+        yTitle: 'Avg. CPU (%)',
+        yLeftExtent: {
+          mode: 'custom',
+          lowerBound: 0,
+          upperBound: 1,
+        },
+        yRightExtent: {
+          mode: 'full',
+        },
+        axisTitlesVisibilitySettings: {
+          x: false,
+          yLeft: false,
+          yRight: true,
+        },
+        tickLabelsVisibilitySettings: {
+          x: true,
+          yLeft: true,
+          yRight: true,
+        },
+        labelsOrientation: {
+          x: 0,
+          yLeft: 0,
+          yRight: 0,
+        },
+        gridlinesVisibilitySettings: {
+          x: true,
+          yLeft: true,
+          yRight: true,
+        },
+        preferredSeriesType: 'line',
+        layers: [
+          {
+            layerId: 'bb4f23e7-58d4-4fea-a4ad-dd5942b0298b',
+            accessors: ['58e2fdac-a24a-49b5-b96b-4ac1a730deb6'],
+            position: 'top',
+            seriesType: 'line',
+            showGridlines: false,
+            layerType: 'data',
+            xAccessor: '1c5550b8-dfcd-4ebb-ab63-93875c46f080',
+            splitAccessor: '46608776-642c-41e7-afa9-60ea18311929',
+          },
+        ],
+      },
+      query: {
+        query: '',
+        language: 'kuery',
+      },
+      filters: [],
+      datasourceStates: {
+        indexpattern: {
+          layers: {
+            'bb4f23e7-58d4-4fea-a4ad-dd5942b0298b': {
+              columns: {
+                '1c5550b8-dfcd-4ebb-ab63-93875c46f080': {
+                  label: '@timestamp',
+                  dataType: 'date',
+                  operationType: 'date_histogram',
+                  sourceField: '@timestamp',
+                  isBucketed: true,
+                  scale: 'interval',
+                  params: {
+                    interval: 'auto',
+                  },
+                },
+                '58e2fdac-a24a-49b5-b96b-4ac1a730deb6': {
+                  label: 'Average of host.cpu.usage',
+                  dataType: 'number',
+                  operationType: 'average',
+                  sourceField: 'host.cpu.usage',
+                  isBucketed: false,
+                  scale: 'ratio',
+                  params: {
+                    format: {
+                      id: 'percent',
+                      params: {
+                        decimals: 0,
+                      },
+                    },
+                  },
+                },
+                '46608776-642c-41e7-afa9-60ea18311929': {
+                  label: 'Top values of host.name',
+                  dataType: 'string',
+                  operationType: 'terms',
+                  scale: 'ordinal',
+                  sourceField: 'host.name',
+                  isBucketed: true,
+                  params: {
+                    size: 5,
+                    orderBy: {
+                      type: 'column',
+                      columnId: '58e2fdac-a24a-49b5-b96b-4ac1a730deb6',
+                    },
+                    orderDirection: 'desc',
+                    otherBucket: true,
+                    missingBucket: false,
+                  },
+                },
+              },
+              columnOrder: [
+                '46608776-642c-41e7-afa9-60ea18311929',
+                '1c5550b8-dfcd-4ebb-ab63-93875c46f080',
+                '58e2fdac-a24a-49b5-b96b-4ac1a730deb6',
+              ],
+              incompleteColumns: {},
+            },
+          },
+        },
+      },
+    },
+    references: [
+      {
+        type: 'index-pattern',
+        id: 'infra_metrics_static_index_pattern_id__',
+        name: 'indexpattern-datasource-current-indexpattern',
+      },
+      {
+        type: 'index-pattern',
+        id: 'infra_metrics_static_index_pattern_id__',
+        name: 'indexpattern-datasource-layer-bb4f23e7-58d4-4fea-a4ad-dd5942b0298b',
+      },
+    ],
+  };
+}

--- a/x-pack/plugins/observability/public/pages/overview/panels/index.ts
+++ b/x-pack/plugins/observability/public/pages/overview/panels/index.ts
@@ -7,3 +7,4 @@
 
 export * from './cpu_panel';
 export * from './log_rate_panel';
+export * from './log_stream_panel';

--- a/x-pack/plugins/observability/public/pages/overview/panels/index.ts
+++ b/x-pack/plugins/observability/public/pages/overview/panels/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './cpu_panel';
+export * from './log_rate_panel';

--- a/x-pack/plugins/observability/public/pages/overview/panels/log_rate_panel.ts
+++ b/x-pack/plugins/observability/public/pages/overview/panels/log_rate_panel.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataView } from 'src/plugins/data/common';
+import { ObsPanel } from './types';
+
+export const logRatePanel: ObsPanel = async (observabilityDataViews, id, coordinates) => {
+  const dataView = await observabilityDataViews.getIndexPattern('infra_logs');
+  // console.log('logRatePanel', { dataView });
+
+  return {
+    gridData: {
+      ...coordinates,
+      i: id.toString(),
+    },
+    type: 'lens',
+    explicitInput: {
+      id: id.toString(),
+      attributes: getLensAttributes(dataView),
+    },
+  };
+};
+
+function getLensAttributes(dataView: DataView) {
+  return {
+    title: 'Log rate per dataset',
+    description: '',
+    visualizationType: 'lnsXY',
+    references: [
+      {
+        type: 'index-pattern',
+        id: dataView.id,
+        name: 'indexpattern-datasource-current-indexpattern',
+      },
+      {
+        type: 'index-pattern',
+        id: dataView.id,
+        name: 'indexpattern-datasource-layer-bb4f23e7-58d4-4fea-a4ad-dd5942b0298b',
+      },
+    ],
+    state: {
+      visualization: {
+        legend: {
+          isVisible: true,
+          position: 'right',
+          isInside: true,
+        },
+        valueLabels: 'hide',
+        fittingFunction: 'None',
+        yLeftExtent: {
+          mode: 'full',
+        },
+        yRightExtent: {
+          mode: 'full',
+        },
+        axisTitlesVisibilitySettings: {
+          x: false,
+          yLeft: false,
+          yRight: true,
+        },
+        tickLabelsVisibilitySettings: {
+          x: true,
+          yLeft: true,
+          yRight: true,
+        },
+        labelsOrientation: {
+          x: 0,
+          yLeft: 0,
+          yRight: 0,
+        },
+        gridlinesVisibilitySettings: {
+          x: true,
+          yLeft: true,
+          yRight: true,
+        },
+        preferredSeriesType: 'bar_stacked',
+        layers: [
+          {
+            layerId: 'bb4f23e7-58d4-4fea-a4ad-dd5942b0298b',
+            seriesType: 'bar_stacked',
+            xAccessor: '4e8b204d-6f5b-45a7-8b80-ace67ce6c02e',
+            splitAccessor: 'ddb0ccd3-0eee-4ac4-8166-9cac19ca8e7d',
+            accessors: ['b00f51ec-4605-4d7a-8105-3cbc5802aa27'],
+            layerType: 'data',
+          },
+        ],
+      },
+      query: {
+        query: '',
+        language: 'kuery',
+      },
+      filters: [],
+      datasourceStates: {
+        indexpattern: {
+          layers: {
+            'bb4f23e7-58d4-4fea-a4ad-dd5942b0298b': {
+              columns: {
+                '4e8b204d-6f5b-45a7-8b80-ace67ce6c02e': {
+                  label: '@timestamp',
+                  dataType: 'date',
+                  operationType: 'date_histogram',
+                  sourceField: '@timestamp',
+                  isBucketed: true,
+                  scale: 'interval',
+                  params: {
+                    interval: 'auto',
+                  },
+                },
+                'b00f51ec-4605-4d7a-8105-3cbc5802aa27': {
+                  label: 'Count of records',
+                  dataType: 'number',
+                  operationType: 'count',
+                  isBucketed: false,
+                  scale: 'ratio',
+                  sourceField: 'Records',
+                },
+                'ddb0ccd3-0eee-4ac4-8166-9cac19ca8e7d': {
+                  label: 'Top values of event.dataset',
+                  dataType: 'string',
+                  operationType: 'terms',
+                  scale: 'ordinal',
+                  sourceField: 'event.dataset',
+                  isBucketed: true,
+                  params: {
+                    size: 5,
+                    orderBy: {
+                      type: 'column',
+                      columnId: 'b00f51ec-4605-4d7a-8105-3cbc5802aa27',
+                    },
+                    orderDirection: 'desc',
+                    otherBucket: true,
+                    missingBucket: false,
+                  },
+                },
+              },
+              columnOrder: [
+                'ddb0ccd3-0eee-4ac4-8166-9cac19ca8e7d',
+                '4e8b204d-6f5b-45a7-8b80-ace67ce6c02e',
+                'b00f51ec-4605-4d7a-8105-3cbc5802aa27',
+              ],
+              incompleteColumns: {},
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/x-pack/plugins/observability/public/pages/overview/panels/log_stream_panel.ts
+++ b/x-pack/plugins/observability/public/pages/overview/panels/log_stream_panel.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ObsPanel } from './types';
+
+export const logStreamPanel: ObsPanel = async (dataView, id, coordinates) => {
+  return {
+    gridData: {
+      ...coordinates,
+      i: id.toString(),
+    },
+    type: 'LOG_STREAM_EMBEDDABLE',
+    explicitInput: {
+      id: id.toString(),
+    },
+  };
+};

--- a/x-pack/plugins/observability/public/pages/overview/panels/types.ts
+++ b/x-pack/plugins/observability/public/pages/overview/panels/types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ObservabilityIndexPatterns } from '../../../components/shared/exploratory_view/utils/observability_index_patterns';
+
+interface PanelCoordinates {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export type ObsPanel = (
+  observabilityDataViews: ObservabilityIndexPatterns,
+  id: number,
+  coordinates: PanelCoordinates
+) => Promise<any>;

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -24,6 +24,7 @@ import type {
   DataPublicPluginSetup,
   DataPublicPluginStart,
 } from '../../../../src/plugins/data/public';
+import type { DashboardStart } from '../../../../src/plugins/dashboard/public';
 import type { DiscoverStart } from '../../../../src/plugins/discover/public';
 import type { EmbeddableStart } from '../../../../src/plugins/embeddable/public';
 import type {
@@ -56,6 +57,7 @@ export interface ObservabilityPublicPluginsSetup {
 
 export interface ObservabilityPublicPluginsStart {
   cases: CasesUiStart;
+  dashboard: DashboardStart;
   embeddable: EmbeddableStart;
   home?: HomePublicPluginStart;
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;


### PR DESCRIPTION
## Summary

This is a proof of concept of how we can use an embedded dashboard for the overview page. It contains two lens visualizations and one log stream embeddable.

AFAIK the lens visualizations need data views (index patterns) to work. I'm reusing the work that the Synthetics team did to generate data views on the fly for the Exploratory view. If we move forward with this approach I want to move that code to a shared location in https://github.com/elastic/kibana/issues/120210 and refactor the deprecated APIs that they are using.

I want feedback about using the dashboard embeddable versus other approaches and the ergonomics of how to add panels.

