### PR TITLE
[8.0] Fix ByteSizeValue parser to be consistent with Elasticsearch (#120653)

### DIFF
--- a/packages/kbn-config-schema/src/byte_size_value/index.test.ts
+++ b/packages/kbn-config-schema/src/byte_size_value/index.test.ts
@@ -30,6 +30,11 @@ describe('parsing units', () => {
     expect(ByteSizeValue.parse('1gb').getValueInBytes()).toBe(1073741824);
   });
 
+  test('case insensitive units', () => {
+    expect(ByteSizeValue.parse('1KB').getValueInBytes()).toBe(1024);
+    expect(ByteSizeValue.parse('1Mb').getValueInBytes()).toBe(1024 * 1024);
+  });
+
   test('throws an error when unsupported unit specified', () => {
     expect(() => ByteSizeValue.parse('1tb')).toThrowErrorMatchingInlineSnapshot(
       `"Failed to parse value as byte value. Value must be either number of bytes, or follow the format <count>[b|kb|mb|gb] (e.g., '1024kb', '200mb', '1gb'), where the number is a safe positive integer."`

--- a/packages/kbn-config-schema/src/byte_size_value/index.ts
+++ b/packages/kbn-config-schema/src/byte_size_value/index.ts
@@ -22,7 +22,7 @@ function renderUnit(value: number, unit: string) {
 
 export class ByteSizeValue {
   public static parse(text: string): ByteSizeValue {
-    const match = /([1-9][0-9]*)(b|kb|mb|gb)/.exec(text);
+    const match = /([1-9][0-9]*)(b|kb|mb|gb)/i.exec(text);
     if (!match) {
       const number = Number(text);
       if (typeof number !== 'number' || isNaN(number)) {
@@ -35,7 +35,7 @@ export class ByteSizeValue {
     }
 
     const value = parseInt(match[1], 10);
-    const unit = match[2];
+    const unit = match[2].toLowerCase();
 
     return new ByteSizeValue(value * unitMultiplier[unit]);
   }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix ByteSizeValue parser to be consistent with Elasticsearch (#120653)