### PR TITLE
[build] Include x-pack example plugins when using example-plugins flag

### DIFF
--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -45,14 +45,14 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
   /**
    * verify, reset, and initialize the build environment
    */
-  if (options.initialize) {
-    await run(Tasks.VerifyEnv);
-    await run(Tasks.Clean);
-    await run(
-      options.downloadFreshNode ? Tasks.DownloadNodeBuilds : Tasks.VerifyExistingNodeBuilds
-    );
-    await run(Tasks.ExtractNodeBuilds);
-  }
+  // if (options.initialize) {
+  //   await run(Tasks.VerifyEnv);
+  //   await run(Tasks.Clean);
+  //   await run(
+  //     options.downloadFreshNode ? Tasks.DownloadNodeBuilds : Tasks.VerifyExistingNodeBuilds
+  //   );
+  //   await run(Tasks.ExtractNodeBuilds);
+  // }
 
   /**
    * build example plugins
@@ -60,6 +60,7 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
   if (options.createExamplePlugins) {
     await run(Tasks.BuildKibanaExamplePlugins);
   }
+  return;
 
   /**
    * run platform-generic build tasks

--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -45,14 +45,14 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
   /**
    * verify, reset, and initialize the build environment
    */
-  // if (options.initialize) {
-  //   await run(Tasks.VerifyEnv);
-  //   await run(Tasks.Clean);
-  //   await run(
-  //     options.downloadFreshNode ? Tasks.DownloadNodeBuilds : Tasks.VerifyExistingNodeBuilds
-  //   );
-  //   await run(Tasks.ExtractNodeBuilds);
-  // }
+  if (options.initialize) {
+    await run(Tasks.VerifyEnv);
+    await run(Tasks.Clean);
+    await run(
+      options.downloadFreshNode ? Tasks.DownloadNodeBuilds : Tasks.VerifyExistingNodeBuilds
+    );
+    await run(Tasks.ExtractNodeBuilds);
+  }
 
   /**
    * build example plugins
@@ -60,7 +60,6 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
   if (options.createExamplePlugins) {
     await run(Tasks.BuildKibanaExamplePlugins);
   }
-  return;
 
   /**
    * run platform-generic build tasks

--- a/src/dev/build/tasks/build_kibana_example_plugins.ts
+++ b/src/dev/build/tasks/build_kibana_example_plugins.ts
@@ -13,17 +13,23 @@ import { exec, mkdirp, copyAll, Task } from '../lib';
 
 export const BuildKibanaExamplePlugins: Task = {
   description: 'Building distributable versions of Kibana example plugins',
-  async run(config, log, build) {
-    const examplesDir = Path.resolve(REPO_ROOT, 'examples');
+  async run(config, log) {
     const args = [
-      '../../scripts/plugin_helpers',
+      Path.resolve(REPO_ROOT, 'scripts/plugin_helpers'),
       'build',
       `--kibana-version=${config.getBuildVersion()}`,
     ];
 
-    const folders = Fs.readdirSync(examplesDir, { withFileTypes: true })
-      .filter((f) => f.isDirectory())
-      .map((f) => Path.resolve(REPO_ROOT, 'examples', f.name));
+    const getExampleFolders = (dir: string) => {
+      return Fs.readdirSync(dir, { withFileTypes: true })
+        .filter((f) => f.isDirectory())
+        .map((f) => Path.resolve(dir, f.name));
+    };
+
+    const folders = [
+      ...getExampleFolders(Path.resolve(REPO_ROOT, 'examples')),
+      ...getExampleFolders(Path.resolve(REPO_ROOT, 'x-pack/examples')),
+    ];
 
     for (const examplePlugin of folders) {
       try {
@@ -40,8 +46,8 @@ export const BuildKibanaExamplePlugins: Task = {
 
     const pluginsDir = config.resolveFromTarget('example_plugins');
     await mkdirp(pluginsDir);
-    await copyAll(examplesDir, pluginsDir, {
-      select: ['*/build/*.zip'],
+    await copyAll(REPO_ROOT, pluginsDir, {
+      select: ['examples/*/build/*.zip', 'x-pack/examples/*/build/*.zip'],
     });
   },
 };


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/104194 introduced the ability to build example plugins during the build process.  The implementation assumed all plugins were located in the `examples` folder.  That change is amended here to also include `x-pack/examples`.