### PR TITLE
[7.16] [Reporting] do not pass a deprecated param by default (#120671)

### DIFF
--- a/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
@@ -94,7 +94,7 @@ export class CsvGenerator {
         index: index.title,
         scroll: scrollSettings.duration,
         size: scrollSettings.size,
-        ignore_throttled: !includeFrozen,
+        ignore_throttled: includeFrozen ? false : undefined, // "true" will cause deprecation warnings logged in ES
       },
     };
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Reporting] do not pass a deprecated param by default (#120671)