### PR TITLE
[8.0] [Security Solutions] Removes tech debt of exporting all from linter rule for cases plugin in the common section

### DIFF
--- a/x-pack/plugins/cases/common/index.ts
+++ b/x-pack/plugins/cases/common/index.ts
@@ -5,11 +5,28 @@
  * 2.0.
  */
 
-// TODO: https://github.com/elastic/kibana/issues/110896
-/* eslint-disable @kbn/eslint/no_export_all */
+// Careful of exporting anything from this file as any file(s) you export here will cause your page bundle size to increase.
+// If you're using functions/types/etc... internally or within integration tests it's best to import directly from their paths
+// than expose the functions/types/etc... here. You should _only_ expose functions/types/etc... that need to be shared with other plugins here.
 
-export * from './constants';
-export * from './api';
-export * from './ui/types';
-export * from './utils/connectors_api';
-export * from './utils/user_actions';
+// When you do have to add things here you might want to consider creating a package such as kbn-cases-constants to share with
+// other plugins instead as packages are easier to break down and you do not have to carry the cost of extra plugin weight on
+// first download since the other plugins/areas of your code can directly pull from the package in their async imports.
+// For example, constants below could eventually be in a "kbn-cases-constants" instead.
+// See: https://docs.elastic.dev/kibana-dev-docs/key-concepts/platform-intro#public-plugin-api
+
+export { CASES_URL, SECURITY_SOLUTION_OWNER, ENABLE_CASE_CONNECTOR } from './constants';
+
+export { CommentType, CaseStatuses, getCasesFromAlertsUrl, throwErrors } from './api';
+
+export type {
+  SubCase,
+  Case,
+  Ecs,
+  CasesContextValue,
+  CaseViewRefreshPropInterface,
+} from './ui/types';
+
+export { StatusAll } from './ui/types';
+
+export { getCreateConnectorUrl, getAllConnectorsUrl } from './utils/connectors_api';

--- a/x-pack/plugins/cases/common/index.ts
+++ b/x-pack/plugins/cases/common/index.ts
@@ -19,13 +19,7 @@ export { CASES_URL, SECURITY_SOLUTION_OWNER, ENABLE_CASE_CONNECTOR } from './con
 
 export { CommentType, CaseStatuses, getCasesFromAlertsUrl, throwErrors } from './api';
 
-export type {
-  SubCase,
-  Case,
-  Ecs,
-  CasesContextValue,
-  CaseViewRefreshPropInterface,
-} from './ui/types';
+export type { SubCase, Case, Ecs, CaseViewRefreshPropInterface } from './ui/types';
 
 export { StatusAll } from './ui/types';
 

--- a/x-pack/plugins/cases/common/utils/connectors_api.ts
+++ b/x-pack/plugins/cases/common/utils/connectors_api.ts
@@ -9,7 +9,7 @@
  * Actions and connectors API endpoint helpers
  */
 
-import { ACTION_URL, ACTION_TYPES_URL, CONNECTORS_URL } from '../../common';
+import { ACTION_URL, ACTION_TYPES_URL, CONNECTORS_URL } from '../../common/constants';
 
 /**
  *

--- a/x-pack/plugins/cases/public/common/lib/kibana/hooks.ts
+++ b/x-pack/plugins/cases/public/common/lib/kibana/hooks.ts
@@ -10,7 +10,7 @@ import moment from 'moment-timezone';
 import { useCallback, useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 
-import { DEFAULT_DATE_FORMAT, DEFAULT_DATE_FORMAT_TZ } from '../../../../common';
+import { DEFAULT_DATE_FORMAT, DEFAULT_DATE_FORMAT_TZ } from '../../../../common/constants';
 import { AuthenticatedUser } from '../../../../../security/common/model';
 import { convertToCamelCase } from '../../../containers/utils';
 import { StartServices } from '../../../types';

--- a/x-pack/plugins/cases/public/common/mock/register_connectors.ts
+++ b/x-pack/plugins/cases/public/common/mock/register_connectors.ts
@@ -8,7 +8,7 @@
 import { TriggersAndActionsUIPublicPluginStart } from '../../../../triggers_actions_ui/public';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { actionTypeRegistryMock } from '../../../../triggers_actions_ui/public/application/action_type_registry.mock';
-import { CaseActionConnector } from '../../../common';
+import { CaseActionConnector } from '../../../common/ui/types';
 
 const getUniqueActionTypeIds = (connectors: CaseActionConnector[]) =>
   new Set(connectors.map((connector) => connector.actionTypeId));

--- a/x-pack/plugins/cases/public/common/user_actions/parsers.test.ts
+++ b/x-pack/plugins/cases/public/common/user_actions/parsers.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ConnectorTypes, noneConnectorId } from '../../../common';
+import { ConnectorTypes, noneConnectorId } from '../../../common/api';
 import { parseStringAsConnector, parseStringAsExternalService } from './parsers';
 
 describe('user actions utility functions', () => {

--- a/x-pack/plugins/cases/public/common/user_actions/parsers.ts
+++ b/x-pack/plugins/cases/public/common/user_actions/parsers.ts
@@ -12,7 +12,7 @@ import {
   noneConnectorId,
   CaseFullExternalService,
   CaseUserActionExternalServiceRt,
-} from '../../../common';
+} from '../../../common/api';
 
 export const parseStringAsConnector = (
   id: string | null,

--- a/x-pack/plugins/cases/public/components/add_comment/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/index.test.tsx
@@ -12,7 +12,8 @@ import { noop } from 'lodash/fp';
 
 import { TestProviders } from '../../common/mock';
 
-import { CommentRequest, CommentType, SECURITY_SOLUTION_OWNER } from '../../../common';
+import { CommentRequest, CommentType } from '../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { usePostComment } from '../../containers/use_post_comment';
 import { AddComment, AddCommentProps, AddCommentRefObject } from '.';
 import { CasesTimelineIntegrationProvider } from '../timeline_context';

--- a/x-pack/plugins/cases/public/components/add_comment/index.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/index.tsx
@@ -17,7 +17,7 @@ import { EuiButton, EuiFlexItem, EuiFlexGroup, EuiLoadingSpinner } from '@elasti
 import styled from 'styled-components';
 import { isEmpty } from 'lodash';
 
-import { CommentType } from '../../../common';
+import { CommentType } from '../../../common/api';
 import { usePostComment } from '../../containers/use_post_comment';
 import { Case } from '../../containers/types';
 import { EuiMarkdownEditorRef, MarkdownEditorForm } from '../markdown_editor';

--- a/x-pack/plugins/cases/public/components/add_comment/schema.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/schema.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CommentRequestUserType } from '../../../common';
+import { CommentRequestUserType } from '../../../common/api';
 import { FIELD_TYPES, fieldValidators, FormSchema } from '../../common/shared_imports';
 import * as i18n from './translations';
 

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_generic.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_generic.tsx
@@ -13,15 +13,12 @@ import classnames from 'classnames';
 
 import {
   Case,
-  CaseStatuses,
-  CaseType,
-  CommentRequestAlertType,
   CaseStatusWithAllStatus,
   FilterOptions,
   SortFieldCase,
   SubCase,
-  caseStatuses,
-} from '../../../common';
+} from '../../../common/ui/types';
+import { CaseStatuses, CaseType, CommentRequestAlertType, caseStatuses } from '../../../common/api';
 import { SELECTABLE_MESSAGE_COLLECTIONS } from '../../common/translations';
 import { useGetActionLicense } from '../../containers/use_get_action_license';
 import { useGetCases } from '../../containers/use_get_cases';

--- a/x-pack/plugins/cases/public/components/all_cases/columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns.tsx
@@ -22,16 +22,14 @@ import {
 import { RIGHT_ALIGNMENT } from '@elastic/eui/lib/services';
 import styled from 'styled-components';
 
+import { Case, DeleteCase, SubCase } from '../../../common/ui/types';
 import {
   CaseStatuses,
   CaseType,
   CommentType,
   CommentRequestAlertType,
-  DeleteCase,
-  Case,
-  SubCase,
   ActionConnector,
-} from '../../../common';
+} from '../../../common/api';
 import { getEmptyTagValue } from '../empty_value';
 import { FormattedRelativePreferenceDate } from '../formatted_date';
 import { CaseDetailsHrefSchema, CaseDetailsLink, CasesNavigation } from '../links';

--- a/x-pack/plugins/cases/public/components/all_cases/count.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/count.tsx
@@ -7,7 +7,7 @@
 
 import React, { FunctionComponent, useEffect } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { CaseStatuses } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
 import { Stats } from '../status';
 import { useGetCasesStatus } from '../../containers/use_get_cases_status';
 

--- a/x-pack/plugins/cases/public/components/all_cases/expanded_row.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/expanded_row.tsx
@@ -10,7 +10,7 @@ import { EuiBasicTable as _EuiBasicTable } from '@elastic/eui';
 import styled from 'styled-components';
 import { Case, SubCase } from '../../containers/types';
 import { CasesColumns } from './columns';
-import { AssociationType } from '../../../common';
+import { AssociationType } from '../../../common/api';
 
 type ExpandedRowMap = Record<string, Element> | {};
 

--- a/x-pack/plugins/cases/public/components/all_cases/helpers.ts
+++ b/x-pack/plugins/cases/public/components/all_cases/helpers.ts
@@ -6,7 +6,7 @@
  */
 
 import { filter } from 'lodash/fp';
-import { AssociationType, CaseStatuses, CaseType } from '../../../common';
+import { AssociationType, CaseStatuses, CaseType } from '../../../common/api';
 import { Case, SubCase } from '../../containers/types';
 import { statuses } from '../status';
 

--- a/x-pack/plugins/cases/public/components/all_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/index.test.tsx
@@ -20,7 +20,9 @@ import {
   connectorsMock,
 } from '../../containers/mock';
 
-import { CaseStatuses, CaseType, SECURITY_SOLUTION_OWNER, StatusAll } from '../../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
+import { StatusAll } from '../../../common/ui/types';
+import { CaseStatuses, CaseType } from '../../../common/api';
 import { getEmptyTagValue } from '../empty_value';
 import { useDeleteCases } from '../../containers/use_delete_cases';
 import { useGetCases } from '../../containers/use_get_cases';

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/index.test.tsx
@@ -11,7 +11,7 @@ import { mount } from 'enzyme';
 import { AllCasesSelectorModal } from '.';
 import { TestProviders } from '../../../common/mock';
 import { AllCasesGeneric } from '../all_cases_generic';
-import { SECURITY_SOLUTION_OWNER } from '../../../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../../../common/constants';
 
 jest.mock('../../../methods');
 jest.mock('../all_cases_generic');

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/index.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/index.tsx
@@ -15,14 +15,8 @@ import {
   EuiModalHeaderTitle,
 } from '@elastic/eui';
 import styled from 'styled-components';
-import {
-  Case,
-  CaseStatusWithAllStatus,
-  SubCase,
-} from '../../../../common/ui';
-import {
-  CommentRequestAlertType,
-} from '../../../../common/api';
+import { Case, CaseStatusWithAllStatus, SubCase } from '../../../../common/ui';
+import { CommentRequestAlertType } from '../../../../common/api';
 import { CasesNavigation } from '../../links';
 import * as i18n from '../../../common/translations';
 import { AllCasesGeneric } from '../all_cases_generic';

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/index.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/index.tsx
@@ -18,9 +18,11 @@ import styled from 'styled-components';
 import {
   Case,
   CaseStatusWithAllStatus,
-  CommentRequestAlertType,
   SubCase,
-} from '../../../../common';
+} from '../../../../common/ui';
+import {
+  CommentRequestAlertType,
+} from '../../../../common/api';
 import { CasesNavigation } from '../../links';
 import * as i18n from '../../../common/translations';
 import { AllCasesGeneric } from '../all_cases_generic';

--- a/x-pack/plugins/cases/public/components/all_cases/status_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/status_filter.test.tsx
@@ -9,7 +9,8 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/react';
 
