### PR TITLE
[Fleet] fix setup error during test

### DIFF
--- a/src/core/server/saved_objects/migrations/integration_tests/7_13_0_failed_action_tasks.test.ts
+++ b/src/core/server/saved_objects/migrations/integration_tests/7_13_0_failed_action_tasks.test.ts
@@ -19,8 +19,7 @@ async function removeLogFile() {
   await fs.unlink(logFilePath).catch(() => void 0);
 }
 
-// FLAKY: https://github.com/elastic/kibana/issues/118626
-describe.skip('migration from 7.13 to 7.14+ with many failed action_tasks', () => {
+describe('migration from 7.13 to 7.14+ with many failed action_tasks', () => {
   let esServer: kbnTestServer.TestElasticsearchUtils;
   let root: Root;
   let startES: () => Promise<kbnTestServer.TestElasticsearchUtils>;

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -341,7 +341,7 @@ export async function ensureDefaultComponentTemplate(
     await putComponentTemplate(esClient, logger, {
       name: FLEET_GLOBAL_COMPONENT_TEMPLATE_NAME,
       body: FLEET_GLOBAL_COMPONENT_TEMPLATE_CONTENT,
-    });
+    }).clusterPromise;
   }
 
   return { isCreated: !existingTemplate };


### PR DESCRIPTION
## Summary

Fixing flaky tests caused by error in fleet setup after stop is invoked
https://github.com/elastic/kibana/issues/118626
https://github.com/elastic/kibana/issues/120840

The culprit was a missing await of a promise inside setup.
I could simulate this locally by adding a mockFunction in putComponentTemplate to return a Promise.reject:

```
const mockFunction = () => Promise.reject(new EsErrors.NoLivingConnectionsError());
function putComponentTemplate(...) {
...
  return {
    clusterPromise: retryTransientEsErrors(
      () => mockFunction(),
      { logger }
    ),
    name,
  };
}
```

In kibana logs verified that server doesn't crash on this error like before, and `Fleet setup failed` is logged.
```
[2021-12-09T16:02:20.524+01:00][WARN ][plugins.fleet] Fleet setup failed
[2021-12-09T16:02:20.524+01:00][WARN ][plugins.fleet] NoLivingConnectionsError: Given the configuration, the ConnectionPool was not able to find a usable Connection for this request.
    at mockFunction (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts:207:43)
    at esCall (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts:220:13)
    at retryTransientEsErrors (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/services/epm/elasticsearch/retry.ts:35:18)
    at retryTransientEsErrors (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/services/epm/elasticsearch/retry.ts:48:14)
    at ensureDefaultComponentTemplate (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts:342:5)
    at async Promise.all (index 0)
    at ensureFleetGlobalEsAssets (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/services/setup.ts:141:27)
    at createSetupSideEffects (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/services/setup.ts:76:5)
    at awaitIfPending (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/services/setup_utils.ts:30:20)
    at /Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/plugin.ts:381:9
[2021-12-09T16:02:20.532+01:00][INFO ][plugins.securitySolution] Dependent plugin setup complete - Starting ManifestTask
```