### PR TITLE
[8.0] [Component templates] Unskip form payload component integration test (#120756)

### DIFF
--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/component_template_edit.test.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/component_template_edit.test.tsx
@@ -74,13 +74,15 @@ describe('<ComponentTemplateEdit />', () => {
     expect(nameInput.props().disabled).toEqual(true);
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/84906
-  describe.skip('form payload', () => {
+  describe('form payload', () => {
     it('should send the correct payload with changed values', async () => {
       const { actions, component, form } = testBed;
 
       await act(async () => {
         form.setInputValue('versionField.input', '1');
+      });
+
+      await act(async () => {
         actions.clickNextButton();
       });
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Component templates] Unskip form payload component integration test (#120756)