### PR TITLE
[Reporting] fix unsupported platform crash

### DIFF
--- a/x-pack/plugins/screenshotting/server/browsers/install.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/install.ts
@@ -25,7 +25,7 @@ export async function install(
   platform: string = process.platform,
   architecture: string = os.arch()
 ): Promise<string> {
-  const pkg = paths.find(platform, architecture);
+  const pkg = paths.find(platform, architecture + '-foo');
 
   if (!pkg) {
     throw new Error(`Unsupported platform: ${platform}-${architecture}`);

--- a/x-pack/plugins/screenshotting/server/browsers/install.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/install.ts
@@ -25,7 +25,7 @@ export async function install(
   platform: string = process.platform,
   architecture: string = os.arch()
 ): Promise<string> {
-  const pkg = paths.find(platform, architecture + '-foo');
+  const pkg = paths.find(platform, architecture);
 
   if (!pkg) {
     throw new Error(`Unsupported platform: ${platform}-${architecture}`);

--- a/x-pack/plugins/screenshotting/server/plugin.test.ts
+++ b/x-pack/plugins/screenshotting/server/plugin.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+jest.mock('./browsers/install');
+
+import type { ScreenshotModePluginSetup } from 'src/plugins/screenshot_mode/server';
+import { CoreSetup, CoreStart, PluginInitializerContext } from 'kibana/server';
+import { coreMock } from 'src/core/server/mocks';
+import { ScreenshottingPlugin } from './plugin';
+import { install } from './browsers/install';
+
+let initContext: PluginInitializerContext;
+let coreSetup: CoreSetup;
+let coreStart: CoreStart;
+let setupDeps: {
+  screenshotMode: ScreenshotModePluginSetup;
+};
+
+beforeEach(() => {
+  const configSchema = {
+    browser: { chromium: { disableSandbox: false } },
+  };
+  initContext = coreMock.createPluginInitializerContext(configSchema);
+  coreSetup = coreMock.createSetup({});
+  coreStart = coreMock.createStart();
+  setupDeps = {
+    screenshotMode: {} as ScreenshotModePluginSetup,
+  };
+});
+
+test('sets up and starts properly', async () => {
+  const plugin = new ScreenshottingPlugin(initContext);
+  const setupContract = plugin.setup(coreSetup, setupDeps);
+  expect(setupContract).toMatchInlineSnapshot(`Object {}`);
+
+  await coreSetup.getStartServices();
+
+  const startContract = plugin.start(coreStart);
+  expect(startContract).toMatchInlineSnapshot(`
+    Object {
+      "diagnose": [Function],
+      "getScreenshots": [Function],
+    }
+  `);
+});
+
+test('handles setup issues', async () => {
+  const plugin = new ScreenshottingPlugin(initContext);
+  (install as jest.Mock).mockRejectedValue(`Unsupported platform!!!`);
+
+  const setupContract = plugin.setup(coreSetup, setupDeps);
+  expect(setupContract).toMatchInlineSnapshot(`Object {}`);
+
+  await coreSetup.getStartServices();
+
+  const startContract = plugin.start(coreStart);
+  expect(startContract).toMatchInlineSnapshot(`
+    Object {
+      "diagnose": [Function],
+      "getScreenshots": [Function],
+    }
+  `);
+});

--- a/x-pack/plugins/screenshotting/server/plugin.test.ts
+++ b/x-pack/plugins/screenshotting/server/plugin.test.ts
@@ -7,55 +7,70 @@
 
 jest.mock('./browsers/install');
 
-import type { ScreenshotModePluginSetup } from 'src/plugins/screenshot_mode/server';
-import { CoreSetup, CoreStart, PluginInitializerContext } from 'kibana/server';
+import type { CoreSetup, CoreStart, PluginInitializerContext } from 'kibana/server';
 import { coreMock } from 'src/core/server/mocks';
-import { ScreenshottingPlugin } from './plugin';
+import type { ScreenshotModePluginSetup } from 'src/plugins/screenshot_mode/server';
 import { install } from './browsers/install';
+import { ScreenshottingPlugin } from './plugin';
 
-let initContext: PluginInitializerContext;
-let coreSetup: CoreSetup;
-let coreStart: CoreStart;
-let setupDeps: Parameters<ScreenshottingPlugin['setup']>[1];
+describe('ScreenshottingPlugin', () => {
+  let initContext: PluginInitializerContext;
+  let coreSetup: CoreSetup;
+  let coreStart: CoreStart;
+  let setupDeps: Parameters<ScreenshottingPlugin['setup']>[1];
+  let plugin: ScreenshottingPlugin;
 
-beforeEach(() => {
-  const configSchema = {
-    browser: { chromium: { disableSandbox: false } },
-  };
-  initContext = coreMock.createPluginInitializerContext(configSchema);
-  coreSetup = coreMock.createSetup({});
-  coreStart = coreMock.createStart();
-  setupDeps = {
-    screenshotMode: {} as ScreenshotModePluginSetup,
-  };
-});
+  beforeEach(() => {
+    const configSchema = {
+      browser: { chromium: { disableSandbox: false } },
+    };
+    initContext = coreMock.createPluginInitializerContext(configSchema);
+    coreSetup = coreMock.createSetup({});
+    coreStart = coreMock.createStart();
+    setupDeps = {
+      screenshotMode: {} as ScreenshotModePluginSetup,
+    };
+    plugin = new ScreenshottingPlugin(initContext);
+  });
 
-test('sets up and starts properly', async () => {
-  const plugin = new ScreenshottingPlugin(initContext);
-  const setupContract = plugin.setup(coreSetup, setupDeps);
-  expect(setupContract).toEqual({});
+  describe('setup', () => {
+    test('returns a setup contract', async () => {
+      const setupContract = plugin.setup(coreSetup, setupDeps);
+      expect(setupContract).toEqual({});
+    });
 
-  await coreSetup.getStartServices();
+    test('handles setup issues', async () => {
+      (install as jest.Mock).mockRejectedValue(`Unsupported platform!!!`);
 
-  const startContract = plugin.start(coreStart);
-  expect(startContract).toEqual(expect.objectContaining({
-    diagnose: expect.any(Function),
-    getScreenshots: expect.any(Function),
-  }));
-});
+      const setupContract = plugin.setup(coreSetup, setupDeps);
+      expect(setupContract).toEqual({});
 
-test('handles setup issues', async () => {
-  const plugin = new ScreenshottingPlugin(initContext);
-  (install as jest.Mock).mockRejectedValue(`Unsupported platform!!!`);
+      await coreSetup.getStartServices();
 
-  const setupContract = plugin.setup(coreSetup, setupDeps);
-  expect(setupContract).toMatchInlineSnapshot(`Object {}`);
+      const startContract = plugin.start(coreStart);
+      expect(startContract).toEqual(
+        expect.objectContaining({
+          diagnose: expect.any(Function),
+          getScreenshots: expect.any(Function),
+        })
+      );
+    });
+  });
 
-  await coreSetup.getStartServices();
+  describe('start', () => {
+    beforeEach(async () => {
+      plugin.setup(coreSetup, setupDeps);
+      await coreSetup.getStartServices();
+    });
 
-  const startContract = plugin.start(coreStart);
-  expect(startContract).toEqual(expect.objectContaining({
-    diagnose: expect.any(Function),
-    getScreenshots: expect.any(Function),
-  }));
+    test('returns a start contract', async () => {
+      const startContract = plugin.start(coreStart);
+      expect(startContract).toEqual(
+        expect.objectContaining({
+          diagnose: expect.any(Function),
+          getScreenshots: expect.any(Function),
+        })
+      );
+    });
+  });
 });

--- a/x-pack/plugins/screenshotting/server/plugin.test.ts
+++ b/x-pack/plugins/screenshotting/server/plugin.test.ts
@@ -16,9 +16,7 @@ import { install } from './browsers/install';
 let initContext: PluginInitializerContext;
 let coreSetup: CoreSetup;
 let coreStart: CoreStart;
-let setupDeps: {
-  screenshotMode: ScreenshotModePluginSetup;
-};
+let setupDeps: Parameters<ScreenshottingPlugin['setup']>[1];
 
 beforeEach(() => {
   const configSchema = {
@@ -35,17 +33,15 @@ beforeEach(() => {
 test('sets up and starts properly', async () => {
   const plugin = new ScreenshottingPlugin(initContext);
   const setupContract = plugin.setup(coreSetup, setupDeps);
-  expect(setupContract).toMatchInlineSnapshot(`Object {}`);
+  expect(setupContract).toEqual({});
 
   await coreSetup.getStartServices();
 
   const startContract = plugin.start(coreStart);
-  expect(startContract).toMatchInlineSnapshot(`
-    Object {
-      "diagnose": [Function],
-      "getScreenshots": [Function],
-    }
-  `);
+  expect(startContract).toEqual(expect.objectContaining({
+    diagnose: expect.any(Function),
+    getScreenshots: expect.any(Function),
+  }));
 });
 
 test('handles setup issues', async () => {
@@ -58,10 +54,8 @@ test('handles setup issues', async () => {
   await coreSetup.getStartServices();
 
   const startContract = plugin.start(coreStart);
-  expect(startContract).toMatchInlineSnapshot(`
-    Object {
-      "diagnose": [Function],
-      "getScreenshots": [Function],
-    }
-  `);
+  expect(startContract).toEqual(expect.objectContaining({
+    diagnose: expect.any(Function),
+    getScreenshots: expect.any(Function),
+  }));
 });

--- a/x-pack/plugins/screenshotting/server/plugin.ts
+++ b/x-pack/plugins/screenshotting/server/plugin.ts
@@ -66,23 +66,24 @@ export class ScreenshottingPlugin implements Plugin<void, ScreenshottingStart, S
         return new HeadlessChromiumDriverFactory(this.screenshotMode, config, logger, binaryPath);
       } catch (error) {
         this.logger.error('Error in screenshotting setup, it may not function properly.');
-
-        throw error;
+        this.logger.error(error);
       }
-    })();
+    })() as Promise<HeadlessChromiumDriverFactory>;
 
     return {};
   }
 
   start({}: CoreStart): ScreenshottingStart {
-    return {
-      diagnose: () =>
-        from(this.browserDriverFactory).pipe(switchMap((factory) => factory.diagnose())),
-      getScreenshots: (options) =>
-        from(this.browserDriverFactory).pipe(
-          switchMap((factory) => getScreenshots(factory, this.logger.get('screenshot'), options))
-        ),
-    };
+    return (
+      this.browserDriverFactory && {
+        diagnose: () =>
+          from(this.browserDriverFactory).pipe(switchMap((factory) => factory.diagnose())),
+        getScreenshots: (options) =>
+          from(this.browserDriverFactory).pipe(
+            switchMap((factory) => getScreenshots(factory, this.logger.get('screenshot'), options))
+          ),
+      }
+    );
   }
 
   stop() {}

--- a/x-pack/plugins/screenshotting/server/plugin.ts
+++ b/x-pack/plugins/screenshotting/server/plugin.ts
@@ -65,8 +65,9 @@ export class ScreenshottingPlugin implements Plugin<void, ScreenshottingStart, S
       return new HeadlessChromiumDriverFactory(this.screenshotMode, config, logger, binaryPath);
     })();
 
-    this.browserDriverFactory.catch(() => {
+    this.browserDriverFactory.catch((error) => {
       this.logger.error('Error in screenshotting setup, it may not function properly.');
+      this.logger.error(error);
     });
 
     return {};

--- a/x-pack/plugins/screenshotting/server/plugin.ts
+++ b/x-pack/plugins/screenshotting/server/plugin.ts
@@ -45,7 +45,7 @@ export class ScreenshottingPlugin implements Plugin<void, ScreenshottingStart, S
   private config: ConfigType;
   private logger: Logger;
   private screenshotMode!: ScreenshotModePluginSetup;
-  private browserDriverFactory!: Promise<HeadlessChromiumDriverFactory | undefined>;
+  private browserDriverFactory!: Promise<HeadlessChromiumDriverFactory>;
 
   constructor(context: PluginInitializerContext<ConfigType>) {
     this.logger = context.logger.get();
@@ -76,10 +76,10 @@ export class ScreenshottingPlugin implements Plugin<void, ScreenshottingStart, S
   start({}: CoreStart): ScreenshottingStart {
     return {
       diagnose: () =>
-        from(this.browserDriverFactory).pipe(switchMap((factory) => factory!.diagnose())),
+        from(this.browserDriverFactory).pipe(switchMap((factory) => factory.diagnose())),
       getScreenshots: (options) =>
         from(this.browserDriverFactory).pipe(
-          switchMap((factory) => getScreenshots(factory!, this.logger.get('screenshot'), options))
+          switchMap((factory) => getScreenshots(factory, this.logger.get('screenshot'), options))
         ),
     };
   }


### PR DESCRIPTION
## Summary

Caused by: https://github.com/elastic/kibana/pull/120110

This PR fixes a server crash that occurs when the platform doesn't have a supported Chromium binary available for Reporting.

Today, a user on the Darwin arm64 platform will get a crash when they try to start Kibana:
```
[2021-12-07T10:43:28.569-06:00][ERROR][plugins.screenshotting] Error in screenshotting setup, it may not function properly.
Unhandled Promise rejection detected:

Error: Unsupported platform: darwin-arm64
    at install (/Users/smith/Code/kibana/x-pack/plugins/screenshotting/server/browsers/install.ts:32:11)
```

Now, they will still see the error logged but the server will not crash. This change also has a proper stack trace logged:
```
[2021-12-07T10:27:21.833-07:00][ERROR][plugins.screenshotting] Error in screenshotting setup, it may not function properly.
[2021-12-07T10:27:21.834-07:00][ERROR][plugins.screenshotting] Error: Unsupported platform: darwin-arm64
    at install (/home/tsullivan/elastic/kibana/x-pack/plugins/screenshotting/server/browsers/install.ts:31:11)
    at /home/tsullivan/elastic/kibana/x-pack/plugins/screenshotting/server/plugin.ts:63:11
    at ScreenshottingPlugin.setup (/home/tsullivan/elastic/kibana/x-pack/plugins/screenshotting/server/plugin.ts:57:33)
    at PluginWrapper.setup (/home/tsullivan/elastic/kibana/src/core/server/plugins/plugin.ts:108:26)
    at PluginsSystem.setupPlugins (/home/tsullivan/elastic/kibana/src/core/server/plugins/plugins_system.ts:129:40)
    at PluginsService.setup (/home/tsullivan/elastic/kibana/src/core/server/plugins/plugins_service.ts:171:52)
    at Server.setup (/home/tsullivan/elastic/kibana/src/core/server/server.ts:282:26)
    at Root.setup (/home/tsullivan/elastic/kibana/src/core/server/root/index.ts:52:14)
    at bootstrap (/home/tsullivan/elastic/kibana/src/core/server/bootstrap.ts:101:5)
    at Command.<anonymous> (/home/tsullivan/elastic/kibana/src/cli/serve/serve.js:244:5)

```

When this error is logged, if the user tries to generate a PNG or PDF report in the Kibana instance, they will see a failed report with an appropriate error:
![image](https://user-images.githubusercontent.com/908371/145089185-56479a22-a43c-4857-a68d-3a67e20eb37e.png)
![image](https://user-images.githubusercontent.com/908371/145089243-9190cf8f-3b7f-46c7-b018-5a8f6d1b785a.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
