### PR TITLE
[7.16] [Fleet] Use deterministic UUID's for default policies (#120776)

### DIFF
--- a/x-pack/plugins/fleet/common/constants/preconfiguration.ts
+++ b/x-pack/plugins/fleet/common/constants/preconfiguration.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import uuidv5 from 'uuid/v5';
+
 import type { PreconfiguredAgentPolicy } from '../types';
 
 import {
@@ -15,6 +17,9 @@ import {
   monitoringTypes,
 } from './epm';
 
+// UUID v5 values require a namespace. We use UUID v5 for some of our preconfigured ID values.
+export const UUID_V5_NAMESPACE = 'dde7c2de-1370-4c19-9975-b473d0e03508';
+
 export const PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE =
   'fleet-preconfiguration-deletion-record';
 
@@ -22,14 +27,16 @@ export const PRECONFIGURATION_LATEST_KEYWORD = 'latest';
 
 type PreconfiguredAgentPolicyWithDefaultInputs = Omit<
   PreconfiguredAgentPolicy,
-  'package_policies' | 'id'
+  'package_policies'
 > & {
   package_policies: Array<Omit<PreconfiguredAgentPolicy['package_policies'][0], 'inputs'>>;
 };
 
+export const DEFAULT_AGENT_POLICY_ID_SEED = 'default-agent-policy';
 export const DEFAULT_SYSTEM_PACKAGE_POLICY_ID = 'default-system-policy';
 
 export const DEFAULT_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
+  id: uuidv5(DEFAULT_AGENT_POLICY_ID_SEED, UUID_V5_NAMESPACE),
   name: 'Default policy',
   namespace: 'default',
   description: 'Default agent policy created by Kibana',
@@ -47,9 +54,11 @@ export const DEFAULT_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
   monitoring_enabled: monitoringTypes,
 };
 
-export const DEFAULT_FLEET_SERVER_POLICY_ID = 'default-fleet-server-policy';
+export const DEFAULT_FLEET_SERVER_POLICY_ID = 'default-fleet-server-agent-policy';
+export const DEFAULT_FLEET_SERVER_AGENT_POLICY_ID_SEED = 'default-fleet-server';
 
 export const DEFAULT_FLEET_SERVER_AGENT_POLICY: PreconfiguredAgentPolicyWithDefaultInputs = {
+  id: uuidv5(DEFAULT_FLEET_SERVER_AGENT_POLICY_ID_SEED, UUID_V5_NAMESPACE),
   name: 'Default Fleet Server policy',
   namespace: 'default',
   description: 'Default Fleet Server agent policy created by Kibana',


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Fleet] Use deterministic UUID's for default policies (#120776)