### PR TITLE
[Fleet] Fix Fleet server authz

### DIFF
--- a/x-pack/plugins/fleet/server/routes/security.ts
+++ b/x-pack/plugins/fleet/server/routes/security.ts
@@ -151,8 +151,8 @@ export async function getAuthzFromRequest(req: KibanaRequest): Promise<FleetAuth
 
       // Once we implement Kibana RBAC, use `checkPrivileges` for all privileges instead of only integrations.read
       return calculateAuthz({
-        fleet: { all: true, setup: true },
-        integrations: { all: true, read: intRead.authorized },
+        fleet: { all: false, setup: false },
+        integrations: { all: false, read: intRead.authorized },
       });
     }
   }


### PR DESCRIPTION
## Description 

Fix fleet server authz to require `superuser` or fleet setup privileges for every other action than integrations read.


