### PR TITLE
[Security Solution] Host isolation exceptions by policy, add missing validation when no policy is selected

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/effected_policy_select/utils.ts
+++ b/x-pack/plugins/security_solution/public/management/components/effected_policy_select/utils.ts
@@ -47,7 +47,7 @@ export function getEffectedPolicySelectionByTags(
   tags: string[],
   policies: PolicyData[]
 ): EffectedPolicySelection {
-  if (tags.length === 0 || tags.find((tag) => tag === GLOBAL_POLICY_TAG)) {
+  if (tags.find((tag) => tag === GLOBAL_POLICY_TAG)) {
     return {
       isGlobal: true,
       selected: [],

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.test.tsx
@@ -233,5 +233,21 @@ describe('When on the host isolation exceptions entry form', () => {
         'true'
       );
     });
+
+    it('should show the policies selector when no policy is selected', () => {
+      existingException.tags = [];
+
+      renderResult = render(existingException);
+
+      expect(renderResult.queryByTestId('effectedPolicies-select-policiesSelectable')).toBeTruthy();
+    });
+
+    it('should show the policies selector when no policy is selected and there are previous tags', () => {
+      existingException.tags = ['non-a-policy-tag'];
+
+      renderResult = render(existingException);
+
+      expect(renderResult.queryByTestId('effectedPolicies-select-policiesSelectable')).toBeTruthy();
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.tsx
@@ -73,7 +73,7 @@ export const HostIsolationExceptionsForm: React.FC<{
 
   // set current policies if not previously selected
   useEffect(() => {
-    if (selectedPolicies.selected.length === 0 && exception.tags && exception.tags.length > 0) {
+    if (selectedPolicies.selected.length === 0 && exception.tags) {
       setSelectedPolicies(getEffectedPolicySelectionByTags(exception.tags, policies));
     }
   }, [exception.tags, policies, selectedPolicies.selected.length]);

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.tsx
@@ -73,7 +73,7 @@ export const HostIsolationExceptionsForm: React.FC<{
 
   // set current policies if not previously selected
   useEffect(() => {
-    if (selectedPolicies.selected.length === 0 && exception.tags) {
+    if (selectedPolicies.selected.length === 0 && exception.tags && exception.tags.length > 0) {
       setSelectedPolicies(getEffectedPolicySelectionByTags(exception.tags, policies));
     }
   }, [exception.tags, policies, selectedPolicies.selected.length]);


### PR DESCRIPTION
## Summary

Fixes an issue introduced with https://github.com/elastic/kibana/pull/119828 when the switch between global and per-policy won't work on specific cases:

* When the exception is per-policy without policies
* When a non-policy tag is present.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios