### PR TITLE
Prevent creating saved objects with empty IDs

### DIFF
--- a/src/core/server/saved_objects/service/lib/repository.test.ts
+++ b/src/core/server/saved_objects/service/lib/repository.test.ts
@@ -2272,7 +2272,16 @@ describe('SavedObjectsRepository', () => {
 
       it(`self-generates an id if none is provided`, async () => {
         await createSuccess(type, attributes);
-        expect(client.create).toHaveBeenCalledWith(
+        expect(client.create).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            id: expect.objectContaining(/index-pattern:[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/),
+          }),
+          expect.anything()
+        );
+        await createSuccess(type, attributes, { id: '' });
+        expect(client.create).toHaveBeenNthCalledWith(
+          2,
           expect.objectContaining({
             id: expect.objectContaining(/index-pattern:[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/),
           }),
@@ -4161,6 +4170,13 @@ describe('SavedObjectsRepository', () => {
         await test({});
       });
 
+      it(`throws when id is empty`, async () => {
+        await expect(
+          savedObjectsRepository.incrementCounter(type, '', counterFields)
+        ).rejects.toThrowError(createBadRequestError('id cannot be empty'));
+        expect(client.update).not.toHaveBeenCalled();
+      });
+
       it(`throws when counterField is not CounterField type`, async () => {
         const test = async (field: unknown[]) => {
           await expect(
@@ -4684,6 +4700,13 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when type is hidden`, async () => {
         await expectNotFoundError(HIDDEN_TYPE, id);
+        expect(client.update).not.toHaveBeenCalled();
+      });
+
+      it(`throws when id is empty`, async () => {
+        await expect(savedObjectsRepository.update(type, '', attributes)).rejects.toThrowError(
+          createBadRequestError('id cannot be empty')
+        );
         expect(client.update).not.toHaveBeenCalled();
       });
 

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -303,7 +303,6 @@ export class SavedObjectsRepository {
     options: SavedObjectsCreateOptions = {}
   ): Promise<SavedObject<T>> {
     const {
-      id = SavedObjectsUtils.generateId(),
       migrationVersion,
       coreMigrationVersion,
       overwrite = false,
@@ -313,6 +312,7 @@ export class SavedObjectsRepository {
       initialNamespaces,
       version,
     } = options;
+    const id = options.id || SavedObjectsUtils.generateId();
     const namespace = normalizeNamespace(options.namespace);
 
     this.validateInitialNamespaces(type, initialNamespaces);
@@ -1231,6 +1231,9 @@ export class SavedObjectsRepository {
     if (!this._allowedTypes.includes(type)) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);
     }
+    if (!id) {
+      throw SavedObjectsErrorHelpers.createBadRequestError('id cannot be empty'); // prevent potentially upserting a saved object with an empty ID
+    }
 
     const { version, references, upsert, refresh = DEFAULT_REFRESH_SETTING } = options;
     const namespace = normalizeNamespace(options.namespace);
@@ -1753,6 +1756,10 @@ export class SavedObjectsRepository {
       initialize = false,
       upsertAttributes,
     } = options;
+
+    if (!id) {
+      throw SavedObjectsErrorHelpers.createBadRequestError('id cannot be empty'); // prevent potentially upserting a saved object with an empty ID
+    }
 
     const normalizedCounterFields = counterFields.map((counterField) => {
       /**


### PR DESCRIPTION
Resolves #118957.

The SavedObjectsRepository no longer allows consumers to create saved objects with empty IDs.

Scenarios:

* `bulkCreate` w/ `id: undefined` -> generate a random object ID
* `bulkCreate` w/ `id: ''` -> generate a random object ID
* `create` w/ `id: undefined` -> generate a random object ID
* `create` w/ `id: ''` -> generate a random object ID
* `update` w/ `id: undefined` -> throw 400 Bad Request
* `update` w/ `id: ''` -> throw 400 Bad Request
* `incrementCounter` w/ `id: undefined` -> throw 400 Bad Request
* `incrementCounter` w/ `id: ''` -> throw 400 Bad Request

Notes:
* I did not change `bulkCreate`, it always behaved this way
* I changed `create `to match the behavior of `bulkCreate`
* I changed `update` and `incrementCounter` because these can use the `upsert` option to create new saved objects
* I did not change `bulkUpdate` because it doesn't support the `upsert` option
  * I can change this to match the new behavior of `update`, I'm on the fence about it

Further validation of saved object IDs should be added in a follow-on issue (#105039). This issue is minimal in scope and is intended to prevent users from accidentally creating saved objects that can't be deserialized.