### PR TITLE
[7.16] [Cases] Fix remark stringify version to match remark parse (#119995)

### DIFF
--- a/package.json
+++ b/package.json
@@ -368,7 +368,7 @@
     "redux-thunks": "^1.0.0",
     "regenerator-runtime": "^0.13.3",
     "remark-parse": "^8.0.3",
-    "remark-stringify": "^9.0.0",
+    "remark-stringify": "^8.0.3",
     "require-in-the-middle": "^5.1.0",
     "reselect": "^4.0.0",
     "resize-observer-polyfill": "^1.5.1",

--- a/x-pack/plugins/cases/common/utils/markdown_plugins/lens/serializer.ts
+++ b/x-pack/plugins/cases/common/utils/markdown_plugins/lens/serializer.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { Plugin } from 'unified';
 import type { TimeRange } from 'src/plugins/data/common';
 import { LENS_ID } from './constants';
 
@@ -13,8 +14,13 @@ export interface LensSerializerProps {
   timeRange: TimeRange;
 }
 
-export const LensSerializer = ({ timeRange, attributes }: LensSerializerProps) =>
+const serializeLens = ({ timeRange, attributes }: LensSerializerProps) =>
   `!{${LENS_ID}${JSON.stringify({
     timeRange,
     attributes,
   })}}`;
+
+export const LensSerializer: Plugin = function () {
+  const Compiler = this.Compiler;
+  Compiler.prototype.visitors.lens = serializeLens;
+};

--- a/x-pack/plugins/cases/common/utils/markdown_plugins/timeline/serializer.ts
+++ b/x-pack/plugins/cases/common/utils/markdown_plugins/timeline/serializer.ts
@@ -5,8 +5,14 @@
  * 2.0.
  */
 
+import { Plugin } from 'unified';
 export interface TimelineSerializerProps {
   match: string;
 }
 
-export const TimelineSerializer = ({ match }: TimelineSerializerProps) => match;
+const serializeTimeline = ({ match }: TimelineSerializerProps) => match;
+
+export const TimelineSerializer: Plugin = function () {
+  const Compiler = this.Compiler;
+  Compiler.prototype.visitors.timeline = serializeTimeline;
+};

--- a/x-pack/plugins/cases/common/utils/markdown_plugins/utils.test.ts
+++ b/x-pack/plugins/cases/common/utils/markdown_plugins/utils.test.ts
@@ -18,5 +18,93 @@ describe('markdown utils', () => {
       const parsed = parseCommentString('hello\n');
       expect(stringifyMarkdownComment(parsed)).toEqual('hello\n');
     });
+
+    // This check ensures the version of remark-stringify supports tables. From version 9+ this is not supported by default.
+    it('parses and stringifies github formatted markdown correctly', () => {
+      const parsed = parseCommentString(`| Tables   |      Are      |  Cool |
+      |----------|:-------------:|------:|
+      | col 1 is |  left-aligned | $1600 |
+      | col 2 is |    centered   |   $12 |
+      | col 3 is | right-aligned |    $1 |`);
+
+      expect(stringifyMarkdownComment(parsed)).toMatchInlineSnapshot(`
+        "| Tables   |      Are      |  Cool |
+        | -------- | :-----------: | ----: |
+        | col 1 is |  left-aligned | $1600 |
+        | col 2 is |    centered   |   $12 |
+        | col 3 is | right-aligned |    $1 |
+        "
+      `);
+    });
+
+    it('parses a timeline url', () => {
+      const timelineUrl =
+        '[asdasdasdasd](http://localhost:5601/moq/app/security/timelines?timeline=(id%3A%27e4362a60-f478-11eb-a4b0-ebefce184d8d%27%2CisOpen%3A!t))';
+
+      const parsedNodes = parseCommentString(timelineUrl);
+
+      expect(parsedNodes).toMatchInlineSnapshot(`
+        Object {
+          "children": Array [
+            Object {
+              "match": "[asdasdasdasd](http://localhost:5601/moq/app/security/timelines?timeline=(id%3A%27e4362a60-f478-11eb-a4b0-ebefce184d8d%27%2CisOpen%3A!t))",
+              "position": Position {
+                "end": Object {
+                  "column": 138,
+                  "line": 1,
+                  "offset": 137,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "timeline",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 138,
+              "line": 1,
+              "offset": 137,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "root",
+        }
+      `);
+    });
+
+    it('stringifies a timeline url', () => {
+      const timelineUrl =
+        '[asdasdasdasd](http://localhost:5601/moq/app/security/timelines?timeline=(id%3A%27e4362a60-f478-11eb-a4b0-ebefce184d8d%27%2CisOpen%3A!t))';
+
+      const parsedNodes = parseCommentString(timelineUrl);
+
+      expect(stringifyMarkdownComment(parsedNodes)).toEqual(`${timelineUrl}\n`);
+    });
+
+    it('parses a lens visualization', () => {
+      const lensVisualization =
+        '!{lens{"timeRange":{"from":"now-7d","to":"now","mode":"relative"},"attributes":{"title":"TEst22","type":"lens","visualizationType":"lnsMetric","state":{"datasourceStates":{"indexpattern":{"layers":{"layer1":{"columnOrder":["col2"],"columns":{"col2":{"dataType":"number","isBucketed":false,"label":"Count of records","operationType":"count","scale":"ratio","sourceField":"Records"}}}}}},"visualization":{"layerId":"layer1","accessor":"col2"},"query":{"language":"kuery","query":""},"filters":[]},"references":[{"type":"index-pattern","id":"90943e30-9a47-11e8-b64d-95841ca0b247","name":"indexpattern-datasource-current-indexpattern"},{"type":"index-pattern","id":"90943e30-9a47-11e8-b64d-95841ca0b247","name":"indexpattern-datasource-layer-layer1"}]}}}';
+
+      const parsedNodes = parseCommentString(lensVisualization);
+      expect(parsedNodes.children[0].type).toEqual('lens');
+    });
+
+    it('stringifies a lens visualization', () => {
+      const lensVisualization =
+        '!{lens{"timeRange":{"from":"now-7d","to":"now","mode":"relative"},"attributes":{"title":"TEst22","type":"lens","visualizationType":"lnsMetric","state":{"datasourceStates":{"indexpattern":{"layers":{"layer1":{"columnOrder":["col2"],"columns":{"col2":{"dataType":"number","isBucketed":false,"label":"Count of records","operationType":"count","scale":"ratio","sourceField":"Records"}}}}}},"visualization":{"layerId":"layer1","accessor":"col2"},"query":{"language":"kuery","query":""},"filters":[]},"references":[{"type":"index-pattern","id":"90943e30-9a47-11e8-b64d-95841ca0b247","name":"indexpattern-datasource-current-indexpattern"},{"type":"index-pattern","id":"90943e30-9a47-11e8-b64d-95841ca0b247","name":"indexpattern-datasource-layer-layer1"}]}}}';
+
+      const parsedNodes = parseCommentString(lensVisualization);
+
+      expect(stringifyMarkdownComment(parsedNodes)).toEqual(`${lensVisualization}\n`);
+    });
   });
 });

