### PR TITLE
[7.16] fix order of Lens tests (#120460)

### DIFF
--- a/x-pack/test/functional/apps/lens/index.ts
+++ b/x-pack/test/functional/apps/lens/index.ts
@@ -39,6 +39,15 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     });
 
     describe('', function () {
+      this.tags(['ciGroup16', 'skipFirefox']);
+
+      loadTestFile(require.resolve('./add_to_dashboard'));
+      loadTestFile(require.resolve('./table'));
+      loadTestFile(require.resolve('./runtime_fields'));
+      loadTestFile(require.resolve('./dashboard'));
+    });
+
+    describe('', function () {
       this.tags(['ciGroup4', 'skipFirefox']);
 
       loadTestFile(require.resolve('./colors'));
@@ -56,15 +65,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
       // has to be last one in the suite because it overrides saved objects
       loadTestFile(require.resolve('./rollup'));
-    });
-
-    describe('', function () {
-      this.tags(['ciGroup16', 'skipFirefox']);
-
-      loadTestFile(require.resolve('./add_to_dashboard'));
-      loadTestFile(require.resolve('./table'));
-      loadTestFile(require.resolve('./runtime_fields'));
-      loadTestFile(require.resolve('./dashboard'));
     });
   });
 }


### PR DESCRIPTION
Backports the following commits to 7.16:
 - fix order of Lens tests (#120460)