### PR TITLE
[DOCS] Removes tag from 7.16 what's new

### DIFF
--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -1,8 +1,6 @@
 [[whats-new]]
 == What's new in {minor-version}
 
-coming::[7.16.0]
-
 Here are the highlights of what's new and improved in {minor-version}.
 For detailed information about this release,
 check out the <<release-notes-7.16.0, release notes>>.


### PR DESCRIPTION
This PR removes the tag at the top of the What's New doc in 7.16.

