### PR TITLE
[8.0] [Expressions] Fix execution to forward the same variables context into a subexpression (#120628)

### DIFF
--- a/src/plugins/expressions/common/execution/execution.test.ts
+++ b/src/plugins/expressions/common/execution/execution.test.ts
@@ -310,6 +310,13 @@ describe('Execution', () => {
       const { result } = await run('var name="foo"', { variables });
       expect(result).toBe('bar');
     });
+
+    test('can access variables set from the parent expression', async () => {
+      const { result } = await run(
+        'var_set name="a" value="bar" | var_set name="b" value={var name="a"} | var name="b"'
+      );
+      expect(result).toBe('bar');
+    });
   });
 
   describe('inspector adapters', () => {

--- a/src/plugins/expressions/common/execution/execution.ts
+++ b/src/plugins/expressions/common/execution/execution.ts
@@ -559,10 +559,10 @@ export class Execution<
   interpret<T>(ast: ExpressionAstNode, input: T): Observable<ExecutionResult<unknown>> {
     switch (getType(ast)) {
       case 'expression':
-        const execution = this.execution.executor.createExecution(
-          ast as ExpressionAstExpression,
-          this.execution.params
-        );
+        const execution = this.execution.executor.createExecution(ast as ExpressionAstExpression, {
+          ...this.execution.params,
+          variables: this.context.variables,
+        });
         this.childExecutions.push(execution);
 
         return execution.start(input, true);


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Expressions] Fix execution to forward the same variables context into a subexpression (#120628)