### PR TITLE
[8.0] [Lens] fix not-working test for conflict for embeddables (#120211)

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable.test.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.test.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import React from 'react';
 import {
   Embeddable,
   LensByValueInput,
@@ -16,6 +16,7 @@ import {
 } from './embeddable';
 import { ReactExpressionRendererProps } from 'src/plugins/expressions/public';
 import { Query, TimeRange, Filter, IndexPatternsContract } from 'src/plugins/data/public';
+import { spacesPluginMock } from '../../../spaces/public/mocks';
 import { Document } from '../persistence';
 import { dataPluginMock } from '../../../../../src/plugins/data/public/mocks';
 import { VIS_EVENT_TO_TRIGGER } from '../../../../../src/plugins/visualizations/public/embeddable';
@@ -255,6 +256,10 @@ describe('embeddable', () => {
         } as LensUnwrapResult);
       }
     );
+    const spacesPluginStart = spacesPluginMock.createStartContract();
+    spacesPluginStart.ui.components.getEmbeddableLegacyUrlConflict = jest.fn(() => (
+      <>getEmbeddableLegacyUrlConflict</>
+    ));
     const embeddable = new Embeddable(
       {
         timefilter: dataPluginMock.createSetupContract().query.timefilter.timefilter,
@@ -263,6 +268,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         indexPatternService: {} as IndexPatternsContract,
+        spaces: spacesPluginStart,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -283,7 +289,9 @@ describe('embeddable', () => {
       {} as LensEmbeddableInput
     );
     await embeddable.initializeSavedVis({} as LensEmbeddableInput);
+    embeddable.render(mountpoint);
     expect(expressionRenderer).toHaveBeenCalledTimes(0);
+    expect(spacesPluginStart.ui.components.getEmbeddableLegacyUrlConflict).toHaveBeenCalled();
   });
 
   it('should initialize output with deduped list of index patterns', async () => {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Lens] fix not-working test for conflict for embeddables (#120211)