### PR TITLE
[Lens] flaky gauge  fix

### DIFF
--- a/x-pack/test/functional/apps/lens/gauge.ts
+++ b/x-pack/test/functional/apps/lens/gauge.ts
@@ -85,9 +85,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.closeDimensionEditor();
 
       await PageObjects.lens.openVisualOptions();
-      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMajor', 'custom title');
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMajor', 'custom title', {
+        clearWithKeyboard: true,
+        typeCharByChar: true,
+      });
       await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor-select', 'custom');
-      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor', 'custom subtitle');
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor', 'custom subtitle', {
+        clearWithKeyboard: true,
+      });
 
       await PageObjects.lens.waitForVisualization();
 

--- a/x-pack/test/functional/apps/lens/gauge.ts
+++ b/x-pack/test/functional/apps/lens/gauge.ts
@@ -13,10 +13,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const elasticChart = getService('elasticChart');
   const testSubjects = getService('testSubjects');
   const find = getService('find');
-  const retry = getService('retry');
 
-  // Failing: See https://github.com/elastic/kibana/issues/120670
-  describe.skip('lens gauge', () => {
+  describe('lens gauge', () => {
     before(async () => {
       await PageObjects.visualize.navigateToNewVisualization();
       await PageObjects.visualize.clickVisType('lens');
@@ -34,7 +32,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         operation: 'average',
         field: 'bytes',
       });
-
       await PageObjects.lens.waitForVisualization();
     });
 
@@ -51,18 +48,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should reflect edits for gauge', async () => {
-      await PageObjects.lens.openVisualOptions();
-      await retry.try(async () => {
-        await testSubjects.setValue('lnsToolbarGaugeLabelMajor', 'custom title');
-      });
-      await retry.try(async () => {
-        await testSubjects.setValue('lnsToolbarGaugeLabelMinor-select', 'custom');
-      });
-      await retry.try(async () => {
-        await testSubjects.setValue('lnsToolbarGaugeLabelMinor', 'custom subtitle');
-      });
-
-      await PageObjects.lens.waitForVisualization();
       await PageObjects.lens.configureDimension({
         dimension: 'lnsGauge_metricDimensionPanel > lns-dimensionTrigger',
         operation: 'count',
@@ -98,6 +83,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
       await PageObjects.lens.waitForVisualization();
       await PageObjects.lens.closeDimensionEditor();
+
+      await PageObjects.lens.openVisualOptions();
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMajor', 'custom title');
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor-select', 'custom');
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor', 'custom subtitle');
+
+      await PageObjects.lens.waitForVisualization();
 
       const elementWithInfo = await find.byCssSelector('.echScreenReaderOnly');
       const textContent = await elementWithInfo.getAttribute('textContent');

--- a/x-pack/test/functional/apps/lens/gauge.ts
+++ b/x-pack/test/functional/apps/lens/gauge.ts
@@ -80,7 +80,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await PageObjects.lens.openVisualOptions();
       await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMajor', 'custom title');
-      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor-select', 'custom');
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor-select', 'custom', {});
       await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor', 'custom subtitle');
 
       await PageObjects.lens.waitForVisualization();

--- a/x-pack/test/functional/apps/lens/gauge.ts
+++ b/x-pack/test/functional/apps/lens/gauge.ts
@@ -58,6 +58,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.setEuiSwitch('lnsDynamicColoringGaugeSwitch', 'check');
       await PageObjects.lens.closeDimensionEditor();
 
+      await PageObjects.lens.openVisualOptions();
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMajor', 'custom title');
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor-select', 'custom', {});
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor', 'custom subtitle');
+
+      await PageObjects.lens.waitForVisualization();
       await PageObjects.lens.openDimensionEditor(
         'lnsGauge_goalDimensionPanel > lns-empty-dimension'
       );
@@ -77,13 +83,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.retrySetValue('lns-indexPattern-static_value-input', '25000');
       await PageObjects.lens.waitForVisualization();
       await PageObjects.lens.closeDimensionEditor();
-
-      await PageObjects.lens.openVisualOptions();
-      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMajor', 'custom title');
-      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor-select', 'custom', {});
-      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor', 'custom subtitle');
-
-      await PageObjects.lens.waitForVisualization();
 
       const elementWithInfo = await find.byCssSelector('.echScreenReaderOnly');
       const textContent = await elementWithInfo.getAttribute('textContent');

--- a/x-pack/test/functional/apps/lens/gauge.ts
+++ b/x-pack/test/functional/apps/lens/gauge.ts
@@ -67,32 +67,21 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.openDimensionEditor(
         'lnsGauge_minDimensionPanel > lns-empty-dimension-suggested-value'
       );
-
-      await testSubjects.setValue('lns-indexPattern-static_value-input', '1000', {
-        clearWithKeyboard: true,
-      });
+      await PageObjects.lens.retrySetValue('lns-indexPattern-static_value-input', '1000');
       await PageObjects.lens.waitForVisualization();
       await PageObjects.lens.closeDimensionEditor();
 
       await PageObjects.lens.openDimensionEditor(
         'lnsGauge_maxDimensionPanel > lns-empty-dimension-suggested-value'
       );
-
-      await testSubjects.setValue('lns-indexPattern-static_value-input', '25000', {
-        clearWithKeyboard: true,
-      });
+      await PageObjects.lens.retrySetValue('lns-indexPattern-static_value-input', '25000');
       await PageObjects.lens.waitForVisualization();
       await PageObjects.lens.closeDimensionEditor();
 
       await PageObjects.lens.openVisualOptions();
-      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMajor', 'custom title', {
-        clearWithKeyboard: true,
-        typeCharByChar: true,
-      });
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMajor', 'custom title');
       await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor-select', 'custom');
-      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor', 'custom subtitle', {
-        clearWithKeyboard: true,
-      });
+      await PageObjects.lens.retrySetValue('lnsToolbarGaugeLabelMinor', 'custom subtitle');
 
       await PageObjects.lens.waitForVisualization();
 

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -596,7 +596,14 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
         await testSubjects.exists('lnsVisualOptionsButton');
       });
     },