--- a/x-pack/plugins/cases/common/utils/markdown_plugins/utils.ts
+++ b/x-pack/plugins/cases/common/utils/markdown_plugins/utils.ts
@@ -45,20 +45,13 @@ export const parseCommentString = (comment: string) => {
 export const stringifyMarkdownComment = (comment: MarkdownNode) =>
   unified()
     .use([
-      [
-        remarkStringify,
-        {
-          allowDangerousHtml: true,
-          handlers: {
-            /*
-              because we're using rison in the timeline url we need
-              to make sure that markdown parser doesn't modify the url
-            */
-            timeline: TimelineSerializer,
-            lens: LensSerializer,
-          },
-        },
-      ],
+      [remarkStringify],
+      /*
+        because we're using rison in the timeline url we need
+        to make sure that markdown parser doesn't modify the url
+      */
+      LensSerializer,
+      TimelineSerializer,
     ])
     .stringify(comment);
 

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/user_actions.test.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/user_actions.test.ts
@@ -7,7 +7,11 @@
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import { SavedObjectMigrationContext, SavedObjectSanitizedDoc } from 'kibana/server';
+import {
+  SavedObjectMigrationContext,
+  SavedObjectSanitizedDoc,
+  SavedObjectsMigrationLogger,
+} from 'kibana/server';
 import { migrationMocks } from 'src/core/server/mocks';
 import { CaseUserActionAttributes, CASE_USER_ACTION_SAVED_OBJECT } from '../../../common';
 import {
@@ -216,7 +220,19 @@ describe('user action migrations', () => {
 
           userActionsConnectorIdMigration(userAction, context);
 
-          expect(context.log.error).toHaveBeenCalled();
+          const log = context.log as jest.Mocked<SavedObjectsMigrationLogger>;
+          expect(log.error.mock.calls[0]).toMatchInlineSnapshot(`
+            Array [
+              "Failed to migrate user action connector with doc id: 1 version: 8.0.0 error: Unexpected token a in JSON at position 1",
+              Object {
+                "migrations": Object {
+                  "userAction": Object {
+                    "id": "1",
+                  },
+                },
+              },
+            ]
+          `);
         });
       });
 
@@ -384,7 +400,19 @@ describe('user action migrations', () => {
 
           userActionsConnectorIdMigration(userAction, context);
 
-          expect(context.log.error).toHaveBeenCalled();
+          const log = context.log as jest.Mocked<SavedObjectsMigrationLogger>;
+          expect(log.error.mock.calls[0]).toMatchInlineSnapshot(`
+            Array [
+              "Failed to migrate user action connector with doc id: 1 version: 8.0.0 error: Unexpected token b in JSON at position 1",
+              Object {
+                "migrations": Object {
+                  "userAction": Object {
+                    "id": "1",
+                  },
+                },
+              },
+            ]
+          `);
         });
       });
 
