### PR TITLE
[Discover] No more grumpy Kibana 

### DIFF
--- a/packages/kbn-cli-dev-mode/src/base_path_proxy_server.ts
+++ b/packages/kbn-cli-dev-mode/src/base_path_proxy_server.ts
@@ -21,8 +21,7 @@ import { DevConfig, HttpConfig } from './config';
 import { Log } from './log';
 
 const ONE_GIGABYTE = 1024 * 1024 * 1024;
-const alphabet = 'abcdefghijklmnopqrztuvwxyz'.split('');
-const getRandomBasePath = () => sampleSize(alphabet, 3).join('');
+const getRandomBasePath = () => 'tim';
 
 export interface BasePathProxyServerOptions {
   shouldRedirectFromOldBasePath: (path: string) => boolean;


### PR DESCRIPTION
## Summary
By default starting Kibana in dev mode appends a random generated 3 letter word

There are days when `yarn start` Kibana is nice to it's developer when it's started multiple times

...localhost:5601/**you**/app/discover/...
...localhost:5601/**are**/app/discover/...
...localhost:5601/**god**/app/discover/...

There are days when `yarn start` Kibana can be really grumpy, really offensive to it's poor suffering developer

...localhost:5601/**bad**/app/discover/...
...localhost:5601/**you**/app/discover/...
...localhost:5601/**are**/app/discover/...

There are even days when Kibana can be 😱 


<img width="194" alt="Bildschirmfoto 2021-12-07 um 17 42 41" src="https://user-images.githubusercontent.com/463851/145070202-abf56cdd-0dce-4165-865c-83c7de83d647.png">


This PR suggests a always friendly Kibana dev experience, because it changes the random generated word to be always:

...localhost:5601/**tim**/app/discover/...

Thank you Tim!
