### PR TITLE
[Fleet] fix agent status filter

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -241,7 +241,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         .join(' or ');
 
       if (kueryBuilder) {
-        kueryBuilder = `(${kueryBuilder}) and ${kueryStatus}`;
+        kueryBuilder = `(${kueryBuilder}) and (${kueryStatus})`;
       } else {
         kueryBuilder = kueryStatus;
       }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/120731

Fixes issue where agent status filters returned incorrect policies when one policy id was filtered.
There are multiple filter conditions representing statuses (e.g. Updating) which was not combined correctly with the policy_id filter (missing paranthesis for precedence).

To verify:

1. Locally enroll 2 agents, unenroll one to have one Healthy and one Updating
2. Filter on the policy name which has Healthy status
3. Select status filter Unhealthy 
4. Verify that the other agent is not showing up




https://user-images.githubusercontent.com/90178898/145209844-6b09e0dd-a09b-4910-a17c-bb2963e9cf70.mov

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
