### PR TITLE
[ML] Add synced annotation line to Anomaly detection explorer charts 

### DIFF
--- a/x-pack/plugins/ml/public/application/components/chart_annotation_line/chart_annotation_line.tsx
+++ b/x-pack/plugins/ml/public/application/components/chart_annotation_line/chart_annotation_line.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC, useMemo } from 'react';
+import { ChartAnnotationLineService } from './chart_annotation_line_service';
+
+interface MLChartAnnotationLineProps {
+  children: (chartAnnotationLineService: ChartAnnotationLineService) => React.ReactElement;
+}
+
+export const MLChartAnnotationLine: FC<MLChartAnnotationLineProps> = ({ children }) => {
+  const service = useMemo(() => new ChartAnnotationLineService(), []);
+
+  return <>{children(service)}</>;
+};

--- a/x-pack/plugins/ml/public/application/components/chart_annotation_line/chart_annotation_line_service.ts
+++ b/x-pack/plugins/ml/public/application/components/chart_annotation_line/chart_annotation_line_service.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BehaviorSubject, Observable } from 'rxjs';
+import { isEqual } from 'lodash';
+import { distinctUntilChanged } from 'rxjs/operators';
+
+export interface ChartAnnotationLineValue {
+  skipHeader?: boolean;
+}
+
+export interface AnnotationLineHeader {
+  skipHeader: boolean;
+}
+
+export type AnnotationLineData = ChartAnnotationLineValue[];
+
+export interface ChartAnnotationLineState {
+  isAnnotationLineVisible: boolean;
+  xValue: number | string | Date | null;
+}
+
+export const getChartAnnotationLineDefaultState = (): ChartAnnotationLineState => ({
+  isAnnotationLineVisible: false,
+  xValue: null,
+});
+
+export class ChartAnnotationLineService {
+  private chartAnnotationLine$ = new BehaviorSubject<ChartAnnotationLineState>(
+    getChartAnnotationLineDefaultState()
+  );
+
+  public annotationLineState$: Observable<ChartAnnotationLineState> = this.chartAnnotationLine$
+    .asObservable()
+    .pipe(distinctUntilChanged(isEqual));
+
+  public update(xValue: number) {
+    if (!xValue) {
+      throw new Error('value is required for the annotation line');
+    }
+
+    console.log('xValue', xValue);
+    this.chartAnnotationLine$.next({
+      ...this.chartAnnotationLine$.getValue(),
+      isAnnotationLineVisible: true,
+      xValue,
+    });
+  }
+
+  public hide() {
+    this.chartAnnotationLine$.next({
+      ...getChartAnnotationLineDefaultState(),
+      isAnnotationLineVisible: false,
+    });
+  }
+}

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_chart_distribution.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_chart_distribution.js
@@ -256,9 +256,9 @@ export class ExplorerChartDistribution extends React.Component {
 
       drawRareChartAxes();
       drawRareChartHighlightedSpan();
+      drawRareChartAnnotationLine(lineChartGroup, vizWidth, chartHeight, margin);
       drawRareChartDots(data, lineChartGroup, lineChartValuesLine);
       drawRareChartMarkers(data);
-      drawRareChartAnnotationLine(lineChartGroup, vizWidth, chartHeight, margin);
     }
 
     function drawRareChartAxes() {
@@ -446,28 +446,25 @@ export class ExplorerChartDistribution extends React.Component {
         .attr('class', 'mouse-over-effects')
         .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
       mouseG
-        .append('path') // this is the black vertical line to follow mouse
+        .append('path')
         .attr('class', 'mouse-line')
         .style('stroke', 'black')
         .style('stroke-width', '1px');
 
       mouseG
-        .append('svg:rect') // append a rect to catch mouse movements on canvas
-        .attr('width', svgWidth) // can't catch mouse events on a g element
+        .append('svg:rect')
+        .attr('width', svgWidth)
         .attr('height', svgHeight)
         .attr('fill', 'none')
         .attr('opacity', 0)
         .attr('pointer-events', 'all')
         .on('mouseout', function () {
-          // on mouse out hide line, circles and text
           d3.selectAll('.mouse-line').style('opacity', '0');
         })
         .on('mouseover', function () {
-          // on mouse in show line, circles and text
           d3.selectAll('.mouse-line').style('opacity', '1');
         })
         .on('mousemove', function () {
-          // mouse moving over canvas
           const mouse = d3.mouse(this);
           d3.selectAll('.mouse-line').attr('d', function () {
             let d = 'M' + mouse[0] + ',' + svgHeight;

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_chart_single_metric.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_chart_single_metric.js
@@ -73,7 +73,7 @@ export class ExplorerChartSingleMetric extends React.Component {
     }
 
     const fieldFormat = mlFieldFormatService.getFieldFormat(config.jobId, config.detectorIndex);
-
+    let svg = undefined;
     let vizWidth = 0;
     const chartHeight = 170;
 
@@ -99,7 +99,7 @@ export class ExplorerChartSingleMetric extends React.Component {
       const svgWidth = $el.width();
       const svgHeight = chartHeight + margin.top + margin.bottom;
 
-      const svg = chartElement
+      svg = chartElement
         .append('svg')
         .classed('ml-explorer-chart-svg', true)
         .attr('width', svgWidth)
@@ -180,10 +180,48 @@ export class ExplorerChartSingleMetric extends React.Component {
         .style('stroke-width', 1);
 
       drawLineChartAxes();
-      drawLineChartHighlightedSpan();
+      drawLineChartHighlightedSpan(vizWidth, chartHeight);
       drawLineChartPaths(data);
+      drawChartAnnotationLine(lineChartGroup, vizWidth, chartHeight, margin);
       drawLineChartDots(data, lineChartGroup, lineChartValuesLine);
       drawLineChartMarkers(data);
+    }
+
+    function drawChartAnnotationLine(anchor, svgWidth, svgHeight, margin) {
+      const mouseG = svg
+        .append('g')
+        .attr('class', 'mouse-over-effects')
+        .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+      mouseG
+        .append('path') // this is the black vertical line to follow mouse
+        .attr('class', 'mouse-line')
+        .style('stroke', 'black')
+        .style('stroke-width', '1px');
+
+      mouseG
+        .append('svg:rect') // append a rect to catch mouse movements on canvas
+        .attr('width', svgWidth) // can't catch mouse events on a g element
+        .attr('height', svgHeight)
+        .attr('fill', 'none')
+        .attr('opacity', 0)
+        .attr('pointer-events', 'all')
+        .on('mouseout', function () {
+          // on mouse out hide line, circles and text
+          d3.selectAll('.mouse-line').style('opacity', '0');
+        })
+        .on('mouseover', function () {
+          // on mouse in show line, circles and text
+          d3.selectAll('.mouse-line').style('opacity', '1');
+        })
+        .on('mousemove', function () {
+          // mouse moving over canvas
+          const mouse = d3.mouse(this);
+          d3.selectAll('.mouse-line').attr('d', function () {
+            let d = 'M' + mouse[0] + ',' + svgHeight;
+            d += ' ' + mouse[0] + ',' + 0;
+            return d;
+          });
+        });
     }
 
     function drawLineChartAxes() {

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_chart_single_metric.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_chart_single_metric.js
@@ -181,8 +181,8 @@ export class ExplorerChartSingleMetric extends React.Component {
 
       drawLineChartAxes();
       drawLineChartHighlightedSpan(vizWidth, chartHeight);
-      drawLineChartPaths(data);
       drawChartAnnotationLine(lineChartGroup, vizWidth, chartHeight, margin);
+      drawLineChartPaths(data);
       drawLineChartDots(data, lineChartGroup, lineChartValuesLine);
       drawLineChartMarkers(data);
     }
@@ -193,28 +193,25 @@ export class ExplorerChartSingleMetric extends React.Component {
         .attr('class', 'mouse-over-effects')
         .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
       mouseG
-        .append('path') // this is the black vertical line to follow mouse
+        .append('path')
         .attr('class', 'mouse-line')
         .style('stroke', 'black')
         .style('stroke-width', '1px');
 
       mouseG
-        .append('svg:rect') // append a rect to catch mouse movements on canvas
-        .attr('width', svgWidth) // can't catch mouse events on a g element
+        .append('svg:rect')
+        .attr('width', svgWidth)
         .attr('height', svgHeight)
         .attr('fill', 'none')
         .attr('opacity', 0)
         .attr('pointer-events', 'all')
         .on('mouseout', function () {
-          // on mouse out hide line, circles and text
           d3.selectAll('.mouse-line').style('opacity', '0');
         })
         .on('mouseover', function () {
-          // on mouse in show line, circles and text
           d3.selectAll('.mouse-line').style('opacity', '1');
         })
         .on('mousemove', function () {
-          // mouse moving over canvas
           const mouse = d3.mouse(this);
           d3.selectAll('.mouse-line').attr('d', function () {
             let d = 'M' + mouse[0] + ',' + svgHeight;

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
@@ -6,7 +6,7 @@
  */
 import './_index.scss';
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 
 import {
   EuiButtonEmpty,
@@ -35,6 +35,7 @@ import { ML_JOB_AGGREGATION } from '../../../../common/constants/aggregation_typ
 import { ExplorerChartsErrorCallOuts } from './explorer_charts_error_callouts';
 import { addItemToRecentlyAccessed } from '../../util/recently_accessed';
 import { EmbeddedMapComponentWrapper } from './explorer_chart_embedded_map';
+import { ChartAnnotationLineService } from '../../components/chart_annotation_line/chart_annotation_line_service';
 const textTooManyBuckets = i18n.translate('xpack.ml.explorer.charts.tooManyBucketsDescription', {
   defaultMessage:
     'This selection contains too many buckets to be displayed. You should shorten the time range of the view or narrow the selection in the timeline.',
@@ -74,6 +75,7 @@ function ExplorerChartContainer({
   showSelectedInterval,
 }) {
   const [explorerSeriesLink, setExplorerSeriesLink] = useState('');
+  const chartAnnotationLineService = useMemo(() => new ChartAnnotationLineService(), []);
 
   useEffect(() => {
     let isCancelled = false;


### PR DESCRIPTION
## Summary

This PR adds a line to all the Anomaly explorer charts on the same page when the user mouseovers the chart.

https://user-images.githubusercontent.com/43350163/144934778-760f7c0f-e8f2-4767-8836-7f126c08db67.mov


