### PR TITLE
[8.0] Creating io-ts types for synthetics monitors. (#120105)

### DIFF
--- a/x-pack/plugins/uptime/common/runtime_types/monitor_management/config_key.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/monitor_management/config_key.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+import { tEnum } from '../../utils/t_enum';
+
+// values must match keys in the integration package
+export enum ConfigKey {
+  APM_SERVICE_NAME = 'service.name',
+  HOSTS = 'hosts',
+  IGNORE_HTTPS_ERRORS = 'ignore_https_errors',
+  JOURNEY_FILTERS_MATCH = 'filter_journeys.match',
+  JOURNEY_FILTERS_TAGS = 'filter_journeys.tags',
+  MAX_REDIRECTS = 'max_redirects',
+  METADATA = '__ui',
+  MONITOR_TYPE = 'type',
+  NAME = 'name',
+  PARAMS = 'params',
+  PASSWORD = 'password',
+  PROXY_URL = 'proxy_url',
+  PROXY_USE_LOCAL_RESOLVER = 'proxy_use_local_resolver',
+  RESPONSE_BODY_CHECK_NEGATIVE = 'check.response.body.negative',
+  RESPONSE_BODY_CHECK_POSITIVE = 'check.response.body.positive',
+  RESPONSE_BODY_INDEX = 'response.include_body',
+  RESPONSE_HEADERS_CHECK = 'check.response.headers',
+  RESPONSE_HEADERS_INDEX = 'response.include_headers',
+  RESPONSE_RECEIVE_CHECK = 'check.receive',
+  RESPONSE_STATUS_CHECK = 'check.response.status',
+  REQUEST_BODY_CHECK = 'check.request.body',
+  REQUEST_HEADERS_CHECK = 'check.request.headers',
+  REQUEST_METHOD_CHECK = 'check.request.method',
+  REQUEST_SEND_CHECK = 'check.send',
+  SCHEDULE = 'schedule',
+  SCREENSHOTS = 'screenshots',
+  SOURCE_INLINE = 'source.inline.script',
+  SOURCE_ZIP_URL = 'source.zip_url.url',
+  SOURCE_ZIP_USERNAME = 'source.zip_url.username',
+  SOURCE_ZIP_PASSWORD = 'source.zip_url.password',
+  SOURCE_ZIP_FOLDER = 'source.zip_url.folder',
+  SOURCE_ZIP_PROXY_URL = 'source.zip_url.proxy_url',
+  SYNTHETICS_ARGS = 'synthetics_args',
+  TLS_CERTIFICATE_AUTHORITIES = 'ssl.certificate_authorities',
+  TLS_CERTIFICATE = 'ssl.certificate',
+  TLS_KEY = 'ssl.key',
+  TLS_KEY_PASSPHRASE = 'ssl.key_passphrase',
+  TLS_VERIFICATION_MODE = 'ssl.verification_mode',
+  TLS_VERSION = 'ssl.supported_protocols',
+  TAGS = 'tags',
+  TIMEOUT = 'timeout',
+  THROTTLING_CONFIG = 'throttling.config',
+  IS_THROTTLING_ENABLED = 'throttling.is_enabled',
+  DOWNLOAD_SPEED = 'throttling.download_speed',
+  UPLOAD_SPEED = 'throttling.upload_speed',
+  LATENCY = 'throttling.latency',
+  URLS = 'urls',
+  USERNAME = 'username',
+  WAIT = 'wait',
+  ZIP_URL_TLS_CERTIFICATE_AUTHORITIES = 'source.zip_url.ssl.certificate_authorities',
+  ZIP_URL_TLS_CERTIFICATE = 'source.zip_url.ssl.certificate',
+  ZIP_URL_TLS_KEY = 'source.zip_url.ssl.key',
+  ZIP_URL_TLS_KEY_PASSPHRASE = 'source.zip_url.ssl.key_passphrase',
+  ZIP_URL_TLS_VERIFICATION_MODE = 'source.zip_url.ssl.verification_mode',
+  ZIP_URL_TLS_VERSION = 'source.zip_url.ssl.supported_protocols',
+}
+
+export const ConfigKeyCodec = tEnum<ConfigKey>('ConfigKey', ConfigKey);
+export type ConfigKeyType = t.TypeOf<typeof ConfigKeyCodec>;

--- a/x-pack/plugins/uptime/common/runtime_types/monitor_management/index.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/monitor_management/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './config_key';
+export * from './monitor_configs';
+export * from './monitor_meta_data';
+export * from './monitor_types';

--- a/x-pack/plugins/uptime/common/runtime_types/monitor_management/monitor_configs.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/monitor_management/monitor_configs.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+import { tEnum } from '../../utils/t_enum';
+
+export enum DataStream {
+  HTTP = 'http',
+  TCP = 'tcp',
+  ICMP = 'icmp',
+  BROWSER = 'browser',
+}
+
+export const DataStreamCodec = tEnum<DataStream>('DataStream', DataStream);
+export type DataStreamType = t.TypeOf<typeof DataStreamCodec>;
+
+export enum HTTPMethod {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  DELETE = 'DELETE',
+  HEAD = 'HEAD',
+}
+
+export const HTTPMethodCodec = tEnum<HTTPMethod>('HTTPMethod', HTTPMethod);
+export type HTTPMethodType = t.TypeOf<typeof HTTPMethodCodec>;
+
+export enum ResponseBodyIndexPolicy {
+  ALWAYS = 'always',
+  NEVER = 'never',
+  ON_ERROR = 'on_error',
+}
+
+export const ResponseBodyIndexPolicyCodec = tEnum<ResponseBodyIndexPolicy>(
+  'ResponseBodyIndexPolicy',
+  ResponseBodyIndexPolicy
+);
+export type ResponseBodyIndexPolicyType = t.TypeOf<typeof ResponseBodyIndexPolicyCodec>;
+
+export enum MonacoEditorLangId {
+  JSON = 'xjson',
+  PLAINTEXT = 'plaintext',
+  XML = 'xml',
+  JAVASCRIPT = 'javascript',
+}
+
+export const MonacoEditorLangIdCodec = tEnum<MonacoEditorLangId>(
+  'MonacoEditorLangId',
+  MonacoEditorLangId
+);
+export type MonacoEditorLangIdType = t.TypeOf<typeof MonacoEditorLangIdCodec>;
+
+export enum Mode {
+  FORM = 'form',
+  JSON = 'json',
+  PLAINTEXT = 'text',
+  XML = 'xml',
+}
+
+export const ModeCodec = tEnum<Mode>('Mode', Mode);
+export type ModeType = t.TypeOf<typeof ModeCodec>;
+
+export enum ContentType {
+  JSON = 'application/json',
+  TEXT = 'text/plain',
+  XML = 'application/xml',
+  FORM = 'application/x-www-form-urlencoded',
+}
+
+export const ContentTypeCodec = tEnum<ContentType>('ContentType', ContentType);
+export type ContentTypeType = t.TypeOf<typeof ContentTypeCodec>;
+
+export enum ScheduleUnit {
+  MINUTES = 'm',
+  SECONDS = 's',
+}
+
+export const ScheduleUnitCodec = tEnum<ScheduleUnit>('ScheduleUnit', ScheduleUnit);
+export type ScheduleUnitType = t.TypeOf<typeof ScheduleUnitCodec>;
+
+export enum VerificationMode {
+  CERTIFICATE = 'certificate',
+  FULL = 'full',
+  NONE = 'none',
+  STRICT = 'strict',
+}
+
+export const VerificationModeCodec = tEnum<VerificationMode>('VerificationMode', VerificationMode);
+export type VerificationModeType = t.TypeOf<typeof VerificationModeCodec>;
+
+export enum TLSVersion {
+  ONE_ZERO = 'TLSv1.0',
+  ONE_ONE = 'TLSv1.1',
+  ONE_TWO = 'TLSv1.2',
+  ONE_THREE = 'TLSv1.3',
+}
+
+export const TLSVersionCodec = tEnum<TLSVersion>('TLSVersion', TLSVersion);
+export type TLSVersionType = t.TypeOf<typeof TLSVersionCodec>;
+
+export enum ScreenshotOption {
+  ON = 'on',
+  OFF = 'off',
+  ONLY_ON_FAILURE = 'only-on-failure',
+}
+
+export const ScreenshotOptionCodec = tEnum<ScreenshotOption>('ScreenshotOption', ScreenshotOption);
+export type ScreenshotOptionType = t.TypeOf<typeof ScreenshotOptionCodec>;
+
+export enum ThrottlingSuffix {
+  DOWNLOAD = 'd',
+  UPLOAD = 'u',
+  LATENCY = 'l',
+}
+
+export const ThrottlingSuffixCodec = tEnum<ThrottlingSuffix>('ThrottlingSuffix', ThrottlingSuffix);
+export type ThrottlingSuffixType = t.TypeOf<typeof ThrottlingSuffixCodec>;

--- a/x-pack/plugins/uptime/common/runtime_types/monitor_management/monitor_meta_data.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/monitor_management/monitor_meta_data.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+
+const ScriptSourceCodec = t.interface({
+  is_generated_script: t.boolean,
+  file_name: t.string,
+});
+
+export const MetadataCodec = t.partial({
+  is_tls_enabled: t.boolean,
+  is_zip_url_tls_enabled: t.boolean,
+  script_source: ScriptSourceCodec,
+});
+
+export type Metadata = t.TypeOf<typeof MetadataCodec>;

--- a/x-pack/plugins/uptime/common/runtime_types/monitor_management/monitor_types.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/monitor_management/monitor_types.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+import { ConfigKey } from './config_key';
+import {
+  DataStreamCodec,
+  ModeCodec,
+  ResponseBodyIndexPolicyCodec,
+  ScheduleUnitCodec,
+} from './monitor_configs';
+import { MetadataCodec } from './monitor_meta_data';
+import { TLSVersionCodec, VerificationModeCodec } from './monitor_configs';
+
+const Schedule = t.interface({
+  number: t.string,
+  unit: ScheduleUnitCodec,
+});
+
+// TLSFields
+export const TLSFieldsCodec = t.partial({
+  [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: t.string,
+  [ConfigKey.TLS_CERTIFICATE]: t.string,
+  [ConfigKey.TLS_KEY]: t.string,
+  [ConfigKey.TLS_KEY_PASSPHRASE]: t.string,
+  [ConfigKey.TLS_VERIFICATION_MODE]: VerificationModeCodec,
+  [ConfigKey.TLS_VERSION]: t.array(TLSVersionCodec),
+});
+
+export type TLSFields = t.TypeOf<typeof TLSFieldsCodec>;
+
+// ZipUrlTLSFields
+export const ZipUrlTLSFieldsCodec = t.partial({
+  [ConfigKey.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: t.string,
+  [ConfigKey.ZIP_URL_TLS_CERTIFICATE]: t.string,
+  [ConfigKey.ZIP_URL_TLS_KEY]: t.string,
+  [ConfigKey.ZIP_URL_TLS_KEY_PASSPHRASE]: t.string,
+  [ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]: VerificationModeCodec,
+  [ConfigKey.ZIP_URL_TLS_VERSION]: t.array(TLSVersionCodec),
+});
+
+export type ZipUrlTLSFields = t.TypeOf<typeof ZipUrlTLSFieldsCodec>;
+
+// CommonFields
+export const CommonFieldsCodec = t.interface({
+  [ConfigKey.MONITOR_TYPE]: DataStreamCodec,
+  [ConfigKey.SCHEDULE]: Schedule,
+  [ConfigKey.APM_SERVICE_NAME]: t.string,
+  [ConfigKey.TIMEOUT]: t.string,
+  [ConfigKey.TAGS]: t.array(t.string),
+});
+
+export type CommonFields = t.TypeOf<typeof CommonFieldsCodec>;
+
+// TCP Simple Fields
+export const TCPSimpleFieldsCodec = t.intersection([
+  t.interface({
+    [ConfigKey.METADATA]: MetadataCodec,
+    [ConfigKey.HOSTS]: t.string,
+  }),
+  CommonFieldsCodec,
+]);
+
+export type TCPSimpleFields = t.TypeOf<typeof TCPSimpleFieldsCodec>;
+
+// TCPAdvancedFields
+export const TCPAdvancedFieldsCodec = t.interface({
+  [ConfigKey.PROXY_URL]: t.string,
+  [ConfigKey.PROXY_USE_LOCAL_RESOLVER]: t.boolean,
+  [ConfigKey.RESPONSE_RECEIVE_CHECK]: t.string,
+  [ConfigKey.REQUEST_SEND_CHECK]: t.string,
+});
+
+export type TCPAdvancedFields = t.TypeOf<typeof TCPAdvancedFieldsCodec>;
+
+// TCPFields
+export const TCPFieldsCodec = t.intersection([
+  TCPSimpleFieldsCodec,
+  TCPAdvancedFieldsCodec,
+  TLSFieldsCodec,
+]);
+
+export type TCPFields = t.TypeOf<typeof TCPFieldsCodec>;
+
+// ICMP SimpleFields
+export const ICMPSimpleFieldsCodec = t.intersection([
+  t.interface({
+    [ConfigKey.HOSTS]: t.string,
+    [ConfigKey.WAIT]: t.string,
+  }),
+  CommonFieldsCodec,
+]);
+
+export type ICMPSimpleFields = t.TypeOf<typeof ICMPSimpleFieldsCodec>;
+export type ICMPFields = t.TypeOf<typeof ICMPSimpleFieldsCodec>;
+
+// HTTPSimpleFields
+export const HTTPSimpleFieldsCodec = t.intersection([
+  t.interface({
+    [ConfigKey.METADATA]: MetadataCodec,
+    [ConfigKey.MAX_REDIRECTS]: t.string,
+    [ConfigKey.URLS]: t.string,
+  }),
+  CommonFieldsCodec,
+]);
+
+export type HTTPSimpleFields = t.TypeOf<typeof HTTPSimpleFieldsCodec>;
+
+// HTTPAdvancedFields
+export const HTTPAdvancedFieldsCodec = t.interface({
+  [ConfigKey.PASSWORD]: t.string,
+  [ConfigKey.PROXY_URL]: t.string,
+  [ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]: t.array(t.string),
+  [ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]: t.array(t.string),
+  [ConfigKey.RESPONSE_BODY_INDEX]: ResponseBodyIndexPolicyCodec,
+  [ConfigKey.RESPONSE_HEADERS_CHECK]: t.record(t.string, t.string),
+  [ConfigKey.RESPONSE_HEADERS_INDEX]: t.boolean,
+  [ConfigKey.RESPONSE_STATUS_CHECK]: t.array(t.string),
+  [ConfigKey.REQUEST_BODY_CHECK]: t.interface({ value: t.string, type: ModeCodec }),
+  [ConfigKey.REQUEST_HEADERS_CHECK]: t.record(t.string, t.string),
+  [ConfigKey.REQUEST_METHOD_CHECK]: t.string,
+  [ConfigKey.USERNAME]: t.string,
+});
+
+export type HTTPAdvancedFields = t.TypeOf<typeof HTTPAdvancedFieldsCodec>;
+
+// HTTPFields
+export const HTTPFieldsCodec = t.intersection([
+  HTTPSimpleFieldsCodec,
+  HTTPAdvancedFieldsCodec,
+  TLSFieldsCodec,
+]);
+export type HTTPFields = t.TypeOf<typeof HTTPFieldsCodec>;
+
+// Browser Fields
+export const ThrottlingConfigKeyCodec = t.union([
+  t.literal(ConfigKey.DOWNLOAD_SPEED),
+  t.literal(ConfigKey.UPLOAD_SPEED),
+  t.literal(ConfigKey.LATENCY),
+]);
+
+export type ThrottlingConfigKey = t.TypeOf<typeof ThrottlingConfigKeyCodec>;
+
+export const BrowserSimpleFieldsCodec = t.intersection([
+  t.interface({
+    [ConfigKey.METADATA]: MetadataCodec,
+    [ConfigKey.SOURCE_INLINE]: t.string,
+    [ConfigKey.SOURCE_ZIP_URL]: t.string,
+    [ConfigKey.SOURCE_ZIP_FOLDER]: t.string,
+    [ConfigKey.SOURCE_ZIP_USERNAME]: t.string,
+    [ConfigKey.SOURCE_ZIP_PASSWORD]: t.string,
+    [ConfigKey.SOURCE_ZIP_PROXY_URL]: t.string,
+    [ConfigKey.PARAMS]: t.string,
+  }),
+  ZipUrlTLSFieldsCodec,
+  CommonFieldsCodec,
+]);
+
+export const BrowserAdvancedFieldsCodec = t.interface({
+  [ConfigKey.SYNTHETICS_ARGS]: t.array(t.string),
+  [ConfigKey.SCREENSHOTS]: t.string,
+  [ConfigKey.JOURNEY_FILTERS_MATCH]: t.string,
+  [ConfigKey.JOURNEY_FILTERS_TAGS]: t.array(t.string),
+  [ConfigKey.IGNORE_HTTPS_ERRORS]: t.boolean,
+  [ConfigKey.IS_THROTTLING_ENABLED]: t.boolean,
+  [ConfigKey.DOWNLOAD_SPEED]: t.string,
+  [ConfigKey.UPLOAD_SPEED]: t.string,
+  [ConfigKey.LATENCY]: t.string,
+  [ConfigKey.THROTTLING_CONFIG]: t.string,
+});
+
+export const BrowserFieldsCodec = t.intersection([
+  BrowserSimpleFieldsCodec,
+  BrowserAdvancedFieldsCodec,
+]);
+
+export type BrowserFields = t.TypeOf<typeof BrowserFieldsCodec>;
+export type BrowserSimpleFields = t.TypeOf<typeof BrowserSimpleFieldsCodec>;
+export type BrowserAdvancedFields = t.TypeOf<typeof BrowserAdvancedFieldsCodec>;
+
+export const MonitorFieldsCodec = t.intersection([
+  HTTPFieldsCodec,
+  TCPFieldsCodec,
+  ICMPSimpleFieldsCodec,
+  BrowserFieldsCodec,
+  t.interface({
+    [ConfigKey.NAME]: t.string,
+  }),
+]);
+
+export type MonitorFields = t.TypeOf<typeof MonitorFieldsCodec>;

--- a/x-pack/plugins/uptime/common/utils/t_enum.ts
+++ b/x-pack/plugins/uptime/common/utils/t_enum.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+
+/**
+ * This utility function can be used to turn a TypeScript enum into a io-ts codec.
+ *
+ * @example
+ * import { PathReporter } from "io-ts/lib/PathReporter";
+ *
+ * enum Thing {
+ *  FOO = "foo",
+ *  BAR = "bar"
+ * }
+ *
+ * const ThingCodec = tEnum<Thing>("Thing", Thing);
+ *
+ * console.log(PathReporter.report(ThingCodec.decode('invalidvalue')));
+ * // prints [ 'Invalid value "invalidvalue" supplied to : Thing' ]
+ * console.log(PathReporter.report(ThingCodec.decode('foo')));
+ * // prints [ 'No errors!' ]
+ */
+export function tEnum<EnumType>(enumName: string, theEnum: Record<string, string | number>) {
+  const isEnumValue = (input: unknown): input is EnumType =>
+    Object.values<unknown>(theEnum).includes(input);
+
+  return new t.Type<EnumType>(
+    enumName,
+    isEnumValue,
+    (input, context) => (isEnumValue(input) ? t.success(input) : t.failure(input, context)),
+    t.identity
+  );
+}

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.test.tsx
@@ -10,11 +10,11 @@ import userEvent from '@testing-library/user-event';
 import { render } from '../../../lib/helper/rtl_helpers';
 import { BrowserAdvancedFields } from './advanced_fields';
 import {
-  ConfigKeys,
-  DataStream,
-  IBrowserAdvancedFields,
-  IBrowserSimpleFields,
+  ConfigKey,
+  BrowserAdvancedFields as BrowserAdvancedFieldsType,
+  BrowserSimpleFields,
   Validation,
+  DataStream,
 } from '../types';
 import {
   BrowserAdvancedFieldsContextProvider,
@@ -38,8 +38,8 @@ describe('<BrowserAdvancedFields />', () => {
     defaultSimpleFields = defaultBrowserSimpleFields,
     validate = defaultValidation,
   }: {
-    defaultValues?: IBrowserAdvancedFields;
-    defaultSimpleFields?: IBrowserSimpleFields;
+    defaultValues?: BrowserAdvancedFieldsType;
+    defaultSimpleFields?: BrowserSimpleFields;
     validate?: Validation;
   }) => {
     return (
@@ -59,7 +59,7 @@ describe('<BrowserAdvancedFields />', () => {
     const syntheticsArgs = getByLabelText('Synthetics args');
     const screenshots = getByLabelText('Screenshot options') as HTMLInputElement;
 
-    expect(screenshots.value).toEqual(defaultConfig[ConfigKeys.SCREENSHOTS]);
+    expect(screenshots.value).toEqual(defaultConfig[ConfigKey.SCREENSHOTS]);
     expect(syntheticsArgs).toBeInTheDocument();
   });
 
@@ -86,7 +86,7 @@ describe('<BrowserAdvancedFields />', () => {
       <WrappedComponent
         defaultSimpleFields={{
           ...defaultBrowserSimpleFields,
-          [ConfigKeys.SOURCE_ZIP_URL]: 'https://elastic.zip',
+          [ConfigKey.SOURCE_ZIP_URL]: 'https://elastic.zip',
         }}
       />
     );

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.tsx
@@ -20,7 +20,7 @@ import { ComboBox } from '../combo_box';
 
 import { useBrowserAdvancedFieldsContext, useBrowserSimpleFieldsContext } from '../contexts';
 
-import { ConfigKeys, Validation, ScreenshotOption } from '../types';
+import { ConfigKey, Validation, ScreenshotOption } from '../types';
 
 import { OptionalLabel } from '../optional_label';
 import { ThrottlingFields } from './throttling_fields';
@@ -34,7 +34,7 @@ export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
   const { fields: simpleFields } = useBrowserSimpleFieldsContext();
 
   const handleInputChange = useCallback(
-    ({ value, configKey }: { value: unknown; configKey: ConfigKeys }) => {
+    ({ value, configKey }: { value: unknown; configKey: ConfigKey }) => {
       setFields((prevFields) => ({ ...prevFields, [configKey]: value }));
     },
     [setFields]
@@ -47,7 +47,7 @@ export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
       data-test-subj="syntheticsBrowserAdvancedFieldsAccordion"
     >
       <EuiSpacer size="m" />
-      {simpleFields[ConfigKeys.SOURCE_ZIP_URL] && (
+      {simpleFields[ConfigKey.SOURCE_ZIP_URL] && (
         <EuiDescribedFormGroup
           title={
             <h4>
@@ -81,11 +81,11 @@ export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
             }
           >
             <EuiFieldText
-              value={fields[ConfigKeys.JOURNEY_FILTERS_MATCH]}
+              value={fields[ConfigKey.JOURNEY_FILTERS_MATCH]}
               onChange={(event) =>
                 handleInputChange({
                   value: event.target.value,
-                  configKey: ConfigKeys.JOURNEY_FILTERS_MATCH,
+                  configKey: ConfigKey.JOURNEY_FILTERS_MATCH,
                 })
               }
               data-test-subj="syntheticsBrowserJourneyFiltersMatch"
@@ -107,9 +107,9 @@ export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
             }
           >
             <ComboBox
-              selectedOptions={fields[ConfigKeys.JOURNEY_FILTERS_TAGS]}
+              selectedOptions={fields[ConfigKey.JOURNEY_FILTERS_TAGS]}
               onChange={(value) =>
-                handleInputChange({ value, configKey: ConfigKeys.JOURNEY_FILTERS_TAGS })
+                handleInputChange({ value, configKey: ConfigKey.JOURNEY_FILTERS_TAGS })
               }
               data-test-subj="syntheticsBrowserJourneyFiltersTags"
             />
@@ -146,7 +146,7 @@ export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
         >
           <EuiCheckbox
             id="syntheticsBrowserIgnoreHttpsErrorsCheckbox"
-            checked={fields[ConfigKeys.IGNORE_HTTPS_ERRORS]}
+            checked={fields[ConfigKey.IGNORE_HTTPS_ERRORS]}
             label={
               <FormattedMessage
                 id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.ignoreHttpsErrors.label"
@@ -156,7 +156,7 @@ export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
             onChange={(event) =>
               handleInputChange({
                 value: event.target.checked,
-                configKey: ConfigKeys.IGNORE_HTTPS_ERRORS,
+                configKey: ConfigKey.IGNORE_HTTPS_ERRORS,
               })
             }
           />
@@ -179,11 +179,11 @@ export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
         >
           <EuiSelect
             options={requestMethodOptions}
-            value={fields[ConfigKeys.SCREENSHOTS]}
+            value={fields[ConfigKey.SCREENSHOTS]}
             onChange={(event) =>
               handleInputChange({
                 value: event.target.value,
-                configKey: ConfigKeys.SCREENSHOTS,
+                configKey: ConfigKey.SCREENSHOTS,
               })
             }
             data-test-subj="syntheticsBrowserScreenshots"
@@ -205,10 +205,8 @@ export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
           }
         >
           <ComboBox
-            selectedOptions={fields[ConfigKeys.SYNTHETICS_ARGS]}
-            onChange={(value) =>
-              handleInputChange({ value, configKey: ConfigKeys.SYNTHETICS_ARGS })
-            }
+            selectedOptions={fields[ConfigKey.SYNTHETICS_ARGS]}
+            onChange={(value) => handleInputChange({ value, configKey: ConfigKey.SYNTHETICS_ARGS })}
             data-test-subj="syntheticsBrowserSyntheticsArgs"
           />
         </EuiFormRow>

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/formatters.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/formatters.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { BrowserFields, ConfigKeys } from '../types';
+import { BrowserFields, ConfigKey } from '../types';
 import {
   Formatter,
   commonFormatters,
@@ -22,53 +22,52 @@ import {
 export type BrowserFormatMap = Record<keyof BrowserFields, Formatter>;
 
 const throttlingFormatter: Formatter = (fields) => {
-  if (!fields[ConfigKeys.IS_THROTTLING_ENABLED]) return 'false';
+  if (!fields[ConfigKey.IS_THROTTLING_ENABLED]) return 'false';
 
   const getThrottlingValue = (v: string | undefined, suffix: 'd' | 'u' | 'l') =>
     v !== '' && v !== undefined ? `${v}${suffix}` : null;
 
   return [
-    getThrottlingValue(fields[ConfigKeys.DOWNLOAD_SPEED], 'd'),
-    getThrottlingValue(fields[ConfigKeys.UPLOAD_SPEED], 'u'),
-    getThrottlingValue(fields[ConfigKeys.LATENCY], 'l'),
+    getThrottlingValue(fields[ConfigKey.DOWNLOAD_SPEED], 'd'),
+    getThrottlingValue(fields[ConfigKey.UPLOAD_SPEED], 'u'),
+    getThrottlingValue(fields[ConfigKey.LATENCY], 'l'),
   ]
     .filter((v) => v !== null)
     .join('/');
 };
 
 export const browserFormatters: BrowserFormatMap = {
-  [ConfigKeys.METADATA]: (fields) => objectToJsonFormatter(fields[ConfigKeys.METADATA]),
-  [ConfigKeys.SOURCE_ZIP_URL]: null,
-  [ConfigKeys.SOURCE_ZIP_USERNAME]: null,
-  [ConfigKeys.SOURCE_ZIP_PASSWORD]: null,
-  [ConfigKeys.SOURCE_ZIP_FOLDER]: null,
-  [ConfigKeys.SOURCE_ZIP_PROXY_URL]: null,
-  [ConfigKeys.SOURCE_INLINE]: (fields) => stringToJsonFormatter(fields[ConfigKeys.SOURCE_INLINE]),
-  [ConfigKeys.PARAMS]: null,
-  [ConfigKeys.SCREENSHOTS]: null,
-  [ConfigKeys.IS_THROTTLING_ENABLED]: null,
-  [ConfigKeys.DOWNLOAD_SPEED]: null,
-  [ConfigKeys.UPLOAD_SPEED]: null,
-  [ConfigKeys.LATENCY]: null,
-  [ConfigKeys.SYNTHETICS_ARGS]: (fields) =>
-    arrayToJsonFormatter(fields[ConfigKeys.SYNTHETICS_ARGS]),
-  [ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: (fields) =>
-    tlsValueToYamlFormatter(fields[ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]),
-  [ConfigKeys.ZIP_URL_TLS_CERTIFICATE]: (fields) =>
-    tlsValueToYamlFormatter(fields[ConfigKeys.ZIP_URL_TLS_CERTIFICATE]),
-  [ConfigKeys.ZIP_URL_TLS_KEY]: (fields) =>
-    tlsValueToYamlFormatter(fields[ConfigKeys.ZIP_URL_TLS_KEY]),
-  [ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE]: (fields) =>
-    tlsValueToStringFormatter(fields[ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE]),
-  [ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]: (fields) =>
-    tlsValueToStringFormatter(fields[ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]),
-  [ConfigKeys.ZIP_URL_TLS_VERSION]: (fields) =>
-    tlsArrayToYamlFormatter(fields[ConfigKeys.ZIP_URL_TLS_VERSION]),
-  [ConfigKeys.JOURNEY_FILTERS_MATCH]: (fields) =>
-    stringToJsonFormatter(fields[ConfigKeys.JOURNEY_FILTERS_MATCH]),
-  [ConfigKeys.JOURNEY_FILTERS_TAGS]: (fields) =>
-    arrayToJsonFormatter(fields[ConfigKeys.JOURNEY_FILTERS_TAGS]),
-  [ConfigKeys.THROTTLING_CONFIG]: throttlingFormatter,
-  [ConfigKeys.IGNORE_HTTPS_ERRORS]: null,
+  [ConfigKey.METADATA]: (fields) => objectToJsonFormatter(fields[ConfigKey.METADATA]),
+  [ConfigKey.SOURCE_ZIP_URL]: null,
+  [ConfigKey.SOURCE_ZIP_USERNAME]: null,
+  [ConfigKey.SOURCE_ZIP_PASSWORD]: null,
+  [ConfigKey.SOURCE_ZIP_FOLDER]: null,
+  [ConfigKey.SOURCE_ZIP_PROXY_URL]: null,
+  [ConfigKey.SOURCE_INLINE]: (fields) => stringToJsonFormatter(fields[ConfigKey.SOURCE_INLINE]),
+  [ConfigKey.PARAMS]: null,
+  [ConfigKey.SCREENSHOTS]: null,
+  [ConfigKey.IS_THROTTLING_ENABLED]: null,
+  [ConfigKey.DOWNLOAD_SPEED]: null,
+  [ConfigKey.UPLOAD_SPEED]: null,
+  [ConfigKey.LATENCY]: null,
+  [ConfigKey.SYNTHETICS_ARGS]: (fields) => arrayToJsonFormatter(fields[ConfigKey.SYNTHETICS_ARGS]),
+  [ConfigKey.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: (fields) =>
+    tlsValueToYamlFormatter(fields[ConfigKey.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]),
+  [ConfigKey.ZIP_URL_TLS_CERTIFICATE]: (fields) =>
+    tlsValueToYamlFormatter(fields[ConfigKey.ZIP_URL_TLS_CERTIFICATE]),
+  [ConfigKey.ZIP_URL_TLS_KEY]: (fields) =>
+    tlsValueToYamlFormatter(fields[ConfigKey.ZIP_URL_TLS_KEY]),
+  [ConfigKey.ZIP_URL_TLS_KEY_PASSPHRASE]: (fields) =>
+    tlsValueToStringFormatter(fields[ConfigKey.ZIP_URL_TLS_KEY_PASSPHRASE]),
+  [ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]: (fields) =>
+    tlsValueToStringFormatter(fields[ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]),
+  [ConfigKey.ZIP_URL_TLS_VERSION]: (fields) =>
+    tlsArrayToYamlFormatter(fields[ConfigKey.ZIP_URL_TLS_VERSION]),
+  [ConfigKey.JOURNEY_FILTERS_MATCH]: (fields) =>
+    stringToJsonFormatter(fields[ConfigKey.JOURNEY_FILTERS_MATCH]),
+  [ConfigKey.JOURNEY_FILTERS_TAGS]: (fields) =>
+    arrayToJsonFormatter(fields[ConfigKey.JOURNEY_FILTERS_TAGS]),
+  [ConfigKey.THROTTLING_CONFIG]: throttlingFormatter,
+  [ConfigKey.IGNORE_HTTPS_ERRORS]: null,
   ...commonFormatters,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/normalizers.test.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/normalizers.test.ts
@@ -5,62 +5,62 @@
  * 2.0.
  */
 
-import { ConfigKeys } from '../types';
+import { ConfigKey } from '../types';
 import { getThrottlingParamNormalizer, isThrottlingEnabledNormalizer } from './normalizers';
 import { defaultBrowserAdvancedFields } from '../contexts';
 
 describe('browser normalizers', () => {
   const makeThrottlingConfig = (value: string) => ({
-    [ConfigKeys.THROTTLING_CONFIG]: { value },
+    [ConfigKey.THROTTLING_CONFIG]: { value },
   });
 
   describe('throttlingToParameterNormalizer', () => {
     it('can extract download values', () => {
       const fields = makeThrottlingConfig('10d/5u/2.5l');
 
-      expect(getThrottlingParamNormalizer(ConfigKeys.DOWNLOAD_SPEED)(fields)).toEqual('10');
+      expect(getThrottlingParamNormalizer(ConfigKey.DOWNLOAD_SPEED)(fields)).toEqual('10');
     });
 
     it('can extract upload values', () => {
       const fields = makeThrottlingConfig('10d/5u/2.5l');
 
-      expect(getThrottlingParamNormalizer(ConfigKeys.UPLOAD_SPEED)(fields)).toEqual('5');
+      expect(getThrottlingParamNormalizer(ConfigKey.UPLOAD_SPEED)(fields)).toEqual('5');
     });
 
     it('can extract latency values', () => {
       const fields = makeThrottlingConfig('10d/5u/2.5l');
 
-      expect(getThrottlingParamNormalizer(ConfigKeys.LATENCY)(fields)).toEqual('2.5');
+      expect(getThrottlingParamNormalizer(ConfigKey.LATENCY)(fields)).toEqual('2.5');
     });
 
     it('returns default values when throttling is disabled', () => {
       const fields = makeThrottlingConfig('false');
 
-      expect(getThrottlingParamNormalizer(ConfigKeys.DOWNLOAD_SPEED)(fields)).toEqual(
-        defaultBrowserAdvancedFields[ConfigKeys.DOWNLOAD_SPEED]
+      expect(getThrottlingParamNormalizer(ConfigKey.DOWNLOAD_SPEED)(fields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKey.DOWNLOAD_SPEED]
       );
-      expect(getThrottlingParamNormalizer(ConfigKeys.UPLOAD_SPEED)(fields)).toEqual(
-        defaultBrowserAdvancedFields[ConfigKeys.UPLOAD_SPEED]
+      expect(getThrottlingParamNormalizer(ConfigKey.UPLOAD_SPEED)(fields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKey.UPLOAD_SPEED]
       );
-      expect(getThrottlingParamNormalizer(ConfigKeys.LATENCY)(fields)).toEqual(
-        defaultBrowserAdvancedFields[ConfigKeys.LATENCY]
+      expect(getThrottlingParamNormalizer(ConfigKey.LATENCY)(fields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKey.LATENCY]
       );
     });
 
     it("returns default values when the desired suffix doesn't exist", () => {
       const noUploadFields = makeThrottlingConfig('10d/2.5l');
-      expect(getThrottlingParamNormalizer(ConfigKeys.UPLOAD_SPEED)(noUploadFields)).toEqual(
-        defaultBrowserAdvancedFields[ConfigKeys.UPLOAD_SPEED]
+      expect(getThrottlingParamNormalizer(ConfigKey.UPLOAD_SPEED)(noUploadFields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKey.UPLOAD_SPEED]
       );
 
       const noDownloadFields = makeThrottlingConfig('10u/2.5l');
-      expect(getThrottlingParamNormalizer(ConfigKeys.DOWNLOAD_SPEED)(noDownloadFields)).toEqual(
-        defaultBrowserAdvancedFields[ConfigKeys.DOWNLOAD_SPEED]
+      expect(getThrottlingParamNormalizer(ConfigKey.DOWNLOAD_SPEED)(noDownloadFields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKey.DOWNLOAD_SPEED]
       );
 
       const noLatencyFields = makeThrottlingConfig('10d/5u');
-      expect(getThrottlingParamNormalizer(ConfigKeys.LATENCY)(noLatencyFields)).toEqual(
-        defaultBrowserAdvancedFields[ConfigKeys.LATENCY]
+      expect(getThrottlingParamNormalizer(ConfigKey.LATENCY)(noLatencyFields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKey.LATENCY]
       );
     });
   });

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/normalizers.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/normalizers.ts
@@ -7,7 +7,7 @@
 
 import {
   BrowserFields,
-  ConfigKeys,
+  ConfigKey,
   ThrottlingSuffix,
   ThrottlingConfigKey,
   configKeyToThrottlingSuffix,
@@ -28,11 +28,11 @@ const defaultBrowserFields = {
   ...defaultBrowserAdvancedFields,
 };
 
-export const getBrowserNormalizer = (key: ConfigKeys) => {
+export const getBrowserNormalizer = (key: ConfigKey) => {
   return getNormalizer(key, defaultBrowserFields);
 };
 
-export const getBrowserJsonToJavascriptNormalizer = (key: ConfigKeys) => {
+export const getBrowserJsonToJavascriptNormalizer = (key: ConfigKey) => {
   return getJsonToJavascriptNormalizer(key, defaultBrowserFields);
 };
 
@@ -52,7 +52,7 @@ export function throttlingToParameterNormalizer(
 export const isThrottlingEnabledNormalizer: Normalizer = function isThrottlingEnabledNormalizer(
   fields
 ) {
-  const throttlingEnabled = fields?.[ConfigKeys.THROTTLING_CONFIG]?.value;
+  const throttlingEnabled = fields?.[ConfigKey.THROTTLING_CONFIG]?.value;
 
   // If we have any value that's not an explicit "false" it means throttling is "on"
   return throttlingEnabled !== 'false';
@@ -61,48 +61,48 @@ export const isThrottlingEnabledNormalizer: Normalizer = function isThrottlingEn
 export function getThrottlingParamNormalizer(key: ThrottlingConfigKey): Normalizer {
   const paramSuffix = configKeyToThrottlingSuffix[key];
   return (fields) =>
-    throttlingToParameterNormalizer(paramSuffix, fields?.[ConfigKeys.THROTTLING_CONFIG]?.value) ??
+    throttlingToParameterNormalizer(paramSuffix, fields?.[ConfigKey.THROTTLING_CONFIG]?.value) ??
     defaultBrowserFields[key];
 }
 
 export const browserNormalizers: BrowserNormalizerMap = {
-  [ConfigKeys.METADATA]: getBrowserJsonToJavascriptNormalizer(ConfigKeys.METADATA),
-  [ConfigKeys.SOURCE_ZIP_URL]: getBrowserNormalizer(ConfigKeys.SOURCE_ZIP_URL),
-  [ConfigKeys.SOURCE_ZIP_USERNAME]: getBrowserNormalizer(ConfigKeys.SOURCE_ZIP_USERNAME),
-  [ConfigKeys.SOURCE_ZIP_PASSWORD]: getBrowserNormalizer(ConfigKeys.SOURCE_ZIP_PASSWORD),
-  [ConfigKeys.SOURCE_ZIP_FOLDER]: getBrowserNormalizer(ConfigKeys.SOURCE_ZIP_FOLDER),
-  [ConfigKeys.SOURCE_INLINE]: getBrowserJsonToJavascriptNormalizer(ConfigKeys.SOURCE_INLINE),
-  [ConfigKeys.SOURCE_ZIP_PROXY_URL]: getBrowserNormalizer(ConfigKeys.SOURCE_ZIP_PROXY_URL),
-  [ConfigKeys.PARAMS]: getBrowserNormalizer(ConfigKeys.PARAMS),
-  [ConfigKeys.SCREENSHOTS]: getBrowserNormalizer(ConfigKeys.SCREENSHOTS),
-  [ConfigKeys.SYNTHETICS_ARGS]: getBrowserJsonToJavascriptNormalizer(ConfigKeys.SYNTHETICS_ARGS),
-  [ConfigKeys.IS_THROTTLING_ENABLED]: isThrottlingEnabledNormalizer,
-  [ConfigKeys.DOWNLOAD_SPEED]: getThrottlingParamNormalizer(ConfigKeys.DOWNLOAD_SPEED),
-  [ConfigKeys.UPLOAD_SPEED]: getThrottlingParamNormalizer(ConfigKeys.UPLOAD_SPEED),
-  [ConfigKeys.LATENCY]: getThrottlingParamNormalizer(ConfigKeys.LATENCY),
-  [ConfigKeys.THROTTLING_CONFIG]: getBrowserNormalizer(ConfigKeys.THROTTLING_CONFIG),
-  [ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: getBrowserJsonToJavascriptNormalizer(
-    ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES
+  [ConfigKey.METADATA]: getBrowserJsonToJavascriptNormalizer(ConfigKey.METADATA),
+  [ConfigKey.SOURCE_ZIP_URL]: getBrowserNormalizer(ConfigKey.SOURCE_ZIP_URL),
+  [ConfigKey.SOURCE_ZIP_USERNAME]: getBrowserNormalizer(ConfigKey.SOURCE_ZIP_USERNAME),
+  [ConfigKey.SOURCE_ZIP_PASSWORD]: getBrowserNormalizer(ConfigKey.SOURCE_ZIP_PASSWORD),
+  [ConfigKey.SOURCE_ZIP_FOLDER]: getBrowserNormalizer(ConfigKey.SOURCE_ZIP_FOLDER),
+  [ConfigKey.SOURCE_INLINE]: getBrowserJsonToJavascriptNormalizer(ConfigKey.SOURCE_INLINE),
+  [ConfigKey.SOURCE_ZIP_PROXY_URL]: getBrowserNormalizer(ConfigKey.SOURCE_ZIP_PROXY_URL),
+  [ConfigKey.PARAMS]: getBrowserNormalizer(ConfigKey.PARAMS),
+  [ConfigKey.SCREENSHOTS]: getBrowserNormalizer(ConfigKey.SCREENSHOTS),
+  [ConfigKey.SYNTHETICS_ARGS]: getBrowserJsonToJavascriptNormalizer(ConfigKey.SYNTHETICS_ARGS),
+  [ConfigKey.IS_THROTTLING_ENABLED]: isThrottlingEnabledNormalizer,
+  [ConfigKey.DOWNLOAD_SPEED]: getThrottlingParamNormalizer(ConfigKey.DOWNLOAD_SPEED),
+  [ConfigKey.UPLOAD_SPEED]: getThrottlingParamNormalizer(ConfigKey.UPLOAD_SPEED),
+  [ConfigKey.LATENCY]: getThrottlingParamNormalizer(ConfigKey.LATENCY),
+  [ConfigKey.THROTTLING_CONFIG]: getBrowserNormalizer(ConfigKey.THROTTLING_CONFIG),
+  [ConfigKey.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: getBrowserJsonToJavascriptNormalizer(
+    ConfigKey.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES
   ),
-  [ConfigKeys.ZIP_URL_TLS_CERTIFICATE]: getBrowserJsonToJavascriptNormalizer(
-    ConfigKeys.ZIP_URL_TLS_CERTIFICATE
+  [ConfigKey.ZIP_URL_TLS_CERTIFICATE]: getBrowserJsonToJavascriptNormalizer(
+    ConfigKey.ZIP_URL_TLS_CERTIFICATE
   ),
-  [ConfigKeys.ZIP_URL_TLS_KEY]: getBrowserJsonToJavascriptNormalizer(ConfigKeys.ZIP_URL_TLS_KEY),
-  [ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE]: getBrowserNormalizer(
-    ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE
+  [ConfigKey.ZIP_URL_TLS_KEY]: getBrowserJsonToJavascriptNormalizer(ConfigKey.ZIP_URL_TLS_KEY),
+  [ConfigKey.ZIP_URL_TLS_KEY_PASSPHRASE]: getBrowserNormalizer(
+    ConfigKey.ZIP_URL_TLS_KEY_PASSPHRASE
   ),
-  [ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]: getBrowserNormalizer(
-    ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE
+  [ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]: getBrowserNormalizer(
+    ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE
   ),
-  [ConfigKeys.ZIP_URL_TLS_VERSION]: getBrowserJsonToJavascriptNormalizer(
-    ConfigKeys.ZIP_URL_TLS_VERSION
+  [ConfigKey.ZIP_URL_TLS_VERSION]: getBrowserJsonToJavascriptNormalizer(
+    ConfigKey.ZIP_URL_TLS_VERSION
   ),
-  [ConfigKeys.JOURNEY_FILTERS_MATCH]: getBrowserJsonToJavascriptNormalizer(
-    ConfigKeys.JOURNEY_FILTERS_MATCH
+  [ConfigKey.JOURNEY_FILTERS_MATCH]: getBrowserJsonToJavascriptNormalizer(
+    ConfigKey.JOURNEY_FILTERS_MATCH
   ),
-  [ConfigKeys.JOURNEY_FILTERS_TAGS]: getBrowserJsonToJavascriptNormalizer(
-    ConfigKeys.JOURNEY_FILTERS_TAGS
+  [ConfigKey.JOURNEY_FILTERS_TAGS]: getBrowserJsonToJavascriptNormalizer(
+    ConfigKey.JOURNEY_FILTERS_TAGS
   ),
-  [ConfigKeys.IGNORE_HTTPS_ERRORS]: getBrowserNormalizer(ConfigKeys.IGNORE_HTTPS_ERRORS),
+  [ConfigKey.IGNORE_HTTPS_ERRORS]: getBrowserNormalizer(ConfigKey.IGNORE_HTTPS_ERRORS),
   ...commonNormalizers,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/simple_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/simple_fields.tsx
@@ -8,7 +8,8 @@
 import React, { memo, useMemo, useCallback } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiFormRow } from '@elastic/eui';
-import { ConfigKeys, Validation } from '../types';
+import { Validation } from '../types';
+import { ConfigKey } from '../types';
 import { useBrowserSimpleFieldsContext } from '../contexts';
 import { ScheduleField } from '../schedule_field';
 import { SourceField } from './source_field';
@@ -20,7 +21,7 @@ interface Props {
 
 export const BrowserSimpleFields = memo<Props>(({ validate }) => {
   const { fields, setFields, defaultValues } = useBrowserSimpleFieldsContext();
-  const handleInputChange = ({ value, configKey }: { value: unknown; configKey: ConfigKeys }) => {
+  const handleInputChange = ({ value, configKey }: { value: unknown; configKey: ConfigKey }) => {
     setFields((prevFields) => ({ ...prevFields, [configKey]: value }));
   };
   const onChangeSourceField = useCallback(
@@ -37,15 +38,15 @@ export const BrowserSimpleFields = memo<Props>(({ validate }) => {
     }) => {
       setFields((prevFields) => ({
         ...prevFields,
-        [ConfigKeys.SOURCE_ZIP_URL]: zipUrl,
-        [ConfigKeys.SOURCE_ZIP_PROXY_URL]: proxyUrl,
-        [ConfigKeys.SOURCE_ZIP_FOLDER]: folder,
-        [ConfigKeys.SOURCE_ZIP_USERNAME]: username,
-        [ConfigKeys.SOURCE_ZIP_PASSWORD]: password,
-        [ConfigKeys.SOURCE_INLINE]: inlineScript,
-        [ConfigKeys.PARAMS]: params,
-        [ConfigKeys.METADATA]: {
-          ...prevFields[ConfigKeys.METADATA],
+        [ConfigKey.SOURCE_ZIP_URL]: zipUrl,
+        [ConfigKey.SOURCE_ZIP_PROXY_URL]: proxyUrl,
+        [ConfigKey.SOURCE_ZIP_FOLDER]: folder,
+        [ConfigKey.SOURCE_ZIP_USERNAME]: username,
+        [ConfigKey.SOURCE_ZIP_PASSWORD]: password,
+        [ConfigKey.SOURCE_INLINE]: inlineScript,
+        [ConfigKey.PARAMS]: params,
+        [ConfigKey.METADATA]: {
+          ...prevFields[ConfigKey.METADATA],
           script_source: {
             is_generated_script: isGeneratedScript,
             file_name: fileName,
@@ -66,7 +67,7 @@ export const BrowserSimpleFields = memo<Props>(({ validate }) => {
             defaultMessage="Monitor interval"
           />
         }
-        isInvalid={!!validate[ConfigKeys.SCHEDULE]?.(fields)}
+        isInvalid={!!validate[ConfigKey.SCHEDULE]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.monitorInterval.error"
@@ -78,11 +79,11 @@ export const BrowserSimpleFields = memo<Props>(({ validate }) => {
           onChange={(schedule) =>
             handleInputChange({
               value: schedule,
-              configKey: ConfigKeys.SCHEDULE,
+              configKey: ConfigKey.SCHEDULE,
             })
           }
-          number={fields[ConfigKeys.SCHEDULE].number}
-          unit={fields[ConfigKeys.SCHEDULE].unit}
+          number={fields[ConfigKey.SCHEDULE].number}
+          unit={fields[ConfigKey.SCHEDULE].unit}
         />
       </EuiFormRow>
       <EuiFormRow
@@ -97,16 +98,16 @@ export const BrowserSimpleFields = memo<Props>(({ validate }) => {
           onChange={onChangeSourceField}
           defaultConfig={useMemo(
             () => ({
-              zipUrl: defaultValues[ConfigKeys.SOURCE_ZIP_URL],
-              proxyUrl: defaultValues[ConfigKeys.SOURCE_ZIP_PROXY_URL],
-              folder: defaultValues[ConfigKeys.SOURCE_ZIP_FOLDER],
-              username: defaultValues[ConfigKeys.SOURCE_ZIP_USERNAME],
-              password: defaultValues[ConfigKeys.SOURCE_ZIP_PASSWORD],
-              inlineScript: defaultValues[ConfigKeys.SOURCE_INLINE],
-              params: defaultValues[ConfigKeys.PARAMS],
+              zipUrl: defaultValues[ConfigKey.SOURCE_ZIP_URL],
+              proxyUrl: defaultValues[ConfigKey.SOURCE_ZIP_PROXY_URL],
+              folder: defaultValues[ConfigKey.SOURCE_ZIP_FOLDER],
+              username: defaultValues[ConfigKey.SOURCE_ZIP_USERNAME],
+              password: defaultValues[ConfigKey.SOURCE_ZIP_PASSWORD],
+              inlineScript: defaultValues[ConfigKey.SOURCE_INLINE],
+              params: defaultValues[ConfigKey.PARAMS],
               isGeneratedScript:
-                defaultValues[ConfigKeys.METADATA].script_source?.is_generated_script,
-              fileName: defaultValues[ConfigKeys.METADATA].script_source?.file_name,
+                defaultValues[ConfigKey.METADATA].script_source?.is_generated_script,
+              fileName: defaultValues[ConfigKey.METADATA].script_source?.file_name,
             }),
             [defaultValues]
           )}

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../lib/helper/rtl_helpers';
 import { ThrottlingFields } from './throttling_fields';
-import { DataStream, IBrowserAdvancedFields, IBrowserSimpleFields, Validation } from '../types';
+import { DataStream, BrowserAdvancedFields, BrowserSimpleFields, Validation } from '../types';
 import {
   BrowserAdvancedFieldsContextProvider,
   BrowserSimpleFieldsContextProvider,
@@ -32,8 +32,8 @@ describe('<ThrottlingFields />', () => {
     defaultSimpleFields = defaultBrowserSimpleFields,
     validate = defaultValidation,
   }: {
-    defaultValues?: IBrowserAdvancedFields;
-    defaultSimpleFields?: IBrowserSimpleFields;
+    defaultValues?: BrowserAdvancedFields;
+    defaultSimpleFields?: BrowserSimpleFields;
     validate?: Validation;
   }) => {
     return (

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.tsx
@@ -18,17 +18,17 @@ import {
 
 import { OptionalLabel } from '../optional_label';
 import { useBrowserAdvancedFieldsContext } from '../contexts';
-import { Validation, ConfigKeys } from '../types';
+import { Validation, ConfigKey } from '../types';
 
 interface Props {
   validate: Validation;
 }
 
 type ThrottlingConfigs =
-  | ConfigKeys.IS_THROTTLING_ENABLED
-  | ConfigKeys.DOWNLOAD_SPEED
-  | ConfigKeys.UPLOAD_SPEED
-  | ConfigKeys.LATENCY;
+  | ConfigKey.IS_THROTTLING_ENABLED
+  | ConfigKey.DOWNLOAD_SPEED
+  | ConfigKey.UPLOAD_SPEED
+  | ConfigKey.LATENCY;
 
 export const ThrottlingFields = memo<Props>(({ validate }) => {
   const { fields, setFields } = useBrowserAdvancedFieldsContext();
@@ -40,7 +40,7 @@ export const ThrottlingFields = memo<Props>(({ validate }) => {
     [setFields]
   );
 
-  const throttlingInputs = fields[ConfigKeys.IS_THROTTLING_ENABLED] ? (
+  const throttlingInputs = fields[ConfigKey.IS_THROTTLING_ENABLED] ? (
     <>
       <EuiSpacer size="m" />
       <EuiFormRow
@@ -51,7 +51,7 @@ export const ThrottlingFields = memo<Props>(({ validate }) => {
           />
         }
         labelAppend={<OptionalLabel />}
-        isInvalid={!!validate[ConfigKeys.DOWNLOAD_SPEED]?.(fields)}
+        isInvalid={!!validate[ConfigKey.DOWNLOAD_SPEED]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.error"
@@ -62,11 +62,11 @@ export const ThrottlingFields = memo<Props>(({ validate }) => {
         <EuiFieldNumber
           min={0}
           step={0.001}
-          value={fields[ConfigKeys.DOWNLOAD_SPEED]}
+          value={fields[ConfigKey.DOWNLOAD_SPEED]}
           onChange={(event) => {
             handleInputChange({
               value: event.target.value,
-              configKey: ConfigKeys.DOWNLOAD_SPEED,
+              configKey: ConfigKey.DOWNLOAD_SPEED,
             });
           }}
           data-test-subj="syntheticsBrowserDownloadSpeed"
@@ -85,7 +85,7 @@ export const ThrottlingFields = memo<Props>(({ validate }) => {
           />
         }
         labelAppend={<OptionalLabel />}
-        isInvalid={!!validate[ConfigKeys.UPLOAD_SPEED]?.(fields)}
+        isInvalid={!!validate[ConfigKey.UPLOAD_SPEED]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.error"
@@ -96,11 +96,11 @@ export const ThrottlingFields = memo<Props>(({ validate }) => {
         <EuiFieldNumber
           min={0}
           step={0.001}
-          value={fields[ConfigKeys.UPLOAD_SPEED]}
+          value={fields[ConfigKey.UPLOAD_SPEED]}
           onChange={(event) =>
             handleInputChange({
               value: event.target.value,
-              configKey: ConfigKeys.UPLOAD_SPEED,
+              configKey: ConfigKey.UPLOAD_SPEED,
             })
           }
           data-test-subj="syntheticsBrowserUploadSpeed"
@@ -119,7 +119,7 @@ export const ThrottlingFields = memo<Props>(({ validate }) => {
           />
         }
         labelAppend={<OptionalLabel />}
-        isInvalid={!!validate[ConfigKeys.LATENCY]?.(fields)}
+        isInvalid={!!validate[ConfigKey.LATENCY]?.(fields)}
         data-test-subj="syntheticsBrowserLatency"
         error={
           <FormattedMessage
@@ -130,11 +130,11 @@ export const ThrottlingFields = memo<Props>(({ validate }) => {
       >
         <EuiFieldNumber
           min={0}
-          value={fields[ConfigKeys.LATENCY]}
+          value={fields[ConfigKey.LATENCY]}
           onChange={(event) =>
             handleInputChange({
               value: event.target.value,
-              configKey: ConfigKeys.LATENCY,
+              configKey: ConfigKey.LATENCY,
             })
           }
           append={
@@ -168,7 +168,7 @@ export const ThrottlingFields = memo<Props>(({ validate }) => {
         id={'uptimeFleetIsThrottlingEnabled'}
         aria-label="enable throttling configuration"
         data-test-subj="syntheticsBrowserIsThrottlingEnabled"
-        checked={fields[ConfigKeys.IS_THROTTLING_ENABLED]}
+        checked={fields[ConfigKey.IS_THROTTLING_ENABLED]}
         label={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.switch.description"
@@ -178,7 +178,7 @@ export const ThrottlingFields = memo<Props>(({ validate }) => {
         onChange={(event) =>
           handleInputChange({
             value: event.target.checked,
-            configKey: ConfigKeys.IS_THROTTLING_ENABLED,
+            configKey: ConfigKey.IS_THROTTLING_ENABLED,
           })
         }
       />

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/zip_url_tls_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/zip_url_tls_fields.test.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { render } from '../../../lib/helper/rtl_helpers';
 import { ZipUrlTLSFields } from './zip_url_tls_fields';
-import { ConfigKeys, VerificationMode } from '../types';
+import { ConfigKey, VerificationMode } from '../types';
 import {
   BrowserSimpleFieldsContextProvider,
   PolicyConfigContextProvider,
@@ -57,31 +57,31 @@ describe('<SourceField />', () => {
     const verificationMode = getByLabelText('Verification mode') as HTMLInputElement;
 
     const newValues = {
-      [ConfigKeys.TLS_CERTIFICATE]: 'sampleClientCertificate',
-      [ConfigKeys.TLS_KEY]: 'sampleClientKey',
-      [ConfigKeys.TLS_KEY_PASSPHRASE]: 'sampleClientKeyPassphrase',
-      [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]: 'sampleCertificateAuthorities',
-      [ConfigKeys.TLS_VERIFICATION_MODE]: VerificationMode.NONE,
+      [ConfigKey.TLS_CERTIFICATE]: 'sampleClientCertificate',
+      [ConfigKey.TLS_KEY]: 'sampleClientKey',
+      [ConfigKey.TLS_KEY_PASSPHRASE]: 'sampleClientKeyPassphrase',
+      [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: 'sampleCertificateAuthorities',
+      [ConfigKey.TLS_VERIFICATION_MODE]: VerificationMode.NONE,
     };
 
     fireEvent.change(clientCertificate, {
-      target: { value: newValues[ConfigKeys.TLS_CERTIFICATE] },
+      target: { value: newValues[ConfigKey.TLS_CERTIFICATE] },
     });
-    fireEvent.change(clientKey, { target: { value: newValues[ConfigKeys.TLS_KEY] } });
+    fireEvent.change(clientKey, { target: { value: newValues[ConfigKey.TLS_KEY] } });
     fireEvent.change(clientKeyPassphrase, {
-      target: { value: newValues[ConfigKeys.TLS_KEY_PASSPHRASE] },
+      target: { value: newValues[ConfigKey.TLS_KEY_PASSPHRASE] },
     });
     fireEvent.change(certificateAuthorities, {
-      target: { value: newValues[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES] },
+      target: { value: newValues[ConfigKey.TLS_CERTIFICATE_AUTHORITIES] },
     });
     fireEvent.change(verificationMode, {
-      target: { value: newValues[ConfigKeys.TLS_VERIFICATION_MODE] },
+      target: { value: newValues[ConfigKey.TLS_VERIFICATION_MODE] },
     });
 
-    expect(clientCertificate.value).toEqual(newValues[ConfigKeys.TLS_CERTIFICATE]);
-    expect(clientKey.value).toEqual(newValues[ConfigKeys.TLS_KEY]);
-    expect(certificateAuthorities.value).toEqual(newValues[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]);
-    expect(verificationMode.value).toEqual(newValues[ConfigKeys.TLS_VERIFICATION_MODE]);
+    expect(clientCertificate.value).toEqual(newValues[ConfigKey.TLS_CERTIFICATE]);
+    expect(clientKey.value).toEqual(newValues[ConfigKey.TLS_KEY]);
+    expect(certificateAuthorities.value).toEqual(newValues[ConfigKey.TLS_CERTIFICATE_AUTHORITIES]);
+    expect(verificationMode.value).toEqual(newValues[ConfigKey.TLS_VERIFICATION_MODE]);
   });
 
   it('shows warning when verification mode is set to none', () => {

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/zip_url_tls_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/zip_url_tls_fields.tsx
@@ -18,7 +18,7 @@ import {
   defaultTLSFields,
 } from '../contexts';
 
-import { ConfigKeys } from '../types';
+import { ConfigKey } from '../types';
 
 export const ZipUrlTLSFields = () => {
   const { defaultValues, setFields } = useBrowserSimpleFieldsContext();
@@ -28,12 +28,12 @@ export const ZipUrlTLSFields = () => {
     (tlsConfig: TLSConfig) => {
       setFields((prevFields) => ({
         ...prevFields,
-        [ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: tlsConfig.certificateAuthorities,
-        [ConfigKeys.ZIP_URL_TLS_CERTIFICATE]: tlsConfig.certificate,
-        [ConfigKeys.ZIP_URL_TLS_KEY]: tlsConfig.key,
-        [ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE]: tlsConfig.keyPassphrase,
-        [ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]: tlsConfig.verificationMode,
-        [ConfigKeys.ZIP_URL_TLS_VERSION]: tlsConfig.version,
+        [ConfigKey.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: tlsConfig.certificateAuthorities,
+        [ConfigKey.ZIP_URL_TLS_CERTIFICATE]: tlsConfig.certificate,
+        [ConfigKey.ZIP_URL_TLS_KEY]: tlsConfig.key,
+        [ConfigKey.ZIP_URL_TLS_KEY_PASSPHRASE]: tlsConfig.keyPassphrase,
+        [ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]: tlsConfig.verificationMode,
+        [ConfigKey.ZIP_URL_TLS_VERSION]: tlsConfig.version,
       }));
     },
     [setFields]
@@ -43,12 +43,12 @@ export const ZipUrlTLSFields = () => {
     if (!isZipUrlTLSEnabled) {
       setFields((prevFields) => ({
         ...prevFields,
-        [ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: undefined,
-        [ConfigKeys.ZIP_URL_TLS_CERTIFICATE]: undefined,
-        [ConfigKeys.ZIP_URL_TLS_KEY]: undefined,
-        [ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE]: undefined,
-        [ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]: undefined,
-        [ConfigKeys.ZIP_URL_TLS_VERSION]: undefined,
+        [ConfigKey.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: undefined,
+        [ConfigKey.ZIP_URL_TLS_CERTIFICATE]: undefined,
+        [ConfigKey.ZIP_URL_TLS_KEY]: undefined,
+        [ConfigKey.ZIP_URL_TLS_KEY_PASSPHRASE]: undefined,
+        [ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]: undefined,
+        [ConfigKey.ZIP_URL_TLS_VERSION]: undefined,
       }));
     }
   }, [setFields, isZipUrlTLSEnabled]);
@@ -72,22 +72,21 @@ export const ZipUrlTLSFields = () => {
           <TLSOptions
             defaultValues={{
               certificateAuthorities:
-                defaultValues[ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES] ||
-                defaultTLSFields[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES],
+                defaultValues[ConfigKey.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES] ||
+                defaultTLSFields[ConfigKey.TLS_CERTIFICATE_AUTHORITIES],
               certificate:
-                defaultValues[ConfigKeys.ZIP_URL_TLS_CERTIFICATE] ||
-                defaultTLSFields[ConfigKeys.TLS_CERTIFICATE],
-              key:
-                defaultValues[ConfigKeys.ZIP_URL_TLS_KEY] || defaultTLSFields[ConfigKeys.TLS_KEY],
+                defaultValues[ConfigKey.ZIP_URL_TLS_CERTIFICATE] ||
+                defaultTLSFields[ConfigKey.TLS_CERTIFICATE],
+              key: defaultValues[ConfigKey.ZIP_URL_TLS_KEY] || defaultTLSFields[ConfigKey.TLS_KEY],
               keyPassphrase:
-                defaultValues[ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE] ||
-                defaultTLSFields[ConfigKeys.TLS_KEY_PASSPHRASE],
+                defaultValues[ConfigKey.ZIP_URL_TLS_KEY_PASSPHRASE] ||
+                defaultTLSFields[ConfigKey.TLS_KEY_PASSPHRASE],
               verificationMode:
-                defaultValues[ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE] ||
-                defaultTLSFields[ConfigKeys.TLS_VERIFICATION_MODE],
+                defaultValues[ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE] ||
+                defaultTLSFields[ConfigKey.TLS_VERIFICATION_MODE],
               version:
-                defaultValues[ConfigKeys.ZIP_URL_TLS_VERSION] ||
-                defaultTLSFields[ConfigKeys.TLS_VERSION],
+                defaultValues[ConfigKey.ZIP_URL_TLS_VERSION] ||
+                defaultTLSFields[ConfigKey.TLS_VERSION],
             }}
             onChange={handleOnChange}
             tlsRole="client"

--- a/x-pack/plugins/uptime/public/components/fleet_package/common/common_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/common/common_fields.tsx
@@ -8,14 +8,15 @@
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiFormRow, EuiFieldText, EuiFieldNumber } from '@elastic/eui';
-import { ConfigKeys, Validation, ICommonFields } from '../types';
+import { Validation } from '../types';
+import { ConfigKey, CommonFields as CommonFieldsType } from '../types';
 import { ComboBox } from '../combo_box';
 import { OptionalLabel } from '../optional_label';
 
 interface Props {
   validate: Validation;
-  fields: ICommonFields;
-  onChange: ({ value, configKey }: { value: string | string[]; configKey: ConfigKeys }) => void;
+  fields: CommonFieldsType;
+  onChange: ({ value, configKey }: { value: string | string[]; configKey: ConfigKey }) => void;
 }
 
 export function CommonFields({ fields, onChange, validate }: Props) {
@@ -37,11 +38,11 @@ export function CommonFields({ fields, onChange, validate }: Props) {
         }
       >
         <EuiFieldText
-          value={fields[ConfigKeys.APM_SERVICE_NAME]}
+          value={fields[ConfigKey.APM_SERVICE_NAME]}
           onChange={(event) =>
             onChange({
               value: event.target.value,
-              configKey: ConfigKeys.APM_SERVICE_NAME,
+              configKey: ConfigKey.APM_SERVICE_NAME,
             })
           }
           data-test-subj="syntheticsAPMServiceName"
@@ -54,9 +55,9 @@ export function CommonFields({ fields, onChange, validate }: Props) {
             defaultMessage="Timeout in seconds"
           />
         }
-        isInvalid={!!validate[ConfigKeys.TIMEOUT]?.(fields)}
+        isInvalid={!!validate[ConfigKey.TIMEOUT]?.(fields)}
         error={
-          parseInt(fields[ConfigKeys.TIMEOUT], 10) < 0 ? (
+          parseInt(fields[ConfigKey.TIMEOUT], 10) < 0 ? (
             <FormattedMessage
               id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.timeout.moreThanZeroError"
               defaultMessage="Timeout must be greater than or equal to 0"
@@ -77,11 +78,11 @@ export function CommonFields({ fields, onChange, validate }: Props) {
       >
         <EuiFieldNumber
           min={0}
-          value={fields[ConfigKeys.TIMEOUT]}
+          value={fields[ConfigKey.TIMEOUT]}
           onChange={(event) =>
             onChange({
               value: event.target.value,
-              configKey: ConfigKeys.TIMEOUT,
+              configKey: ConfigKey.TIMEOUT,
             })
           }
           step={'any'}
@@ -103,8 +104,8 @@ export function CommonFields({ fields, onChange, validate }: Props) {
         }
       >
         <ComboBox
-          selectedOptions={fields[ConfigKeys.TAGS]}
-          onChange={(value) => onChange({ value, configKey: ConfigKeys.TAGS })}
+          selectedOptions={fields[ConfigKey.TAGS]}
+          onChange={(value) => onChange({ value, configKey: ConfigKey.TAGS })}
           data-test-subj="syntheticsTags"
         />
       </EuiFormRow>

--- a/x-pack/plugins/uptime/public/components/fleet_package/common/default_values.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/common/default_values.ts
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
-import { ICommonFields, ConfigKeys, ScheduleUnit, DataStream } from '../types';
+import { CommonFields, ConfigKey, ScheduleUnit, DataStream } from '../types';
 
-export const defaultValues: ICommonFields = {
-  [ConfigKeys.MONITOR_TYPE]: DataStream.HTTP,
-  [ConfigKeys.SCHEDULE]: {
+export const defaultValues: CommonFields = {
+  [ConfigKey.MONITOR_TYPE]: DataStream.HTTP,
+  [ConfigKey.SCHEDULE]: {
     number: '3',
     unit: ScheduleUnit.MINUTES,
   },
-  [ConfigKeys.APM_SERVICE_NAME]: '',
-  [ConfigKeys.TAGS]: [],
-  [ConfigKeys.TIMEOUT]: '16',
+  [ConfigKey.APM_SERVICE_NAME]: '',
+  [ConfigKey.TAGS]: [],
+  [ConfigKey.TIMEOUT]: '16',
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/common/formatters.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/common/formatters.ts
@@ -5,22 +5,22 @@
  * 2.0.
  */
 
-import { ICommonFields, ICustomFields, ConfigKeys } from '../types';
+import { CommonFields, MonitorFields, ConfigKey } from '../types';
 
-export type Formatter = null | ((fields: Partial<ICustomFields>) => string | null);
+export type Formatter = null | ((fields: Partial<MonitorFields>) => string | null);
 
-export type CommonFormatMap = Record<keyof ICommonFields | ConfigKeys.NAME, Formatter>;
+export type CommonFormatMap = Record<keyof CommonFields | ConfigKey.NAME, Formatter>;
 
 export const commonFormatters: CommonFormatMap = {
-  [ConfigKeys.NAME]: null,
-  [ConfigKeys.MONITOR_TYPE]: null,
-  [ConfigKeys.SCHEDULE]: (fields) =>
+  [ConfigKey.NAME]: null,
+  [ConfigKey.MONITOR_TYPE]: null,
+  [ConfigKey.SCHEDULE]: (fields) =>
     JSON.stringify(
-      `@every ${fields[ConfigKeys.SCHEDULE]?.number}${fields[ConfigKeys.SCHEDULE]?.unit}`
+      `@every ${fields[ConfigKey.SCHEDULE]?.number}${fields[ConfigKey.SCHEDULE]?.unit}`
     ),
-  [ConfigKeys.APM_SERVICE_NAME]: null,
-  [ConfigKeys.TAGS]: (fields) => arrayToJsonFormatter(fields[ConfigKeys.TAGS]),
-  [ConfigKeys.TIMEOUT]: (fields) => secondsToCronFormatter(fields[ConfigKeys.TIMEOUT]),
+  [ConfigKey.APM_SERVICE_NAME]: null,
+  [ConfigKey.TAGS]: (fields) => arrayToJsonFormatter(fields[ConfigKey.TAGS]),
+  [ConfigKey.TIMEOUT]: (fields) => secondsToCronFormatter(fields[ConfigKey.TIMEOUT]),
 };
 
 export const arrayToJsonFormatter = (value: string[] = []) =>

--- a/x-pack/plugins/uptime/public/components/fleet_package/common/normalizers.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/common/normalizers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ICommonFields, ConfigKeys } from '../types';
+import { CommonFields, ConfigKey } from '../types';
 import { NewPackagePolicyInput } from '../../../../../fleet/common';
 import { defaultValues as commonDefaultValues } from './default_values';
 
@@ -13,7 +13,7 @@ import { defaultValues as commonDefaultValues } from './default_values';
 export type Normalizer = (fields: NewPackagePolicyInput['vars']) => unknown;
 
 // create a type of all the common policy fields, as well as the fleet managed 'name' field
-export type CommonNormalizerMap = Record<keyof ICommonFields | ConfigKeys.NAME, Normalizer>;
+export type CommonNormalizerMap = Record<keyof CommonFields | ConfigKey.NAME, Normalizer>;
 
 /**
  * Takes a cron formatted seconds and returns just the number of seconds. Assumes that cron is already in seconds format.
@@ -43,25 +43,25 @@ export function getCronNormalizer<Fields>(key: string, defaultValues: Fields): N
     cronToSecondsNormalizer(fields?.[key]?.value) ?? defaultValues[key as keyof Fields];
 }
 
-export const getCommonNormalizer = (key: ConfigKeys) => {
+export const getCommonNormalizer = (key: ConfigKey) => {
   return getNormalizer(key, commonDefaultValues);
 };
 
-export const getCommonjsonToJavascriptNormalizer = (key: ConfigKeys) => {
+export const getCommonjsonToJavascriptNormalizer = (key: ConfigKey) => {
   return getJsonToJavascriptNormalizer(key, commonDefaultValues);
 };
 
-export const getCommonCronToSecondsNormalizer = (key: ConfigKeys) => {
+export const getCommonCronToSecondsNormalizer = (key: ConfigKey) => {
   return getCronNormalizer(key, commonDefaultValues);
 };
 
 export const commonNormalizers: CommonNormalizerMap = {
-  [ConfigKeys.NAME]: (fields) => fields?.[ConfigKeys.NAME]?.value ?? '',
-  [ConfigKeys.MONITOR_TYPE]: getCommonNormalizer(ConfigKeys.MONITOR_TYPE),
-  [ConfigKeys.SCHEDULE]: (fields) => {
-    const value = fields?.[ConfigKeys.SCHEDULE]?.value;
+  [ConfigKey.NAME]: (fields) => fields?.[ConfigKey.NAME]?.value ?? '',
+  [ConfigKey.MONITOR_TYPE]: getCommonNormalizer(ConfigKey.MONITOR_TYPE),
+  [ConfigKey.SCHEDULE]: (fields) => {
+    const value = fields?.[ConfigKey.SCHEDULE]?.value;
     if (value) {
-      const fullString = JSON.parse(fields?.[ConfigKeys.SCHEDULE]?.value);
+      const fullString = JSON.parse(fields?.[ConfigKey.SCHEDULE]?.value);
       const fullSchedule = fullString.replace('@every ', '');
       const unit = fullSchedule.slice(-1);
       const number = fullSchedule.slice(0, fullSchedule.length - 1);
@@ -70,10 +70,10 @@ export const commonNormalizers: CommonNormalizerMap = {
         number,
       };
     } else {
-      return commonDefaultValues[ConfigKeys.SCHEDULE];
+      return commonDefaultValues[ConfigKey.SCHEDULE];
     }
   },
-  [ConfigKeys.APM_SERVICE_NAME]: getCommonNormalizer(ConfigKeys.APM_SERVICE_NAME),
-  [ConfigKeys.TAGS]: getCommonjsonToJavascriptNormalizer(ConfigKeys.TAGS),
-  [ConfigKeys.TIMEOUT]: getCommonCronToSecondsNormalizer(ConfigKeys.TIMEOUT),
+  [ConfigKey.APM_SERVICE_NAME]: getCommonNormalizer(ConfigKey.APM_SERVICE_NAME),
+  [ConfigKey.TAGS]: getCommonjsonToJavascriptNormalizer(ConfigKey.TAGS),
+  [ConfigKey.TIMEOUT]: getCommonCronToSecondsNormalizer(ConfigKey.TIMEOUT),
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/browser_context.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/browser_context.tsx
@@ -6,47 +6,47 @@
  */
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
-import { IBrowserSimpleFields, ConfigKeys, DataStream } from '../types';
+import { BrowserSimpleFields, ConfigKey, DataStream } from '../types';
 import { defaultValues as commonDefaultValues } from '../common/default_values';
 
-interface IBrowserSimpleFieldsContext {
-  setFields: React.Dispatch<React.SetStateAction<IBrowserSimpleFields>>;
-  fields: IBrowserSimpleFields;
-  defaultValues: IBrowserSimpleFields;
+interface BrowserSimpleFieldsContext {
+  setFields: React.Dispatch<React.SetStateAction<BrowserSimpleFields>>;
+  fields: BrowserSimpleFields;
+  defaultValues: BrowserSimpleFields;
 }
 
-interface IBrowserSimpleFieldsContextProvider {
+interface BrowserSimpleFieldsContextProvider {
   children: React.ReactNode;
-  defaultValues?: IBrowserSimpleFields;
+  defaultValues?: BrowserSimpleFields;
 }
 
-export const initialValues: IBrowserSimpleFields = {
+export const initialValues: BrowserSimpleFields = {
   ...commonDefaultValues,
-  [ConfigKeys.METADATA]: {
+  [ConfigKey.METADATA]: {
     script_source: {
       is_generated_script: false,
       file_name: '',
     },
     is_zip_url_tls_enabled: false,
   },
-  [ConfigKeys.MONITOR_TYPE]: DataStream.BROWSER,
-  [ConfigKeys.SOURCE_ZIP_URL]: '',
-  [ConfigKeys.SOURCE_ZIP_USERNAME]: '',
-  [ConfigKeys.SOURCE_ZIP_PASSWORD]: '',
-  [ConfigKeys.SOURCE_ZIP_FOLDER]: '',
-  [ConfigKeys.SOURCE_ZIP_PROXY_URL]: '',
-  [ConfigKeys.SOURCE_INLINE]: '',
-  [ConfigKeys.PARAMS]: '',
-  [ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: undefined,
-  [ConfigKeys.ZIP_URL_TLS_CERTIFICATE]: undefined,
-  [ConfigKeys.ZIP_URL_TLS_KEY]: undefined,
-  [ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE]: undefined,
-  [ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]: undefined,
-  [ConfigKeys.ZIP_URL_TLS_VERSION]: undefined,
+  [ConfigKey.MONITOR_TYPE]: DataStream.BROWSER,
+  [ConfigKey.SOURCE_ZIP_URL]: '',
+  [ConfigKey.SOURCE_ZIP_USERNAME]: '',
+  [ConfigKey.SOURCE_ZIP_PASSWORD]: '',
+  [ConfigKey.SOURCE_ZIP_FOLDER]: '',
+  [ConfigKey.SOURCE_ZIP_PROXY_URL]: '',
+  [ConfigKey.SOURCE_INLINE]: '',
+  [ConfigKey.PARAMS]: '',
+  [ConfigKey.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: undefined,
+  [ConfigKey.ZIP_URL_TLS_CERTIFICATE]: undefined,
+  [ConfigKey.ZIP_URL_TLS_KEY]: undefined,
+  [ConfigKey.ZIP_URL_TLS_KEY_PASSPHRASE]: undefined,
+  [ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]: undefined,
+  [ConfigKey.ZIP_URL_TLS_VERSION]: undefined,
 };
 
-const defaultContext: IBrowserSimpleFieldsContext = {
-  setFields: (_fields: React.SetStateAction<IBrowserSimpleFields>) => {
+const defaultContext: BrowserSimpleFieldsContext = {
+  setFields: (_fields: React.SetStateAction<BrowserSimpleFields>) => {
     throw new Error(
       'setFields was not initialized for Browser Simple Fields, set it when you invoke the context'
     );
@@ -60,8 +60,8 @@ export const BrowserSimpleFieldsContext = createContext(defaultContext);
 export const BrowserSimpleFieldsContextProvider = ({
   children,
   defaultValues = initialValues,
-}: IBrowserSimpleFieldsContextProvider) => {
-  const [fields, setFields] = useState<IBrowserSimpleFields>(defaultValues);
+}: BrowserSimpleFieldsContextProvider) => {
+  const [fields, setFields] = useState<BrowserSimpleFields>(defaultValues);
 
   const value = useMemo(() => {
     return { fields, setFields, defaultValues };

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/browser_context_advanced.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/browser_context_advanced.tsx
@@ -6,34 +6,34 @@
  */
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
-import { IBrowserAdvancedFields, ConfigKeys, ScreenshotOption } from '../types';
+import { BrowserAdvancedFields, ConfigKey, ScreenshotOption } from '../types';
 
-interface IBrowserAdvancedFieldsContext {
-  setFields: React.Dispatch<React.SetStateAction<IBrowserAdvancedFields>>;
-  fields: IBrowserAdvancedFields;
-  defaultValues: IBrowserAdvancedFields;
+interface BrowserAdvancedFieldsContext {
+  setFields: React.Dispatch<React.SetStateAction<BrowserAdvancedFields>>;
+  fields: BrowserAdvancedFields;
+  defaultValues: BrowserAdvancedFields;
 }
 
-interface IBrowserAdvancedFieldsContextProvider {
+interface BrowserAdvancedFieldsContextProvider {
   children: React.ReactNode;
-  defaultValues?: IBrowserAdvancedFields;
+  defaultValues?: BrowserAdvancedFields;
 }
 
-export const initialValues: IBrowserAdvancedFields = {
-  [ConfigKeys.SCREENSHOTS]: ScreenshotOption.ON,
-  [ConfigKeys.SYNTHETICS_ARGS]: [],
-  [ConfigKeys.JOURNEY_FILTERS_MATCH]: '',
-  [ConfigKeys.JOURNEY_FILTERS_TAGS]: [],
-  [ConfigKeys.IGNORE_HTTPS_ERRORS]: false,
-  [ConfigKeys.IS_THROTTLING_ENABLED]: true,
-  [ConfigKeys.DOWNLOAD_SPEED]: '5',
-  [ConfigKeys.UPLOAD_SPEED]: '3',
-  [ConfigKeys.LATENCY]: '20',
-  [ConfigKeys.THROTTLING_CONFIG]: '5d/3u/20l',
+export const initialValues: BrowserAdvancedFields = {
+  [ConfigKey.SCREENSHOTS]: ScreenshotOption.ON,
+  [ConfigKey.SYNTHETICS_ARGS]: [],
+  [ConfigKey.JOURNEY_FILTERS_MATCH]: '',
+  [ConfigKey.JOURNEY_FILTERS_TAGS]: [],
+  [ConfigKey.IGNORE_HTTPS_ERRORS]: false,
+  [ConfigKey.IS_THROTTLING_ENABLED]: true,
+  [ConfigKey.DOWNLOAD_SPEED]: '5',
+  [ConfigKey.UPLOAD_SPEED]: '3',
+  [ConfigKey.LATENCY]: '20',
+  [ConfigKey.THROTTLING_CONFIG]: '5d/3u/20l',
 };
 
-const defaultContext: IBrowserAdvancedFieldsContext = {
-  setFields: (_fields: React.SetStateAction<IBrowserAdvancedFields>) => {
+const defaultContext: BrowserAdvancedFieldsContext = {
+  setFields: (_fields: React.SetStateAction<BrowserAdvancedFields>) => {
     throw new Error(
       'setFields was not initialized for Browser Advanced Fields, set it when you invoke the context'
     );
@@ -47,8 +47,8 @@ export const BrowserAdvancedFieldsContext = createContext(defaultContext);
 export const BrowserAdvancedFieldsContextProvider = ({
   children,
   defaultValues = initialValues,
-}: IBrowserAdvancedFieldsContextProvider) => {
-  const [fields, setFields] = useState<IBrowserAdvancedFields>(defaultValues);
+}: BrowserAdvancedFieldsContextProvider) => {
+  const [fields, setFields] = useState<BrowserAdvancedFields>(defaultValues);
 
   const value = useMemo(() => {
     return { fields, setFields, defaultValues };

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/browser_provider.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/browser_provider.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { ReactNode } from 'react';
-import { BrowserFields, IBrowserSimpleFields, IBrowserAdvancedFields } from '../types';
+import { BrowserFields, BrowserSimpleFields, BrowserAdvancedFields } from '../types';
 import {
   BrowserSimpleFieldsContextProvider,
   BrowserAdvancedFieldsContextProvider,
@@ -24,22 +24,22 @@ export const BrowserContextProvider = ({
   defaultValues,
   children,
 }: BrowserContextProviderProps) => {
-  const simpleKeys = Object.keys(defaultBrowserSimpleFields) as Array<keyof IBrowserSimpleFields>;
+  const simpleKeys = Object.keys(defaultBrowserSimpleFields) as Array<keyof BrowserSimpleFields>;
   const advancedKeys = Object.keys(defaultBrowserAdvancedFields) as Array<
-    keyof IBrowserAdvancedFields
+    keyof BrowserAdvancedFields
   >;
-  const formattedDefaultSimpleFields = formatDefaultValues<IBrowserSimpleFields>(
+  const formattedDefaultSimpleFields = formatDefaultValues<BrowserSimpleFields>(
     simpleKeys,
     defaultValues || {}
   );
-  const formattedDefaultAdvancedFields = formatDefaultValues<IBrowserAdvancedFields>(
+  const formattedDefaultAdvancedFields = formatDefaultValues<BrowserAdvancedFields>(
     advancedKeys,
     defaultValues || {}
   );
-  const simpleFields: IBrowserSimpleFields | undefined = defaultValues
+  const simpleFields: BrowserSimpleFields | undefined = defaultValues
     ? formattedDefaultSimpleFields
     : undefined;
-  const advancedFields: IBrowserAdvancedFields | undefined = defaultValues
+  const advancedFields: BrowserAdvancedFields | undefined = defaultValues
     ? formattedDefaultAdvancedFields
     : undefined;
   return (

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/http_context.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/http_context.tsx
@@ -6,32 +6,32 @@
  */
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
-import { IHTTPSimpleFields, ConfigKeys, DataStream } from '../types';
+import { HTTPSimpleFields, ConfigKey, DataStream } from '../types';
 import { defaultValues as commonDefaultValues } from '../common/default_values';
 
-interface IHTTPSimpleFieldsContext {
-  setFields: React.Dispatch<React.SetStateAction<IHTTPSimpleFields>>;
-  fields: IHTTPSimpleFields;
-  defaultValues: IHTTPSimpleFields;
+interface HTTPSimpleFieldsContext {
+  setFields: React.Dispatch<React.SetStateAction<HTTPSimpleFields>>;
+  fields: HTTPSimpleFields;
+  defaultValues: HTTPSimpleFields;
 }
 
-interface IHTTPSimpleFieldsContextProvider {
+interface HTTPSimpleFieldsContextProvider {
   children: React.ReactNode;
-  defaultValues?: IHTTPSimpleFields;
+  defaultValues?: HTTPSimpleFields;
 }
 
-export const initialValues: IHTTPSimpleFields = {
+export const initialValues: HTTPSimpleFields = {
   ...commonDefaultValues,
-  [ConfigKeys.METADATA]: {
+  [ConfigKey.METADATA]: {
     is_tls_enabled: false,
   },
-  [ConfigKeys.URLS]: '',
-  [ConfigKeys.MAX_REDIRECTS]: '0',
-  [ConfigKeys.MONITOR_TYPE]: DataStream.HTTP,
+  [ConfigKey.URLS]: '',
+  [ConfigKey.MAX_REDIRECTS]: '0',
+  [ConfigKey.MONITOR_TYPE]: DataStream.HTTP,
 };
 
-const defaultContext: IHTTPSimpleFieldsContext = {
-  setFields: (_fields: React.SetStateAction<IHTTPSimpleFields>) => {
+const defaultContext: HTTPSimpleFieldsContext = {
+  setFields: (_fields: React.SetStateAction<HTTPSimpleFields>) => {
     throw new Error(
       'setFields was not initialized for HTTP Simple Fields, set it when you invoke the context'
     );
@@ -45,8 +45,8 @@ export const HTTPSimpleFieldsContext = createContext(defaultContext);
 export const HTTPSimpleFieldsContextProvider = ({
   children,
   defaultValues = initialValues,
-}: IHTTPSimpleFieldsContextProvider) => {
-  const [fields, setFields] = useState<IHTTPSimpleFields>(defaultValues);
+}: HTTPSimpleFieldsContextProvider) => {
+  const [fields, setFields] = useState<HTTPSimpleFields>(defaultValues);
 
   const value = useMemo(() => {
     return { fields, setFields, defaultValues };

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/http_context_advanced.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/http_context_advanced.tsx
@@ -6,45 +6,39 @@
  */
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
-import {
-  IHTTPAdvancedFields,
-  ConfigKeys,
-  Mode,
-  ResponseBodyIndexPolicy,
-  HTTPMethod,
-} from '../types';
+import { HTTPAdvancedFields, ConfigKey, Mode, ResponseBodyIndexPolicy, HTTPMethod } from '../types';
 
-interface IHTTPAdvancedFieldsContext {
-  setFields: React.Dispatch<React.SetStateAction<IHTTPAdvancedFields>>;
-  fields: IHTTPAdvancedFields;
-  defaultValues: IHTTPAdvancedFields;
+interface HTTPAdvancedFieldsContext {
+  setFields: React.Dispatch<React.SetStateAction<HTTPAdvancedFields>>;
+  fields: HTTPAdvancedFields;
+  defaultValues: HTTPAdvancedFields;
 }
 
-interface IHTTPAdvancedFieldsContextProvider {
+interface HTTPAdvancedFieldsContextProvider {
   children: React.ReactNode;
-  defaultValues?: IHTTPAdvancedFields;
+  defaultValues?: HTTPAdvancedFields;
 }
 
-export const initialValues: IHTTPAdvancedFields = {
-  [ConfigKeys.PASSWORD]: '',
-  [ConfigKeys.PROXY_URL]: '',
-  [ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE]: [],
-  [ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE]: [],
-  [ConfigKeys.RESPONSE_BODY_INDEX]: ResponseBodyIndexPolicy.ON_ERROR,
-  [ConfigKeys.RESPONSE_HEADERS_CHECK]: {},
-  [ConfigKeys.RESPONSE_HEADERS_INDEX]: true,
-  [ConfigKeys.RESPONSE_STATUS_CHECK]: [],
-  [ConfigKeys.REQUEST_BODY_CHECK]: {
+export const initialValues: HTTPAdvancedFields = {
+  [ConfigKey.PASSWORD]: '',
+  [ConfigKey.PROXY_URL]: '',
+  [ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]: [],
+  [ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]: [],
+  [ConfigKey.RESPONSE_BODY_INDEX]: ResponseBodyIndexPolicy.ON_ERROR,
+  [ConfigKey.RESPONSE_HEADERS_CHECK]: {},
+  [ConfigKey.RESPONSE_HEADERS_INDEX]: true,
+  [ConfigKey.RESPONSE_STATUS_CHECK]: [],
+  [ConfigKey.REQUEST_BODY_CHECK]: {
     value: '',
     type: Mode.PLAINTEXT,
   },
-  [ConfigKeys.REQUEST_HEADERS_CHECK]: {},
-  [ConfigKeys.REQUEST_METHOD_CHECK]: HTTPMethod.GET,
-  [ConfigKeys.USERNAME]: '',
+  [ConfigKey.REQUEST_HEADERS_CHECK]: {},
+  [ConfigKey.REQUEST_METHOD_CHECK]: HTTPMethod.GET,
+  [ConfigKey.USERNAME]: '',
 };
 
-export const defaultContext: IHTTPAdvancedFieldsContext = {
-  setFields: (_fields: React.SetStateAction<IHTTPAdvancedFields>) => {
+export const defaultContext: HTTPAdvancedFieldsContext = {
+  setFields: (_fields: React.SetStateAction<HTTPAdvancedFields>) => {
     throw new Error('setFields was not initialized, set it when you invoke the context');
   },
   fields: initialValues,
@@ -56,8 +50,8 @@ export const HTTPAdvancedFieldsContext = createContext(defaultContext);
 export const HTTPAdvancedFieldsContextProvider = ({
   children,
   defaultValues = initialValues,
-}: IHTTPAdvancedFieldsContextProvider) => {
-  const [fields, setFields] = useState<IHTTPAdvancedFields>(defaultValues);
+}: HTTPAdvancedFieldsContextProvider) => {
+  const [fields, setFields] = useState<HTTPAdvancedFields>(defaultValues);
 
   const value = useMemo(() => {
     return { fields, setFields, defaultValues };

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/http_provider.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/http_provider.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { ReactNode } from 'react';
-import { HTTPFields, IHTTPSimpleFields, IHTTPAdvancedFields } from '../types';
+import { HTTPFields, HTTPSimpleFields, HTTPAdvancedFields } from '../types';
 import {
   HTTPSimpleFieldsContextProvider,
   HTTPAdvancedFieldsContextProvider,
@@ -21,18 +21,18 @@ interface HTTPContextProviderProps {
 }
 
 export const HTTPContextProvider = ({ defaultValues, children }: HTTPContextProviderProps) => {
-  const simpleKeys = Object.keys(defaultHTTPSimpleFields) as Array<keyof IHTTPSimpleFields>;
-  const advancedKeys = Object.keys(defaultHTTPAdvancedFields) as Array<keyof IHTTPAdvancedFields>;
-  const formattedDefaultHTTPSimpleFields = formatDefaultValues<IHTTPSimpleFields>(
+  const simpleKeys = Object.keys(defaultHTTPSimpleFields) as Array<keyof HTTPSimpleFields>;
+  const advancedKeys = Object.keys(defaultHTTPAdvancedFields) as Array<keyof HTTPAdvancedFields>;
+  const formattedDefaultHTTPSimpleFields = formatDefaultValues<HTTPSimpleFields>(
     simpleKeys,
     defaultValues || {}
   );
-  const formattedDefaultHTTPAdvancedFields = formatDefaultValues<IHTTPAdvancedFields>(
+  const formattedDefaultHTTPAdvancedFields = formatDefaultValues<HTTPAdvancedFields>(
     advancedKeys,
     defaultValues || {}
   );
   const httpAdvancedFields = defaultValues ? formattedDefaultHTTPAdvancedFields : undefined;
-  const httpSimpleFields: IHTTPSimpleFields | undefined = defaultValues
+  const httpSimpleFields: HTTPSimpleFields | undefined = defaultValues
     ? formattedDefaultHTTPSimpleFields
     : undefined;
   return (

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/icmp_context.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/icmp_context.tsx
@@ -6,29 +6,29 @@
  */
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
-import { IICMPSimpleFields, ConfigKeys, DataStream } from '../types';
+import { ICMPSimpleFields, ConfigKey, DataStream } from '../types';
 import { defaultValues as commonDefaultValues } from '../common/default_values';
 
-interface IICMPSimpleFieldsContext {
-  setFields: React.Dispatch<React.SetStateAction<IICMPSimpleFields>>;
-  fields: IICMPSimpleFields;
-  defaultValues: IICMPSimpleFields;
+interface ICMPSimpleFieldsContext {
+  setFields: React.Dispatch<React.SetStateAction<ICMPSimpleFields>>;
+  fields: ICMPSimpleFields;
+  defaultValues: ICMPSimpleFields;
 }
 
-interface IICMPSimpleFieldsContextProvider {
+interface ICMPSimpleFieldsContextProvider {
   children: React.ReactNode;
-  defaultValues?: IICMPSimpleFields;
+  defaultValues?: ICMPSimpleFields;
 }
 
-export const initialValues: IICMPSimpleFields = {
+export const initialValues: ICMPSimpleFields = {
   ...commonDefaultValues,
-  [ConfigKeys.HOSTS]: '',
-  [ConfigKeys.MONITOR_TYPE]: DataStream.ICMP,
-  [ConfigKeys.WAIT]: '1',
+  [ConfigKey.HOSTS]: '',
+  [ConfigKey.MONITOR_TYPE]: DataStream.ICMP,
+  [ConfigKey.WAIT]: '1',
 };
 
-const defaultContext: IICMPSimpleFieldsContext = {
-  setFields: (_fields: React.SetStateAction<IICMPSimpleFields>) => {
+const defaultContext: ICMPSimpleFieldsContext = {
+  setFields: (_fields: React.SetStateAction<ICMPSimpleFields>) => {
     throw new Error(
       'setFields was not initialized for ICMP Simple Fields, set it when you invoke the context'
     );
@@ -42,8 +42,8 @@ export const ICMPSimpleFieldsContext = createContext(defaultContext);
 export const ICMPSimpleFieldsContextProvider = ({
   children,
   defaultValues = initialValues,
-}: IICMPSimpleFieldsContextProvider) => {
-  const [fields, setFields] = useState<IICMPSimpleFields>(defaultValues);
+}: ICMPSimpleFieldsContextProvider) => {
+  const [fields, setFields] = useState<ICMPSimpleFields>(defaultValues);
 
   const value = useMemo(() => {
     return { fields, setFields, defaultValues };

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/synthetics_context_providers.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/synthetics_context_providers.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { HTTPFields, TCPFields, ICMPFields, BrowserFields, ITLSFields, DataStream } from '../types';
+import { HTTPFields, TCPFields, ICMPFields, BrowserFields, TLSFields, DataStream } from '../types';
 import {
   PolicyConfigContextProvider,
   TCPContextProvider,
@@ -22,7 +22,7 @@ interface Props {
   tcpDefaultValues?: TCPFields;
   icmpDefaultValues?: ICMPFields;
   browserDefaultValues?: BrowserFields;
-  tlsDefaultValues?: ITLSFields;
+  tlsDefaultValues?: TLSFields;
   policyDefaultValues?: {
     defaultMonitorType: DataStream;
     defaultIsTLSEnabled: boolean;

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/tcp_context.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/tcp_context.tsx
@@ -6,31 +6,31 @@
  */
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
-import { ITCPSimpleFields, ConfigKeys, DataStream } from '../types';
+import { TCPSimpleFields, ConfigKey, DataStream } from '../types';
 import { defaultValues as commonDefaultValues } from '../common/default_values';
 
-interface ITCPSimpleFieldsContext {
-  setFields: React.Dispatch<React.SetStateAction<ITCPSimpleFields>>;
-  fields: ITCPSimpleFields;
-  defaultValues: ITCPSimpleFields;
+interface TCPSimpleFieldsContext {
+  setFields: React.Dispatch<React.SetStateAction<TCPSimpleFields>>;
+  fields: TCPSimpleFields;
+  defaultValues: TCPSimpleFields;
 }
 
-interface ITCPSimpleFieldsContextProvider {
+interface TCPSimpleFieldsContextProvider {
   children: React.ReactNode;
-  defaultValues?: ITCPSimpleFields;
+  defaultValues?: TCPSimpleFields;
 }
 
-export const initialValues: ITCPSimpleFields = {
+export const initialValues: TCPSimpleFields = {
   ...commonDefaultValues,
-  [ConfigKeys.METADATA]: {
+  [ConfigKey.METADATA]: {
     is_tls_enabled: false,
   },
-  [ConfigKeys.HOSTS]: '',
-  [ConfigKeys.MONITOR_TYPE]: DataStream.TCP,
+  [ConfigKey.HOSTS]: '',
+  [ConfigKey.MONITOR_TYPE]: DataStream.TCP,
 };
 
-const defaultContext: ITCPSimpleFieldsContext = {
-  setFields: (_fields: React.SetStateAction<ITCPSimpleFields>) => {
+const defaultContext: TCPSimpleFieldsContext = {
+  setFields: (_fields: React.SetStateAction<TCPSimpleFields>) => {
     throw new Error(
       'setFields was not initialized for TCP Simple Fields, set it when you invoke the context'
     );
@@ -44,8 +44,8 @@ export const TCPSimpleFieldsContext = createContext(defaultContext);
 export const TCPSimpleFieldsContextProvider = ({
   children,
   defaultValues = initialValues,
-}: ITCPSimpleFieldsContextProvider) => {
-  const [fields, setFields] = useState<ITCPSimpleFields>(defaultValues);
+}: TCPSimpleFieldsContextProvider) => {
+  const [fields, setFields] = useState<TCPSimpleFields>(defaultValues);
 
   const value = useMemo(() => {
     return { fields, setFields, defaultValues };

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/tcp_context_advanced.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/tcp_context_advanced.tsx
@@ -6,28 +6,28 @@
  */
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
-import { ITCPAdvancedFields, ConfigKeys } from '../types';
+import { TCPAdvancedFields, ConfigKey } from '../types';
 
-interface ITCPAdvancedFieldsContext {
-  setFields: React.Dispatch<React.SetStateAction<ITCPAdvancedFields>>;
-  fields: ITCPAdvancedFields;
-  defaultValues: ITCPAdvancedFields;
+interface TCPAdvancedFieldsContext {
+  setFields: React.Dispatch<React.SetStateAction<TCPAdvancedFields>>;
+  fields: TCPAdvancedFields;
+  defaultValues: TCPAdvancedFields;
 }
 
-interface ITCPAdvancedFieldsContextProvider {
+interface TCPAdvancedFieldsContextProvider {
   children: React.ReactNode;
-  defaultValues?: ITCPAdvancedFields;
+  defaultValues?: TCPAdvancedFields;
 }
 
-export const initialValues: ITCPAdvancedFields = {
-  [ConfigKeys.PROXY_URL]: '',
-  [ConfigKeys.PROXY_USE_LOCAL_RESOLVER]: false,
-  [ConfigKeys.RESPONSE_RECEIVE_CHECK]: '',
-  [ConfigKeys.REQUEST_SEND_CHECK]: '',
+export const initialValues: TCPAdvancedFields = {
+  [ConfigKey.PROXY_URL]: '',
+  [ConfigKey.PROXY_USE_LOCAL_RESOLVER]: false,
+  [ConfigKey.RESPONSE_RECEIVE_CHECK]: '',
+  [ConfigKey.REQUEST_SEND_CHECK]: '',
 };
 
-const defaultContext: ITCPAdvancedFieldsContext = {
-  setFields: (_fields: React.SetStateAction<ITCPAdvancedFields>) => {
+const defaultContext: TCPAdvancedFieldsContext = {
+  setFields: (_fields: React.SetStateAction<TCPAdvancedFields>) => {
     throw new Error('setFields was not initialized, set it when you invoke the context');
   },
   fields: initialValues, // mutable
@@ -39,8 +39,8 @@ export const TCPAdvancedFieldsContext = createContext(defaultContext);
 export const TCPAdvancedFieldsContextProvider = ({
   children,
   defaultValues = initialValues,
-}: ITCPAdvancedFieldsContextProvider) => {
-  const [fields, setFields] = useState<ITCPAdvancedFields>(defaultValues);
+}: TCPAdvancedFieldsContextProvider) => {
+  const [fields, setFields] = useState<TCPAdvancedFields>(defaultValues);
 
   const value = useMemo(() => {
     return { fields, setFields, defaultValues };

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/tcp_provider.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/tcp_provider.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { ReactNode } from 'react';
-import { TCPFields, ITCPSimpleFields, ITCPAdvancedFields } from '../types';
+import { TCPFields, TCPSimpleFields, TCPAdvancedFields } from '../types';
 import {
   TCPSimpleFieldsContextProvider,
   TCPAdvancedFieldsContextProvider,
@@ -21,20 +21,20 @@ interface TCPContextProviderProps {
 }
 
 export const TCPContextProvider = ({ defaultValues, children }: TCPContextProviderProps) => {
-  const simpleKeys = Object.keys(defaultTCPSimpleFields) as Array<keyof ITCPSimpleFields>;
-  const advancedKeys = Object.keys(defaultTCPAdvancedFields) as Array<keyof ITCPAdvancedFields>;
-  const formattedDefaultSimpleFields = formatDefaultValues<ITCPSimpleFields>(
+  const simpleKeys = Object.keys(defaultTCPSimpleFields) as Array<keyof TCPSimpleFields>;
+  const advancedKeys = Object.keys(defaultTCPAdvancedFields) as Array<keyof TCPAdvancedFields>;
+  const formattedDefaultSimpleFields = formatDefaultValues<TCPSimpleFields>(
     simpleKeys,
     defaultValues || {}
   );
-  const formattedDefaultAdvancedFields = formatDefaultValues<ITCPAdvancedFields>(
+  const formattedDefaultAdvancedFields = formatDefaultValues<TCPAdvancedFields>(
     advancedKeys,
     defaultValues || {}
   );
-  const simpleFields: ITCPSimpleFields | undefined = defaultValues
+  const simpleFields: TCPSimpleFields | undefined = defaultValues
     ? formattedDefaultSimpleFields
     : undefined;
-  const advancedFields: ITCPAdvancedFields | undefined = defaultValues
+  const advancedFields: TCPAdvancedFields | undefined = defaultValues
     ? formattedDefaultAdvancedFields
     : undefined;
   return (

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/tls_fields_context.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/tls_fields_context.tsx
@@ -6,24 +6,24 @@
  */
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
-import { ITLSFields } from '../types';
+import { TLSFields } from '../types';
 import { defaultValues as tlsDefaultValues } from '../tls/default_values';
 
-interface ITLSFieldsContext {
-  setFields: React.Dispatch<React.SetStateAction<ITLSFields>>;
-  fields: ITLSFields;
-  defaultValues: ITLSFields;
+interface TLSFieldsContext {
+  setFields: React.Dispatch<React.SetStateAction<TLSFields>>;
+  fields: TLSFields;
+  defaultValues: TLSFields;
 }
 
-interface ITLSFieldsContextProvider {
+interface TLSFieldsContextProvider {
   children: React.ReactNode;
-  defaultValues?: ITLSFields;
+  defaultValues?: TLSFields;
 }
 
-export const initialValues: ITLSFields = tlsDefaultValues;
+export const initialValues: TLSFields = tlsDefaultValues;
 
-const defaultContext: ITLSFieldsContext = {
-  setFields: (_fields: React.SetStateAction<ITLSFields>) => {
+const defaultContext: TLSFieldsContext = {
+  setFields: (_fields: React.SetStateAction<TLSFields>) => {
     throw new Error('setFields was not initialized, set it when you invoke the context');
   },
   fields: initialValues, // mutable
@@ -35,8 +35,8 @@ export const TLSFieldsContext = createContext(defaultContext);
 export const TLSFieldsContextProvider = ({
   children,
   defaultValues = initialValues,
-}: ITLSFieldsContextProvider) => {
-  const [fields, setFields] = useState<ITLSFields>(defaultValues);
+}: TLSFieldsContextProvider) => {
+  const [fields, setFields] = useState<TLSFields>(defaultValues);
 
   const value = useMemo(() => {
     return { fields, setFields, defaultValues };

--- a/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.test.tsx
@@ -18,7 +18,7 @@ import {
   TLSFieldsContextProvider,
 } from './contexts';
 import { CustomFields } from './custom_fields';
-import { ConfigKeys, DataStream, ScheduleUnit } from './types';
+import { ConfigKey, DataStream, ScheduleUnit } from './types';
 import { validate as centralValidation } from './validation';
 import { defaultConfig } from './synthetics_policy_create_extension';
 
@@ -85,20 +85,20 @@ describe('<CustomFields />', () => {
     const timeout = getByLabelText('Timeout in seconds') as HTMLInputElement;
     expect(monitorType).toBeInTheDocument();
     expect(url).toBeInTheDocument();
-    expect(url.value).toEqual(defaultHTTPConfig[ConfigKeys.URLS]);
+    expect(url.value).toEqual(defaultHTTPConfig[ConfigKey.URLS]);
     expect(proxyUrl).toBeInTheDocument();
-    expect(proxyUrl.value).toEqual(defaultHTTPConfig[ConfigKeys.PROXY_URL]);
+    expect(proxyUrl.value).toEqual(defaultHTTPConfig[ConfigKey.PROXY_URL]);
     expect(monitorIntervalNumber).toBeInTheDocument();
-    expect(monitorIntervalNumber.value).toEqual(defaultHTTPConfig[ConfigKeys.SCHEDULE].number);
+    expect(monitorIntervalNumber.value).toEqual(defaultHTTPConfig[ConfigKey.SCHEDULE].number);
     expect(monitorIntervalUnit).toBeInTheDocument();
-    expect(monitorIntervalUnit.value).toEqual(defaultHTTPConfig[ConfigKeys.SCHEDULE].unit);
+    expect(monitorIntervalUnit.value).toEqual(defaultHTTPConfig[ConfigKey.SCHEDULE].unit);
     // expect(tags).toBeInTheDocument();
     expect(apmServiceName).toBeInTheDocument();
-    expect(apmServiceName.value).toEqual(defaultHTTPConfig[ConfigKeys.APM_SERVICE_NAME]);
+    expect(apmServiceName.value).toEqual(defaultHTTPConfig[ConfigKey.APM_SERVICE_NAME]);
     expect(maxRedirects).toBeInTheDocument();
-    expect(maxRedirects.value).toEqual(`${defaultHTTPConfig[ConfigKeys.MAX_REDIRECTS]}`);
+    expect(maxRedirects.value).toEqual(`${defaultHTTPConfig[ConfigKey.MAX_REDIRECTS]}`);
     expect(timeout).toBeInTheDocument();
-    expect(timeout.value).toEqual(`${defaultHTTPConfig[ConfigKeys.TIMEOUT]}`);
+    expect(timeout.value).toEqual(`${defaultHTTPConfig[ConfigKey.TIMEOUT]}`);
 
     // ensure other monitor type options are not in the DOM
     expect(queryByLabelText('Host')).not.toBeInTheDocument();
@@ -145,11 +145,11 @@ describe('<CustomFields />', () => {
     expect(verificationMode).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(ca.value).toEqual(defaultHTTPConfig[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]);
-      expect(clientKey.value).toEqual(defaultHTTPConfig[ConfigKeys.TLS_KEY]);
-      expect(clientKeyPassphrase.value).toEqual(defaultHTTPConfig[ConfigKeys.TLS_KEY_PASSPHRASE]);
-      expect(clientCertificate.value).toEqual(defaultHTTPConfig[ConfigKeys.TLS_CERTIFICATE]);
-      expect(verificationMode.value).toEqual(defaultHTTPConfig[ConfigKeys.TLS_VERIFICATION_MODE]);
+      expect(ca.value).toEqual(defaultHTTPConfig[ConfigKey.TLS_CERTIFICATE_AUTHORITIES]);
+      expect(clientKey.value).toEqual(defaultHTTPConfig[ConfigKey.TLS_KEY]);
+      expect(clientKeyPassphrase.value).toEqual(defaultHTTPConfig[ConfigKey.TLS_KEY_PASSPHRASE]);
+      expect(clientCertificate.value).toEqual(defaultHTTPConfig[ConfigKey.TLS_CERTIFICATE]);
+      expect(verificationMode.value).toEqual(defaultHTTPConfig[ConfigKey.TLS_VERIFICATION_MODE]);
     });
   });
 
@@ -186,14 +186,14 @@ describe('<CustomFields />', () => {
     );
     const monitorType = getByLabelText('Monitor Type') as HTMLInputElement;
     expect(monitorType).toBeInTheDocument();
-    expect(monitorType.value).toEqual(defaultHTTPConfig[ConfigKeys.MONITOR_TYPE]);
+    expect(monitorType.value).toEqual(defaultHTTPConfig[ConfigKey.MONITOR_TYPE]);
     fireEvent.change(monitorType, { target: { value: DataStream.TCP } });
 
     // expect tcp fields to be in the DOM
     const host = getByLabelText('Host:Port') as HTMLInputElement;
 
     expect(host).toBeInTheDocument();
-    expect(host.value).toEqual(defaultTCPConfig[ConfigKeys.HOSTS]);
+    expect(host.value).toEqual(defaultTCPConfig[ConfigKey.HOSTS]);
 
     // expect HTTP fields not to be in the DOM
     expect(queryByLabelText('URL')).not.toBeInTheDocument();

--- a/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.tsx
@@ -19,7 +19,7 @@ import {
   EuiCallOut,
   EuiLink,
 } from '@elastic/eui';
-import { ConfigKeys, DataStream, Validation } from './types';
+import { ConfigKey, DataStream, Validation } from './types';
 import { usePolicyConfigContext } from './contexts';
 import { TLSFields } from './tls_fields';
 import { HTTPSimpleFields } from './http/simple_fields';
@@ -109,8 +109,8 @@ export const CustomFields = memo<Props>(({ validate, dataStreams = [], children 
                   />
                 }
                 isInvalid={
-                  !!validate[ConfigKeys.MONITOR_TYPE]?.({
-                    [ConfigKeys.MONITOR_TYPE]: monitorType,
+                  !!validate[ConfigKey.MONITOR_TYPE]?.({
+                    [ConfigKey.MONITOR_TYPE]: monitorType as DataStream,
                   })
                 }
                 error={

--- a/x-pack/plugins/uptime/public/components/fleet_package/hooks/use_policy.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/hooks/use_policy.ts
@@ -9,7 +9,7 @@ import { useMemo } from 'react';
 import {
   PolicyConfig,
   DataStream,
-  ConfigKeys,
+  ConfigKey,
   HTTPFields,
   TCPFields,
   ICMPFields,
@@ -84,34 +84,34 @@ export const usePolicy = (fleetPolicyName: string = '') => {
         ...httpSimpleFields,
         ...httpAdvancedFields,
         ...tlsFields,
-        [ConfigKeys.METADATA]: {
-          ...httpSimpleFields[ConfigKeys.METADATA],
+        [ConfigKey.METADATA]: {
+          ...httpSimpleFields[ConfigKey.METADATA],
           ...metadata,
         },
-        [ConfigKeys.NAME]: fleetPolicyName || monitorName,
+        [ConfigKey.NAME]: fleetPolicyName || monitorName,
       } as HTTPFields,
       [DataStream.TCP]: {
         ...tcpSimpleFields,
         ...tcpAdvancedFields,
         ...tlsFields,
-        [ConfigKeys.METADATA]: {
-          ...tcpSimpleFields[ConfigKeys.METADATA],
+        [ConfigKey.METADATA]: {
+          ...tcpSimpleFields[ConfigKey.METADATA],
           ...metadata,
         },
-        [ConfigKeys.NAME]: fleetPolicyName || monitorName,
+        [ConfigKey.NAME]: fleetPolicyName || monitorName,
       } as TCPFields,
       [DataStream.ICMP]: {
         ...icmpSimpleFields,
-        [ConfigKeys.NAME]: fleetPolicyName || monitorName,
+        [ConfigKey.NAME]: fleetPolicyName || monitorName,
       } as ICMPFields,
       [DataStream.BROWSER]: {
         ...browserSimpleFields,
         ...browserAdvancedFields,
-        [ConfigKeys.METADATA]: {
-          ...browserSimpleFields[ConfigKeys.METADATA],
+        [ConfigKey.METADATA]: {
+          ...browserSimpleFields[ConfigKey.METADATA],
           ...metadata,
         },
-        [ConfigKeys.NAME]: fleetPolicyName || monitorName,
+        [ConfigKey.NAME]: fleetPolicyName || monitorName,
       } as BrowserFields,
     }),
     [

--- a/x-pack/plugins/uptime/public/components/fleet_package/hooks/use_update_policy.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/hooks/use_update_policy.test.tsx
@@ -9,14 +9,14 @@ import { useUpdatePolicy } from './use_update_policy';
 import { NewPackagePolicy } from '../../../../../fleet/public';
 import { validate } from '../validation';
 import {
-  ConfigKeys,
+  ConfigKey,
   DataStream,
   TLSVersion,
-  ICommonFields,
+  CommonFields,
   ScheduleUnit,
   ICMPFields,
   TCPFields,
-  ITLSFields,
+  TLSFields,
   HTTPFields,
   BrowserFields,
 } from '../types';
@@ -336,21 +336,21 @@ describe('useBarChartsHooks', () => {
     },
   };
 
-  const defaultCommonFields: Partial<ICommonFields> = {
-    [ConfigKeys.APM_SERVICE_NAME]: 'APM Service name',
-    [ConfigKeys.TAGS]: ['some', 'tags'],
-    [ConfigKeys.SCHEDULE]: {
+  const defaultCommonFields: Partial<CommonFields> = {
+    [ConfigKey.APM_SERVICE_NAME]: 'APM Service name',
+    [ConfigKey.TAGS]: ['some', 'tags'],
+    [ConfigKey.SCHEDULE]: {
       number: '5',
       unit: ScheduleUnit.MINUTES,
     },
-    [ConfigKeys.TIMEOUT]: '17',
+    [ConfigKey.TIMEOUT]: '17',
   };
 
-  const defaultTLSFields: Partial<ITLSFields> = {
-    [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]: 'ca',
-    [ConfigKeys.TLS_CERTIFICATE]: 'cert',
-    [ConfigKeys.TLS_KEY]: 'key',
-    [ConfigKeys.TLS_KEY_PASSPHRASE]: 'password',
+  const defaultTLSFields: Partial<TLSFields> = {
+    [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: 'ca',
+    [ConfigKey.TLS_CERTIFICATE]: 'cert',
+    [ConfigKey.TLS_KEY]: 'key',
+    [ConfigKey.TLS_KEY_PASSPHRASE]: 'password',
   };
 
   it('handles http data stream', async () => {
@@ -373,8 +373,8 @@ describe('useBarChartsHooks', () => {
       ...defaultConfig[DataStream.HTTP],
       ...defaultCommonFields,
       ...defaultTLSFields,
-      [ConfigKeys.URLS]: 'url',
-      [ConfigKeys.PROXY_URL]: 'proxyUrl',
+      [ConfigKey.URLS]: 'url',
+      [ConfigKey.PROXY_URL]: 'proxyUrl',
     };
 
     // expect only http to be enabled
@@ -391,28 +391,26 @@ describe('useBarChartsHooks', () => {
     await waitFor(() => {
       const vars = result.current.updatedPolicy.inputs[0]?.streams[0]?.vars;
 
-      expect(vars?.[ConfigKeys.MONITOR_TYPE].value).toEqual(config[ConfigKeys.MONITOR_TYPE]);
-      expect(vars?.[ConfigKeys.URLS].value).toEqual(config[ConfigKeys.URLS]);
-      expect(vars?.[ConfigKeys.SCHEDULE].value).toEqual(
+      expect(vars?.[ConfigKey.MONITOR_TYPE].value).toEqual(config[ConfigKey.MONITOR_TYPE]);
+      expect(vars?.[ConfigKey.URLS].value).toEqual(config[ConfigKey.URLS]);
+      expect(vars?.[ConfigKey.SCHEDULE].value).toEqual(
         JSON.stringify(
-          `@every ${config[ConfigKeys.SCHEDULE].number}${config[ConfigKeys.SCHEDULE].unit}`
+          `@every ${config[ConfigKey.SCHEDULE].number}${config[ConfigKey.SCHEDULE].unit}`
         )
       );
-      expect(vars?.[ConfigKeys.PROXY_URL].value).toEqual(config[ConfigKeys.PROXY_URL]);
-      expect(vars?.[ConfigKeys.APM_SERVICE_NAME].value).toEqual(
-        config[ConfigKeys.APM_SERVICE_NAME]
+      expect(vars?.[ConfigKey.PROXY_URL].value).toEqual(config[ConfigKey.PROXY_URL]);
+      expect(vars?.[ConfigKey.APM_SERVICE_NAME].value).toEqual(config[ConfigKey.APM_SERVICE_NAME]);
+      expect(vars?.[ConfigKey.TIMEOUT].value).toEqual(`${config[ConfigKey.TIMEOUT]}s`);
+      expect(vars?.[ConfigKey.RESPONSE_BODY_CHECK_POSITIVE].value).toEqual(null);
+      expect(vars?.[ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE].value).toEqual(null);
+      expect(vars?.[ConfigKey.RESPONSE_STATUS_CHECK].value).toEqual(null);
+      expect(vars?.[ConfigKey.REQUEST_HEADERS_CHECK].value).toEqual(null);
+      expect(vars?.[ConfigKey.RESPONSE_HEADERS_CHECK].value).toEqual(null);
+      expect(vars?.[ConfigKey.RESPONSE_BODY_INDEX].value).toEqual(
+        config[ConfigKey.RESPONSE_BODY_INDEX]
       );
-      expect(vars?.[ConfigKeys.TIMEOUT].value).toEqual(`${config[ConfigKeys.TIMEOUT]}s`);
-      expect(vars?.[ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE].value).toEqual(null);
-      expect(vars?.[ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE].value).toEqual(null);
-      expect(vars?.[ConfigKeys.RESPONSE_STATUS_CHECK].value).toEqual(null);
-      expect(vars?.[ConfigKeys.REQUEST_HEADERS_CHECK].value).toEqual(null);
-      expect(vars?.[ConfigKeys.RESPONSE_HEADERS_CHECK].value).toEqual(null);
-      expect(vars?.[ConfigKeys.RESPONSE_BODY_INDEX].value).toEqual(
-        config[ConfigKeys.RESPONSE_BODY_INDEX]
-      );
-      expect(vars?.[ConfigKeys.RESPONSE_HEADERS_INDEX].value).toEqual(
-        config[ConfigKeys.RESPONSE_HEADERS_INDEX]
+      expect(vars?.[ConfigKey.RESPONSE_HEADERS_INDEX].value).toEqual(
+        config[ConfigKey.RESPONSE_HEADERS_INDEX]
       );
     });
   });
@@ -435,11 +433,11 @@ describe('useBarChartsHooks', () => {
       ...initialProps,
       config: {
         ...defaultConfig[DataStream.HTTP],
-        [ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE]: ['test'],
-        [ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE]: ['test'],
-        [ConfigKeys.RESPONSE_STATUS_CHECK]: ['test'],
-        [ConfigKeys.TAGS]: ['test'],
-        [ConfigKeys.TLS_VERSION]: [TLSVersion.ONE_ONE],
+        [ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]: ['test'],
+        [ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]: ['test'],
+        [ConfigKey.RESPONSE_STATUS_CHECK]: ['test'],
+        [ConfigKey.TAGS]: ['test'],
+        [ConfigKey.TLS_VERSION]: [TLSVersion.ONE_ONE],
       },
     });
 
@@ -452,33 +450,33 @@ describe('useBarChartsHooks', () => {
 
       const vars = result.current.updatedPolicy.inputs[0]?.streams[0]?.vars;
 
-      expect(vars?.[ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE].value).toEqual('["test"]');
-      expect(vars?.[ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE].value).toEqual('["test"]');
-      expect(vars?.[ConfigKeys.RESPONSE_STATUS_CHECK].value).toEqual('["test"]');
-      expect(vars?.[ConfigKeys.TAGS].value).toEqual('["test"]');
-      expect(vars?.[ConfigKeys.TLS_VERSION].value).toEqual('["TLSv1.1"]');
+      expect(vars?.[ConfigKey.RESPONSE_BODY_CHECK_POSITIVE].value).toEqual('["test"]');
+      expect(vars?.[ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE].value).toEqual('["test"]');
+      expect(vars?.[ConfigKey.RESPONSE_STATUS_CHECK].value).toEqual('["test"]');
+      expect(vars?.[ConfigKey.TAGS].value).toEqual('["test"]');
+      expect(vars?.[ConfigKey.TLS_VERSION].value).toEqual('["TLSv1.1"]');
     });
 
     rerender({
       ...initialProps,
       config: {
         ...defaultConfig[DataStream.HTTP],
-        [ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE]: [],
-        [ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE]: [],
-        [ConfigKeys.RESPONSE_STATUS_CHECK]: [],
-        [ConfigKeys.TAGS]: [],
-        [ConfigKeys.TLS_VERSION]: [],
+        [ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]: [],
+        [ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]: [],
+        [ConfigKey.RESPONSE_STATUS_CHECK]: [],
+        [ConfigKey.TAGS]: [],
+        [ConfigKey.TLS_VERSION]: [],
       },
     });
 
     await waitFor(() => {
       const vars = result.current.updatedPolicy.inputs[0]?.streams[0]?.vars;
 
-      expect(vars?.[ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE].value).toEqual(null);
-      expect(vars?.[ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE].value).toEqual(null);
-      expect(vars?.[ConfigKeys.RESPONSE_STATUS_CHECK].value).toEqual(null);
-      expect(vars?.[ConfigKeys.TAGS].value).toEqual(null);
-      expect(vars?.[ConfigKeys.TLS_VERSION].value).toEqual(null);
+      expect(vars?.[ConfigKey.RESPONSE_BODY_CHECK_POSITIVE].value).toEqual(null);
+      expect(vars?.[ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE].value).toEqual(null);
+      expect(vars?.[ConfigKey.RESPONSE_STATUS_CHECK].value).toEqual(null);
+      expect(vars?.[ConfigKey.TAGS].value).toEqual(null);
+      expect(vars?.[ConfigKey.TLS_VERSION].value).toEqual(null);
     });
   });
 
@@ -506,11 +504,11 @@ describe('useBarChartsHooks', () => {
       ...defaultConfig[DataStream.TCP],
       ...defaultCommonFields,
       ...defaultTLSFields,
-      [ConfigKeys.HOSTS]: 'sampleHost',
-      [ConfigKeys.PROXY_URL]: 'proxyUrl',
-      [ConfigKeys.PROXY_USE_LOCAL_RESOLVER]: true,
-      [ConfigKeys.RESPONSE_RECEIVE_CHECK]: 'response',
-      [ConfigKeys.REQUEST_SEND_CHECK]: 'request',
+      [ConfigKey.HOSTS]: 'sampleHost',
+      [ConfigKey.PROXY_URL]: 'proxyUrl',
+      [ConfigKey.PROXY_USE_LOCAL_RESOLVER]: true,
+      [ConfigKey.RESPONSE_RECEIVE_CHECK]: 'response',
+      [ConfigKey.REQUEST_SEND_CHECK]: 'request',
     };
 
     rerender({
@@ -526,26 +524,24 @@ describe('useBarChartsHooks', () => {
         updatedPolicy: result.current.updatedPolicy,
       });
 
-      expect(vars?.[ConfigKeys.MONITOR_TYPE].value).toEqual(config[ConfigKeys.MONITOR_TYPE]);
-      expect(vars?.[ConfigKeys.HOSTS].value).toEqual(config[ConfigKeys.HOSTS]);
-      expect(vars?.[ConfigKeys.SCHEDULE].value).toEqual(
+      expect(vars?.[ConfigKey.MONITOR_TYPE].value).toEqual(config[ConfigKey.MONITOR_TYPE]);
+      expect(vars?.[ConfigKey.HOSTS].value).toEqual(config[ConfigKey.HOSTS]);
+      expect(vars?.[ConfigKey.SCHEDULE].value).toEqual(
         JSON.stringify(
-          `@every ${config[ConfigKeys.SCHEDULE].number}${config[ConfigKeys.SCHEDULE].unit}`
+          `@every ${config[ConfigKey.SCHEDULE].number}${config[ConfigKey.SCHEDULE].unit}`
         )
       );
-      expect(vars?.[ConfigKeys.PROXY_URL].value).toEqual(config[ConfigKeys.PROXY_URL]);
-      expect(vars?.[ConfigKeys.APM_SERVICE_NAME].value).toEqual(
-        config[ConfigKeys.APM_SERVICE_NAME]
+      expect(vars?.[ConfigKey.PROXY_URL].value).toEqual(config[ConfigKey.PROXY_URL]);
+      expect(vars?.[ConfigKey.APM_SERVICE_NAME].value).toEqual(config[ConfigKey.APM_SERVICE_NAME]);
+      expect(vars?.[ConfigKey.TIMEOUT].value).toEqual(`${config[ConfigKey.TIMEOUT]}s`);
+      expect(vars?.[ConfigKey.PROXY_USE_LOCAL_RESOLVER].value).toEqual(
+        config[ConfigKey.PROXY_USE_LOCAL_RESOLVER]
       );
-      expect(vars?.[ConfigKeys.TIMEOUT].value).toEqual(`${config[ConfigKeys.TIMEOUT]}s`);
-      expect(vars?.[ConfigKeys.PROXY_USE_LOCAL_RESOLVER].value).toEqual(
-        config[ConfigKeys.PROXY_USE_LOCAL_RESOLVER]
+      expect(vars?.[ConfigKey.RESPONSE_RECEIVE_CHECK].value).toEqual(
+        config[ConfigKey.RESPONSE_RECEIVE_CHECK]
       );
-      expect(vars?.[ConfigKeys.RESPONSE_RECEIVE_CHECK].value).toEqual(
-        config[ConfigKeys.RESPONSE_RECEIVE_CHECK]
-      );
-      expect(vars?.[ConfigKeys.REQUEST_SEND_CHECK].value).toEqual(
-        config[ConfigKeys.REQUEST_SEND_CHECK]
+      expect(vars?.[ConfigKey.REQUEST_SEND_CHECK].value).toEqual(
+        config[ConfigKey.REQUEST_SEND_CHECK]
       );
     });
   });
@@ -566,8 +562,8 @@ describe('useBarChartsHooks', () => {
     const config: ICMPFields = {
       ...defaultConfig[DataStream.ICMP],
       ...defaultCommonFields,
-      [ConfigKeys.WAIT]: '2',
-      [ConfigKeys.HOSTS]: 'sampleHost',
+      [ConfigKey.WAIT]: '2',
+      [ConfigKey.HOSTS]: 'sampleHost',
     };
 
     // expect only icmp to be enabled
@@ -585,18 +581,16 @@ describe('useBarChartsHooks', () => {
     await waitFor(() => {
       const vars = result.current.updatedPolicy.inputs[2]?.streams[0]?.vars;
 
-      expect(vars?.[ConfigKeys.MONITOR_TYPE].value).toEqual(config[ConfigKeys.MONITOR_TYPE]);
-      expect(vars?.[ConfigKeys.HOSTS].value).toEqual(config[ConfigKeys.HOSTS]);
-      expect(vars?.[ConfigKeys.SCHEDULE].value).toEqual(
+      expect(vars?.[ConfigKey.MONITOR_TYPE].value).toEqual(config[ConfigKey.MONITOR_TYPE]);
+      expect(vars?.[ConfigKey.HOSTS].value).toEqual(config[ConfigKey.HOSTS]);
+      expect(vars?.[ConfigKey.SCHEDULE].value).toEqual(
         JSON.stringify(
-          `@every ${config[ConfigKeys.SCHEDULE].number}${config[ConfigKeys.SCHEDULE].unit}`
+          `@every ${config[ConfigKey.SCHEDULE].number}${config[ConfigKey.SCHEDULE].unit}`
         )
       );
-      expect(vars?.[ConfigKeys.APM_SERVICE_NAME].value).toEqual(
-        config[ConfigKeys.APM_SERVICE_NAME]
-      );
-      expect(vars?.[ConfigKeys.TIMEOUT].value).toEqual(`${config[ConfigKeys.TIMEOUT]}s`);
-      expect(vars?.[ConfigKeys.WAIT].value).toEqual(`${config[ConfigKeys.WAIT]}s`);
+      expect(vars?.[ConfigKey.APM_SERVICE_NAME].value).toEqual(config[ConfigKey.APM_SERVICE_NAME]);
+      expect(vars?.[ConfigKey.TIMEOUT].value).toEqual(`${config[ConfigKey.TIMEOUT]}s`);
+      expect(vars?.[ConfigKey.WAIT].value).toEqual(`${config[ConfigKey.WAIT]}s`);
 
       expect(onChange).toBeCalledWith({
         isValid: false,
@@ -629,16 +623,16 @@ describe('useBarChartsHooks', () => {
     const config: BrowserFields = {
       ...defaultConfig[DataStream.BROWSER],
       ...defaultCommonFields,
-      [ConfigKeys.SOURCE_INLINE]: 'inlineScript',
-      [ConfigKeys.SOURCE_ZIP_URL]: 'zipFolder',
-      [ConfigKeys.SOURCE_ZIP_FOLDER]: 'zipFolder',
-      [ConfigKeys.SOURCE_ZIP_USERNAME]: 'username',
-      [ConfigKeys.SOURCE_ZIP_PASSWORD]: 'password',
-      [ConfigKeys.SCREENSHOTS]: 'off',
-      [ConfigKeys.SYNTHETICS_ARGS]: ['args'],
-      [ConfigKeys.DOWNLOAD_SPEED]: '13',
-      [ConfigKeys.UPLOAD_SPEED]: '3',
-      [ConfigKeys.LATENCY]: '7',
+      [ConfigKey.SOURCE_INLINE]: 'inlineScript',
+      [ConfigKey.SOURCE_ZIP_URL]: 'zipFolder',
+      [ConfigKey.SOURCE_ZIP_FOLDER]: 'zipFolder',
+      [ConfigKey.SOURCE_ZIP_USERNAME]: 'username',
+      [ConfigKey.SOURCE_ZIP_PASSWORD]: 'password',
+      [ConfigKey.SCREENSHOTS]: 'off',
+      [ConfigKey.SYNTHETICS_ARGS]: ['args'],
+      [ConfigKey.DOWNLOAD_SPEED]: '13',
+      [ConfigKey.UPLOAD_SPEED]: '3',
+      [ConfigKey.LATENCY]: '7',
     };
 
     rerender({
@@ -649,30 +643,28 @@ describe('useBarChartsHooks', () => {
     await waitFor(() => {
       const vars = result.current.updatedPolicy.inputs[3]?.streams[0]?.vars;
 
-      expect(vars?.[ConfigKeys.SOURCE_ZIP_FOLDER].value).toEqual(
-        config[ConfigKeys.SOURCE_ZIP_FOLDER]
+      expect(vars?.[ConfigKey.SOURCE_ZIP_FOLDER].value).toEqual(
+        config[ConfigKey.SOURCE_ZIP_FOLDER]
       );
-      expect(vars?.[ConfigKeys.SOURCE_ZIP_PASSWORD].value).toEqual(
-        config[ConfigKeys.SOURCE_ZIP_PASSWORD]
+      expect(vars?.[ConfigKey.SOURCE_ZIP_PASSWORD].value).toEqual(
+        config[ConfigKey.SOURCE_ZIP_PASSWORD]
       );
-      expect(vars?.[ConfigKeys.SOURCE_ZIP_URL].value).toEqual(config[ConfigKeys.SOURCE_ZIP_URL]);
-      expect(vars?.[ConfigKeys.SOURCE_INLINE].value).toEqual(
-        JSON.stringify(config[ConfigKeys.SOURCE_INLINE])
+      expect(vars?.[ConfigKey.SOURCE_ZIP_URL].value).toEqual(config[ConfigKey.SOURCE_ZIP_URL]);
+      expect(vars?.[ConfigKey.SOURCE_INLINE].value).toEqual(
+        JSON.stringify(config[ConfigKey.SOURCE_INLINE])
       );
-      expect(vars?.[ConfigKeys.SOURCE_ZIP_PASSWORD].value).toEqual(
-        config[ConfigKeys.SOURCE_ZIP_PASSWORD]
+      expect(vars?.[ConfigKey.SOURCE_ZIP_PASSWORD].value).toEqual(
+        config[ConfigKey.SOURCE_ZIP_PASSWORD]
       );
-      expect(vars?.[ConfigKeys.SCREENSHOTS].value).toEqual(config[ConfigKeys.SCREENSHOTS]);
-      expect(vars?.[ConfigKeys.SYNTHETICS_ARGS].value).toEqual(
-        JSON.stringify(config[ConfigKeys.SYNTHETICS_ARGS])
+      expect(vars?.[ConfigKey.SCREENSHOTS].value).toEqual(config[ConfigKey.SCREENSHOTS]);
+      expect(vars?.[ConfigKey.SYNTHETICS_ARGS].value).toEqual(
+        JSON.stringify(config[ConfigKey.SYNTHETICS_ARGS])
       );
-      expect(vars?.[ConfigKeys.APM_SERVICE_NAME].value).toEqual(
-        config[ConfigKeys.APM_SERVICE_NAME]
-      );
-      expect(vars?.[ConfigKeys.TIMEOUT].value).toEqual(`${config[ConfigKeys.TIMEOUT]}s`);
-      expect(vars?.[ConfigKeys.THROTTLING_CONFIG].value).toEqual(
-        `${config[ConfigKeys.DOWNLOAD_SPEED]}d/${config[ConfigKeys.UPLOAD_SPEED]}u/${
-          config[ConfigKeys.LATENCY]
+      expect(vars?.[ConfigKey.APM_SERVICE_NAME].value).toEqual(config[ConfigKey.APM_SERVICE_NAME]);
+      expect(vars?.[ConfigKey.TIMEOUT].value).toEqual(`${config[ConfigKey.TIMEOUT]}s`);
+      expect(vars?.[ConfigKey.THROTTLING_CONFIG].value).toEqual(
+        `${config[ConfigKey.DOWNLOAD_SPEED]}d/${config[ConfigKey.UPLOAD_SPEED]}u/${
+          config[ConfigKey.LATENCY]
         }l`
       );
 

--- a/x-pack/plugins/uptime/public/components/fleet_package/hooks/use_update_policy.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/hooks/use_update_policy.ts
@@ -6,13 +6,13 @@
  */
 import { useEffect, useRef, useState } from 'react';
 import { NewPackagePolicy } from '../../../../../fleet/public';
-import { ConfigKeys, DataStream, Validation, ICustomFields } from '../types';
+import { ConfigKey, DataStream, Validation, MonitorFields } from '../types';
 import { formatters } from '../helpers/formatters';
 
 interface Props {
   monitorType: DataStream;
-  defaultConfig: Partial<ICustomFields>;
-  config: Partial<ICustomFields>;
+  defaultConfig: Partial<MonitorFields>;
+  config: Partial<MonitorFields>;
   newPolicy: NewPackagePolicy;
   onChange: (opts: {
     /** is current form state is valid */
@@ -33,11 +33,11 @@ export const useUpdatePolicy = ({
 }: Props) => {
   const [updatedPolicy, setUpdatedPolicy] = useState<NewPackagePolicy>(newPolicy);
   // Update the integration policy with our custom fields
-  const currentConfig = useRef<Partial<ICustomFields>>(defaultConfig);
+  const currentConfig = useRef<Partial<MonitorFields>>(defaultConfig);
 
   useEffect(() => {
-    const configKeys = Object.keys(config) as ConfigKeys[];
-    const validationKeys = Object.keys(validate[monitorType]) as ConfigKeys[];
+    const configKeys = Object.keys(config) as ConfigKey[];
+    const validationKeys = Object.keys(validate[monitorType]) as ConfigKey[];
     const configDidUpdate = configKeys.some((key) => config[key] !== currentConfig.current[key]);
     const isValid =
       !!newPolicy.name && !validationKeys.find((key) => validate[monitorType]?.[key]?.(config));

--- a/x-pack/plugins/uptime/public/components/fleet_package/http/advanced_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/http/advanced_fields.test.tsx
@@ -9,7 +9,13 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { render } from '../../../lib/helper/rtl_helpers';
 import { HTTPAdvancedFields } from './advanced_fields';
-import { ConfigKeys, DataStream, HTTPMethod, IHTTPAdvancedFields, Validation } from '../types';
+import {
+  ConfigKey,
+  DataStream,
+  HTTPMethod,
+  HTTPAdvancedFields as HTTPAdvancedFieldsType,
+  Validation,
+} from '../types';
 import {
   HTTPAdvancedFieldsContextProvider,
   defaultHTTPAdvancedFields as defaultConfig,
@@ -44,7 +50,7 @@ describe('<HTTPAdvancedFields />', () => {
     defaultValues,
     validate = defaultValidation,
   }: {
-    defaultValues?: IHTTPAdvancedFields;
+    defaultValues?: HTTPAdvancedFieldsType;
     validate?: Validation;
   }) => {
     return (
@@ -73,25 +79,25 @@ describe('<HTTPAdvancedFields />', () => {
     const username = getByLabelText('Username') as HTMLInputElement;
     const password = getByLabelText('Password') as HTMLInputElement;
     expect(requestMethod).toBeInTheDocument();
-    expect(requestMethod.value).toEqual(defaultConfig[ConfigKeys.REQUEST_METHOD_CHECK]);
+    expect(requestMethod.value).toEqual(defaultConfig[ConfigKey.REQUEST_METHOD_CHECK]);
     expect(requestHeaders).toBeInTheDocument();
     expect(requestBody).toBeInTheDocument();
     expect(indexResponseBody).toBeInTheDocument();
     expect(indexResponseBody.checked).toBe(true);
     expect(indexResponseBodySelect).toBeInTheDocument();
-    expect(indexResponseBodySelect.value).toEqual(defaultConfig[ConfigKeys.RESPONSE_BODY_INDEX]);
+    expect(indexResponseBodySelect.value).toEqual(defaultConfig[ConfigKey.RESPONSE_BODY_INDEX]);
     expect(indexResponseHeaders).toBeInTheDocument();
     expect(indexResponseHeaders.checked).toBe(true);
     expect(proxyUrl).toBeInTheDocument();
-    expect(proxyUrl.value).toEqual(defaultConfig[ConfigKeys.PROXY_URL]);
+    expect(proxyUrl.value).toEqual(defaultConfig[ConfigKey.PROXY_URL]);
     expect(responseStatusEquals).toBeInTheDocument();
     expect(responseBodyContains).toBeInTheDocument();
     expect(responseBodyDoesNotContain).toBeInTheDocument();
     expect(responseHeadersContain).toBeInTheDocument();
     expect(username).toBeInTheDocument();
-    expect(username.value).toBe(defaultConfig[ConfigKeys.USERNAME]);
+    expect(username.value).toBe(defaultConfig[ConfigKey.USERNAME]);
     expect(password).toBeInTheDocument();
-    expect(password.value).toBe(defaultConfig[ConfigKeys.PASSWORD]);
+    expect(password.value).toBe(defaultConfig[ConfigKey.PASSWORD]);
   });
 
   it('handles changing fields', () => {

--- a/x-pack/plugins/uptime/public/components/fleet_package/http/advanced_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/http/advanced_fields.tsx
@@ -22,7 +22,7 @@ import {
 
 import { useHTTPAdvancedFieldsContext } from '../contexts';
 
-import { ConfigKeys, HTTPMethod, Validation } from '../types';
+import { ConfigKey, HTTPMethod, Validation } from '../types';
 
 import { OptionalLabel } from '../optional_label';
 import { HeaderField } from '../header_field';
@@ -37,7 +37,7 @@ interface Props {
 export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
   const { fields, setFields } = useHTTPAdvancedFieldsContext();
   const handleInputChange = useCallback(
-    ({ value, configKey }: { value: unknown; configKey: ConfigKeys }) => {
+    ({ value, configKey }: { value: unknown; configKey: ConfigKey }) => {
       setFields((prevFields) => ({ ...prevFields, [configKey]: value }));
     },
     [setFields]
@@ -89,11 +89,11 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
           }
         >
           <EuiFieldText
-            value={fields[ConfigKeys.USERNAME]}
+            value={fields[ConfigKey.USERNAME]}
             onChange={(event) =>
               handleInputChange({
                 value: event.target.value,
-                configKey: ConfigKeys.USERNAME,
+                configKey: ConfigKey.USERNAME,
               })
             }
             data-test-subj="syntheticsUsername"
@@ -115,11 +115,11 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
           }
         >
           <EuiFieldPassword
-            value={fields[ConfigKeys.PASSWORD]}
+            value={fields[ConfigKey.PASSWORD]}
             onChange={(event) =>
               handleInputChange({
                 value: event.target.value,
-                configKey: ConfigKeys.PASSWORD,
+                configKey: ConfigKey.PASSWORD,
               })
             }
             data-test-subj="syntheticsPassword"
@@ -141,11 +141,11 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
           }
         >
           <EuiFieldText
-            value={fields[ConfigKeys.PROXY_URL]}
+            value={fields[ConfigKey.PROXY_URL]}
             onChange={(event) =>
               handleInputChange({
                 value: event.target.value,
-                configKey: ConfigKeys.PROXY_URL,
+                configKey: ConfigKey.PROXY_URL,
               })
             }
             data-test-subj="syntheticsProxyUrl"
@@ -167,11 +167,11 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
         >
           <EuiSelect
             options={requestMethodOptions}
-            value={fields[ConfigKeys.REQUEST_METHOD_CHECK]}
+            value={fields[ConfigKey.REQUEST_METHOD_CHECK]}
             onChange={(event) =>
               handleInputChange({
                 value: event.target.value,
-                configKey: ConfigKeys.REQUEST_METHOD_CHECK,
+                configKey: ConfigKey.REQUEST_METHOD_CHECK,
               })
             }
             data-test-subj="syntheticsRequestMethod"
@@ -186,7 +186,7 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
             />
           }
           labelAppend={<OptionalLabel />}
-          isInvalid={!!validate[ConfigKeys.REQUEST_HEADERS_CHECK]?.(fields)}
+          isInvalid={!!validate[ConfigKey.REQUEST_HEADERS_CHECK]?.(fields)}
           error={
             <FormattedMessage
               id="xpack.uptime.createPackagePolicy.stepConfigure.httpAdvancedOptions.requestHeadersField.error"
@@ -202,16 +202,16 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
         >
           <HeaderField
             contentMode={
-              fields[ConfigKeys.REQUEST_BODY_CHECK].value
-                ? fields[ConfigKeys.REQUEST_BODY_CHECK].type
+              fields[ConfigKey.REQUEST_BODY_CHECK].value
+                ? fields[ConfigKey.REQUEST_BODY_CHECK].type
                 : undefined
             } // only pass contentMode if the request body is truthy
-            defaultValue={fields[ConfigKeys.REQUEST_HEADERS_CHECK]}
+            defaultValue={fields[ConfigKey.REQUEST_HEADERS_CHECK]}
             onChange={useCallback(
               (value) =>
                 handleInputChange({
                   value,
-                  configKey: ConfigKeys.REQUEST_HEADERS_CHECK,
+                  configKey: ConfigKey.REQUEST_HEADERS_CHECK,
                 }),
               [handleInputChange]
             )}
@@ -235,13 +235,13 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
           fullWidth
         >
           <RequestBodyField
-            value={fields[ConfigKeys.REQUEST_BODY_CHECK].value}
-            type={fields[ConfigKeys.REQUEST_BODY_CHECK].type}
+            value={fields[ConfigKey.REQUEST_BODY_CHECK].value}
+            type={fields[ConfigKey.REQUEST_BODY_CHECK].type}
             onChange={useCallback(
               (value) =>
                 handleInputChange({
                   value,
-                  configKey: ConfigKeys.REQUEST_BODY_CHECK,
+                  configKey: ConfigKey.REQUEST_BODY_CHECK,
                 }),
               [handleInputChange]
             )}
@@ -280,7 +280,7 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
         >
           <EuiCheckbox
             id={'uptimeFleetIndexResponseHeaders'}
-            checked={fields[ConfigKeys.RESPONSE_HEADERS_INDEX]}
+            checked={fields[ConfigKey.RESPONSE_HEADERS_INDEX]}
             label={
               <FormattedMessage
                 id="xpack.uptime.createPackagePolicy.stepConfigure.httpAdvancedOptions.responseConfig.indexResponseHeaders"
@@ -290,7 +290,7 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
             onChange={(event) =>
               handleInputChange({
                 value: event.target.checked,
-                configKey: ConfigKeys.RESPONSE_HEADERS_INDEX,
+                configKey: ConfigKey.RESPONSE_HEADERS_INDEX,
               })
             }
           />
@@ -307,10 +307,10 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
           }
         >
           <ResponseBodyIndexField
-            defaultValue={fields[ConfigKeys.RESPONSE_BODY_INDEX]}
+            defaultValue={fields[ConfigKey.RESPONSE_BODY_INDEX]}
             onChange={useCallback(
               (policy) =>
-                handleInputChange({ value: policy, configKey: ConfigKeys.RESPONSE_BODY_INDEX }),
+                handleInputChange({ value: policy, configKey: ConfigKey.RESPONSE_BODY_INDEX }),
               [handleInputChange]
             )}
           />
@@ -340,7 +340,7 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
             />
           }
           labelAppend={<OptionalLabel />}
-          isInvalid={!!validate[ConfigKeys.RESPONSE_STATUS_CHECK]?.(fields)}
+          isInvalid={!!validate[ConfigKey.RESPONSE_STATUS_CHECK]?.(fields)}
           error={
             <FormattedMessage
               id="xpack.uptime.createPackagePolicy.stepConfigure.httpAdvancedOptions.responseChecks.responseStatusCheck.error"
@@ -356,11 +356,11 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
           )}
         >
           <ComboBox
-            selectedOptions={fields[ConfigKeys.RESPONSE_STATUS_CHECK]}
+            selectedOptions={fields[ConfigKey.RESPONSE_STATUS_CHECK]}
             onChange={(value) =>
               handleInputChange({
                 value,
-                configKey: ConfigKeys.RESPONSE_STATUS_CHECK,
+                configKey: ConfigKey.RESPONSE_STATUS_CHECK,
               })
             }
             data-test-subj="syntheticsResponseStatusCheck"
@@ -375,7 +375,7 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
             />
           }
           labelAppend={<OptionalLabel />}
-          isInvalid={!!validate[ConfigKeys.RESPONSE_HEADERS_CHECK]?.(fields)}
+          isInvalid={!!validate[ConfigKey.RESPONSE_HEADERS_CHECK]?.(fields)}
           error={[
             <FormattedMessage
               id="xpack.uptime.createPackagePolicy.stepConfigure.httpAdvancedOptions.responseHeadersField.error"
@@ -390,12 +390,12 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
           }
         >
           <HeaderField
-            defaultValue={fields[ConfigKeys.RESPONSE_HEADERS_CHECK]}
+            defaultValue={fields[ConfigKey.RESPONSE_HEADERS_CHECK]}
             onChange={useCallback(
               (value) =>
                 handleInputChange({
                   value,
-                  configKey: ConfigKeys.RESPONSE_HEADERS_CHECK,
+                  configKey: ConfigKey.RESPONSE_HEADERS_CHECK,
                 }),
               [handleInputChange]
             )}
@@ -419,12 +419,12 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
           )}
         >
           <ComboBox
-            selectedOptions={fields[ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE]}
+            selectedOptions={fields[ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]}
             onChange={useCallback(
               (value) =>
                 handleInputChange({
                   value,
-                  configKey: ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE,
+                  configKey: ConfigKey.RESPONSE_BODY_CHECK_POSITIVE,
                 }),
               [handleInputChange]
             )}
@@ -448,12 +448,12 @@ export const HTTPAdvancedFields = memo<Props>(({ validate }) => {
           )}
         >
           <ComboBox
-            selectedOptions={fields[ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE]}
+            selectedOptions={fields[ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]}
             onChange={useCallback(
               (value) =>
                 handleInputChange({
                   value,
-                  configKey: ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE,
+                  configKey: ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE,
                 }),
               [handleInputChange]
             )}

--- a/x-pack/plugins/uptime/public/components/fleet_package/http/formatters.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/http/formatters.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { HTTPFields, ConfigKeys } from '../types';
+import { HTTPFields, ConfigKey } from '../types';
 import {
   Formatter,
   commonFormatters,
@@ -17,29 +17,29 @@ import { tlsFormatters } from '../tls/formatters';
 export type HTTPFormatMap = Record<keyof HTTPFields, Formatter>;
 
 export const httpFormatters: HTTPFormatMap = {
-  [ConfigKeys.METADATA]: (fields) => objectToJsonFormatter(fields[ConfigKeys.METADATA]),
-  [ConfigKeys.URLS]: null,
-  [ConfigKeys.MAX_REDIRECTS]: null,
-  [ConfigKeys.USERNAME]: null,
-  [ConfigKeys.PASSWORD]: null,
-  [ConfigKeys.PROXY_URL]: null,
-  [ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE]: (fields) =>
-    arrayToJsonFormatter(fields[ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE]),
-  [ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE]: (fields) =>
-    arrayToJsonFormatter(fields[ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE]),
-  [ConfigKeys.RESPONSE_BODY_INDEX]: null,
-  [ConfigKeys.RESPONSE_HEADERS_CHECK]: (fields) =>
-    objectToJsonFormatter(fields[ConfigKeys.RESPONSE_HEADERS_CHECK]),
-  [ConfigKeys.RESPONSE_HEADERS_INDEX]: null,
-  [ConfigKeys.RESPONSE_STATUS_CHECK]: (fields) =>
-    arrayToJsonFormatter(fields[ConfigKeys.RESPONSE_STATUS_CHECK]),
-  [ConfigKeys.REQUEST_BODY_CHECK]: (fields) =>
-    fields[ConfigKeys.REQUEST_BODY_CHECK]?.value
-      ? JSON.stringify(fields[ConfigKeys.REQUEST_BODY_CHECK]?.value)
+  [ConfigKey.METADATA]: (fields) => objectToJsonFormatter(fields[ConfigKey.METADATA]),
+  [ConfigKey.URLS]: null,
+  [ConfigKey.MAX_REDIRECTS]: null,
+  [ConfigKey.USERNAME]: null,
+  [ConfigKey.PASSWORD]: null,
+  [ConfigKey.PROXY_URL]: null,
+  [ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]: (fields) =>
+    arrayToJsonFormatter(fields[ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]),
+  [ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]: (fields) =>
+    arrayToJsonFormatter(fields[ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]),
+  [ConfigKey.RESPONSE_BODY_INDEX]: null,
+  [ConfigKey.RESPONSE_HEADERS_CHECK]: (fields) =>
+    objectToJsonFormatter(fields[ConfigKey.RESPONSE_HEADERS_CHECK]),
+  [ConfigKey.RESPONSE_HEADERS_INDEX]: null,
+  [ConfigKey.RESPONSE_STATUS_CHECK]: (fields) =>
+    arrayToJsonFormatter(fields[ConfigKey.RESPONSE_STATUS_CHECK]),
+  [ConfigKey.REQUEST_BODY_CHECK]: (fields) =>
+    fields[ConfigKey.REQUEST_BODY_CHECK]?.value
+      ? JSON.stringify(fields[ConfigKey.REQUEST_BODY_CHECK]?.value)
       : null,
-  [ConfigKeys.REQUEST_HEADERS_CHECK]: (fields) =>
-    objectToJsonFormatter(fields[ConfigKeys.REQUEST_HEADERS_CHECK]),
-  [ConfigKeys.REQUEST_METHOD_CHECK]: null,
+  [ConfigKey.REQUEST_HEADERS_CHECK]: (fields) =>
+    objectToJsonFormatter(fields[ConfigKey.REQUEST_HEADERS_CHECK]),
+  [ConfigKey.REQUEST_METHOD_CHECK]: null,
   ...tlsFormatters,
   ...commonFormatters,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/http/normalizers.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/http/normalizers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { HTTPFields, ConfigKeys, ContentType, contentTypesToMode } from '../types';
+import { HTTPFields, ConfigKey, ContentType, contentTypesToMode } from '../types';
 import {
   Normalizer,
   commonNormalizers,
@@ -22,47 +22,47 @@ const defaultHTTPValues = {
   ...defaultHTTPAdvancedFields,
 };
 
-export const getHTTPNormalizer = (key: ConfigKeys) => {
+export const getHTTPNormalizer = (key: ConfigKey) => {
   return getNormalizer(key, defaultHTTPValues);
 };
 
-export const getHTTPJsonToJavascriptNormalizer = (key: ConfigKeys) => {
+export const getHTTPJsonToJavascriptNormalizer = (key: ConfigKey) => {
   return getJsonToJavascriptNormalizer(key, defaultHTTPValues);
 };
 
 export const httpNormalizers: HTTPNormalizerMap = {
-  [ConfigKeys.METADATA]: getHTTPJsonToJavascriptNormalizer(ConfigKeys.METADATA),
-  [ConfigKeys.URLS]: getHTTPNormalizer(ConfigKeys.URLS),
-  [ConfigKeys.MAX_REDIRECTS]: getHTTPNormalizer(ConfigKeys.MAX_REDIRECTS),
-  [ConfigKeys.USERNAME]: getHTTPNormalizer(ConfigKeys.USERNAME),
-  [ConfigKeys.PASSWORD]: getHTTPNormalizer(ConfigKeys.PASSWORD),
-  [ConfigKeys.PROXY_URL]: getHTTPNormalizer(ConfigKeys.PROXY_URL),
-  [ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE]: getHTTPJsonToJavascriptNormalizer(
-    ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE
+  [ConfigKey.METADATA]: getHTTPJsonToJavascriptNormalizer(ConfigKey.METADATA),
+  [ConfigKey.URLS]: getHTTPNormalizer(ConfigKey.URLS),
+  [ConfigKey.MAX_REDIRECTS]: getHTTPNormalizer(ConfigKey.MAX_REDIRECTS),
+  [ConfigKey.USERNAME]: getHTTPNormalizer(ConfigKey.USERNAME),
+  [ConfigKey.PASSWORD]: getHTTPNormalizer(ConfigKey.PASSWORD),
+  [ConfigKey.PROXY_URL]: getHTTPNormalizer(ConfigKey.PROXY_URL),
+  [ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]: getHTTPJsonToJavascriptNormalizer(
+    ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE
   ),
-  [ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE]: getHTTPJsonToJavascriptNormalizer(
-    ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE
+  [ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]: getHTTPJsonToJavascriptNormalizer(
+    ConfigKey.RESPONSE_BODY_CHECK_POSITIVE
   ),
-  [ConfigKeys.RESPONSE_BODY_INDEX]: getHTTPNormalizer(ConfigKeys.RESPONSE_BODY_INDEX),
-  [ConfigKeys.RESPONSE_HEADERS_CHECK]: getHTTPJsonToJavascriptNormalizer(
-    ConfigKeys.RESPONSE_HEADERS_CHECK
+  [ConfigKey.RESPONSE_BODY_INDEX]: getHTTPNormalizer(ConfigKey.RESPONSE_BODY_INDEX),
+  [ConfigKey.RESPONSE_HEADERS_CHECK]: getHTTPJsonToJavascriptNormalizer(
+    ConfigKey.RESPONSE_HEADERS_CHECK
   ),
-  [ConfigKeys.RESPONSE_HEADERS_INDEX]: getHTTPNormalizer(ConfigKeys.RESPONSE_HEADERS_INDEX),
-  [ConfigKeys.RESPONSE_STATUS_CHECK]: getHTTPJsonToJavascriptNormalizer(
-    ConfigKeys.RESPONSE_STATUS_CHECK
+  [ConfigKey.RESPONSE_HEADERS_INDEX]: getHTTPNormalizer(ConfigKey.RESPONSE_HEADERS_INDEX),
+  [ConfigKey.RESPONSE_STATUS_CHECK]: getHTTPJsonToJavascriptNormalizer(
+    ConfigKey.RESPONSE_STATUS_CHECK
   ),
-  [ConfigKeys.REQUEST_BODY_CHECK]: (fields) => {
-    const requestBody = fields?.[ConfigKeys.REQUEST_BODY_CHECK]?.value;
-    const requestHeaders = fields?.[ConfigKeys.REQUEST_HEADERS_CHECK]?.value;
+  [ConfigKey.REQUEST_BODY_CHECK]: (fields) => {
+    const requestBody = fields?.[ConfigKey.REQUEST_BODY_CHECK]?.value;
+    const requestHeaders = fields?.[ConfigKey.REQUEST_HEADERS_CHECK]?.value;
     if (requestBody) {
       const headers = requestHeaders
-        ? JSON.parse(fields?.[ConfigKeys.REQUEST_HEADERS_CHECK]?.value)
-        : defaultHTTPAdvancedFields[ConfigKeys.REQUEST_HEADERS_CHECK];
+        ? JSON.parse(fields?.[ConfigKey.REQUEST_HEADERS_CHECK]?.value)
+        : defaultHTTPAdvancedFields[ConfigKey.REQUEST_HEADERS_CHECK];
       const requestBodyValue =
         requestBody !== null && requestBody !== undefined
           ? JSON.parse(requestBody)
-          : defaultHTTPAdvancedFields[ConfigKeys.REQUEST_BODY_CHECK]?.value;
-      let requestBodyType = defaultHTTPAdvancedFields[ConfigKeys.REQUEST_BODY_CHECK]?.type;
+          : defaultHTTPAdvancedFields[ConfigKey.REQUEST_BODY_CHECK]?.value;
+      let requestBodyType = defaultHTTPAdvancedFields[ConfigKey.REQUEST_BODY_CHECK]?.type;
       Object.keys(headers || []).some((headerKey) => {
         if (headerKey === 'Content-Type' && contentTypesToMode[headers[headerKey] as ContentType]) {
           requestBodyType = contentTypesToMode[headers[headerKey] as ContentType];
@@ -74,13 +74,13 @@ export const httpNormalizers: HTTPNormalizerMap = {
         type: requestBodyType,
       };
     } else {
-      return defaultHTTPAdvancedFields[ConfigKeys.REQUEST_BODY_CHECK];
+      return defaultHTTPAdvancedFields[ConfigKey.REQUEST_BODY_CHECK];
     }
   },
-  [ConfigKeys.REQUEST_HEADERS_CHECK]: getHTTPJsonToJavascriptNormalizer(
-    ConfigKeys.REQUEST_HEADERS_CHECK
+  [ConfigKey.REQUEST_HEADERS_CHECK]: getHTTPJsonToJavascriptNormalizer(
+    ConfigKey.REQUEST_HEADERS_CHECK
   ),
-  [ConfigKeys.REQUEST_METHOD_CHECK]: getHTTPNormalizer(ConfigKeys.REQUEST_METHOD_CHECK),
+  [ConfigKey.REQUEST_METHOD_CHECK]: getHTTPNormalizer(ConfigKey.REQUEST_METHOD_CHECK),
   ...commonNormalizers,
   ...tlsNormalizers,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/http/simple_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/http/simple_fields.tsx
@@ -8,7 +8,7 @@
 import React, { memo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiFormRow, EuiFieldText, EuiFieldNumber } from '@elastic/eui';
-import { ConfigKeys, Validation } from '../types';
+import { ConfigKey, Validation } from '../types';
 import { useHTTPSimpleFieldsContext } from '../contexts';
 import { OptionalLabel } from '../optional_label';
 import { ScheduleField } from '../schedule_field';
@@ -20,7 +20,7 @@ interface Props {
 
 export const HTTPSimpleFields = memo<Props>(({ validate }) => {
   const { fields, setFields } = useHTTPSimpleFieldsContext();
-  const handleInputChange = ({ value, configKey }: { value: unknown; configKey: ConfigKeys }) => {
+  const handleInputChange = ({ value, configKey }: { value: unknown; configKey: ConfigKey }) => {
     setFields((prevFields) => ({ ...prevFields, [configKey]: value }));
   };
 
@@ -33,7 +33,7 @@ export const HTTPSimpleFields = memo<Props>(({ validate }) => {
             defaultMessage="URL"
           />
         }
-        isInvalid={!!validate[ConfigKeys.URLS]?.(fields)}
+        isInvalid={!!validate[ConfigKey.URLS]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.URL.error"
@@ -42,9 +42,9 @@ export const HTTPSimpleFields = memo<Props>(({ validate }) => {
         }
       >
         <EuiFieldText
-          value={fields[ConfigKeys.URLS]}
+          value={fields[ConfigKey.URLS]}
           onChange={(event) =>
-            handleInputChange({ value: event.target.value, configKey: ConfigKeys.URLS })
+            handleInputChange({ value: event.target.value, configKey: ConfigKey.URLS })
           }
           data-test-subj="syntheticsUrlField"
         />
@@ -57,7 +57,7 @@ export const HTTPSimpleFields = memo<Props>(({ validate }) => {
             defaultMessage="Monitor interval"
           />
         }
-        isInvalid={!!validate[ConfigKeys.SCHEDULE]?.(fields)}
+        isInvalid={!!validate[ConfigKey.SCHEDULE]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.monitorInterval.error"
@@ -69,11 +69,11 @@ export const HTTPSimpleFields = memo<Props>(({ validate }) => {
           onChange={(schedule) =>
             handleInputChange({
               value: schedule,
-              configKey: ConfigKeys.SCHEDULE,
+              configKey: ConfigKey.SCHEDULE,
             })
           }
-          number={fields[ConfigKeys.SCHEDULE].number}
-          unit={fields[ConfigKeys.SCHEDULE].unit}
+          number={fields[ConfigKey.SCHEDULE].number}
+          unit={fields[ConfigKey.SCHEDULE].unit}
         />
       </EuiFormRow>
       <EuiFormRow
@@ -83,7 +83,7 @@ export const HTTPSimpleFields = memo<Props>(({ validate }) => {
             defaultMessage="Max redirects"
           />
         }
-        isInvalid={!!validate[ConfigKeys.MAX_REDIRECTS]?.(fields)}
+        isInvalid={!!validate[ConfigKey.MAX_REDIRECTS]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.maxRedirects.error"
@@ -100,11 +100,11 @@ export const HTTPSimpleFields = memo<Props>(({ validate }) => {
       >
         <EuiFieldNumber
           min={0}
-          value={fields[ConfigKeys.MAX_REDIRECTS]}
+          value={fields[ConfigKey.MAX_REDIRECTS]}
           onChange={(event) =>
             handleInputChange({
               value: event.target.value,
-              configKey: ConfigKeys.MAX_REDIRECTS,
+              configKey: ConfigKey.MAX_REDIRECTS,
             })
           }
         />

--- a/x-pack/plugins/uptime/public/components/fleet_package/icmp/formatters.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/icmp/formatters.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { ICMPFields, ConfigKeys } from '../types';
+import { ICMPFields, ConfigKey } from '../types';
 import { Formatter, commonFormatters, secondsToCronFormatter } from '../common/formatters';
 
 export type ICMPFormatMap = Record<keyof ICMPFields, Formatter>;
 
 export const icmpFormatters: ICMPFormatMap = {
-  [ConfigKeys.HOSTS]: null,
-  [ConfigKeys.WAIT]: (fields) => secondsToCronFormatter(fields[ConfigKeys.WAIT]),
+  [ConfigKey.HOSTS]: null,
+  [ConfigKey.WAIT]: (fields) => secondsToCronFormatter(fields[ConfigKey.WAIT]),
   ...commonFormatters,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/icmp/normalizers.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/icmp/normalizers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ICMPFields, ConfigKeys } from '../types';
+import { ICMPFields, ConfigKey } from '../types';
 import {
   Normalizer,
   commonNormalizers,
@@ -16,16 +16,16 @@ import { defaultICMPSimpleFields } from '../contexts';
 
 export type ICMPNormalizerMap = Record<keyof ICMPFields, Normalizer>;
 
-export const getICMPNormalizer = (key: ConfigKeys) => {
+export const getICMPNormalizer = (key: ConfigKey) => {
   return getNormalizer(key, defaultICMPSimpleFields);
 };
 
-export const getICMPCronToSecondsNormalizer = (key: ConfigKeys) => {
+export const getICMPCronToSecondsNormalizer = (key: ConfigKey) => {
   return getCronNormalizer(key, defaultICMPSimpleFields);
 };
 
 export const icmpNormalizers: ICMPNormalizerMap = {
-  [ConfigKeys.HOSTS]: getICMPNormalizer(ConfigKeys.HOSTS),
-  [ConfigKeys.WAIT]: getICMPCronToSecondsNormalizer(ConfigKeys.WAIT),
+  [ConfigKey.HOSTS]: getICMPNormalizer(ConfigKey.HOSTS),
+  [ConfigKey.WAIT]: getICMPCronToSecondsNormalizer(ConfigKey.WAIT),
   ...commonNormalizers,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/icmp/simple_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/icmp/simple_fields.tsx
@@ -8,7 +8,7 @@
 import React, { memo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiFormRow, EuiFieldText, EuiFieldNumber } from '@elastic/eui';
-import { ConfigKeys, Validation } from '../types';
+import { ConfigKey, Validation } from '../types';
 import { useICMPSimpleFieldsContext } from '../contexts';
 import { OptionalLabel } from '../optional_label';
 import { ScheduleField } from '../schedule_field';
@@ -20,7 +20,7 @@ interface Props {
 
 export const ICMPSimpleFields = memo<Props>(({ validate }) => {
   const { fields, setFields } = useICMPSimpleFieldsContext();
-  const handleInputChange = ({ value, configKey }: { value: unknown; configKey: ConfigKeys }) => {
+  const handleInputChange = ({ value, configKey }: { value: unknown; configKey: ConfigKey }) => {
     setFields((prevFields) => ({ ...prevFields, [configKey]: value }));
   };
 
@@ -33,7 +33,7 @@ export const ICMPSimpleFields = memo<Props>(({ validate }) => {
             defaultMessage="Host"
           />
         }
-        isInvalid={!!validate[ConfigKeys.HOSTS]?.(fields)}
+        isInvalid={!!validate[ConfigKey.HOSTS]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.icmp.hosts.error"
@@ -42,11 +42,11 @@ export const ICMPSimpleFields = memo<Props>(({ validate }) => {
         }
       >
         <EuiFieldText
-          value={fields[ConfigKeys.HOSTS]}
+          value={fields[ConfigKey.HOSTS]}
           onChange={(event) =>
             handleInputChange({
               value: event.target.value,
-              configKey: ConfigKeys.HOSTS,
+              configKey: ConfigKey.HOSTS,
             })
           }
           data-test-subj="syntheticsICMPHostField"
@@ -60,7 +60,7 @@ export const ICMPSimpleFields = memo<Props>(({ validate }) => {
             defaultMessage="Monitor interval"
           />
         }
-        isInvalid={!!validate[ConfigKeys.SCHEDULE]?.(fields)}
+        isInvalid={!!validate[ConfigKey.SCHEDULE]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.monitorInterval.error"
@@ -72,11 +72,11 @@ export const ICMPSimpleFields = memo<Props>(({ validate }) => {
           onChange={(schedule) =>
             handleInputChange({
               value: schedule,
-              configKey: ConfigKeys.SCHEDULE,
+              configKey: ConfigKey.SCHEDULE,
             })
           }
-          number={fields[ConfigKeys.SCHEDULE].number}
-          unit={fields[ConfigKeys.SCHEDULE].unit}
+          number={fields[ConfigKey.SCHEDULE].number}
+          unit={fields[ConfigKey.SCHEDULE].unit}
         />
       </EuiFormRow>
       <EuiFormRow
@@ -86,7 +86,7 @@ export const ICMPSimpleFields = memo<Props>(({ validate }) => {
             defaultMessage="Wait in seconds"
           />
         }
-        isInvalid={!!validate[ConfigKeys.WAIT]?.(fields)}
+        isInvalid={!!validate[ConfigKey.WAIT]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.wait.error"
@@ -103,11 +103,11 @@ export const ICMPSimpleFields = memo<Props>(({ validate }) => {
       >
         <EuiFieldNumber
           min={0}
-          value={fields[ConfigKeys.WAIT]}
+          value={fields[ConfigKey.WAIT]}
           onChange={(event) =>
             handleInputChange({
               value: event.target.value,
-              configKey: ConfigKeys.WAIT,
+              configKey: ConfigKey.WAIT,
             })
           }
           step={'any'}

--- a/x-pack/plugins/uptime/public/components/fleet_package/schedule_field.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/schedule_field.tsx
@@ -9,11 +9,11 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 
 import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiSelect } from '@elastic/eui';
-import { ConfigKeys, ICustomFields, ScheduleUnit } from './types';
+import { ConfigKey, MonitorFields, ScheduleUnit } from './types';
 
 interface Props {
   number: string;
-  onChange: (schedule: ICustomFields[ConfigKeys.SCHEDULE]) => void;
+  onChange: (schedule: MonitorFields[ConfigKey.SCHEDULE]) => void;
   unit: ScheduleUnit;
 }
 

--- a/x-pack/plugins/uptime/public/components/fleet_package/synthetics_policy_create_extension.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/synthetics_policy_create_extension.tsx
@@ -8,7 +8,8 @@
 import React, { memo, useEffect, useMemo } from 'react';
 import { PackagePolicyCreateExtensionComponentProps } from '../../../../fleet/public';
 import { useTrackPageview } from '../../../../observability/public';
-import { PolicyConfig, DataStream } from './types';
+import { DataStream } from './types';
+import { PolicyConfig } from './types';
 import {
   usePolicyConfigContext,
   defaultHTTPSimpleFields,

--- a/x-pack/plugins/uptime/public/components/fleet_package/synthetics_policy_create_extension_wrapper.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/synthetics_policy_create_extension_wrapper.test.tsx
@@ -13,7 +13,7 @@ import { render } from '../../lib/helper/rtl_helpers';
 import { NewPackagePolicy } from '../../../../fleet/public';
 import { SyntheticsPolicyCreateExtensionWrapper } from './synthetics_policy_create_extension_wrapper';
 import { defaultConfig } from './synthetics_policy_create_extension';
-import { ConfigKeys, DataStream, ScheduleUnit, VerificationMode } from './types';
+import { ConfigKey, DataStream, ScheduleUnit, VerificationMode } from './types';
 
 // ensures that fields appropriately match to their label
 jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => ({
@@ -351,19 +351,19 @@ describe('<SyntheticsPolicyCreateExtension />', () => {
     expect(monitorType).toBeInTheDocument();
     expect(monitorType.value).toEqual(DataStream.HTTP);
     expect(url).toBeInTheDocument();
-    expect(url.value).toEqual(defaultHTTPConfig[ConfigKeys.URLS]);
+    expect(url.value).toEqual(defaultHTTPConfig[ConfigKey.URLS]);
     expect(proxyUrl).toBeInTheDocument();
-    expect(proxyUrl.value).toEqual(defaultHTTPConfig[ConfigKeys.PROXY_URL]);
+    expect(proxyUrl.value).toEqual(defaultHTTPConfig[ConfigKey.PROXY_URL]);
     expect(monitorIntervalNumber).toBeInTheDocument();
-    expect(monitorIntervalNumber.value).toEqual(defaultHTTPConfig[ConfigKeys.SCHEDULE].number);
+    expect(monitorIntervalNumber.value).toEqual(defaultHTTPConfig[ConfigKey.SCHEDULE].number);
     expect(monitorIntervalUnit).toBeInTheDocument();
-    expect(monitorIntervalUnit.value).toEqual(defaultHTTPConfig[ConfigKeys.SCHEDULE].unit);
+    expect(monitorIntervalUnit.value).toEqual(defaultHTTPConfig[ConfigKey.SCHEDULE].unit);
     expect(apmServiceName).toBeInTheDocument();
-    expect(apmServiceName.value).toEqual(defaultHTTPConfig[ConfigKeys.APM_SERVICE_NAME]);
+    expect(apmServiceName.value).toEqual(defaultHTTPConfig[ConfigKey.APM_SERVICE_NAME]);
     expect(maxRedirects).toBeInTheDocument();
-    expect(maxRedirects.value).toEqual(`${defaultHTTPConfig[ConfigKeys.MAX_REDIRECTS]}`);
+    expect(maxRedirects.value).toEqual(`${defaultHTTPConfig[ConfigKey.MAX_REDIRECTS]}`);
     expect(timeout).toBeInTheDocument();
-    expect(timeout.value).toEqual(`${defaultHTTPConfig[ConfigKeys.TIMEOUT]}`);
+    expect(timeout.value).toEqual(`${defaultHTTPConfig[ConfigKey.TIMEOUT]}`);
 
     // ensure other monitor type options are not in the DOM
     expect(queryByLabelText('Host')).not.toBeInTheDocument();
@@ -521,7 +521,7 @@ describe('<SyntheticsPolicyCreateExtension />', () => {
     const host = getByLabelText('Host:Port') as HTMLInputElement;
 
     expect(host).toBeInTheDocument();
-    expect(host.value).toEqual(defaultTCPConfig[ConfigKeys.HOSTS]);
+    expect(host.value).toEqual(defaultTCPConfig[ConfigKey.HOSTS]);
 
     // expect HTTP fields not to be in the DOM
     expect(queryByLabelText('URL')).not.toBeInTheDocument();
@@ -767,23 +767,23 @@ describe('<SyntheticsPolicyCreateExtension />', () => {
 
     await waitFor(() => {
       fireEvent.change(ca, { target: { value: 'certificateAuthorities' } });
-      expect(ca.value).toEqual(defaultHTTPConfig[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]);
+      expect(ca.value).toEqual(defaultHTTPConfig[ConfigKey.TLS_CERTIFICATE_AUTHORITIES]);
     });
     await waitFor(() => {
       fireEvent.change(clientCertificate, { target: { value: 'clientCertificate' } });
-      expect(clientCertificate.value).toEqual(defaultHTTPConfig[ConfigKeys.TLS_KEY]);
+      expect(clientCertificate.value).toEqual(defaultHTTPConfig[ConfigKey.TLS_KEY]);
     });
     await waitFor(() => {
       fireEvent.change(clientKey, { target: { value: 'clientKey' } });
-      expect(clientKey.value).toEqual(defaultHTTPConfig[ConfigKeys.TLS_KEY]);
+      expect(clientKey.value).toEqual(defaultHTTPConfig[ConfigKey.TLS_KEY]);
     });
     await waitFor(() => {
       fireEvent.change(clientKeyPassphrase, { target: { value: 'clientKeyPassphrase' } });
-      expect(clientKeyPassphrase.value).toEqual(defaultHTTPConfig[ConfigKeys.TLS_KEY_PASSPHRASE]);
+      expect(clientKeyPassphrase.value).toEqual(defaultHTTPConfig[ConfigKey.TLS_KEY_PASSPHRASE]);
     });
     await waitFor(() => {
       fireEvent.change(verificationMode, { target: { value: VerificationMode.NONE } });
-      expect(verificationMode.value).toEqual(defaultHTTPConfig[ConfigKeys.TLS_VERIFICATION_MODE]);
+      expect(verificationMode.value).toEqual(defaultHTTPConfig[ConfigKey.TLS_VERIFICATION_MODE]);
     });
 
     await waitFor(() => {
@@ -799,23 +799,23 @@ describe('<SyntheticsPolicyCreateExtension />', () => {
                   ...defaultNewPolicy.inputs[0].streams[0],
                   vars: {
                     ...defaultNewPolicy.inputs[0].streams[0].vars,
-                    [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]: {
+                    [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: {
                       value: '"certificateAuthorities"',
                       type: 'yaml',
                     },
-                    [ConfigKeys.TLS_CERTIFICATE]: {
+                    [ConfigKey.TLS_CERTIFICATE]: {
                       value: '"clientCertificate"',
                       type: 'yaml',
                     },
-                    [ConfigKeys.TLS_KEY]: {
+                    [ConfigKey.TLS_KEY]: {
                       value: '"clientKey"',
                       type: 'yaml',
                     },
-                    [ConfigKeys.TLS_KEY_PASSPHRASE]: {
+                    [ConfigKey.TLS_KEY_PASSPHRASE]: {
                       value: 'clientKeyPassphrase',
                       type: 'text',
                     },
-                    [ConfigKeys.TLS_VERIFICATION_MODE]: {
+                    [ConfigKey.TLS_VERIFICATION_MODE]: {
                       value: VerificationMode.NONE,
                       type: 'text',
                     },

--- a/x-pack/plugins/uptime/public/components/fleet_package/synthetics_policy_edit_extension.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/synthetics_policy_edit_extension.tsx
@@ -9,7 +9,7 @@ import React, { memo } from 'react';
 import { PackagePolicyEditExtensionComponentProps } from '../../../../fleet/public';
 import { useTrackPageview } from '../../../../observability/public';
 import { usePolicyConfigContext } from './contexts';
-import { ICustomFields, PolicyConfig } from './types';
+import { MonitorFields, PolicyConfig } from './types';
 import { CustomFields } from './custom_fields';
 import { useUpdatePolicy } from './hooks/use_update_policy';
 import { usePolicy } from './hooks/use_policy';
@@ -18,7 +18,7 @@ import { validate } from './validation';
 interface SyntheticsPolicyEditExtensionProps {
   newPolicy: PackagePolicyEditExtensionComponentProps['newPolicy'];
   onChange: PackagePolicyEditExtensionComponentProps['onChange'];
-  defaultConfig: Partial<ICustomFields>;
+  defaultConfig: Partial<MonitorFields>;
 }
 
 /**

--- a/x-pack/plugins/uptime/public/components/fleet_package/synthetics_policy_edit_extension_wrapper.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/synthetics_policy_edit_extension_wrapper.test.tsx
@@ -12,7 +12,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { render } from '../../lib/helper/rtl_helpers';
 import { NewPackagePolicy } from '../../../../fleet/public';
 import { SyntheticsPolicyEditExtensionWrapper } from './synthetics_policy_edit_extension_wrapper';
-import { ConfigKeys, DataStream, ScheduleUnit } from './types';
+import { ConfigKey, DataStream, ScheduleUnit } from './types';
 import { defaultConfig } from './synthetics_policy_create_extension';
 
 // ensures that fields appropriately match to their label
@@ -370,25 +370,23 @@ describe('<SyntheticsPolicyEditExtension />', () => {
     const verificationMode = getByLabelText('Verification mode') as HTMLInputElement;
     const enableTLSConfig = getByLabelText('Enable TLS configuration') as HTMLInputElement;
     expect(url).toBeInTheDocument();
-    expect(url.value).toEqual(defaultHTTPConfig[ConfigKeys.URLS]);
+    expect(url.value).toEqual(defaultHTTPConfig[ConfigKey.URLS]);
     expect(proxyUrl).toBeInTheDocument();
-    expect(proxyUrl.value).toEqual(defaultHTTPConfig[ConfigKeys.PROXY_URL]);
+    expect(proxyUrl.value).toEqual(defaultHTTPConfig[ConfigKey.PROXY_URL]);
     expect(monitorIntervalNumber).toBeInTheDocument();
-    expect(monitorIntervalNumber.value).toEqual(defaultHTTPConfig[ConfigKeys.SCHEDULE].number);
+    expect(monitorIntervalNumber.value).toEqual(defaultHTTPConfig[ConfigKey.SCHEDULE].number);
     expect(monitorIntervalUnit).toBeInTheDocument();
-    expect(monitorIntervalUnit.value).toEqual(defaultHTTPConfig[ConfigKeys.SCHEDULE].unit);
+    expect(monitorIntervalUnit.value).toEqual(defaultHTTPConfig[ConfigKey.SCHEDULE].unit);
     expect(apmServiceName).toBeInTheDocument();
-    expect(apmServiceName.value).toEqual(defaultHTTPConfig[ConfigKeys.APM_SERVICE_NAME]);
+    expect(apmServiceName.value).toEqual(defaultHTTPConfig[ConfigKey.APM_SERVICE_NAME]);
     expect(maxRedirects).toBeInTheDocument();
-    expect(maxRedirects.value).toEqual(`${defaultHTTPConfig[ConfigKeys.MAX_REDIRECTS]}`);
+    expect(maxRedirects.value).toEqual(`${defaultHTTPConfig[ConfigKey.MAX_REDIRECTS]}`);
     expect(timeout).toBeInTheDocument();
-    expect(timeout.value).toEqual(`${defaultHTTPConfig[ConfigKeys.TIMEOUT]}`);
+    expect(timeout.value).toEqual(`${defaultHTTPConfig[ConfigKey.TIMEOUT]}`);
     // expect TLS settings to be in the document when at least one tls key is populated
     expect(enableTLSConfig.getAttribute('aria-checked')).toEqual('true');
     expect(verificationMode).toBeInTheDocument();
-    expect(verificationMode.value).toEqual(
-      `${defaultHTTPConfig[ConfigKeys.TLS_VERIFICATION_MODE]}`
-    );
+    expect(verificationMode.value).toEqual(`${defaultHTTPConfig[ConfigKey.TLS_VERIFICATION_MODE]}`);
 
     // ensure other monitor type options are not in the DOM
     expect(queryByLabelText('Host')).not.toBeInTheDocument();
@@ -606,7 +604,7 @@ describe('<SyntheticsPolicyEditExtension />', () => {
       expect(enableTLSConfig.getAttribute('aria-checked')).toEqual('true');
       expect(verificationMode).toBeInTheDocument();
       expect(verificationMode.value).toEqual(
-        `${defaultHTTPConfig[ConfigKeys.TLS_VERIFICATION_MODE]}`
+        `${defaultHTTPConfig[ConfigKey.TLS_VERIFICATION_MODE]}`
       );
     }
   );
@@ -839,7 +837,7 @@ describe('<SyntheticsPolicyEditExtension />', () => {
                   };
                   return acc;
                 }, {}),
-                [ConfigKeys.MONITOR_TYPE]: {
+                [ConfigKey.MONITOR_TYPE]: {
                   value: 'http',
                   type: 'text',
                 },
@@ -865,19 +863,19 @@ describe('<SyntheticsPolicyEditExtension />', () => {
     const enableTLSConfig = getByLabelText('Enable TLS configuration') as HTMLInputElement;
 
     expect(url).toBeInTheDocument();
-    expect(url.value).toEqual(defaultHTTPConfig[ConfigKeys.URLS]);
+    expect(url.value).toEqual(defaultHTTPConfig[ConfigKey.URLS]);
     expect(proxyUrl).toBeInTheDocument();
-    expect(proxyUrl.value).toEqual(defaultHTTPConfig[ConfigKeys.PROXY_URL]);
+    expect(proxyUrl.value).toEqual(defaultHTTPConfig[ConfigKey.PROXY_URL]);
     expect(monitorIntervalNumber).toBeInTheDocument();
-    expect(monitorIntervalNumber.value).toEqual(defaultHTTPConfig[ConfigKeys.SCHEDULE].number);
+    expect(monitorIntervalNumber.value).toEqual(defaultHTTPConfig[ConfigKey.SCHEDULE].number);
     expect(monitorIntervalUnit).toBeInTheDocument();
-    expect(monitorIntervalUnit.value).toEqual(defaultHTTPConfig[ConfigKeys.SCHEDULE].unit);
+    expect(monitorIntervalUnit.value).toEqual(defaultHTTPConfig[ConfigKey.SCHEDULE].unit);
     expect(apmServiceName).toBeInTheDocument();
-    expect(apmServiceName.value).toEqual(defaultHTTPConfig[ConfigKeys.APM_SERVICE_NAME]);
+    expect(apmServiceName.value).toEqual(defaultHTTPConfig[ConfigKey.APM_SERVICE_NAME]);
     expect(maxRedirects).toBeInTheDocument();
-    expect(maxRedirects.value).toEqual(`${defaultHTTPConfig[ConfigKeys.MAX_REDIRECTS]}`);
+    expect(maxRedirects.value).toEqual(`${defaultHTTPConfig[ConfigKey.MAX_REDIRECTS]}`);
     expect(timeout).toBeInTheDocument();
-    expect(timeout.value).toEqual(`${defaultHTTPConfig[ConfigKeys.TIMEOUT]}`);
+    expect(timeout.value).toEqual(`${defaultHTTPConfig[ConfigKey.TIMEOUT]}`);
 
     /* expect TLS settings not to be in the document when and Enable TLS settings not to be checked
      * when all TLS values are falsey */
@@ -894,7 +892,7 @@ describe('<SyntheticsPolicyEditExtension />', () => {
     await waitFor(() => {
       const requestMethod = getByLabelText('Request method') as HTMLInputElement;
       expect(requestMethod).toBeInTheDocument();
-      expect(requestMethod.value).toEqual(`${defaultHTTPConfig[ConfigKeys.REQUEST_METHOD_CHECK]}`);
+      expect(requestMethod.value).toEqual(`${defaultHTTPConfig[ConfigKey.REQUEST_METHOD_CHECK]}`);
     });
   });
 
@@ -923,7 +921,7 @@ describe('<SyntheticsPolicyEditExtension />', () => {
                   };
                   return acc;
                 }, {}),
-                [ConfigKeys.MONITOR_TYPE]: {
+                [ConfigKey.MONITOR_TYPE]: {
                   value: DataStream.TCP,
                   type: 'text',
                 },
@@ -944,17 +942,17 @@ describe('<SyntheticsPolicyEditExtension />', () => {
     const apmServiceName = getByLabelText('APM service name') as HTMLInputElement;
     const timeout = getByLabelText('Timeout in seconds') as HTMLInputElement;
     expect(host).toBeInTheDocument();
-    expect(host.value).toEqual(defaultTCPConfig[ConfigKeys.HOSTS]);
+    expect(host.value).toEqual(defaultTCPConfig[ConfigKey.HOSTS]);
     expect(proxyUrl).toBeInTheDocument();
-    expect(proxyUrl.value).toEqual(defaultTCPConfig[ConfigKeys.PROXY_URL]);
+    expect(proxyUrl.value).toEqual(defaultTCPConfig[ConfigKey.PROXY_URL]);
     expect(monitorIntervalNumber).toBeInTheDocument();
-    expect(monitorIntervalNumber.value).toEqual(defaultTCPConfig[ConfigKeys.SCHEDULE].number);
+    expect(monitorIntervalNumber.value).toEqual(defaultTCPConfig[ConfigKey.SCHEDULE].number);
     expect(monitorIntervalUnit).toBeInTheDocument();
-    expect(monitorIntervalUnit.value).toEqual(defaultTCPConfig[ConfigKeys.SCHEDULE].unit);
+    expect(monitorIntervalUnit.value).toEqual(defaultTCPConfig[ConfigKey.SCHEDULE].unit);
     expect(apmServiceName).toBeInTheDocument();
-    expect(apmServiceName.value).toEqual(defaultTCPConfig[ConfigKeys.APM_SERVICE_NAME]);
+    expect(apmServiceName.value).toEqual(defaultTCPConfig[ConfigKey.APM_SERVICE_NAME]);
     expect(timeout).toBeInTheDocument();
-    expect(timeout.value).toEqual(`${defaultTCPConfig[ConfigKeys.TIMEOUT]}`);
+    expect(timeout.value).toEqual(`${defaultTCPConfig[ConfigKey.TIMEOUT]}`);
 
     // ensure other monitor type options are not in the DOM
     expect(queryByLabelText('Url')).not.toBeInTheDocument();
@@ -997,7 +995,7 @@ describe('<SyntheticsPolicyEditExtension />', () => {
                   };
                   return acc;
                 }, {}),
-                [ConfigKeys.MONITOR_TYPE]: {
+                [ConfigKey.MONITOR_TYPE]: {
                   value: DataStream.ICMP,
                   type: 'text',
                 },
@@ -1017,17 +1015,17 @@ describe('<SyntheticsPolicyEditExtension />', () => {
     const timeout = getByLabelText('Timeout in seconds') as HTMLInputElement;
     const wait = getByLabelText('Wait in seconds') as HTMLInputElement;
     expect(host).toBeInTheDocument();
-    expect(host.value).toEqual(defaultICMPConfig[ConfigKeys.HOSTS]);
+    expect(host.value).toEqual(defaultICMPConfig[ConfigKey.HOSTS]);
     expect(monitorIntervalNumber).toBeInTheDocument();
-    expect(monitorIntervalNumber.value).toEqual(defaultICMPConfig[ConfigKeys.SCHEDULE].number);
+    expect(monitorIntervalNumber.value).toEqual(defaultICMPConfig[ConfigKey.SCHEDULE].number);
     expect(monitorIntervalUnit).toBeInTheDocument();
-    expect(monitorIntervalUnit.value).toEqual(defaultICMPConfig[ConfigKeys.SCHEDULE].unit);
+    expect(monitorIntervalUnit.value).toEqual(defaultICMPConfig[ConfigKey.SCHEDULE].unit);
     expect(apmServiceName).toBeInTheDocument();
-    expect(apmServiceName.value).toEqual(defaultICMPConfig[ConfigKeys.APM_SERVICE_NAME]);
+    expect(apmServiceName.value).toEqual(defaultICMPConfig[ConfigKey.APM_SERVICE_NAME]);
     expect(timeout).toBeInTheDocument();
-    expect(timeout.value).toEqual(`${defaultICMPConfig[ConfigKeys.TIMEOUT]}`);
+    expect(timeout.value).toEqual(`${defaultICMPConfig[ConfigKey.TIMEOUT]}`);
     expect(wait).toBeInTheDocument();
-    expect(wait.value).toEqual(`${defaultICMPConfig[ConfigKeys.WAIT]}`);
+    expect(wait.value).toEqual(`${defaultICMPConfig[ConfigKey.WAIT]}`);
 
     // ensure other monitor type options are not in the DOM
     expect(queryByLabelText('Url')).not.toBeInTheDocument();
@@ -1067,7 +1065,7 @@ describe('<SyntheticsPolicyEditExtension />', () => {
                   };
                   return acc;
                 }, {}),
-                [ConfigKeys.MONITOR_TYPE]: {
+                [ConfigKey.MONITOR_TYPE]: {
                   value: DataStream.BROWSER,
                   type: 'text',
                 },
@@ -1086,15 +1084,15 @@ describe('<SyntheticsPolicyEditExtension />', () => {
     const apmServiceName = getByLabelText('APM service name') as HTMLInputElement;
     const timeout = getByLabelText('Timeout in seconds') as HTMLInputElement;
     expect(zipUrl).toBeInTheDocument();
-    expect(zipUrl.value).toEqual(defaultBrowserConfig[ConfigKeys.SOURCE_ZIP_URL]);
+    expect(zipUrl.value).toEqual(defaultBrowserConfig[ConfigKey.SOURCE_ZIP_URL]);
     expect(monitorIntervalNumber).toBeInTheDocument();
-    expect(monitorIntervalNumber.value).toEqual(defaultBrowserConfig[ConfigKeys.SCHEDULE].number);
+    expect(monitorIntervalNumber.value).toEqual(defaultBrowserConfig[ConfigKey.SCHEDULE].number);
     expect(monitorIntervalUnit).toBeInTheDocument();
-    expect(monitorIntervalUnit.value).toEqual(defaultBrowserConfig[ConfigKeys.SCHEDULE].unit);
+    expect(monitorIntervalUnit.value).toEqual(defaultBrowserConfig[ConfigKey.SCHEDULE].unit);
     expect(apmServiceName).toBeInTheDocument();
-    expect(apmServiceName.value).toEqual(defaultBrowserConfig[ConfigKeys.APM_SERVICE_NAME]);
+    expect(apmServiceName.value).toEqual(defaultBrowserConfig[ConfigKey.APM_SERVICE_NAME]);
     expect(timeout).toBeInTheDocument();
-    expect(timeout.value).toEqual(`${defaultBrowserConfig[ConfigKeys.TIMEOUT]}`);
+    expect(timeout.value).toEqual(`${defaultBrowserConfig[ConfigKey.TIMEOUT]}`);
 
     // ensure other monitor type options are not in the DOM
     expect(queryByLabelText('Url')).not.toBeInTheDocument();

--- a/x-pack/plugins/uptime/public/components/fleet_package/synthetics_policy_edit_extension_wrapper.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/synthetics_policy_edit_extension_wrapper.tsx
@@ -7,7 +7,8 @@
 
 import React, { memo, useMemo } from 'react';
 import { PackagePolicyEditExtensionComponentProps } from '../../../../fleet/public';
-import { PolicyConfig, ConfigKeys, DataStream, ITLSFields, ICustomFields } from './types';
+import { PolicyConfig, MonitorFields } from './types';
+import { ConfigKey, DataStream, TLSFields } from '././types';
 import { SyntheticsPolicyEditExtension } from './synthetics_policy_edit_extension';
 import {
   PolicyConfigContextProvider,
@@ -46,36 +47,36 @@ export const SyntheticsPolicyEditExtensionWrapper = memo<PackagePolicyEditExtens
           Object.values(DataStream).includes(stream.data_stream.dataset as DataStream)
         )?.vars;
 
-        const type: DataStream = vars?.[ConfigKeys.MONITOR_TYPE].value as DataStream;
+        const type: DataStream = vars?.[ConfigKey.MONITOR_TYPE].value as DataStream;
 
-        const configKeys: ConfigKeys[] = Object.values(ConfigKeys) || ([] as ConfigKeys[]);
-        const formattedDefaultConfigForMonitorType: ICustomFields =
-          configKeys.reduce<ICustomFields>((acc: ICustomFields, key: ConfigKeys) => {
+        const configKeys: ConfigKey[] = Object.values(ConfigKey) || ([] as ConfigKey[]);
+        const formattedDefaultConfigForMonitorType: MonitorFields =
+          configKeys.reduce<MonitorFields>((acc: MonitorFields, key: ConfigKey) => {
             return {
               ...acc,
               [key]: normalizers[key]?.(vars),
             };
-          }, {} as ICustomFields);
+          }, {} as MonitorFields);
 
-        const tlsConfig: ITLSFields = {
-          [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]:
-            formattedDefaultConfigForMonitorType[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES],
-          [ConfigKeys.TLS_CERTIFICATE]:
-            formattedDefaultConfigForMonitorType[ConfigKeys.TLS_CERTIFICATE],
-          [ConfigKeys.TLS_KEY]: formattedDefaultConfigForMonitorType[ConfigKeys.TLS_KEY],
-          [ConfigKeys.TLS_KEY_PASSPHRASE]:
-            formattedDefaultConfigForMonitorType[ConfigKeys.TLS_KEY_PASSPHRASE],
-          [ConfigKeys.TLS_VERIFICATION_MODE]:
-            formattedDefaultConfigForMonitorType[ConfigKeys.TLS_VERIFICATION_MODE],
-          [ConfigKeys.TLS_VERSION]: formattedDefaultConfigForMonitorType[ConfigKeys.TLS_VERSION],
+        const tlsConfig: TLSFields = {
+          [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]:
+            formattedDefaultConfigForMonitorType[ConfigKey.TLS_CERTIFICATE_AUTHORITIES],
+          [ConfigKey.TLS_CERTIFICATE]:
+            formattedDefaultConfigForMonitorType[ConfigKey.TLS_CERTIFICATE],
+          [ConfigKey.TLS_KEY]: formattedDefaultConfigForMonitorType[ConfigKey.TLS_KEY],
+          [ConfigKey.TLS_KEY_PASSPHRASE]:
+            formattedDefaultConfigForMonitorType[ConfigKey.TLS_KEY_PASSPHRASE],
+          [ConfigKey.TLS_VERIFICATION_MODE]:
+            formattedDefaultConfigForMonitorType[ConfigKey.TLS_VERIFICATION_MODE],
+          [ConfigKey.TLS_VERSION]: formattedDefaultConfigForMonitorType[ConfigKey.TLS_VERSION],
         };
 
         enableTLS =
-          formattedDefaultConfigForMonitorType[ConfigKeys.METADATA].is_tls_enabled ||
-          Boolean(vars?.[ConfigKeys.TLS_VERIFICATION_MODE]?.value);
+          formattedDefaultConfigForMonitorType[ConfigKey.METADATA].is_tls_enabled ||
+          Boolean(vars?.[ConfigKey.TLS_VERIFICATION_MODE]?.value);
         enableZipUrlTLS =
-          formattedDefaultConfigForMonitorType[ConfigKeys.METADATA].is_zip_url_tls_enabled ||
-          Boolean(vars?.[ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]?.value);
+          formattedDefaultConfigForMonitorType[ConfigKey.METADATA].is_zip_url_tls_enabled ||
+          Boolean(vars?.[ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]?.value);
 
         const formattedDefaultConfig: Partial<PolicyConfig> = {
           [type]: formattedDefaultConfigForMonitorType,

--- a/x-pack/plugins/uptime/public/components/fleet_package/tcp/advanced_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tcp/advanced_fields.test.tsx
@@ -13,7 +13,7 @@ import {
   TCPAdvancedFieldsContextProvider,
   defaultTCPAdvancedFields as defaultConfig,
 } from '../contexts';
-import { ConfigKeys, ITCPAdvancedFields } from '../types';
+import { ConfigKey, TCPAdvancedFields as TCPAdvancedFieldsType } from '../types';
 
 // ensures fields and labels map appropriately
 jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => ({
@@ -24,7 +24,7 @@ describe('<TCPAdvancedFields />', () => {
   const WrappedComponent = ({
     defaultValues = defaultConfig,
   }: {
-    defaultValues?: ITCPAdvancedFields;
+    defaultValues?: TCPAdvancedFieldsType;
   }) => {
     return (
       <TCPAdvancedFieldsContextProvider defaultValues={defaultValues}>
@@ -41,11 +41,11 @@ describe('<TCPAdvancedFields />', () => {
     // ComboBox has an issue with associating labels with the field
     const responseContains = getByLabelText('Check response contains') as HTMLInputElement;
     expect(requestPayload).toBeInTheDocument();
-    expect(requestPayload.value).toEqual(defaultConfig[ConfigKeys.REQUEST_SEND_CHECK]);
+    expect(requestPayload.value).toEqual(defaultConfig[ConfigKey.REQUEST_SEND_CHECK]);
     expect(proxyURL).toBeInTheDocument();
-    expect(proxyURL.value).toEqual(defaultConfig[ConfigKeys.PROXY_URL]);
+    expect(proxyURL.value).toEqual(defaultConfig[ConfigKey.PROXY_URL]);
     expect(responseContains).toBeInTheDocument();
-    expect(responseContains.value).toEqual(defaultConfig[ConfigKeys.RESPONSE_RECEIVE_CHECK]);
+    expect(responseContains.value).toEqual(defaultConfig[ConfigKey.RESPONSE_RECEIVE_CHECK]);
   });
 
   it('handles changing fields', () => {

--- a/x-pack/plugins/uptime/public/components/fleet_package/tcp/advanced_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tcp/advanced_fields.tsx
@@ -18,7 +18,7 @@ import {
 
 import { useTCPAdvancedFieldsContext } from '../contexts';
 
-import { ConfigKeys } from '../types';
+import { ConfigKey } from '../types';
 
 import { OptionalLabel } from '../optional_label';
 
@@ -26,7 +26,7 @@ export const TCPAdvancedFields = () => {
   const { fields, setFields } = useTCPAdvancedFieldsContext();
 
   const handleInputChange = useCallback(
-    ({ value, configKey }: { value: unknown; configKey: ConfigKeys }) => {
+    ({ value, configKey }: { value: unknown; configKey: ConfigKey }) => {
       setFields((prevFields) => ({ ...prevFields, [configKey]: value }));
     },
     [setFields]
@@ -72,21 +72,21 @@ export const TCPAdvancedFields = () => {
           }
         >
           <EuiFieldText
-            value={fields[ConfigKeys.PROXY_URL]}
+            value={fields[ConfigKey.PROXY_URL]}
             onChange={(event) =>
               handleInputChange({
                 value: event.target.value,
-                configKey: ConfigKeys.PROXY_URL,
+                configKey: ConfigKey.PROXY_URL,
               })
             }
             data-test-subj="syntheticsProxyUrl"
           />
         </EuiFormRow>
-        {!!fields[ConfigKeys.PROXY_URL] && (
+        {!!fields[ConfigKey.PROXY_URL] && (
           <EuiFormRow data-test-subj="syntheticsUseLocalResolver">
             <EuiCheckbox
               id={'uptimeFleetUseLocalResolverCheckbox'}
-              checked={fields[ConfigKeys.PROXY_USE_LOCAL_RESOLVER]}
+              checked={fields[ConfigKey.PROXY_USE_LOCAL_RESOLVER]}
               label={
                 <FormattedMessage
                   id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.resolveHostnamesLocally"
@@ -96,7 +96,7 @@ export const TCPAdvancedFields = () => {
               onChange={(event) =>
                 handleInputChange({
                   value: event.target.checked,
-                  configKey: ConfigKeys.PROXY_USE_LOCAL_RESOLVER,
+                  configKey: ConfigKey.PROXY_USE_LOCAL_RESOLVER,
                 })
               }
             />
@@ -118,12 +118,12 @@ export const TCPAdvancedFields = () => {
           }
         >
           <EuiFieldText
-            value={fields[ConfigKeys.REQUEST_SEND_CHECK]}
+            value={fields[ConfigKey.REQUEST_SEND_CHECK]}
             onChange={useCallback(
               (event) =>
                 handleInputChange({
                   value: event.target.value,
-                  configKey: ConfigKeys.REQUEST_SEND_CHECK,
+                  configKey: ConfigKey.REQUEST_SEND_CHECK,
                 }),
               [handleInputChange]
             )}
@@ -163,12 +163,12 @@ export const TCPAdvancedFields = () => {
           }
         >
           <EuiFieldText
-            value={fields[ConfigKeys.RESPONSE_RECEIVE_CHECK]}
+            value={fields[ConfigKey.RESPONSE_RECEIVE_CHECK]}
             onChange={useCallback(
               (event) =>
                 handleInputChange({
                   value: event.target.value,
-                  configKey: ConfigKeys.RESPONSE_RECEIVE_CHECK,
+                  configKey: ConfigKey.RESPONSE_RECEIVE_CHECK,
                 }),
               [handleInputChange]
             )}

--- a/x-pack/plugins/uptime/public/components/fleet_package/tcp/formatters.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tcp/formatters.ts
@@ -5,19 +5,19 @@
  * 2.0.
  */
 
-import { TCPFields, ConfigKeys } from '../types';
+import { TCPFields, ConfigKey } from '../types';
 import { Formatter, commonFormatters, objectToJsonFormatter } from '../common/formatters';
 import { tlsFormatters } from '../tls/formatters';
 
 export type TCPFormatMap = Record<keyof TCPFields, Formatter>;
 
 export const tcpFormatters: TCPFormatMap = {
-  [ConfigKeys.METADATA]: (fields) => objectToJsonFormatter(fields[ConfigKeys.METADATA]),
-  [ConfigKeys.HOSTS]: null,
-  [ConfigKeys.PROXY_URL]: null,
-  [ConfigKeys.PROXY_USE_LOCAL_RESOLVER]: null,
-  [ConfigKeys.RESPONSE_RECEIVE_CHECK]: null,
-  [ConfigKeys.REQUEST_SEND_CHECK]: null,
+  [ConfigKey.METADATA]: (fields) => objectToJsonFormatter(fields[ConfigKey.METADATA]),
+  [ConfigKey.HOSTS]: null,
+  [ConfigKey.PROXY_URL]: null,
+  [ConfigKey.PROXY_USE_LOCAL_RESOLVER]: null,
+  [ConfigKey.RESPONSE_RECEIVE_CHECK]: null,
+  [ConfigKey.REQUEST_SEND_CHECK]: null,
   ...tlsFormatters,
   ...commonFormatters,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/tcp/normalizers.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tcp/normalizers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { TCPFields, ConfigKeys } from '../types';
+import { TCPFields, ConfigKey } from '../types';
 import {
   Normalizer,
   commonNormalizers,
@@ -22,21 +22,21 @@ const defaultTCPFields = {
 
 export type TCPNormalizerMap = Record<keyof TCPFields, Normalizer>;
 
-export const getTCPNormalizer = (key: ConfigKeys) => {
+export const getTCPNormalizer = (key: ConfigKey) => {
   return getNormalizer(key, defaultTCPFields);
 };
 
-export const getTCPJsonToJavascriptNormalizer = (key: ConfigKeys) => {
+export const getTCPJsonToJavascriptNormalizer = (key: ConfigKey) => {
   return getJsonToJavascriptNormalizer(key, defaultTCPFields);
 };
 
 export const tcpNormalizers: TCPNormalizerMap = {
-  [ConfigKeys.METADATA]: getTCPJsonToJavascriptNormalizer(ConfigKeys.METADATA),
-  [ConfigKeys.HOSTS]: getTCPNormalizer(ConfigKeys.HOSTS),
-  [ConfigKeys.PROXY_URL]: getTCPNormalizer(ConfigKeys.PROXY_URL),
-  [ConfigKeys.PROXY_USE_LOCAL_RESOLVER]: getTCPNormalizer(ConfigKeys.PROXY_USE_LOCAL_RESOLVER),
-  [ConfigKeys.RESPONSE_RECEIVE_CHECK]: getTCPNormalizer(ConfigKeys.RESPONSE_RECEIVE_CHECK),
-  [ConfigKeys.REQUEST_SEND_CHECK]: getTCPNormalizer(ConfigKeys.REQUEST_SEND_CHECK),
+  [ConfigKey.METADATA]: getTCPJsonToJavascriptNormalizer(ConfigKey.METADATA),
+  [ConfigKey.HOSTS]: getTCPNormalizer(ConfigKey.HOSTS),
+  [ConfigKey.PROXY_URL]: getTCPNormalizer(ConfigKey.PROXY_URL),
+  [ConfigKey.PROXY_USE_LOCAL_RESOLVER]: getTCPNormalizer(ConfigKey.PROXY_USE_LOCAL_RESOLVER),
+  [ConfigKey.RESPONSE_RECEIVE_CHECK]: getTCPNormalizer(ConfigKey.RESPONSE_RECEIVE_CHECK),
+  [ConfigKey.REQUEST_SEND_CHECK]: getTCPNormalizer(ConfigKey.REQUEST_SEND_CHECK),
   ...tlsNormalizers,
   ...commonNormalizers,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/tcp/simple_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tcp/simple_fields.tsx
@@ -8,7 +8,7 @@
 import React, { memo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiFormRow, EuiFieldText } from '@elastic/eui';
-import { ConfigKeys, Validation } from '../types';
+import { ConfigKey, Validation } from '../types';
 import { useTCPSimpleFieldsContext } from '../contexts';
 import { ScheduleField } from '../schedule_field';
 import { CommonFields } from '../common/common_fields';
@@ -19,7 +19,7 @@ interface Props {
 
 export const TCPSimpleFields = memo<Props>(({ validate }) => {
   const { fields, setFields } = useTCPSimpleFieldsContext();
-  const handleInputChange = ({ value, configKey }: { value: unknown; configKey: ConfigKeys }) => {
+  const handleInputChange = ({ value, configKey }: { value: unknown; configKey: ConfigKey }) => {
     setFields((prevFields) => ({ ...prevFields, [configKey]: value }));
   };
 
@@ -32,7 +32,7 @@ export const TCPSimpleFields = memo<Props>(({ validate }) => {
             defaultMessage="Host:Port"
           />
         }
-        isInvalid={!!validate[ConfigKeys.HOSTS]?.(fields)}
+        isInvalid={!!validate[ConfigKey.HOSTS]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.tcp.hosts.error"
@@ -41,11 +41,11 @@ export const TCPSimpleFields = memo<Props>(({ validate }) => {
         }
       >
         <EuiFieldText
-          value={fields[ConfigKeys.HOSTS]}
+          value={fields[ConfigKey.HOSTS]}
           onChange={(event) =>
             handleInputChange({
               value: event.target.value,
-              configKey: ConfigKeys.HOSTS,
+              configKey: ConfigKey.HOSTS,
             })
           }
           data-test-subj="syntheticsTCPHostField"
@@ -60,7 +60,7 @@ export const TCPSimpleFields = memo<Props>(({ validate }) => {
             defaultMessage="Monitor interval"
           />
         }
-        isInvalid={!!validate[ConfigKeys.SCHEDULE]?.(fields)}
+        isInvalid={!!validate[ConfigKey.SCHEDULE]?.(fields)}
         error={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.monitorInterval.error"
@@ -72,11 +72,11 @@ export const TCPSimpleFields = memo<Props>(({ validate }) => {
           onChange={(schedule) =>
             handleInputChange({
               value: schedule,
-              configKey: ConfigKeys.SCHEDULE,
+              configKey: ConfigKey.SCHEDULE,
             })
           }
-          number={fields[ConfigKeys.SCHEDULE].number}
-          unit={fields[ConfigKeys.SCHEDULE].unit}
+          number={fields[ConfigKey.SCHEDULE].number}
+          unit={fields[ConfigKey.SCHEDULE].unit}
         />
       </EuiFormRow>
       <CommonFields fields={fields} onChange={handleInputChange} validate={validate} />

--- a/x-pack/plugins/uptime/public/components/fleet_package/tls/default_values.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tls/default_values.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { ITLSFields, ConfigKeys, VerificationMode, TLSVersion } from '../types';
+import { TLSFields, ConfigKey, VerificationMode, TLSVersion } from '../types';
 
-export const defaultValues: ITLSFields = {
-  [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]: '',
-  [ConfigKeys.TLS_CERTIFICATE]: '',
-  [ConfigKeys.TLS_KEY]: '',
-  [ConfigKeys.TLS_KEY_PASSPHRASE]: '',
-  [ConfigKeys.TLS_VERIFICATION_MODE]: VerificationMode.FULL,
-  [ConfigKeys.TLS_VERSION]: [TLSVersion.ONE_ONE, TLSVersion.ONE_TWO, TLSVersion.ONE_THREE],
+export const defaultValues: TLSFields = {
+  [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: '',
+  [ConfigKey.TLS_CERTIFICATE]: '',
+  [ConfigKey.TLS_KEY]: '',
+  [ConfigKey.TLS_KEY_PASSPHRASE]: '',
+  [ConfigKey.TLS_VERIFICATION_MODE]: VerificationMode.FULL,
+  [ConfigKey.TLS_VERSION]: [TLSVersion.ONE_ONE, TLSVersion.ONE_TWO, TLSVersion.ONE_THREE],
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/tls/formatters.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tls/formatters.ts
@@ -5,22 +5,22 @@
  * 2.0.
  */
 
-import { ITLSFields, ConfigKeys } from '../types';
+import { TLSFields, ConfigKey } from '../types';
 import { Formatter } from '../common/formatters';
 
-type TLSFormatMap = Record<keyof ITLSFields, Formatter>;
+type TLSFormatMap = Record<keyof TLSFields, Formatter>;
 
 export const tlsFormatters: TLSFormatMap = {
-  [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]: (fields) =>
-    tlsValueToYamlFormatter(fields[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]),
-  [ConfigKeys.TLS_CERTIFICATE]: (fields) =>
-    tlsValueToYamlFormatter(fields[ConfigKeys.TLS_CERTIFICATE]),
-  [ConfigKeys.TLS_KEY]: (fields) => tlsValueToYamlFormatter(fields[ConfigKeys.TLS_KEY]),
-  [ConfigKeys.TLS_KEY_PASSPHRASE]: (fields) =>
-    tlsValueToStringFormatter(fields[ConfigKeys.TLS_KEY_PASSPHRASE]),
-  [ConfigKeys.TLS_VERIFICATION_MODE]: (fields) =>
-    tlsValueToStringFormatter(fields[ConfigKeys.TLS_VERIFICATION_MODE]),
-  [ConfigKeys.TLS_VERSION]: (fields) => tlsArrayToYamlFormatter(fields[ConfigKeys.TLS_VERSION]),
+  [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: (fields) =>
+    tlsValueToYamlFormatter(fields[ConfigKey.TLS_CERTIFICATE_AUTHORITIES]),
+  [ConfigKey.TLS_CERTIFICATE]: (fields) =>
+    tlsValueToYamlFormatter(fields[ConfigKey.TLS_CERTIFICATE]),
+  [ConfigKey.TLS_KEY]: (fields) => tlsValueToYamlFormatter(fields[ConfigKey.TLS_KEY]),
+  [ConfigKey.TLS_KEY_PASSPHRASE]: (fields) =>
+    tlsValueToStringFormatter(fields[ConfigKey.TLS_KEY_PASSPHRASE]),
+  [ConfigKey.TLS_VERIFICATION_MODE]: (fields) =>
+    tlsValueToStringFormatter(fields[ConfigKey.TLS_VERIFICATION_MODE]),
+  [ConfigKey.TLS_VERSION]: (fields) => tlsArrayToYamlFormatter(fields[ConfigKey.TLS_VERSION]),
 };
 
 // only add tls settings if they are enabled by the user and isEnabled is true

--- a/x-pack/plugins/uptime/public/components/fleet_package/tls/normalizers.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tls/normalizers.ts
@@ -5,40 +5,40 @@
  * 2.0.
  */
 
-import { ITLSFields, ConfigKeys } from '../types';
+import { TLSFields, ConfigKey } from '../types';
 import { Normalizer } from '../common/normalizers';
 import { defaultTLSFields } from '../contexts';
 
-type TLSNormalizerMap = Record<keyof ITLSFields, Normalizer>;
+type TLSNormalizerMap = Record<keyof TLSFields, Normalizer>;
 
 export const tlsNormalizers: TLSNormalizerMap = {
-  [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]: (fields) =>
+  [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: (fields) =>
     tlsJsonToObjectNormalizer(
-      fields?.[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]?.value,
-      ConfigKeys.TLS_CERTIFICATE_AUTHORITIES
+      fields?.[ConfigKey.TLS_CERTIFICATE_AUTHORITIES]?.value,
+      ConfigKey.TLS_CERTIFICATE_AUTHORITIES
     ),
-  [ConfigKeys.TLS_CERTIFICATE]: (fields) =>
+  [ConfigKey.TLS_CERTIFICATE]: (fields) =>
     tlsJsonToObjectNormalizer(
-      fields?.[ConfigKeys.TLS_CERTIFICATE]?.value,
-      ConfigKeys.TLS_CERTIFICATE
+      fields?.[ConfigKey.TLS_CERTIFICATE]?.value,
+      ConfigKey.TLS_CERTIFICATE
     ),
-  [ConfigKeys.TLS_KEY]: (fields) =>
-    tlsJsonToObjectNormalizer(fields?.[ConfigKeys.TLS_KEY]?.value, ConfigKeys.TLS_KEY),
-  [ConfigKeys.TLS_KEY_PASSPHRASE]: (fields) =>
+  [ConfigKey.TLS_KEY]: (fields) =>
+    tlsJsonToObjectNormalizer(fields?.[ConfigKey.TLS_KEY]?.value, ConfigKey.TLS_KEY),
+  [ConfigKey.TLS_KEY_PASSPHRASE]: (fields) =>
     tlsStringToObjectNormalizer(
-      fields?.[ConfigKeys.TLS_KEY_PASSPHRASE]?.value,
-      ConfigKeys.TLS_KEY_PASSPHRASE
+      fields?.[ConfigKey.TLS_KEY_PASSPHRASE]?.value,
+      ConfigKey.TLS_KEY_PASSPHRASE
     ),
-  [ConfigKeys.TLS_VERIFICATION_MODE]: (fields) =>
+  [ConfigKey.TLS_VERIFICATION_MODE]: (fields) =>
     tlsStringToObjectNormalizer(
-      fields?.[ConfigKeys.TLS_VERIFICATION_MODE]?.value,
-      ConfigKeys.TLS_VERIFICATION_MODE
+      fields?.[ConfigKey.TLS_VERIFICATION_MODE]?.value,
+      ConfigKey.TLS_VERIFICATION_MODE
     ),
-  [ConfigKeys.TLS_VERSION]: (fields) =>
-    tlsJsonToObjectNormalizer(fields?.[ConfigKeys.TLS_VERSION]?.value, ConfigKeys.TLS_VERSION),
+  [ConfigKey.TLS_VERSION]: (fields) =>
+    tlsJsonToObjectNormalizer(fields?.[ConfigKey.TLS_VERSION]?.value, ConfigKey.TLS_VERSION),
 };
 
-export const tlsStringToObjectNormalizer = (value: string = '', key: keyof ITLSFields) =>
+export const tlsStringToObjectNormalizer = (value: string = '', key: keyof TLSFields) =>
   value ?? defaultTLSFields[key];
-export const tlsJsonToObjectNormalizer = (value: string = '', key: keyof ITLSFields) =>
+export const tlsJsonToObjectNormalizer = (value: string = '', key: keyof TLSFields) =>
   value ? JSON.parse(value) : defaultTLSFields[key];

--- a/x-pack/plugins/uptime/public/components/fleet_package/tls_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tls_fields.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { render } from '../../lib/helper/rtl_helpers';
 import { TLSFields } from './tls_fields';
-import { ConfigKeys, VerificationMode } from './types';
+import { ConfigKey, VerificationMode } from './types';
 import {
   TLSFieldsContextProvider,
   PolicyConfigContextProvider,
@@ -52,31 +52,31 @@ describe('<TLSFields />', () => {
     const verificationMode = getByLabelText('Verification mode') as HTMLInputElement;
 
     const newValues = {
-      [ConfigKeys.TLS_CERTIFICATE]: 'sampleClientCertificate',
-      [ConfigKeys.TLS_KEY]: 'sampleClientKey',
-      [ConfigKeys.TLS_KEY_PASSPHRASE]: 'sampleClientKeyPassphrase',
-      [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]: 'sampleCertificateAuthorities',
-      [ConfigKeys.TLS_VERIFICATION_MODE]: VerificationMode.NONE,
+      [ConfigKey.TLS_CERTIFICATE]: 'sampleClientCertificate',
+      [ConfigKey.TLS_KEY]: 'sampleClientKey',
+      [ConfigKey.TLS_KEY_PASSPHRASE]: 'sampleClientKeyPassphrase',
+      [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: 'sampleCertificateAuthorities',
+      [ConfigKey.TLS_VERIFICATION_MODE]: VerificationMode.NONE,
     };
 
     fireEvent.change(clientCertificate, {
-      target: { value: newValues[ConfigKeys.TLS_CERTIFICATE] },
+      target: { value: newValues[ConfigKey.TLS_CERTIFICATE] },
     });
-    fireEvent.change(clientKey, { target: { value: newValues[ConfigKeys.TLS_KEY] } });
+    fireEvent.change(clientKey, { target: { value: newValues[ConfigKey.TLS_KEY] } });
     fireEvent.change(clientKeyPassphrase, {
-      target: { value: newValues[ConfigKeys.TLS_KEY_PASSPHRASE] },
+      target: { value: newValues[ConfigKey.TLS_KEY_PASSPHRASE] },
     });
     fireEvent.change(certificateAuthorities, {
-      target: { value: newValues[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES] },
+      target: { value: newValues[ConfigKey.TLS_CERTIFICATE_AUTHORITIES] },
     });
     fireEvent.change(verificationMode, {
-      target: { value: newValues[ConfigKeys.TLS_VERIFICATION_MODE] },
+      target: { value: newValues[ConfigKey.TLS_VERIFICATION_MODE] },
     });
 
-    expect(clientCertificate.value).toEqual(newValues[ConfigKeys.TLS_CERTIFICATE]);
-    expect(clientKey.value).toEqual(newValues[ConfigKeys.TLS_KEY]);
-    expect(certificateAuthorities.value).toEqual(newValues[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]);
-    expect(verificationMode.value).toEqual(newValues[ConfigKeys.TLS_VERIFICATION_MODE]);
+    expect(clientCertificate.value).toEqual(newValues[ConfigKey.TLS_CERTIFICATE]);
+    expect(clientKey.value).toEqual(newValues[ConfigKey.TLS_KEY]);
+    expect(certificateAuthorities.value).toEqual(newValues[ConfigKey.TLS_CERTIFICATE_AUTHORITIES]);
+    expect(verificationMode.value).toEqual(newValues[ConfigKey.TLS_VERIFICATION_MODE]);
   });
 
   it('shows warning when verification mode is set to none', () => {

--- a/x-pack/plugins/uptime/public/components/fleet_package/tls_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tls_fields.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useEffect } from 'react';
 import { TLSOptions, TLSConfig } from './common/tls_options';
 import { useTLSFieldsContext, usePolicyConfigContext } from './contexts';
 
-import { ConfigKeys } from './types';
+import { ConfigKey } from './types';
 
 export const TLSFields = () => {
   const { defaultValues, setFields } = useTLSFieldsContext();
@@ -19,12 +19,12 @@ export const TLSFields = () => {
   const handleOnChange = useCallback(
     (tlsConfig: TLSConfig) => {
       setFields({
-        [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]: tlsConfig.certificateAuthorities,
-        [ConfigKeys.TLS_CERTIFICATE]: tlsConfig.certificate,
-        [ConfigKeys.TLS_KEY]: tlsConfig.key,
-        [ConfigKeys.TLS_KEY_PASSPHRASE]: tlsConfig.keyPassphrase,
-        [ConfigKeys.TLS_VERIFICATION_MODE]: tlsConfig.verificationMode,
-        [ConfigKeys.TLS_VERSION]: tlsConfig.version,
+        [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: tlsConfig.certificateAuthorities,
+        [ConfigKey.TLS_CERTIFICATE]: tlsConfig.certificate,
+        [ConfigKey.TLS_KEY]: tlsConfig.key,
+        [ConfigKey.TLS_KEY_PASSPHRASE]: tlsConfig.keyPassphrase,
+        [ConfigKey.TLS_VERIFICATION_MODE]: tlsConfig.verificationMode,
+        [ConfigKey.TLS_VERSION]: tlsConfig.version,
       });
     },
     [setFields]
@@ -33,12 +33,12 @@ export const TLSFields = () => {
   useEffect(() => {
     if (!isTLSEnabled) {
       setFields({
-        [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]: undefined,
-        [ConfigKeys.TLS_CERTIFICATE]: undefined,
-        [ConfigKeys.TLS_KEY]: undefined,
-        [ConfigKeys.TLS_KEY_PASSPHRASE]: undefined,
-        [ConfigKeys.TLS_VERIFICATION_MODE]: undefined,
-        [ConfigKeys.TLS_VERSION]: undefined,
+        [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: undefined,
+        [ConfigKey.TLS_CERTIFICATE]: undefined,
+        [ConfigKey.TLS_KEY]: undefined,
+        [ConfigKey.TLS_KEY_PASSPHRASE]: undefined,
+        [ConfigKey.TLS_VERIFICATION_MODE]: undefined,
+        [ConfigKey.TLS_VERSION]: undefined,
       });
     }
   }, [setFields, isTLSEnabled]);
@@ -46,12 +46,12 @@ export const TLSFields = () => {
   return isTLSEnabled ? (
     <TLSOptions
       defaultValues={{
-        certificateAuthorities: defaultValues[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES],
-        certificate: defaultValues[ConfigKeys.TLS_CERTIFICATE],
-        key: defaultValues[ConfigKeys.TLS_KEY],
-        keyPassphrase: defaultValues[ConfigKeys.TLS_KEY_PASSPHRASE],
-        verificationMode: defaultValues[ConfigKeys.TLS_VERIFICATION_MODE],
-        version: defaultValues[ConfigKeys.TLS_VERSION],
+        certificateAuthorities: defaultValues[ConfigKey.TLS_CERTIFICATE_AUTHORITIES],
+        certificate: defaultValues[ConfigKey.TLS_CERTIFICATE],
+        key: defaultValues[ConfigKey.TLS_KEY],
+        keyPassphrase: defaultValues[ConfigKey.TLS_KEY_PASSPHRASE],
+        verificationMode: defaultValues[ConfigKey.TLS_VERIFICATION_MODE],
+        version: defaultValues[ConfigKey.TLS_VERSION],
       }}
       onChange={handleOnChange}
       tlsRole="client"

--- a/x-pack/plugins/uptime/public/components/fleet_package/types.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/types.tsx
@@ -4,250 +4,23 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import {
+  HTTPFields,
+  TCPFields,
+  ICMPFields,
+  BrowserFields,
+  ConfigKey,
+  ContentType,
+  DataStream,
+  MonitorFields,
+  Mode,
+  ThrottlingConfigKey,
+  ThrottlingSuffix,
+  ThrottlingSuffixType,
+} from '../../../common/runtime_types/monitor_management';
+export * from '../../../common/runtime_types/monitor_management';
 
-export enum DataStream {
-  HTTP = 'http',
-  TCP = 'tcp',
-  ICMP = 'icmp',
-  BROWSER = 'browser',
-}
-
-export enum HTTPMethod {
-  GET = 'GET',
-  POST = 'POST',
-  PUT = 'PUT',
-  DELETE = 'DELETE',
-  HEAD = 'HEAD',
-}
-
-export enum ResponseBodyIndexPolicy {
-  ALWAYS = 'always',
-  NEVER = 'never',
-  ON_ERROR = 'on_error',
-}
-
-export enum MonacoEditorLangId {
-  JSON = 'xjson',
-  PLAINTEXT = 'plaintext',
-  XML = 'xml',
-  JAVASCRIPT = 'javascript',
-}
-
-export enum Mode {
-  FORM = 'form',
-  JSON = 'json',
-  PLAINTEXT = 'text',
-  XML = 'xml',
-}
-
-export enum ContentType {
-  JSON = 'application/json',
-  TEXT = 'text/plain',
-  XML = 'application/xml',
-  FORM = 'application/x-www-form-urlencoded',
-}
-
-export enum ScheduleUnit {
-  MINUTES = 'm',
-  SECONDS = 's',
-}
-
-export enum VerificationMode {
-  CERTIFICATE = 'certificate',
-  FULL = 'full',
-  NONE = 'none',
-  STRICT = 'strict',
-}
-
-export enum TLSVersion {
-  ONE_ZERO = 'TLSv1.0',
-  ONE_ONE = 'TLSv1.1',
-  ONE_TWO = 'TLSv1.2',
-  ONE_THREE = 'TLSv1.3',
-}
-
-export enum ScreenshotOption {
-  ON = 'on',
-  OFF = 'off',
-  ONLY_ON_FAILURE = 'only-on-failure',
-}
-
-export enum ThrottlingSuffix {
-  DOWNLOAD = 'd',
-  UPLOAD = 'u',
-  LATENCY = 'l',
-}
-
-// values must match keys in the integration package
-export enum ConfigKeys {
-  APM_SERVICE_NAME = 'service.name',
-  HOSTS = 'hosts',
-  IGNORE_HTTPS_ERRORS = 'ignore_https_errors',
-  JOURNEY_FILTERS_MATCH = 'filter_journeys.match',
-  JOURNEY_FILTERS_TAGS = 'filter_journeys.tags',
-  MAX_REDIRECTS = 'max_redirects',
-  METADATA = '__ui',
-  MONITOR_TYPE = 'type',
-  NAME = 'name',
-  PARAMS = 'params',
-  PASSWORD = 'password',
-  PROXY_URL = 'proxy_url',
-  PROXY_USE_LOCAL_RESOLVER = 'proxy_use_local_resolver',
-  RESPONSE_BODY_CHECK_NEGATIVE = 'check.response.body.negative',
-  RESPONSE_BODY_CHECK_POSITIVE = 'check.response.body.positive',
-  RESPONSE_BODY_INDEX = 'response.include_body',
-  RESPONSE_HEADERS_CHECK = 'check.response.headers',
-  RESPONSE_HEADERS_INDEX = 'response.include_headers',
-  RESPONSE_RECEIVE_CHECK = 'check.receive',
-  RESPONSE_STATUS_CHECK = 'check.response.status',
-  REQUEST_BODY_CHECK = 'check.request.body',
-  REQUEST_HEADERS_CHECK = 'check.request.headers',
-  REQUEST_METHOD_CHECK = 'check.request.method',
-  REQUEST_SEND_CHECK = 'check.send',
-  SCHEDULE = 'schedule',
-  SCREENSHOTS = 'screenshots',
-  SOURCE_INLINE = 'source.inline.script',
-  SOURCE_ZIP_URL = 'source.zip_url.url',
-  SOURCE_ZIP_USERNAME = 'source.zip_url.username',
-  SOURCE_ZIP_PASSWORD = 'source.zip_url.password',
-  SOURCE_ZIP_FOLDER = 'source.zip_url.folder',
-  SOURCE_ZIP_PROXY_URL = 'source.zip_url.proxy_url',
-  SYNTHETICS_ARGS = 'synthetics_args',
-  TLS_CERTIFICATE_AUTHORITIES = 'ssl.certificate_authorities',
-  TLS_CERTIFICATE = 'ssl.certificate',
-  TLS_KEY = 'ssl.key',
-  TLS_KEY_PASSPHRASE = 'ssl.key_passphrase',
-  TLS_VERIFICATION_MODE = 'ssl.verification_mode',
-  TLS_VERSION = 'ssl.supported_protocols',
-  TAGS = 'tags',
-  TIMEOUT = 'timeout',
-  THROTTLING_CONFIG = 'throttling.config',
-  IS_THROTTLING_ENABLED = 'throttling.is_enabled',
-  DOWNLOAD_SPEED = 'throttling.download_speed',
-  UPLOAD_SPEED = 'throttling.upload_speed',
-  LATENCY = 'throttling.latency',
-  URLS = 'urls',
-  USERNAME = 'username',
-  WAIT = 'wait',
-  ZIP_URL_TLS_CERTIFICATE_AUTHORITIES = 'source.zip_url.ssl.certificate_authorities',
-  ZIP_URL_TLS_CERTIFICATE = 'source.zip_url.ssl.certificate',
-  ZIP_URL_TLS_KEY = 'source.zip_url.ssl.key',
-  ZIP_URL_TLS_KEY_PASSPHRASE = 'source.zip_url.ssl.key_passphrase',
-  ZIP_URL_TLS_VERIFICATION_MODE = 'source.zip_url.ssl.verification_mode',
-  ZIP_URL_TLS_VERSION = 'source.zip_url.ssl.supported_protocols',
-}
-
-export interface Metadata {
-  is_tls_enabled?: boolean;
-  is_zip_url_tls_enabled?: boolean;
-  script_source?: {
-    is_generated_script: boolean;
-    file_name: string;
-  };
-}
-
-export interface ICommonFields {
-  [ConfigKeys.MONITOR_TYPE]: DataStream;
-  [ConfigKeys.SCHEDULE]: { number: string; unit: ScheduleUnit };
-  [ConfigKeys.APM_SERVICE_NAME]: string;
-  [ConfigKeys.TIMEOUT]: string;
-  [ConfigKeys.TAGS]: string[];
-}
-
-export type IHTTPSimpleFields = {
-  [ConfigKeys.METADATA]: Metadata;
-  [ConfigKeys.MAX_REDIRECTS]: string;
-  [ConfigKeys.URLS]: string;
-} & ICommonFields;
-
-export type ITCPSimpleFields = {
-  [ConfigKeys.METADATA]: Metadata;
-  [ConfigKeys.HOSTS]: string;
-} & ICommonFields;
-
-export type IICMPSimpleFields = {
-  [ConfigKeys.HOSTS]: string;
-  [ConfigKeys.WAIT]: string;
-} & ICommonFields;
-
-export interface ITLSFields {
-  [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]?: string;
-  [ConfigKeys.TLS_CERTIFICATE]?: string;
-  [ConfigKeys.TLS_KEY]?: string;
-  [ConfigKeys.TLS_KEY_PASSPHRASE]?: string;
-  [ConfigKeys.TLS_VERIFICATION_MODE]?: VerificationMode;
-  [ConfigKeys.TLS_VERSION]?: TLSVersion[];
-}
-
-export interface IZipUrlTLSFields {
-  [ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]?: ITLSFields[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES];
-  [ConfigKeys.ZIP_URL_TLS_CERTIFICATE]?: ITLSFields[ConfigKeys.TLS_CERTIFICATE];
-  [ConfigKeys.ZIP_URL_TLS_KEY]?: ITLSFields[ConfigKeys.TLS_KEY];
-  [ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE]?: ITLSFields[ConfigKeys.TLS_KEY_PASSPHRASE];
-  [ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]?: ITLSFields[ConfigKeys.TLS_VERIFICATION_MODE];
-  [ConfigKeys.ZIP_URL_TLS_VERSION]?: ITLSFields[ConfigKeys.TLS_VERSION];
-}
-
-export interface IHTTPAdvancedFields {
-  [ConfigKeys.PASSWORD]: string;
-  [ConfigKeys.PROXY_URL]: string;
-  [ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE]: string[];
-  [ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE]: string[];
-  [ConfigKeys.RESPONSE_BODY_INDEX]: ResponseBodyIndexPolicy;
-  [ConfigKeys.RESPONSE_HEADERS_CHECK]: Record<string, string>;
-  [ConfigKeys.RESPONSE_HEADERS_INDEX]: boolean;
-  [ConfigKeys.RESPONSE_STATUS_CHECK]: string[];
-  [ConfigKeys.REQUEST_BODY_CHECK]: { value: string; type: Mode };
-  [ConfigKeys.REQUEST_HEADERS_CHECK]: Record<string, string>;
-  [ConfigKeys.REQUEST_METHOD_CHECK]: string;
-  [ConfigKeys.USERNAME]: string;
-}
-
-export interface ITCPAdvancedFields {
-  [ConfigKeys.PROXY_URL]: string;
-  [ConfigKeys.PROXY_USE_LOCAL_RESOLVER]: boolean;
-  [ConfigKeys.RESPONSE_RECEIVE_CHECK]: string;
-  [ConfigKeys.REQUEST_SEND_CHECK]: string;
-}
-
-export type IBrowserSimpleFields = {
-  [ConfigKeys.METADATA]: Metadata;
-  [ConfigKeys.SOURCE_INLINE]: string;
-  [ConfigKeys.SOURCE_ZIP_URL]: string;
-  [ConfigKeys.SOURCE_ZIP_FOLDER]: string;
-  [ConfigKeys.SOURCE_ZIP_USERNAME]: string;
-  [ConfigKeys.SOURCE_ZIP_PASSWORD]: string;
-  [ConfigKeys.SOURCE_ZIP_PROXY_URL]: string;
-  [ConfigKeys.PARAMS]: string;
-} & ICommonFields &
-  IZipUrlTLSFields;
-
-export interface IBrowserAdvancedFields {
-  [ConfigKeys.SYNTHETICS_ARGS]: string[];
-  [ConfigKeys.SCREENSHOTS]: string;
-  [ConfigKeys.JOURNEY_FILTERS_MATCH]: string;
-  [ConfigKeys.JOURNEY_FILTERS_TAGS]: string[];
-  [ConfigKeys.IGNORE_HTTPS_ERRORS]: boolean;
-  [ConfigKeys.IS_THROTTLING_ENABLED]: boolean;
-  [ConfigKeys.DOWNLOAD_SPEED]: string;
-  [ConfigKeys.UPLOAD_SPEED]: string;
-  [ConfigKeys.LATENCY]: string;
-  [ConfigKeys.THROTTLING_CONFIG]: string;
-}
-
-export type HTTPFields = IHTTPSimpleFields & IHTTPAdvancedFields & ITLSFields;
-export type TCPFields = ITCPSimpleFields & ITCPAdvancedFields & ITLSFields;
-export type ICMPFields = IICMPSimpleFields;
-export type BrowserFields = IBrowserSimpleFields & IBrowserAdvancedFields;
-
-export type ICustomFields = HTTPFields &
-  TCPFields &
-  ICMPFields &
-  BrowserFields & {
-    [ConfigKeys.NAME]: string;
-  };
-
-export type Monitor = Partial<ICustomFields>;
+export type Monitor = Partial<MonitorFields>;
 
 export interface PolicyConfig {
   [DataStream.HTTP]: HTTPFields;
@@ -256,9 +29,9 @@ export interface PolicyConfig {
   [DataStream.BROWSER]: BrowserFields;
 }
 
-export type Validator = (config: Partial<ICustomFields>) => boolean;
+export type Validator = (config: Partial<MonitorFields>) => boolean;
 
-export type Validation = Partial<Record<ConfigKeys, Validator>>;
+export type Validation = Partial<Record<ConfigKey, Validator>>;
 
 export const contentTypesToMode = {
   [ContentType.FORM]: Mode.FORM,
@@ -267,13 +40,8 @@ export const contentTypesToMode = {
   [ContentType.XML]: Mode.XML,
 };
 
-export type ThrottlingConfigKey =
-  | ConfigKeys.DOWNLOAD_SPEED
-  | ConfigKeys.UPLOAD_SPEED
-  | ConfigKeys.LATENCY;
-
-export const configKeyToThrottlingSuffix: Record<ThrottlingConfigKey, ThrottlingSuffix> = {
-  [ConfigKeys.DOWNLOAD_SPEED]: ThrottlingSuffix.DOWNLOAD,
-  [ConfigKeys.UPLOAD_SPEED]: ThrottlingSuffix.UPLOAD,
-  [ConfigKeys.LATENCY]: ThrottlingSuffix.LATENCY,
+export const configKeyToThrottlingSuffix: Record<ThrottlingConfigKey, ThrottlingSuffixType> = {
+  [ConfigKey.DOWNLOAD_SPEED]: ThrottlingSuffix.DOWNLOAD,
+  [ConfigKey.UPLOAD_SPEED]: ThrottlingSuffix.UPLOAD,
+  [ConfigKey.LATENCY]: ThrottlingSuffix.LATENCY,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/validation.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/validation.tsx
@@ -4,14 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import {
-  ConfigKeys,
-  DataStream,
-  ICustomFields,
-  Validator,
-  Validation,
-  ScheduleUnit,
-} from './types';
+import { ConfigKey, DataStream, ScheduleUnit, MonitorFields, Validator, Validation } from './types';
 
 export const digitsOnly = /^[0-9]*$/g;
 export const includesValidPort = /[^\:]+:[0-9]{1,5}$/g;
@@ -57,13 +50,13 @@ const validateTimeout = ({
 
 // validation functions return true when invalid
 const validateCommon: ValidationLibrary = {
-  [ConfigKeys.SCHEDULE]: ({ [ConfigKeys.SCHEDULE]: value }) => {
-    const { number, unit } = value as ICustomFields[ConfigKeys.SCHEDULE];
+  [ConfigKey.SCHEDULE]: ({ [ConfigKey.SCHEDULE]: value }) => {
+    const { number, unit } = value as MonitorFields[ConfigKey.SCHEDULE];
     const parsedFloat = parseFloat(number);
     return !parsedFloat || !unit || parsedFloat < 1;
   },
-  [ConfigKeys.TIMEOUT]: ({ [ConfigKeys.TIMEOUT]: timeout, [ConfigKeys.SCHEDULE]: schedule }) => {
-    const { number, unit } = schedule as ICustomFields[ConfigKeys.SCHEDULE];
+  [ConfigKey.TIMEOUT]: ({ [ConfigKey.TIMEOUT]: timeout, [ConfigKey.SCHEDULE]: schedule }) => {
+    const { number, unit } = schedule as MonitorFields[ConfigKey.SCHEDULE];
 
     return (
       !timeout ||
@@ -78,38 +71,38 @@ const validateCommon: ValidationLibrary = {
 };
 
 const validateHTTP: ValidationLibrary = {
-  [ConfigKeys.RESPONSE_STATUS_CHECK]: ({ [ConfigKeys.RESPONSE_STATUS_CHECK]: value }) => {
-    const statusCodes = value as ICustomFields[ConfigKeys.RESPONSE_STATUS_CHECK];
+  [ConfigKey.RESPONSE_STATUS_CHECK]: ({ [ConfigKey.RESPONSE_STATUS_CHECK]: value }) => {
+    const statusCodes = value as MonitorFields[ConfigKey.RESPONSE_STATUS_CHECK];
     return statusCodes.length ? statusCodes.some((code) => !`${code}`.match(digitsOnly)) : false;
   },
-  [ConfigKeys.RESPONSE_HEADERS_CHECK]: ({ [ConfigKeys.RESPONSE_HEADERS_CHECK]: value }) => {
-    const headers = value as ICustomFields[ConfigKeys.RESPONSE_HEADERS_CHECK];
-    return validateHeaders<ICustomFields[ConfigKeys.RESPONSE_HEADERS_CHECK]>(headers);
+  [ConfigKey.RESPONSE_HEADERS_CHECK]: ({ [ConfigKey.RESPONSE_HEADERS_CHECK]: value }) => {
+    const headers = value as MonitorFields[ConfigKey.RESPONSE_HEADERS_CHECK];
+    return validateHeaders<MonitorFields[ConfigKey.RESPONSE_HEADERS_CHECK]>(headers);
   },
-  [ConfigKeys.REQUEST_HEADERS_CHECK]: ({ [ConfigKeys.REQUEST_HEADERS_CHECK]: value }) => {
-    const headers = value as ICustomFields[ConfigKeys.REQUEST_HEADERS_CHECK];
-    return validateHeaders<ICustomFields[ConfigKeys.REQUEST_HEADERS_CHECK]>(headers);
+  [ConfigKey.REQUEST_HEADERS_CHECK]: ({ [ConfigKey.REQUEST_HEADERS_CHECK]: value }) => {
+    const headers = value as MonitorFields[ConfigKey.REQUEST_HEADERS_CHECK];
+    return validateHeaders<MonitorFields[ConfigKey.REQUEST_HEADERS_CHECK]>(headers);
   },
-  [ConfigKeys.MAX_REDIRECTS]: ({ [ConfigKeys.MAX_REDIRECTS]: value }) =>
+  [ConfigKey.MAX_REDIRECTS]: ({ [ConfigKey.MAX_REDIRECTS]: value }) =>
     (!!value && !`${value}`.match(digitsOnly)) ||
-    parseFloat(value as ICustomFields[ConfigKeys.MAX_REDIRECTS]) < 0,
-  [ConfigKeys.URLS]: ({ [ConfigKeys.URLS]: value }) => !value,
+    parseFloat(value as MonitorFields[ConfigKey.MAX_REDIRECTS]) < 0,
+  [ConfigKey.URLS]: ({ [ConfigKey.URLS]: value }) => !value,
   ...validateCommon,
 };
 
 const validateTCP: Record<string, Validator> = {
-  [ConfigKeys.HOSTS]: ({ [ConfigKeys.HOSTS]: value }) => {
+  [ConfigKey.HOSTS]: ({ [ConfigKey.HOSTS]: value }) => {
     return !value || !`${value}`.match(includesValidPort);
   },
   ...validateCommon,
 };
 
 const validateICMP: ValidationLibrary = {
-  [ConfigKeys.HOSTS]: ({ [ConfigKeys.HOSTS]: value }) => !value,
-  [ConfigKeys.WAIT]: ({ [ConfigKeys.WAIT]: value }) =>
+  [ConfigKey.HOSTS]: ({ [ConfigKey.HOSTS]: value }) => !value,
+  [ConfigKey.WAIT]: ({ [ConfigKey.WAIT]: value }) =>
     !!value &&
     !digitsOnly.test(`${value}`) &&
-    parseFloat(value as ICustomFields[ConfigKeys.WAIT]) < 0,
+    parseFloat(value as MonitorFields[ConfigKey.WAIT]) < 0,
   ...validateCommon,
 };
 
@@ -121,19 +114,19 @@ const validateThrottleValue = (speed: string | undefined, allowZero?: boolean) =
 
 const validateBrowser: ValidationLibrary = {
   ...validateCommon,
-  [ConfigKeys.SOURCE_ZIP_URL]: ({
-    [ConfigKeys.SOURCE_ZIP_URL]: zipUrl,
-    [ConfigKeys.SOURCE_INLINE]: inlineScript,
+  [ConfigKey.SOURCE_ZIP_URL]: ({
+    [ConfigKey.SOURCE_ZIP_URL]: zipUrl,
+    [ConfigKey.SOURCE_INLINE]: inlineScript,
   }) => !zipUrl && !inlineScript,
-  [ConfigKeys.SOURCE_INLINE]: ({
-    [ConfigKeys.SOURCE_ZIP_URL]: zipUrl,
-    [ConfigKeys.SOURCE_INLINE]: inlineScript,
+  [ConfigKey.SOURCE_INLINE]: ({
+    [ConfigKey.SOURCE_ZIP_URL]: zipUrl,
+    [ConfigKey.SOURCE_INLINE]: inlineScript,
   }) => !zipUrl && !inlineScript,
-  [ConfigKeys.DOWNLOAD_SPEED]: ({ [ConfigKeys.DOWNLOAD_SPEED]: downloadSpeed }) =>
+  [ConfigKey.DOWNLOAD_SPEED]: ({ [ConfigKey.DOWNLOAD_SPEED]: downloadSpeed }) =>
     validateThrottleValue(downloadSpeed),
-  [ConfigKeys.UPLOAD_SPEED]: ({ [ConfigKeys.UPLOAD_SPEED]: uploadSpeed }) =>
+  [ConfigKey.UPLOAD_SPEED]: ({ [ConfigKey.UPLOAD_SPEED]: uploadSpeed }) =>
     validateThrottleValue(uploadSpeed),
-  [ConfigKeys.LATENCY]: ({ [ConfigKeys.LATENCY]: latency }) => validateThrottleValue(latency, true),
+  [ConfigKey.LATENCY]: ({ [ConfigKey.LATENCY]: latency }) => validateThrottleValue(latency, true),
 };
 
 export type ValidateDictionary = Record<DataStream, Validation>;

--- a/x-pack/plugins/uptime/public/components/monitor_management/formatters/browser.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/formatters/browser.ts
@@ -5,36 +5,36 @@
  * 2.0.
  */
 
-import { BrowserFields, ConfigKeys } from '../../fleet_package/types';
+import { BrowserFields, ConfigKey } from '../../fleet_package/types';
 import { Formatter, commonFormatters, objectFormatter, arrayFormatter } from './common';
 
 export type BrowserFormatMap = Record<keyof BrowserFields, Formatter>;
 
 export const browserFormatters: BrowserFormatMap = {
-  [ConfigKeys.METADATA]: (fields) => objectFormatter(fields[ConfigKeys.METADATA]),
-  [ConfigKeys.SOURCE_ZIP_URL]: null,
-  [ConfigKeys.SOURCE_ZIP_USERNAME]: null,
-  [ConfigKeys.SOURCE_ZIP_PASSWORD]: null,
-  [ConfigKeys.SOURCE_ZIP_FOLDER]: null,
-  [ConfigKeys.SOURCE_ZIP_PROXY_URL]: null,
-  [ConfigKeys.SOURCE_INLINE]: null,
-  [ConfigKeys.PARAMS]: null,
-  [ConfigKeys.SCREENSHOTS]: null,
-  [ConfigKeys.SYNTHETICS_ARGS]: (fields) => null,
-  [ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: null,
-  [ConfigKeys.ZIP_URL_TLS_CERTIFICATE]: null,
-  [ConfigKeys.ZIP_URL_TLS_KEY]: null,
-  [ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE]: null,
-  [ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]: null,
-  [ConfigKeys.IS_THROTTLING_ENABLED]: null,
-  [ConfigKeys.THROTTLING_CONFIG]: null,
-  [ConfigKeys.DOWNLOAD_SPEED]: null,
-  [ConfigKeys.UPLOAD_SPEED]: null,
-  [ConfigKeys.LATENCY]: null,
-  [ConfigKeys.ZIP_URL_TLS_VERSION]: (fields) =>
-    arrayFormatter(fields[ConfigKeys.ZIP_URL_TLS_VERSION]),
-  [ConfigKeys.JOURNEY_FILTERS_MATCH]: null,
-  [ConfigKeys.JOURNEY_FILTERS_TAGS]: null,
-  [ConfigKeys.IGNORE_HTTPS_ERRORS]: null,
+  [ConfigKey.METADATA]: (fields) => objectFormatter(fields[ConfigKey.METADATA]),
+  [ConfigKey.SOURCE_ZIP_URL]: null,
+  [ConfigKey.SOURCE_ZIP_USERNAME]: null,
+  [ConfigKey.SOURCE_ZIP_PASSWORD]: null,
+  [ConfigKey.SOURCE_ZIP_FOLDER]: null,
+  [ConfigKey.SOURCE_ZIP_PROXY_URL]: null,
+  [ConfigKey.SOURCE_INLINE]: null,
+  [ConfigKey.PARAMS]: null,
+  [ConfigKey.SCREENSHOTS]: null,
+  [ConfigKey.SYNTHETICS_ARGS]: (fields) => null,
+  [ConfigKey.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: null,
+  [ConfigKey.ZIP_URL_TLS_CERTIFICATE]: null,
+  [ConfigKey.ZIP_URL_TLS_KEY]: null,
+  [ConfigKey.ZIP_URL_TLS_KEY_PASSPHRASE]: null,
+  [ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]: null,
+  [ConfigKey.IS_THROTTLING_ENABLED]: null,
+  [ConfigKey.THROTTLING_CONFIG]: null,
+  [ConfigKey.DOWNLOAD_SPEED]: null,
+  [ConfigKey.UPLOAD_SPEED]: null,
+  [ConfigKey.LATENCY]: null,
+  [ConfigKey.ZIP_URL_TLS_VERSION]: (fields) =>
+    arrayFormatter(fields[ConfigKey.ZIP_URL_TLS_VERSION]),
+  [ConfigKey.JOURNEY_FILTERS_MATCH]: null,
+  [ConfigKey.JOURNEY_FILTERS_TAGS]: null,
+  [ConfigKey.IGNORE_HTTPS_ERRORS]: null,
   ...commonFormatters,
 };

--- a/x-pack/plugins/uptime/public/components/monitor_management/formatters/common.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/formatters/common.ts
@@ -5,22 +5,22 @@
  * 2.0.
  */
 
-import { ICommonFields, ICustomFields, ConfigKeys } from '../../fleet_package/types';
+import { CommonFields, MonitorFields, ConfigKey } from '../../fleet_package/types';
 
 export type Formatter =
   | null
-  | ((fields: Partial<ICustomFields>) => string | string[] | Record<string, string> | null);
+  | ((fields: Partial<MonitorFields>) => string | string[] | Record<string, string> | null);
 
-export type CommonFormatMap = Record<keyof ICommonFields | ConfigKeys.NAME, Formatter>;
+export type CommonFormatMap = Record<keyof CommonFields | ConfigKey.NAME, Formatter>;
 
 export const commonFormatters: CommonFormatMap = {
-  [ConfigKeys.NAME]: null,
-  [ConfigKeys.MONITOR_TYPE]: null,
-  [ConfigKeys.SCHEDULE]: (fields) =>
-    `@every ${fields[ConfigKeys.SCHEDULE]?.number}${fields[ConfigKeys.SCHEDULE]?.unit}`,
-  [ConfigKeys.APM_SERVICE_NAME]: null,
-  [ConfigKeys.TAGS]: null,
-  [ConfigKeys.TIMEOUT]: (fields) => secondsToCronFormatter(fields[ConfigKeys.TIMEOUT]),
+  [ConfigKey.NAME]: null,
+  [ConfigKey.MONITOR_TYPE]: null,
+  [ConfigKey.SCHEDULE]: (fields) =>
+    `@every ${fields[ConfigKey.SCHEDULE]?.number}${fields[ConfigKey.SCHEDULE]?.unit}`,
+  [ConfigKey.APM_SERVICE_NAME]: null,
+  [ConfigKey.TAGS]: null,
+  [ConfigKey.TIMEOUT]: (fields) => secondsToCronFormatter(fields[ConfigKey.TIMEOUT]),
 };
 
 export const arrayFormatter = (value: string[] = []) => (value.length ? value : null);

--- a/x-pack/plugins/uptime/public/components/monitor_management/formatters/http.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/formatters/http.ts
@@ -5,33 +5,33 @@
  * 2.0.
  */
 
-import { HTTPFields, ConfigKeys } from '../../fleet_package/types';
+import { HTTPFields, ConfigKey } from '../../fleet_package/types';
 import { Formatter, commonFormatters, objectFormatter, arrayFormatter } from './common';
 import { tlsFormatters } from './tls';
 
 export type HTTPFormatMap = Record<keyof HTTPFields, Formatter>;
 
 export const httpFormatters: HTTPFormatMap = {
-  [ConfigKeys.METADATA]: (fields) => objectFormatter(fields[ConfigKeys.METADATA]),
-  [ConfigKeys.URLS]: null,
-  [ConfigKeys.MAX_REDIRECTS]: null,
-  [ConfigKeys.USERNAME]: null,
-  [ConfigKeys.PASSWORD]: null,
-  [ConfigKeys.PROXY_URL]: null,
-  [ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE]: (fields) =>
-    arrayFormatter(fields[ConfigKeys.RESPONSE_BODY_CHECK_NEGATIVE]),
-  [ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE]: (fields) =>
-    arrayFormatter(fields[ConfigKeys.RESPONSE_BODY_CHECK_POSITIVE]),
-  [ConfigKeys.RESPONSE_BODY_INDEX]: null,
-  [ConfigKeys.RESPONSE_HEADERS_CHECK]: (fields) =>
-    objectFormatter(fields[ConfigKeys.RESPONSE_HEADERS_CHECK]),
-  [ConfigKeys.RESPONSE_HEADERS_INDEX]: null,
-  [ConfigKeys.RESPONSE_STATUS_CHECK]: (fields) =>
-    arrayFormatter(fields[ConfigKeys.RESPONSE_STATUS_CHECK]),
-  [ConfigKeys.REQUEST_BODY_CHECK]: (fields) => fields[ConfigKeys.REQUEST_BODY_CHECK]?.value || null,
-  [ConfigKeys.REQUEST_HEADERS_CHECK]: (fields) =>
-    objectFormatter(fields[ConfigKeys.REQUEST_HEADERS_CHECK]),
-  [ConfigKeys.REQUEST_METHOD_CHECK]: null,
+  [ConfigKey.METADATA]: (fields) => objectFormatter(fields[ConfigKey.METADATA]),
+  [ConfigKey.URLS]: null,
+  [ConfigKey.MAX_REDIRECTS]: null,
+  [ConfigKey.USERNAME]: null,
+  [ConfigKey.PASSWORD]: null,
+  [ConfigKey.PROXY_URL]: null,
+  [ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]: (fields) =>
+    arrayFormatter(fields[ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]),
+  [ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]: (fields) =>
+    arrayFormatter(fields[ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]),
+  [ConfigKey.RESPONSE_BODY_INDEX]: null,
+  [ConfigKey.RESPONSE_HEADERS_CHECK]: (fields) =>
+    objectFormatter(fields[ConfigKey.RESPONSE_HEADERS_CHECK]),
+  [ConfigKey.RESPONSE_HEADERS_INDEX]: null,
+  [ConfigKey.RESPONSE_STATUS_CHECK]: (fields) =>
+    arrayFormatter(fields[ConfigKey.RESPONSE_STATUS_CHECK]),
+  [ConfigKey.REQUEST_BODY_CHECK]: (fields) => fields[ConfigKey.REQUEST_BODY_CHECK]?.value || null,
+  [ConfigKey.REQUEST_HEADERS_CHECK]: (fields) =>
+    objectFormatter(fields[ConfigKey.REQUEST_HEADERS_CHECK]),
+  [ConfigKey.REQUEST_METHOD_CHECK]: null,
   ...tlsFormatters,
   ...commonFormatters,
 };

--- a/x-pack/plugins/uptime/public/components/monitor_management/formatters/icmp.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/formatters/icmp.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { ICMPFields, ConfigKeys } from '../../fleet_package/types';
+import { ICMPFields, ConfigKey } from '../../fleet_package/types';
 import { Formatter, commonFormatters, secondsToCronFormatter } from './common';
 
 export type ICMPFormatMap = Record<keyof ICMPFields, Formatter>;
 
 export const icmpFormatters: ICMPFormatMap = {
-  [ConfigKeys.HOSTS]: null,
-  [ConfigKeys.WAIT]: (fields) => secondsToCronFormatter(fields[ConfigKeys.WAIT]),
+  [ConfigKey.HOSTS]: null,
+  [ConfigKey.WAIT]: (fields) => secondsToCronFormatter(fields[ConfigKey.WAIT]),
   ...commonFormatters,
 };

--- a/x-pack/plugins/uptime/public/components/monitor_management/formatters/tcp.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/formatters/tcp.ts
@@ -5,19 +5,19 @@
  * 2.0.
  */
 
-import { TCPFields, ConfigKeys } from '../../fleet_package/types';
+import { TCPFields, ConfigKey } from '../../fleet_package/types';
 import { Formatter, commonFormatters } from './common';
 import { tlsFormatters } from './tls';
 
 export type TCPFormatMap = Record<keyof TCPFields, Formatter>;
 
 export const tcpFormatters: TCPFormatMap = {
-  [ConfigKeys.METADATA]: null,
-  [ConfigKeys.HOSTS]: null,
-  [ConfigKeys.PROXY_URL]: null,
-  [ConfigKeys.PROXY_USE_LOCAL_RESOLVER]: null,
-  [ConfigKeys.RESPONSE_RECEIVE_CHECK]: null,
-  [ConfigKeys.REQUEST_SEND_CHECK]: null,
+  [ConfigKey.METADATA]: null,
+  [ConfigKey.HOSTS]: null,
+  [ConfigKey.PROXY_URL]: null,
+  [ConfigKey.PROXY_USE_LOCAL_RESOLVER]: null,
+  [ConfigKey.RESPONSE_RECEIVE_CHECK]: null,
+  [ConfigKey.REQUEST_SEND_CHECK]: null,
   ...tlsFormatters,
   ...commonFormatters,
 };

--- a/x-pack/plugins/uptime/public/components/monitor_management/formatters/tls.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/formatters/tls.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
-import { ITLSFields, ConfigKeys } from '../../fleet_package/types';
+import { TLSFields, ConfigKey } from '../../fleet_package/types';
 import { arrayFormatter, Formatter } from './common';
 
-type TLSFormatMap = Record<keyof ITLSFields, Formatter>;
+type TLSFormatMap = Record<keyof TLSFields, Formatter>;
 
 export const tlsFormatters: TLSFormatMap = {
-  [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]: null,
-  [ConfigKeys.TLS_CERTIFICATE]: null,
-  [ConfigKeys.TLS_KEY]: null,
-  [ConfigKeys.TLS_KEY_PASSPHRASE]: null,
-  [ConfigKeys.TLS_VERIFICATION_MODE]: null,
-  [ConfigKeys.TLS_VERSION]: (fields) => arrayFormatter(fields[ConfigKeys.TLS_VERSION]),
+  [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: null,
+  [ConfigKey.TLS_CERTIFICATE]: null,
+  [ConfigKey.TLS_KEY]: null,
+  [ConfigKey.TLS_KEY_PASSPHRASE]: null,
+  [ConfigKey.TLS_VERIFICATION_MODE]: null,
+  [ConfigKey.TLS_VERSION]: (fields) => arrayFormatter(fields[ConfigKey.TLS_VERSION]),
 };

--- a/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_format_monitor.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_format_monitor.ts
@@ -6,18 +6,18 @@
  */
 import { useEffect, useRef, useState } from 'react';
 import { omitBy, isNil } from 'lodash';
-import { ConfigKeys, DataStream, Validation, ICustomFields } from '../../fleet_package/types';
+import { ConfigKey, DataStream, Validation, MonitorFields } from '../../fleet_package/types';
 import { formatters } from '../formatters';
 
 interface Props {
   monitorType: DataStream;
-  defaultConfig: Partial<ICustomFields>;
-  config: Partial<ICustomFields>;
+  defaultConfig: Partial<MonitorFields>;
+  config: Partial<MonitorFields>;
   validate: Record<DataStream, Validation>;
 }
 
-const formatMonitorConfig = (configKeys: ConfigKeys[], config: Partial<ICustomFields>) => {
-  const formattedMonitor = {} as Record<ConfigKeys, any>;
+const formatMonitorConfig = (configKeys: ConfigKey[], config: Partial<MonitorFields>) => {
+  const formattedMonitor = {} as Record<ConfigKey, any>;
 
   configKeys.forEach((key) => {
     const value = config[key] ?? null;
@@ -28,19 +28,19 @@ const formatMonitorConfig = (configKeys: ConfigKeys[], config: Partial<ICustomFi
     }
   });
 
-  return omitBy(formattedMonitor, isNil) as Partial<ICustomFields>;
+  return omitBy(formattedMonitor, isNil) as Partial<MonitorFields>;
 };
 
 export const useFormatMonitor = ({ monitorType, defaultConfig, config, validate }: Props) => {
-  const [formattedMonitor, setFormattedMonitor] = useState<Partial<ICustomFields>>(
-    formatMonitorConfig(Object.keys(config) as ConfigKeys[], config)
+  const [formattedMonitor, setFormattedMonitor] = useState<Partial<MonitorFields>>(
+    formatMonitorConfig(Object.keys(config) as ConfigKey[], config)
   );
   const [isValid, setIsValid] = useState(false);
-  const currentConfig = useRef<Partial<ICustomFields>>(defaultConfig);
+  const currentConfig = useRef<Partial<MonitorFields>>(defaultConfig);
 
   useEffect(() => {
-    const configKeys = Object.keys(config) as ConfigKeys[];
-    const validationKeys = Object.keys(validate[monitorType]) as ConfigKeys[];
+    const configKeys = Object.keys(config) as ConfigKey[];
+    const validationKeys = Object.keys(validate[monitorType]) as ConfigKey[];
     const configDidUpdate = configKeys.some((key) => config[key] !== currentConfig.current[key]);
     const isValidT =
       !!config.name && !validationKeys.find((key) => validate[monitorType]?.[key]?.(config));

--- a/x-pack/plugins/uptime/public/pages/edit_monitor.tsx
+++ b/x-pack/plugins/uptime/public/pages/edit_monitor.tsx
@@ -7,9 +7,9 @@
 
 import React, { useMemo } from 'react';
 import {
-  ConfigKeys,
-  ICustomFields,
-  ITLSFields,
+  ConfigKey,
+  MonitorFields,
+  TLSFields,
   PolicyConfig,
   DataStream,
 } from '../components/fleet_package/types';
@@ -30,40 +30,40 @@ export const EditMonitorPage: React.FC = () => {
     tlsConfig: defaultTLSConfig,
   } = useMemo(() => {
     /* TODO: fetch current monitor to be edited from saved objects based on url param */
-    const monitor = {} as Record<ConfigKeys, any>; // fetch
+    const monitor = {} as Record<ConfigKey, any>; // fetch
 
     let enableTLS = false;
     let enableZipUrlTLS = false;
     const getDefaultConfig = () => {
-      const type: DataStream = monitor[ConfigKeys.MONITOR_TYPE] as DataStream;
+      const type: DataStream = monitor[ConfigKey.MONITOR_TYPE] as DataStream;
 
-      const configKeys: ConfigKeys[] = Object.values(ConfigKeys) || ([] as ConfigKeys[]);
-      const formattedDefaultConfigForMonitorType: ICustomFields = configKeys.reduce<ICustomFields>(
-        (acc: ICustomFields, key: ConfigKeys) => {
+      const configKeys: ConfigKey[] = Object.values(ConfigKey) || ([] as ConfigKey[]);
+      const formattedDefaultConfigForMonitorType: MonitorFields = configKeys.reduce<MonitorFields>(
+        (acc: MonitorFields, key: ConfigKey) => {
           return {
             ...acc,
             key,
           };
         },
-        {} as ICustomFields
+        {} as MonitorFields
       );
 
-      const tlsConfig: ITLSFields = {
-        [ConfigKeys.TLS_CERTIFICATE_AUTHORITIES]:
-          formattedDefaultConfigForMonitorType[ConfigKeys.TLS_CERTIFICATE_AUTHORITIES],
-        [ConfigKeys.TLS_CERTIFICATE]:
-          formattedDefaultConfigForMonitorType[ConfigKeys.TLS_CERTIFICATE],
-        [ConfigKeys.TLS_KEY]: formattedDefaultConfigForMonitorType[ConfigKeys.TLS_KEY],
-        [ConfigKeys.TLS_KEY_PASSPHRASE]:
-          formattedDefaultConfigForMonitorType[ConfigKeys.TLS_KEY_PASSPHRASE],
-        [ConfigKeys.TLS_VERIFICATION_MODE]:
-          formattedDefaultConfigForMonitorType[ConfigKeys.TLS_VERIFICATION_MODE],
-        [ConfigKeys.TLS_VERSION]: formattedDefaultConfigForMonitorType[ConfigKeys.TLS_VERSION],
+      const tlsConfig: TLSFields = {
+        [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]:
+          formattedDefaultConfigForMonitorType[ConfigKey.TLS_CERTIFICATE_AUTHORITIES],
+        [ConfigKey.TLS_CERTIFICATE]:
+          formattedDefaultConfigForMonitorType[ConfigKey.TLS_CERTIFICATE],
+        [ConfigKey.TLS_KEY]: formattedDefaultConfigForMonitorType[ConfigKey.TLS_KEY],
+        [ConfigKey.TLS_KEY_PASSPHRASE]:
+          formattedDefaultConfigForMonitorType[ConfigKey.TLS_KEY_PASSPHRASE],
+        [ConfigKey.TLS_VERIFICATION_MODE]:
+          formattedDefaultConfigForMonitorType[ConfigKey.TLS_VERIFICATION_MODE],
+        [ConfigKey.TLS_VERSION]: formattedDefaultConfigForMonitorType[ConfigKey.TLS_VERSION],
       };
 
-      enableTLS = Boolean(formattedDefaultConfigForMonitorType[ConfigKeys.TLS_VERIFICATION_MODE]);
+      enableTLS = Boolean(formattedDefaultConfigForMonitorType[ConfigKey.TLS_VERIFICATION_MODE]);
       enableZipUrlTLS = Boolean(
-        formattedDefaultConfigForMonitorType[ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]
+        formattedDefaultConfigForMonitorType[ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]
       );
 
       const formattedDefaultConfig: Partial<PolicyConfig> = {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Creating io-ts types for synthetics monitors. (#120105)