### PR TITLE
[Security Solution] Add inject/extract references logic to new security rule type

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -38,6 +38,7 @@ import { RuleExecutionLogClient, truncateMessageList } from '../rule_execution_l
 import { RuleExecutionStatus } from '../../../../common/detection_engine/schemas/common/schemas';
 import { scheduleThrottledNotificationActions } from '../notifications/schedule_throttle_notification_actions';
 import aadFieldConversion from '../routes/index/signal_aad_mapping.json';
+import { extractReferences, injectReferences } from '../signals/saved_object_references';
 
 /* eslint-disable complexity */
 export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
@@ -47,6 +48,11 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
     const persistenceRuleType = createPersistenceRuleTypeWrapper({ ruleDataClient, logger });
     return persistenceRuleType({
       ...type,
+      useSavedObjectReferences: {
+        extractReferences: (params) => extractReferences({ logger, params }),
+        injectReferences: (params, savedObjectReferences) =>
+          injectReferences({ logger, params, savedObjectReferences }),
+      },
       async executor(options) {
         const {
           alertId,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/saved_object_references/extract_references.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/saved_object_references/extract_references.ts
@@ -31,13 +31,13 @@ import { extractExceptionsList } from './extract_exceptions_list';
  * @param params The params of the base rule(s).
  * @returns The rule parameters and the saved object references to store.
  */
-export const extractReferences = ({
+export const extractReferences = <TParams extends RuleParams>({
   logger,
   params,
 }: {
   logger: Logger;
-  params: RuleParams;
-}): RuleParamsAndRefs<RuleParams> => {
+  params: TParams;
+}): RuleParamsAndRefs<TParams> => {
   const exceptionReferences = extractExceptionsList({
     logger,
     exceptionsList: params.exceptionsList,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/saved_object_references/inject_references.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/saved_object_references/inject_references.ts
@@ -28,21 +28,21 @@ import { injectExceptionsReferences } from './inject_exceptions_list';
  * @param savedObjectReferences The saved object references to merge with the rule params
  * @returns The rule parameters with the saved object references.
  */
-export const injectReferences = ({
+export const injectReferences = <TParams extends RuleParams>({
   logger,
   params,
   savedObjectReferences,
 }: {
   logger: Logger;
-  params: RuleParams;
+  params: TParams;
   savedObjectReferences: SavedObjectReference[];
-}): RuleParams => {
+}): TParams => {
   const exceptionsList = injectExceptionsReferences({
     logger,
     exceptionsList: params.exceptionsList,
     savedObjectReferences,
   });
-  const ruleParamsWithSavedObjectReferences: RuleParams = {
+  const ruleParamsWithSavedObjectReferences: TParams = {
     ...params,
     exceptionsList,
   };


### PR DESCRIPTION
## Summary
Extends https://github.com/elastic/kibana/pull/107064 to the new rule registry based executors. In summary, Saved Object references are injected/extracted to/from the `exceptionsList` rule parameter.