### PR TITLE
[8.0] add timestamp header to rect annotation tooltip (#120702)

### DIFF
--- a/x-pack/plugins/ml/common/types/results.ts
+++ b/x-pack/plugins/ml/common/types/results.ts
@@ -11,10 +11,14 @@ import { LineAnnotationDatum, RectAnnotationDatum } from '@elastic/charts';
 export interface GetStoppedPartitionResult {
   jobs: string[] | Record<string, string[]>;
 }
+
+export interface MLRectAnnotationDatum extends RectAnnotationDatum {
+  header: number;
+}
 export interface GetDatafeedResultsChartDataResult {
   bucketResults: number[][];
   datafeedResults: number[][];
-  annotationResultsRect: RectAnnotationDatum[];
+  annotationResultsRect: MLRectAnnotationDatum[];
   annotationResultsLine: LineAnnotationDatum[];
   modelSnapshotResultsLine: LineAnnotationDatum[];
 }

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -32,6 +32,7 @@ import {
   Axis,
   Chart,
   CurveType,
+  CustomAnnotationTooltip,
   LineAnnotation,
   LineSeries,
   LineAnnotationDatum,
@@ -68,6 +69,14 @@ function setLineAnnotationHeader(lineDatum: LineAnnotationDatum) {
   lineDatum.header = dateFormatter(lineDatum.dataValue);
   return lineDatum;
 }
+
+const customTooltip: CustomAnnotationTooltip = ({ details, datum }) => (
+  <div className="echAnnotation__tooltip">
+    {/* @ts-ignore 'header does not exist on type RectAnnotationDatum' */}
+    <p className="echAnnotation__header">{dateFormatter(datum.header)}</p>
+    <div className="echAnnotation__details">{details}</div>
+  </div>
+);
 
 export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({ jobId, end, onClose }) => {
   const [data, setData] = useState<{
@@ -385,6 +394,7 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({ jobId, end, 
                             />
                             <RectAnnotation
                               key="annotation-results-rect"
+                              customTooltip={customTooltip}
                               dataValues={annotationData.rect}
                               id={i18n.translate(
                                 'xpack.ml.jobsList.datafeedChart.annotationRectSeriesId',

--- a/x-pack/plugins/ml/server/models/results_service/results_service.ts
+++ b/x-pack/plugins/ml/server/models/results_service/results_service.ts
@@ -746,6 +746,8 @@ export function resultsServiceProvider(mlClient: MlClient, client?: IScopedClust
             x1: endTimestamp,
           },
           details: annotation.annotation,
+          // Added for custom RectAnnotation tooltip with formatted timestamp
+          header: timestamp,
         });
       }
     });


### PR DESCRIPTION
Backports the following commits to 8.0:
 - add timestamp header to rect annotation tooltip (#120702)