### PR TITLE
[Security Solution][Endpoint] Improve endpoint performance with Trusted Apps path wildcards

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/trusted_app_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/trusted_app_generator.ts
@@ -67,13 +67,29 @@ export class TrustedAppGenerator extends BaseDataGenerator<TrustedApp> {
       ...(scopeType === 'policy' ? { policies: this.randomArray(5, () => this.randomUUID()) } : {}),
     }) as EffectScope;
 
+    const os = this.randomOSFamily();
+    const pathEntry = this.randomChoice([
+      {
+        field: ConditionEntryField.PATH,
+        operator: 'included',
+        type: 'match',
+        value: os !== 'windows' ? '/one/two/three' : 'c:\\fol\\bin.exe',
+      },
+      {
+        field: ConditionEntryField.PATH,
+        operator: 'included',
+        type: 'wildcard',
+        value: os !== 'windows' ? '/one/t*/*re/three.app' : 'c:\\fol*\\*ub*\\bin.exe',
+      },
+    ]);
+
     // TS types are conditional when it comes to the combination of OS and ENTRIES
     // @ts-expect-error TS2322
     return merge(
       {
         description: `Generator says we trust ${name}`,
         name,
-        os: this.randomOSFamily(),
+        os,
         effectScope,
         entries: [
           {
@@ -82,12 +98,7 @@ export class TrustedAppGenerator extends BaseDataGenerator<TrustedApp> {
             type: 'match',
             value: '1234234659af249ddf3e40864e9fb241',
           },
-          {
-            field: ConditionEntryField.PATH,
-            operator: 'included',
-            type: 'match',
-            value: '/one/two/three',
-          },
+          pathEntry,
         ],
       },
       overrides

--- a/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isPathValid } from './validations';
+import { isPathValid, hasSimpleExecutableName } from './validations';
 import { OperatingSystem, ConditionEntryField } from '../../types';
 
 describe('Unacceptable Windows wildcard paths', () => {
@@ -500,6 +500,61 @@ describe('Unacceptable Mac/Linux exact paths', () => {
         field: ConditionEntryField.PATH,
         type: 'match',
         value: '/opt/bin/file.d-mg',
+      })
+    ).toEqual(false);
+  });
+});
+
+describe('Executable filenames with wildcard PATHS', () => {
+  it('should return TRUE when MAC/LINUX wildcard paths have an executable name', () => {
+    expect(
+      hasSimpleExecutableName({
+        os: OperatingSystem.LINUX,
+        type: 'wildcard',
+        value: '/opt/*/app',
+      })
+    ).toEqual(true);
+    expect(
+      hasSimpleExecutableName({
+        os: OperatingSystem.MAC,
+        type: 'wildcard',
+        value: '/op*/**/app.dmg',
+      })
+    ).toEqual(true);
+  });
+
+  it('should return TRUE when WINDOWS wildcards paths have a executable name', () => {
+    expect(
+      hasSimpleExecutableName({
+        os: OperatingSystem.WINDOWS,
+        type: 'wildcard',
+        value: 'c:\\**\\path.exe',
+      })
+    ).toEqual(true);
+  });
+
+  it('should return FALSE when MAC/LINUX wildcard paths have a wildcard in executable name', () => {
+    expect(
+      hasSimpleExecutableName({
+        os: OperatingSystem.LINUX,
+        type: 'wildcard',
+        value: '/op/*/*pp',
+      })
+    ).toEqual(false);
+    expect(
+      hasSimpleExecutableName({
+        os: OperatingSystem.MAC,
+        type: 'wildcard',
+        value: '/op*/b**/ap.m**',
+      })
+    ).toEqual(false);
+  });
+  it('should return FALSE when WINDOWS wildcards paths have a wildcard in executable name', () => {
+    expect(
+      hasSimpleExecutableName({
+        os: OperatingSystem.WINDOWS,
+        type: 'wildcard',
+        value: 'c:\\**\\pa*h.exe',
       })
     ).toEqual(false);
   });

--- a/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.ts
@@ -34,6 +34,21 @@ export const getDuplicateFields = (entries: ConditionEntry[]) => {
     .map((entry) => entry[0]);
 };
 
+const WIN_EXEC_PATH = /\\(\w+\.\w+)$/i;
+const UNIX_EXEC_PATH = /\/\w+\.*\w*$/i;
+
+export const getExecutableName = ({
+  os,
+  value,
+}: {
+  os: OperatingSystem;
+  value: string;
+}): string => {
+  const execName =
+    os === OperatingSystem.WINDOWS ? value.match(WIN_EXEC_PATH) : value.match(UNIX_EXEC_PATH);
+  return execName ? execName[0].replaceAll(/\/|\\/gi, '') : '';
+};
+
 export const hasSimpleExecutableName = ({
   os,
   type,
@@ -44,9 +59,7 @@ export const hasSimpleExecutableName = ({
   value: string;
 }): boolean => {
   if (type === 'wildcard') {
-    return os === OperatingSystem.WINDOWS
-      ? /\\(\w+\.\w+)$/i.test(value)
-      : /\/\w+\.*\w*$/i.test(value);
+    return os === OperatingSystem.WINDOWS ? WIN_EXEC_PATH.test(value) : UNIX_EXEC_PATH.test(value);
   }
   return true;
 };

--- a/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.ts
@@ -34,6 +34,23 @@ export const getDuplicateFields = (entries: ConditionEntry[]) => {
     .map((entry) => entry[0]);
 };
 
+export const hasSimpleExecutableName = ({
+  os,
+  type,
+  value,
+}: {
+  os: OperatingSystem;
+  type: TrustedAppEntryTypes;
+  value: string;
+}): boolean => {
+  if (type === 'wildcard') {
+    return os === OperatingSystem.WINDOWS
+      ? /\\(\w+\.\w+)$/i.test(value)
+      : /\/\w+\.*\w*$/i.test(value);
+  }
+  return true;
+};
+
 export const isPathValid = ({
   os,
   field,

--- a/x-pack/plugins/security_solution/common/utils/path_placeholder.ts
+++ b/x-pack/plugins/security_solution/common/utils/path_placeholder.ts
@@ -9,11 +9,11 @@ import { ConditionEntryField, OperatingSystem, TrustedAppEntryTypes } from '../e
 
 export const getPlaceholderText = () => ({
   windows: {
-    wildcard: 'C:\\sample\\**\\*',
+    wildcard: 'C:\\sample\\**\\path.exe',
     exact: 'C:\\sample\\path.exe',
   },
   others: {
-    wildcard: '/opt/**/*',
+    wildcard: '/opt/**/app',
     exact: '/opt/bin',
   },
 });

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.tsx
@@ -30,6 +30,7 @@ import {
 import {
   isValidHash,
   isPathValid,
+  hasSimpleExecutableName,
 } from '../../../../../../common/endpoint/service/trusted_apps/validations';
 
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
@@ -136,6 +137,13 @@ const validateFormValues = (values: MaybeImmutable<NewTrustedApp>): ValidationRe
     );
   } else {
     values.entries.forEach((entry, index) => {
+      const isValidPathEntry = isPathValid({
+        os: values.os,
+        field: entry.field,
+        type: entry.type,
+        value: entry.value,
+      });
+
       if (!entry.field || !entry.value.trim()) {
         isValid = false;
         addResultToValidation(
@@ -161,9 +169,7 @@ const validateFormValues = (values: MaybeImmutable<NewTrustedApp>): ValidationRe
             values: { row: index + 1 },
           })
         );
-      } else if (
-        !isPathValid({ os: values.os, field: entry.field, type: entry.type, value: entry.value })
-      ) {
+      } else if (!isValidPathEntry) {
         addResultToValidation(
           validation,
           'entries',
@@ -172,6 +178,22 @@ const validateFormValues = (values: MaybeImmutable<NewTrustedApp>): ValidationRe
             defaultMessage: '[{row}] Path may be formed incorrectly; verify value',
             values: { row: index + 1 },
           })
+        );
+      } else if (
+        isValidPathEntry &&
+        !hasSimpleExecutableName({ os: values.os, value: entry.value, type: entry.type })
+      ) {
+        addResultToValidation(
+          validation,
+          'entries',
+          'warnings',
+          i18n.translate(
+            'xpack.securitySolution.trustedapps.create.conditionFieldDegradedPerformanceMsg',
+            {
+              defaultMessage: `[{row}] A wildcard in the filename will affect endpoint's performance`,
+              values: { row: index + 1 },
+            }
+          )
         );
       }
     });

--- a/x-pack/plugins/security_solution/server/endpoint/schemas/artifacts/lists.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/schemas/artifacts/lists.ts
@@ -48,6 +48,24 @@ export const translatedEntryMatchWildcard = t.exact(
 );
 export type TranslatedEntryMatchWildcard = t.TypeOf<typeof translatedEntryMatchWildcard>;
 
+export const translatedEntryMatchWildcardNameMatcher = t.keyof({
+  exact_cased: null,
+  exact_caseless: null,
+});
+export type TranslatedEntryMatchWildcardNameMatcher = t.TypeOf<
+  typeof translatedEntryMatchWildcardNameMatcher
+>;
+
+export const translatedEntryMatchWildcardName = t.exact(
+  t.type({
+    field: t.string,
+    operator,
+    type: translatedEntryMatchWildcardNameMatcher,
+    value: t.string,
+  })
+);
+export type TranslatedEntryMatchWildcardName = t.TypeOf<typeof translatedEntryMatchWildcardName>;
+
 export const translatedEntryMatch = t.exact(
   t.type({
     field: t.string,
@@ -83,6 +101,12 @@ export const translatedEntry = t.union([
   translatedEntryMatchAny,
 ]);
 export type TranslatedEntry = t.TypeOf<typeof translatedEntry>;
+
+export const translatedPerformantEntries = t.array(
+  t.union([translatedEntryMatchWildcard, translatedEntryMatchWildcardName])
+);
+
+export type TranslatedPerformantEntries = t.TypeOf<typeof translatedPerformantEntries>;
 
 export const translatedExceptionListItem = t.exact(
   t.type({


### PR DESCRIPTION
## Summary

Displays a soft warning when the matching path has wildcard executable name. If the wildcard path has a proper executable in the path then it adds a `process.name` value to the TA artifact.

![image](https://user-images.githubusercontent.com/1849116/144618656-8819f597-1db7-495e-b034-6117d331d6c3.png)

**Linux entries**
![image](https://user-images.githubusercontent.com/1849116/145383919-4ce671a8-b697-4398-a383-d661018a46fe.png)

**Mac entries**
![image](https://user-images.githubusercontent.com/1849116/145384658-c1becacb-108a-4cee-8ccb-b598e20d7d1e.png)

**Windows entries**
![iamge](https://user-images.githubusercontent.com/1849116/145384705-90e2ec67-40cf-4e6f-ab1b-d420816c5834.png)


### Checklist

Delete any items that are not applicable to this PR.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
