### PR TITLE
[Fleet] Handle ID's for preconfigured package policies

### DIFF
--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -87,7 +87,7 @@ Optional properties are:
   `data_output_id`:: ID of the output to send data (Need to be identical to `monitoring_output_id`)
   `monitoring_output_id`:: ID of the output to send monitoring data. (Need to be identical to `data_output_id`)
   `package_policies`:: List of integration policies to add to this policy.
-    `id`::: (required) Unique ID of the integration policy.
+    `id`::: (required) Unique ID of the integration policy. The ID may be a number or string.
     `name`::: (required) Name of the integration policy.
     `package`::: (required) Integration that this policy configures
       `name`:::: Name of the integration associated with this policy.
@@ -129,6 +129,7 @@ xpack.fleet.agentPolicies:
       - package:
           name: system
         name: System Integration
+        id: preconfigured-system
         inputs:
           - type: system/metrics
             enabled: true

--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -87,6 +87,7 @@ Optional properties are:
   `data_output_id`:: ID of the output to send data (Need to be identical to `monitoring_output_id`)
   `monitoring_output_id`:: ID of the output to send monitoring data. (Need to be identical to `data_output_id`)
   `package_policies`:: List of integration policies to add to this policy.
+    `id`::: (required) ID of the integration policy.
     `name`::: (required) Name of the integration policy.
     `package`::: (required) Integration that this policy configures
       `name`:::: Name of the integration associated with this policy.

--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -87,7 +87,7 @@ Optional properties are:
   `data_output_id`:: ID of the output to send data (Need to be identical to `monitoring_output_id`)
   `monitoring_output_id`:: ID of the output to send monitoring data. (Need to be identical to `data_output_id`)
   `package_policies`:: List of integration policies to add to this policy.
-    `id`::: (required) Unique ID of the integration policy. The ID may be a number or string.
+    `id`::: Unique ID of the integration policy. The ID may be a number or string.
     `name`::: (required) Name of the integration policy.
     `package`::: (required) Integration that this policy configures
       `name`:::: Name of the integration associated with this policy.

--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -87,7 +87,7 @@ Optional properties are:
   `data_output_id`:: ID of the output to send data (Need to be identical to `monitoring_output_id`)
   `monitoring_output_id`:: ID of the output to send monitoring data. (Need to be identical to `data_output_id`)
   `package_policies`:: List of integration policies to add to this policy.
-    `id`::: (required) ID of the integration policy.
+    `id`::: (required) Unique ID of the integration policy.
     `name`::: (required) Name of the integration policy.
     `package`::: (required) Integration that this policy configures
       `name`:::: Name of the integration associated with this policy.

--- a/x-pack/plugins/fleet/common/constants/preconfiguration.ts
+++ b/x-pack/plugins/fleet/common/constants/preconfiguration.ts
@@ -30,12 +30,15 @@ type PreconfiguredAgentPolicyWithDefaultInputs = Omit<
   package_policies: Array<Omit<PreconfiguredAgentPolicy['package_policies'][0], 'inputs'>>;
 };
 