-    async retrySetValue(input: string, value: string, options = {}) {
+    async retrySetValue(
+      input: string,
+      value: string,
+      options = {
+        clearWithKeyboard: true,
+        typeCharByChar: true,
+      } as Record<string, boolean>
+    ) {
       await retry.try(async () => {
         await testSubjects.setValue(input, value, options);
         expect(await (await testSubjects.find(input)).getAttribute('value')).to.eql(value);

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -596,9 +596,9 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
         await testSubjects.exists('lnsVisualOptionsButton');
       });
     },
-    async retrySetValue(input: string, value: string) {
+    async retrySetValue(input: string, value: string, options = {}) {
       await retry.try(async () => {
-        await testSubjects.setValue(input, value);
+        await testSubjects.setValue(input, value, options);
         expect(await (await testSubjects.find(input)).getAttribute('value')).to.eql(value);
       });
     },

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -596,6 +596,12 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
         await testSubjects.exists('lnsVisualOptionsButton');
       });
     },
+    async retrySetValue(input: string, value: string) {
+      await retry.try(async () => {
+        await testSubjects.setValue(input, value);
+        expect(await (await testSubjects.find(input)).getAttribute('value')).to.eql(value);
+      });
+    },
     async useCurvedLines() {
       await testSubjects.click('lnsCurveStyleToggle');
     },

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -673,6 +673,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       const queryTerm = searchTerm ?? subVisualizationId.substring(subVisualizationId.length - 3);
       return await testSubjects.setValue('lnsChartSwitchSearch', queryTerm, {
         clearWithKeyboard: true,
+        typeCharByChar: true,
       });
     },
 

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -680,7 +680,6 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       const queryTerm = searchTerm ?? subVisualizationId.substring(subVisualizationId.length - 3);
       return await testSubjects.setValue('lnsChartSwitchSearch', queryTerm, {
         clearWithKeyboard: true,
-        typeCharByChar: true,
       });
     },
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/120670

Looks like it's fixed : https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/290

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
