### PR TITLE
[8.0] [App Search, Crawler] Use consistent casing for validation step titles (#120064)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
@@ -507,16 +507,16 @@ describe('AddDomainLogic', () => {
             networkConnectivity: {
               state: 'invalid',
               message:
-                'Unable to establish a network connection because the "Initial Validation" check failed.',
+                'Unable to establish a network connection because the "Initial validation" check failed.',
             },
             indexingRestrictions: {
               state: 'invalid',
               message:
-                'Unable to determine indexing restrictions because the "Network Connectivity" check failed.',
+                'Unable to determine indexing restrictions because the "Network connectivity" check failed.',
             },
             contentVerification: {
               state: 'invalid',
-              message: 'Unable to verify content because the "Indexing Restrictions" check failed.',
+              message: 'Unable to verify content because the "Indexing restrictions" check failed.',
             },
           });
         });
@@ -602,16 +602,16 @@ describe('AddDomainLogic', () => {
             networkConnectivity: {
               state: 'invalid',
               message:
-                'Unable to establish a network connection because the "Initial Validation" check failed.',
+                'Unable to establish a network connection because the "Initial validation" check failed.',
             },
             indexingRestrictions: {
               state: 'invalid',
               message:
-                'Unable to determine indexing restrictions because the "Network Connectivity" check failed.',
+                'Unable to determine indexing restrictions because the "Network connectivity" check failed.',
             },
             contentVerification: {
               state: 'invalid',
-              message: 'Unable to verify content because the "Indexing Restrictions" check failed.',
+              message: 'Unable to verify content because the "Indexing restrictions" check failed.',
             },
           });
         });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_validation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_validation.tsx
@@ -86,7 +86,7 @@ export const AddDomainValidation: React.FC = () => {
             label={i18n.translate(
               'xpack.enterpriseSearch.appSearch.crawler.addDomainForm.contentVerificationLabel',
               {
-                defaultMessage: 'Content Verification',
+                defaultMessage: 'Content verification',
               }
             )}
           />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/utils.ts
@@ -82,7 +82,7 @@ const allFailureResultChanges: CrawlerDomainValidationResultChange = {
       'xpack.enterpriseSearch.appSearch.crawler.addDomainForm.networkConnectivityFailureMessage',
       {
         defaultMessage:
-          'Unable to establish a network connection because the "Initial Validation" check failed.',
+          'Unable to establish a network connection because the "Initial validation" check failed.',
       }
     ),
   },
@@ -92,7 +92,7 @@ const allFailureResultChanges: CrawlerDomainValidationResultChange = {
       'xpack.enterpriseSearch.appSearch.crawler.addDomainForm.indexingRestrictionsFailureMessage',
       {
         defaultMessage:
-          'Unable to determine indexing restrictions because the "Network Connectivity" check failed.',
+          'Unable to determine indexing restrictions because the "Network connectivity" check failed.',
       }
     ),
   },
@@ -102,7 +102,7 @@ const allFailureResultChanges: CrawlerDomainValidationResultChange = {
       'xpack.enterpriseSearch.appSearch.crawler.addDomainForm.contentVerificationFailureMessage',
       {
         defaultMessage:
-          'Unable to verify content because the "Indexing Restrictions" check failed.',
+          'Unable to verify content because the "Indexing restrictions" check failed.',
       }
     ),
   },


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [App Search, Crawler] Use consistent casing for validation step titles (#120064)