### PR TITLE
[Fleet] Use a fixed id for settings saved object

### DIFF
--- a/x-pack/plugins/fleet/common/constants/settings.ts
+++ b/x-pack/plugins/fleet/common/constants/settings.ts
@@ -6,3 +6,5 @@
  */
 
 export const GLOBAL_SETTINGS_SAVED_OBJECT_TYPE = 'ingest_manager_settings';
+
+export const GLOBAL_SETTINGS_ID = 'fleet-default-settings';

--- a/x-pack/plugins/fleet/server/services/settings.ts
+++ b/x-pack/plugins/fleet/server/services/settings.ts
@@ -11,6 +11,7 @@ import type { SavedObjectsClientContract } from 'kibana/server';
 import {
   decodeCloudId,
   GLOBAL_SETTINGS_SAVED_OBJECT_TYPE,
+  GLOBAL_SETTINGS_ID,
   normalizeHostsForAgents,
 } from '../../common';
 import type { SettingsSOAttributes, Settings, BaseSettings } from '../../common';
@@ -80,10 +81,17 @@ export async function saveSettings(
   } catch (e) {
     if (e.isBoom && e.output.statusCode === 404) {
       const defaultSettings = createDefaultSettings();
-      const res = await soClient.create<SettingsSOAttributes>(GLOBAL_SETTINGS_SAVED_OBJECT_TYPE, {
-        ...defaultSettings,
-        ...data,
-      });
+      const res = await soClient.create<SettingsSOAttributes>(
+        GLOBAL_SETTINGS_SAVED_OBJECT_TYPE,
+        {
+          ...defaultSettings,
+          ...data,
+        },
+        {
+          id: GLOBAL_SETTINGS_ID,
+          overwrite: true,
+        }
+      );
 
       return {
         id: res.id,


### PR DESCRIPTION
## Summary

To allow the fleet setup to be more idempotent we should use a fixed id for the Fleet settings saved object.

That PR does that, so we only have one settings saved object even with concurrent fleet setup.