### PR TITLE
[ML] Fixing data view search based on title

### DIFF
--- a/x-pack/plugins/ml/public/application/util/index_utils.ts
+++ b/x-pack/plugins/ml/public/application/util/index_utils.ts
@@ -48,11 +48,12 @@ export async function getDataViewIdFromName(name: string): Promise<string | null
   if (dataViewsContract === null) {
     throw new Error('Data views are not initialized!');
   }
-  const [dv] = await dataViewsContract?.find(name);
-  if (!dv) {
+  const dataViews = await dataViewsContract.find(name);
+  const dataView = dataViews.find(({ title }) => title === name);
+  if (!dataView) {
     return null;
   }
-  return dv.id ?? dv.title;
+  return dataView.id ?? dataView.title;
 }
 
 export function getDataViewById(id: string): Promise<DataView> {

--- a/x-pack/plugins/ml/server/lib/alerts/alerting_service.ts
+++ b/x-pack/plugins/ml/server/lib/alerts/alerting_service.ts
@@ -108,7 +108,9 @@ export function alertingServiceProvider(
       try {
         const dataViewsService = await getDataViewsService();
 
-        const dataView = (await dataViewsService.find(indexPattern, 1))[0];
+        const dataViews = await dataViewsService.find(indexPattern, 1);
+        const dataView = dataViews.find(({ title }) => title === indexPattern);
+
         if (!dataView) return;
 
         return dataView.fieldFormatMap;

--- a/x-pack/plugins/ml/server/lib/alerts/alerting_service.ts
+++ b/x-pack/plugins/ml/server/lib/alerts/alerting_service.ts
@@ -108,7 +108,7 @@ export function alertingServiceProvider(
       try {
         const dataViewsService = await getDataViewsService();
 
-        const dataViews = await dataViewsService.find(indexPattern, 1);
+        const dataViews = await dataViewsService.find(indexPattern);
         const dataView = dataViews.find(({ title }) => title === indexPattern);
 
         if (!dataView) return;


### PR DESCRIPTION
The data view service's find function will return multiple results if a wildcard is used in the title, so we have to perform an additional search to match the exact title.
Also addresses this comment https://github.com/elastic/kibana/pull/118006#discussion_r756187254

