### PR TITLE
[failedTestReporter] don't search for existing issues unless we're writing to GH

### DIFF
--- a/packages/kbn-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
+++ b/packages/kbn-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
@@ -124,11 +124,13 @@ export function runFailedTestsReporterCli() {
               continue;
             }
 
-            let existingIssue: GithubIssueMini | undefined = await githubApi.findFailedTestIssue(
-              (i) =>
-                getIssueMetadata(i.body, 'test.class') === failure.classname &&
-                getIssueMetadata(i.body, 'test.name') === failure.name
-            );
+            let existingIssue: GithubIssueMini | undefined = updateGithub
+              ? await githubApi.findFailedTestIssue(
+                  (i) =>
+                    getIssueMetadata(i.body, 'test.class') === failure.classname &&
+                    getIssueMetadata(i.body, 'test.name') === failure.name
+                )
+              : undefined;
 
             if (!existingIssue) {
               const newlyCreated = newlyCreatedIssues.find(


### PR DESCRIPTION
We're struggling to stay under our rate limit with the Github API because of the way we associate test failures with github issues, and the number of workers on CI searching for existing issues to match to test failures. This PR updates the failed test reporter to not search for existing issues unless we are actually going to report the failures to Github. This should prevent PRs/failed test reporter/ES Snapshot Verification from contributing to our API usage like they have been.