### PR TITLE
[Fleet] Fix bug caused by API changes

### DIFF
--- a/x-pack/plugins/fleet/server/routes/epm/index.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/index.ts
@@ -172,7 +172,8 @@ export const registerRoutes = (routers: { rbac: FleetRouter; superuser: FleetRou
         response
       );
       if (resp.payload?.item) {
-        return response.ok({ body: { response: resp.payload.item } });
+        // returning item as well here, because pkgVersion is optional in new GET endpoint, and if not specified, the router selects the deprecated route
+        return response.ok({ body: { item: resp.payload.item, response: resp.payload.item } });
       }
       return resp;
     }

--- a/x-pack/test/fleet_api_integration/apis/epm/get.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/get.ts
@@ -102,5 +102,15 @@ export default function (providerContext: FtrProviderContext) {
         .auth(testUsers.fleet_read_only.username, testUsers.fleet_read_only.password)
         .expect(200);
     });
+
+    it('returns package info in item field when calling without version', async function () {
+      // this will install through the registry by default
+      await installPackage(testPkgName, testPkgVersion);
+      const res = await supertest.get(`/api/fleet/epm/packages/${testPkgName}`).expect(200);
+      const packageInfo = res.body.item;
+      // the uploaded version will have this description
+      expect(packageInfo.name).to.equal('apache');
+      await uninstallPackage(testPkgName, testPkgVersion);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixed bug caused by API changes in https://github.com/elastic/kibana/pull/119494

Steps to reproduce:
1. Go to kibana Integrations
2. Select Endpoint Security (this url: http://localhost:5601/julia/app/integrations/detail/endpoint/overview)
3. Page not loading, giving an error.
Expected with this fix: Endpoint page opens as expected without error

![image](https://user-images.githubusercontent.com/90178898/145391345-bc52e949-c977-46df-ac96-599ce87e4c49.png)

Root cause: 

Made `/epm/packages/pkgkey` route deprecated returning `response` field, and instead using `/epm/packages/pkgName/pkgVersion` returning `item` field from UI.

In some cases, `pkgVersion` is not specified (optional path param), and in this case, router calls the deprecated API.
To fix this, I'm returning `item` field from deprecated API as well. This makes it easier to remove the deprecated API later, since the UI is already using the new `item` field.

After fix:
![image](https://user-images.githubusercontent.com/90178898/145391972-e3d4d7b2-d760-4783-91b8-00b797ada700.png)



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
