### PR TITLE
[data views] restore support for exclusion in index pattern

### DIFF
--- a/src/plugins/data_views/server/fetcher/index_patterns_fetcher.test.ts
+++ b/src/plugins/data_views/server/fetcher/index_patterns_fetcher.test.ts
@@ -32,8 +32,14 @@ describe('Index Pattern Fetcher - server', () => {
     indexPatterns = new IndexPatternsFetcher(esClient);
   });
   it('Removes pattern without matching indices', async () => {
+    // first field caps request returns empty
     const result = await indexPatterns.validatePatternListActive(patternList);
     expect(result).toEqual(['b', 'c']);
+  });
+  it('Keeps matching and negating patterns', async () => {
+    // first field caps request returns empty
+    const result = await indexPatterns.validatePatternListActive(['-a', 'b', 'c']);
+    expect(result).toEqual(['-a', 'c']);
   });
   it('Returns all patterns when all match indices', async () => {
     esClient = {

--- a/src/plugins/data_views/server/fetcher/index_patterns_fetcher.ts
+++ b/src/plugins/data_views/server/fetcher/index_patterns_fetcher.ts
@@ -133,6 +133,10 @@ export class IndexPatternsFetcher {
     const result = await Promise.all(
       patternList
         .map(async (index) => {
+          // perserve negated patterns
+          if (index.startsWith('-')) {
+            return true;
+          }
           const searchResponse = await this.elasticsearchClient.fieldCaps({
             index,
             fields: '_id',


### PR DESCRIPTION
## Summary

While index patterns typically include indices, they can exclude as well. This PR restores this functionality. Aiming to get this in for 7.16.1 so will do functional tests as a follow up - they would have prevented the problem from occurring in the first place.

closes https://github.com/elastic/kibana/issues/120604
