### PR TITLE
[Workplace Search] Refactor documentation links to use `docLinks` service directly

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/license_callout/license_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/license_callout/license_callout.tsx
@@ -9,8 +9,9 @@ import React from 'react';
 
 import { EuiLink, EuiFlexItem, EuiFlexGroup, EuiText } from '@elastic/eui';
 
+import { docLinks } from '../../../../shared/doc_links';
+
 import { EXPLORE_PLATINUM_FEATURES_LINK } from '../../../constants';
-import { ENT_SEARCH_LICENSE_MANAGEMENT } from '../../../routes';
 
 interface LicenseCalloutProps {
   message?: string;
@@ -20,7 +21,7 @@ export const LicenseCallout: React.FC<LicenseCalloutProps> = ({ message }) => {
   const title = (
     <>
       {message}{' '}
-      <EuiLink target="_blank" external href={ENT_SEARCH_LICENSE_MANAGEMENT}>
+      <EuiLink target="_blank" external href={docLinks.licenseManagement}>
         <strong>{EXPLORE_PLATINUM_FEATURES_LINK}</strong>
       </EuiLink>
     </>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -22,7 +22,6 @@ export const LOGOUT_ROUTE = '/logout';
 export const LEAVE_FEEDBACK_EMAIL = 'support@elastic.co';
 export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elastic%20Workplace%20Search%20Feedback`;
 
-export const DOCUMENT_PERMISSIONS_DOCS_URL = docLinks.workplaceSearchDocumentPermissions;
 export const ENT_SEARCH_LICENSE_MANAGEMENT = docLinks.licenseManagement;
 export const SECURITY_DOCS_URL = docLinks.workplaceSearchSecurity;
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -22,34 +22,18 @@ export const LOGOUT_ROUTE = '/logout';
 export const LEAVE_FEEDBACK_EMAIL = 'support@elastic.co';
 export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elastic%20Workplace%20Search%20Feedback`;
 
-export const BOX_DOCS_URL = docLinks.workplaceSearchBox;
-export const CONFLUENCE_DOCS_URL = docLinks.workplaceSearchConfluenceCloud;
-export const CONFLUENCE_SERVER_DOCS_URL = docLinks.workplaceSearchConfluenceServer;
 export const CUSTOM_SOURCE_DOCS_URL = docLinks.workplaceSearchCustomSources;
 export const CUSTOM_API_DOCUMENT_PERMISSIONS_DOCS_URL =
   docLinks.workplaceSearchCustomSourcePermissions;
 export const DIFFERENT_SYNC_TYPES_DOCS_URL = docLinks.workplaceSearchIndexingSchedule;
 export const DOCUMENT_PERMISSIONS_DOCS_URL = docLinks.workplaceSearchDocumentPermissions;
-export const DROPBOX_DOCS_URL = docLinks.workplaceSearchDropbox;
 export const ENT_SEARCH_LICENSE_MANAGEMENT = docLinks.licenseManagement;
 export const EXTERNAL_IDENTITIES_DOCS_URL = docLinks.workplaceSearchExternalIdentities;
 export const GETTING_STARTED_DOCS_URL = docLinks.workplaceSearchGettingStarted;
-export const GITHUB_DOCS_URL = docLinks.workplaceSearchGitHub;
-export const GITHUB_ENTERPRISE_DOCS_URL = docLinks.workplaceSearchGitHub;
-export const GMAIL_DOCS_URL = docLinks.workplaceSearchGmail;
-export const GOOGLE_DRIVE_DOCS_URL = docLinks.workplaceSearchGoogleDrive;
-export const JIRA_DOCS_URL = docLinks.workplaceSearchJiraCloud;
-export const JIRA_SERVER_DOCS_URL = docLinks.workplaceSearchJiraServer;
 export const OBJECTS_AND_ASSETS_DOCS_URL = docLinks.workplaceSearchSynch;
-export const ONEDRIVE_DOCS_URL = docLinks.workplaceSearchOneDrive;
 export const PRIVATE_SOURCES_DOCS_URL = docLinks.workplaceSearchPermissions;
-export const SALESFORCE_DOCS_URL = docLinks.workplaceSearchSalesforce;
 export const SECURITY_DOCS_URL = docLinks.workplaceSearchSecurity;
-export const SERVICENOW_DOCS_URL = docLinks.workplaceSearchServiceNow;
-export const SHAREPOINT_DOCS_URL = docLinks.workplaceSearchSharePoint;
-export const SLACK_DOCS_URL = docLinks.workplaceSearchSlack;
 export const SYNCHRONIZATION_DOCS_URL = docLinks.workplaceSearchSynch;
-export const ZENDESK_DOCS_URL = docLinks.workplaceSearchZendesk;
 
 export const PERSONAL_PATH = '/p';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -29,7 +29,6 @@ export const DIFFERENT_SYNC_TYPES_DOCS_URL = docLinks.workplaceSearchIndexingSch
 export const DOCUMENT_PERMISSIONS_DOCS_URL = docLinks.workplaceSearchDocumentPermissions;
 export const ENT_SEARCH_LICENSE_MANAGEMENT = docLinks.licenseManagement;
 export const EXTERNAL_IDENTITIES_DOCS_URL = docLinks.workplaceSearchExternalIdentities;
-export const GETTING_STARTED_DOCS_URL = docLinks.workplaceSearchGettingStarted;
 export const OBJECTS_AND_ASSETS_DOCS_URL = docLinks.workplaceSearchSynch;
 export const PRIVATE_SOURCES_DOCS_URL = docLinks.workplaceSearchPermissions;
 export const SECURITY_DOCS_URL = docLinks.workplaceSearchSecurity;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -22,7 +22,6 @@ export const LOGOUT_ROUTE = '/logout';
 export const LEAVE_FEEDBACK_EMAIL = 'support@elastic.co';
 export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elastic%20Workplace%20Search%20Feedback`;
 
-export const ENT_SEARCH_LICENSE_MANAGEMENT = docLinks.licenseManagement;
 export const SECURITY_DOCS_URL = docLinks.workplaceSearchSecurity;
 
 export const PERSONAL_PATH = '/p';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -23,7 +23,6 @@ export const LEAVE_FEEDBACK_EMAIL = 'support@elastic.co';
 export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elastic%20Workplace%20Search%20Feedback`;
 
 export const CUSTOM_SOURCE_DOCS_URL = docLinks.workplaceSearchCustomSources;
-export const DIFFERENT_SYNC_TYPES_DOCS_URL = docLinks.workplaceSearchIndexingSchedule;
 export const DOCUMENT_PERMISSIONS_DOCS_URL = docLinks.workplaceSearchDocumentPermissions;
 export const ENT_SEARCH_LICENSE_MANAGEMENT = docLinks.licenseManagement;
 export const EXTERNAL_IDENTITIES_DOCS_URL = docLinks.workplaceSearchExternalIdentities;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -27,7 +27,6 @@ export const DOCUMENT_PERMISSIONS_DOCS_URL = docLinks.workplaceSearchDocumentPer
 export const ENT_SEARCH_LICENSE_MANAGEMENT = docLinks.licenseManagement;
 export const EXTERNAL_IDENTITIES_DOCS_URL = docLinks.workplaceSearchExternalIdentities;
 export const OBJECTS_AND_ASSETS_DOCS_URL = docLinks.workplaceSearchSynch;
-export const PRIVATE_SOURCES_DOCS_URL = docLinks.workplaceSearchPermissions;
 export const SECURITY_DOCS_URL = docLinks.workplaceSearchSecurity;
 
 export const PERSONAL_PATH = '/p';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -7,8 +7,6 @@
 
 import { generatePath } from 'react-router-dom';
 
-import { docLinks } from '../shared/doc_links';
-
 import {
   GITHUB_VIA_APP_SERVICE_TYPE,
   GITHUB_ENTERPRISE_SERVER_VIA_APP_SERVICE_TYPE,
@@ -21,8 +19,6 @@ export const LOGOUT_ROUTE = '/logout';
 
 export const LEAVE_FEEDBACK_EMAIL = 'support@elastic.co';
 export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elastic%20Workplace%20Search%20Feedback`;
-
-export const SECURITY_DOCS_URL = docLinks.workplaceSearchSecurity;
 
 export const PERSONAL_PATH = '/p';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -23,8 +23,6 @@ export const LEAVE_FEEDBACK_EMAIL = 'support@elastic.co';
 export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elastic%20Workplace%20Search%20Feedback`;
 
 export const CUSTOM_SOURCE_DOCS_URL = docLinks.workplaceSearchCustomSources;
-export const CUSTOM_API_DOCUMENT_PERMISSIONS_DOCS_URL =
-  docLinks.workplaceSearchCustomSourcePermissions;
 export const DIFFERENT_SYNC_TYPES_DOCS_URL = docLinks.workplaceSearchIndexingSchedule;
 export const DOCUMENT_PERMISSIONS_DOCS_URL = docLinks.workplaceSearchDocumentPermissions;
 export const ENT_SEARCH_LICENSE_MANAGEMENT = docLinks.licenseManagement;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -24,7 +24,6 @@ export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elasti
 
 export const DOCUMENT_PERMISSIONS_DOCS_URL = docLinks.workplaceSearchDocumentPermissions;
 export const ENT_SEARCH_LICENSE_MANAGEMENT = docLinks.licenseManagement;
-export const EXTERNAL_IDENTITIES_DOCS_URL = docLinks.workplaceSearchExternalIdentities;
 export const SECURITY_DOCS_URL = docLinks.workplaceSearchSecurity;
 
 export const PERSONAL_PATH = '/p';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -26,7 +26,6 @@ export const CUSTOM_SOURCE_DOCS_URL = docLinks.workplaceSearchCustomSources;
 export const DOCUMENT_PERMISSIONS_DOCS_URL = docLinks.workplaceSearchDocumentPermissions;
 export const ENT_SEARCH_LICENSE_MANAGEMENT = docLinks.licenseManagement;
 export const EXTERNAL_IDENTITIES_DOCS_URL = docLinks.workplaceSearchExternalIdentities;
-export const OBJECTS_AND_ASSETS_DOCS_URL = docLinks.workplaceSearchSynch;
 export const SECURITY_DOCS_URL = docLinks.workplaceSearchSecurity;
 
 export const PERSONAL_PATH = '/p';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -29,7 +29,6 @@ export const EXTERNAL_IDENTITIES_DOCS_URL = docLinks.workplaceSearchExternalIden
 export const OBJECTS_AND_ASSETS_DOCS_URL = docLinks.workplaceSearchSynch;
 export const PRIVATE_SOURCES_DOCS_URL = docLinks.workplaceSearchPermissions;
 export const SECURITY_DOCS_URL = docLinks.workplaceSearchSecurity;
-export const SYNCHRONIZATION_DOCS_URL = docLinks.workplaceSearchSynch;
 
 export const PERSONAL_PATH = '/p';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -22,7 +22,6 @@ export const LOGOUT_ROUTE = '/logout';
 export const LEAVE_FEEDBACK_EMAIL = 'support@elastic.co';
 export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elastic%20Workplace%20Search%20Feedback`;
 
-export const CUSTOM_SOURCE_DOCS_URL = docLinks.workplaceSearchCustomSources;
 export const DOCUMENT_PERMISSIONS_DOCS_URL = docLinks.workplaceSearchDocumentPermissions;
 export const ENT_SEARCH_LICENSE_MANAGEMENT = docLinks.licenseManagement;
 export const EXTERNAL_IDENTITIES_DOCS_URL = docLinks.workplaceSearchExternalIdentities;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_completed.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_completed.tsx
@@ -21,13 +21,9 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { docLinks } from '../../../../../shared/doc_links';
 import { EuiLinkTo, EuiButtonTo } from '../../../../../shared/react_router_helpers';
-import {
-  getSourcesPath,
-  ADD_SOURCE_PATH,
-  SECURITY_PATH,
-  PRIVATE_SOURCES_DOCS_URL,
-} from '../../../../routes';
+import { getSourcesPath, ADD_SOURCE_PATH, SECURITY_PATH } from '../../../../routes';
 
 import {
   CONFIG_COMPLETED_PRIVATE_SOURCES_DISABLED_LINK,
@@ -126,7 +122,7 @@ export const ConfigCompleted: React.FC<ConfigCompletedProps> = ({
                         <EuiLink
                           target="_blank"
                           data-test-subj="ConfigCompletedPrivateSourcesDocsLink"
-                          href={PRIVATE_SOURCES_DOCS_URL}
+                          href={docLinks.workplaceSearchPermissions}
                         >
                           {CONFIG_COMPLETED_PRIVATE_SOURCES_DOCS_LINK}
                         </EuiLink>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_custom.tsx
@@ -20,7 +20,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { CUSTOM_SOURCE_DOCS_URL } from '../../../../routes';
+import { docLinks } from '../../../../../shared/doc_links';
 
 import { SOURCE_NAME_LABEL } from '../../constants';
 
@@ -63,7 +63,7 @@ export const ConfigureCustom: React.FC<ConfigureCustomProps> = ({
                 defaultMessage="{link} to learn more about Custom API Sources."
                 values={{
                   link: (
-                    <EuiLink href={CUSTOM_SOURCE_DOCS_URL} target="_blank">
+                    <EuiLink href={docLinks.workplaceSearchCustomSources} target="_blank">
                       {CONFIG_CUSTOM_LINK_TEXT}
                     </EuiLink>
                   ),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/document_permissions_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/document_permissions_callout.tsx
@@ -17,8 +17,8 @@ import {
   EuiText,
 } from '@elastic/eui';
 
+import { docLinks } from '../../../../../shared/doc_links';
 import { EXPLORE_PLATINUM_FEATURES_LINK } from '../../../../constants';
-import { ENT_SEARCH_LICENSE_MANAGEMENT } from '../../../../routes';
 
 import {
   SOURCE_FEATURES_DOCUMENT_LEVEL_PERMISSIONS_FEATURE,
@@ -45,7 +45,7 @@ export const DocumentPermissionsCallout: React.FC = () => {
         </EuiText>
         <EuiSpacer size="s" />
         <EuiText size="xs">
-          <EuiLink external target="_blank" href={ENT_SEARCH_LICENSE_MANAGEMENT}>
+          <EuiLink external target="_blank" href={docLinks.licenseManagement}>
             {EXPLORE_PLATINUM_FEATURES_LINK}
           </EuiLink>
         </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/document_permissions_field.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/document_permissions_field.tsx
@@ -18,7 +18,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { DOCUMENT_PERMISSIONS_DOCS_URL } from '../../../../routes';
+import { docLinks } from '../../../../../shared/doc_links';
 import { LEARN_MORE_LINK } from '../../constants';
 
 import {
@@ -42,7 +42,7 @@ export const DocumentPermissionsField: React.FC<Props> = ({
   setValue,
 }) => {
   const whichDocsLink = (
-    <EuiLink target="_blank" href={DOCUMENT_PERMISSIONS_DOCS_URL}>
+    <EuiLink target="_blank" href={docLinks.workplaceSearchDocumentPermissions}>
       {CONNECT_WHICH_OPTION_LINK}
     </EuiLink>
   );
@@ -64,7 +64,7 @@ export const DocumentPermissionsField: React.FC<Props> = ({
                 defaultMessage="Document-level permissions are not yet available for this source. {link}"
                 values={{
                   link: (
-                    <EuiLink target="_blank" href={DOCUMENT_PERMISSIONS_DOCS_URL}>
+                    <EuiLink target="_blank" href={docLinks.workplaceSearchDocumentPermissions}>
                       {LEARN_MORE_LINK}
                     </EuiLink>
                   ),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_custom.tsx
@@ -31,7 +31,6 @@ import { LicenseBadge } from '../../../../components/shared/license_badge';
 import {
   SOURCES_PATH,
   SOURCE_DISPLAY_SETTINGS_PATH,
-  ENT_SEARCH_LICENSE_MANAGEMENT,
   getContentSourcePath,
   getSourcesPath,
 } from '../../../../routes';
@@ -192,7 +191,7 @@ export const SaveCustom: React.FC<SaveCustomProps> = ({
                 <EuiSpacer size="xs" />
                 {!hasPlatinumLicense && (
                   <EuiText size="s">
-                    <EuiLink target="_blank" href={ENT_SEARCH_LICENSE_MANAGEMENT}>
+                    <EuiLink target="_blank" href={docLinks.licenseManagement}>
                       {LEARN_CUSTOM_FEATURES_BUTTON}
                     </EuiLink>
                   </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_custom.tsx
@@ -24,13 +24,13 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { docLinks } from '../../../../../shared/doc_links';
 import { LicensingLogic } from '../../../../../shared/licensing';
 import { EuiLinkTo } from '../../../../../shared/react_router_helpers';
 import { LicenseBadge } from '../../../../components/shared/license_badge';
 import {
   SOURCES_PATH,
   SOURCE_DISPLAY_SETTINGS_PATH,
-  CUSTOM_API_DOCUMENT_PERMISSIONS_DOCS_URL,
   ENT_SEARCH_LICENSE_MANAGEMENT,
   getContentSourcePath,
   getSourcesPath,
@@ -178,7 +178,10 @@ export const SaveCustom: React.FC<SaveCustomProps> = ({
                       defaultMessage="{link} manage content access content on individual or group attributes. Allow or deny access to specific documents."
                       values={{
                         link: (
-                          <EuiLink target="_blank" href={CUSTOM_API_DOCUMENT_PERMISSIONS_DOCS_URL}>
+                          <EuiLink
+                            target="_blank"
+                            href={docLinks.workplaceSearchCustomSourcePermissions}
+                          >
                             {SAVE_CUSTOM_DOC_PERMISSIONS_LINK}
                           </EuiLink>
                         ),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -47,7 +47,6 @@ import {
   DOCUMENTATION_LINK_TITLE,
 } from '../../../constants';
 import {
-  DOCUMENT_PERMISSIONS_DOCS_URL,
   ENT_SEARCH_LICENSE_MANAGEMENT,
   SYNC_FREQUENCY_PATH,
   BLOCKED_TIME_WINDOWS_PATH,
@@ -346,7 +345,7 @@ export const Overview: React.FC = () => {
                   defaultMessage="{learnMoreLink} about permissions"
                   values={{
                     learnMoreLink: (
-                      <EuiLink target="_blank" href={DOCUMENT_PERMISSIONS_DOCS_URL}>
+                      <EuiLink target="_blank" href={docLinks.workplaceSearchDocumentPermissions}>
                         {LEARN_MORE_LINK}
                       </EuiLink>
                     ),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -33,6 +33,7 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { CANCEL_BUTTON_LABEL, START_BUTTON_LABEL } from '../../../../shared/constants';
+import { docLinks } from '../../../../shared/doc_links';
 import { EuiListGroupItemTo, EuiLinkTo } from '../../../../shared/react_router_helpers';
 import { AppLogic } from '../../../app_logic';
 import aclImage from '../../../assets/supports_acl.svg';
@@ -46,7 +47,6 @@ import {
   DOCUMENTATION_LINK_TITLE,
 } from '../../../constants';
 import {
-  CUSTOM_SOURCE_DOCS_URL,
   DOCUMENT_PERMISSIONS_DOCS_URL,
   ENT_SEARCH_LICENSE_MANAGEMENT,
   EXTERNAL_IDENTITIES_DOCS_URL,
@@ -569,7 +569,7 @@ export const Overview: React.FC = () => {
                         defaultMessage="{learnMoreLink} about custom sources."
                         values={{
                           learnMoreLink: (
-                            <EuiLink target="_blank" href={CUSTOM_SOURCE_DOCS_URL}>
+                            <EuiLink target="_blank" href={docLinks.workplaceSearchCustomSources}>
                               {LEARN_MORE_LINK}
                             </EuiLink>
                           ),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -49,7 +49,6 @@ import {
 import {
   DOCUMENT_PERMISSIONS_DOCS_URL,
   ENT_SEARCH_LICENSE_MANAGEMENT,
-  EXTERNAL_IDENTITIES_DOCS_URL,
   SYNC_FREQUENCY_PATH,
   BLOCKED_TIME_WINDOWS_PATH,
   getGroupPath,
@@ -408,7 +407,7 @@ export const Overview: React.FC = () => {
                 defaultMessage="The {externalIdentitiesLink} must be used to configure user access mappings. Read the guide to learn more."
                 values={{
                   externalIdentitiesLink: (
-                    <EuiLink target="_blank" href={EXTERNAL_IDENTITIES_DOCS_URL}>
+                    <EuiLink target="_blank" href={docLinks.workplaceSearchExternalIdentities}>
                       {EXTERNAL_IDENTITIES_LINK}
                     </EuiLink>
                   ),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -47,7 +47,6 @@ import {
   DOCUMENTATION_LINK_TITLE,
 } from '../../../constants';
 import {
-  ENT_SEARCH_LICENSE_MANAGEMENT,
   SYNC_FREQUENCY_PATH,
   BLOCKED_TIME_WINDOWS_PATH,
   getGroupPath,
@@ -464,7 +463,7 @@ export const Overview: React.FC = () => {
       </EuiText>
       <EuiSpacer size="s" />
       <EuiText size="s">
-        <EuiLink target="_blank" href={ENT_SEARCH_LICENSE_MANAGEMENT}>
+        <EuiLink target="_blank" href={docLinks.licenseManagement}>
           {LEARN_CUSTOM_FEATURES_BUTTON}
         </EuiLink>
       </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.tsx
@@ -31,12 +31,12 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { docLinks } from '../../../../shared/doc_links';
 import { TruncatedContent } from '../../../../shared/truncate';
 import { ComponentLoader } from '../../../components/shared/component_loader';
 import { TablePaginationBar } from '../../../components/shared/table_pagination_bar';
 import { ViewContentHeader } from '../../../components/shared/view_content_header';
 import { NAV, CUSTOM_SERVICE_TYPE } from '../../../constants';
-import { CUSTOM_SOURCE_DOCS_URL } from '../../../routes';
 import { SourceContentItem } from '../../../types';
 import {
   NO_CONTENT_MESSAGE,
@@ -110,7 +110,7 @@ export const SourceContent: React.FC = () => {
                 defaultMessage="Learn more about adding content in our {documentationLink}"
                 values={{
                   documentationLink: (
-                    <EuiLink target="_blank" href={CUSTOM_SOURCE_DOCS_URL}>
+                    <EuiLink target="_blank" href={docLinks.workplaceSearchCustomSources}>
                       {CUSTOM_DOCUMENTATION_LINK}
                     </EuiLink>
                   ),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_layout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_layout.tsx
@@ -12,11 +12,11 @@ import moment from 'moment';
 
 import { EuiButton, EuiCallOut, EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
 
+import { docLinks } from '../../../../shared/doc_links';
 import { PageTemplateProps } from '../../../../shared/layout';
 import { AppLogic } from '../../../app_logic';
 import { WorkplaceSearchPageTemplate, PersonalDashboardLayout } from '../../../components/layout';
 import { NAV } from '../../../constants';
-import { ENT_SEARCH_LICENSE_MANAGEMENT } from '../../../routes';
 
 import {
   SOURCE_DISABLED_CALLOUT_TITLE,
@@ -53,7 +53,7 @@ export const SourceLayout: React.FC<PageTemplateProps> = ({
     <>
       <EuiCallOut title={SOURCE_DISABLED_CALLOUT_TITLE} color="warning" iconType="alert">
         <p>{SOURCE_DISABLED_CALLOUT_DESCRIPTION}</p>
-        <EuiButton color="warning" href={ENT_SEARCH_LICENSE_MANAGEMENT}>
+        <EuiButton color="warning" href={docLinks.licenseManagement}>
           {SOURCE_DISABLED_CALLOUT_BUTTON}
         </EuiButton>
       </EuiCallOut>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/frequency.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/frequency.tsx
@@ -21,10 +21,10 @@ import {
 } from '@elastic/eui';
 
 import { SAVE_BUTTON_LABEL } from '../../../../../shared/constants';
+import { docLinks } from '../../../../../shared/doc_links';
 import { UnsavedChangesPrompt } from '../../../../../shared/unsaved_changes_prompt';
 import { ViewContentHeader } from '../../../../components/shared/view_content_header';
 import { NAV, RESET_BUTTON } from '../../../../constants';
-import { DIFFERENT_SYNC_TYPES_DOCS_URL } from '../../../../routes';
 import {
   LEARN_MORE_LINK,
   SOURCE_FREQUENCY_DESCRIPTION,
@@ -102,7 +102,7 @@ export const Frequency: React.FC<FrequencyProps> = ({ tabId }) => {
         description={
           <>
             {SOURCE_FREQUENCY_DESCRIPTION}{' '}
-            <EuiLink href={DIFFERENT_SYNC_TYPES_DOCS_URL} external>
+            <EuiLink href={docLinks.workplaceSearchIndexingSchedule} external>
               {LEARN_MORE_LINK}
             </EuiLink>
           </>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/objects_and_assets.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/objects_and_assets.tsx
@@ -22,10 +22,10 @@ import {
 } from '@elastic/eui';
 
 import { SAVE_BUTTON_LABEL } from '../../../../../shared/constants';
+import { docLinks } from '../../../../../shared/doc_links';
 import { UnsavedChangesPrompt } from '../../../../../shared/unsaved_changes_prompt';
 import { ViewContentHeader } from '../../../../components/shared/view_content_header';
 import { NAV, RESET_BUTTON } from '../../../../constants';
-import { OBJECTS_AND_ASSETS_DOCS_URL } from '../../../../routes';
 import {
   LEARN_MORE_LINK,
   SYNC_MANAGEMENT_CONTENT_EXTRACTION_LABEL,
@@ -87,7 +87,7 @@ export const ObjectsAndAssets: React.FC = () => {
         description={
           <>
             {SOURCE_OBJECTS_AND_ASSETS_DESCRIPTION}{' '}
-            <EuiLink href={OBJECTS_AND_ASSETS_DOCS_URL} external>
+            <EuiLink href={docLinks.workplaceSearchSynch} external>
               {LEARN_MORE_LINK}
             </EuiLink>
           </>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/synchronization.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/synchronization.tsx
@@ -11,9 +11,9 @@ import { useActions, useValues } from 'kea';
 
 import { EuiCallOut, EuiLink, EuiPanel, EuiSwitch, EuiSpacer, EuiText } from '@elastic/eui';
 
+import { docLinks } from '../../../../../shared/doc_links';
 import { ViewContentHeader } from '../../../../components/shared/view_content_header';
 import { NAV } from '../../../../constants';
-import { SYNCHRONIZATION_DOCS_URL } from '../../../../routes';
 import {
   LEARN_MORE_LINK,
   SOURCE_SYNCHRONIZATION_DESCRIPTION,
@@ -68,7 +68,7 @@ export const Synchronization: React.FC = () => {
         description={
           <>
             {SOURCE_SYNCHRONIZATION_DESCRIPTION}{' '}
-            <EuiLink href={SYNCHRONIZATION_DOCS_URL} external>
+            <EuiLink href={docLinks.workplaceSearchSynch} external>
               {LEARN_MORE_LINK}
             </EuiLink>
           </>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -7,6 +7,8 @@
 
 import { i18n } from '@kbn/i18n';
 
+import { docLinks } from '../../../shared/doc_links';
+
 import { SOURCE_NAMES, SOURCE_OBJ_TYPES, GITHUB_LINK_TITLE } from '../../constants';
 import {
   ADD_BOX_PATH,
@@ -45,22 +47,6 @@ import {
   EDIT_SLACK_PATH,
   EDIT_ZENDESK_PATH,
   EDIT_CUSTOM_PATH,
-  BOX_DOCS_URL,
-  CONFLUENCE_DOCS_URL,
-  CONFLUENCE_SERVER_DOCS_URL,
-  GITHUB_ENTERPRISE_DOCS_URL,
-  DROPBOX_DOCS_URL,
-  GITHUB_DOCS_URL,
-  GMAIL_DOCS_URL,
-  GOOGLE_DRIVE_DOCS_URL,
-  JIRA_DOCS_URL,
-  JIRA_SERVER_DOCS_URL,
-  ONEDRIVE_DOCS_URL,
-  SALESFORCE_DOCS_URL,
-  SERVICENOW_DOCS_URL,
-  SHAREPOINT_DOCS_URL,
-  SLACK_DOCS_URL,
-  ZENDESK_DOCS_URL,
   CUSTOM_SOURCE_DOCS_URL,
 } from '../../routes';
 import { FeatureIds, SourceDataItem } from '../../types';
@@ -75,7 +61,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: BOX_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchBox,
       applicationPortalUrl: 'https://app.box.com/developers/console',
     },
     objTypes: [SOURCE_OBJ_TYPES.FOLDERS, SOURCE_OBJ_TYPES.ALL_FILES],
@@ -104,7 +90,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: true,
-      documentationUrl: CONFLUENCE_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchConfluenceCloud,
       applicationPortalUrl: 'https://developer.atlassian.com/console/myapps/',
     },
     objTypes: [
@@ -138,7 +124,7 @@ export const staticSourceData = [
       isPublicKey: true,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: CONFLUENCE_SERVER_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchConfluenceServer,
     },
     objTypes: [
       SOURCE_OBJ_TYPES.PAGES,
@@ -170,7 +156,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: DROPBOX_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchDropbox,
       applicationPortalUrl: 'https://www.dropbox.com/developers/apps',
     },
     objTypes: [SOURCE_OBJ_TYPES.FOLDERS, SOURCE_OBJ_TYPES.ALL_FILES],
@@ -200,7 +186,7 @@ export const staticSourceData = [
       hasOauthRedirect: true,
       needsBaseUrl: false,
       needsConfiguration: true,
-      documentationUrl: GITHUB_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchGitHub,
       applicationPortalUrl: 'https://github.com/settings/developers',
       applicationLinkTitle: GITHUB_LINK_TITLE,
     },
@@ -242,7 +228,7 @@ export const staticSourceData = [
           defaultMessage: 'GitHub Enterprise URL',
         }
       ),
-      documentationUrl: GITHUB_ENTERPRISE_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchGitHub,
       applicationPortalUrl: 'https://github.com/settings/developers',
       applicationLinkTitle: GITHUB_LINK_TITLE,
     },
@@ -277,7 +263,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: GMAIL_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchGmail,
       applicationPortalUrl: 'https://console.developers.google.com/',
     },
     objTypes: [SOURCE_OBJ_TYPES.EMAILS],
@@ -295,7 +281,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: GOOGLE_DRIVE_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchGoogleDrive,
       applicationPortalUrl: 'https://console.developers.google.com/',
     },
     objTypes: [
@@ -328,7 +314,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: true,
-      documentationUrl: JIRA_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchJiraCloud,
       applicationPortalUrl: 'https://developer.atlassian.com/console/myapps/',
     },
     objTypes: [
@@ -364,7 +350,7 @@ export const staticSourceData = [
       isPublicKey: true,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: JIRA_SERVER_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchJiraServer,
       applicationPortalUrl: '',
     },
     objTypes: [
@@ -399,7 +385,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: ONEDRIVE_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchOneDrive,
       applicationPortalUrl: 'https://portal.azure.com/',
     },
     objTypes: [SOURCE_OBJ_TYPES.FOLDERS, SOURCE_OBJ_TYPES.ALL_FILES],
@@ -428,7 +414,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: SALESFORCE_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchSalesforce,
       applicationPortalUrl: 'https://salesforce.com/',
     },
     objTypes: [
@@ -464,7 +450,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: SALESFORCE_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchSalesforce,
       applicationPortalUrl: 'https://test.salesforce.com/',
     },
     objTypes: [
@@ -500,7 +486,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: false,
       needsBaseUrl: true,
-      documentationUrl: SERVICENOW_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchServiceNow,
       applicationPortalUrl: 'https://www.servicenow.com/my-account/sign-in.html',
     },
     objTypes: [
@@ -533,7 +519,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: SHAREPOINT_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchSharePoint,
       applicationPortalUrl: 'https://portal.azure.com/',
     },
     objTypes: [SOURCE_OBJ_TYPES.FOLDERS, SOURCE_OBJ_TYPES.SITES, SOURCE_OBJ_TYPES.ALL_FILES],
@@ -562,7 +548,7 @@ export const staticSourceData = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: SLACK_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchSlack,
       applicationPortalUrl: 'https://api.slack.com/apps/',
     },
     objTypes: [
@@ -585,7 +571,7 @@ export const staticSourceData = [
       hasOauthRedirect: true,
       needsBaseUrl: false,
       needsSubdomain: true,
-      documentationUrl: ZENDESK_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchZendesk,
       applicationPortalUrl: 'https://www.zendesk.com/login/',
     },
     objTypes: [SOURCE_OBJ_TYPES.TICKETS],

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -47,7 +47,6 @@ import {
   EDIT_SLACK_PATH,
   EDIT_ZENDESK_PATH,
   EDIT_CUSTOM_PATH,
-  CUSTOM_SOURCE_DOCS_URL,
 } from '../../routes';
 import { FeatureIds, SourceDataItem } from '../../types';
 
@@ -603,7 +602,7 @@ export const staticSourceData = [
         defaultMessage:
           'To create a Custom API Source, provide a human-readable and descriptive name. The name will appear as-is in the various search experiences and management interfaces.',
       }),
-      documentationUrl: CUSTOM_SOURCE_DOCS_URL,
+      documentationUrl: docLinks.workplaceSearchCustomSources,
       applicationPortalUrl: '',
     },
     accountContextOnly: false,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_view.tsx
@@ -24,9 +24,10 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { docLinks } from '../../../shared/doc_links';
 import { Loading } from '../../../shared/loading';
 import { SourceIcon } from '../../components/shared/source_icon';
-import { EXTERNAL_IDENTITIES_DOCS_URL, DOCUMENT_PERMISSIONS_DOCS_URL } from '../../routes';
+import { DOCUMENT_PERMISSIONS_DOCS_URL } from '../../routes';
 
 import {
   EXTERNAL_IDENTITIES_LINK,
@@ -82,7 +83,7 @@ export const SourcesView: React.FC<SourcesViewProps> = ({ children }) => {
               values={{
                 addedSourceName,
                 externalIdentitiesLink: (
-                  <EuiLink target="_blank" href={EXTERNAL_IDENTITIES_DOCS_URL}>
+                  <EuiLink target="_blank" href={docLinks.workplaceSearchExternalIdentities}>
                     {EXTERNAL_IDENTITIES_LINK}
                   </EuiLink>
                 ),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_view.tsx
@@ -27,7 +27,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { docLinks } from '../../../shared/doc_links';
 import { Loading } from '../../../shared/loading';
 import { SourceIcon } from '../../components/shared/source_icon';
-import { DOCUMENT_PERMISSIONS_DOCS_URL } from '../../routes';
 
 import {
   EXTERNAL_IDENTITIES_LINK,
@@ -97,7 +96,7 @@ export const SourcesView: React.FC<SourcesViewProps> = ({ children }) => {
               defaultMessage="Documents will not be searchable from Workplace Search until user and group mappings have been configured. {documentPermissionsLink}."
               values={{
                 documentPermissionsLink: (
-                  <EuiLink target="_blank" href={DOCUMENT_PERMISSIONS_DOCS_URL}>
+                  <EuiLink target="_blank" href={docLinks.workplaceSearchDocumentPermissions}>
                     {DOCUMENT_PERMISSIONS_LINK}
                   </EuiLink>
                 ),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings.tsx
@@ -12,6 +12,7 @@ import { useActions, useValues } from 'kea';
 import { EuiSpacer } from '@elastic/eui';
 
 import { WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
+import { docLinks } from '../../../shared/doc_links';
 import {
   RoleMappingsTable,
   RoleMappingsHeading,
@@ -22,7 +23,6 @@ import {
 } from '../../../shared/role_mapping';
 import { ROLE_MAPPINGS_TITLE } from '../../../shared/role_mapping/constants';
 import { WorkplaceSearchPageTemplate } from '../../components/layout';
-import { SECURITY_DOCS_URL } from '../../routes';
 
 import { ROLE_MAPPINGS_TABLE_HEADER } from './constants';
 
@@ -56,7 +56,7 @@ export const RoleMappings: React.FC = () => {
   const rolesEmptyState = (
     <RolesEmptyPrompt
       productName={WORKPLACE_SEARCH_PLUGIN.NAME}
-      docsLink={SECURITY_DOCS_URL}
+      docsLink={docLinks.workplaceSearchSecurity}
       onEnable={enableRoleBasedAccess}
     />
   );
@@ -65,7 +65,7 @@ export const RoleMappings: React.FC = () => {
     <section>
       <RoleMappingsHeading
         productName={WORKPLACE_SEARCH_PLUGIN.NAME}
-        docsLink={SECURITY_DOCS_URL}
+        docsLink={docLinks.workplaceSearchSecurity}
         onClick={() => initializeRoleMapping()}
       />
       <RoleMappingsTable

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/oauth_application.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/oauth_application.tsx
@@ -23,6 +23,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 
+import { docLinks } from '../../../../shared/doc_links';
 import { LicensingLogic } from '../../../../shared/licensing';
 import { WorkplaceSearchPageTemplate } from '../../../components/layout';
 import { ContentSection } from '../../../components/shared/content_section';
@@ -49,7 +50,6 @@ import {
   NON_PLATINUM_OAUTH_DESCRIPTION,
   EXPLORE_PLATINUM_FEATURES_LINK,
 } from '../../../constants';
-import { ENT_SEARCH_LICENSE_MANAGEMENT } from '../../../routes';
 import { SettingsLogic } from '../settings_logic';
 
 export const OauthApplication: React.FC = () => {
@@ -100,7 +100,7 @@ export const OauthApplication: React.FC = () => {
     <>
       <EuiText color="subdued">{NON_PLATINUM_OAUTH_DESCRIPTION}</EuiText>
       <EuiSpacer />
-      <EuiLink external target="_blank" href={ENT_SEARCH_LICENSE_MANAGEMENT}>
+      <EuiLink external target="_blank" href={docLinks.licenseManagement}>
         {EXPLORE_PLATINUM_FEATURES_LINK}
       </EuiLink>
     </>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.tsx
@@ -12,14 +12,14 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
+import { docLinks } from '../../../shared/doc_links';
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
-import { GETTING_STARTED_DOCS_URL } from '../../routes';
 
 import GettingStarted from './assets/getting_started.png';
 
-const GETTING_STARTED_LINK_URL = GETTING_STARTED_DOCS_URL;
+const GETTING_STARTED_LINK_URL = docLinks.workplaceSearchGettingStarted;
 
 export const SetupGuide: React.FC = () => {
   return (


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/2191

## Summary

As a result of [this PR](https://github.com/elastic/kibana/pull/118814), we no longer define our documentation links directly in the `routes` file. However, we still have constant declarations that merely point to the `docsLinks` properties. This PR eliminates the middle step and access the `docsLinks` properties directly in the components and remove these references.