### PR TITLE
[Fleet] Use deterministic UUID's for default policies

### DIFF
--- a/x-pack/plugins/fleet/common/constants/preconfiguration.ts
+++ b/x-pack/plugins/fleet/common/constants/preconfiguration.ts
@@ -6,6 +6,7 @@
  */
 
 import { uniqBy } from 'lodash';
+import uuidv5 from 'uuid/v5';
 
 import type { PreconfiguredAgentPolicy } from '../types';
 
@@ -18,6 +19,9 @@ import {
   autoUpgradePoliciesPackages,
 } from './epm';
 
+// UUID v5 values require a namespace. We use UUID v5 for some of our preconfigured ID values.
+export const UUID_V5_NAMESPACE = 'dde7c2de-1370-4c19-9975-b473d0e03508';
+
 export const PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE =
   'fleet-preconfiguration-deletion-record';
 
@@ -25,14 +29,16 @@ export const PRECONFIGURATION_LATEST_KEYWORD = 'latest';
 
 type PreconfiguredAgentPolicyWithDefaultInputs = Omit<
   PreconfiguredAgentPolicy,
-  'package_policies' | 'id'
+  'package_policies'
 > & {
   package_policies: Array<Omit<PreconfiguredAgentPolicy['package_policies'][0], 'inputs'>>;
 };
 
+export const DEFAULT_AGENT_POLICY_ID_SEED = 'default-agent-policy';
 export const DEFAULT_SYSTEM_PACKAGE_POLICY_ID = 'default-system-policy';
 
 export const DEFAULT_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
+  id: uuidv5(DEFAULT_AGENT_POLICY_ID_SEED, UUID_V5_NAMESPACE),
   name: 'Default policy',
   namespace: 'default',
   description: 'Default agent policy created by Kibana',
@@ -50,9 +56,11 @@ export const DEFAULT_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
   monitoring_enabled: monitoringTypes,
 };
 
-export const DEFAULT_FLEET_SERVER_POLICY_ID = 'default-fleet-server-policy';
+export const DEFAULT_FLEET_SERVER_POLICY_ID = 'default-fleet-server-agent-policy';
+export const DEFAULT_FLEET_SERVER_AGENT_POLICY_ID_SEED = 'default-fleet-server';
 
 export const DEFAULT_FLEET_SERVER_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
+  id: uuidv5(DEFAULT_FLEET_SERVER_AGENT_POLICY_ID_SEED, UUID_V5_NAMESPACE),
   name: 'Default Fleet Server policy',
   namespace: 'default',
   description: 'Default Fleet Server agent policy created by Kibana',

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -138,7 +138,7 @@ class AgentPolicyService {
     const isDefaultPolicy =
       preconfiguredAgentPolicy.is_default || preconfiguredAgentPolicy.is_default_fleet_server;
 
-    if (isDefaultPolicy && !id) {
+    if (isDefaultPolicy) {
       searchParams = {
         searchFields: [
           preconfiguredAgentPolicy.is_default_fleet_server
@@ -155,7 +155,7 @@ class AgentPolicyService {
 
     if (!searchParams) throw new Error('Missing ID');
 
-    return await this.ensureAgentPolicy(soClient, esClient, newAgentPolicy, searchParams);
+    return await this.ensureAgentPolicy(soClient, esClient, newAgentPolicy, searchParams, id);
   }
 
   private async ensureAgentPolicy(
@@ -167,7 +167,8 @@ class AgentPolicyService {
       | {
           searchFields: string[];
           search: string;
-        }
+        },
+    id?: string | number
   ): Promise<{
     created: boolean;
     policy: AgentPolicy;
@@ -205,7 +206,7 @@ class AgentPolicyService {
     if (agentPolicies.total === 0) {
       return {
         created: true,
-        policy: await this.create(soClient, esClient, newAgentPolicy),
+        policy: await this.create(soClient, esClient, newAgentPolicy, { id: String(id) }),
       };
     }
 

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -34,7 +34,12 @@ import type {
   ListWithKuery,
   NewPackagePolicy,
 } from '../types';
-import { agentPolicyStatuses, packageToPackagePolicy, AGENT_POLICY_INDEX } from '../../common';
+import {
+  agentPolicyStatuses,
+  packageToPackagePolicy,
+  AGENT_POLICY_INDEX,
+  UUID_V5_NAMESPACE,
+} from '../../common';
 import type {
   DeleteAgentPolicyResponse,
   FleetServerPolicy,
@@ -60,9 +65,6 @@ import { appContextService } from './app_context';
 import { getFullAgentPolicy } from './agent_policies';
 
 const SAVED_OBJECT_TYPE = AGENT_POLICY_SAVED_OBJECT_TYPE;
-
-// UUID v5 values require a namespace
-const UUID_V5_NAMESPACE = 'dde7c2de-1370-4c19-9975-b473d0e03508';
 
 class AgentPolicyService {
   private triggerAgentPolicyUpdatedEvent = async (

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -138,7 +138,7 @@ class AgentPolicyService {
     const isDefaultPolicy =
       preconfiguredAgentPolicy.is_default || preconfiguredAgentPolicy.is_default_fleet_server;
 
-    if (isDefaultPolicy) {
+    if (isDefaultPolicy && !id) {
       searchParams = {
         searchFields: [
           preconfiguredAgentPolicy.is_default_fleet_server

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -134,14 +134,11 @@ class AgentPolicyService {
     };
 
     let searchParams;
-    if (id) {
-      searchParams = {
-        id: String(id),
-      };
-    } else if (
-      preconfiguredAgentPolicy.is_default ||
-      preconfiguredAgentPolicy.is_default_fleet_server
-    ) {
+
+    const isDefaultPolicy =
+      preconfiguredAgentPolicy.is_default || preconfiguredAgentPolicy.is_default_fleet_server;
+
+    if (isDefaultPolicy) {
       searchParams = {
         searchFields: [
           preconfiguredAgentPolicy.is_default_fleet_server
@@ -150,7 +147,12 @@ class AgentPolicyService {
         ],
         search: 'true',
       };
+    } else if (id) {
+      searchParams = {
+        id: String(id),
+      };
     }
+
     if (!searchParams) throw new Error('Missing ID');
 
     return await this.ensureAgentPolicy(soClient, esClient, newAgentPolicy, searchParams);


### PR DESCRIPTION
## Summary

Update Fleet's preconfiguration process to use deterministic UUIDs for our default policies. This ensures idempotency when multiple Fleet setups may be run simultaneously in a high-availability Kibana environment. 

Resolves #120613 

## How to test

Run Fleet setup w/ no preconfigured policies in your `kibana.dev.yml` against a fresh ES/Kibana environment. Note the ID's generated, they should be:

- Default Fleet Server policy: 499b5aa7-d214-5b5d-838b-3cd76469844e
- Default policy: 2016d7cc-135e-5583-9758-3ba01f5a06e5

Tear down your environment and start a new, completely empty ES/Kibana environment. Re-run setup and note that the same UUID values are generated for these policies. 
