### PR TITLE
[ML] Ensures validation call is successful in outlier detection wizard

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/analysis_fields_table.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/analysis_fields_table.tsx
@@ -85,6 +85,7 @@ const checkboxDisabledCheck = (item: FieldSelectionItem) =>
 export const AnalysisFieldsTable: FC<{
   dependentVariable?: string;
   includes: string[];
+  isJobTypeWithDepVar: boolean;
   setFormState: React.Dispatch<React.SetStateAction<any>>;
   minimumFieldsRequiredMessage?: string;
   setMinimumFieldsRequiredMessage: React.Dispatch<React.SetStateAction<any>>;
@@ -95,6 +96,7 @@ export const AnalysisFieldsTable: FC<{
   ({
     dependentVariable,
     includes,
+    isJobTypeWithDepVar,
     setFormState,
     minimumFieldsRequiredMessage,
     setMinimumFieldsRequiredMessage,
@@ -120,7 +122,7 @@ export const AnalysisFieldsTable: FC<{
       } else if (includes.length > 0) {
         setFormState({
           includes:
-            dependentVariable && includes.includes(dependentVariable)
+            (dependentVariable && includes.includes(dependentVariable)) || !isJobTypeWithDepVar
               ? includes
               : [...includes, dependentVariable],
         });
@@ -234,6 +236,7 @@ export const AnalysisFieldsTable: FC<{
               onTableChange={(selection: string[]) => {
                 // dependent variable must always be in includes
                 if (
+                  isJobTypeWithDepVar &&
                   dependentVariable !== undefined &&
                   dependentVariable !== '' &&
                   selection.length === 0

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step_form.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step_form.tsx
@@ -670,6 +670,7 @@ export const ConfigurationStepForm: FC<ConfigurationStepProps> = ({
       <AnalysisFieldsTable
         dependentVariable={dependentVariable}
         includes={includes}
+        isJobTypeWithDepVar={isJobTypeWithDepVar}
         minimumFieldsRequiredMessage={minimumFieldsRequiredMessage}
         setMinimumFieldsRequiredMessage={setMinimumFieldsRequiredMessage}
         tableItems={firstUpdate.current ? includesTableItems : tableItems}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/120734

This PR ensures that the default dependent variable - an empty string - doesn't get added to the `includes` fields when it is a job type that does not support dependent variables.




