### PR TITLE
[failedTestReporter] send github api request counts to ci-stats

### DIFF
--- a/packages/kbn-test/src/failed_tests_reporter/buildkite_metadata.ts
+++ b/packages/kbn-test/src/failed_tests_reporter/buildkite_metadata.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export interface BuildkiteMetadata {
+  buildId?: string;
+  jobId?: string;
+  url?: string;
+  jobName?: string;
+  jobUrl?: string;
+}
+
+export function getBuildkiteMetadata(): BuildkiteMetadata {
+  // Buildkite steps that use `parallelism` need a numerical suffix added to identify them
+  // We should also increment the number by one, since it's 0-based
+  const jobNumberSuffix = process.env.BUILDKITE_PARALLEL_JOB
+    ? ` #${parseInt(process.env.BUILDKITE_PARALLEL_JOB, 10) + 1}`
+    : '';
+
+  const buildUrl = process.env.BUILDKITE_BUILD_URL;
+  const jobUrl = process.env.BUILDKITE_JOB_ID
+    ? `${buildUrl}#${process.env.BUILDKITE_JOB_ID}`
+    : undefined;
+
+  return {
+    buildId: process.env.BUJILDKITE_BUILD_ID,
+    jobId: process.env.BUILDKITE_JOB_ID,
+    url: buildUrl,
+    jobUrl,
+    jobName: process.env.BUILDKITE_LABEL
+      ? `${process.env.BUILDKITE_LABEL}${jobNumberSuffix}`
+      : undefined,
+  };
+}

--- a/packages/kbn-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
+++ b/packages/kbn-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
@@ -9,7 +9,7 @@
 import Path from 'path';
 
 import { REPO_ROOT } from '@kbn/utils';
-import { run, createFailError, createFlagError } from '@kbn/dev-utils';
+import { run, createFailError, createFlagError, CiStatsReporter } from '@kbn/dev-utils';
 import globby from 'globby';
 import normalize from 'normalize-path';
 
@@ -22,6 +22,7 @@ import { addMessagesToReport } from './add_messages_to_report';
 import { getReportMessageIter } from './report_metadata';
 import { reportFailuresToEs } from './report_failures_to_es';
 import { reportFailuresToFile } from './report_failures_to_file';
+import { getBuildkiteMetadata } from './buildkite_metadata';
 
 const DEFAULT_PATTERNS = [Path.resolve(REPO_ROOT, 'target/junit/**/*.xml')];
 
@@ -71,108 +72,127 @@ export function runFailedTestsReporterCli() {
         dryRun: !updateGithub,
       });
 
-      const buildUrl = flags['build-url'] || (updateGithub ? '' : 'http://buildUrl');
-      if (typeof buildUrl !== 'string' || !buildUrl) {
-        throw createFlagError('Missing --build-url or process.env.BUILD_URL');
-      }
+      const bkMeta = getBuildkiteMetadata();
 
