### PR TITLE
[Fleet] make put component template idempotent for @custom and fleet global templates

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -291,7 +291,6 @@ async function installDataStreamComponentTemplates(params: {
   });
   const templateNames = Object.keys(templates);
   const templateEntries = Object.entries(templates);
-
   // TODO: Check return values for errors
   await Promise.all(
     templateEntries.map(async ([name, body]) => {
@@ -307,7 +306,6 @@ async function installDataStreamComponentTemplates(params: {
           const { clusterPromise } = putComponentTemplate(esClient, logger, {
             body,
             name,
-            create: true,
           });
           return clusterPromise;
         }
@@ -343,7 +341,6 @@ export async function ensureDefaultComponentTemplate(
     await putComponentTemplate(esClient, logger, {
       name: FLEET_GLOBAL_COMPONENT_TEMPLATE_NAME,
       body: FLEET_GLOBAL_COMPONENT_TEMPLATE_CONTENT,
-      create: true,
     });
   }
 


### PR DESCRIPTION
## Description 

Resolve [#https://github.com/elastic/kibana/issues/118609](https://github.com/elastic/kibana/issues/118609)

In Kibana HA environments, we cannot guarantee that put component template will be call only one time, in this case we should probably allow to update the component template.

## How to tests

I was able to reproduce the errrors with the very scientific diff below 
```diff
--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -44,6 +44,13 @@ export async function setupFleet(
   soClient: SavedObjectsClientContract,
   esClient: ElasticsearchClient
 ): Promise<SetupStatus> {
+  await Promise.all([
+    createSetupSideEffects(soClient, esClient),
+    createSetupSideEffects(soClient, esClient),
+    createSetupSideEffects(soClient, esClient),
+    createSetupSideEffects(soClient, esClient),
+    createSetupSideEffects(soClient, esClient),
+  ]);
   return awaitIfPending(async () => createSetupSideEffects(soClient, esClient));
 }
 ```