### PR TITLE
[Stack Monitoring] separate out mb and legacy index patterns from requests

### DIFF
--- a/x-pack/plugins/monitoring/server/lib/elasticsearch/get_last_recovery.ts
+++ b/x-pack/plugins/monitoring/server/lib/elasticsearch/get_last_recovery.ts
@@ -86,7 +86,12 @@ export function handleMbLastRecoveries(resp: ElasticsearchResponse, start: numbe
   return filtered;
 }
 
-export async function getLastRecovery(req: LegacyRequest, esIndexPattern: string, size: number) {
+export async function getLastRecovery(
+  req: LegacyRequest,
+  esIndexPattern: string,
+  mbIndexPattern: string,
+  size: number
+) {
   checkParam(esIndexPattern, 'esIndexPattern in elasticsearch/getLastRecovery');
 
   const start = req.payload.timeRange.min;
@@ -105,7 +110,7 @@ export async function getLastRecovery(req: LegacyRequest, esIndexPattern: string
     },
   };
   const mbParams = {
-    index: esIndexPattern,
+    index: mbIndexPattern,
     size,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
@@ -46,7 +46,12 @@ export function esOverviewRoute(server) {
         ccs,
         true
       );
-      const mbIndexPattern = prefixIndexPattern(config, 'metricbeat-*', ccs, true);
+      const mbIndexPattern = prefixIndexPattern(
+        config,
+        config.get('monitoring.ui.metricbeat.index'),
+        ccs,
+        true
+      );
 
       const filebeatIndexPattern = prefixIndexPattern(
         config,

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
@@ -40,6 +40,14 @@ export function esOverviewRoute(server) {
       const ccs = req.payload.ccs;
       const clusterUuid = req.params.clusterUuid;
       const esIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
+      const esLegacyIndexPattern = prefixIndexPattern(
+        config,
+        INDEX_PATTERN_ELASTICSEARCH,
+        ccs,
+        true
+      );
+      const mbIndexPattern = prefixIndexPattern(config, 'metricbeat-*', ccs, true);
+
       const filebeatIndexPattern = prefixIndexPattern(
         config,
         config.get('monitoring.ui.logs.index'),
@@ -54,7 +62,12 @@ export function esOverviewRoute(server) {
         const [clusterStats, metrics, shardActivity, logs] = await Promise.all([
           getClusterStats(req, esIndexPattern, clusterUuid),
           getMetrics(req, esIndexPattern, metricSet),
-          getLastRecovery(req, esIndexPattern, config.get('monitoring.ui.max_bucket_size')),
+          getLastRecovery(
+            req,
+            esLegacyIndexPattern,
+            mbIndexPattern,
+            config.get('monitoring.ui.max_bucket_size')
+          ),
           getLogs(config, req, filebeatIndexPattern, { clusterUuid, start, end }),
         ]);
         const indicesUnassignedShardStats = await getIndicesUnassignedShardStats(


### PR DESCRIPTION
Addresses slow loading in the ES overview page https://github.com/elastic/kibana/issues/117885.

In 7.14, the shard activity for getting the latest recovery [was changed](https://github.com/elastic/kibana/pull/96205/) to have 2 separate requests in order to accommodate the introduction of `metricbeat-*` index pattern.  One for `metricbeat-*` and the other for `.monitoring-*`.  The metricbeat docs are different and the query needs to get 10k documents, but it also still includes the `.monitoring` index patterns in its search which isn't necessary.  The same holds true for the legacy requests querying `metricbeat-*` index.  This separates them out.  So a user who has no `metricbeat-*` indices isn't suddenly going to have a performance issue.


<details>
<summary>legacy query params before</summary>

```
{
  "index": ".monitoring-es-6-*,.monitoring-es-7-*,metricbeat-*",
  "size": 1,
  "ignore_unavailable": true,
  "body": {
    "_source": [
      "index_recovery.shards"
    ],
    "sort": {
      "timestamp": {
        "order": "desc",
        "unmapped_type": "long"
      }
    },
    "query": {
      "bool": {
        "filter": [
          {
            "bool": {
              "should": [
                {
                  "term": {
                    "type": "index_recovery"
                  }
                },
                {
                  "term": {
                    "metricset.name": "index_recovery"
                  }
                }
              ]
            }
          },
          {
            "term": {
              "cluster_uuid": "sVkxxtOdQe-TNy3ECQ0bmQ"
            }
          },
          {
            "range": {
              "timestamp": {
                "format": "epoch_millis",
                "gte": 1638979303889,
                "lte": 1638980203889
              }
            }
          }
        ]
      }
    }
  }
}

```
</details>


<details>
<summary>legacy query params after</summary>

```
{
  "index": ".monitoring-es-6-*,.monitoring-es-7-*",
  "size": 1,
  "ignore_unavailable": true,
  "body": {
    "_source": [
      "index_recovery.shards"
    ],
    "sort": {
      "timestamp": {
        "order": "desc",
        "unmapped_type": "long"
      }
    },
    "query": {
      "bool": {
        "filter": [
          {
            "bool": {
              "should": [
                {
                  "term": {
                    "type": "index_recovery"
                  }
                },
                {
                  "term": {
                    "metricset.name": "index_recovery"
                  }
                }
              ]
            }
          },
          {
            "term": {
              "cluster_uuid": "sVkxxtOdQe-TNy3ECQ0bmQ"
            }
          },
          {
            "range": {
              "timestamp": {
                "format": "epoch_millis",
                "gte": 1638995534235,
                "lte": 1638996434235
              }
            }
          }
        ]
      }
    }
  }
}
```
</details>

<details>
<summary>metricbeat query params before</summary>

```
{
  "index": ".monitoring-es-6-*,.monitoring-es-7-*,metricbeat-*",
  "size": 10000,
  "ignore_unavailable": true,
  "body": {
    "_source": [
      "elasticsearch.index.recovery",
      "@timestamp"
    ],
    "sort": {
      "timestamp": {
        "order": "desc",
        "unmapped_type": "long"
      }
    },
    "query": {
      "bool": {
        "filter": [
          {
            "bool": {
              "should": [
                {
                  "term": {
                    "type": "index_recovery"
                  }
                },
                {
                  "term": {
                    "metricset.name": "index_recovery"
                  }
                }
              ]
            }
          },
          {
            "term": {
              "cluster_uuid": "sVkxxtOdQe-TNy3ECQ0bmQ"
            }
          },
          {
            "range": {
              "timestamp": {
                "format": "epoch_millis",
                "gte": 1638979270889,
                "lte": 1638980170889
              }
            }
          }
        ]
      }
    },
    "aggs": {
      "max_timestamp": {
        "max": {
          "field": "@timestamp"
        }
      }
    }
  }
}
```
</details>

<details>
<summary>metricbeat query params after</summary>

```
{
  "index": "metricbeat-*",
  "size": 10000,
  "ignore_unavailable": true,
  "body": {
    "_source": [
      "elasticsearch.index.recovery",
      "@timestamp"
    ],
    "sort": {
      "timestamp": {
        "order": "desc",
        "unmapped_type": "long"
      }
    },
    "query": {
      "bool": {
        "filter": [
          {
            "bool": {
              "should": [
                {
                  "term": {
                    "type": "index_recovery"
                  }
                },
                {
                  "term": {
                    "metricset.name": "index_recovery"
                  }
                }
              ]
            }
          },
          {
            "term": {
              "cluster_uuid": "sVkxxtOdQe-TNy3ECQ0bmQ"
            }
          },
          {
            "range": {
              "timestamp": {
                "format": "epoch_millis",
                "gte": 1638995534235,
                "lte": 1638996434235
              }
            }
          }
        ]
      }
    },
    "aggs": {
      "max_timestamp": {
        "max": {
          "field": "@timestamp"
        }
      }
    }
  }
}
```
</details>