+export const DEFAULT_SYSTEM_PACKAGE_POLICY_ID = 'default-system-policy';
+
 export const DEFAULT_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
   name: 'Default policy',
   namespace: 'default',
   description: 'Default agent policy created by Kibana',
   package_policies: [
     {
+      id: DEFAULT_SYSTEM_PACKAGE_POLICY_ID,
       name: `${FLEET_SYSTEM_PACKAGE}-1`,
       package: {
         name: FLEET_SYSTEM_PACKAGE,
@@ -47,12 +50,15 @@ export const DEFAULT_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
   monitoring_enabled: monitoringTypes,
 };
 
+export const DEFAULT_FLEET_SERVER_POLICY_ID = 'default-system-policy';
+
 export const DEFAULT_FLEET_SERVER_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
   name: 'Default Fleet Server policy',
   namespace: 'default',
   description: 'Default Fleet Server agent policy created by Kibana',
   package_policies: [
     {
+      id: DEFAULT_FLEET_SERVER_POLICY_ID,
       name: `${FLEET_SERVER_PACKAGE}-1`,
       package: {
         name: FLEET_SERVER_PACKAGE,

--- a/x-pack/plugins/fleet/common/constants/preconfiguration.ts
+++ b/x-pack/plugins/fleet/common/constants/preconfiguration.ts
@@ -50,7 +50,7 @@ export const DEFAULT_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
   monitoring_enabled: monitoringTypes,
 };
 
-export const DEFAULT_FLEET_SERVER_POLICY_ID = 'default-system-policy';
+export const DEFAULT_FLEET_SERVER_POLICY_ID = 'default-fleet-server-policy';
 
 export const DEFAULT_FLEET_SERVER_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
   name: 'Default Fleet Server policy',

--- a/x-pack/plugins/fleet/common/types/models/package_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/package_policy.ts
@@ -56,6 +56,7 @@ export interface PackagePolicyInput extends Omit<NewPackagePolicyInput, 'streams
 }
 
 export interface NewPackagePolicy {
+  id?: string | number;
   name: string;
   description?: string;
   namespace: string;

--- a/x-pack/plugins/fleet/common/types/models/preconfiguration.ts
+++ b/x-pack/plugins/fleet/common/types/models/preconfiguration.ts
@@ -25,7 +25,7 @@ export interface PreconfiguredAgentPolicy extends Omit<NewAgentPolicy, 'namespac
   namespace?: string;
   package_policies: Array<
     Partial<Omit<NewPackagePolicy, 'inputs' | 'package'>> & {
-      id: string | number;
+      id?: string | number;
       name: string;
       package: Partial<PackagePolicyPackage> & { name: string };
       inputs?: InputsOverride[];

--- a/x-pack/plugins/fleet/common/types/models/preconfiguration.ts
+++ b/x-pack/plugins/fleet/common/types/models/preconfiguration.ts
@@ -25,6 +25,7 @@ export interface PreconfiguredAgentPolicy extends Omit<NewAgentPolicy, 'namespac
   namespace?: string;
   package_policies: Array<
     Partial<Omit<NewPackagePolicy, 'inputs' | 'package'>> & {
+      id: string | number;
       name: string;
       package: Partial<PackagePolicyPackage> & { name: string };
       inputs?: InputsOverride[];

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -7,6 +7,7 @@
 
 import { uniq, omit } from 'lodash';
 import uuid from 'uuid/v4';
+import uuidv5 from 'uuid/v5';
 import type {
   ElasticsearchClient,
   SavedObjectsClientContract,
@@ -57,7 +58,11 @@ import { agentPolicyUpdateEventHandler } from './agent_policy_update';
 import { normalizeKuery, escapeSearchQueryPhrase } from './saved_object';
 import { appContextService } from './app_context';
 import { getFullAgentPolicy } from './agent_policies';
+
 const SAVED_OBJECT_TYPE = AGENT_POLICY_SAVED_OBJECT_TYPE;
+
+// UUID v5 values require a namespace
+const UUID_V5_NAMESPACE = 'dde7c2de-1370-4c19-9975-b473d0e03508';
 
 class AgentPolicyService {
   private triggerAgentPolicyUpdatedEvent = async (
@@ -804,8 +809,14 @@ export async function addPackageToAgentPolicy(
     ? transformPackagePolicy(basePackagePolicy)
     : basePackagePolicy;
 
+  // If an ID is provided via preconfiguration, use that value. Otherwise fall back to
+  // a UUID v5 value seeded from the agent policy's ID and the provided package policy name.
+  const id = packagePolicyId
+    ? String(packagePolicyId)
+    : uuidv5(`${agentPolicy.id}-${packagePolicyName}`, UUID_V5_NAMESPACE);
+
   await packagePolicyService.create(soClient, esClient, newPackagePolicy, {
-    id: packagePolicyId ? String(packagePolicyId) : undefined,
+    id,
     bumpRevision: bumpAgentPolicyRevison,
     skipEnsureInstalled: true,
     skipUniqueNameVerification: true,

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -780,6 +780,7 @@ export async function addPackageToAgentPolicy(
   agentPolicy: AgentPolicy,
   defaultOutput: Output,
   packagePolicyName?: string,
+  packagePolicyId?: string | number,
   packagePolicyDescription?: string,
   transformPackagePolicy?: (p: NewPackagePolicy) => NewPackagePolicy,
   bumpAgentPolicyRevison = false
@@ -804,6 +805,7 @@ export async function addPackageToAgentPolicy(
     : basePackagePolicy;
 
   await packagePolicyService.create(soClient, esClient, newPackagePolicy, {
+    id: packagePolicyId ? String(packagePolicyId) : undefined,
     bumpRevision: bumpAgentPolicyRevison,
     skipEnsureInstalled: true,
     skipUniqueNameVerification: true,

--- a/x-pack/plugins/fleet/server/services/preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.test.ts
@@ -415,6 +415,7 @@ describe('policy preconfiguration', () => {
         id: 'test-id',
         package_policies: [
           {
+            id: 'test-package',
             package: { name: 'test_package' },
             name: 'Test package',
           },
@@ -446,6 +447,7 @@ describe('policy preconfiguration', () => {
         id: 'test-id',
         package_policies: [
           {
+            id: 'test-package',
             package: { name: 'test_package' },
             name: 'Test package',
           },
@@ -601,6 +603,7 @@ describe('comparePreconfiguredPolicyToCurrent', () => {
     unenroll_timeout: 60,
     package_policies: [
       {
+        id: 'test_package_policy',
         package: { name: 'test_package' },
         name: 'Test package',
       },
@@ -653,6 +656,7 @@ describe('comparePreconfiguredPolicyToCurrent', () => {
         ...baseConfig,
         package_policies: [
           {
+            id: 'different_package_policy',
             package: { name: 'different_package' },
             name: 'Different package',
           },

--- a/x-pack/plugins/fleet/server/services/preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.test.ts
@@ -415,7 +415,6 @@ describe('policy preconfiguration', () => {
         id: 'test-id',
         package_policies: [
           {
-            id: 'test-package',
             package: { name: 'test_package' },
             name: 'Test package',
           },
@@ -603,7 +602,6 @@ describe('comparePreconfiguredPolicyToCurrent', () => {
     unenroll_timeout: 60,
     package_policies: [
       {
-        id: 'test_package_policy',
         package: { name: 'test_package' },
         name: 'Test package',
       },
@@ -656,7 +654,6 @@ describe('comparePreconfiguredPolicyToCurrent', () => {
         ...baseConfig,
         package_policies: [
           {
-            id: 'different_package_policy',
             package: { name: 'different_package' },
             name: 'Different package',
           },

--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -404,7 +404,7 @@ async function addPreconfiguredPolicyPackages(
   agentPolicy: AgentPolicy,
   installedPackagePolicies: Array<
     Partial<Omit<NewPackagePolicy, 'inputs'>> & {
-      id: string | number;
+      id?: string | number;
       name: string;
       installedPackage: Installation;
       inputs?: InputsOverride[];

--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -404,6 +404,7 @@ async function addPreconfiguredPolicyPackages(
   agentPolicy: AgentPolicy,
   installedPackagePolicies: Array<
     Partial<Omit<NewPackagePolicy, 'inputs'>> & {
+      id: string | number;
       name: string;
       installedPackage: Installation;
       inputs?: InputsOverride[];
@@ -413,7 +414,7 @@ async function addPreconfiguredPolicyPackages(
   bumpAgentPolicyRevison = false
 ) {
   // Add packages synchronously to avoid overwriting
-  for (const { installedPackage, name, description, inputs } of installedPackagePolicies) {
+  for (const { installedPackage, id, name, description, inputs } of installedPackagePolicies) {
     const packageInfo = await getPackageInfo({
       savedObjectsClient: soClient,
       pkgName: installedPackage.name,
@@ -427,6 +428,7 @@ async function addPreconfiguredPolicyPackages(
       agentPolicy,
       defaultOutput,
       name,
+      id,
       description,
       (policy) => preconfigurePackageInputs(policy, packageInfo, inputs),
       bumpAgentPolicyRevison

--- a/x-pack/plugins/fleet/server/types/models/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/types/models/preconfiguration.ts
@@ -106,6 +106,7 @@ export const PreconfiguredAgentPoliciesSchema = schema.arrayOf(
     monitoring_output_id: schema.maybe(schema.string()),
     package_policies: schema.arrayOf(
       schema.object({
+        id: schema.oneOf([schema.string(), schema.number()]),
         name: schema.string(),
         package: schema.object({
           name: schema.string(),

--- a/x-pack/plugins/fleet/server/types/models/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/types/models/preconfiguration.ts
@@ -106,7 +106,7 @@ export const PreconfiguredAgentPoliciesSchema = schema.arrayOf(
     monitoring_output_id: schema.maybe(schema.string()),
     package_policies: schema.arrayOf(
       schema.object({
-        id: schema.oneOf([schema.string(), schema.number()]),
+        id: schema.maybe(schema.oneOf([schema.string(), schema.number()])),
         name: schema.string(),
         package: schema.object({
           name: schema.string(),


### PR DESCRIPTION
## Summary

Add logic for ID values in preconfigured package policies, as well as Fleet's default policies.

- For Fleet's default policies, add a hard-coded ID to the generated package policies
- Require an ID value for all preconfigured package policies

Resolves #120612

## To test

You can test a few pieces of behavior here. 

### Preconfigured ID's

Add a preconfigured package policy with an ID, e.g. 

```yml
xpack.fleet.packages:
  - name: log
    version: latest
xpack.fleet.agentPolicies:
  - name: Custom Logs Policy
    id: custom-logs-123
    namespace: default
    package_policies:
      - package:
          name: log
        name: log-1
        id: preconfigured-custom-logs
        inputs:
          - type: logfile
            enabled: true
            streams:
              - data_stream:
                  dataset: log.log
                enabled: true
                vars:
                  - name: paths
                    value:
                    - /var/log/my.log
```

Note that the ID comes through as the ID for the SO generated. You can confirm this via the "Edit integration policy" screen in Kibana.

### Deterministic ID's for preconfigured policies

Add some preconfigured policies to your `kibana.yml` without providing an ID for each package policy, e.g.


```yml
xpack.fleet.packages:
  - name: log
    version: latest
xpack.fleet.agentPolicies:
  - name: Custom Logs Policy
    id: custom-logs-123
    namespace: default
    package_policies:
      - package:
          name: log
        name: log-1
        inputs:
          - type: logfile
            enabled: true
            streams:
              - data_stream:
                  dataset: log.log
                enabled: true
                vars:
                  - name: paths
                    value:
                    - /var/log/my.log
      - package:
          name: log
        name: log-2
        inputs:
          - type: logfile
            enabled: true
            streams:
              - data_stream:
                  dataset: log.log
                enabled: true
                vars:
                  - name: paths
                    value:
                    - /var/log/my.log
```

Run Fleet setup against a fresh instance of Elasticsearch and note the ID's generated for your policies. Then, tear down Elasticsearch and wipe any data persisted. Run Elasticsearch + Kibana again from scratch and note that the UUID values generated for your policies are the same again. 

e.g. for me, I ran the policies and got the following results across two distinct Fleet setups:

log-1 | log-2
-- | --
b3bbc631-a29e-5443-a4fc-a038cf21e0d5 | 3f71a685-4569-5619-adf2-8082d6c9b96b
b3bbc631-a29e-5443-a4fc-a038cf21e0d5 | 3f71a685-4569-5619-adf2-8082d6c9b96b

### Predictable ID's for default policies

Remove any preconfigured policies from your `kibana.dev.yml` and start a fresh Elasticsearch/Kibana environment. Run Fleet setup and note that the default package policies should now have hard-coded ID's as follows:

Default Fleet Policy → System Integration: `default-system-policy`
Default Fleet Server Policy → Fleet Server Integration: `default-fleet-server-policy`
