### PR TITLE
[App Search, Crawler] Show validation errors in domain form

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_flyout.tsx
@@ -64,7 +64,14 @@ export const AddDomainFlyout: React.FC = () => {
                 </h2>
               </EuiTitle>
             </EuiFlyoutHeader>
-            <EuiFlyoutBody banner={<AddDomainFormErrors />}>
+            <EuiFlyoutBody
+              banner={
+                <>
+                  <EuiSpacer size="l" />
+                  <AddDomainFormErrors />
+                </>
+              }
+            >
               <EuiText>
                 {i18n.translate(
                   'xpack.enterpriseSearch.appSearch.crawler.addDomainFlyout.description',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -12,17 +12,22 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
+import { useValues } from 'kea';
+
 import { getPageHeaderActions } from '../../../test_helpers';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
 import { AddDomainForm } from './components/add_domain/add_domain_form';
+import { AddDomainFormErrors } from './components/add_domain/add_domain_form_errors';
 import { AddDomainFormSubmitButton } from './components/add_domain/add_domain_form_submit_button';
+import { AddDomainLogic } from './components/add_domain/add_domain_logic';
 import { CrawlDetailsFlyout } from './components/crawl_details_flyout';
 import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { CrawlerStatusBanner } from './components/crawler_status_banner';
 import { CrawlerStatusIndicator } from './components/crawler_status_indicator/crawler_status_indicator';
 import { DomainsTable } from './components/domains_table';
 import { ManageCrawlsPopover } from './components/manage_crawls_popover/manage_crawls_popover';
+import { CrawlerLogic } from './crawler_logic';
 import { CrawlerOverview } from './crawler_overview';
 import {
   CrawlerDomainFromServer,
@@ -190,5 +195,24 @@ describe('CrawlerOverview', () => {
     const wrapper = shallow(<CrawlerOverview />);
 
     expect(wrapper.find(CrawlDetailsFlyout)).toHaveLength(1);
+  });
+
+  it('contains a AddDomainFormErrors when there are errors', () => {
+    const errors = ['Domain name already exists'];
+
+    (useValues as jest.Mock).mockImplementation((logic) => {
+      switch (logic) {
+        case AddDomainLogic:
+          return { errors };
+        case CrawlerLogic:
+          return { ...mockValues, domains: [], events: [] };
+        default:
+          return {};
+      }
+    });
+
+    const wrapper = shallow(<CrawlerOverview />);
+
+    expect(wrapper.find(AddDomainFormErrors)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -19,7 +19,9 @@ import { AppSearchPageTemplate } from '../layout';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
 import { AddDomainForm } from './components/add_domain/add_domain_form';
+import { AddDomainFormErrors } from './components/add_domain/add_domain_form_errors';
 import { AddDomainFormSubmitButton } from './components/add_domain/add_domain_form_submit_button';
+import { AddDomainLogic } from './components/add_domain/add_domain_logic';
 import { CrawlDetailsFlyout } from './components/crawl_details_flyout';
 import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { CrawlerStatusBanner } from './components/crawler_status_banner';
@@ -31,6 +33,7 @@ import { CrawlerLogic } from './crawler_logic';
 
 export const CrawlerOverview: React.FC = () => {
   const { events, dataLoading, domains } = useValues(CrawlerLogic);
+  const { errors: addDomainErrors } = useValues(AddDomainLogic);
 
   return (
     <AppSearchPageTemplate
@@ -87,6 +90,12 @@ export const CrawlerOverview: React.FC = () => {
               </EuiLink>
             </p>
           </EuiText>
+          {addDomainErrors && (
+            <>
+              <EuiSpacer size="l" />
+              <AddDomainFormErrors />
+            </>
+          )}
           <EuiSpacer size="l" />
           <AddDomainForm />
           <EuiSpacer />


### PR DESCRIPTION
## Summary

Currently, we do not show potential validations error in the crawler overview page. This PR adds support for that:

<img width="1140" alt="CleanShot 2021-12-08 at 13 03 09@2x" src="https://user-images.githubusercontent.com/809707/145216969-17500f73-a3dd-4b64-8e44-efe995ca0d6f.png">

Also, the whitespace around the validation errors (when the domain form is in the flyout) are being tweaked.

**Before:**
<img width="1140" alt="CleanShot 2021-12-08 at 13 10 18@2x" src="https://user-images.githubusercontent.com/809707/145217235-a50172e1-12bf-4f25-ad06-279c16d19bfd.png">

**After:**
<img width="1140" alt="CleanShot 2021-12-08 at 13 08 33@2x" src="https://user-images.githubusercontent.com/809707/145217257-8feac7f7-f648-473c-9e05-0d104c7f27ec.png">