### PR TITLE
[Lens] Temporarily exclude Mosaic/Waffle from the suggestions list

### DIFF
--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.test.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.test.ts
@@ -784,8 +784,7 @@ describe('suggestions', () => {
       ).toHaveLength(0);
     });
 
-    /** The following test should be activated when Experimental flag will be removed from the Waffle chart **/
-    it.skip('mosaic type should be added only in case of 2 groups', () => {
+    it('mosaic type should be hidden from the suggestion list', () => {
       expect(
         suggestions({
           table: {
@@ -828,97 +827,6 @@ describe('suggestions', () => {
           },
           keptLayerIds: ['first'],
         }).filter(({ hide, state }) => !hide && state.shape === 'mosaic')
-      ).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "hide": false,
-            "previewIcon": "bullseye",
-            "score": 0.6,
-            "state": Object {
-              "layers": Array [
-                Object {
-                  "categoryDisplay": "default",
-                  "groups": Array [
-                    "a",
-                    "b",
-                  ],
-                  "layerId": "first",
-                  "layerType": "data",
-                  "legendDisplay": "show",
-                  "legendMaxLines": 1,
-                  "metric": "c",
-                  "nestedLegend": true,
-                  "numberDisplay": "hidden",
-                  "percentDecimals": 0,
-                  "truncateLegend": true,
-                },
-              ],
-              "palette": undefined,
-              "shape": "mosaic",
-            },
-            "title": "As Mosaic",
-          },
-        ]
-      `);
-    });
-
-    it('mosaic type should be added only in case of 2 groups (negative test)', () => {
-      const meta: Parameters<typeof suggestions>[0] = {
-        table: {
-          layerId: 'first',
-          isMultiRow: true,
-          columns: [
-            {
-              columnId: 'a',
-              operation: { label: 'Top 5', dataType: 'string' as DataType, isBucketed: true },
-            },
-            {
-              columnId: 'c',
-              operation: { label: 'Count', dataType: 'number' as DataType, isBucketed: false },
-            },
-          ],
-          changeType: 'unchanged',
-        },
-        state: {
-          shape: 'pie',
-          layers: [
-            {
-              layerId: 'first',
-              layerType: layerTypes.DATA,
-              groups: ['a', 'b'],
-              metric: 'c',
-
-              numberDisplay: 'hidden',
-              categoryDisplay: 'inside',
-              legendDisplay: 'show',
-              percentDecimals: 0,
-              legendMaxLines: 1,
-              truncateLegend: true,
-              nestedLegend: true,
-            },
-          ],
-        },
-        keptLayerIds: ['first'],
-      };
-
-      // test with 1 group
-      expect(
-        suggestions(meta).filter(({ hide, state }) => !hide && state.shape === 'mosaic')
-      ).toMatchInlineSnapshot(`Array []`);
-
-      meta.table.columns.push({
-        columnId: 'b',
-        operation: { label: 'Top 6', dataType: 'string' as DataType, isBucketed: true },
-      });
-
-      meta.table.columns.push({
-        columnId: 'c',
-        operation: { label: 'Top 7', dataType: 'string' as DataType, isBucketed: true },
-      });
-
-      // test with 3 groups
-      expect(
-        suggestions(meta).filter(({ hide, state }) => !hide && state.shape === 'mosaic')
       ).toMatchInlineSnapshot(`Array []`);
     });
   });
@@ -953,8 +861,7 @@ describe('suggestions', () => {
       ).toHaveLength(0);
     });
 
-    /** The following test should be activated when Experimental flag will be removed from the Mosaic chart **/
-    it.skip('waffle type should be added only in case of 1 group', () => {
+    it('waffle type should be hidden from the suggestion list', () => {
       expect(
         suggestions({
           table: {
@@ -992,62 +899,6 @@ describe('suggestions', () => {
           },
           keptLayerIds: ['first'],
         }).filter(({ hide, state }) => !hide && state.shape === 'waffle')
-      ).toMatchInlineSnapshot(`Array []`);
-    });
-
-    it('waffle type should be added only in case of 1 group (negative test)', () => {
-      const meta: Parameters<typeof suggestions>[0] = {
-        table: {
-          layerId: 'first',
-          isMultiRow: true,
-          columns: [
-            {
-              columnId: 'c',
-              operation: { label: 'Count', dataType: 'number' as DataType, isBucketed: false },
-            },
-          ],
-          changeType: 'unchanged',
-        },
-        state: {
-          shape: 'pie',
-          layers: [
-            {
-              layerId: 'first',
-              layerType: layerTypes.DATA,
-              groups: ['a', 'b'],
-              metric: 'c',
-
-              numberDisplay: 'hidden',
-              categoryDisplay: 'inside',
-              legendDisplay: 'show',
-              percentDecimals: 0,
-              legendMaxLines: 1,
-              truncateLegend: true,
-              nestedLegend: true,
-            },
-          ],
-        },
-        keptLayerIds: ['first'],
-      };
-
-      // test with no group
-      expect(
-        suggestions(meta).filter(({ hide, state }) => state.shape === 'waffle')
-      ).toMatchInlineSnapshot(`Array []`);
-
-      meta.table.columns.push({
-        columnId: 'b',
-        operation: { label: 'Top 6', dataType: 'string' as DataType, isBucketed: true },
-      });
-
-      meta.table.columns.push({
-        columnId: 'c',
-        operation: { label: 'Top 7', dataType: 'string' as DataType, isBucketed: true },
-      });
-
-      // test with 2 groups
-      expect(
-        suggestions(meta).filter(({ hide, state }) => !hide && state.shape === 'waffle')
       ).toMatchInlineSnapshot(`Array []`);
     });
   });

--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.test.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.test.ts
@@ -784,7 +784,8 @@ describe('suggestions', () => {
       ).toHaveLength(0);
     });
 
-    it('mosaic type should be added only in case of 2 groups', () => {
+    /** The following test should be activated when Experimental flag will be removed from the Waffle chart **/
+    it.skip('mosaic type should be added only in case of 2 groups', () => {
       expect(
         suggestions({
           table: {
@@ -952,7 +953,8 @@ describe('suggestions', () => {
       ).toHaveLength(0);
     });
 
-    it('waffle type should be added only in case of 1 group', () => {
+    /** The following test should be activated when Experimental flag will be removed from the Mosaic chart **/
+    it.skip('waffle type should be added only in case of 1 group', () => {
       expect(
         suggestions({
           table: {
@@ -971,14 +973,13 @@ describe('suggestions', () => {
             changeType: 'unchanged',
           },
           state: {
-            shape: 'waffle',
+            shape: 'pie',
             layers: [
               {
                 layerId: 'first',
                 layerType: layerTypes.DATA,
                 groups: ['a', 'b'],
                 metric: 'c',
-
                 numberDisplay: 'hidden',
                 categoryDisplay: 'inside',
                 legendDisplay: 'show',
@@ -1031,7 +1032,7 @@ describe('suggestions', () => {
 
       // test with no group
       expect(
-        suggestions(meta).filter(({ hide, state }) => !hide && state.shape === 'waffle')
+        suggestions(meta).filter(({ hide, state }) => state.shape === 'waffle')
       ).toMatchInlineSnapshot(`Array []`);
 
       meta.table.columns.push({

--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
@@ -233,11 +233,6 @@ export function suggestions({
       },
       previewIcon: 'bullseye',
       hide: true,
-      /** The following code should be uncomment when Experimental flag will be removed from Mosaic chart **/
-      // groups.length !== 2 ||
-      // table.changeType === 'reduced' ||
-      // hasIntervalScale(groups) ||
-      // (state && state.shape === 'mosaic'),
     });
   }
 
@@ -277,11 +272,6 @@ export function suggestions({
       },
       previewIcon: 'bullseye',
       hide: true,
-      /** The following code should be uncomment when Experimental flag will be removed from Waffle chart **/
-      // groups.length !== 1 ||
-      // table.changeType === 'reduced' ||
-      // hasIntervalScale(groups) ||
-      // (state && state.shape === 'waffle'),
     });
   }
 

--- a/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/suggestions.ts
@@ -232,11 +232,12 @@ export function suggestions({
         ],
       },
       previewIcon: 'bullseye',
-      hide:
-        groups.length !== 2 ||
-        table.changeType === 'reduced' ||
-        hasIntervalScale(groups) ||
-        (state && state.shape === 'mosaic'),
+      hide: true,
+      /** The following code should be uncomment when Experimental flag will be removed from Mosaic chart **/
+      // groups.length !== 2 ||
+      // table.changeType === 'reduced' ||
+      // hasIntervalScale(groups) ||
+      // (state && state.shape === 'mosaic'),
     });
   }
 
@@ -275,11 +276,12 @@ export function suggestions({
         ],
       },
       previewIcon: 'bullseye',
-      hide:
-        groups.length !== 1 ||
-        table.changeType === 'reduced' ||
-        hasIntervalScale(groups) ||
-        (state && state.shape === 'waffle'),
+      hide: true,
+      /** The following code should be uncomment when Experimental flag will be removed from Waffle chart **/
+      // groups.length !== 1 ||
+      // table.changeType === 'reduced' ||
+      // hasIntervalScale(groups) ||
+      // (state && state.shape === 'waffle'),
     });
   }
 


### PR DESCRIPTION
## Summary

By analogy with the previous visualizations with the `experimental` flag, we decided to temporarily not show `Waffle`/`Mosaic` charts in the `Suggestions` list

This PR excludes them from the list.