### PR TITLE
[RAC][Observability] stop indexing severity value in uptime

### DIFF
--- a/x-pack/plugins/uptime/server/lib/alerts/duration_anomaly.test.ts
+++ b/x-pack/plugins/uptime/server/lib/alerts/duration_anomaly.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 import {
-  ALERT_SEVERITY,
   ALERT_EVALUATION_VALUE,
   ALERT_EVALUATION_THRESHOLD,
   ALERT_REASON,
@@ -170,7 +169,6 @@ describe('duration anomaly alert', () => {
             'observer.geo.name': anomaly.entityValue,
             [ALERT_EVALUATION_VALUE]: anomaly.actualSort,
             [ALERT_EVALUATION_THRESHOLD]: anomaly.typicalSort,
-            [ALERT_SEVERITY]: getSeverityType(anomaly.severity),
             [ALERT_REASON]: `Abnormal (${getSeverityType(
               anomaly.severity
             )} level) response time detected on uptime-monitor with url ${

--- a/x-pack/plugins/uptime/server/lib/alerts/duration_anomaly.ts
+++ b/x-pack/plugins/uptime/server/lib/alerts/duration_anomaly.ts
@@ -8,7 +8,6 @@ import { KibanaRequest, SavedObjectsClientContract } from 'kibana/server';
 import moment from 'moment';
 import { schema } from '@kbn/config-schema';
 import {
-  ALERT_SEVERITY,
   ALERT_EVALUATION_VALUE,
   ALERT_EVALUATION_THRESHOLD,
   ALERT_REASON,
@@ -134,7 +133,6 @@ export const durationAnomalyAlertFactory: UptimeAlertTypeFactory<ActionGroupIds>
             'anomaly.bucket_span.minutes': summary.bucketSpan,
             [ALERT_EVALUATION_VALUE]: anomaly.actualSort,
             [ALERT_EVALUATION_THRESHOLD]: anomaly.typicalSort,
-            [ALERT_SEVERITY]: summary.severity,
             [ALERT_REASON]: generateAlertMessage(
               CommonDurationAnomalyTranslations.defaultActionMessage,
               summary

--- a/x-pack/plugins/uptime/server/lib/alerts/status_check.test.ts
+++ b/x-pack/plugins/uptime/server/lib/alerts/status_check.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { ALERT_REASON, ALERT_SEVERITY_WARNING, ALERT_SEVERITY } from '@kbn/rule-data-utils';
+import { ALERT_REASON } from '@kbn/rule-data-utils';
 import {
   generateFilterDSL,
   hasFilters,
@@ -75,7 +75,6 @@ const mockStatusAlertDocument = (
       [ALERT_REASON]: `Monitor first with url ${monitorInfo?.url?.full} is down from ${
         monitorInfo.observer?.geo?.name
       }. The latest error message is ${monitorInfo.error?.message || ''}`,
-      [ALERT_SEVERITY]: ALERT_SEVERITY_WARNING,
     },
     id: getInstanceId(
       monitorInfo,
@@ -96,7 +95,6 @@ const mockAvailabilityAlertDocument = (monitor: GetMonitorAvailabilityResult) =>
       )}% availability expected is 99.34% from ${
         monitorInfo.observer?.geo?.name
       }. The latest error message is ${monitorInfo.error?.message || ''}`,
-      [ALERT_SEVERITY]: ALERT_SEVERITY_WARNING,
     },
     id: getInstanceId(monitorInfo, `${monitorInfo?.monitor.id}-${monitorInfo.observer?.geo?.name}`),
   };

--- a/x-pack/plugins/uptime/server/lib/alerts/status_check.ts
+++ b/x-pack/plugins/uptime/server/lib/alerts/status_check.ts
@@ -7,7 +7,6 @@
 import { min } from 'lodash';
 import datemath from '@elastic/datemath';
 import { schema } from '@kbn/config-schema';
-import { ALERT_SEVERITY_WARNING, ALERT_SEVERITY } from '@kbn/rule-data-utils';
 import { i18n } from '@kbn/i18n';
 import { JsonObject } from '@kbn/utility-types';
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
@@ -159,7 +158,6 @@ export const getMonitorAlertDocument = (monitorSummary: Record<string, string | 
   'observer.geo.name': monitorSummary.observerLocation,
   'error.message': monitorSummary.latestErrorMessage,
   'agent.name': monitorSummary.observerHostname,
-  [ALERT_SEVERITY]: ALERT_SEVERITY_WARNING,
   [ALERT_REASON]: monitorSummary.reason,
 });
 

--- a/x-pack/plugins/uptime/server/lib/alerts/tls.test.ts
+++ b/x-pack/plugins/uptime/server/lib/alerts/tls.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 import moment from 'moment';
-import { ALERT_SEVERITY_WARNING, ALERT_SEVERITY } from '@kbn/rule-data-utils';
 import { tlsAlertFactory, getCertSummary } from './tls';
 import { TLS } from '../../../common/constants/alerts';
 import { CertResult, DynamicSettings } from '../../../common/runtime_types';
@@ -115,7 +114,6 @@ describe('tls alert', () => {
             'tls.server.x509.not_after': cert.not_after,
             'tls.server.x509.not_before': cert.not_before,
             'tls.server.hash.sha256': cert.sha256,
-            [ALERT_SEVERITY]: ALERT_SEVERITY_WARNING,
           }),
           id: `${cert.common_name}-${cert.issuer?.replace(/\s/g, '_')}-${cert.sha256}`,
         });

--- a/x-pack/plugins/uptime/server/lib/alerts/tls.ts
+++ b/x-pack/plugins/uptime/server/lib/alerts/tls.ts
@@ -6,7 +6,7 @@
  */
 import moment from 'moment';
 import { schema } from '@kbn/config-schema';
-import { ALERT_REASON, ALERT_SEVERITY_WARNING, ALERT_SEVERITY } from '@kbn/rule-data-utils';
+import { ALERT_REASON } from '@kbn/rule-data-utils';
 import { UptimeAlertTypeFactory } from './types';
 import { updateState, generateAlertMessage } from './common';
 import { TLS } from '../../../common/constants/alerts';
@@ -167,7 +167,6 @@ export const tlsAlertFactory: UptimeAlertTypeFactory<ActionGroupIds> = (_server,
             'tls.server.x509.not_after': cert.not_after,
             'tls.server.x509.not_before': cert.not_before,
             'tls.server.hash.sha256': cert.sha256,
-            [ALERT_SEVERITY]: ALERT_SEVERITY_WARNING,
             [ALERT_REASON]: generateAlertMessage(TlsTranslations.defaultActionMessage, summary),
           },
         });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/120868

### Notes for the reviewer
Could you verify that the severity `indexed value` is not used in the construction of the reason message? I didn't find any usage of it in the reason, but I would like a confirmation.