### PR TITLE
[7.16] do not add depvar to includes for outlier job (#120816)

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/analysis_fields_table.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/analysis_fields_table.tsx
@@ -85,6 +85,7 @@ const checkboxDisabledCheck = (item: FieldSelectionItem) =>
 export const AnalysisFieldsTable: FC<{
   dependentVariable?: string;
   includes: string[];
+  isJobTypeWithDepVar: boolean;
   setFormState: React.Dispatch<React.SetStateAction<any>>;
   minimumFieldsRequiredMessage?: string;
   setMinimumFieldsRequiredMessage: React.Dispatch<React.SetStateAction<any>>;
@@ -95,6 +96,7 @@ export const AnalysisFieldsTable: FC<{
   ({
     dependentVariable,
     includes,
+    isJobTypeWithDepVar,
     setFormState,
     minimumFieldsRequiredMessage,
     setMinimumFieldsRequiredMessage,
@@ -120,7 +122,7 @@ export const AnalysisFieldsTable: FC<{
       } else if (includes.length > 0) {
         setFormState({
           includes:
-            dependentVariable && includes.includes(dependentVariable)
+            (dependentVariable && includes.includes(dependentVariable)) || !isJobTypeWithDepVar
               ? includes
               : [...includes, dependentVariable],
         });
@@ -234,6 +236,7 @@ export const AnalysisFieldsTable: FC<{
               onTableChange={(selection: string[]) => {
                 // dependent variable must always be in includes
                 if (
+                  isJobTypeWithDepVar &&
                   dependentVariable !== undefined &&
                   dependentVariable !== '' &&
                   selection.length === 0

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step_form.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step_form.tsx
@@ -670,6 +670,7 @@ export const ConfigurationStepForm: FC<ConfigurationStepProps> = ({
       <AnalysisFieldsTable
         dependentVariable={dependentVariable}
         includes={includes}
+        isJobTypeWithDepVar={isJobTypeWithDepVar}
         minimumFieldsRequiredMessage={minimumFieldsRequiredMessage}
         setMinimumFieldsRequiredMessage={setMinimumFieldsRequiredMessage}
         tableItems={firstUpdate.current ? includesTableItems : tableItems}


### PR DESCRIPTION
Backports the following commits to 7.16:
 - do not add depvar to includes for outlier job (#120816)