### PR TITLE
[APM] agent keys management improvements

### DIFF
--- a/x-pack/plugins/apm/common/privilege_type.ts
+++ b/x-pack/plugins/apm/common/privilege_type.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+
+export const enum PrivilegeType {
+  SOURCEMAP = 'sourcemap:write',
+  EVENT = 'event:write',
+  AGENT_CONFIG = 'config_agent:read',
+}
+
+export const privilegesTypeRt = t.array(
+  t.union([
+    t.literal(PrivilegeType.SOURCEMAP),
+    t.literal(PrivilegeType.EVENT),
+    t.literal(PrivilegeType.AGENT_CONFIG),
+  ])
+);

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/agent_keys_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/agent_keys_table.tsx
@@ -82,7 +82,7 @@ export function AgentKeysTable({ agentKeys, onKeyDelete }: Props) {
           description: i18n.translate(
             'xpack.apm.settings.agentKeys.table.deleteActionDescription',
             {
-              defaultMessage: 'Delete this agent key',
+              defaultMessage: 'Delete this APM agent key',
             }
           ),
           icon: 'trash',
@@ -144,7 +144,7 @@ export function AgentKeysTable({ agentKeys, onKeyDelete }: Props) {
         tableCaption={i18n.translate(
           'xpack.apm.settings.agentKeys.tableCaption',
           {
-            defaultMessage: 'Agent keys',
+            defaultMessage: 'APM Agent keys',
           }
         )}
         items={agentKeys ?? []}

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/agent_keys_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/agent_keys_table.tsx
@@ -144,7 +144,7 @@ export function AgentKeysTable({ agentKeys, onKeyDelete }: Props) {
         tableCaption={i18n.translate(
           'xpack.apm.settings.agentKeys.tableCaption',
           {
-            defaultMessage: 'APM Agent keys',
+            defaultMessage: 'APM agent keys',
           }
         )}
         items={agentKeys ?? []}

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/confirm_delete_modal.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/confirm_delete_modal.tsx
@@ -34,14 +34,14 @@ export function ConfirmDeleteModal({ agentKey, onCancel, onConfirm }: Props) {
       });
       toasts.addSuccess(
         i18n.translate('xpack.apm.settings.agentKeys.invalidate.succeeded', {
-          defaultMessage: 'Deleted agent key "{name}"',
+          defaultMessage: 'Deleted APM agent key "{name}"',
           values: { name },
         })
       );
     } catch (error) {
       toasts.addDanger(
         i18n.translate('xpack.apm.settings.agentKeys.invalidate.failed', {
-          defaultMessage: 'Error deleting agent key "{name}"',
+          defaultMessage: 'Error deleting APM agent key "{name}"',
           values: { name },
         })
       );
@@ -53,7 +53,7 @@ export function ConfirmDeleteModal({ agentKey, onCancel, onConfirm }: Props) {
       title={i18n.translate(
         'xpack.apm.settings.agentKeys.deleteConfirmModal.title',
         {
-          defaultMessage: 'Delete agent key "{name}"?',
+          defaultMessage: 'Delete APM agent key "{name}"?',
           values: { name },
         }
       )}

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/create_agent_key.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/create_agent_key.tsx
@@ -67,7 +67,7 @@ export function CreateAgentKeyFlyout({ onCancel, onSuccess, onError }: Props) {
 
     try {
       const { agentKey } = await callApmApi({
-        endpoint: 'POST /apm/agent_keys',
+        endpoint: 'POST /api/apm/agent_keys',
         signal: null,
         params: {
           body: {

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/create_agent_key.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/create_agent_key.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiButton,
@@ -28,9 +28,8 @@ import {
 } from '@elastic/eui';
 import { isEmpty } from 'lodash';
 import { callApmApi } from '../../../../services/rest/createCallApmApi';
-import { useKibana } from '../../../../../../../../src/plugins/kibana_react/public';
-import { ApmPluginStartDeps } from '../../../../plugin';
 import { CreateApiKeyResponse } from '../../../../../common/agent_key_types';
+import { useCurrentUser } from '../../../../hooks/use_current_user';
 
 interface Props {
   onCancel: () => void;
@@ -39,17 +38,13 @@ interface Props {
 }
 
 export function CreateAgentKeyFlyout({ onCancel, onSuccess, onError }: Props) {
-  const {
-    services: { security },
-  } = useKibana<ApmPluginStartDeps>();
-
-  const [username, setUsername] = useState('');
-
   const [formTouched, setFormTouched] = useState(false);
   const [keyName, setKeyName] = useState('');
   const [agentConfigChecked, setAgentConfigChecked] = useState(true);
   const [eventWriteChecked, setEventWriteChecked] = useState(true);
   const [sourcemapChecked, setSourcemapChecked] = useState(true);
+
+  const currentUser = useCurrentUser();
 
   const isInputInvalid = isEmpty(keyName);
   const isFormInvalid = formTouched && isInputInvalid;
@@ -58,18 +53,6 @@ export function CreateAgentKeyFlyout({ onCancel, onSuccess, onError }: Props) {
     'xpack.apm.settings.agentKeys.createKeyFlyout.name.placeholder',
     { defaultMessage: 'Enter a name' }
   );
-
-  useEffect(() => {
-    const getCurrentUser = async () => {
-      try {
-        const authenticatedUser = await security?.authc.getCurrentUser();
-        setUsername(authenticatedUser?.username || '');
-      } catch {
-        setUsername('');
-      }
-    };
-    getCurrentUser();
-  }, [security?.authc]);
 
   const createAgentKeyTitle = i18n.translate(
     'xpack.apm.settings.agentKeys.createKeyFlyout.createAgentKey',
@@ -112,14 +95,14 @@ export function CreateAgentKeyFlyout({ onCancel, onSuccess, onError }: Props) {
 
       <EuiFlyoutBody>
         <EuiForm isInvalid={isFormInvalid} error={formError}>
-          {username && (
+          {currentUser && (
             <EuiFormRow
               label={i18n.translate(
                 'xpack.apm.settings.agentKeys.createKeyFlyout.userTitle',
                 { defaultMessage: 'User' }
               )}
             >
-              <EuiText>{username}</EuiText>
+              <EuiText>{currentUser?.username}</EuiText>
             </EuiFormRow>
           )}
           <EuiFormRow

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/create_agent_key.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/create_agent_key.tsx
@@ -34,7 +34,7 @@ import { useCurrentUser } from '../../../../hooks/use_current_user';
 interface Props {
   onCancel: () => void;
   onSuccess: (agentKey: CreateApiKeyResponse) => void;
-  onError: (keyName: string) => void;
+  onError: (keyName: string, message: string) => void;
 }
 
 export function CreateAgentKeyFlyout({ onCancel, onSuccess, onError }: Props) {
@@ -81,7 +81,7 @@ export function CreateAgentKeyFlyout({ onCancel, onSuccess, onError }: Props) {
 
       onSuccess(agentKey);
     } catch (error) {
-      onError(keyName);
+      onError(keyName, error.body?.message || error.message);
     }
   };
 

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/create_agent_key/agent_key_callout.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/create_agent_key/agent_key_callout.tsx
@@ -13,6 +13,7 @@ import {
   EuiButtonIcon,
   EuiCopy,
   EuiFormControlLayout,
+  EuiFieldText,
 } from '@elastic/eui';
 
 interface Props {
@@ -66,9 +67,8 @@ export function AgentKeyCallOut({ name, token }: Props) {
             </EuiCopy>
           }
         >
-          <input
-            type="text"
-            className="euiFieldText euiFieldText--inGroup"
+          <EuiFieldText
+            className="euiFieldText--inGroup"
             readOnly
             value={token}
             aria-label={i18n.translate(

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/create_agent_key/agent_key_callout.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/create_agent_key/agent_key_callout.tsx
@@ -12,7 +12,6 @@ import {
   EuiCallOut,
   EuiButtonIcon,
   EuiCopy,
-  EuiFormControlLayout,
   EuiFieldText,
 } from '@elastic/eui';
 
@@ -44,9 +43,15 @@ export function AgentKeyCallOut({ name, token }: Props) {
             }
           )}
         </p>
-        <EuiFormControlLayout
-          style={{ backgroundColor: 'transparent' }}
+        <EuiFieldText
           readOnly
+          value={token}
+          aria-label={i18n.translate(
+            'xpack.apm.settings.agentKeys.copyAgentKeyField.agentKeyLabel',
+            {
+              defaultMessage: 'APM agent key',
+            }
+          )}
           prepend="Base64"
           append={
             <EuiCopy textToCopy={token}>
@@ -66,19 +71,7 @@ export function AgentKeyCallOut({ name, token }: Props) {
               )}
             </EuiCopy>
           }
-        >
-          <EuiFieldText
-            className="euiFieldText--inGroup"
-            readOnly
-            value={token}
-            aria-label={i18n.translate(
-              'xpack.apm.settings.agentKeys.copyAgentKeyField.agentKeyLabel',
-              {
-                defaultMessage: 'Agent key',
-              }
-            )}
-          />
-        </EuiFormControlLayout>
+        />
       </EuiCallOut>
       <EuiSpacer size="m" />
     </>

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/index.tsx
@@ -123,11 +123,12 @@ export function AgentKeys() {
             setIsFlyoutVisible(false);
             refetchAgentKeys();
           }}
-          onError={(keyName: string) => {
+          onError={(keyName: string, message: string) => {
             toasts.addDanger(
               i18n.translate('xpack.apm.settings.agentKeys.crate.failed', {
-                defaultMessage: 'Error creating agent key "{keyName}"',
-                values: { keyName },
+                defaultMessage:
+                  'Error creating agent key "{keyName}". Error: "{message}"',
+                values: { keyName, message },
               })
             );
             setIsFlyoutVisible(false);

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/index.tsx
@@ -84,7 +84,7 @@ export function AgentKeys() {
           <EuiTitle>
             <h2>
               {i18n.translate('xpack.apm.settings.agentKeys.title', {
-                defaultMessage: 'APM Agent keys',
+                defaultMessage: 'APM agent keys',
               })}
             </h2>
           </EuiTitle>

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_keys/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_keys/index.tsx
@@ -75,7 +75,7 @@ export function AgentKeys() {
       <EuiText color="subdued">
         {i18n.translate('xpack.apm.settings.agentKeys.descriptionText', {
           defaultMessage:
-            'View and delete agent keys. An agent key sends requests on behalf of a user.',
+            'View and delete APM agent keys. An APM agent key sends requests on behalf of a user.',
         })}
       </EuiText>
       <EuiSpacer size="m" />
@@ -84,7 +84,7 @@ export function AgentKeys() {
           <EuiTitle>
             <h2>
               {i18n.translate('xpack.apm.settings.agentKeys.title', {
-                defaultMessage: 'Agent keys',
+                defaultMessage: 'APM Agent keys',
               })}
             </h2>
           </EuiTitle>
@@ -99,7 +99,7 @@ export function AgentKeys() {
               {i18n.translate(
                 'xpack.apm.settings.agentKeys.createAgentKeyButton',
                 {
-                  defaultMessage: 'Create agent key',
+                  defaultMessage: 'Create APM agent key',
                 }
               )}
             </EuiButton>
@@ -127,7 +127,7 @@ export function AgentKeys() {
             toasts.addDanger(
               i18n.translate('xpack.apm.settings.agentKeys.crate.failed', {
                 defaultMessage:
-                  'Error creating agent key "{keyName}". Error: "{message}"',
+                  'Error creating APM agent key "{keyName}". Error: "{message}"',
                 values: { keyName, message },
               })
             );
@@ -185,7 +185,7 @@ function AgentKeysContent({
               {i18n.translate(
                 'xpack.apm.settings.agentKeys.agentKeysLoadingPromptTitle',
                 {
-                  defaultMessage: 'Loading Agent keys...',
+                  defaultMessage: 'Loading APM agent keys...',
                 }
               )}
             </h2>
@@ -203,7 +203,7 @@ function AgentKeysContent({
               {i18n.translate(
                 'xpack.apm.settings.agentKeys.agentKeysErrorPromptTitle',
                 {
-                  defaultMessage: 'Could not load agent keys.',
+                  defaultMessage: 'Could not load APM agent keys.',
                 }
               )}
             </h2>
@@ -236,7 +236,7 @@ function AgentKeysContent({
           <p>
             {i18n.translate('xpack.apm.settings.agentKeys.emptyPromptBody', {
               defaultMessage:
-                'Create keys to authorize agent requests to the APM Server.',
+                'Create APM agent keys to authorize APM agent requests to the APM Server.',
             })}
           </p>
         }
@@ -249,7 +249,7 @@ function AgentKeysContent({
             {i18n.translate(
               'xpack.apm.settings.agentKeys.createAgentKeyButton',
               {
-                defaultMessage: 'Create agent key',
+                defaultMessage: 'Create APM agent key',
               }
             )}
           </EuiButton>

--- a/x-pack/plugins/apm/public/hooks/use_current_user.ts
+++ b/x-pack/plugins/apm/public/hooks/use_current_user.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState, useEffect } from 'react';
+import { useKibana } from '../../../../../src/plugins/kibana_react/public';
+import { ApmPluginStartDeps } from '../plugin';
+import { AuthenticatedUser } from '../../../security/common/model';
+
+export function useCurrentUser() {
+  const {
+    services: { security },
+  } = useKibana<ApmPluginStartDeps>();
+
+  const [user, setUser] = useState<AuthenticatedUser>();
+
+  useEffect(() => {
+    const getCurrentUser = async () => {
+      try {
+        const authenticatedUser = await security?.authc.getCurrentUser();
+        setUser(authenticatedUser);
+      } catch {
+        setUser(undefined);
+      }
+    };
+    getCurrentUser();
+  }, [security?.authc]);
+
+  return user;
+}

--- a/x-pack/plugins/apm/server/routes/agent_keys/create_agent_key.ts
+++ b/x-pack/plugins/apm/server/routes/agent_keys/create_agent_key.ts
@@ -82,7 +82,7 @@ export async function createAgentKey({
     throw Boom.internal(error);
   }
 
-  const { name = 'apm-key', sourcemap, event, agentConfig } = requestBody;
+  const { name, sourcemap, event, agentConfig } = requestBody;
 
   const privileges: PrivilegeType[] = [];
   if (!sourcemap && !event && !agentConfig) {

--- a/x-pack/plugins/apm/server/routes/agent_keys/create_agent_key.ts
+++ b/x-pack/plugins/apm/server/routes/agent_keys/create_agent_key.ts
@@ -8,17 +8,14 @@
 import Boom from '@hapi/boom';
 import { ApmPluginRequestHandlerContext } from '../typings';
 import { CreateApiKeyResponse } from '../../../common/agent_key_types';
+import { PrivilegeType } from '../../../common/privilege_type';
 
-const enum PrivilegeType {
-  SOURCEMAP = 'sourcemap:write',
-  EVENT = 'event:write',
-  AGENT_CONFIG = 'config_agent:read',
-}
+const resource = '*';
 
 interface SecurityHasPrivilegesResponse {
   application: {
     apm: {
-      '-': {
+      [resource]: {
         [PrivilegeType.SOURCEMAP]: boolean;
         [PrivilegeType.EVENT]: boolean;
         [PrivilegeType.AGENT_CONFIG]: boolean;
@@ -36,73 +33,54 @@ export async function createAgentKey({
   context: ApmPluginRequestHandlerContext;
   requestBody: {
     name: string;
-    sourcemap?: boolean;
-    event?: boolean;
-    agentConfig?: boolean;
+    privileges: string[];
   };
 }) {
+  const { name, privileges } = requestBody;
+  const application = {
+    application: 'apm',
+    privileges,
+    resources: [resource],
+  };
+
   // Elasticsearch will allow a user without the right apm privileges to create API keys, but the keys won't validate
   // check first whether the user has the right privileges, and bail out early if not
   const {
-    body: { application, username, has_all_requested: hasRequiredPrivileges },
+    body: {
+      application: userApplicationPrivileges,
+      username,
+      has_all_requested: hasRequiredPrivileges,
+    },
   } = await context.core.elasticsearch.client.asCurrentUser.security.hasPrivileges<SecurityHasPrivilegesResponse>(
     {
       body: {
-        application: [
-          {
-            application: 'apm',
-            privileges: [
-              PrivilegeType.SOURCEMAP,
-              PrivilegeType.EVENT,
-              PrivilegeType.AGENT_CONFIG,
-            ],
-            resources: ['-'],
-          },
-        ],
+        application: [application],
       },
     }
   );
 
   if (!hasRequiredPrivileges) {
-    const missingPrivileges = Object.entries(application.apm['-'])
+    const missingPrivileges = Object.entries(
+      userApplicationPrivileges.apm[resource]
+    )
       .filter((x) => !x[1])
-      .map((x) => x[0])
-      .join(', ');
-    const error = `${username} is missing the following requested privilege(s): ${missingPrivileges}.\
-    You might try with the superuser, or add the APM application privileges to the role of the authenticated user, eg.:
-    PUT /_security/role/my_role {
+      .map((x) => x[0]);
+
+    const error = `${username} is missing the following requested privilege(s): ${missingPrivileges.join(
+      ', '
+    )}.\
+    You might try with the superuser, or add the missing APM application privileges to the role of the authenticated user, eg.:
+    PUT /_security/role/my_role
+    {
       ...
       "applications": [{
         "application": "apm",
-        "privileges": ["sourcemap:write", "event:write", "config_agent:read"],
-        "resources": ["*"]
+        "privileges": ${JSON.stringify(missingPrivileges)},
+        "resources": [${resource}]
       }],
       ...
     }`;
     throw Boom.internal(error);
-  }
-
-  const { name, sourcemap, event, agentConfig } = requestBody;
-
-  const privileges: PrivilegeType[] = [];
-  if (!sourcemap && !event && !agentConfig) {
-    privileges.push(
-      PrivilegeType.SOURCEMAP,
-      PrivilegeType.EVENT,
-      PrivilegeType.AGENT_CONFIG
-    );
-  }
-
-  if (sourcemap) {
-    privileges.push(PrivilegeType.SOURCEMAP);
-  }
-
-  if (event) {
-    privileges.push(PrivilegeType.EVENT);
-  }
-
-  if (agentConfig) {
-    privileges.push(PrivilegeType.AGENT_CONFIG);
   }
 
   const body = {
@@ -114,13 +92,7 @@ export async function createAgentKey({
       apm: {
         cluster: [],
         index: [],
-        applications: [
-          {
-            application: 'apm',
-            privileges,
-            resources: ['*'],
-          },
-        ],
+        applications: [application],
       },
     },
   };

--- a/x-pack/plugins/apm/server/routes/agent_keys/invalidate_agent_key.ts
+++ b/x-pack/plugins/apm/server/routes/agent_keys/invalidate_agent_key.ts
@@ -19,6 +19,7 @@ export async function invalidateAgentKey({
     {
       body: {
         ids: [id],
+        owner: true,
       },
     }
   );

--- a/x-pack/plugins/apm/server/routes/agent_keys/route.ts
+++ b/x-pack/plugins/apm/server/routes/agent_keys/route.ts
@@ -8,13 +8,13 @@
 import Boom from '@hapi/boom';
 import { i18n } from '@kbn/i18n';
 import * as t from 'io-ts';
-import { toBooleanRt } from '@kbn/io-ts-utils/to_boolean_rt';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { createApmServerRouteRepository } from '../apm_routes/create_apm_server_route_repository';
 import { getAgentKeys } from './get_agent_keys';
 import { getAgentKeysPrivileges } from './get_agent_keys_privileges';
 import { invalidateAgentKey } from './invalidate_agent_key';
 import { createAgentKey } from './create_agent_key';
+import { privilegesTypeRt } from '../../../common/privilege_type';
 
 const agentKeysRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/agent_keys',
@@ -80,16 +80,10 @@ const createAgentKeyRoute = createApmServerRoute({
   endpoint: 'POST /api/apm/agent_keys',
   options: { tags: ['access:apm', 'access:apm_write'] },
   params: t.type({
-    body: t.intersection([
-      t.partial({
-        sourcemap: toBooleanRt,
-        event: toBooleanRt,
-        agentConfig: toBooleanRt,
-      }),
-      t.type({
-        name: t.string,
-      }),
-    ]),
+    body: t.type({
+      name: t.string,
+      privileges: privilegesTypeRt,
+    }),
   }),
   handler: async (resources) => {
     const { context, params } = resources;

--- a/x-pack/plugins/apm/server/routes/agent_keys/route.ts
+++ b/x-pack/plugins/apm/server/routes/agent_keys/route.ts
@@ -77,7 +77,7 @@ const invalidateAgentKeyRoute = createApmServerRoute({
 });
 
 const createAgentKeyRoute = createApmServerRoute({
-  endpoint: 'POST /apm/agent_keys',
+  endpoint: 'POST /api/apm/agent_keys',
   options: { tags: ['access:apm', 'access:apm_write'] },
   params: t.type({
     body: t.intersection([


### PR DESCRIPTION
## Summary
Improvements for agent key management:

- Add `useCurrentUser` hook
- Remove `EuiFormControlLayout` and use `EuiFieldText` instead of input element
- Display error messages in the UI when creating agent keys
- Removes default agent key name and privileges when creating agent keys
- Use single state in the form for creating agent keys
- Use privileges array in the create agent key endpoint
- Change ...agent key... instances to ...APM agent key...