### PR TITLE
[APM] Prefer `service.name` for logs correlation

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_logs/index.test.ts
+++ b/x-pack/plugins/apm/public/components/app/service_logs/index.test.ts
@@ -7,26 +7,53 @@
 import { getInfrastructureKQLFilter } from './';
 
 describe('service logs', () => {
+  const serviceName = 'opbeans-node';
+
   describe('getInfrastructureKQLFilter', () => {
-    it('filter by container id', () => {
+    it('filter by service name', () => {
       expect(
-        getInfrastructureKQLFilter({
-          serviceInfrastructure: {
-            containerIds: ['foo', 'bar'],
-            hostNames: ['baz', `quz`],
+        getInfrastructureKQLFilter(
+          {
+            serviceInfrastructure: {
+              containerIds: [],
+              hostNames: [],
+            },
           },
-        })
-      ).toEqual('container.id: "foo" or container.id: "bar"');
+          serviceName
+        )
+      ).toEqual('service.name: "opbeans-node"');
     });
-    it('filter by host names', () => {
+
+    it('filter by container id as fallback', () => {
       expect(
-        getInfrastructureKQLFilter({
-          serviceInfrastructure: {
-            containerIds: [],
-            hostNames: ['baz', `quz`],
+        getInfrastructureKQLFilter(
+          {
+            serviceInfrastructure: {
+              containerIds: ['foo', 'bar'],
+              hostNames: ['baz', `quz`],
+            },
           },
-        })
-      ).toEqual('host.name: "baz" or host.name: "quz"');
+          serviceName
+        )
+      ).toEqual(
+        'service.name: "opbeans-node" or (not service.name and (container.id: "foo" or container.id: "bar"))'
+      );
+    });
+
+    it('filter by host names as fallback', () => {
+      expect(
+        getInfrastructureKQLFilter(
+          {
+            serviceInfrastructure: {
+              containerIds: [],
+              hostNames: ['baz', `quz`],
+            },
+          },
+          serviceName
+        )
+      ).toEqual(
+        'service.name: "opbeans-node" or (not service.name and (host.name: "baz" or host.name: "quz"))'
+      );
     });
   });
 });

--- a/x-pack/plugins/apm/public/components/app/service_logs/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_logs/index.tsx
@@ -18,6 +18,7 @@ import { APIReturnType } from '../../../services/rest/createCallApmApi';
 import {
   CONTAINER_ID,
   HOSTNAME,
+  SERVICE_NAME,
 } from '../../../../common/elasticsearch_fieldnames';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useTimeRange } from '../../../hooks/use_time_range';
@@ -86,20 +87,27 @@ export function ServiceLogs() {
       height={'60vh'}
       startTimestamp={moment(start).valueOf()}
       endTimestamp={moment(end).valueOf()}
-      query={getInfrastructureKQLFilter(data)}
+      query={getInfrastructureKQLFilter(data, serviceName)}
     />
   );
 }
 
 export const getInfrastructureKQLFilter = (
-  data?: APIReturnType<'GET /internal/apm/services/{serviceName}/infrastructure'>
+  data:
+    | APIReturnType<'GET /internal/apm/services/{serviceName}/infrastructure'>
+    | undefined,
+  serviceName: string
 ) => {
   const containerIds = data?.serviceInfrastructure?.containerIds ?? [];
   const hostNames = data?.serviceInfrastructure?.hostNames ?? [];
 
-  const kqlFilter = containerIds.length
+  const infraAttributes = containerIds.length
     ? containerIds.map((id) => `${CONTAINER_ID}: "${id}"`)
     : hostNames.map((id) => `${HOSTNAME}: "${id}"`);
 
-  return kqlFilter.join(' or ');
+  const infraAttributesJoined = infraAttributes.join(' or ');
+
+  return infraAttributes.length
+    ? `${SERVICE_NAME}: "${serviceName}" or (not ${SERVICE_NAME} and (${infraAttributesJoined}))`
+    : `${SERVICE_NAME}: "${serviceName}"`;
 };


### PR DESCRIPTION
I was made aware of a simple improvement we could make to the logs correlation. 

Currently we show logs for a particular service in APM based on container id or hostname. This means that if multiple services are running in the same container or host, unrelated logs will be displayed.

This change avoids that by correlating on `service.name` when available and then falling back to `container.id` and `host.name` if needed.

cc @axw @felixbarny @alex-fedotyev 