### PR TITLE
[Security Solution][Detections] Fix Last response and Last run columns in the Rule Monitoring table

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
@@ -408,14 +408,14 @@ export const getMonitoringColumns = (columnsProps: GetColumnsProps): TableColumn
       truncateText: true,
     },
     {
-      field: 'current_status.status',
+      field: 'status',
       name: i18n.COLUMN_LAST_RESPONSE,
       render: (value: Rule['status'] | undefined) => <RuleExecutionStatusBadge status={value} />,
       width: '12%',
       truncateText: true,
     },
     {
-      field: 'current_status.status_date',
+      field: 'status_date',
       name: i18n.COLUMN_LAST_COMPLETE_RUN,
       render: (value: Rule['status_date'] | undefined) => {
         return value == null ? (


### PR DESCRIPTION
**Related to:** https://github.com/elastic/kibana/pull/120217#discussion_r763258705

## Summary

**Last response** and **Last run** columns work in the Rule Management table, but are displayed as empty in the Rule Monitoring table. This PR adds a small fix for that.

### Before

![](https://puu.sh/IuiWA/fd999f5196.png)

![](https://puu.sh/IuiZX/846e28bd36.png)

### After

![](https://puu.sh/IujUZ/809fd1e762.png)

![](https://puu.sh/IujVm/9719f52bbd.png)
