### PR TITLE
chore(NA): removes unused dep @types/elasticsearch

### DIFF
--- a/package.json
+++ b/package.json
@@ -521,7 +521,6 @@
     "@types/ejs": "^3.0.6",
     "@types/elastic__apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace/npm_module_types",
     "@types/elastic__datemath": "link:bazel-bin/packages/elastic-datemath/npm_module_types",
-    "@types/elasticsearch": "^5.0.33",
     "@types/enzyme": "^3.10.8",
     "@types/eslint": "^7.28.0",
     "@types/express": "^4.17.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5403,11 +5403,6 @@
   version "0.0.0"
   uid ""
 
-"@types/elasticsearch@^5.0.33":
-  version "5.0.33"
-  resolved "https://registry.yarnpkg.com/@types/elasticsearch/-/elasticsearch-5.0.33.tgz#b0fd37dc674f498223b6d68c313bdfd71f4d812b"
-  integrity sha512-n/g9pqJEpE4fyUE8VvHNGtl7E2Wv8TCroNwfgAeJKRV4ghDENahtrAo1KMsFNIejBD2gDAlEUa4CM4oEEd8p9Q==
-
 "@types/enzyme@^3.10.8":
   version "3.10.8"
   resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.8.tgz#ad7ac9d3af3de6fd0673773123fafbc63db50d42"


### PR DESCRIPTION
I just realised we are not using `@types/elasticsearch` anymore. This is a simple PR to remove it from our `package.json`