### PR TITLE
canvas plugin lifecycle

### DIFF
--- a/src/plugins/presentation_util/public/plugin.ts
+++ b/src/plugins/presentation_util/public/plugin.ts
@@ -67,7 +67,9 @@ export class PresentationUtilPlugin
     };
     embeddable.registerEmbeddableFactory(OPTIONS_LIST_CONTROL, optionsListFactory);
 
-    return {};
+    return {
+      registerExpressionsLanguage,
+    };
   }
 
   public start(

--- a/src/plugins/presentation_util/public/types.ts
+++ b/src/plugins/presentation_util/public/types.ts
@@ -13,8 +13,9 @@ import { DataViewsPublicPluginStart } from '../../data_views/public';
 import { EmbeddableSetup, EmbeddableStart } from '../../embeddable/public';
 import { registerExpressionsLanguage } from '.';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface PresentationUtilPluginSetup {}
+export interface PresentationUtilPluginSetup {
+  registerExpressionsLanguage: typeof registerExpressionsLanguage;
+}
 
 export interface PresentationUtilPluginStart {
   ContextProvider: React.FC;

--- a/x-pack/plugins/canvas/canvas_plugin_src/plugin.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/plugin.ts
@@ -41,18 +41,19 @@ export class CanvasSrcPlugin implements Plugin<void, void, SetupDeps, StartDeps>
 
     plugins.canvas.addRenderers(renderFunctions);
 
-    core.getStartServices().then(([coreStart, depsStart]) => {
-      const externalFunctions = initFunctions({
-        embeddablePersistableStateService: {
-          extract: depsStart.embeddable.extract,
-          inject: depsStart.embeddable.inject,
-        },
-      });
-      plugins.canvas.addFunctions(externalFunctions);
-      plugins.canvas.addRenderers(
-        renderFunctionFactories.map((factory: any) => factory(coreStart, depsStart))
-      );
+    const externalFunctions = initFunctions({
+      embeddablePersistableStateService: {
+        extract: plugins.embeddable.extract,
+        inject: plugins.embeddable.inject,
+      },
     });
+    plugins.canvas.addFunctions(externalFunctions);
+
+    // pass core.getStartServices into your  factories (don't await and pass in results)
+    // this allows us to register things at setup time
+    plugins.canvas.addRenderers(
+      renderFunctionFactories.map((factory: any) => factory(core.getStartServices))
+    );
 
     plugins.canvas.addDatasourceUIs(async () => {
       // @ts-expect-error

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { CoreStart } from '../../../../../../src/core/public';
+import { CoreStart, StartServicesAccessor } from '../../../../../../src/core/public';
 import { StartDeps } from '../../plugin';
 import { KibanaThemeProvider } from '../../../../../../src/plugins/kibana_react/public';
 import {
@@ -57,16 +57,18 @@ const renderEmbeddableFactory = (core: CoreStart, plugins: StartDeps) => {
 };
 
 export const embeddableRendererFactory = (
-  core: CoreStart,
-  plugins: StartDeps
+  getStartServices: StartServicesAccessor<StartDeps>
 ): RendererFactory<EmbeddableExpression<EmbeddableInput>> => {
-  const renderEmbeddable = renderEmbeddableFactory(core, plugins);
   return () => ({
     name: 'embeddable',
     displayName: strings.getDisplayName(),
     help: strings.getHelpDescription(),
     reuseDomNode: true,
     render: async (domNode, { input, embeddableType }, handlers) => {
+      const [core, plugins] = await getStartServices();
+
+      const renderEmbeddable = renderEmbeddableFactory(core, plugins);
+
       const uniqueId = handlers.getElementId();
       const isByValueEnabled = plugins.presentationUtil.labsService.isProjectEnabled(
         'labs:canvas:byValueEmbeddable'

--- a/x-pack/plugins/canvas/public/plugin.tsx
+++ b/x-pack/plugins/canvas/public/plugin.tsx
@@ -37,7 +37,7 @@ import { PresentationUtilPluginStart } from '../../../../src/plugins/presentatio
 import { getPluginApi, CanvasApi } from './plugin_api';
 import { setupExpressions } from './setup_expressions';
 import { pluginServiceRegistry } from './services/kibana';
-
+import { CanvasSrcPlugin } from '../canvas_plugin_src/plugin';
 export type { CoreStart, CoreSetup };
 
 /**
@@ -103,6 +103,12 @@ export class CanvasPlugin
       }));
     }
 
+    setupExpressions({ coreSetup, setupPlugins });
+
+    const srcPlugin = new CanvasSrcPlugin();
+
+    srcPlugin.setup(coreSetup, { canvas: canvasApi });
+
     coreSetup.application.register({
       category: DEFAULT_APP_CATEGORIES.kibana,
       id: CANVAS_APP,
@@ -111,12 +117,6 @@ export class CanvasPlugin
       order: 3000,
       updater$: this.appUpdater,
       mount: async (params: AppMountParameters) => {
-        const { CanvasSrcPlugin } = await import('../canvas_plugin_src/plugin');
-        const srcPlugin = new CanvasSrcPlugin();
-
-        srcPlugin.setup(coreSetup, { canvas: canvasApi });
-        setupExpressions({ coreSetup, setupPlugins });
-
         // Get start services
         const [coreStart, startPlugins] = await coreSetup.getStartServices();
 


### PR DESCRIPTION
## Summary

canvas currently doesn't register expression functions and renderers in time (setup lifecycle)

all the renderers (and functions) accepting start services in should be refactored to rather get `getStartServices` accessor in and resolve it when executed and then the registration should be moved to correct place.


