### PR TITLE
[8.0] fix order of Lens tests (#120460)

### DIFF
--- a/x-pack/test/functional/apps/lens/index.ts
+++ b/x-pack/test/functional/apps/lens/index.ts
@@ -48,6 +48,15 @@ export default function ({ getService, loadTestFile, getPageObjects }: FtrProvid
     });
 
     describe('', function () {
+      this.tags(['ciGroup16', 'skipFirefox']);
+
+      loadTestFile(require.resolve('./add_to_dashboard'));
+      loadTestFile(require.resolve('./table'));
+      loadTestFile(require.resolve('./runtime_fields'));
+      loadTestFile(require.resolve('./dashboard'));
+    });
+
+    describe('', function () {
       this.tags(['ciGroup4', 'skipFirefox']);
 
       loadTestFile(require.resolve('./colors'));
@@ -64,15 +73,6 @@ export default function ({ getService, loadTestFile, getPageObjects }: FtrProvid
       loadTestFile(require.resolve('./lens_reporting'));
       // has to be last one in the suite because it overrides saved objects
       loadTestFile(require.resolve('./rollup'));
-    });
-
-    describe('', function () {
-      this.tags(['ciGroup16', 'skipFirefox']);
-
-      loadTestFile(require.resolve('./add_to_dashboard'));
-      loadTestFile(require.resolve('./table'));
-      loadTestFile(require.resolve('./runtime_fields'));
-      loadTestFile(require.resolve('./dashboard'));
     });
   });
 }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - fix order of Lens tests (#120460)