### PR TITLE
[ML] Anomaly Detection Delayed Data visualization: adds formatted timestamp header to annotation tooltip

### DIFF
--- a/x-pack/plugins/ml/common/types/results.ts
+++ b/x-pack/plugins/ml/common/types/results.ts
@@ -11,10 +11,14 @@ import { LineAnnotationDatum, RectAnnotationDatum } from '@elastic/charts';
 export interface GetStoppedPartitionResult {
   jobs: string[] | Record<string, string[]>;
 }
+
+export interface MLRectAnnotationDatum extends RectAnnotationDatum {
+  header: number;
+}
 export interface GetDatafeedResultsChartDataResult {
   bucketResults: number[][];
   datafeedResults: number[][];
-  annotationResultsRect: RectAnnotationDatum[];
+  annotationResultsRect: MLRectAnnotationDatum[];
   annotationResultsLine: LineAnnotationDatum[];
   modelSnapshotResultsLine: LineAnnotationDatum[];
 }

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -32,6 +32,7 @@ import {
   Axis,
   Chart,
   CurveType,
+  CustomAnnotationTooltip,
   LineAnnotation,
   LineSeries,
   LineAnnotationDatum,
@@ -68,6 +69,14 @@ function setLineAnnotationHeader(lineDatum: LineAnnotationDatum) {
   lineDatum.header = dateFormatter(lineDatum.dataValue);
   return lineDatum;
 }
+
+const customTooltip: CustomAnnotationTooltip = ({ details, datum }) => (
+  <div className="echAnnotation__tooltip">
+    {/* @ts-ignore 'header does not exist on type RectAnnotationDatum' */}
+    <p className="echAnnotation__header">{dateFormatter(datum.header)}</p>
+    <div className="echAnnotation__details">{details}</div>
+  </div>
+);
 
 export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({ jobId, end, onClose }) => {
   const [data, setData] = useState<{
@@ -385,6 +394,7 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({ jobId, end, 
                             />
                             <RectAnnotation
                               key="annotation-results-rect"
+                              customTooltip={customTooltip}
                               dataValues={annotationData.rect}
                               id={i18n.translate(
                                 'xpack.ml.jobsList.datafeedChart.annotationRectSeriesId',

--- a/x-pack/plugins/ml/server/models/results_service/results_service.ts
+++ b/x-pack/plugins/ml/server/models/results_service/results_service.ts
@@ -780,6 +780,8 @@ export function resultsServiceProvider(mlClient: MlClient, client?: IScopedClust
             x1: endTimestamp,
           },
           details: annotation.annotation,
+          // Added for custom RectAnnotation tooltip with formatted timestamp
+          header: timestamp,
         });
       }
     });


### PR DESCRIPTION
## Summary

Related issue https://github.com/elastic/kibana/issues/99510

- adds timestamp info to rectangle annotation data returned by endpoint
- adds custom tooltip to rectangle annotation component with formatted timestamp so it matches the line annotation 


<img width="576" alt="Screen Shot 2021-12-07 at 4 36 24 PM" src="https://user-images.githubusercontent.com/6446462/145124287-42150088-a573-4366-aea0-85a040a33a14.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



