### PR TITLE
[8.0] chore(NA): splits types from code on @kbn/es-query (#120783)

### DIFF
--- a/package.json
+++ b/package.json
@@ -566,6 +566,7 @@
     "@types/kbn__dev-utils": "link:bazel-bin/packages/kbn-dev-utils/npm_module_types",
     "@types/kbn__docs-utils": "link:bazel-bin/packages/kbn-docs-utils/npm_module_types",
     "@types/kbn__es-archiver": "link:bazel-bin/packages/kbn-es-archiver/npm_module_types",
+    "@types/kbn__es-query": "link:bazel-bin/packages/kbn-es-query/npm_module_types",
     "@types/kbn__i18n": "link:bazel-bin/packages/kbn-i18n/npm_module_types",
     "@types/kbn__i18n-react": "link:bazel-bin/packages/kbn-i18n-react/npm_module_types",
     "@types/license-checker": "15.0.0",

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -88,6 +88,7 @@ filegroup(
       "//packages/kbn-dev-utils:build_types",
       "//packages/kbn-docs-utils:build_types",
       "//packages/kbn-es-archiver:build_types",
+      "//packages/kbn-es-query:build_types",
       "//packages/kbn-i18n:build_types",
       "//packages/kbn-i18n-react:build_types",
   ],

--- a/packages/kbn-es-query/BUILD.bazel
+++ b/packages/kbn-es-query/BUILD.bazel
@@ -1,10 +1,11 @@
-load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
+load("@npm//@bazel/typescript:index.bzl", "ts_config")
 load("@npm//peggy:index.bzl", "peggy")
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
-load("//src/dev/bazel:index.bzl", "jsts_transpiler")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types", "ts_project")
 
 PKG_BASE_NAME = "kbn-es-query"
 PKG_REQUIRE_NAME = "@kbn/es-query"
+TYPES_PKG_REQUIRE_NAME = "@types/kbn__es-query"
 
 SOURCE_FILES = glob(
   [
@@ -104,7 +105,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES + [":grammar"],
-  deps = RUNTIME_DEPS + [":target_node", ":target_web", ":tsc_types"],
+  deps = RUNTIME_DEPS + [":target_node", ":target_web"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )
@@ -120,6 +121,23 @@ filegroup(
   name = "build",
   srcs = [
     ":npm_module",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+pkg_npm_types(
+  name = "npm_module_types",
+  srcs = SRCS,
+  deps = [":tsc_types"],
+  package_name = TYPES_PKG_REQUIRE_NAME,
+  tsconfig = ":tsconfig",
+  visibility = ["//visibility:public"],
+)
+
+filegroup(
+  name = "build_types",
+  srcs = [
+    ":npm_module_types",
   ],
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-es-query/package.json
+++ b/packages/kbn-es-query/package.json
@@ -2,7 +2,6 @@
   "name": "@kbn/es-query",
   "browser": "./target_web/index.js",
   "main": "./target_node/index.js",
-  "types": "./target_types/index.d.ts",
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true

--- a/packages/kbn-es-query/src/es_query/index.ts
+++ b/packages/kbn-es-query/src/es_query/index.ts
@@ -20,5 +20,6 @@ export type {
   DataViewBase,
   DataViewFieldBase,
   IFieldSubTypeMulti,
+  IFieldSubTypeMultiOptional,
   IFieldSubTypeNested,
 } from './types';

--- a/packages/kbn-es-query/src/es_query/index.ts
+++ b/packages/kbn-es-query/src/es_query/index.ts
@@ -22,4 +22,5 @@ export type {
   IFieldSubTypeMulti,
   IFieldSubTypeMultiOptional,
   IFieldSubTypeNested,
+  IFieldSubTypeNestedOptional,
 } from './types';

--- a/packages/kbn-es-query/src/kuery/index.ts
+++ b/packages/kbn-es-query/src/kuery/index.ts
@@ -23,4 +23,5 @@ export const toElasticsearchQuery = (...params: Parameters<typeof astToElasticse
 export { KQLSyntaxError } from './kuery_syntax_error';
 export { nodeTypes, nodeBuilder } from './node_types';
 export { fromKueryExpression } from './ast';
-export type { DslQuery, KueryNode, KueryQueryOptions } from './types';
+export type { FunctionTypeBuildNode, NodeTypes } from './node_types';
+export type { DslQuery, KueryNode, KueryQueryOptions, KueryParseOptions } from './types';

--- a/packages/kbn-es-query/src/kuery/node_types/index.ts
+++ b/packages/kbn-es-query/src/kuery/node_types/index.ts
@@ -10,9 +10,9 @@ import * as functionType from './function';
 import * as literal from './literal';
 import * as namedArg from './named_arg';
 import * as wildcard from './wildcard';
-import { NodeTypes } from './types';
+import { FunctionTypeBuildNode, NodeTypes } from './types';
 
-export type { NodeTypes };
+export type { FunctionTypeBuildNode, NodeTypes };
 export { nodeBuilder } from './node_builder';
 
 /**

--- a/packages/kbn-rule-data-utils/BUILD.bazel
+++ b/packages/kbn-rule-data-utils/BUILD.bazel
@@ -34,7 +34,7 @@ RUNTIME_DEPS = [
 ]
 
 TYPES_DEPS = [
-  "//packages/kbn-es-query",
+  "//packages/kbn-es-query:npm_module_types",
   "@npm//@elastic/elasticsearch",
   "@npm//tslib",
   "@npm//utility-types",

--- a/packages/kbn-securitysolution-autocomplete/BUILD.bazel
+++ b/packages/kbn-securitysolution-autocomplete/BUILD.bazel
@@ -46,7 +46,7 @@ RUNTIME_DEPS = [
 ]
 
 TYPES_DEPS = [
-  "//packages/kbn-es-query",
+  "//packages/kbn-es-query:npm_module_types",
   "//packages/kbn-i18n",
   "//packages/kbn-securitysolution-list-hooks",
   "//packages/kbn-securitysolution-list-utils",

--- a/packages/kbn-securitysolution-list-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-utils/BUILD.bazel
@@ -38,11 +38,12 @@ RUNTIME_DEPS = [
 ]
 
 TYPES_DEPS = [
-  "//packages/kbn-es-query",
-  "//packages/kbn-i18n",
+  "//packages/kbn-es-query:npm_module_types",
+  "//packages/kbn-i18n:npm_module_types",
   "//packages/kbn-securitysolution-io-ts-list-types",
   "//packages/kbn-securitysolution-list-constants",
   "//packages/kbn-securitysolution-utils",
+  "@npm//@elastic/elasticsearch",
   "@npm//@types/jest",
   "@npm//@types/lodash",
   "@npm//@types/node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5816,6 +5816,10 @@
   version "0.0.0"
   uid ""
 
+"@types/kbn__es-query@link:bazel-bin/packages/kbn-es-query/npm_module_types":
+  version "0.0.0"
+  uid ""
+
 "@types/kbn__i18n-react@link:bazel-bin/packages/kbn-i18n-react/npm_module_types":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
Backports the following commits to 8.0:
 - chore(NA): splits types from code on @kbn/es-query (#120783)