### PR TITLE
Unskip a11y tests

### DIFF
--- a/x-pack/test/accessibility/apps/lens.ts
+++ b/x-pack/test/accessibility/apps/lens.ts
@@ -15,8 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const listingTable = getService('listingTable');
   const kibanaServer = getService('kibanaServer');
 
-  // Failing: See https://github.com/elastic/kibana/issues/115614
-  describe.skip('Lens', () => {
+  describe('Lens', () => {
     const lensChartName = 'MyLensChart';
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/115614

Unskips Lens a11y tests as the EUI blocker has been fixed.