@@ -554,7 +582,19 @@ describe('user action migrations', () => {
 
           userActionsConnectorIdMigration(userAction, context);
 
-          expect(context.log.error).toHaveBeenCalled();
+          const log = context.log as jest.Mocked<SavedObjectsMigrationLogger>;
+          expect(log.error.mock.calls[0]).toMatchInlineSnapshot(`
+            Array [
+              "Failed to migrate user action connector with doc id: 1 version: 8.0.0 error: Unexpected token e in JSON at position 1",
+              Object {
+                "migrations": Object {
+                  "userAction": Object {
+                    "id": "1",
+                  },
+                },
+              },
+            ]
+          `);
         });
       });
     });

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/utils.test.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/utils.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SavedObjectsMigrationLogger } from 'kibana/server';
+import { migrationMocks } from '../../../../../../src/core/server/mocks';
+import { logError } from './utils';
+
+describe('migration utils', () => {
+  const context = migrationMocks.createContext();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs an error', () => {
+    const log = context.log as jest.Mocked<SavedObjectsMigrationLogger>;
+
+    logError({
+      id: '1',
+      context,
+      error: new Error('an error'),
+      docType: 'a document',
+      docKey: 'key',
+    });
+
+    expect(log.error.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "Failed to migrate a document with doc id: 1 version: 8.0.0 error: an error",
+        Object {
+          "migrations": Object {
+            "key": Object {
+              "id": "1",
+            },
+          },
+        },
+      ]
+    `);
+  });
+});

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/utils.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/utils.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LogMeta, SavedObjectMigrationContext } from '../../../../../../src/core/server';
+
+interface MigrationLogMeta extends LogMeta {
+  migrations: {
+    [x: string]: {
+      id: string;
+    };
+  };
+}
+
+export function logError({
+  id,
+  context,
+  error,
+  docType,
+  docKey,
+}: {
+  id: string;
+  context: SavedObjectMigrationContext;
+  error: Error;
+  docType: string;
+  docKey: string;
+}) {
+  context.log.error<MigrationLogMeta>(
+    `Failed to migrate ${docType} with doc id: ${id} version: ${context.migrationVersion} error: ${error.message}`,
+    {
+      migrations: {
+        [docKey]: {
+          id,
+        },
+      },
+    }
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16396,6 +16396,11 @@ is-alphabetical@1.0.4, is-alphabetical@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
   integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
 
+is-alphanumeric@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
+  integrity sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=
+
 is-alphanumerical@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz#dfb4aa4d1085e33bdb61c2dee9c80e9c6c19f53b"
@@ -19008,7 +19013,7 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
-longest-streak@^2.0.0:
+longest-streak@^2.0.0, longest-streak@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
@@ -19261,6 +19266,13 @@ markdown-it@^11.0.0:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+markdown-table@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-2.0.0.tgz#194a90ced26d31fe753d8b9434430214c011865b"
+  integrity sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
+  dependencies:
+    repeat-string "^1.0.0"
+
 markdown-to-jsx@^6.11.4:
   version "6.11.4"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz#b4528b1ab668aef7fe61c1535c27e837819392c5"
@@ -19332,6 +19344,13 @@ mdast-squeeze-paragraphs@^4.0.0:
   integrity sha512-zxdPn69hkQ1rm4J+2Cs2j6wDEv7O17TfXTJ33tl/+JPIoEmtV9t2ZzBM5LPHE8QlHsmVD8t3vPKCyY3oH+H8MQ==
   dependencies:
     unist-util-remove "^2.0.0"
+
+mdast-util-compact@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz#cabc69a2f43103628326f35b1acf735d55c99490"
+  integrity sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==
+  dependencies:
+    unist-util-visit "^2.0.0"
 
 mdast-util-definitions@^4.0.0:
   version "4.0.0"
@@ -24447,6 +24466,26 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
+remark-stringify@^8.0.3:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-8.1.1.tgz#e2a9dc7a7bf44e46a155ec78996db896780d8ce5"
+  integrity sha512-q4EyPZT3PcA3Eq7vPpT6bIdokXzFGp9i85igjmhRyXWmPs0Y6/d2FYwUNotKAWyLch7g0ASZJn/KHHcHZQ163A==
+  dependencies:
+    ccount "^1.0.0"
+    is-alphanumeric "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    longest-streak "^2.0.1"
+    markdown-escapes "^1.0.0"
+    markdown-table "^2.0.0"
+    mdast-util-compact "^2.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    stringify-entities "^3.0.0"
+    unherit "^1.0.4"
+    xtend "^4.0.1"
+
 remark-stringify@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-9.0.1.tgz#576d06e910548b0a7191a71f27b33f1218862894"
@@ -26478,7 +26517,7 @@ string_decoder@~0.10.x:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
   integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
-stringify-entities@^3.0.1:
+stringify-entities@^3.0.0, stringify-entities@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-3.0.1.tgz#32154b91286ab0869ab2c07696223bd23b6dbfc0"
   integrity sha512-Lsk3ISA2++eJYqBMPKcr/8eby1I6L0gP0NlxF8Zja6c05yr/yCYyb2c9PwXjd08Ib3If1vn1rbs1H5ZtVuOfvQ==


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Cases] Fix remark stringify version to match remark parse (#119995)