### PR TITLE
[8.0] [Security Solutions] Removes tech debt of exporting all from linter rule for timeline plugin (#120437)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
@@ -15,7 +15,7 @@ import { useKibana } from '../../../common/lib/kibana';
 
 import * as i18n from './translations';
 import { CreateFieldComponentType, TimelineId } from '../../../../../timelines/common';
-import { tGridActions } from '../../../../../timelines/public';
+import { upsertColumn } from '../../../../../timelines/public';
 import { useDataView } from '../../../common/containers/source/use_data_view';
 import { SourcererScopeName } from '../../../common/store/sourcerer/model';
 import { sourcererSelectors } from '../../../common/store';
@@ -59,7 +59,7 @@ export const CreateFieldButton = React.memo<CreateFieldButtonProps>(
 
             // Add the new field to the event table
             dispatch(
-              tGridActions.upsertColumn({
+              upsertColumn({
                 column: {
                   columnHeaderType: defaultColumnHeaderType,
                   id: field.name,

--- a/x-pack/plugins/security_solution/public/timelines/components/formatted_ip/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/formatted_ip/index.test.tsx
@@ -44,6 +44,17 @@ jest.mock('../../../common/components/drag_and_drop/draggable_wrapper', () => {
   };
 });
 
+jest.mock('../../store/timeline', () => {
+  const original = jest.requireActual('../../store/timeline');
+  return {
+    ...original,
+    timelineActions: {
+      ...original.timelineActions,
+      toggleDetailPanel: jest.fn(),
+    },
+  };
+});
+
 describe('FormattedIp', () => {
   const props = {
     value: '192.168.1.1',
@@ -53,16 +64,13 @@ describe('FormattedIp', () => {
     fieldName: 'host.ip',
   };
 
-  let toggleDetailPanel: jest.SpyInstance;
   let toggleExpandedDetail: jest.SpyInstance;
 
   beforeAll(() => {
-    toggleDetailPanel = jest.spyOn(timelineActions, 'toggleDetailPanel');
     toggleExpandedDetail = jest.spyOn(activeTimeline, 'toggleExpandedDetail');
   });
 
   afterEach(() => {
-    toggleDetailPanel.mockClear();
     toggleExpandedDetail.mockClear();
   });
   test('should render ip address', () => {
@@ -98,7 +106,7 @@ describe('FormattedIp', () => {
 
     wrapper.find('[data-test-subj="network-details"]').first().simulate('click');
     await waitFor(() => {
-      expect(toggleDetailPanel).not.toHaveBeenCalled();
+      expect(timelineActions.toggleDetailPanel).not.toHaveBeenCalled();
       expect(toggleExpandedDetail).not.toHaveBeenCalled();
     });
   });
@@ -120,7 +128,7 @@ describe('FormattedIp', () => {
 
     wrapper.find('[data-test-subj="network-details"]').first().simulate('click');
     await waitFor(() => {
-      expect(toggleDetailPanel).toHaveBeenCalledWith({
+      expect(timelineActions.toggleDetailPanel).toHaveBeenCalledWith({
         panelView: 'networkDetail',
         params: {
           flowTarget: 'source',
@@ -176,7 +184,7 @@ describe('FormattedIp', () => {
 
     wrapper.find('[data-test-subj="network-details"]').first().simulate('click');
     await waitFor(() => {
-      expect(toggleDetailPanel).toHaveBeenCalledWith({
+      expect(timelineActions.toggleDetailPanel).toHaveBeenCalledWith({
         panelView: 'networkDetail',
         params: {
           flowTarget: 'source',

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.test.tsx
@@ -40,6 +40,17 @@ jest.mock('../../../../../common/components/draggables', () => ({
   DefaultDraggable: () => <div data-test-subj="DefaultDraggable" />,
 }));
 
+jest.mock('../../../../store/timeline', () => {
+  const original = jest.requireActual('../../../../store/timeline');
+  return {
+    ...original,
+    timelineActions: {
+      ...original.timelineActions,
+      toggleDetailPanel: jest.fn(),
+    },
+  };
+});
+
 describe('HostName', () => {
   const props = {
     fieldName: 'host.name',
@@ -49,16 +60,13 @@ describe('HostName', () => {
     value: 'Mock Host',
   };
 
-  let toggleDetailPanel: jest.SpyInstance;
   let toggleExpandedDetail: jest.SpyInstance;
 
   beforeAll(() => {
-    toggleDetailPanel = jest.spyOn(timelineActions, 'toggleDetailPanel');
     toggleExpandedDetail = jest.spyOn(activeTimeline, 'toggleExpandedDetail');
   });
 
   afterEach(() => {
-    toggleDetailPanel.mockClear();
     toggleExpandedDetail.mockClear();
   });
   test('should render host name', () => {
@@ -96,7 +104,7 @@ describe('HostName', () => {
 
     wrapper.find('[data-test-subj="host-details-button"]').first().simulate('click');
     await waitFor(() => {
-      expect(toggleDetailPanel).not.toHaveBeenCalled();
+      expect(timelineActions.toggleDetailPanel).not.toHaveBeenCalled();
       expect(toggleExpandedDetail).not.toHaveBeenCalled();
     });
   });
@@ -118,7 +126,7 @@ describe('HostName', () => {
 
     wrapper.find('[data-test-subj="host-details-button"]').first().simulate('click');
     await waitFor(() => {
-      expect(toggleDetailPanel).toHaveBeenCalledWith({
+      expect(timelineActions.toggleDetailPanel).toHaveBeenCalledWith({
         panelView: 'hostDetail',
         params: {
           hostName: props.value,
@@ -172,7 +180,7 @@ describe('HostName', () => {
 
     wrapper.find('[data-test-subj="host-details-button"]').first().simulate('click');
     await waitFor(() => {
-      expect(toggleDetailPanel).toHaveBeenCalledWith({
+      expect(timelineActions.toggleDetailPanel).toHaveBeenCalledWith({
         panelView: 'hostDetail',
         params: {
           hostName: props.value,

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/actions.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/actions.ts
@@ -24,9 +24,7 @@ import type {
   TimelinePersistInput,
   SerializedFilterQuery,
 } from '../../../../common/types/timeline';
-import { tGridActions } from '../../../../../timelines/public';
-import { ResolveTimelineConfig } from '../../components/open_timeline/types';
-export const {
+export {
   applyDeltaToColumnWidth,
   clearEventsDeleted,
   clearEventsLoading,
@@ -46,7 +44,8 @@ export const {
   updateItemsPerPageOptions,
   updateSort,
   upsertColumn,
-} = tGridActions;
+} from '../../../../../timelines/public';
+import { ResolveTimelineConfig } from '../../components/open_timeline/types';
 
 const actionCreator = actionCreatorFactory('x-pack/security_solution/local/timeline');
 

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/selectors.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/selectors.ts
@@ -7,13 +7,11 @@
 
 import { createSelector } from 'reselect';
 
-import { tGridSelectors } from '../../../../../timelines/public';
+export { getManageTimelineById } from '../../../../../timelines/public';
 import { State } from '../../../common/store/types';
 
 import { TimelineModel } from './model';
 import { AutoSavedWarningMsg, InsertTimeline, TimelineById } from './types';
-
-export const { getManageTimelineById } = tGridSelectors;
 
 const selectTimelineById = (state: State): TimelineById => state.timeline.timelineById;
 

--- a/x-pack/plugins/timelines/common/index.ts
+++ b/x-pack/plugins/timelines/common/index.ts
@@ -5,14 +5,82 @@
  * 2.0.
  */
 
-// TODO: https://github.com/elastic/kibana/issues/110904
-/* eslint-disable @kbn/eslint/no_export_all */
+// Careful of exporting anything from this file as any file(s) you export here will cause your page bundle size to increase.
+// If you're using functions/types/etc... internally or within integration tests it's best to import directly from their paths
+// than expose the functions/types/etc... here. You should _only_ expose functions/types/etc... that need to be shared with other plugins here.
+
+// When you do have to add things here you might want to consider creating a package to share with
+// other plugins instead as packages are easier to break down and you do not have to carry the cost of extra plugin weight on
+// first download since the other plugins/areas of your code can directly pull from the package in their async imports.
+// See: https://docs.elastic.dev/kibana-dev-docs/key-concepts/platform-intro#public-plugin-api
 
 export { DELETED_SECURITY_SOLUTION_DATA_VIEW } from './constants';
 
-export * from './types';
-export * from './search_strategy';
-export * from './utils/accessibility';
+export type {
+  ActionProps,
+  AlertWorkflowStatus,
+  CellValueElementProps,
+  CreateFieldComponentType,
+  ColumnId,
+  ColumnRenderer,
+  ColumnHeaderType,
+  ColumnHeaderOptions,
+  ControlColumnProps,
+  DataProvidersAnd,
+  DataProvider,
+  GenericActionRowCellRenderProps,
+  HeaderActionProps,
+  HeaderCellRender,
+  QueryOperator,
+  QueryMatch,
+  RowCellRender,
+  RowRenderer,
+  SetEventsDeleted,
+  SetEventsLoading,
+} from './types';
 
-export const PLUGIN_ID = 'timelines';
-export const PLUGIN_NAME = 'timelines';
+export { IS_OPERATOR, EXISTS_OPERATOR, DataProviderType, TimelineId } from './types';
+
+export type {
+  BeatFields,
+  BrowserField,
+  BrowserFields,
+  CursorType,
+  DocValueFields,
+  EqlOptionsData,
+  EqlOptionsSelected,
+  FieldsEqlOptions,
+  FieldInfo,
+  IndexField,
+  IndexFieldsStrategyRequest,
+  IndexFieldsStrategyResponse,
+  LastTimeDetails,
+  TimelineNonEcsData,
+  Inspect,
+  SortField,
+  TimerangeInput,
+  TimelineEdges,
+  TimelineItem,
+  TimelineEventsAllStrategyResponse,
+  TimelineEventsAllRequestOptions,
+  TimelineEventsDetailsItem,
+  TimelineEventsDetailsStrategyResponse,
+  TimelineEventsDetailsRequestOptions,
+  TimelineEventsLastEventTimeStrategyResponse,
+  TimelineEventsLastEventTimeRequestOptions,
+  TimelineEqlRequestOptions,
+  TimelineEqlResponse,
+  TimelineKpiStrategyRequest,
+  TimelineKpiStrategyResponse,
+  TotalValue,
+  PaginationInputPaginated,
+} from './search_strategy';
+
+export {
+  Direction,
+  EntityType,
+  LastEventIndexKey,
+  EMPTY_BROWSER_FIELDS,
+  EMPTY_DOCVALUE_FIELD,
+  EMPTY_INDEX_FIELDS,
+} from './search_strategy';

--- a/x-pack/plugins/timelines/common/types/timeline/cells/index.ts
+++ b/x-pack/plugins/timelines/common/types/timeline/cells/index.ts
@@ -7,7 +7,7 @@
 
 import { EuiDataGridCellValueElementProps } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
-import { RowRenderer } from '../../..';
+import { RowRenderer } from '../../../types';
 import { Ecs } from '../../../ecs';
 import { BrowserFields, TimelineNonEcsData } from '../../../search_strategy';
 import { ColumnHeaderOptions } from '../columns';

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action.tsx
@@ -8,12 +8,12 @@
 import React, { memo, useMemo, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { CaseStatuses, StatusAll } from '../../../../../../cases/common';
-import { TimelineItem } from '../../../../../common/';
+import { TimelineItem } from '../../../../../common/search_strategy';
 import { useAddToCase, normalizedEventFields } from '../../../../hooks/use_add_to_case';
 import { useKibana } from '../../../../../../../../src/plugins/kibana_react/public';
 import { TimelinesStartServices } from '../../../../types';
+import { setOpenAddToExistingCase, setOpenAddToNewCase } from '../../../../store/t_grid/actions';
 import { CreateCaseFlyout } from './create/flyout';
-import { tGridActions } from '../../../../';
 import * as i18n from './translations';
 
 export interface AddToCaseActionProps {
@@ -78,8 +78,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
       updateCase: onCaseSuccess,
       userCanCrud: casePermissions?.crud ?? false,
       owner: [owner],
-      onClose: () =>
-        dispatch(tGridActions.setOpenAddToExistingCase({ id: eventId, isOpen: false })),
+      onClose: () => dispatch(setOpenAddToExistingCase({ id: eventId, isOpen: false })),
     };
   }, [
     casePermissions?.crud,
@@ -96,7 +95,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
   ]);
 
   const closeCaseFlyoutOpen = useCallback(() => {
-    dispatch(tGridActions.setOpenAddToNewCase({ id: eventId, isOpen: false }));
+    dispatch(setOpenAddToNewCase({ id: eventId, isOpen: false }));
   }, [dispatch, eventId]);
 
   return (

--- a/x-pack/plugins/timelines/public/components/drag_and_drop/helpers.ts
+++ b/x-pack/plugins/timelines/public/components/drag_and_drop/helpers.ts
@@ -10,8 +10,10 @@ import { KEYBOARD_DRAG_OFFSET, getFieldIdFromDraggable } from '@kbn/securitysolu
 import { Dispatch } from 'redux';
 import { isString, keyBy } from 'lodash/fp';
 
-import { stopPropagationAndPreventDefault, TimelineId } from '../../../common';
-import type { BrowserField, BrowserFields, ColumnHeaderOptions } from '../../../common';
+import { stopPropagationAndPreventDefault } from '../../../common/utils/accessibility';
+import { TimelineId } from '../../../common/types';
+import type { BrowserField, BrowserFields } from '../../../common/search_strategy';
+import type { ColumnHeaderOptions } from '../../../common/types';
 import { tGridActions } from '../../store/t_grid';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../t_grid/body/constants';
 

--- a/x-pack/plugins/timelines/public/components/drag_and_drop/index.tsx
+++ b/x-pack/plugins/timelines/public/components/drag_and_drop/index.tsx
@@ -17,7 +17,8 @@ import React, { useCallback } from 'react';
 import { DropResult, DragDropContext, BeforeCapture } from 'react-beautiful-dnd';
 import { useDispatch } from 'react-redux';
 
-import type { ColumnHeaderOptions, BrowserFields } from '../../../common';
+import type { BrowserFields } from '../../../common/search_strategy';
+import type { ColumnHeaderOptions } from '../../../common/types';
 import { useAddToTimelineSensor } from '../../hooks/use_add_to_timeline';
 import { addFieldToTimelineColumns, getTimelineIdFromColumnDroppableId } from './helpers';
 

--- a/x-pack/plugins/timelines/public/components/hover_actions/actions/add_to_timeline.tsx
+++ b/x-pack/plugins/timelines/public/components/hover_actions/actions/add_to_timeline.tsx
@@ -11,12 +11,13 @@ import { DraggableId } from 'react-beautiful-dnd';
 import { useDispatch } from 'react-redux';
 
 import { isEmpty } from 'lodash';
-import { DataProvider, stopPropagationAndPreventDefault, TimelineId } from '../../../../common';
+import { stopPropagationAndPreventDefault } from '../../../../common/utils/accessibility';
+import { DataProvider, TimelineId } from '../../../../common/types';
 import { TooltipWithKeyboardShortcut } from '../../tooltip_with_keyboard_shortcut';
 import { getAdditionalScreenReaderOnlyContext } from '../utils';
 import { useAddToTimeline } from '../../../hooks/use_add_to_timeline';
 import { HoverActionComponentProps } from './types';
-import { tGridActions } from '../../..';
+import { addProviderToTimeline } from '../../../store/t_grid/actions';
 import { useAppToasts } from '../../../hooks/use_app_toasts';
 import * as i18n from './translations';
 
@@ -74,7 +75,7 @@ const AddToTimelineButton: React.FC<AddToTimelineButtonProps> = React.memo(
         addDataProvider.forEach((provider) => {
           if (provider) {
             dispatch(
-              tGridActions.addProviderToTimeline({
+              addProviderToTimeline({
                 id: TimelineId.active,
                 dataProvider: provider,
               })

--- a/x-pack/plugins/timelines/public/components/hover_actions/actions/column_toggle.tsx
+++ b/x-pack/plugins/timelines/public/components/hover_actions/actions/column_toggle.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { EuiContextMenuItem, EuiButtonEmpty, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { stopPropagationAndPreventDefault } from '../../../../common';
+import { stopPropagationAndPreventDefault } from '../../../../common/utils/accessibility';
 import { TooltipWithKeyboardShortcut } from '../../tooltip_with_keyboard_shortcut';
 import { getAdditionalScreenReaderOnlyContext } from '../utils';
 import { defaultColumnHeaderType } from '../../t_grid/body/column_headers/default_headers';

--- a/x-pack/plugins/timelines/public/components/hover_actions/actions/copy.tsx
+++ b/x-pack/plugins/timelines/public/components/hover_actions/actions/copy.tsx
@@ -10,7 +10,7 @@ import copy from 'copy-to-clipboard';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 
-import { stopPropagationAndPreventDefault } from '../../../../common';
+import { stopPropagationAndPreventDefault } from '../../../../common/utils/accessibility';
 import { WithCopyToClipboard } from '../../clipboard/with_copy_to_clipboard';
 import { HoverActionComponentProps } from './types';
 import { COPY_TO_CLIPBOARD_BUTTON_CLASS_NAME } from '../../clipboard';

--- a/x-pack/plugins/timelines/public/components/hover_actions/actions/filter_for_value.tsx
+++ b/x-pack/plugins/timelines/public/components/hover_actions/actions/filter_for_value.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 
-import { stopPropagationAndPreventDefault } from '../../../../common';
+import { stopPropagationAndPreventDefault } from '../../../../common/utils/accessibility';
 import { TooltipWithKeyboardShortcut } from '../../tooltip_with_keyboard_shortcut';
 import { createFilter, getAdditionalScreenReaderOnlyContext } from '../utils';
 import { HoverActionComponentProps, FilterValueFnArgs } from './types';

--- a/x-pack/plugins/timelines/public/components/hover_actions/actions/filter_out_value.tsx
+++ b/x-pack/plugins/timelines/public/components/hover_actions/actions/filter_out_value.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 
-import { stopPropagationAndPreventDefault } from '../../../../common';
+import { stopPropagationAndPreventDefault } from '../../../../common/utils/accessibility';
 import { TooltipWithKeyboardShortcut } from '../../tooltip_with_keyboard_shortcut';
 import { createFilter, getAdditionalScreenReaderOnlyContext } from '../utils';
 import { HoverActionComponentProps, FilterValueFnArgs } from './types';

--- a/x-pack/plugins/timelines/public/components/hover_actions/actions/overflow.tsx
+++ b/x-pack/plugins/timelines/public/components/hover_actions/actions/overflow.tsx
@@ -17,7 +17,7 @@ import {
 } from '@elastic/eui';
 
 import styled from 'styled-components';
-import { stopPropagationAndPreventDefault } from '../../../../common';
+import { stopPropagationAndPreventDefault } from '../../../../common/utils/accessibility';
 import { TooltipWithKeyboardShortcut } from '../../tooltip_with_keyboard_shortcut';
 import { getAdditionalScreenReaderOnlyContext } from '../utils';
 import { HoverActionComponentProps } from './types';

--- a/x-pack/plugins/timelines/public/components/stateful_event_context.ts
+++ b/x-pack/plugins/timelines/public/components/stateful_event_context.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createContext } from 'react';
+import { StatefulEventContextType } from '../types';
+
+export const StatefulEventContext = createContext<StatefulEventContextType | null>(null);

--- a/x-pack/plugins/timelines/public/components/t_grid/body/column_headers/header/helpers.ts
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/column_headers/header/helpers.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { Direction } from '../../../../../../common';
-import type { ColumnHeaderOptions } from '../../../../../../common';
+import { Direction } from '../../../../../../common/search_strategy';
+import type { ColumnHeaderOptions } from '../../../../../../common/types';
 import { assertUnreachable } from '../../../../../../common/utility_types';
 import { Sort, SortDirection } from '../../sort';
 

--- a/x-pack/plugins/timelines/public/components/t_grid/body/column_headers/helpers.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/column_headers/helpers.test.tsx
@@ -23,7 +23,7 @@ import {
   DEFAULT_DATE_COLUMN_MIN_WIDTH,
 } from '../constants';
 import { mockBrowserFields } from '../../../../mock/browser_fields';
-import { ColumnHeaderOptions } from '../../../../../common';
+import { ColumnHeaderOptions } from '../../../../../common/types';
 
 window.matchMedia = jest.fn().mockImplementation((query) => {
   return {

--- a/x-pack/plugins/timelines/public/components/t_grid/body/control_columns/checkbox.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/control_columns/checkbox.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { render, fireEvent } from '@testing-library/react';
-import { ActionProps, HeaderActionProps, TimelineTabs } from '../../../../../common';
+import { ActionProps, HeaderActionProps, TimelineTabs } from '../../../../../common/types';
 import { HeaderCheckBox, RowCheckBox } from './checkbox';
 import React from 'react';
 

--- a/x-pack/plugins/timelines/public/components/t_grid/body/control_columns/checkbox.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/control_columns/checkbox.tsx
@@ -8,7 +8,7 @@
 import { EuiCheckbox, EuiLoadingSpinner } from '@elastic/eui';
 import React, { useCallback } from 'react';
 import { ALERT_RULE_PRODUCER } from '@kbn/rule-data-utils';
-import { ActionProps, HeaderActionProps } from '../../../../../common';
+import type { ActionProps, HeaderActionProps } from '../../../../../common/types';
 import * as i18n from './translations';
 
 export const RowCheckBox = ({

--- a/x-pack/plugins/timelines/public/components/t_grid/body/control_columns/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/control_columns/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ControlColumnProps } from '../../../../../common';
+import type { ControlColumnProps } from '../../../../../common/types';
 import { HeaderCheckBox, RowCheckBox } from './checkbox';
 
 export const checkBoxControlColumn: ControlColumnProps = {

--- a/x-pack/plugins/timelines/public/components/t_grid/body/events/stateful_row_renderer/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/events/stateful_row_renderer/index.tsx
@@ -13,7 +13,7 @@ import {
   ARIA_COLINDEX_ATTRIBUTE,
   ARIA_ROWINDEX_ATTRIBUTE,
   getRowRendererClassName,
-} from '../../../../../../common';
+} from '../../../../../../common/utils/accessibility';
 import { useStatefulEventFocus } from '../use_stateful_event_focus';
 
 import * as i18n from '../translations';

--- a/x-pack/plugins/timelines/public/components/t_grid/body/events/use_stateful_event_focus/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/events/use_stateful_event_focus/index.tsx
@@ -6,8 +6,13 @@
  */
 
 import React, { useCallback, useState, useMemo } from 'react';
-import { focusColumn, isArrowDownOrArrowUp, isArrowUp, isEscape } from '../../../../../../common';
-import type { OnColumnFocused } from '../../../../../../common';
+import {
+  focusColumn,
+  isArrowDownOrArrowUp,
+  isArrowUp,
+  isEscape,
+} from '../../../../../../common/utils/accessibility';
+import type { OnColumnFocused } from '../../../../../../common/utils/accessibility';
 
 type FocusOwnership = 'not-owned' | 'owned';
 

--- a/x-pack/plugins/timelines/public/components/t_grid/body/helpers.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/helpers.test.tsx
@@ -7,7 +7,7 @@
 
 import { omit } from 'lodash/fp';
 
-import { ColumnHeaderOptions } from '../../../../common';
+import { ColumnHeaderOptions } from '../../../../common/types';
 import { Ecs } from '../../../../common/ecs';
 import {
   allowSorting,

--- a/x-pack/plugins/timelines/public/components/t_grid/body/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/index.tsx
@@ -68,7 +68,8 @@ import type { BrowserFields } from '../../../../common/search_strategy/index_fie
 import type { OnRowSelected, OnSelectAll } from '../types';
 import type { Refetch } from '../../../store/t_grid/inputs';
 import { getPageRowIndex } from '../../../../common/utils/pagination';
-import { StatefulEventContext, StatefulFieldsBrowser } from '../../../';
+import { StatefulEventContext } from '../../../components/stateful_event_context';
+import { StatefulFieldsBrowser } from '../../../components/t_grid/toolbar/fields_browser';
 import { tGridActions, TGridModel, tGridSelectors, TimelineState } from '../../../store/t_grid';
 import { useDeepEqualSelector } from '../../../hooks/use_selector';
 import { RowAction } from './row_action';

--- a/x-pack/plugins/timelines/public/components/t_grid/event_rendered_view/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/event_rendered_view/index.tsx
@@ -27,7 +27,8 @@ import styled from 'styled-components';
 
 import { useUiSetting } from '../../../../../../../src/plugins/kibana_react/public';
 
-import type { BrowserFields, RowRenderer, TimelineItem } from '../../../../common';
+import type { BrowserFields, TimelineItem } from '../../../../common/search_strategy';
+import type { RowRenderer } from '../../../../common/types';
 import { RuleName } from '../../rule_name';
 import { isEventBuildingBlockType } from '../body/helpers';
 

--- a/x-pack/plugins/timelines/public/components/t_grid/helpers.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/helpers.tsx
@@ -15,7 +15,7 @@ import {
   getTableSkipFocus,
   handleSkipFocus,
   stopPropagationAndPreventDefault,
-} from '../../../common';
+} from '../../../common/utils/accessibility';
 import type { BrowserFields } from '../../../common/search_strategy/index_fields';
 import { DataProviderType, EXISTS_OPERATOR } from '../../../common/types/timeline';
 import type { DataProvider, DataProvidersAnd } from '../../../common/types/timeline';

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/bulk_actions/alert_status_bulk_actions.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/bulk_actions/alert_status_bulk_actions.tsx
@@ -13,7 +13,7 @@ import type {
   SetEventsDeleted,
   OnUpdateAlertStatusSuccess,
   OnUpdateAlertStatusError,
-} from '../../../../../common';
+} from '../../../../../common/types';
 import type { Refetch } from '../../../../store/t_grid/inputs';
 import { tGridActions, TGridModel, tGridSelectors, TimelineState } from '../../../../store/t_grid';
 import { BulkActions } from './';

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/categories_pane.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/categories_pane.tsx
@@ -13,8 +13,8 @@ import {
   DATA_COLINDEX_ATTRIBUTE,
   DATA_ROWINDEX_ATTRIBUTE,
   onKeyDownFocusHandler,
-} from '../../../../../common';
-import type { BrowserFields } from '../../../../../common';
+} from '../../../../../common/utils/accessibility';
+import type { BrowserFields } from '../../../../../common/search_strategy';
 import { getCategoryColumns } from './category_columns';
 import { CATEGORIES_PANE_CLASS_NAME, TABLE_HEIGHT } from './helpers';
 

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/category.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/category.tsx
@@ -14,8 +14,9 @@ import {
   DATA_COLINDEX_ATTRIBUTE,
   DATA_ROWINDEX_ATTRIBUTE,
   onKeyDownFocusHandler,
-} from '../../../../../common';
-import type { BrowserFields, OnUpdateColumns } from '../../../../../common';
+} from '../../../../../common/utils/accessibility';
+import type { BrowserFields } from '../../../../../common/search_strategy';
+import type { OnUpdateColumns } from '../../../../../common/types';
 
 import { CategoryTitle } from './category_title';
 import { getFieldColumns } from './field_items';

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/category_columns.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/category_columns.tsx
@@ -27,7 +27,8 @@ import {
 import * as i18n from './translations';
 import { tGridSelectors } from '../../../../store/t_grid';
 import { getColumnsWithTimestamp } from '../../../utils/helpers';
-import type { OnUpdateColumns, BrowserFields } from '../../../../../common';
+import type { BrowserFields } from '../../../../../common/search_strategy';
+import type { OnUpdateColumns } from '../../../../../common/types';
 
 const CategoryName = styled.span<{ bold: boolean }>`
   .euiText {

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/category_title.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/category_title.tsx
@@ -9,7 +9,8 @@ import { EuiFlexGroup, EuiFlexItem, EuiScreenReaderOnly, EuiTitle } from '@elast
 import React from 'react';
 
 import { CountBadge, getFieldBrowserCategoryTitleClassName, getFieldCount } from './helpers';
-import type { BrowserFields, OnUpdateColumns } from '../../../../../common';
+import type { BrowserFields } from '../../../../../common/search_strategy';
+import type { OnUpdateColumns } from '../../../../../common/types';
 
 import { ViewAllButton } from './category_columns';
 import * as i18n from './translations';

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/field_browser.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/field_browser.tsx
@@ -21,12 +21,13 @@ import React, { useEffect, useCallback, useRef, useMemo } from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
 
-import type {
-  BrowserFields,
-  ColumnHeaderOptions,
-  CreateFieldComponentType,
-} from '../../../../../common';
-import { isEscape, isTab, stopPropagationAndPreventDefault } from '../../../../../common';
+import type { BrowserFields } from '../../../../../common/search_strategy';
+import type { ColumnHeaderOptions, CreateFieldComponentType } from '../../../../../common/types';
+import {
+  isEscape,
+  isTab,
+  stopPropagationAndPreventDefault,
+} from '../../../../../common/utils/accessibility';
 import { CategoriesPane } from './categories_pane';
 import { FieldsPane } from './fields_pane';
 import { Search } from './search';

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/field_items.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/field_items.test.tsx
@@ -16,7 +16,7 @@ import { Category } from './category';
 import { getFieldColumns, getFieldItems } from './field_items';
 import { FIELDS_PANE_WIDTH } from './helpers';
 import { useMountAppended } from '../../../utils/use_mount_appended';
-import { ColumnHeaderOptions } from '../../../../../common';
+import { ColumnHeaderOptions } from '../../../../../common/types';
 
 const selectedCategoryId = 'base';
 const selectedCategoryFields = mockBrowserFields[selectedCategoryId].fields;

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/field_items.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/field_items.tsx
@@ -19,7 +19,8 @@ import styled from 'styled-components';
 
 import { getEmptyValue } from '../../../empty_value';
 import { getExampleText, getIconFromType } from '../../../utils/helpers';
-import type { ColumnHeaderOptions, BrowserField } from '../../../../../common';
+import type { BrowserField } from '../../../../../common/search_strategy';
+import type { ColumnHeaderOptions } from '../../../../../common/types';
 import { defaultColumnHeaderType } from '../../body/column_headers/default_headers';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../../body/constants';
 import { TruncatableText } from '../../../truncatable_text';

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/fields_pane.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/fields_pane.tsx
@@ -15,7 +15,8 @@ import { getFieldItems } from './field_items';
 import { FIELDS_PANE_WIDTH, TABLE_HEIGHT } from './helpers';
 
 import * as i18n from './translations';
-import type { BrowserFields, ColumnHeaderOptions, OnUpdateColumns } from '../../../../../common';
+import type { BrowserFields } from '../../../../../common/search_strategy';
+import type { ColumnHeaderOptions, OnUpdateColumns } from '../../../../../common/types';
 import { tGridActions } from '../../../../store/t_grid';
 
 const NoFieldsPanel = styled.div`

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/helpers.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/helpers.test.tsx
@@ -16,7 +16,7 @@ import {
   getFieldCount,
   filterBrowserFieldsByFieldName,
 } from './helpers';
-import { BrowserFields } from '../../../../../common';
+import { BrowserFields } from '../../../../../common/search_strategy';
 
 const timelineId = 'test';
 

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/helpers.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/helpers.tsx
@@ -13,9 +13,9 @@ import {
   elementOrChildrenHasFocus,
   skipFocusInContainerTo,
   stopPropagationAndPreventDefault,
-} from '../../../../../public';
+} from '../../../../../common/utils/accessibility';
 import { TimelineId } from '../../../../../public/types';
-import type { BrowserField, BrowserFields } from '../../../../../common';
+import type { BrowserField, BrowserFields } from '../../../../../common/search_strategy';
 import { defaultHeaders } from '../../../../store/t_grid/defaults';
 import { DEFAULT_CATEGORY_NAME } from '../../body/column_headers/default_headers';
 

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/search.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/search.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import styled from 'styled-components';
-import type { BrowserFields } from '../../../../../common';
+import type { BrowserFields } from '../../../../../common/search_strategy';
 
 import { getFieldBrowserSearchInputClassName, getFieldCount } from './helpers';
 

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/types.ts
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CreateFieldComponentType } from '../../../../../common';
+import { CreateFieldComponentType } from '../../../../../common/types';
 import type { BrowserFields } from '../../../../../common/search_strategy/index_fields';
 import type { ColumnHeaderOptions } from '../../../../../common/types/timeline/columns';
 

--- a/x-pack/plugins/timelines/public/components/utils/helpers.ts
+++ b/x-pack/plugins/timelines/public/components/utils/helpers.ts
@@ -6,7 +6,8 @@
  */
 
 import { getOr, isEmpty, uniqBy } from 'lodash/fp';
-import { BrowserField, BrowserFields, ColumnHeaderOptions } from '../../../common';
+import type { BrowserField, BrowserFields } from '../../../common/search_strategy';
+import { ColumnHeaderOptions } from '../../../common/types';
 import { defaultHeaders } from '../t_grid/body/column_headers/default_headers';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../t_grid/body/constants';
 

--- a/x-pack/plugins/timelines/public/container/index.tsx
+++ b/x-pack/plugins/timelines/public/container/index.tsx
@@ -12,7 +12,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Subscription } from 'rxjs';
 import { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { tGridActions } from '..';
+import {
+  clearEventsLoading,
+  clearEventsDeleted,
+  setTimelineUpdatedAt,
+} from '../store/t_grid/actions';
 
 import type { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
 import { isCompleteResponse, isErrorResponse } from '../../../../../src/plugins/data/common';
@@ -143,8 +147,8 @@ export const useTimelineEvents = ({
 
   const clearSignalsState = useCallback(() => {
     if (id != null && detectionsTimelineIds.some((timelineId) => timelineId === id)) {
-      dispatch(tGridActions.clearEventsLoading({ id }));
-      dispatch(tGridActions.clearEventsDeleted({ id }));
+      dispatch(clearEventsLoading({ id }));
+      dispatch(clearEventsDeleted({ id }));
     }
   }, [dispatch, id]);
 
@@ -165,7 +169,7 @@ export const useTimelineEvents = ({
 
   const setUpdated = useCallback(
     (updatedAt: number) => {
-      dispatch(tGridActions.setTimelineUpdatedAt({ id, updated: updatedAt }));
+      dispatch(setTimelineUpdatedAt({ id, updated: updatedAt }));
     },
     [dispatch, id]
   );

--- a/x-pack/plugins/timelines/public/container/source/index.tsx
+++ b/x-pack/plugins/timelines/public/container/source/index.tsx
@@ -18,7 +18,7 @@ import {
   IndexField,
   IndexFieldsStrategyRequest,
   IndexFieldsStrategyResponse,
-} from '../../../common';
+} from '../../../common/search_strategy';
 import * as i18n from './translations';
 
 import type { DataPublicPluginStart } from '../../../../../../src/plugins/data/public';

--- a/x-pack/plugins/timelines/public/container/use_update_alerts.ts
+++ b/x-pack/plugins/timelines/public/container/use_update_alerts.ts
@@ -9,7 +9,7 @@ import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { CoreStart } from '../../../../../src/core/public';
 
 import { useKibana } from '../../../../../src/plugins/kibana_react/public';
-import { AlertStatus } from '../../../timelines/common';
+import type { AlertStatus } from '../../../timelines/common/types';
 import {
   DETECTION_ENGINE_SIGNALS_STATUS_URL,
   RAC_ALERTS_BULK_UPDATE_URL,

--- a/x-pack/plugins/timelines/public/hooks/use_add_to_case.ts
+++ b/x-pack/plugins/timelines/public/hooks/use_add_to_case.ts
@@ -12,7 +12,7 @@ import { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils/technical
 import { useKibana } from '../../../../../src/plugins/kibana_react/public';
 import { Case, SubCase } from '../../../cases/common';
 import { TimelinesStartServices } from '../types';
-import { TimelineItem } from '../../common/';
+import { TimelineItem } from '../../common/search_strategy';
 import { tGridActions } from '../store/t_grid';
 import { useDeepEqualSelector } from './use_selector';
 import { createUpdateSuccessToaster } from '../components/actions/timeline/cases/helpers';

--- a/x-pack/plugins/timelines/public/index.ts
+++ b/x-pack/plugins/timelines/public/index.ts
@@ -5,29 +5,46 @@
  * 2.0.
  */
 
-// TODO: https://github.com/elastic/kibana/issues/110904
-/* eslint-disable @kbn/eslint/no_export_all */
+// Careful of exporting anything from this file as any file(s) you export here will cause your page bundle size to increase.
+// If you're using functions/types/etc... internally or within integration tests it's best to import directly from their paths
+// than expose the functions/types/etc... here. You should _only_ expose functions/types/etc... that need to be shared with other plugins here.
 
-import { createContext } from 'react';
+// When you do have to add things here you might want to consider creating a package to share with
+// other plugins instead as packages are easier to break down and you do not have to carry the cost of extra plugin weight on
+// first download since the other plugins/areas of your code can directly pull from the package in their async imports.
+// See: https://docs.elastic.dev/kibana-dev-docs/key-concepts/platform-intro#public-plugin-api
 
 import { TimelinesPlugin } from './plugin';
-import type { StatefulEventContextType } from './types';
-export * as tGridActions from './store/t_grid/actions';
-export * as tGridSelectors from './store/t_grid/selectors';
-export type {
-  Inspect,
-  SortField,
-  TimerangeInput,
-  PaginationInputPaginated,
-  DocValueFields,
-  CursorType,
-  TotalValue,
-} from '../common/search_strategy/common';
-export { Direction } from '../common/search_strategy/common';
+
+export {
+  upsertColumn,
+  applyDeltaToColumnWidth,
+  updateColumnOrder,
+  updateColumnWidth,
+  toggleDetailPanel,
+  removeColumn,
+  updateIsLoading,
+  updateColumns,
+  updateItemsPerPage,
+  updateItemsPerPageOptions,
+  updateSort,
+  setSelected,
+  clearSelected,
+  setEventsLoading,
+  clearEventsLoading,
+  setEventsDeleted,
+  clearEventsDeleted,
+  initializeTGridSettings,
+  setTGridSelectAll,
+} from './store/t_grid/actions';
+
+export { getManageTimelineById } from './store/t_grid/selectors';
+
 export { tGridReducer } from './store/t_grid/reducer';
-export type { TGridModelForTimeline, TimelineState, TimelinesUIStart } from './types';
+export type { TimelinesUIStart, TGridModelForTimeline, TimelineState } from './types';
 export type { TGridType, SortDirection, State as TGridState, TGridModel } from './types';
 export type { OnColumnFocused } from '../common/utils/accessibility';
+
 export {
   ARIA_COLINDEX_ATTRIBUTE,
   ARIA_ROWINDEX_ATTRIBUTE,
@@ -47,27 +64,25 @@ export {
   getRowRendererClassName,
   getTableSkipFocus,
   handleSkipFocus,
-  onFocusReFocusDraggable,
   onKeyDownFocusHandler,
-  skipFocusInContainerTo,
   stopPropagationAndPreventDefault,
 } from '../common/utils/accessibility';
-export { getPageRowIndex } from '../common/utils/pagination';
+
 export {
   addFieldToTimelineColumns,
   getTimelineIdFromColumnDroppableId,
 } from './components/drag_and_drop/helpers';
+
 export { getActionsColumnWidth } from './components/t_grid/body/column_headers/helpers';
 export { DEFAULT_ACTION_BUTTON_WIDTH } from './components/t_grid/body/constants';
-export { StatefulFieldsBrowser } from './components/t_grid/toolbar/fields_browser';
 export { useStatusBulkActionItems } from './hooks/use_status_bulk_action_items';
+export { getPageRowIndex } from '../common/utils/pagination';
+
 // This exports static code and TypeScript types,
 // as well as, Kibana Platform `plugin()` initializer.
 export function plugin() {
   return new TimelinesPlugin();
 }
 
-export const StatefulEventContext = createContext<StatefulEventContextType | null>(null);
+export { StatefulEventContext } from './components/stateful_event_context';
 export { TimelineContext } from './components/t_grid/shared';
-
-export type { CreateFieldComponentType } from '../common';

--- a/x-pack/plugins/timelines/public/mock/global_state.ts
+++ b/x-pack/plugins/timelines/public/mock/global_state.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Direction } from '../../common';
+import { Direction } from '../../common/search_strategy';
 import { TimelineState } from '../types';
 import { defaultHeaders } from './header';
 

--- a/x-pack/plugins/timelines/public/mock/t_grid.tsx
+++ b/x-pack/plugins/timelines/public/mock/t_grid.tsx
@@ -11,7 +11,7 @@ import { TGridIntegratedProps } from '../components/t_grid/integrated';
 import { mockBrowserFields, mockDocValueFields, mockRuntimeMappings } from './browser_fields';
 import { mockDataProviders } from './mock_data_providers';
 import { mockTimelineData } from './mock_timeline_data';
-import { ColumnHeaderOptions, TimelineId } from '../../common';
+import { ColumnHeaderOptions, TimelineId } from '../../common/types';
 import { mockIndexNames, mockIndexPattern } from './index_pattern';
 import { EventRenderedViewProps } from '../components/t_grid/event_rendered_view';
 

--- a/x-pack/plugins/timelines/public/store/t_grid/helpers.test.tsx
+++ b/x-pack/plugins/timelines/public/store/t_grid/helpers.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SortColumnTimeline } from '../../../common';
+import { SortColumnTimeline } from '../../../common/types';
 import { tGridDefaults } from './defaults';
 import {
   setInitializeTgridSettings,

--- a/x-pack/plugins/timelines/public/store/t_grid/types.ts
+++ b/x-pack/plugins/timelines/public/store/t_grid/types.ts
@@ -6,7 +6,7 @@
  */
 
 import { Storage } from '../../../../../../src/plugins/kibana_utils/public';
-import type { ColumnHeaderOptions } from '../../../common';
+import type { ColumnHeaderOptions } from '../../../common/types';
 import type { TGridModel, TGridModelSettings } from './model';
 
 export type { TGridModel };

--- a/x-pack/plugins/timelines/public/types.ts
+++ b/x-pack/plugins/timelines/public/types.ts
@@ -18,13 +18,13 @@ import type {
   UseDraggableKeyboardWrapper,
   UseDraggableKeyboardWrapperProps,
 } from './components';
-export type { SortDirection } from '../common';
+export type { SortDirection } from '../common/types';
 import type { TGridIntegratedProps } from './components/t_grid/integrated';
 import type { TGridStandaloneProps } from './components/t_grid/standalone';
 import type { UseAddToTimelineProps, UseAddToTimeline } from './hooks/use_add_to_timeline';
 import { HoverActionsConfig } from './components/hover_actions/index';
 import type { AddToCaseActionProps } from './components/actions/timeline/cases/add_to_case_action';
-import { TimelineTabs } from '../common';
+import { TimelineTabs } from '../common/types';
 export * from './store/t_grid';
 export interface TimelinesUIStart {
   getHoverActions: () => HoverActionsConfig;

--- a/x-pack/plugins/timelines/server/search_strategy/index_fields/index.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/index_fields/index.ts
@@ -15,14 +15,13 @@ import {
   SearchStrategyDependencies,
 } from '../../../../../../src/plugins/data/server';
 
-// TODO cleanup path
+import { DELETED_SECURITY_SOLUTION_DATA_VIEW } from '../../../common/constants';
 import {
   IndexFieldsStrategyResponse,
   IndexField,
   IndexFieldsStrategyRequest,
   BeatFields,
-  DELETED_SECURITY_SOLUTION_DATA_VIEW,
-} from '../../../common';
+} from '../../../common/search_strategy';
 import { StartPlugins } from '../../types';
 import type { FieldSpec } from '../../../../../../src/plugins/data_views/common';
 

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/eql/__mocks__/index.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/eql/__mocks__/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EqlSearchStrategyResponse } from '../../../../../../../../src/plugins/data/common';
-import { EqlSearchResponse } from '../../../../../common';
+import { EqlSearchResponse } from '../../../../../common/search_strategy';
 
 export const sequenceResponse = {
   rawResponse: {

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/eql/helpers.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/eql/helpers.ts
@@ -8,8 +8,12 @@
 import { isEmpty } from 'lodash/fp';
 import type { EqlSearchStrategyResponse } from '../../../../../../../src/plugins/data/common';
 import { DEFAULT_MAX_TABLE_QUERY_SIZE } from '../../../../common/constants';
-import { EqlSearchResponse, EqlSequence, EventHit } from '../../../../common';
-import { TimelineEdges } from '../../../../common/search_strategy';
+import {
+  EqlSearchResponse,
+  EqlSequence,
+  EventHit,
+  TimelineEdges,
+} from '../../../../common/search_strategy';
 import {
   TimelineEqlRequestOptions,
   TimelineEqlResponse,

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/eql/index.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/eql/index.ts
@@ -15,7 +15,7 @@ import {
   EqlSearchStrategyResponse,
   EQL_SEARCH_STRATEGY,
 } from '../../../../../../../src/plugins/data/common';
-import { EqlSearchResponse } from '../../../../common';
+import { EqlSearchResponse } from '../../../../common/search_strategy';
 import {
   TimelineEqlRequestOptions,
   TimelineEqlResponse,


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Security Solutions] Removes tech debt of exporting all from linter rule for timeline plugin (#120437)