### PR TITLE
[7.16] [Security Solution] [Endpoint] Disable add endpoint event filters option when is not an event (#119731)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
@@ -86,7 +86,12 @@ describe('InvestigateInResolverAction', () => {
   });
 
   test('it does NOT render AddToCase context menu item when timelineId is not in the allowed list', () => {
-    const wrapper = mount(<AlertContextMenu {...props} timelineId="timeline-test" />, {
+    // In order to enable alert context menu without a timelineId, event needs to be event.kind === 'event' and agent.type === 'endpoint'
+    const customProps = {
+      ...props,
+      ecsRowData: { ...ecsRowData, agent: { type: ['endpoint'] }, event: { kind: ['event'] } },
+    };
+    const wrapper = mount(<AlertContextMenu {...customProps} timelineId="timeline-test" />, {
       wrappingComponent: TestProviders,
     });
     wrapper.find(actionMenuButton).simulate('click');

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
@@ -164,6 +164,7 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
   });
   const { eventFilterActionItems } = useEventFilterAction({
     onAddEventFilterClick: handleOnAddEventFilterClick,
+    disabled: !isEvent,
   });
   const items: React.ReactElement[] = useMemo(
     () =>

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.test.tsx
@@ -227,7 +227,7 @@ describe('take action dropdown', () => {
       });
     });
 
-    test('should disable the "Add Endpoint event filter" button if provided non-event or non-endpoint', async () => {
+    test('should hide the "Add Endpoint event filter" button if provided no event from endpoint', async () => {
       wrapper = mount(
         <TestProviders>
           <TakeActionDropdown
@@ -239,9 +239,7 @@ describe('take action dropdown', () => {
       );
       wrapper.find('button[data-test-subj="take-action-dropdown-btn"]').simulate('click');
       await waitFor(() => {
-        expect(
-          wrapper.find('[data-test-subj="add-event-filter-menu-item"]').first().getDOMNode()
-        ).toBeDisabled();
+        expect(wrapper.exists('[data-test-subj="add-event-filter-menu-item"]')).toBeFalsy();
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
@@ -91,8 +91,6 @@ export const TakeActionDropdown = React.memo(
 
     const isEndpointEvent = useMemo(() => isEvent && isAgentEndpoint, [isEvent, isAgentEndpoint]);
 
-    const disableEventFilterAction = useMemo(() => !isEndpointEvent, [isEndpointEvent]);
-
     const togglePopoverHandler = useCallback(() => {
       setIsPopoverOpen(!isPopoverOpen);
     }, [isPopoverOpen]);
@@ -141,7 +139,7 @@ export const TakeActionDropdown = React.memo(
 
     const { eventFilterActionItems } = useEventFilterAction({
       onAddEventFilterClick: handleOnAddEventFilterClick,
-      disabled: disableEventFilterAction,
+      disabled: !isEndpointEvent,
     });
 
     const afterCaseSelection = useCallback(() => {
@@ -167,8 +165,17 @@ export const TakeActionDropdown = React.memo(
       () =>
         !isEvent && actionsData.ruleId
           ? [...statusActionItems, ...exceptionActionItems]
-          : eventFilterActionItems,
-      [eventFilterActionItems, exceptionActionItems, statusActionItems, isEvent, actionsData.ruleId]
+          : isEndpointEvent
+          ? eventFilterActionItems
+          : [],
+      [
+        eventFilterActionItems,
+        isEndpointEvent,
+        exceptionActionItems,
+        statusActionItems,
+        isEvent,
+        actionsData.ruleId,
+      ]
     );
 
     const { addToCaseActionItems } = useAddToCaseActions({

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.test.tsx
@@ -169,7 +169,7 @@ describe('Actions', () => {
         wrapper.find('[data-test-subj="timeline-context-menu-button"]').first().prop('isDisabled')
       ).toBe(false);
     });
-    test('it enables for event.kind: alert and agent.type: endpoint', () => {
+    test('it disables for event.kind: alert and agent.type: endpoint', () => {
       const ecsData = {
         ...mockTimelineData[0].ecs,
         event: { kind: ['alert'] },
@@ -183,7 +183,7 @@ describe('Actions', () => {
 
       expect(
         wrapper.find('[data-test-subj="timeline-context-menu-button"]').first().prop('isDisabled')
-      ).toBe(false);
+      ).toBe(true);
     });
     test('it shows the analyze event button when the event is from an endpoint', () => {
       const ecsData = {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.tsx
@@ -108,7 +108,7 @@ const ActionsComponent: React.FC<ActionProps> = ({
     () =>
       eventType !== 'signal' &&
       !(
-        (ecsData.event?.kind?.includes('event') || ecsData.event?.kind?.includes('alert')) &&
+        (ecsData.event?.kind?.includes('event') &&
         ecsData.agent?.type?.includes('endpoint')
       ),
     [eventType, ecsData.event?.kind, ecsData.agent?.type]

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.tsx
@@ -107,10 +107,7 @@ const ActionsComponent: React.FC<ActionProps> = ({
   const isContextMenuDisabled = useMemo(
     () =>
       eventType !== 'signal' &&
-      !(
-        (ecsData.event?.kind?.includes('event') &&
-        ecsData.agent?.type?.includes('endpoint')
-      ),
+      !(ecsData.event?.kind?.includes('event') && ecsData.agent?.type?.includes('endpoint')),
     [eventType, ecsData.event?.kind, ecsData.agent?.type]
   );
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Security Solution] [Endpoint] Disable add endpoint event filters option when is not an event (#119731)