-      const patterns = (flags._.length ? flags._ : DEFAULT_PATTERNS).map((p) =>
-        normalize(Path.resolve(p))
-      );
-      log.info('Searching for reports at', patterns);
-      const reportPaths = await globby(patterns, {
-        absolute: true,
-      });
-
-      if (!reportPaths.length) {
-        throw createFailError(`Unable to find any junit reports with patterns [${patterns}]`);
-      }
-
-      log.info('found', reportPaths.length, 'junit reports', reportPaths);
-      const newlyCreatedIssues: Array<{
-        failure: TestFailure;
-        newIssue: GithubIssueMini;
-      }> = [];
-
-      for (const reportPath of reportPaths) {
-        const report = await readTestReport(reportPath);
-        const messages = Array.from(getReportMessageIter(report));
-        const failures = await getFailures(report);
-
-        if (indexInEs) {
-          await reportFailuresToEs(log, failures);
+      try {
+        const buildUrl = flags['build-url'] || (updateGithub ? '' : 'http://buildUrl');
+        if (typeof buildUrl !== 'string' || !buildUrl) {
+          throw createFlagError('Missing --build-url or process.env.BUILD_URL');
         }
 
-        for (const failure of failures) {
-          const pushMessage = (msg: string) => {
-            messages.push({
-              classname: failure.classname,
-              name: failure.name,
-              message: msg,
-            });
-          };
-
-          if (failure.likelyIrrelevant) {
-            pushMessage(
-              'Failure is likely irrelevant' +
-                (updateGithub ? ', so an issue was not created or updated' : '')
-            );
-            continue;
-          }
-
-          let existingIssue: GithubIssueMini | undefined = await githubApi.findFailedTestIssue(
-            (i) =>
-              getIssueMetadata(i.body, 'test.class') === failure.classname &&
-              getIssueMetadata(i.body, 'test.name') === failure.name
-          );
-
-          if (!existingIssue) {
-            const newlyCreated = newlyCreatedIssues.find(
-              ({ failure: f }) => f.classname === failure.classname && f.name === failure.name
-            );
-
-            if (newlyCreated) {
-              existingIssue = newlyCreated.newIssue;
-            }
-          }
-
-          if (existingIssue) {
-            const newFailureCount = await updateFailureIssue(
-              buildUrl,
-              existingIssue,
-              githubApi,
-              branch
-            );
-            const url = existingIssue.html_url;
-            failure.githubIssue = url;
-            failure.failureCount = updateGithub ? newFailureCount : newFailureCount - 1;
-            pushMessage(`Test has failed ${newFailureCount - 1} times on tracked branches: ${url}`);
-            if (updateGithub) {
-              pushMessage(`Updated existing issue: ${url} (fail count: ${newFailureCount})`);
-            }
-            continue;
-          }
-
-          const newIssue = await createFailureIssue(buildUrl, failure, githubApi, branch);
-          pushMessage('Test has not failed recently on tracked branches');
-          if (updateGithub) {
-            pushMessage(`Created new issue: ${newIssue.html_url}`);
-            failure.githubIssue = newIssue.html_url;
-          }
-          newlyCreatedIssues.push({ failure, newIssue });
-          failure.failureCount = updateGithub ? 1 : 0;
-        }
-
-        // mutates report to include messages and writes updated report to disk
-        await addMessagesToReport({
-          report,
-          messages,
-          log,
-          reportPath,
-          dryRun: !flags['report-update'],
+        const patterns = (flags._.length ? flags._ : DEFAULT_PATTERNS).map((p) =>
+          normalize(Path.resolve(p))
+        );
+        log.info('Searching for reports at', patterns);
+        const reportPaths = await globby(patterns, {
+          absolute: true,
         });
 
-        reportFailuresToFile(log, failures);
+        if (!reportPaths.length) {
+          throw createFailError(`Unable to find any junit reports with patterns [${patterns}]`);
+        }
+
+        log.info('found', reportPaths.length, 'junit reports', reportPaths);
+        const newlyCreatedIssues: Array<{
+          failure: TestFailure;
+          newIssue: GithubIssueMini;
+        }> = [];
+
+        for (const reportPath of reportPaths) {
+          const report = await readTestReport(reportPath);
+          const messages = Array.from(getReportMessageIter(report));
+          const failures = await getFailures(report);
+
+          if (indexInEs) {
+            await reportFailuresToEs(log, failures);
+          }
+
+          for (const failure of failures) {
+            const pushMessage = (msg: string) => {
+              messages.push({
+                classname: failure.classname,
+                name: failure.name,
+                message: msg,
+              });
+            };
+
+            if (failure.likelyIrrelevant) {
+              pushMessage(
+                'Failure is likely irrelevant' +
+                  (updateGithub ? ', so an issue was not created or updated' : '')
+              );
+              continue;
+            }
+
+            let existingIssue: GithubIssueMini | undefined = await githubApi.findFailedTestIssue(
+              (i) =>
+                getIssueMetadata(i.body, 'test.class') === failure.classname &&
+                getIssueMetadata(i.body, 'test.name') === failure.name
+            );
+
+            if (!existingIssue) {
+              const newlyCreated = newlyCreatedIssues.find(
+                ({ failure: f }) => f.classname === failure.classname && f.name === failure.name
+              );
+
+              if (newlyCreated) {
+                existingIssue = newlyCreated.newIssue;
+              }
+            }
+
+            if (existingIssue) {
+              const newFailureCount = await updateFailureIssue(
+                buildUrl,
+                existingIssue,
+                githubApi,
+                branch
+              );
+              const url = existingIssue.html_url;
+              failure.githubIssue = url;
+              failure.failureCount = updateGithub ? newFailureCount : newFailureCount - 1;
+              pushMessage(
+                `Test has failed ${newFailureCount - 1} times on tracked branches: ${url}`
+              );
+              if (updateGithub) {
+                pushMessage(`Updated existing issue: ${url} (fail count: ${newFailureCount})`);
+              }
+              continue;
+            }
+
+            const newIssue = await createFailureIssue(buildUrl, failure, githubApi, branch);
+            pushMessage('Test has not failed recently on tracked branches');
+            if (updateGithub) {
+              pushMessage(`Created new issue: ${newIssue.html_url}`);
+              failure.githubIssue = newIssue.html_url;
+            }
+            newlyCreatedIssues.push({ failure, newIssue });
+            failure.failureCount = updateGithub ? 1 : 0;
+          }
+
+          // mutates report to include messages and writes updated report to disk
+          await addMessagesToReport({
+            report,
+            messages,
+            log,
+            reportPath,
+            dryRun: !flags['report-update'],
+          });
+
+          reportFailuresToFile(log, failures, bkMeta);
+        }
+      } finally {
+        await CiStatsReporter.fromEnv(log).metrics([
+          {
+            group: 'github api request count',
+            id: `failed test reporter`,
+            value: githubApi.getRequestCount(),
+            meta: Object.fromEntries(
+              Object.entries(bkMeta).map(
+                ([k, v]) => [`buildkite${k[0].toUpperCase()}${k[0].slice(1)}`, v] as const
+              )
+            ),
+          },
+        ]);
       }
     },
     {

--- a/packages/kbn-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
+++ b/packages/kbn-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
@@ -188,7 +188,7 @@ export function runFailedTestsReporterCli() {
             value: githubApi.getRequestCount(),
             meta: Object.fromEntries(
               Object.entries(bkMeta).map(
-                ([k, v]) => [`buildkite${k[0].toUpperCase()}${k[0].slice(1)}`, v] as const
+                ([k, v]) => [`buildkite${k[0].toUpperCase()}${k.slice(1)}`, v] as const
               )
             ),
           },


### PR DESCRIPTION
We're running into issues with the `kibanamachine` access token using all of it's allowed API requests. It seems to be the case that the failed test reporter is using a lot of requests to iterate through the existing `failed-test` issues when it tried to update the relevant issues. To ensure that's the case we're going to start tracking the number of Github requests made by an execution of the failed test runner using ci-stats. We have mitigations in mind if we can prove that this is where the bulk of our new usage is coming from.

![image](https://user-images.githubusercontent.com/1329312/145122574-391ab2bb-e45c-4cef-929e-3247345a1237.png)
