### PR TITLE
Fix autocomplete suggestions for repository of type `fs` (typo)

### DIFF
--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/snapshot.create_repository.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/snapshot.create_repository.json
@@ -9,7 +9,7 @@
       "settings": {
         "__one_of": [{
           "__condition": {
-            "lines_regex": "type[\"']\\s*:\\s*[\"']fs`"
+            "lines_regex": "type[\"']\\s*:\\s*[\"']fs"
           },
           "__template": {
             "location": "path"


### PR DESCRIPTION
## Summary
While investigating alternative solutions for https://github.com/elastic/kibana/pull/120512 I noticed that autocomplete suggestions for repository `settings` of type `fs` were not working. Other repository types have autocomplete suggestions for `settings`.
NOTE: I'm not sure why, but template autocompletion (the default object printed out when `settings` is selected) is always the template for type `fs`. 

### Before 

https://user-images.githubusercontent.com/6585477/145232349-0572e2a1-0250-4c54-9fc9-432190c97d1c.mov



### After 

https://user-images.githubusercontent.com/6585477/145231863-3772fdd1-8aee-41fc-b2f2-fc4a45c0f297.mov