-import { CaseStatuses, StatusAll } from '../../../common';
+import { StatusAll } from '../../../common/ui/types';
+import { CaseStatuses } from '../../../common/api';
 import { StatusFilter } from './status_filter';
 
 const stats = {

--- a/x-pack/plugins/cases/public/components/all_cases/status_filter.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/status_filter.tsx
@@ -8,7 +8,7 @@
 import React, { memo } from 'react';
 import { EuiSuperSelect, EuiSuperSelectOption, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { Status, statuses } from '../status';
-import { CaseStatusWithAllStatus, StatusAll } from '../../../common';
+import { CaseStatusWithAllStatus, StatusAll } from '../../../common/ui/types';
 
 interface Props {
   stats: Record<CaseStatusWithAllStatus, number | null>;

--- a/x-pack/plugins/cases/public/components/all_cases/table.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table.tsx
@@ -18,7 +18,7 @@ import styled from 'styled-components';
 
 import { CasesTableUtilityBar } from './utility_bar';
 import { CasesNavigation, LinkButton } from '../links';
-import { AllCases, Case, FilterOptions } from '../../../common';
+import { AllCases, Case, FilterOptions } from '../../../common/ui/types';
 import * as i18n from './translations';
 
 interface CasesTableProps {

--- a/x-pack/plugins/cases/public/components/all_cases/table_filters.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table_filters.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { CaseStatuses } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
 import { TestProviders } from '../../common/mock';
 import { useGetTags } from '../../containers/use_get_tags';
 import { useGetReporters } from '../../containers/use_get_reporters';

--- a/x-pack/plugins/cases/public/components/all_cases/table_filters.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table_filters.tsx
@@ -10,7 +10,8 @@ import { isEqual } from 'lodash/fp';
 import styled from 'styled-components';
 import { EuiFlexGroup, EuiFlexItem, EuiFieldSearch, EuiFilterGroup } from '@elastic/eui';
 
-import { CaseStatuses, CaseStatusWithAllStatus, StatusAll } from '../../../common';
+import { StatusAll, CaseStatusWithAllStatus } from '../../../common/ui/types';
+import { CaseStatuses } from '../../../common/api';
 import { FilterOptions } from '../../containers/types';
 import { useGetTags } from '../../containers/use_get_tags';
 import { useGetReporters } from '../../containers/use_get_reporters';

--- a/x-pack/plugins/cases/public/components/all_cases/utility_bar.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/utility_bar.tsx
@@ -15,7 +15,7 @@ import {
   UtilityBarText,
 } from '../utility_bar';
 import * as i18n from './translations';
-import { AllCases, Case, DeleteCase, FilterOptions } from '../../../common';
+import { AllCases, Case, DeleteCase, FilterOptions } from '../../../common/ui/types';
 import { getBulkItems } from '../bulk_actions';
 import { isSelectedCasesIncludeCollections } from './helpers';
 import { useDeleteCases } from '../../containers/use_delete_cases';

--- a/x-pack/plugins/cases/public/components/bulk_actions/index.tsx
+++ b/x-pack/plugins/cases/public/components/bulk_actions/index.tsx
@@ -8,7 +8,8 @@
 import React from 'react';
 import { EuiContextMenuItem } from '@elastic/eui';
 
-import { CaseStatuses, CaseStatusWithAllStatus } from '../../../common';
+import { CaseStatusWithAllStatus } from '../../../common/ui/types';
+import { CaseStatuses } from '../../../common/api';
 import { statuses } from '../status';
 import * as i18n from './translations';
 import { Case } from '../../containers/types';

--- a/x-pack/plugins/cases/public/components/case_action_bar/actions.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/actions.tsx
@@ -11,7 +11,7 @@ import * as i18n from '../case_view/translations';
 import { useDeleteCases } from '../../containers/use_delete_cases';
 import { ConfirmDeleteCaseModal } from '../confirm_delete_case';
 import { PropertyActions } from '../property_actions';
-import { Case } from '../../../common';
+import { Case } from '../../../common/ui/types';
 import { CaseService } from '../../containers/use_get_case_user_actions';
 import { CasesNavigation } from '../links';
 

--- a/x-pack/plugins/cases/public/components/case_action_bar/helpers.test.ts
+++ b/x-pack/plugins/cases/public/components/case_action_bar/helpers.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CaseStatuses } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
 import { basicCase } from '../../containers/mock';
 import { getStatusDate, getStatusTitle } from './helpers';
 

--- a/x-pack/plugins/cases/public/components/case_action_bar/helpers.ts
+++ b/x-pack/plugins/cases/public/components/case_action_bar/helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CaseStatuses } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
 import { Case } from '../../containers/types';
 import { statuses } from '../status';
 

--- a/x-pack/plugins/cases/public/components/case_action_bar/index.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.tsx
@@ -16,7 +16,8 @@ import {
   EuiFlexItem,
   EuiIconTip,
 } from '@elastic/eui';
-import { Case, CaseStatuses, CaseType } from '../../../common';
+import { Case } from '../../../common/ui/types';
+import { CaseStatuses, CaseType } from '../../../common/api';
 import * as i18n from '../case_view/translations';
 import { FormattedRelativePreferenceDate } from '../formatted_date';
 import { Actions } from './actions';

--- a/x-pack/plugins/cases/public/components/case_action_bar/status_context_menu.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/status_context_menu.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { CaseStatuses } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
 import { StatusContextMenu } from './status_context_menu';
 
 describe('SyncAlertsSwitch', () => {

--- a/x-pack/plugins/cases/public/components/case_action_bar/status_context_menu.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/status_context_menu.tsx
@@ -7,7 +7,7 @@
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiPopover, EuiContextMenuPanel, EuiContextMenuItem } from '@elastic/eui';
-import { caseStatuses, CaseStatuses } from '../../../common';
+import { caseStatuses, CaseStatuses } from '../../../common/api';
 import { Status } from '../status';
 import { CHANGE_STATUS } from '../all_cases/translations';
 

--- a/x-pack/plugins/cases/public/components/case_view/helpers.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/helpers.test.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { AssociationType, CommentType, SECURITY_SOLUTION_OWNER } from '../../../common';
+import { AssociationType, CommentType } from '../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { Comment } from '../../containers/types';
 
 import { getManualAlertIdsWithNoRuleId } from './helpers';

--- a/x-pack/plugins/cases/public/components/case_view/helpers.ts
+++ b/x-pack/plugins/cases/public/components/case_view/helpers.ts
@@ -6,7 +6,7 @@
  */
 
 import { isEmpty } from 'lodash';
-import { CommentType } from '../../../common';
+import { CommentType } from '../../../common/api';
 import { Comment } from '../../containers/types';
 
 export const getManualAlertIdsWithNoRuleId = (comments: Comment[]): string[] => {

--- a/x-pack/plugins/cases/public/components/case_view/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/index.test.tsx
@@ -27,7 +27,7 @@ import { waitFor } from '@testing-library/react';
 import { useConnectors } from '../../containers/configure/use_connectors';
 import { connectorsMock } from '../../containers/configure/mock';
 import { usePostPushToService } from '../../containers/use_post_push_to_service';
-import { CaseType, ConnectorTypes } from '../../../common';
+import { CaseType, ConnectorTypes } from '../../../common/api';
 import { useKibana } from '../../common/lib/kibana';
 
 const mockId = basicCase.id;

--- a/x-pack/plugins/cases/public/components/case_view/index.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/index.tsx
@@ -9,15 +9,8 @@ import React, { useCallback, useEffect, useMemo, useState, useRef, MutableRefObj
 import styled from 'styled-components';
 import { EuiFlexGroup, EuiFlexItem, EuiLoadingContent, EuiLoadingSpinner } from '@elastic/eui';
 
-import {
-  CaseStatuses,
-  CaseAttributes,
-  CaseType,
-  Case,
-  CaseConnector,
-  Ecs,
-  CaseViewRefreshPropInterface,
-} from '../../../common';
+import { Case, Ecs, CaseViewRefreshPropInterface } from '../../../common/ui/types';
+import { CaseStatuses, CaseAttributes, CaseType, CaseConnector } from '../../../common/api';
 import { HeaderPage } from '../header_page';
 import { EditableTitle } from '../header_page/editable_title';
 import { TagList } from '../tag_list';

--- a/x-pack/plugins/cases/public/components/configure_cases/__mock__/index.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/__mock__/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ActionTypeConnector, ConnectorTypes } from '../../../../common';
+import { ActionTypeConnector, ConnectorTypes } from '../../../../common/api';
 import { ActionConnector } from '../../../containers/configure/types';
 import { UseConnectorsResponse } from '../../../containers/configure/use_connectors';
 import { ReturnUseCaseConfigure } from '../../../containers/configure/use_configure';

--- a/x-pack/plugins/cases/public/components/configure_cases/connectors.test.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/connectors.test.tsx
@@ -13,7 +13,7 @@ import { Connectors, Props } from './connectors';
 import { TestProviders } from '../../common/mock';
 import { ConnectorsDropdown } from './connectors_dropdown';
 import { connectors, actionTypes } from './__mock__';
-import { ConnectorTypes } from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
 import { useKibana } from '../../common/lib/kibana';
 import { registerConnectorsToMockActionRegistry } from '../../common/mock/register_connectors';
 

--- a/x-pack/plugins/cases/public/components/configure_cases/connectors.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/connectors.tsx
@@ -21,7 +21,7 @@ import * as i18n from './translations';
 
 import { ActionConnector, CaseConnectorMapping } from '../../containers/configure/types';
 import { Mapping } from './mapping';
-import { ActionTypeConnector, ConnectorTypes } from '../../../common';
+import { ActionTypeConnector, ConnectorTypes } from '../../../common/api';
 import { DeprecatedCallout } from '../connectors/deprecated_callout';
 import { isDeprecatedConnector } from '../utils';
 

--- a/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.tsx
@@ -9,7 +9,7 @@ import React, { useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiIconTip, EuiSuperSelect } from '@elastic/eui';
 import styled from 'styled-components';
 
-import { ConnectorTypes } from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
 import { ActionConnector } from '../../containers/configure/types';
 import * as i18n from './translations';
 import { useKibana } from '../../common/lib/kibana';

--- a/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
@@ -26,7 +26,7 @@ import {
   useConnectorsResponse,
   useActionTypesResponse,
 } from './__mock__';
-import { ConnectorTypes, SECURITY_SOLUTION_OWNER } from '../../../common';
+import { ConnectorTypes, SECURITY_SOLUTION_OWNER } from '../../../common/api';
 import { actionTypeRegistryMock } from '../../../../triggers_actions_ui/public/application/action_type_registry.mock';
 
 jest.mock('../../common/lib/kibana');

--- a/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
@@ -26,7 +26,8 @@ import {
   useConnectorsResponse,
   useActionTypesResponse,
 } from './__mock__';
-import { ConnectorTypes, SECURITY_SOLUTION_OWNER } from '../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
+import { ConnectorTypes } from '../../../common/api';
 import { actionTypeRegistryMock } from '../../../../triggers_actions_ui/public/application/action_type_registry.mock';
 
 jest.mock('../../common/lib/kibana');

--- a/x-pack/plugins/cases/public/components/configure_cases/index.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/index.tsx
@@ -11,7 +11,7 @@ import styled, { css } from 'styled-components';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiCallOut, EuiLink } from '@elastic/eui';
 
-import { SUPPORTED_CONNECTORS } from '../../../common';
+import { SUPPORTED_CONNECTORS } from '../../../common/constants';
 import { useKibana } from '../../common/lib/kibana';
 import { useConnectors } from '../../containers/configure/use_connectors';
 import { useActionTypes } from '../../containers/configure/use_action_types';

--- a/x-pack/plugins/cases/public/components/configure_cases/utils.ts
+++ b/x-pack/plugins/cases/public/components/configure_cases/utils.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ConnectorTypeFields, ConnectorTypes } from '../../../common';
+import { ConnectorTypeFields, ConnectorTypes } from '../../../common/api';
 import {
   CaseField,
   ActionType,

--- a/x-pack/plugins/cases/public/components/connector_selector/form.tsx
+++ b/x-pack/plugins/cases/public/components/connector_selector/form.tsx
@@ -12,7 +12,7 @@ import styled from 'styled-components';
 
 import { FieldHook, getFieldValidityAndErrorMessage } from '../../common/shared_imports';
 import { ConnectorsDropdown } from '../configure_cases/connectors_dropdown';
-import { ActionConnector } from '../../../common';
+import { ActionConnector } from '../../../common/api';
 
 interface ConnectorSelectorProps {
   connectors: ActionConnector[];

--- a/x-pack/plugins/cases/public/components/connectors/card.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/card.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { ConnectorTypes } from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
 import { useKibana } from '../../common/lib/kibana';
 import { connectors } from '../configure_cases/__mock__';
 import { ConnectorCard } from './card';

--- a/x-pack/plugins/cases/public/components/connectors/card.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/card.tsx
@@ -9,7 +9,7 @@ import React, { memo, useMemo } from 'react';
 import { EuiCard, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiLoadingSpinner } from '@elastic/eui';
 import styled from 'styled-components';
 
-import { ConnectorTypes } from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
 import { useKibana } from '../../common/lib/kibana';
 import { getConnectorIcon } from '../utils';
 

--- a/x-pack/plugins/cases/public/components/connectors/case/alert_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/case/alert_fields.tsx
@@ -12,7 +12,8 @@ import styled from 'styled-components';
 import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 
 import { ActionParamsProps } from '../../../../../triggers_actions_ui/public/types';
-import { CommentType, SECURITY_SOLUTION_OWNER } from '../../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../../common/constants';
+import { CommentType } from '../../../../common/api';
 
 import { CaseActionParams } from './types';
 import { ExistingCase } from './existing_case';

--- a/x-pack/plugins/cases/public/components/connectors/case/alert_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/case/alert_fields.tsx
@@ -12,7 +12,7 @@ import styled from 'styled-components';
 import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 
 import { ActionParamsProps } from '../../../../../triggers_actions_ui/public/types';
-import { CommentType, SECURITY_SOLUTION_OWNER } from '../../../../common';
+import { CommentType, SECURITY_SOLUTION_OWNER } from '../../../../common/api';
 
 import { CaseActionParams } from './types';
 import { ExistingCase } from './existing_case';

--- a/x-pack/plugins/cases/public/components/connectors/case/existing_case.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/case/existing_case.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useMemo, useCallback } from 'react';
-import { CaseType } from '../../../../common';
+import { CaseType } from '../../../../common/api';
 import {
   useGetCases,
   DEFAULT_QUERY_PARAMS,

--- a/x-pack/plugins/cases/public/components/connectors/fields_form.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/fields_form.tsx
@@ -11,7 +11,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import { CaseActionConnector } from '../types';
 import { ConnectorFieldsProps } from './types';
 import { getCaseConnectors } from '.';
-import { ConnectorTypeFields } from '../../../common';
+import { ConnectorTypeFields } from '../../../common/api';
 
 interface Props extends Omit<ConnectorFieldsProps<ConnectorTypeFields['fields']>, 'connector'> {
   connector: CaseActionConnector | null;

--- a/x-pack/plugins/cases/public/components/connectors/index.ts
+++ b/x-pack/plugins/cases/public/components/connectors/index.ts
@@ -17,7 +17,7 @@ import {
   ServiceNowSIRFieldsType,
   ResilientFieldsType,
   SwimlaneFieldsType,
-} from '../../../common';
+} from '../../../common/api';
 
 export { getActionType as getCaseConnectorUi } from './case';
 

--- a/x-pack/plugins/cases/public/components/connectors/jira/case_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/case_fields.tsx
@@ -10,7 +10,7 @@ import { map } from 'lodash/fp';
 import { EuiFormRow, EuiSelect, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import * as i18n from './translations';
 
-import { ConnectorTypes, JiraFieldsType } from '../../../../common';
+import { ConnectorTypes, JiraFieldsType } from '../../../../common/api';
 import { useKibana } from '../../../common/lib/kibana';
 import { ConnectorFieldsProps } from '../types';
 import { useGetIssueTypes } from './use_get_issue_types';

--- a/x-pack/plugins/cases/public/components/connectors/jira/index.ts
+++ b/x-pack/plugins/cases/public/components/connectors/jira/index.ts
@@ -8,7 +8,7 @@
 import { lazy } from 'react';
 
 import { CaseConnector } from '../types';
-import { ConnectorTypes, JiraFieldsType } from '../../../../common';
+import { ConnectorTypes, JiraFieldsType } from '../../../../common/api';
 import * as i18n from './translations';
 
 export * from './types';

--- a/x-pack/plugins/cases/public/components/connectors/jira/search_issues.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/search_issues.tsx
@@ -9,7 +9,7 @@ import React, { useMemo, useEffect, useCallback, useState, memo } from 'react';
 import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
 
 import { useKibana } from '../../../common/lib/kibana';
-import { ActionConnector } from '../../../../common';
+import { ActionConnector } from '../../../../common/api';
 import { useGetIssues } from './use_get_issues';
 import { useGetSingleIssue } from './use_get_single_issue';
 import * as i18n from './translations';

--- a/x-pack/plugins/cases/public/components/connectors/jira/use_get_fields_by_issue_type.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/use_get_fields_by_issue_type.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { HttpSetup, IToasts } from 'kibana/public';
-import { ActionConnector } from '../../../../common';
+import { ActionConnector } from '../../../../common/api';
 import { getFieldsByIssueType } from './api';
 import { Fields } from './types';
 import * as i18n from './translations';

--- a/x-pack/plugins/cases/public/components/connectors/jira/use_get_issue_types.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/use_get_issue_types.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { HttpSetup, IToasts } from 'kibana/public';
-import { ActionConnector } from '../../../../common';
+import { ActionConnector } from '../../../../common/api';
 import { getIssueTypes } from './api';
 import { IssueTypes } from './types';
 import * as i18n from './translations';

--- a/x-pack/plugins/cases/public/components/connectors/jira/use_get_issues.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/use_get_issues.tsx
@@ -8,7 +8,7 @@
 import { isEmpty, debounce } from 'lodash/fp';
 import { useState, useEffect, useRef } from 'react';
 import { HttpSetup, ToastsApi } from 'kibana/public';
-import { ActionConnector } from '../../../../common';
+import { ActionConnector } from '../../../../common/api';
 import { getIssues } from './api';
 import { Issues } from './types';
 import * as i18n from './translations';

--- a/x-pack/plugins/cases/public/components/connectors/jira/use_get_single_issue.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/use_get_single_issue.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { HttpSetup, ToastsApi } from 'kibana/public';
-import { ActionConnector } from '../../../../common';
+import { ActionConnector } from '../../../../common/api';
 import { getIssue } from './api';
 import { Issue } from './types';
 import * as i18n from './translations';

--- a/x-pack/plugins/cases/public/components/connectors/mock.ts
+++ b/x-pack/plugins/cases/public/components/connectors/mock.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SwimlaneConnectorType } from '../../../common';
+import { SwimlaneConnectorType } from '../../../common/api';
 
 export const connector = {
   id: '123',

--- a/x-pack/plugins/cases/public/components/connectors/resilient/case_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/resilient/case_fields.tsx
@@ -21,7 +21,7 @@ import { useGetIncidentTypes } from './use_get_incident_types';
 import { useGetSeverity } from './use_get_severity';
 
 import * as i18n from './translations';
-import { ConnectorTypes, ResilientFieldsType } from '../../../../common';
+import { ConnectorTypes, ResilientFieldsType } from '../../../../common/api';
 import { ConnectorCard } from '../card';
 
 const ResilientFieldsComponent: React.FunctionComponent<ConnectorFieldsProps<ResilientFieldsType>> =

--- a/x-pack/plugins/cases/public/components/connectors/resilient/index.ts
+++ b/x-pack/plugins/cases/public/components/connectors/resilient/index.ts
@@ -8,7 +8,7 @@
 import { lazy } from 'react';
 
 import { CaseConnector } from '../types';
-import { ConnectorTypes, ResilientFieldsType } from '../../../../common';
+import { ConnectorTypes, ResilientFieldsType } from '../../../../common/api';
 import * as i18n from './translations';
 
 export * from './types';

--- a/x-pack/plugins/cases/public/components/connectors/resilient/use_get_incident_types.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/resilient/use_get_incident_types.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { HttpSetup, ToastsApi } from 'kibana/public';
-import { ActionConnector } from '../../../../common';
+import { ActionConnector } from '../../../../common/api';
 import { getIncidentTypes } from './api';
 import * as i18n from './translations';
 

--- a/x-pack/plugins/cases/public/components/connectors/resilient/use_get_severity.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/resilient/use_get_severity.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { HttpSetup, ToastsApi } from 'kibana/public';
-import { ActionConnector } from '../../../../common';
+import { ActionConnector } from '../../../../common/api';
 import { getSeverity } from './api';
 import * as i18n from './translations';
 

--- a/x-pack/plugins/cases/public/components/connectors/servicenow/index.ts
+++ b/x-pack/plugins/cases/public/components/connectors/servicenow/index.ts
@@ -12,7 +12,7 @@ import {
   ConnectorTypes,
   ServiceNowITSMFieldsType,
   ServiceNowSIRFieldsType,
-} from '../../../../common';
+} from '../../../../common/api';
 import * as i18n from './translations';
 
 export const getServiceNowITSMCaseConnector = (): CaseConnector<ServiceNowITSMFieldsType> => ({

--- a/x-pack/plugins/cases/public/components/connectors/servicenow/servicenow_itsm_case_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/servicenow/servicenow_itsm_case_fields.tsx
@@ -10,7 +10,7 @@ import { EuiFormRow, EuiSelect, EuiSpacer, EuiFlexGroup, EuiFlexItem } from '@el
 import * as i18n from './translations';
 
 import { ConnectorFieldsProps } from '../types';
-import { ConnectorTypes, ServiceNowITSMFieldsType } from '../../../../common';
+import { ConnectorTypes, ServiceNowITSMFieldsType } from '../../../../common/api';
 import { useKibana } from '../../../common/lib/kibana';
 import { ConnectorCard } from '../card';
 import { useGetChoices } from './use_get_choices';

--- a/x-pack/plugins/cases/public/components/connectors/servicenow/servicenow_sir_case_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/servicenow/servicenow_sir_case_fields.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { EuiFormRow, EuiSelect, EuiFlexGroup, EuiFlexItem, EuiCheckbox } from '@elastic/eui';
 
-import { ConnectorTypes, ServiceNowSIRFieldsType } from '../../../../common';
+import { ConnectorTypes, ServiceNowSIRFieldsType } from '../../../../common/api';
 import { useKibana } from '../../../common/lib/kibana';
 import { ConnectorFieldsProps } from '../types';
 import { ConnectorCard } from '../card';

--- a/x-pack/plugins/cases/public/components/connectors/servicenow/use_get_choices.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/servicenow/use_get_choices.test.tsx
@@ -8,7 +8,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 
 import { useKibana } from '../../../common/lib/kibana';
-import { ActionConnector } from '../../../../common';
+import { ActionConnector } from '../../../../common/api';
 import { choices } from '../mock';
 import { useGetChoices, UseGetChoices, UseGetChoicesProps } from './use_get_choices';
 import * as api from './api';

--- a/x-pack/plugins/cases/public/components/connectors/servicenow/use_get_choices.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/servicenow/use_get_choices.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { HttpSetup, IToasts } from 'kibana/public';
-import { ActionConnector } from '../../../../common';
+import { ActionConnector } from '../../../../common/api';
 import { getChoices } from './api';
 import { Choice } from './types';
 import * as i18n from './translations';

--- a/x-pack/plugins/cases/public/components/connectors/swimlane/case_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/swimlane/case_fields.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { SwimlaneConnectorType } from '../../../../common';
+import { SwimlaneConnectorType } from '../../../../common/api';
 import Fields from './case_fields';
 import * as i18n from './translations';
 import { swimlaneConnector as connector } from '../mock';

--- a/x-pack/plugins/cases/public/components/connectors/swimlane/case_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/swimlane/case_fields.tsx
@@ -9,7 +9,7 @@ import React, { useMemo } from 'react';
 import { EuiCallOut } from '@elastic/eui';
 import * as i18n from './translations';
 
-import { ConnectorTypes, SwimlaneFieldsType } from '../../../../common';
+import { ConnectorTypes, SwimlaneFieldsType } from '../../../../common/api';
 import { ConnectorFieldsProps } from '../types';
 import { ConnectorCard } from '../card';
 import { connectorValidator } from './validator';

--- a/x-pack/plugins/cases/public/components/connectors/swimlane/index.ts
+++ b/x-pack/plugins/cases/public/components/connectors/swimlane/index.ts
@@ -8,7 +8,7 @@
 import { lazy } from 'react';
 
 import { CaseConnector } from '../types';
-import { ConnectorTypes, SwimlaneFieldsType } from '../../../../common';
+import { ConnectorTypes, SwimlaneFieldsType } from '../../../../common/api';
 import * as i18n from './translations';
 
 export const getCaseConnector = (): CaseConnector<SwimlaneFieldsType> => {

--- a/x-pack/plugins/cases/public/components/connectors/swimlane/validator.test.ts
+++ b/x-pack/plugins/cases/public/components/connectors/swimlane/validator.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SwimlaneConnectorType } from '../../../../common';
+import { SwimlaneConnectorType } from '../../../../common/api';
 import { swimlaneConnector as connector } from '../mock';
 import { isAnyRequiredFieldNotSet, connectorValidator } from './validator';
 

--- a/x-pack/plugins/cases/public/components/connectors/swimlane/validator.ts
+++ b/x-pack/plugins/cases/public/components/connectors/swimlane/validator.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SwimlaneConnectorType } from '../../../../common';
+import { SwimlaneConnectorType } from '../../../../common/api';
 import { ValidationConfig } from '../../../common/shared_imports';
 import { CaseActionConnector } from '../../types';
 

--- a/x-pack/plugins/cases/public/components/connectors/types.ts
+++ b/x-pack/plugins/cases/public/components/connectors/types.ts
@@ -12,10 +12,10 @@ import {
   ActionType as ThirdPartySupportedActions,
   CaseField,
   ConnectorTypeFields,
-} from '../../../common';
+} from '../../../common/api';
 import { CaseActionConnector } from '../types';
 
-export type { ThirdPartyField as AllThirdPartyFields } from '../../../common';
+export type { ThirdPartyField as AllThirdPartyFields } from '../../../common/api';
 
 export interface ThirdPartyField {
   label: string;

--- a/x-pack/plugins/cases/public/components/create/connector.tsx
+++ b/x-pack/plugins/cases/public/components/create/connector.tsx
@@ -8,7 +8,7 @@
 import React, { memo, useCallback, useMemo, useEffect } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
-import { ConnectorTypes, ActionConnector } from '../../../common';
+import { ConnectorTypes, ActionConnector } from '../../../common/api';
 import {
   UseField,
   useFormData,

--- a/x-pack/plugins/cases/public/components/create/form.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.tsx
@@ -17,7 +17,7 @@ import { Tags } from './tags';
 import { Connector } from './connector';
 import * as i18n from './translations';
 import { SyncAlertsToggle } from './sync_alerts_toggle';
-import { ActionConnector } from '../../../common';
+import { ActionConnector } from '../../../common/api';
 
 interface ContainerProps {
   big?: boolean;

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -10,7 +10,8 @@ import { mount, ReactWrapper } from 'enzyme';
 import { act, waitFor } from '@testing-library/react';
 import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
 
-import { ConnectorTypes, SECURITY_SOLUTION_OWNER } from '../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
+import { ConnectorTypes } from '../../../common/api';
 import { useKibana } from '../../common/lib/kibana';
 import { TestProviders } from '../../common/mock';
 import { usePostCase } from '../../containers/use_post_case';

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -10,7 +10,7 @@ import { mount, ReactWrapper } from 'enzyme';
 import { act, waitFor } from '@testing-library/react';
 import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
 
-import { ConnectorTypes, SECURITY_SOLUTION_OWNER } from '../../../common';
+import { ConnectorTypes, SECURITY_SOLUTION_OWNER } from '../../../common/api';
 import { useKibana } from '../../common/lib/kibana';
 import { TestProviders } from '../../common/mock';
 import { usePostCase } from '../../containers/use_post_case';

--- a/x-pack/plugins/cases/public/components/create/form_context.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.tsx
@@ -14,7 +14,7 @@ import { usePostPushToService } from '../../containers/use_post_push_to_service'
 
 import { useConnectors } from '../../containers/configure/use_connectors';
 import { Case } from '../../containers/types';
-import { CaseType } from '../../../common';
+import { CaseType } from '../../../common/api';
 import { UsePostComment, usePostComment } from '../../containers/use_post_comment';
 import { useOwnerContext } from '../owner_context/use_owner_context';
 import { getConnectorById } from '../utils';

--- a/x-pack/plugins/cases/public/components/create/index.tsx
+++ b/x-pack/plugins/cases/public/components/create/index.tsx
@@ -15,7 +15,7 @@ import { CreateCaseForm } from './form';
 import { FormContext } from './form_context';
 import { SubmitCaseButton } from './submit_button';
 import { Case } from '../../containers/types';
-import { CaseType } from '../../../common';
+import { CaseType } from '../../../common/api';
 import { CasesTimelineIntegration, CasesTimelineIntegrationProvider } from '../timeline_context';
 import { fieldName as descriptionFieldName } from './description';
 import { InsertTimeline } from '../insert_timeline';

--- a/x-pack/plugins/cases/public/components/create/mock.ts
+++ b/x-pack/plugins/cases/public/components/create/mock.ts
@@ -5,12 +5,8 @@
  * 2.0.
  */
 
-import {
-  CasePostRequest,
-  CaseType,
-  ConnectorTypes,
-  SECURITY_SOLUTION_OWNER,
-} from '../../../common';
+import { CasePostRequest, CaseType, ConnectorTypes } from '../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { choices } from '../connectors/mock';
 
 export const sampleTags = ['coke', 'pepsi'];

--- a/x-pack/plugins/cases/public/components/create/schema.tsx
+++ b/x-pack/plugins/cases/public/components/create/schema.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { CasePostRequest, ConnectorTypeFields, MAX_TITLE_LENGTH } from '../../../common';
+import { CasePostRequest, ConnectorTypeFields } from '../../../common/api';
+import { MAX_TITLE_LENGTH } from '../../../common/constants';
 import {
   FIELD_TYPES,
   fieldValidators,

--- a/x-pack/plugins/cases/public/components/edit_connector/helpers.test.ts
+++ b/x-pack/plugins/cases/public/components/edit_connector/helpers.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CaseUserActionConnector, ConnectorTypes } from '../../../common';
+import { CaseUserActionConnector, ConnectorTypes } from '../../../common/api';
 import { CaseUserActions } from '../../containers/types';
 import { getConnectorFieldsFromUserActions } from './helpers';
 

--- a/x-pack/plugins/cases/public/components/edit_connector/helpers.ts
+++ b/x-pack/plugins/cases/public/components/edit_connector/helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ConnectorTypeFields } from '../../../common';
+import { ConnectorTypeFields } from '../../../common/api';
 import { CaseUserActions } from '../../containers/types';
 import { parseStringAsConnector } from '../../common/user_actions';
 

--- a/x-pack/plugins/cases/public/components/edit_connector/index.tsx
+++ b/x-pack/plugins/cases/public/components/edit_connector/index.tsx
@@ -21,7 +21,8 @@ import styled from 'styled-components';
 import { isEmpty, noop } from 'lodash/fp';
 
 import { FieldConfig, Form, UseField, useForm } from '../../common/shared_imports';
-import { ActionConnector, Case, ConnectorTypeFields } from '../../../common';
+import { Case } from '../../../common/ui/types';
+import { ActionConnector, ConnectorTypeFields } from '../../../common/api';
 import { ConnectorSelector } from '../connector_selector/form';
 import { ConnectorFieldsForm } from '../connectors/fields_form';
 import { CaseUserActions } from '../../containers/types';

--- a/x-pack/plugins/cases/public/components/header_page/editable_title.tsx
+++ b/x-pack/plugins/cases/public/components/header_page/editable_title.tsx
@@ -19,7 +19,7 @@ import {
   EuiFormRow,
 } from '@elastic/eui';
 
-import { MAX_TITLE_LENGTH } from '../../../common';
+import { MAX_TITLE_LENGTH } from '../../../common/constants';
 import * as i18n from './translations';
 import { Title } from './title';
 

--- a/x-pack/plugins/cases/public/components/status/button.test.tsx
+++ b/x-pack/plugins/cases/public/components/status/button.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { CaseStatuses } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
 import { StatusActionButton } from './button';
 
 describe('StatusActionButton', () => {

--- a/x-pack/plugins/cases/public/components/status/button.tsx
+++ b/x-pack/plugins/cases/public/components/status/button.tsx
@@ -8,7 +8,7 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import { EuiButton } from '@elastic/eui';
 
-import { CaseStatuses, caseStatuses } from '../../../common';
+import { CaseStatuses, caseStatuses } from '../../../common/api';
 import { statuses } from './config';
 
 interface Props {

--- a/x-pack/plugins/cases/public/components/status/config.ts
+++ b/x-pack/plugins/cases/public/components/status/config.ts
@@ -4,7 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { CaseStatuses, StatusAll } from '../../../common';
+import { StatusAll } from '../../../common/ui/types';
+import { CaseStatuses } from '../../../common/api';
 import * as i18n from './translations';
 import { AllCaseStatus, Statuses } from './types';
 

--- a/x-pack/plugins/cases/public/components/status/stats.test.tsx
+++ b/x-pack/plugins/cases/public/components/status/stats.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { CaseStatuses } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
 import { Stats } from './stats';
 
 describe('Stats', () => {

--- a/x-pack/plugins/cases/public/components/status/stats.tsx
+++ b/x-pack/plugins/cases/public/components/status/stats.tsx
@@ -7,7 +7,7 @@
 
 import React, { memo, useMemo } from 'react';
 import { EuiDescriptionList, EuiLoadingSpinner } from '@elastic/eui';
-import { CaseStatuses } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
 import { statuses } from './config';
 
 export interface Props {

--- a/x-pack/plugins/cases/public/components/status/status.test.tsx
+++ b/x-pack/plugins/cases/public/components/status/status.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { CaseStatuses } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
 import { Status } from './status';
 
 describe('Stats', () => {

--- a/x-pack/plugins/cases/public/components/status/status.tsx
+++ b/x-pack/plugins/cases/public/components/status/status.tsx
@@ -11,7 +11,7 @@ import { EuiBadge } from '@elastic/eui';
 
 import { allCaseStatus, statuses } from './config';
 import * as i18n from './translations';
-import { CaseStatusWithAllStatus, StatusAll } from '../../../common';
+import { CaseStatusWithAllStatus, StatusAll } from '../../../common/ui/types';
 
 interface Props {
   disabled?: boolean;

--- a/x-pack/plugins/cases/public/components/status/types.ts
+++ b/x-pack/plugins/cases/public/components/status/types.ts
@@ -6,7 +6,8 @@
  */
 
 import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
-import { CaseStatuses, StatusAllType } from '../../../common';
+import { StatusAllType } from '../../../common/ui/types';
+import { CaseStatuses } from '../../../common/api';
 
 export type AllCaseStatus = Record<StatusAllType, { color: string; label: string }>;
 

--- a/x-pack/plugins/cases/public/components/types.ts
+++ b/x-pack/plugins/cases/public/components/types.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export type { CaseActionConnector } from '../../common';
+export type { CaseActionConnector } from '../../common/ui/types';

--- a/x-pack/plugins/cases/public/components/use_create_case_modal/create_case_modal.test.tsx
+++ b/x-pack/plugins/cases/public/components/use_create_case_modal/create_case_modal.test.tsx
@@ -11,7 +11,7 @@ import { mount } from 'enzyme';
 import { CreateCaseModal } from './create_case_modal';
 import { TestProviders } from '../../common/mock';
 import { getCreateCaseLazy as getCreateCase } from '../../methods';
-import { SECURITY_SOLUTION_OWNER } from '../../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 
 jest.mock('../../methods');
 const getCreateCaseMock = getCreateCase as jest.Mock;

--- a/x-pack/plugins/cases/public/components/use_create_case_modal/create_case_modal.tsx
+++ b/x-pack/plugins/cases/public/components/use_create_case_modal/create_case_modal.tsx
@@ -10,7 +10,7 @@ import { EuiModal, EuiModalBody, EuiModalHeader, EuiModalHeaderTitle } from '@el
 
 import { Case } from '../../containers/types';
 import * as i18n from '../../common/translations';
-import { CaseType } from '../../../common';
+import { CaseType } from '../../../common/api';
 import { getCreateCaseLazy as getCreateCase } from '../../methods';
 
 export interface CreateCaseModalProps {

--- a/x-pack/plugins/cases/public/components/use_create_case_modal/index.tsx
+++ b/x-pack/plugins/cases/public/components/use_create_case_modal/index.tsx
@@ -6,7 +6,8 @@
  */
 
 import React, { useState, useCallback, useMemo } from 'react';
-import { Case, CaseType } from '../../../common/ui/types';
+import { CaseType } from '../../../common/api';
+import { Case } from '../../../common/ui/types';
 import { useOwnerContext } from '../owner_context/use_owner_context';
 import { CreateCaseModal } from './create_case_modal';
 

--- a/x-pack/plugins/cases/public/components/use_create_case_modal/index.tsx
+++ b/x-pack/plugins/cases/public/components/use_create_case_modal/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useCallback, useMemo } from 'react';
-import { Case, CaseType } from '../../../common';
+import { Case, CaseType } from '../../../common/ui/types';
 import { useOwnerContext } from '../owner_context/use_owner_context';
 import { CreateCaseModal } from './create_case_modal';
 

--- a/x-pack/plugins/cases/public/components/use_push_to_service/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/use_push_to_service/index.test.tsx
@@ -12,7 +12,7 @@ import { render, screen } from '@testing-library/react';
 import '../../common/mock/match_media';
 import { usePushToService, ReturnUsePushToService, UsePushToService } from '.';
 import { TestProviders } from '../../common/mock';
-import { CaseStatuses, ConnectorTypes } from '../../../common';
+import { CaseStatuses, ConnectorTypes } from '../../../common/api';
 import { usePostPushToService } from '../../containers/use_post_push_to_service';
 import { basicPush, actionLicenses } from '../../containers/mock';
 import { useGetActionLicense } from '../../containers/use_get_action_license';

--- a/x-pack/plugins/cases/public/components/use_push_to_service/index.tsx
+++ b/x-pack/plugins/cases/public/components/use_push_to_service/index.tsx
@@ -19,7 +19,8 @@ import {
   getCaseClosedInfo,
 } from './helpers';
 import * as i18n from './translations';
-import { Case, CaseConnector, ActionConnector, CaseStatuses } from '../../../common';
+import { Case } from '../../../common/ui/types';
+import { CaseConnector, ActionConnector, CaseStatuses } from '../../../common/api';
 import { CaseServices } from '../../containers/use_get_case_user_actions';
 import { CasesNavigation } from '../links';
 import { ErrorMessage } from './callout/types';

--- a/x-pack/plugins/cases/public/components/user_action_tree/helpers.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_action_tree/helpers.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { CaseStatuses, ConnectorTypes } from '../../../common';
+import { CaseStatuses, ConnectorTypes } from '../../../common/api';
 import { basicPush, getUserAction } from '../../containers/mock';
 import {
   getLabelTitle,

--- a/x-pack/plugins/cases/public/components/user_action_tree/helpers.tsx
+++ b/x-pack/plugins/cases/public/components/user_action_tree/helpers.tsx
@@ -16,15 +16,15 @@ import {
 import React, { useContext } from 'react';
 import classNames from 'classnames';
 import { ThemeContext } from 'styled-components';
+import { Comment } from '../../../common/ui/types';
 import {
   CaseFullExternalService,
   ActionConnector,
   CaseStatuses,
   CommentType,
-  Comment,
   CommentRequestActionsType,
   noneConnectorId,
-} from '../../../common';
+} from '../../../common/api';
 import { CaseUserActions } from '../../containers/types';
 import { CaseServices } from '../../containers/use_get_case_user_actions';
 import { parseStringAsConnector, parseStringAsExternalService } from '../../common/user_actions';

--- a/x-pack/plugins/cases/public/components/user_action_tree/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_action_tree/index.test.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../containers/mock';
 import { UserActionTree } from '.';
 import { TestProviders } from '../../common/mock';
-import { Ecs } from '../../../common';
+import { Ecs } from '../../../common/ui/types';
 
 const fetchUserActions = jest.fn();
 const onUpdateField = jest.fn();

--- a/x-pack/plugins/cases/public/components/user_action_tree/index.tsx
+++ b/x-pack/plugins/cases/public/components/user_action_tree/index.tsx
@@ -30,12 +30,9 @@ import {
   ActionConnector,
   ActionsCommentRequestRt,
   AlertCommentRequestRt,
-  Case,
-  CaseUserActions,
   CommentType,
   ContextTypeUserRt,
-  Ecs,
-} from '../../../common';
+} from '../../../common/api';
 import { CaseServices } from '../../containers/use_get_case_user_actions';
 import { parseStringAsExternalService } from '../../common/user_actions';
 import { OnUpdateFields } from '../case_view';

--- a/x-pack/plugins/cases/public/components/user_action_tree/index.tsx
+++ b/x-pack/plugins/cases/public/components/user_action_tree/index.tsx
@@ -26,6 +26,8 @@ import * as i18n from './translations';
 import { useUpdateComment } from '../../containers/use_update_comment';
 import { useCurrentUser } from '../../common/lib/kibana';
 import { AddComment } from '../add_comment';
+import { Case, Ecs } from '../../../common/ui/types';
+import { CaseUserActions } from '../../../common/ui';
 import {
   ActionConnector,
   ActionsCommentRequestRt,

--- a/x-pack/plugins/cases/public/components/user_action_tree/user_action_alert_comment_event.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_action_tree/user_action_alert_comment_event.test.tsx
@@ -11,7 +11,7 @@ import { mount } from 'enzyme';
 import { TestProviders } from '../../common/mock';
 import { useKibana } from '../../common/lib/kibana';
 import { AlertCommentEvent } from './user_action_alert_comment_event';
-import { CommentType } from '../../../common';
+import { CommentType } from '../../../common/api';
 
 const props = {
   alertId: 'alert-id-1',

--- a/x-pack/plugins/cases/public/components/user_action_tree/user_action_alert_comment_event.tsx
+++ b/x-pack/plugins/cases/public/components/user_action_tree/user_action_alert_comment_event.tsx
@@ -10,7 +10,7 @@ import { isEmpty } from 'lodash';
 import { EuiText, EuiLoadingSpinner } from '@elastic/eui';
 
 import * as i18n from './translations';
-import { CommentType } from '../../../common';
+import { CommentType } from '../../../common/api';
 import { LinkAnchor } from '../links';
 import { RuleDetailsNavigation } from './helpers';
 

--- a/x-pack/plugins/cases/public/components/utils.ts
+++ b/x-pack/plugins/cases/public/components/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { IconType } from '@elastic/eui';
-import { ConnectorTypes } from '../../common';
+import { ConnectorTypes } from '../../common/api';
 import { FieldConfig, ValidationConfig } from '../common/shared_imports';
 import { StartPlugins } from '../types';
 import { connectorValidator as swimlaneConnectorValidator } from './connectors/swimlane/validator';

--- a/x-pack/plugins/cases/public/containers/__mocks__/api.ts
+++ b/x-pack/plugins/cases/public/containers/__mocks__/api.ts
@@ -28,14 +28,14 @@ import {
   respReporters,
   tags,
 } from '../mock';
+import { ResolvedCase } from '../../../common/ui/types';
 import {
   CasePatchRequest,
   CasePostRequest,
   CommentRequest,
   User,
   CaseStatuses,
-  ResolvedCase,
-} from '../../../common';
+} from '../../../common/api';
 
 export const getCase = async (
   caseId: string,

--- a/x-pack/plugins/cases/public/containers/api.test.tsx
+++ b/x-pack/plugins/cases/public/containers/api.test.tsx
@@ -7,13 +7,8 @@
 
 import { KibanaServices } from '../common/lib/kibana';
 
-import {
-  CASES_URL,
-  ConnectorTypes,
-  CommentType,
-  CaseStatuses,
-  SECURITY_SOLUTION_OWNER,
-} from '../../common';
+import { ConnectorTypes, CommentType, CaseStatuses } from '../../common/api';
+import { CASES_URL, SECURITY_SOLUTION_OWNER } from '../../common/constants';
 
 import {
   deleteCases,

--- a/x-pack/plugins/cases/public/containers/api.ts
+++ b/x-pack/plugins/cases/public/containers/api.ts
@@ -7,15 +7,12 @@
 
 import { assign, omit } from 'lodash';
 
+import { StatusAll, ResolvedCase } from '../../common/ui/types';
 import {
-  CASE_REPORTERS_URL,
-  CASE_STATUS_URL,
-  CASE_TAGS_URL,
   CasePatchRequest,
   CasePostRequest,
   CaseResponse,
   CaseResolveResponse,
-  CASES_URL,
   CasesFindResponse,
   CasesResponse,
   CasesStatusResponse,
@@ -29,16 +26,19 @@ import {
   getCaseUserActionUrl,
   getSubCaseDetailsUrl,
   getSubCaseUserActionUrl,
-  StatusAll,
-  SUB_CASE_DETAILS_URL,
-  SUB_CASES_PATCH_DEL_URL,
   SubCasePatchRequest,
   SubCaseResponse,
   SubCasesResponse,
   User,
-  ResolvedCase,
-} from '../../common';
-
+} from '../../common/api';
+import {
+  CASE_REPORTERS_URL,
+  CASE_STATUS_URL,
+  CASE_TAGS_URL,
+  CASES_URL,
+  SUB_CASE_DETAILS_URL,
+  SUB_CASES_PATCH_DEL_URL,
+} from '../../common/constants';
 import { getAllConnectorTypesUrl } from '../../common/utils/connectors_api';
 
 import { KibanaServices } from '../common/lib/kibana';

--- a/x-pack/plugins/cases/public/containers/configure/__mocks__/api.ts
+++ b/x-pack/plugins/cases/public/containers/configure/__mocks__/api.ts
@@ -10,7 +10,7 @@ import {
   CasesConfigureRequest,
   ActionConnector,
   ActionTypeConnector,
-} from '../../../../common';
+} from '../../../../common/api';
 
 import { ApiProps } from '../../types';
 import { CaseConfigure } from '../types';

--- a/x-pack/plugins/cases/public/containers/configure/api.test.ts
+++ b/x-pack/plugins/cases/public/containers/configure/api.test.ts
@@ -19,7 +19,8 @@ import {
   caseConfigurationResposeMock,
   caseConfigurationCamelCaseResponseMock,
 } from './mock';
-import { ConnectorTypes, SECURITY_SOLUTION_OWNER } from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { KibanaServices } from '../../common/lib/kibana';
 
 const abortCtrl = new AbortController();

--- a/x-pack/plugins/cases/public/containers/configure/api.ts
+++ b/x-pack/plugins/cases/public/containers/configure/api.ts
@@ -10,14 +10,13 @@ import { getAllConnectorTypesUrl } from '../../../common/utils/connectors_api';
 import {
   ActionConnector,
   ActionTypeConnector,
-  CASE_CONFIGURE_CONNECTORS_URL,
-  CASE_CONFIGURE_URL,
   CasesConfigurePatch,
   CasesConfigureRequest,
   CasesConfigureResponse,
   CasesConfigurationsResponse,
   getCaseConfigurationDetailsUrl,
-} from '../../../common';
+} from '../../../common/api';
+import { CASE_CONFIGURE_CONNECTORS_URL, CASE_CONFIGURE_URL } from '../../../common/constants';
 import { KibanaServices } from '../../common/lib/kibana';
 
 import { ApiProps } from '../types';

--- a/x-pack/plugins/cases/public/containers/configure/mock.ts
+++ b/x-pack/plugins/cases/public/containers/configure/mock.ts
@@ -11,8 +11,8 @@ import {
   CasesConfigureResponse,
   CasesConfigureRequest,
   ConnectorTypes,
-  SECURITY_SOLUTION_OWNER,
-} from '../../../common';
+} from '../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { CaseConfigure, CaseConnectorMapping } from './types';
 
 export const mappings: CaseConnectorMapping[] = [

--- a/x-pack/plugins/cases/public/containers/configure/types.ts
+++ b/x-pack/plugins/cases/public/containers/configure/types.ts
@@ -15,7 +15,7 @@ import {
   CasesConfigure,
   ClosureType,
   ThirdPartyField,
-} from '../../../common';
+} from '../../../common/api';
 
 export type {
   ActionConnector,

--- a/x-pack/plugins/cases/public/containers/configure/use_configure.test.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_configure.test.tsx
@@ -15,7 +15,7 @@ import {
 } from './use_configure';
 import { mappings, caseConfigurationCamelCaseResponseMock } from './mock';
 import * as api from './api';
-import { ConnectorTypes } from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
 import { TestProviders } from '../../common/mock';
 
 const mockErrorToast = jest.fn();

--- a/x-pack/plugins/cases/public/containers/configure/use_configure.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_configure.tsx
@@ -10,7 +10,7 @@ import { getCaseConfigure, patchCaseConfigure, postCaseConfigure } from './api';
 
 import * as i18n from './translations';
 import { ClosureType, CaseConfigure, CaseConnector, CaseConnectorMapping } from './types';
-import { ConnectorTypes } from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
 import { useToasts } from '../../common/lib/kibana';
 import { useOwnerContext } from '../../components/owner_context/use_owner_context';
 

--- a/x-pack/plugins/cases/public/containers/mock.ts
+++ b/x-pack/plugins/cases/public/containers/mock.ts
@@ -7,6 +7,8 @@
 
 import { ActionLicense, AllCases, Case, CasesStatus, CaseUserActions, Comment } from './types';
 
+import { isCreateConnector, isPush, isUpdateConnector } from '../../common/utils/user_actions';
+import { ResolvedCase } from '../../common/ui/types';
 import {
   AssociationType,
   CaseUserActionConnector,
@@ -20,14 +22,10 @@ import {
   CommentResponse,
   CommentType,
   ConnectorTypes,
-  ResolvedCase,
-  isCreateConnector,
-  isPush,
-  isUpdateConnector,
-  SECURITY_SOLUTION_OWNER,
   UserAction,
   UserActionField,
-} from '../../common';
+} from '../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 import { UseGetCasesState, DEFAULT_FILTER_OPTIONS, DEFAULT_QUERY_PARAMS } from './use_get_cases';
 export { connectorsMock } from './configure/mock';
 

--- a/x-pack/plugins/cases/public/containers/use_bulk_update_case.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_bulk_update_case.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { renderHook, act } from '@testing-library/react-hooks';
-import { CaseStatuses } from '../../common';
+import { CaseStatuses } from '../../common/api';
 import { useUpdateCases, UseUpdateCases } from './use_bulk_update_case';
 import { basicCase } from './mock';
 import * as api from './api';

--- a/x-pack/plugins/cases/public/containers/use_bulk_update_case.tsx
+++ b/x-pack/plugins/cases/public/containers/use_bulk_update_case.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useCallback, useReducer, useRef, useEffect } from 'react';
-import { CaseStatuses } from '../../common';
+import { CaseStatuses } from '../../common/api';
 import * as i18n from './translations';
 import { patchCasesStatus } from './api';
 import { BulkUpdateStatus, Case } from './types';

--- a/x-pack/plugins/cases/public/containers/use_delete_cases.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_delete_cases.test.tsx
@@ -7,7 +7,7 @@
 
 import { renderHook, act } from '@testing-library/react-hooks';
 
-import { CaseType } from '../../common';
+import { CaseType } from '../../common/api';
 import { useDeleteCases, UseDeleteCase } from './use_delete_cases';
 import * as api from './api';
 

--- a/x-pack/plugins/cases/public/containers/use_get_action_license.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_action_license.tsx
@@ -11,7 +11,7 @@ import { useToasts } from '../common/lib/kibana';
 import { getActionLicense } from './api';
 import * as i18n from './translations';
 import { ActionLicense } from './types';
-import { ConnectorTypes } from '../../common';
+import { ConnectorTypes } from '../../common/api';
 
 export interface ActionLicenseState {
   actionLicense: ActionLicense | null;

--- a/x-pack/plugins/cases/public/containers/use_get_case_user_actions.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case_user_actions.tsx
@@ -9,13 +9,8 @@ import { isEmpty, uniqBy } from 'lodash/fp';
 import { useCallback, useEffect, useState, useRef } from 'react';
 import deepEqual from 'fast-deep-equal';
 
-import {
-  CaseFullExternalService,
-  CaseConnector,
-  CaseExternalService,
-  CaseUserActions,
-  ElasticUser,
-} from '../../common';
+import { ElasticUser, CaseUserActions, CaseExternalService } from '../../common/ui/types';
+import { CaseFullExternalService, CaseConnector } from '../../common/api';
 import { getCaseUserActions, getSubCaseUserActions } from './api';
 import * as i18n from './translations';
 import { convertToCamelCase } from './utils';

--- a/x-pack/plugins/cases/public/containers/use_get_cases.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_cases.test.tsx
@@ -7,7 +7,8 @@
 
 import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { CaseStatuses, SECURITY_SOLUTION_OWNER } from '../../common';
+import { CaseStatuses } from '../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 import {
   DEFAULT_FILTER_OPTIONS,
   DEFAULT_QUERY_PARAMS,

--- a/x-pack/plugins/cases/public/containers/use_get_cases_status.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_cases_status.test.tsx
@@ -11,7 +11,7 @@ import { useGetCasesStatus, UseGetCasesStatus } from './use_get_cases_status';
 import { casesStatus } from './mock';
 import * as api from './api';
 import { TestProviders } from '../common/mock';
-import { SECURITY_SOLUTION_OWNER } from '../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 
 jest.mock('./api');
 jest.mock('../common/lib/kibana');

--- a/x-pack/plugins/cases/public/containers/use_get_reporters.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_reporters.test.tsx
@@ -11,7 +11,7 @@ import { useGetReporters, UseGetReporters } from './use_get_reporters';
 import { reporters, respReporters } from './mock';
 import * as api from './api';
 import { TestProviders } from '../common/mock';
-import { SECURITY_SOLUTION_OWNER } from '../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 
 jest.mock('./api');
 jest.mock('../common/lib/kibana');

--- a/x-pack/plugins/cases/public/containers/use_get_reporters.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_reporters.tsx
@@ -8,7 +8,7 @@
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { isEmpty } from 'lodash/fp';
 
-import { User } from '../../common';
+import { User } from '../../common/api';
 import { getReporters } from './api';
 import * as i18n from './translations';
 import { useToasts } from '../common/lib/kibana';

--- a/x-pack/plugins/cases/public/containers/use_get_tags.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_tags.test.tsx
@@ -11,7 +11,7 @@ import { useGetTags, UseGetTags } from './use_get_tags';
 import { tags } from './mock';
 import * as api from './api';
 import { TestProviders } from '../common/mock';
-import { SECURITY_SOLUTION_OWNER } from '../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 
 jest.mock('./api');
 jest.mock('../common/lib/kibana');

--- a/x-pack/plugins/cases/public/containers/use_post_case.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_post_case.test.tsx
@@ -8,7 +8,8 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { usePostCase, UsePostCase } from './use_post_case';
 import * as api from './api';
-import { ConnectorTypes, SECURITY_SOLUTION_OWNER } from '../../common';
+import { ConnectorTypes } from '../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 import { basicCasePost } from './mock';
 
 jest.mock('./api');

--- a/x-pack/plugins/cases/public/containers/use_post_case.tsx
+++ b/x-pack/plugins/cases/public/containers/use_post_case.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useReducer, useCallback, useRef, useEffect } from 'react';
-import { CasePostRequest } from '../../common';
+import { CasePostRequest } from '../../common/api';
 import { postCase } from './api';
 import * as i18n from './translations';
 import { Case } from './types';

--- a/x-pack/plugins/cases/public/containers/use_post_comment.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_post_comment.test.tsx
@@ -7,7 +7,8 @@
 
 import { renderHook, act } from '@testing-library/react-hooks';
 
-import { CommentType, SECURITY_SOLUTION_OWNER } from '../../common';
+import { CommentType } from '../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 import { usePostComment, UsePostComment } from './use_post_comment';
 import { basicCaseId, basicSubCaseId } from './mock';
 import * as api from './api';

--- a/x-pack/plugins/cases/public/containers/use_post_comment.tsx
+++ b/x-pack/plugins/cases/public/containers/use_post_comment.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useReducer, useCallback, useRef, useEffect } from 'react';
-import { CommentRequest } from '../../common';
+import { CommentRequest } from '../../common/api';
 
 import { postComment } from './api';
 import * as i18n from './translations';

--- a/x-pack/plugins/cases/public/containers/use_post_push_to_service.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_post_push_to_service.test.tsx
@@ -9,7 +9,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { usePostPushToService, UsePostPushToService } from './use_post_push_to_service';
 import { pushedCase } from './mock';
 import * as api from './api';
-import { CaseConnector, ConnectorTypes } from '../../common';
+import { CaseConnector, ConnectorTypes } from '../../common/api';
 
 jest.mock('./api');
 jest.mock('../common/lib/kibana');

--- a/x-pack/plugins/cases/public/containers/use_post_push_to_service.tsx
+++ b/x-pack/plugins/cases/public/containers/use_post_push_to_service.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useReducer, useCallback, useRef, useEffect } from 'react';
-import { CaseConnector } from '../../common';
+import { CaseConnector } from '../../common/api';
 
 import { pushCase } from './api';
 import * as i18n from './translations';

--- a/x-pack/plugins/cases/public/containers/use_update_case.tsx
+++ b/x-pack/plugins/cases/public/containers/use_update_case.tsx
@@ -9,7 +9,8 @@ import { useReducer, useCallback, useRef, useEffect } from 'react';
 
 import { useToasts } from '../common/lib/kibana';
 import { patchCase, patchSubCase } from './api';
-import { UpdateKey, UpdateByKey, CaseStatuses } from '../../common';
+import { UpdateKey, UpdateByKey } from '../../common/ui/types';
+import { CaseStatuses } from '../../common/api';
 import * as i18n from './translations';
 import { createUpdateSuccessToaster } from './utils';
 

--- a/x-pack/plugins/cases/public/containers/use_update_comment.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_update_comment.test.tsx
@@ -11,7 +11,7 @@ import { useUpdateComment, UseUpdateComment } from './use_update_comment';
 import { basicCase, basicCaseCommentPatch, basicSubCaseId } from './mock';
 import * as api from './api';
 import { TestProviders } from '../common/mock';
-import { SECURITY_SOLUTION_OWNER } from '../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 
 jest.mock('./api');
 jest.mock('../common/lib/kibana');

--- a/x-pack/plugins/cases/public/containers/utils.ts
+++ b/x-pack/plugins/cases/public/containers/utils.ts
@@ -32,7 +32,7 @@ import {
   CasePatchRequest,
   CaseResolveResponse,
   CaseResolveResponseRt,
-} from '../../common';
+} from '../../common/api';
 import { AllCases, Case, UpdateByKey } from './types';
 import * as i18n from './translations';
 

--- a/x-pack/plugins/cases/public/plugin.ts
+++ b/x-pack/plugins/cases/public/plugin.ts
@@ -17,7 +17,8 @@ import {
   getRecentCasesLazy,
   getAllCasesSelectorModalLazy,
 } from './methods';
-import { CasesUiConfigType, ENABLE_CASE_CONNECTOR } from '../common';
+import { CasesUiConfigType } from '../common/ui/types';
+import { ENABLE_CASE_CONNECTOR } from '../common/constants';
 
 /**
  * @public

--- a/x-pack/plugins/cases/server/authorization/index.ts
+++ b/x-pack/plugins/cases/server/authorization/index.ts
@@ -11,7 +11,7 @@ import {
   CASE_CONFIGURE_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
   CASE_USER_ACTION_SAVED_OBJECT,
-} from '../../common';
+} from '../../common/constants';
 import { Verbs, ReadOperations, WriteOperations, OperationDetails } from './types';
 
 export * from './authorization';

--- a/x-pack/plugins/cases/server/authorization/utils.test.ts
+++ b/x-pack/plugins/cases/server/authorization/utils.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { nodeBuilder } from '@kbn/es-query';
-import { OWNER_FIELD } from '../../common';
+import { OWNER_FIELD } from '../../common/api';
 import {
   combineFilterWithAuthorizationFilter,
   ensureFieldIsSafeForQuery,

--- a/x-pack/plugins/cases/server/authorization/utils.ts
+++ b/x-pack/plugins/cases/server/authorization/utils.ts
@@ -7,7 +7,7 @@
 
 import { remove, uniq } from 'lodash';
 import { nodeBuilder, KueryNode } from '@kbn/es-query';
-import { OWNER_FIELD } from '../../common';
+import { OWNER_FIELD } from '../../common/api';
 
 export const getOwnersFilter = (
   savedObjectType: string,

--- a/x-pack/plugins/cases/server/client/attachments/add.ts
+++ b/x-pack/plugins/cases/server/client/attachments/add.ts
@@ -21,19 +21,21 @@ import { LensServerPluginSetup } from '../../../../lens/server';
 
 import {
   AlertCommentRequestRt,
-  CASE_COMMENT_SAVED_OBJECT,
   CaseResponse,
   CaseStatuses,
   CaseType,
   CommentRequest,
   CommentRequestRt,
   CommentType,
-  ENABLE_CASE_CONNECTOR,
-  MAX_GENERATED_ALERTS_PER_SUB_CASE,
   SubCaseAttributes,
   throwErrors,
   User,
-} from '../../../common';
+} from '../../../common/api';
+import {
+  CASE_COMMENT_SAVED_OBJECT,
+  ENABLE_CASE_CONNECTOR,
+  MAX_GENERATED_ALERTS_PER_SUB_CASE,
+} from '../../../common/constants';
 import {
   buildCaseUserActionItem,
   buildCommentUserActionItem,

--- a/x-pack/plugins/cases/server/client/attachments/client.ts
+++ b/x-pack/plugins/cases/server/client/attachments/client.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { AlertResponse, CommentResponse } from '../../../common';
+import { AlertResponse, CommentResponse } from '../../../common/api';
 import { CasesClient } from '../client';
 
 import { CasesClientInternal } from '../client_internal';

--- a/x-pack/plugins/cases/server/client/attachments/delete.ts
+++ b/x-pack/plugins/cases/server/client/attachments/delete.ts
@@ -9,13 +9,12 @@ import Boom from '@hapi/boom';
 import pMap from 'p-map';
 
 import { SavedObject } from 'kibana/public';
+import { AssociationType, CommentAttributes } from '../../../common/api';
 import {
-  AssociationType,
   CASE_SAVED_OBJECT,
-  CommentAttributes,
   MAX_CONCURRENT_SEARCHES,
   SUB_CASE_SAVED_OBJECT,
-} from '../../../common';
+} from '../../../common/constants';
 import { CasesClientArgs } from '../types';
 import { buildCommentUserActionItem } from '../../services/user_actions/helpers';
 import { createCaseError, checkEnabledCaseConnectorOrThrow } from '../../common';

--- a/x-pack/plugins/cases/server/client/attachments/get.ts
+++ b/x-pack/plugins/cases/server/client/attachments/get.ts
@@ -18,9 +18,9 @@ import {
   CommentResponseRt,
   CommentsResponse,
   CommentsResponseRt,
-  ENABLE_CASE_CONNECTOR,
   FindQueryParams,
-} from '../../../common';
+} from '../../../common/api';
+import { ENABLE_CASE_CONNECTOR } from '../../../common/constants';
 import {
   createCaseError,
   checkEnabledCaseConnectorOrThrow,

--- a/x-pack/plugins/cases/server/client/attachments/update.ts
+++ b/x-pack/plugins/cases/server/client/attachments/update.ts
@@ -12,13 +12,8 @@ import { SavedObjectsClientContract, Logger } from 'kibana/server';
 import { LensServerPluginSetup } from '../../../../lens/server';
 import { checkEnabledCaseConnectorOrThrow, CommentableCase, createCaseError } from '../../common';
 import { buildCommentUserActionItem } from '../../services/user_actions/helpers';
-import {
-  CASE_SAVED_OBJECT,
-  SUB_CASE_SAVED_OBJECT,
-  CaseResponse,
-  CommentPatchRequest,
-  CommentRequest,
-} from '../../../common';
+import { CaseResponse, CommentPatchRequest, CommentRequest } from '../../../common/api';
+import { CASE_SAVED_OBJECT, SUB_CASE_SAVED_OBJECT } from '../../../common/constants';
 import { AttachmentService, CasesService } from '../../services';
 import { CasesClientArgs } from '..';
 import { decodeCommentRequest } from '../utils';

--- a/x-pack/plugins/cases/server/client/cases/client.ts
+++ b/x-pack/plugins/cases/server/client/cases/client.ts
@@ -13,7 +13,7 @@ import {
   AllTagsFindRequest,
   AllReportersFindRequest,
   CasesByAlertId,
-} from '../../../common';
+} from '../../../common/api';
 import { CasesClient } from '../client';
 import { CasesClientInternal } from '../client_internal';
 import {

--- a/x-pack/plugins/cases/server/client/cases/create.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.ts
@@ -21,9 +21,8 @@ import {
   CasePostRequest,
   CaseType,
   OWNER_FIELD,
-  ENABLE_CASE_CONNECTOR,
-  MAX_TITLE_LENGTH,
-} from '../../../common';
+} from '../../../common/api';
+import { ENABLE_CASE_CONNECTOR, MAX_TITLE_LENGTH } from '../../../common/constants';
 import { buildCaseUserActionItem } from '../../services/user_actions/helpers';
 
 import { Operations } from '../../authorization';

--- a/x-pack/plugins/cases/server/client/cases/delete.ts
+++ b/x-pack/plugins/cases/server/client/cases/delete.ts
@@ -8,13 +8,8 @@
 import pMap from 'p-map';
 import { Boom } from '@hapi/boom';
 import { SavedObject, SavedObjectsClientContract, SavedObjectsFindResponse } from 'kibana/server';
-import {
-  CommentAttributes,
-  ENABLE_CASE_CONNECTOR,
-  MAX_CONCURRENT_SEARCHES,
-  OWNER_FIELD,
-  SubCaseAttributes,
-} from '../../../common';
+import { CommentAttributes, SubCaseAttributes, OWNER_FIELD } from '../../../common/api';
+import { ENABLE_CASE_CONNECTOR, MAX_CONCURRENT_SEARCHES } from '../../../common/constants';
 import { CasesClientArgs } from '..';
 import { createCaseError } from '../../common';
 import { AttachmentService, CasesService } from '../../services';

--- a/x-pack/plugins/cases/server/client/cases/find.ts
+++ b/x-pack/plugins/cases/server/client/cases/find.ts
@@ -18,7 +18,7 @@ import {
   caseStatuses,
   CasesFindResponseRt,
   excess,
-} from '../../../common';
+} from '../../../common/api';
 
 import { createCaseError, transformCases } from '../../common';
 import { constructQueryOptions } from '../utils';

--- a/x-pack/plugins/cases/server/client/cases/get.ts
+++ b/x-pack/plugins/cases/server/client/cases/get.ts
@@ -25,11 +25,11 @@ import {
   AllReportersFindRequest,
   CasesByAlertIDRequest,
   CasesByAlertIDRequestRt,
-  ENABLE_CASE_CONNECTOR,
   CasesByAlertId,
   CasesByAlertIdRt,
   CaseAttributes,
-} from '../../../common';
+} from '../../../common/api';
+import { ENABLE_CASE_CONNECTOR } from '../../../common/constants';
 import { countAlertsForID, createCaseError, flattenCaseSavedObject } from '../../common';
 import { CasesClientArgs } from '..';
 import { Operations } from '../../authorization';

--- a/x-pack/plugins/cases/server/client/cases/mock.ts
+++ b/x-pack/plugins/cases/server/client/cases/mock.ts
@@ -12,8 +12,8 @@ import {
   CaseUserActionsResponse,
   AssociationType,
   CommentResponseAlertsType,
-  SECURITY_SOLUTION_OWNER,
-} from '../../../common';
+} from '../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 
 import { BasicParams } from './types';
 

--- a/x-pack/plugins/cases/server/client/cases/push.ts
+++ b/x-pack/plugins/cases/server/client/cases/push.ts
@@ -15,10 +15,10 @@ import {
   CaseStatuses,
   ExternalServiceResponse,
   CaseType,
-  ENABLE_CASE_CONNECTOR,
   CasesConfigureAttributes,
   CaseAttributes,
-} from '../../../common';
+} from '../../../common/api';
+import { ENABLE_CASE_CONNECTOR } from '../../../common/constants';
 import { buildCaseUserActionItem } from '../../services/user_actions/helpers';
 
 import { createIncident, getCommentContextFromAttributes } from './utils';

--- a/x-pack/plugins/cases/server/client/cases/types.ts
+++ b/x-pack/plugins/cases/server/client/cases/types.ts
@@ -19,7 +19,7 @@ import {
   PushToServiceApiParamsSIR as ServiceNowSIRPushToServiceApiParams,
   ServiceNowITSMIncident,
 } from '../../../../actions/server/builtin_action_types/servicenow/types';
-import { CaseResponse, ConnectorMappingsAttributes } from '../../../common';
+import { CaseResponse, ConnectorMappingsAttributes } from '../../../common/api';
 
 export type Incident = JiraIncident | ResilientIncident | ServiceNowITSMIncident;
 export type PushToServiceApiParams =

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -22,8 +22,6 @@ import { nodeBuilder } from '@kbn/es-query';
 
 import {
   AssociationType,
-  CASE_COMMENT_SAVED_OBJECT,
-  CASE_SAVED_OBJECT,
   CasePatchRequest,
   CasesPatchRequest,
   CasesPatchRequestRt,
@@ -33,14 +31,18 @@ import {
   CaseType,
   CommentAttributes,
   CommentType,
-  ENABLE_CASE_CONNECTOR,
   excess,
+  throwErrors,
+  CaseAttributes,
+} from '../../../common/api';
+import {
+  CASE_COMMENT_SAVED_OBJECT,
+  CASE_SAVED_OBJECT,
+  ENABLE_CASE_CONNECTOR,
   MAX_CONCURRENT_SEARCHES,
   SUB_CASE_SAVED_OBJECT,
-  throwErrors,
   MAX_TITLE_LENGTH,
-  CaseAttributes,
-} from '../../../common';
+} from '../../../common/constants';
 import { buildCaseUserActions } from '../../services/user_actions/helpers';
 import { getCaseToUpdate } from '../utils';
 

--- a/x-pack/plugins/cases/server/client/cases/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.test.ts
@@ -32,7 +32,7 @@ import {
   transformFields,
 } from './utils';
 import { flattenCaseSavedObject } from '../../common';
-import { SECURITY_SOLUTION_OWNER } from '../../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { casesConnectors } from '../../connectors';
 
 const formatComment = {

--- a/x-pack/plugins/cases/server/client/cases/utils.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { flow } from 'lodash';
+import { isPush } from '../../../common/utils/user_actions';
 import {
   ActionConnector,
   CaseFullExternalService,
@@ -21,8 +22,7 @@ import {
   CommentRequestAlertType,
   CommentRequestActionsType,
   CaseUserActionResponse,
-  isPush,
-} from '../../../common';
+} from '../../../common/api';
 import { ActionsClient } from '../../../../actions/server';
 import { CasesClientGetAlertsResponse } from '../../client/alerts/types';
 import {

--- a/x-pack/plugins/cases/server/client/client.ts
+++ b/x-pack/plugins/cases/server/client/client.ts
@@ -11,7 +11,7 @@ import { AttachmentsSubClient, createAttachmentsSubClient } from './attachments/
 import { UserActionsSubClient, createUserActionsSubClient } from './user_actions/client';
 import { CasesClientInternal, createCasesClientInternal } from './client_internal';
 import { createSubCasesClient, SubCasesClient } from './sub_cases/client';
-import { ENABLE_CASE_CONNECTOR } from '../../common';
+import { ENABLE_CASE_CONNECTOR } from '../../common/constants';
 import { ConfigureSubClient, createConfigurationSubClient } from './configure/client';
 import { createStatsSubClient, StatsSubClient } from './stats/client';
 

--- a/x-pack/plugins/cases/server/client/configure/client.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.ts
@@ -30,10 +30,9 @@ import {
   excess,
   GetConfigureFindRequest,
   GetConfigureFindRequestRt,
-  MAX_CONCURRENT_SEARCHES,
-  SUPPORTED_CONNECTORS,
   throwErrors,
-} from '../../../common';
+} from '../../../common/api';
+import { MAX_CONCURRENT_SEARCHES, SUPPORTED_CONNECTORS } from '../../../common/constants';
 import { createCaseError } from '../../common';
 import { CasesClientInternal } from '../client_internal';
 import { CasesClientArgs } from '../types';

--- a/x-pack/plugins/cases/server/client/configure/create_mappings.ts
+++ b/x-pack/plugins/cases/server/client/configure/create_mappings.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ConnectorMappingsAttributes } from '../../../common';
+import { ConnectorMappingsAttributes } from '../../../common/api';
 import { ACTION_SAVED_OBJECT_TYPE } from '../../../../actions/server';
 import { createCaseError } from '../../common';
 import { CasesClientArgs } from '..';

--- a/x-pack/plugins/cases/server/client/configure/get_mappings.ts
+++ b/x-pack/plugins/cases/server/client/configure/get_mappings.ts
@@ -6,7 +6,7 @@
  */
 
 import { SavedObjectsFindResponse } from 'kibana/server';
-import { ConnectorMappings } from '../../../common';
+import { ConnectorMappings } from '../../../common/api';
 import { ACTION_SAVED_OBJECT_TYPE } from '../../../../actions/server';
 import { createCaseError } from '../../common';
 import { CasesClientArgs } from '..';

--- a/x-pack/plugins/cases/server/client/configure/types.ts
+++ b/x-pack/plugins/cases/server/client/configure/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CaseConnector } from '../../../common';
+import { CaseConnector } from '../../../common/api';
 
 export interface MappingsArgs {
   connector: CaseConnector;

--- a/x-pack/plugins/cases/server/client/configure/update_mappings.ts
+++ b/x-pack/plugins/cases/server/client/configure/update_mappings.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ConnectorMappingsAttributes } from '../../../common';
+import { ConnectorMappingsAttributes } from '../../../common/api';
 import { ACTION_SAVED_OBJECT_TYPE } from '../../../../actions/server';
 import { createCaseError } from '../../common';
 import { CasesClientArgs } from '..';

--- a/x-pack/plugins/cases/server/client/factory.ts
+++ b/x-pack/plugins/cases/server/client/factory.ts
@@ -12,7 +12,7 @@ import {
   ElasticsearchClient,
 } from 'kibana/server';
 import { SecurityPluginSetup, SecurityPluginStart } from '../../../security/server';
-import { SAVED_OBJECT_TYPES } from '../../common';
+import { SAVED_OBJECT_TYPES } from '../../common/constants';
 import { Authorization } from '../authorization/authorization';
 import { GetSpaceFn } from '../authorization/types';
 import {

--- a/x-pack/plugins/cases/server/client/stats/client.ts
+++ b/x-pack/plugins/cases/server/client/stats/client.ts
@@ -19,7 +19,7 @@ import {
   throwErrors,
   excess,
   CasesStatusRequestRt,
-} from '../../../common';
+} from '../../../common/api';
 import { Operations } from '../../authorization';
 import { createCaseError } from '../../common';
 import { constructQueryOptions } from '../utils';

--- a/x-pack/plugins/cases/server/client/sub_cases/client.ts
+++ b/x-pack/plugins/cases/server/client/sub_cases/client.ts
@@ -95,13 +95,8 @@ export function createSubCasesClient(
 
 async function deleteSubCase(ids: string[], clientArgs: CasesClientArgs): Promise<void> {
   try {
-    const {
-      unsecuredSavedObjectsClient,
-      user,
-      userActionService,
-      caseService,
-      attachmentService,
-    } = clientArgs;
+    const { unsecuredSavedObjectsClient, user, userActionService, caseService, attachmentService } =
+      clientArgs;
 
     const [comments, subCases] = await Promise.all([
       caseService.getAllSubCaseComments({ unsecuredSavedObjectsClient, id: ids }),

--- a/x-pack/plugins/cases/server/client/sub_cases/client.ts
+++ b/x-pack/plugins/cases/server/client/sub_cases/client.ts
@@ -10,24 +10,22 @@ import Boom from '@hapi/boom';
 
 import { SavedObject } from 'kibana/server';
 import {
-  CASE_SAVED_OBJECT,
   caseStatuses,
   CommentAttributes,
-  MAX_CONCURRENT_SEARCHES,
   SubCaseResponse,
   SubCaseResponseRt,
   SubCasesFindRequest,
   SubCasesFindResponse,
   SubCasesFindResponseRt,
   SubCasesPatchRequest,
-} from '../../../common';
+} from '../../../common/api';
 import { CasesClientArgs, CasesClientInternal } from '..';
 import {
   countAlertsForID,
   createCaseError,
   flattenSubCaseSavedObject,
   transformSubCases,
-} from '../../common';
+} from '../../common/utils';
 import { buildCaseUserActionItem } from '../../services/user_actions/helpers';
 import { constructQueryOptions } from '../utils';
 import { defaultPage, defaultPerPage } from '../../routes/api';
@@ -100,8 +98,13 @@ export function createSubCasesClient(
 
 async function deleteSubCase(ids: string[], clientArgs: CasesClientArgs): Promise<void> {
   try {
-    const { unsecuredSavedObjectsClient, user, userActionService, caseService, attachmentService } =
-      clientArgs;
+    const {
+      unsecuredSavedObjectsClient,
+      user,
+      userActionService,
+      caseService,
+      attachmentService,
+    } = clientArgs;
 
     const [comments, subCases] = await Promise.all([
       caseService.getAllSubCaseComments({ unsecuredSavedObjectsClient, id: ids }),

--- a/x-pack/plugins/cases/server/client/sub_cases/client.ts
+++ b/x-pack/plugins/cases/server/client/sub_cases/client.ts
@@ -19,13 +19,10 @@ import {
   SubCasesFindResponseRt,
   SubCasesPatchRequest,
 } from '../../../common/api';
+import { MAX_CONCURRENT_SEARCHES, CASE_SAVED_OBJECT } from '../../../common/constants';
 import { CasesClientArgs, CasesClientInternal } from '..';
-import {
-  countAlertsForID,
-  createCaseError,
-  flattenSubCaseSavedObject,
-  transformSubCases,
-} from '../../common/utils';
+import { createCaseError } from '../../common/error';
+import { countAlertsForID, flattenSubCaseSavedObject, transformSubCases } from '../../common/utils';
 import { buildCaseUserActionItem } from '../../services/user_actions/helpers';
 import { constructQueryOptions } from '../utils';
 import { defaultPage, defaultPerPage } from '../../routes/api';

--- a/x-pack/plugins/cases/server/client/sub_cases/update.ts
+++ b/x-pack/plugins/cases/server/client/sub_cases/update.ts
@@ -19,12 +19,10 @@ import {
 import { nodeBuilder } from '@kbn/es-query';
 import { CasesService } from '../../services';
 import {
-  CASE_COMMENT_SAVED_OBJECT,
   CaseStatuses,
   CommentAttributes,
   CommentType,
   excess,
-  SUB_CASE_SAVED_OBJECT,
   SubCaseAttributes,
   SubCasePatchRequest,
   SubCaseResponse,
@@ -35,7 +33,8 @@ import {
   throwErrors,
   User,
   CaseAttributes,
-} from '../../../common';
+} from '../../../common/api';
+import { CASE_COMMENT_SAVED_OBJECT, SUB_CASE_SAVED_OBJECT } from '../../../common/constants';
 import { getCaseToUpdate } from '../utils';
 import { buildSubCaseUserActions } from '../../services/user_actions/helpers';
 import {

--- a/x-pack/plugins/cases/server/client/typedoc_interfaces.ts
+++ b/x-pack/plugins/cases/server/client/typedoc_interfaces.ts
@@ -30,7 +30,7 @@ import {
   SubCaseResponse,
   SubCasesFindResponse,
   SubCasesResponse,
-} from '../../common';
+} from '../../common/api';
 
 /**
  * These are simply to make typedoc not attempt to expand the type aliases. If it attempts to expand them

--- a/x-pack/plugins/cases/server/client/types.ts
+++ b/x-pack/plugins/cases/server/client/types.ts
@@ -7,7 +7,7 @@
 
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import { ElasticsearchClient, SavedObjectsClientContract, Logger } from 'kibana/server';
-import { User } from '../../common';
+import { User } from '../../common/api';
 import { Authorization } from '../authorization/authorization';
 import {
   AlertServiceContract,

--- a/x-pack/plugins/cases/server/client/user_actions/get.test.ts
+++ b/x-pack/plugins/cases/server/client/user_actions/get.test.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { CaseUserActionResponse, SUB_CASE_SAVED_OBJECT } from '../../../common';
+import { CaseUserActionResponse } from '../../../common/api';
+import { SUB_CASE_SAVED_OBJECT } from '../../../common/constants';
 import { SUB_CASE_REF_NAME } from '../../common';
 import { extractAttributesWithoutSubCases } from './get';
 

--- a/x-pack/plugins/cases/server/client/user_actions/get.ts
+++ b/x-pack/plugins/cases/server/client/user_actions/get.ts
@@ -9,9 +9,9 @@ import { SavedObjectReference, SavedObjectsFindResponse } from 'kibana/server';
 import {
   CaseUserActionsResponse,
   CaseUserActionsResponseRt,
-  SUB_CASE_SAVED_OBJECT,
   CaseUserActionResponse,
-} from '../../../common';
+} from '../../../common/api';
+import { SUB_CASE_SAVED_OBJECT } from '../../../common/constants';
 import { createCaseError, checkEnabledCaseConnectorOrThrow, SUB_CASE_REF_NAME } from '../../common';
 import { CasesClientArgs } from '..';
 import { Operations } from '../../authorization';

--- a/x-pack/plugins/cases/server/client/utils.ts
+++ b/x-pack/plugins/cases/server/client/utils.ts
@@ -13,19 +13,18 @@ import { identity } from 'fp-ts/lib/function';
 import { pipe } from 'fp-ts/lib/pipeable';
 
 import { nodeBuilder, fromKueryExpression, KueryNode } from '@kbn/es-query';
+import { CASE_SAVED_OBJECT, SUB_CASE_SAVED_OBJECT } from '../../common/constants';
 import {
+  OWNER_FIELD,
   AlertCommentRequestRt,
   ActionsCommentRequestRt,
-  CASE_SAVED_OBJECT,
   CaseStatuses,
   CaseType,
   CommentRequest,
   ContextTypeUserRt,
   excess,
-  OWNER_FIELD,
-  SUB_CASE_SAVED_OBJECT,
   throwErrors,
-} from '../../common';
+} from '../../common/api';
 import { combineFilterWithAuthorizationFilter } from '../authorization/utils';
 import {
   getIDsAndIndicesAsArrays,

--- a/x-pack/plugins/cases/server/common/constants.ts
+++ b/x-pack/plugins/cases/server/common/constants.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { CASE_COMMENT_SAVED_OBJECT, CASE_SAVED_OBJECT, SUB_CASE_SAVED_OBJECT } from '../../common';
+import {
+  CASE_COMMENT_SAVED_OBJECT,
+  CASE_SAVED_OBJECT,
+  SUB_CASE_SAVED_OBJECT,
+} from '../../common/constants';
 
 /**
  * The name of the saved object reference indicating the action connector ID. This is stored in the Saved Object reference

--- a/x-pack/plugins/cases/server/common/models/commentable_case.ts
+++ b/x-pack/plugins/cases/server/common/models/commentable_case.ts
@@ -17,7 +17,6 @@ import {
 import { LensServerPluginSetup } from '../../../../lens/server';
 import {
   AssociationType,
-  CASE_SAVED_OBJECT,
   CaseResponse,
   CaseResponseRt,
   CaseSettings,
@@ -27,13 +26,16 @@ import {
   CommentPatchRequest,
   CommentRequest,
   CommentType,
-  MAX_DOCS_PER_PAGE,
-  SUB_CASE_SAVED_OBJECT,
   SubCaseAttributes,
   User,
   CommentRequestUserType,
   CaseAttributes,
-} from '../../../common';
+} from '../../../common/api';
+import {
+  CASE_SAVED_OBJECT,
+  MAX_DOCS_PER_PAGE,
+  SUB_CASE_SAVED_OBJECT,
+} from '../../../common/constants';
 import { flattenCommentSavedObjects, flattenSubCaseSavedObject, transformNewComment } from '..';
 import { AttachmentService, CasesService } from '../../services';
 import { createCaseError } from '../error';

--- a/x-pack/plugins/cases/server/common/types.ts
+++ b/x-pack/plugins/cases/server/common/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { KueryNode } from '@kbn/es-query';
-import { SavedObjectFindOptions } from '../../common';
+import { SavedObjectFindOptions } from '../../common/api';
 
 /**
  * This structure holds the alert ID and index from an alert comment

--- a/x-pack/plugins/cases/server/common/utils.test.ts
+++ b/x-pack/plugins/cases/server/common/utils.test.ts
@@ -7,7 +7,7 @@
 
 import { SavedObject, SavedObjectsFindResponse } from 'kibana/server';
 import { lensEmbeddableFactory } from '../../../lens/server/embeddable/lens_embeddable_factory';
-import { SECURITY_SOLUTION_OWNER } from '../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 import {
   AssociationType,
   CaseResponse,

--- a/x-pack/plugins/cases/server/common/utils.ts
+++ b/x-pack/plugins/cases/server/common/utils.ts
@@ -32,12 +32,12 @@ import {
   CommentsResponse,
   CommentType,
   ConnectorTypes,
-  ENABLE_CASE_CONNECTOR,
   SubCaseAttributes,
   SubCaseResponse,
   SubCasesFindResponse,
   User,
-} from '../../common';
+} from '../../common/api';
+import { ENABLE_CASE_CONNECTOR } from '../../common/constants';
 import { UpdateAlertRequest } from '../client/alerts/types';
 import {
   parseCommentString,

--- a/x-pack/plugins/cases/server/connectors/case/index.test.ts
+++ b/x-pack/plugins/cases/server/connectors/case/index.test.ts
@@ -27,7 +27,7 @@ import {
   createCasesClientFactory,
   createCasesClientMock,
 } from '../../client/mocks';
-import { SECURITY_SOLUTION_OWNER } from '../../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 
 const services = actionsMock.createServices();
 let caseActionType: CaseActionType;

--- a/x-pack/plugins/cases/server/connectors/case/index.ts
+++ b/x-pack/plugins/cases/server/connectors/case/index.ts
@@ -13,8 +13,8 @@ import {
   CasePostRequest,
   CommentRequest,
   CommentType,
-  ENABLE_CASE_CONNECTOR,
-} from '../../../common';
+} from '../../../common/api';
+import { ENABLE_CASE_CONNECTOR } from '../../../common/constants';
 import { CaseExecutorParamsSchema, CaseConfigurationSchema, CommentSchemaType } from './schema';
 import {
   CaseExecutorResponse,

--- a/x-pack/plugins/cases/server/connectors/case/schema.ts
+++ b/x-pack/plugins/cases/server/connectors/case/schema.ts
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { CommentType, ConnectorTypes } from '../../../common';
+import { CommentType, ConnectorTypes } from '../../../common/api';
 import { validateConnector } from './validators';
 
 // Reserved for future implementation

--- a/x-pack/plugins/cases/server/connectors/case/types.ts
+++ b/x-pack/plugins/cases/server/connectors/case/types.ts
@@ -16,7 +16,7 @@ import {
   ConnectorSchema,
   CommentSchema,
 } from './schema';
-import { CaseResponse, CasesResponse } from '../../../common';
+import { CaseResponse, CasesResponse } from '../../../common/api';
 
 export type CaseConfiguration = TypeOf<typeof CaseConfigurationSchema>;
 export type Connector = TypeOf<typeof ConnectorSchema>;

--- a/x-pack/plugins/cases/server/connectors/case/validators.ts
+++ b/x-pack/plugins/cases/server/connectors/case/validators.ts
@@ -6,7 +6,7 @@
  */
 
 import { Connector } from './types';
-import { ConnectorTypes } from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
 
 export const validateConnector = (connector: Connector) => {
   if (connector.type === ConnectorTypes.none && connector.fields !== null) {

--- a/x-pack/plugins/cases/server/connectors/factory.ts
+++ b/x-pack/plugins/cases/server/connectors/factory.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ConnectorTypes } from '../../common';
+import { ConnectorTypes } from '../../common/api';
 import { ICasesConnector, CasesConnectorsMap } from './types';
 import { getCaseConnector as getJiraCaseConnector } from './jira';
 import { getCaseConnector as getResilientCaseConnector } from './resilient';

--- a/x-pack/plugins/cases/server/connectors/index.ts
+++ b/x-pack/plugins/cases/server/connectors/index.ts
@@ -12,7 +12,7 @@ import {
   ContextTypeAlertSchemaType,
 } from './types';
 import { getActionType as getCaseConnector } from './case';
-import { CommentRequest, CommentType } from '../../common';
+import { CommentRequest, CommentType } from '../../common/api';
 
 export * from './types';
 export { transformConnectorComment } from './case';

--- a/x-pack/plugins/cases/server/connectors/jira/format.ts
+++ b/x-pack/plugins/cases/server/connectors/jira/format.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ConnectorJiraTypeFields } from '../../../common';
+import { ConnectorJiraTypeFields } from '../../../common/api';
 import { Format } from './types';
 
 export const format: Format = (theCase, alerts) => {

--- a/x-pack/plugins/cases/server/connectors/jira/types.ts
+++ b/x-pack/plugins/cases/server/connectors/jira/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { JiraFieldsType } from '../../../common';
+import { JiraFieldsType } from '../../../common/api';
 import { ICasesConnector } from '../types';
 
 interface ExternalServiceFormatterParams extends JiraFieldsType {

--- a/x-pack/plugins/cases/server/connectors/resilient/format.test.ts
+++ b/x-pack/plugins/cases/server/connectors/resilient/format.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CaseResponse } from '../../../common';
+import { CaseResponse } from '../../../common/api';
 import { format } from './format';
 
 describe('IBM Resilient formatter', () => {

--- a/x-pack/plugins/cases/server/connectors/resilient/format.ts
+++ b/x-pack/plugins/cases/server/connectors/resilient/format.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ConnectorResilientTypeFields } from '../../../common';
+import { ConnectorResilientTypeFields } from '../../../common/api';
 import { Format } from './types';
 
 export const format: Format = (theCase, alerts) => {

--- a/x-pack/plugins/cases/server/connectors/resilient/types.ts
+++ b/x-pack/plugins/cases/server/connectors/resilient/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ResilientFieldsType } from '../../../common';
+import { ResilientFieldsType } from '../../../common/api';
 import { ICasesConnector } from '../types';
 
 export type ResilientCaseConnector = ICasesConnector<ResilientFieldsType>;

--- a/x-pack/plugins/cases/server/connectors/servicenow/itsm_format.ts
+++ b/x-pack/plugins/cases/server/connectors/servicenow/itsm_format.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ConnectorServiceNowITSMTypeFields } from '../../../common';
+import { ConnectorServiceNowITSMTypeFields } from '../../../common/api';
 import { ServiceNowITSMFormat } from './types';
 
 export const format: ServiceNowITSMFormat = (theCase, alerts) => {

--- a/x-pack/plugins/cases/server/connectors/servicenow/sir_format.test.ts
+++ b/x-pack/plugins/cases/server/connectors/servicenow/sir_format.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CaseResponse } from '../../../common';
+import { CaseResponse } from '../../../common/api';
 import { format } from './sir_format';
 
 describe('ITSM formatter', () => {

--- a/x-pack/plugins/cases/server/connectors/servicenow/sir_format.ts
+++ b/x-pack/plugins/cases/server/connectors/servicenow/sir_format.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { get } from 'lodash/fp';
-import { ConnectorServiceNowSIRTypeFields } from '../../../common';
+import { ConnectorServiceNowSIRTypeFields } from '../../../common/api';
 import { ServiceNowSIRFormat, SirFieldKey, AlertFieldMappingAndValues } from './types';
 
 export const format: ServiceNowSIRFormat = (theCase, alerts) => {

--- a/x-pack/plugins/cases/server/connectors/servicenow/types.ts
+++ b/x-pack/plugins/cases/server/connectors/servicenow/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ServiceNowITSMFieldsType } from '../../../common';
+import { ServiceNowITSMFieldsType } from '../../../common/api';
 import { ICasesConnector } from '../types';
 
 interface CorrelationValues {

--- a/x-pack/plugins/cases/server/connectors/swimlane/format.test.ts
+++ b/x-pack/plugins/cases/server/connectors/swimlane/format.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CaseResponse } from '../../../common';
+import { CaseResponse } from '../../../common/api';
 import { format } from './format';
 
 describe('Swimlane formatter', () => {

--- a/x-pack/plugins/cases/server/connectors/swimlane/format.ts
+++ b/x-pack/plugins/cases/server/connectors/swimlane/format.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ConnectorSwimlaneTypeFields } from '../../../common';
+import { ConnectorSwimlaneTypeFields } from '../../../common/api';
 import { Format } from './types';
 
 export const format: Format = (theCase) => {

--- a/x-pack/plugins/cases/server/connectors/types.ts
+++ b/x-pack/plugins/cases/server/connectors/types.ts
@@ -6,7 +6,7 @@
  */
 
 import { Logger } from 'kibana/server';
-import { CaseResponse, ConnectorMappingsAttributes } from '../../common';
+import { CaseResponse, ConnectorMappingsAttributes } from '../../common/api';
 import { CasesClientGetAlertsResponse } from '../client/alerts/types';
 import { CasesClientFactory } from '../client/factory';
 import { RegisterActionType } from '../types';

--- a/x-pack/plugins/cases/server/plugin.ts
+++ b/x-pack/plugins/cases/server/plugin.ts
@@ -13,7 +13,7 @@ import {
   PluginSetupContract as ActionsPluginSetup,
   PluginStartContract as ActionsPluginStart,
 } from '../../actions/server';
-import { APP_ID, ENABLE_CASE_CONNECTOR } from '../common';
+import { APP_ID, ENABLE_CASE_CONNECTOR } from '../common/constants';
 
 import { initCaseApi } from './routes/api';
 import {

--- a/x-pack/plugins/cases/server/routes/api/__fixtures__/mock_saved_objects.ts
+++ b/x-pack/plugins/cases/server/routes/api/__fixtures__/mock_saved_objects.ts
@@ -14,8 +14,8 @@ import {
   CommentAttributes,
   CommentType,
   ConnectorTypes,
-  SECURITY_SOLUTION_OWNER,
-} from '../../../../common';
+} from '../../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../../common/constants';
 
 export const mockCases: Array<SavedObject<CaseAttributes>> = [
   {

--- a/x-pack/plugins/cases/server/routes/api/__mocks__/request_responses.ts
+++ b/x-pack/plugins/cases/server/routes/api/__mocks__/request_responses.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { SECURITY_SOLUTION_OWNER, CasePostRequest, ConnectorTypes } from '../../../../common';
+import { CasePostRequest, ConnectorTypes } from '../../../../common/api';
+import { SECURITY_SOLUTION_OWNER } from '../../../../common/constants';
 
 export const newCase: CasePostRequest = {
   title: 'My new case',

--- a/x-pack/plugins/cases/server/routes/api/cases/alerts/get_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/alerts/get_cases.ts
@@ -10,7 +10,8 @@ import Boom from '@hapi/boom';
 
 import { RouteDeps } from '../../types';
 import { escapeHatch, wrapError } from '../../utils';
-import { CASE_ALERTS_URL, CasesByAlertIDRequest } from '../../../../../common';
+import { CasesByAlertIDRequest } from '../../../../../common/api';
+import { CASE_ALERTS_URL } from '../../../../../common/constants';
 
 export function initGetCasesByAlertIdApi({ router, logger }: RouteDeps) {
   router.get(

--- a/x-pack/plugins/cases/server/routes/api/cases/delete_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/delete_cases.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 import { RouteDeps } from '../types';
 import { wrapError } from '../utils';
-import { CASES_URL } from '../../../../common';
+import { CASES_URL } from '../../../../common/constants';
 
 export function initDeleteCasesApi({ router, logger }: RouteDeps) {
   router.delete(

--- a/x-pack/plugins/cases/server/routes/api/cases/find_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/find_cases.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { CASES_URL, CasesFindRequest } from '../../../../common';
+import { CasesFindRequest } from '../../../../common/api';
+import { CASES_URL } from '../../../../common/constants';
 import { wrapError, escapeHatch } from '../utils';
 import { RouteDeps } from '../types';
 

--- a/x-pack/plugins/cases/server/routes/api/cases/get_case.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/get_case.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 import { RouteDeps } from '../types';
 import { wrapError } from '../utils';
-import { CASE_DETAILS_URL } from '../../../../common';
+import { CASE_DETAILS_URL } from '../../../../common/constants';
 
 export function initGetCaseApi({ router, logger }: RouteDeps) {
   router.get(

--- a/x-pack/plugins/cases/server/routes/api/cases/patch_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/patch_cases.ts
@@ -7,7 +7,8 @@
 
 import { escapeHatch, wrapError } from '../utils';
 import { RouteDeps } from '../types';
-import { CASES_URL, CasesPatchRequest } from '../../../../common';
+import { CasesPatchRequest } from '../../../../common/api';
+import { CASES_URL } from '../../../../common/constants';
 
 export function initPatchCasesApi({ router, logger }: RouteDeps) {
   router.patch(

--- a/x-pack/plugins/cases/server/routes/api/cases/post_case.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/post_case.ts
@@ -8,7 +8,8 @@
 import { wrapError, escapeHatch } from '../utils';
 
 import { RouteDeps } from '../types';
-import { CASES_URL, CasePostRequest } from '../../../../common';
+import { CasePostRequest } from '../../../../common/api';
+import { CASES_URL } from '../../../../common/constants';
 
 export function initPostCaseApi({ router, logger }: RouteDeps) {
   router.post(

--- a/x-pack/plugins/cases/server/routes/api/cases/push_case.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/push_case.ts
@@ -12,7 +12,8 @@ import { identity } from 'fp-ts/lib/function';
 
 import { wrapError, escapeHatch } from '../utils';
 
-import { throwErrors, CasePushRequestParamsRt, CASE_PUSH_URL } from '../../../../common';
+import { throwErrors, CasePushRequestParamsRt } from '../../../../common/api';
+import { CASE_PUSH_URL } from '../../../../common/constants';
 import { RouteDeps } from '../types';
 
 export function initPushCaseApi({ router, logger }: RouteDeps) {

--- a/x-pack/plugins/cases/server/routes/api/cases/reporters/get_reporters.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/reporters/get_reporters.ts
@@ -7,7 +7,8 @@
 
 import { RouteDeps } from '../../types';
 import { wrapError, escapeHatch } from '../../utils';
-import { CASE_REPORTERS_URL, AllReportersFindRequest } from '../../../../../common';
+import { AllReportersFindRequest } from '../../../../../common/api';
+import { CASE_REPORTERS_URL } from '../../../../../common/constants';
 
 export function initGetReportersApi({ router, logger }: RouteDeps) {
   router.get(

--- a/x-pack/plugins/cases/server/routes/api/cases/tags/get_tags.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/tags/get_tags.ts
@@ -7,7 +7,8 @@
 
 import { RouteDeps } from '../../types';
 import { wrapError, escapeHatch } from '../../utils';
-import { CASE_TAGS_URL, AllTagsFindRequest } from '../../../../../common';
+import { AllTagsFindRequest } from '../../../../../common/api';
+import { CASE_TAGS_URL } from '../../../../../common/constants';
 
 export function initGetTagsApi({ router, logger }: RouteDeps) {
   router.get(

--- a/x-pack/plugins/cases/server/routes/api/comments/delete_all_comments.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/delete_all_comments.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import { RouteDeps } from '../types';
 import { wrapError } from '../utils';
-import { CASE_COMMENTS_URL } from '../../../../common';
+import { CASE_COMMENTS_URL } from '../../../../common/constants';
 
 export function initDeleteAllCommentsApi({ router, logger }: RouteDeps) {
   router.delete(

--- a/x-pack/plugins/cases/server/routes/api/comments/delete_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/delete_comment.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 import { RouteDeps } from '../types';
 import { wrapError } from '../utils';
-import { CASE_COMMENT_DETAILS_URL } from '../../../../common';
+import { CASE_COMMENT_DETAILS_URL } from '../../../../common/constants';
 
 export function initDeleteCommentApi({ router, logger }: RouteDeps) {
   router.delete(

--- a/x-pack/plugins/cases/server/routes/api/comments/find_comments.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/find_comments.ts
@@ -12,7 +12,8 @@ import { pipe } from 'fp-ts/lib/pipeable';
 import { fold } from 'fp-ts/lib/Either';
 import { identity } from 'fp-ts/lib/function';
 
-import { CASE_COMMENTS_URL, FindQueryParamsRt, throwErrors, excess } from '../../../../common';
+import { FindQueryParamsRt, throwErrors, excess } from '../../../../common/api';
+import { CASE_COMMENTS_URL } from '../../../../common/constants';
 import { RouteDeps } from '../types';
 import { escapeHatch, wrapError } from '../utils';
 

--- a/x-pack/plugins/cases/server/routes/api/comments/get_all_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/get_all_comment.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 import { RouteDeps } from '../types';
 import { wrapError } from '../utils';
-import { CASE_COMMENTS_URL } from '../../../../common';
+import { CASE_COMMENTS_URL } from '../../../../common/constants';
 
 export function initGetAllCommentsApi({ router, logger }: RouteDeps) {
   router.get(

--- a/x-pack/plugins/cases/server/routes/api/comments/get_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/get_comment.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 import { RouteDeps } from '../types';
 import { wrapError } from '../utils';
-import { CASE_COMMENT_DETAILS_URL } from '../../../../common';
+import { CASE_COMMENT_DETAILS_URL } from '../../../../common/constants';
 
 export function initGetCommentApi({ router, logger }: RouteDeps) {
   router.get(

--- a/x-pack/plugins/cases/server/routes/api/comments/patch_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/patch_comment.ts
@@ -13,7 +13,8 @@ import Boom from '@hapi/boom';
 
 import { RouteDeps } from '../types';
 import { escapeHatch, wrapError } from '../utils';
-import { CASE_COMMENTS_URL, CommentPatchRequestRt, throwErrors } from '../../../../common';
+import { CommentPatchRequestRt, throwErrors } from '../../../../common/api';
+import { CASE_COMMENTS_URL } from '../../../../common/constants';
 
 export function initPatchCommentApi({ router, logger }: RouteDeps) {
   router.patch(

--- a/x-pack/plugins/cases/server/routes/api/comments/post_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/post_comment.ts
@@ -9,7 +9,8 @@ import Boom from '@hapi/boom';
 import { schema } from '@kbn/config-schema';
 import { escapeHatch, wrapError } from '../utils';
 import { RouteDeps } from '../types';
-import { CASE_COMMENTS_URL, ENABLE_CASE_CONNECTOR, CommentRequest } from '../../../../common';
+import { CASE_COMMENTS_URL, ENABLE_CASE_CONNECTOR } from '../../../../common/constants';
+import { CommentRequest } from '../../../../common/api';
 
 export function initPostCommentApi({ router, logger }: RouteDeps) {
   router.post(

--- a/x-pack/plugins/cases/server/routes/api/configure/get_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/get_configure.ts
@@ -7,7 +7,8 @@
 
 import { RouteDeps } from '../types';
 import { escapeHatch, wrapError } from '../utils';
-import { CASE_CONFIGURE_URL, GetConfigureFindRequest } from '../../../../common';
+import { CASE_CONFIGURE_URL } from '../../../../common/constants';
+import { GetConfigureFindRequest } from '../../../../common/api';
 
 export function initGetCaseConfigure({ router, logger }: RouteDeps) {
   router.get(

--- a/x-pack/plugins/cases/server/routes/api/configure/get_connectors.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/get_connectors.ts
@@ -8,7 +8,7 @@
 import { RouteDeps } from '../types';
 import { wrapError } from '../utils';
 
-import { CASE_CONFIGURE_CONNECTORS_URL } from '../../../../common';
+import { CASE_CONFIGURE_CONNECTORS_URL } from '../../../../common/constants';
 
 /*
  * Be aware that this api will only return 20 connectors

--- a/x-pack/plugins/cases/server/routes/api/configure/patch_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/patch_configure.ts
@@ -11,12 +11,12 @@ import { fold } from 'fp-ts/lib/Either';
 import { identity } from 'fp-ts/lib/function';
 
 import {
-  CASE_CONFIGURE_DETAILS_URL,
   CaseConfigureRequestParamsRt,
   throwErrors,
   CasesConfigurePatch,
   excess,
-} from '../../../../common';
+} from '../../../../common/api';
+import { CASE_CONFIGURE_DETAILS_URL } from '../../../../common/constants';
 import { RouteDeps } from '../types';
 import { wrapError, escapeHatch } from '../utils';
 

--- a/x-pack/plugins/cases/server/routes/api/configure/post_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/post_configure.ts
@@ -10,7 +10,8 @@ import { pipe } from 'fp-ts/lib/pipeable';
 import { fold } from 'fp-ts/lib/Either';
 import { identity } from 'fp-ts/lib/function';
 
-import { CASE_CONFIGURE_URL, CasesConfigureRequestRt, throwErrors } from '../../../../common';
+import { CasesConfigureRequestRt, throwErrors } from '../../../../common/api';
+import { CASE_CONFIGURE_URL } from '../../../../common/constants';
 import { RouteDeps } from '../types';
 import { wrapError, escapeHatch } from '../utils';
 

--- a/x-pack/plugins/cases/server/routes/api/index.ts
+++ b/x-pack/plugins/cases/server/routes/api/index.ts
@@ -37,7 +37,7 @@ import { initGetSubCaseApi } from './sub_case/get_sub_case';
 import { initPatchSubCasesApi } from './sub_case/patch_sub_cases';
 import { initFindSubCasesApi } from './sub_case/find_sub_cases';
 import { initDeleteSubCasesApi } from './sub_case/delete_sub_cases';
-import { ENABLE_CASE_CONNECTOR } from '../../../common';
+import { ENABLE_CASE_CONNECTOR } from '../../../common/constants';
 import { initGetCasesByAlertIdApi } from './cases/alerts/get_cases';
 import { initGetAllAlertsAttachToCaseApi } from './comments/get_alerts';
 

--- a/x-pack/plugins/cases/server/routes/api/stats/get_status.ts
+++ b/x-pack/plugins/cases/server/routes/api/stats/get_status.ts
@@ -8,7 +8,8 @@
 import { RouteDeps } from '../types';
 import { escapeHatch, wrapError } from '../utils';
 
-import { CASE_STATUS_URL, CasesStatusRequest } from '../../../../common';
+import { CasesStatusRequest } from '../../../../common/api';
+import { CASE_STATUS_URL } from '../../../../common/constants';
 
 export function initGetCasesStatusApi({ router, logger }: RouteDeps) {
   router.get(

--- a/x-pack/plugins/cases/server/routes/api/sub_case/delete_sub_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/sub_case/delete_sub_cases.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import { RouteDeps } from '../types';
 import { wrapError } from '../utils';
-import { SUB_CASES_PATCH_DEL_URL } from '../../../../common';
+import { SUB_CASES_PATCH_DEL_URL } from '../../../../common/constants';
 
 export function initDeleteSubCasesApi({ router, logger }: RouteDeps) {
   router.delete(

--- a/x-pack/plugins/cases/server/routes/api/sub_case/find_sub_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/sub_case/find_sub_cases.ts
@@ -12,7 +12,8 @@ import { pipe } from 'fp-ts/lib/pipeable';
 import { fold } from 'fp-ts/lib/Either';
 import { identity } from 'fp-ts/lib/function';
 
-import { SubCasesFindRequestRt, SUB_CASES_URL, throwErrors } from '../../../../common';
+import { SUB_CASES_URL } from '../../../../common/constants';
+import { SubCasesFindRequestRt, throwErrors } from '../../../../common/api';
 import { RouteDeps } from '../types';
 import { escapeHatch, wrapError } from '../utils';
 

--- a/x-pack/plugins/cases/server/routes/api/sub_case/get_sub_case.ts
+++ b/x-pack/plugins/cases/server/routes/api/sub_case/get_sub_case.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 import { RouteDeps } from '../types';
 import { wrapError } from '../utils';
-import { SUB_CASE_DETAILS_URL } from '../../../../common';
+import { SUB_CASE_DETAILS_URL } from '../../../../common/constants';
 
 export function initGetSubCaseApi({ router, logger }: RouteDeps) {
   router.get(

--- a/x-pack/plugins/cases/server/routes/api/sub_case/patch_sub_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/sub_case/patch_sub_cases.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { SubCasesPatchRequest, SUB_CASES_PATCH_DEL_URL } from '../../../../common';
+import { SubCasesPatchRequest } from '../../../../common/api';
+import { SUB_CASES_PATCH_DEL_URL } from '../../../../common/constants';
 import { RouteDeps } from '../types';
 import { escapeHatch, wrapError } from '../utils';
 

--- a/x-pack/plugins/cases/server/routes/api/user_actions/get_all_user_actions.ts
+++ b/x-pack/plugins/cases/server/routes/api/user_actions/get_all_user_actions.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 import { RouteDeps } from '../types';
 import { wrapError } from '../utils';
-import { CASE_USER_ACTIONS_URL, SUB_CASE_USER_ACTIONS_URL } from '../../../../common';
+import { CASE_USER_ACTIONS_URL, SUB_CASE_USER_ACTIONS_URL } from '../../../../common/constants';
 
 export function initGetAllCaseUserActionsApi({ router, logger }: RouteDeps) {
   router.get(

--- a/x-pack/plugins/cases/server/saved_object_types/cases.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/cases.ts
@@ -12,7 +12,7 @@ import {
   SavedObjectsExportTransformContext,
   SavedObjectsType,
 } from 'src/core/server';
-import { CASE_SAVED_OBJECT } from '../../common';
+import { CASE_SAVED_OBJECT } from '../../common/constants';
 import { ESCaseAttributes } from '../services/cases/types';
 import { handleExport } from './import_export/export';
 import { caseMigrations } from './migrations';

--- a/x-pack/plugins/cases/server/saved_object_types/comments.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/comments.ts
@@ -6,7 +6,7 @@
  */
 
 import { SavedObjectsType } from 'src/core/server';
-import { CASE_COMMENT_SAVED_OBJECT } from '../../common';
+import { CASE_COMMENT_SAVED_OBJECT } from '../../common/constants';
 import { createCommentsMigrations, CreateCommentsMigrationsDeps } from './migrations';
 
 export const createCaseCommentSavedObjectType = ({

--- a/x-pack/plugins/cases/server/saved_object_types/configure.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/configure.ts
@@ -6,7 +6,7 @@
  */
 
 import { SavedObjectsType } from 'src/core/server';
-import { CASE_CONFIGURE_SAVED_OBJECT } from '../../common';
+import { CASE_CONFIGURE_SAVED_OBJECT } from '../../common/constants';
 import { configureMigrations } from './migrations';
 
 export const caseConfigureSavedObjectType: SavedObjectsType = {

--- a/x-pack/plugins/cases/server/saved_object_types/connector_mappings.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/connector_mappings.ts
@@ -6,7 +6,7 @@
  */
 
 import { SavedObjectsType } from 'src/core/server';
-import { CASE_CONNECTOR_MAPPINGS_SAVED_OBJECT } from '../../common';
+import { CASE_CONNECTOR_MAPPINGS_SAVED_OBJECT } from '../../common/constants';
 import { connectorMappingsMigrations } from './migrations';
 
 export const caseConnectorMappingsSavedObjectType: SavedObjectsType = {

--- a/x-pack/plugins/cases/server/saved_object_types/import_export/export.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/import_export/export.ts
@@ -12,15 +12,14 @@ import {
   SavedObjectsClientContract,
   SavedObjectsExportTransformContext,
 } from 'kibana/server';
+import { CaseUserActionAttributes, CommentAttributes } from '../../../common/api';
 import {
-  CaseUserActionAttributes,
   CASE_COMMENT_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
   CASE_USER_ACTION_SAVED_OBJECT,
-  CommentAttributes,
   MAX_DOCS_PER_PAGE,
   SAVED_OBJECT_TYPES,
-} from '../../../common';
+} from '../../../common/constants';
 import { createCaseError, defaultSortField } from '../../common';
 import { ESCaseAttributes } from '../../services/cases/types';
 

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/cases.test.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/cases.test.ts
@@ -9,10 +9,10 @@ import { SavedObjectSanitizedDoc } from 'kibana/server';
 import {
   CaseAttributes,
   CaseFullExternalService,
-  CASE_SAVED_OBJECT,
   ConnectorTypes,
   noneConnectorId,
-} from '../../../common';
+} from '../../../common/api';
+import { CASE_SAVED_OBJECT } from '../../../common/constants';
 import { getNoneCaseConnector } from '../../common';
 import { createExternalService, ESCaseConnectorWithId } from '../../services/test_utils';
 import { caseConnectorIdMigration } from './cases';

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/cases.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/cases.ts
@@ -13,7 +13,7 @@ import {
   SavedObjectSanitizedDoc,
 } from '../../../../../../src/core/server';
 import { ESConnectorFields } from '../../services';
-import { ConnectorTypes, CaseType } from '../../../common';
+import { ConnectorTypes, CaseType } from '../../../common/api';
 import {
   transformConnectorIdToReference,
   transformPushConnectorIdToReference,

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/comments.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/comments.ts
@@ -20,7 +20,7 @@ import {
   SavedObjectMigrationFn,
   SavedObjectMigrationMap,
 } from '../../../../../../src/core/server';
-import { CommentType, AssociationType } from '../../../common';
+import { CommentType, AssociationType } from '../../../common/api';
 import {
   isLensMarkdownNode,
   LensMarkdownNode,

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/configuration.test.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/configuration.test.ts
@@ -7,11 +7,8 @@
 
 import { SavedObjectSanitizedDoc } from 'kibana/server';
 import { ACTION_SAVED_OBJECT_TYPE } from '../../../../actions/server';
-import {
-  CASE_CONFIGURE_SAVED_OBJECT,
-  ConnectorTypes,
-  SECURITY_SOLUTION_OWNER,
-} from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
+import { CASE_CONFIGURE_SAVED_OBJECT, SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { getNoneCaseConnector, CONNECTOR_ID_REFERENCE_NAME } from '../../common';
 import { ESCaseConnectorWithId } from '../../services/test_utils';
 import { ESCasesConfigureAttributes } from '../../services/configure/types';

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/configuration.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/configuration.ts
@@ -11,7 +11,7 @@ import {
   SavedObjectUnsanitizedDoc,
   SavedObjectSanitizedDoc,
 } from '../../../../../../src/core/server';
-import { ConnectorTypes } from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
 import { addOwnerToSO, SanitizedCaseOwner } from '.';
 import { transformConnectorIdToReference } from '../../services/user_actions/transform';
 import { CONNECTOR_ID_REFERENCE_NAME } from '../../common';

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/index.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/index.ts
@@ -9,7 +9,7 @@ import {
   SavedObjectUnsanitizedDoc,
   SavedObjectSanitizedDoc,
 } from '../../../../../../src/core/server';
-import { SECURITY_SOLUTION_OWNER } from '../../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 
 export { caseMigrations } from './cases';
 export { configureMigrations } from './configuration';

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/user_actions.test.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/user_actions.test.ts
@@ -9,7 +9,8 @@
 
 import { SavedObjectMigrationContext, SavedObjectSanitizedDoc } from 'kibana/server';
 import { migrationMocks } from 'src/core/server/mocks';
-import { CaseUserActionAttributes, CASE_USER_ACTION_SAVED_OBJECT } from '../../../common';
+import { CaseUserActionAttributes } from '../../../common/api';
+import { CASE_USER_ACTION_SAVED_OBJECT } from '../../../common/constants';
 import {
   createConnectorObject,
   createExternalService,

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/user_actions.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/user_actions.ts
@@ -14,7 +14,8 @@ import {
   SavedObjectMigrationContext,
   LogMeta,
 } from '../../../../../../src/core/server';
-import { ConnectorTypes, isCreateConnector, isPush, isUpdateConnector } from '../../../common';
+import { isPush, isUpdateConnector, isCreateConnector } from '../../../common/utils/user_actions';
+import { ConnectorTypes } from '../../../common/api';
 
 import { extractConnectorIdFromJson } from '../../services/user_actions/transform';
 import { UserActionFieldType } from '../../services/user_actions/types';

--- a/x-pack/plugins/cases/server/saved_object_types/sub_case.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/sub_case.ts
@@ -6,7 +6,7 @@
  */
 
 import { SavedObjectsType } from 'src/core/server';
-import { SUB_CASE_SAVED_OBJECT } from '../../common';
+import { SUB_CASE_SAVED_OBJECT } from '../../common/constants';
 import { subCasesMigrations } from './migrations';
 
 export const subCaseSavedObjectType: SavedObjectsType = {

--- a/x-pack/plugins/cases/server/saved_object_types/user_actions.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/user_actions.ts
@@ -6,7 +6,7 @@
  */
 
 import { SavedObjectsType } from 'src/core/server';
-import { CASE_USER_ACTION_SAVED_OBJECT } from '../../common';
+import { CASE_USER_ACTION_SAVED_OBJECT } from '../../common/constants';
 import { userActionsMigrations } from './migrations';
 
 export const caseUserActionSavedObjectType: SavedObjectsType = {

--- a/x-pack/plugins/cases/server/scripts/sub_cases/index.ts
+++ b/x-pack/plugins/cases/server/scripts/sub_cases/index.ts
@@ -8,14 +8,8 @@
 import yargs from 'yargs';
 import { ToolingLog } from '@kbn/dev-utils';
 import { KbnClient } from '@kbn/test';
-import {
-  CaseResponse,
-  CaseType,
-  CommentType,
-  ConnectorTypes,
-  CASES_URL,
-  SECURITY_SOLUTION_OWNER,
-} from '../../../common';
+import { CaseResponse, CaseType, CommentType, ConnectorTypes } from '../../../common/api';
+import { CASES_URL, SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { ActionResult, ActionTypeExecutorResult } from '../../../../actions/common';
 import { ContextTypeGeneratedAlertType, createAlertsString } from '../../connectors';
 import {

--- a/x-pack/plugins/cases/server/services/alerts/index.test.ts
+++ b/x-pack/plugins/cases/server/services/alerts/index.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CaseStatuses } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
 import { AlertService, AlertServiceContract } from '.';
 import { elasticsearchServiceMock, loggingSystemMock } from 'src/core/server/mocks';
 import { ALERT_WORKFLOW_STATUS } from '../../../../rule_registry/common/technical_rule_data_field_names';

--- a/x-pack/plugins/cases/server/services/alerts/index.ts
+++ b/x-pack/plugins/cases/server/services/alerts/index.ts
@@ -11,7 +11,8 @@ import { isEmpty } from 'lodash';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 
 import { ElasticsearchClient, Logger } from 'kibana/server';
-import { CaseStatuses, MAX_ALERTS_PER_SUB_CASE, MAX_CONCURRENT_SEARCHES } from '../../../common';
+import { CaseStatuses } from '../../../common/api';
+import { MAX_ALERTS_PER_SUB_CASE, MAX_CONCURRENT_SEARCHES } from '../../../common/constants';
 import { AlertInfo, createCaseError } from '../../common';
 import { UpdateAlertRequest } from '../../client/alerts/types';
 import {

--- a/x-pack/plugins/cases/server/services/attachments/index.ts
+++ b/x-pack/plugins/cases/server/services/attachments/index.ts
@@ -15,13 +15,15 @@ import {
 import type { KueryNode } from '@kbn/es-query';
 import {
   AttributesTypeAlerts,
-  CASE_COMMENT_SAVED_OBJECT,
   CommentAttributes as AttachmentAttributes,
   CommentPatchAttributes as AttachmentPatchAttributes,
+  CommentType,
+} from '../../../common/api';
+import {
+  CASE_COMMENT_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
   MAX_DOCS_PER_PAGE,
-  CommentType,
-} from '../../../common';
+} from '../../../common/constants';
 import { ClientArgs } from '..';
 import { buildFilter, combineFilters } from '../../client/utils';
 

--- a/x-pack/plugins/cases/server/services/cases/index.test.ts
+++ b/x-pack/plugins/cases/server/services/cases/index.test.ts
@@ -13,12 +13,8 @@
  * connector.id.
  */
 
-import {
-  CaseAttributes,
-  CaseConnector,
-  CaseFullExternalService,
-  CASE_SAVED_OBJECT,
-} from '../../../common';
+import { CaseAttributes, CaseConnector, CaseFullExternalService } from '../../../common/api';
+import { CASE_SAVED_OBJECT } from '../../../common/constants';
 import { savedObjectsClientMock } from '../../../../../../src/core/server/mocks';
 import {
   SavedObject,

--- a/x-pack/plugins/cases/server/services/cases/index.ts
+++ b/x-pack/plugins/cases/server/services/cases/index.ts
@@ -24,9 +24,17 @@ import { nodeBuilder, KueryNode } from '@kbn/es-query';
 
 import { SecurityPluginSetup } from '../../../../security/server';
 import {
-  AssociationType,
   CASE_COMMENT_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
+  ENABLE_CASE_CONNECTOR,
+  MAX_CONCURRENT_SEARCHES,
+  MAX_DOCS_PER_PAGE,
+  SUB_CASE_SAVED_OBJECT,
+} from '../../../common/constants';
+import {
+  OWNER_FIELD,
+  GetCaseIdsByAlertIdAggs,
+  AssociationType,
   CaseResponse,
   CasesFindRequest,
   CaseStatuses,
@@ -34,17 +42,11 @@ import {
   caseTypeField,
   CommentAttributes,
   CommentType,
-  ENABLE_CASE_CONNECTOR,
-  GetCaseIdsByAlertIdAggs,
-  MAX_CONCURRENT_SEARCHES,
-  MAX_DOCS_PER_PAGE,
-  OWNER_FIELD,
-  SUB_CASE_SAVED_OBJECT,
   SubCaseAttributes,
   SubCaseResponse,
   User,
   CaseAttributes,
-} from '../../../common';
+} from '../../../common/api';
 import {
   defaultSortField,
   flattenCaseSavedObject,

--- a/x-pack/plugins/cases/server/services/cases/transform.test.ts
+++ b/x-pack/plugins/cases/server/services/cases/transform.test.ts
@@ -17,7 +17,7 @@ import {
   transformUpdateResponseToExternalModel,
 } from './transform';
 import { ACTION_SAVED_OBJECT_TYPE } from '../../../../actions/server';
-import { ConnectorTypes } from '../../../common';
+import { ConnectorTypes } from '../../../common/api';
 import {
   getNoneCaseConnector,
   CONNECTOR_ID_REFERENCE_NAME,

--- a/x-pack/plugins/cases/server/services/cases/transform.ts
+++ b/x-pack/plugins/cases/server/services/cases/transform.ts
@@ -18,7 +18,7 @@ import {
 import { ACTION_SAVED_OBJECT_TYPE } from '../../../../actions/server';
 import { ESCaseAttributes, ExternalServicesWithoutConnectorId } from './types';
 import { CONNECTOR_ID_REFERENCE_NAME, PUSH_CONNECTOR_ID_REFERENCE_NAME } from '../../common';
-import { CaseAttributes, CaseFullExternalService } from '../../../common';
+import { CaseAttributes, CaseFullExternalService } from '../../../common/api';
 import {
   findConnectorIdReference,
   transformFieldsToESModel,

--- a/x-pack/plugins/cases/server/services/cases/types.ts
+++ b/x-pack/plugins/cases/server/services/cases/types.ts
@@ -6,7 +6,7 @@
  */
 
 import * as rt from 'io-ts';
-import { CaseAttributes, CaseExternalServiceBasicRt } from '../../../common';
+import { CaseAttributes, CaseExternalServiceBasicRt } from '../../../common/api';
 import { ESCaseConnector } from '..';
 
 /**

--- a/x-pack/plugins/cases/server/services/configure/index.test.ts
+++ b/x-pack/plugins/cases/server/services/configure/index.test.ts
@@ -9,10 +9,9 @@ import {
   CaseConnector,
   CasesConfigureAttributes,
   CasesConfigurePatch,
-  CASE_CONFIGURE_SAVED_OBJECT,
   ConnectorTypes,
-  SECURITY_SOLUTION_OWNER,
-} from '../../../common';
+} from '../../../common/api';
+import { CASE_CONFIGURE_SAVED_OBJECT, SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { savedObjectsClientMock } from '../../../../../../src/core/server/mocks';
 import {
   SavedObject,

--- a/x-pack/plugins/cases/server/services/configure/index.ts
+++ b/x-pack/plugins/cases/server/services/configure/index.ts
@@ -14,11 +14,8 @@ import {
 } from 'kibana/server';
 
 import { SavedObjectFindOptionsKueryNode, CONNECTOR_ID_REFERENCE_NAME } from '../../common';
-import {
-  CASE_CONFIGURE_SAVED_OBJECT,
-  CasesConfigureAttributes,
-  CasesConfigurePatch,
-} from '../../../common';
+import { CasesConfigureAttributes, CasesConfigurePatch } from '../../../common/api';
+import { CASE_CONFIGURE_SAVED_OBJECT } from '../../../common/constants';
 import { ACTION_SAVED_OBJECT_TYPE } from '../../../../actions/server';
 import {
   transformFieldsToESModel,

--- a/x-pack/plugins/cases/server/services/configure/types.ts
+++ b/x-pack/plugins/cases/server/services/configure/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CasesConfigureAttributes } from '../../../common';
+import { CasesConfigureAttributes } from '../../../common/api';
 import { ESCaseConnector } from '..';
 
 /**

--- a/x-pack/plugins/cases/server/services/connector_mappings/index.ts
+++ b/x-pack/plugins/cases/server/services/connector_mappings/index.ts
@@ -7,7 +7,8 @@
 
 import { Logger, SavedObjectReference, SavedObjectsClientContract } from 'kibana/server';
 
-import { ConnectorMappings, CASE_CONNECTOR_MAPPINGS_SAVED_OBJECT } from '../../../common';
+import { CASE_CONNECTOR_MAPPINGS_SAVED_OBJECT } from '../../../common/constants';
+import { ConnectorMappings } from '../../../common/api';
 import { SavedObjectFindOptionsKueryNode } from '../../common';
 
 interface ClientArgs {

--- a/x-pack/plugins/cases/server/services/connector_reference_handler.test.ts
+++ b/x-pack/plugins/cases/server/services/connector_reference_handler.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { noneConnectorId } from '../../common';
+import { noneConnectorId } from '../../common/api';
 import { ConnectorReferenceHandler } from './connector_reference_handler';
 
 describe('ConnectorReferenceHandler', () => {

--- a/x-pack/plugins/cases/server/services/connector_reference_handler.ts
+++ b/x-pack/plugins/cases/server/services/connector_reference_handler.ts
@@ -6,7 +6,7 @@
  */
 
 import { SavedObjectReference } from 'kibana/server';
-import { noneConnectorId } from '../../common';
+import { noneConnectorId } from '../../common/api';
 
 interface Reference {
   soReference?: SavedObjectReference;

--- a/x-pack/plugins/cases/server/services/index.ts
+++ b/x-pack/plugins/cases/server/services/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { SavedObjectsClientContract } from 'kibana/server';
-import { ConnectorTypes } from '../../common';
+import { ConnectorTypes } from '../../common/api';
 
 export { CasesService } from './cases';
 export { CaseConfigureService } from './configure';

--- a/x-pack/plugins/cases/server/services/test_utils.ts
+++ b/x-pack/plugins/cases/server/services/test_utils.ts
@@ -13,11 +13,10 @@ import {
   CaseFullExternalService,
   CaseStatuses,
   CaseType,
-  CASE_SAVED_OBJECT,
   ConnectorTypes,
   noneConnectorId,
-  SECURITY_SOLUTION_OWNER,
-} from '../../common';
+} from '../../common/api';
+import { CASE_SAVED_OBJECT, SECURITY_SOLUTION_OWNER } from '../../common/constants';
 import { ESCaseAttributes, ExternalServicesWithoutConnectorId } from './cases/types';
 import { ACTION_SAVED_OBJECT_TYPE } from '../../../actions/server';
 

--- a/x-pack/plugins/cases/server/services/transform.test.ts
+++ b/x-pack/plugins/cases/server/services/transform.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { ACTION_SAVED_OBJECT_TYPE } from '../../../actions/server';
-import { ConnectorTypes } from '../../common';
+import { ConnectorTypes } from '../../common/api';
 import { createESJiraConnector, createJiraConnector } from './test_utils';
 import {
   findConnectorIdReference,

--- a/x-pack/plugins/cases/server/services/transform.ts
+++ b/x-pack/plugins/cases/server/services/transform.ts
@@ -6,7 +6,7 @@
  */
 
 import { SavedObjectReference } from 'kibana/server';
-import { CaseConnector, ConnectorTypeFields } from '../../common';
+import { CaseConnector, ConnectorTypeFields } from '../../common/api';
 import { ACTION_SAVED_OBJECT_TYPE } from '../../../actions/server';
 import { getNoneCaseConnector } from '../common';
 import { ESCaseConnector, ESConnectorFields } from '.';

--- a/x-pack/plugins/cases/server/services/user_actions/helpers.test.ts
+++ b/x-pack/plugins/cases/server/services/user_actions/helpers.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { UserActionField } from '../../../common';
+import { UserActionField } from '../../../common/api';
 import { createConnectorObject, createExternalService, createJiraConnector } from '../test_utils';
 import { buildCaseUserActionItem } from './helpers';
 

--- a/x-pack/plugins/cases/server/services/user_actions/helpers.ts
+++ b/x-pack/plugins/cases/server/services/user_actions/helpers.ts
@@ -10,17 +10,19 @@ import { get, isPlainObject, isString } from 'lodash';
 import deepEqual from 'fast-deep-equal';
 
 import {
-  CASE_COMMENT_SAVED_OBJECT,
-  CASE_SAVED_OBJECT,
   CaseUserActionAttributes,
-  OWNER_FIELD,
-  SUB_CASE_SAVED_OBJECT,
   SubCaseAttributes,
   User,
   UserAction,
   UserActionField,
   CaseAttributes,
-} from '../../../common';
+  OWNER_FIELD,
+} from '../../../common/api';
+import {
+  CASE_COMMENT_SAVED_OBJECT,
+  CASE_SAVED_OBJECT,
+  SUB_CASE_SAVED_OBJECT,
+} from '../../../common/constants';
 import { isTwoArraysDifference } from '../../client/utils';
 import { UserActionItem } from '.';
 import { extractConnectorId } from './transform';

--- a/x-pack/plugins/cases/server/services/user_actions/index.test.ts
+++ b/x-pack/plugins/cases/server/services/user_actions/index.test.ts
@@ -7,12 +7,8 @@
 
 import { SavedObject, SavedObjectsFindResult } from 'kibana/server';
 import { transformFindResponseToExternalModel, UserActionItem } from '.';
-import {
-  CaseUserActionAttributes,
-  CASE_USER_ACTION_SAVED_OBJECT,
-  UserAction,
-  UserActionField,
-} from '../../../common';
+import { CaseUserActionAttributes, UserAction, UserActionField } from '../../../common/api';
+import { CASE_USER_ACTION_SAVED_OBJECT } from '../../../common/constants';
 
 import {
   createConnectorObject,

--- a/x-pack/plugins/cases/server/services/user_actions/index.ts
+++ b/x-pack/plugins/cases/server/services/user_actions/index.ts
@@ -12,18 +12,15 @@ import {
   SavedObjectsFindResult,
 } from 'kibana/server';
 
+import { isCreateConnector, isPush, isUpdateConnector } from '../../../common/utils/user_actions';
+import { CaseUserActionAttributes, CaseUserActionResponse } from '../../../common/api';
 import {
   CASE_SAVED_OBJECT,
   CASE_USER_ACTION_SAVED_OBJECT,
-  CaseUserActionAttributes,
   MAX_DOCS_PER_PAGE,
   SUB_CASE_SAVED_OBJECT,
-  CaseUserActionResponse,
   CASE_COMMENT_SAVED_OBJECT,
-  isCreateConnector,
-  isPush,
-  isUpdateConnector,
-} from '../../../common';
+} from '../../../common/constants';
 import { ClientArgs } from '..';
 import { UserActionFieldType } from './types';
 import { CASE_REF_NAME, COMMENT_REF_NAME, SUB_CASE_REF_NAME } from '../../common';

--- a/x-pack/plugins/cases/server/services/user_actions/transform.test.ts
+++ b/x-pack/plugins/cases/server/services/user_actions/transform.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { noneConnectorId } from '../../../common';
+import { noneConnectorId } from '../../../common/api';
 import {
   CONNECTOR_ID_REFERENCE_NAME,
   getNoneCaseConnector,

--- a/x-pack/plugins/cases/server/services/user_actions/transform.ts
+++ b/x-pack/plugins/cases/server/services/user_actions/transform.ts
@@ -11,16 +11,14 @@ import * as rt from 'io-ts';
 import { isString } from 'lodash';
 
 import { SavedObjectReference } from '../../../../../../src/core/server';
+import { isCreateConnector, isPush, isUpdateConnector } from '../../../common/utils/user_actions';
 import {
   CaseAttributes,
   CaseConnector,
   CaseConnectorRt,
   CaseExternalServiceBasicRt,
-  isCreateConnector,
-  isPush,
-  isUpdateConnector,
   noneConnectorId,
-} from '../../../common';
+} from '../../../common/api';
 import {
   CONNECTOR_ID_REFERENCE_NAME,
   getNoneCaseConnector,

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.tsx
@@ -11,7 +11,7 @@ import { EuiFlyout, EuiFlyoutHeader, EuiTitle, EuiFlyoutBody } from '@elastic/eu
 
 import * as i18n from '../translations';
 import { useKibana } from '../../../../../../../../../src/plugins/kibana_react/public';
-import { Case } from '../../../../../../../cases/common';
+import { Case } from '../../../../../../../cases/common/ui/types';
 import type { TimelinesStartServices } from '../../../../../types';
 
 export interface CreateCaseModalProps {

--- a/x-pack/test/case_api_integration/common/fixtures/plugins/cases_client_user/server/plugin.ts
+++ b/x-pack/test/case_api_integration/common/fixtures/plugins/cases_client_user/server/plugin.ts
@@ -12,7 +12,7 @@ import { PluginSetupContract as FeaturesPluginSetup } from '../../../../../../..
 import { SpacesPluginStart } from '../../../../../../../plugins/spaces/server';
 import { SecurityPluginStart } from '../../../../../../../plugins/security/server';
 import { PluginStartContract as CasesPluginStart } from '../../../../../../../plugins/cases/server';
-import { CasesPatchRequest } from '../../../../../../../plugins/cases/common';
+import { CasesPatchRequest } from '../../../../../../../plugins/cases/common/api';
 
 export interface FixtureSetupDeps {
   features: FeaturesPluginSetup;

--- a/x-pack/test/case_api_integration/common/lib/validation.ts
+++ b/x-pack/test/case_api_integration/common/lib/validation.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 
-import { CaseResponse, CasesByAlertId } from '../../../../plugins/cases/common';
+import { CaseResponse, CasesByAlertId } from '../../../../plugins/cases/common/api';
 
 /**
  * Ensure that the result of the alerts API request matches with the cases created for the test.

--- a/x-pack/test/case_api_integration/security_and_spaces/tests/common/alerts/get_cases.ts
+++ b/x-pack/test/case_api_integration/security_and_spaces/tests/common/alerts/get_cases.ts
@@ -17,7 +17,7 @@ import {
   deleteAllCaseItems,
 } from '../../../../common/lib/utils';
 import { validateCasesFromAlertIDResponse } from '../../../../common/lib/validation';
-import { CaseResponse } from '../../../../../../plugins/cases/common';
+import { CaseResponse } from '../../../../../../plugins/cases/common/api';
 import {
   globalRead,
   noKibanaPrivileges,

--- a/x-pack/test/case_api_integration/security_and_spaces/tests/common/cases/import_export.ts
+++ b/x-pack/test/case_api_integration/security_and_spaces/tests/common/cases/import_export.ts
@@ -20,18 +20,20 @@ import {
 import { getPostCaseRequest, postCommentUserReq } from '../../../../common/lib/mock';
 import { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
+  CASES_URL,
+  CASE_SAVED_OBJECT,
+  CASE_USER_ACTION_SAVED_OBJECT,
+  CASE_COMMENT_SAVED_OBJECT,
+} from '../../../../../../plugins/cases/common/constants';
+import {
   AttributesTypeUser,
   CommentsResponse,
-  CASES_URL,
   CaseType,
-  CASE_SAVED_OBJECT,
   CaseAttributes,
-  CASE_USER_ACTION_SAVED_OBJECT,
   CaseUserActionAttributes,
-  CASE_COMMENT_SAVED_OBJECT,
   CasePostRequest,
   CaseUserActionResponse,
-} from '../../../../../../plugins/cases/common';
+} from '../../../../../../plugins/cases/common/api';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/case_api_integration/security_and_spaces/tests/common/cases/migrations.ts
+++ b/x-pack/test/case_api_integration/security_and_spaces/tests/common/cases/migrations.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../../../../plugins/cases/common/constants';
 import { getCase, getCaseSavedObjectsFromES, resolveCase } from '../../../../common/lib/utils';
 import { superUser } from '../../../../common/lib/authentication/users';
-import { AttributesTypeUser } from '../../../../../../plugins/cases/common';
+import { AttributesTypeUser } from '../../../../../../plugins/cases/common/api';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/case_api_integration/security_and_spaces/tests/common/client/update_alert_status.ts
+++ b/x-pack/test/case_api_integration/security_and_spaces/tests/common/client/update_alert_status.ts
@@ -15,7 +15,11 @@ import {
   deleteAllCaseItems,
   getSignalsWithES,
 } from '../../../../common/lib/utils';
-import { CasesResponse, CaseStatuses, CommentType } from '../../../../../../plugins/cases/common';
+import {
+  CasesResponse,
+  CaseStatuses,
+  CommentType,
+} from '../../../../../../plugins/cases/common/api';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/case_api_integration/security_and_spaces/tests/common/user_actions/migrations.ts
+++ b/x-pack/test/case_api_integration/security_and_spaces/tests/common/user_actions/migrations.ts
@@ -15,7 +15,7 @@ import { getCaseUserActions } from '../../../../common/lib/utils';
 import {
   CaseUserActionResponse,
   CaseUserActionsResponse,
-} from '../../../../../../plugins/cases/common';
+} from '../../../../../../plugins/cases/common/api';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetTests({ getService }: FtrProviderContext) {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Security Solutions] Removes tech debt of exporting all from linter rule for security_solution plugin (#120310)
 