### PR TITLE
[DOCS] Removes coming tag from 7.16.0 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -70,8 +70,6 @@ Review important information about the {kib} 7.16.x releases.
 [[release-notes-7.16.0]]
 == {kib} 7.16.0
 
-coming::[7.16.0]
-
 For information about the {kib} 7.16.0 release, review the following information.
 
 [float]


### PR DESCRIPTION
## Summary

Removes coming tag from 7.16.0 release notes

