### PR TITLE
[Cases] Fixing imports

### DIFF
--- a/x-pack/plugins/cases/server/client/metrics/alerts_count.ts
+++ b/x-pack/plugins/cases/server/client/metrics/alerts_count.ts
@@ -7,7 +7,7 @@
 
 import { CaseMetricsResponse } from '../../../common/api';
 import { Operations } from '../../authorization';
-import { createCaseError } from '../../common';
+import { createCaseError } from '../../common/error';
 import { CasesClient } from '../client';
 import { CasesClientArgs } from '../types';
 import { MetricsHandler } from './types';

--- a/x-pack/plugins/cases/server/services/attachments/index.ts
+++ b/x-pack/plugins/cases/server/services/attachments/index.ts
@@ -27,7 +27,7 @@ import {
 } from '../../../common/constants';
 import { ClientArgs } from '..';
 import { buildFilter, combineFilters } from '../../client/utils';
-import { defaultSortField } from '../../common';
+import { defaultSortField } from '../../common/utils';
 
 interface GetAllAlertsAttachToCaseArgs extends ClientArgs {
   caseId: string;


### PR DESCRIPTION
This PR fixes two import failures that resulted from merging this PR: https://github.com/elastic/kibana/pull/120265

```
[ts refs]  proc [tsc] x-pack/plugins/cases/server/services/attachments/index.ts:30:34 - error TS2306: File '/opt/local-ssd/buildkite/builds/kb-c2-4-fa4dc5f21ba2324e/elastic/kibana-on-merge/kibana/x-pack/plugins/cases/server/common/index.ts' is not a module.
[ts refs]  proc [tsc]
[ts refs]  proc [tsc] 30 import { defaultSortField } from '../../common';
[ts refs]  proc [tsc]                                     ~~~~~~~~~~~~~~
[ts refs]  proc [tsc]
[ts refs]  proc [tsc] x-pack/plugins/cases/server/client/metrics/alerts_count.ts:10:33 - error TS2306: File '/opt/local-ssd/buildkite/builds/kb-c2-4-fa4dc5f21ba2324e/elastic/kibana-on-merge/kibana/x-pack/plugins/cases/server/common/index.ts' is not a module.
[ts refs]  proc [tsc]
[ts refs]  proc [tsc] 10 import { createCaseError } from '../../common';
[ts refs]  proc [tsc]                                    ~~~~~~~~~~~~~~
[ts refs]  proc [tsc]
[ts refs]  proc [tsc]
[ts refs]  proc [tsc] Found 2 errors.
[ts refs]  proc [tsc]
[ts refs]  succ ts refs build successfully
```