### PR TITLE
[Fleet] Skip packages w/ ml models during setup

### DIFF
--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -180,7 +180,7 @@ export async function ensurePreconfiguredPackagesAndPolicies(
       pkgVersion: '',
     });
 
-    if (packageInfo.assets.elasticsearch?.ml_model?.length > 0) {
+    if (packageInfo.assets?.elasticsearch?.ml_model?.length > 0) {
       logger.warn(
         `Package ${pkg.name} contains Machine Learning models and cannot be installed via preconfiguration. Skipping.`
       );


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/120903

Check preconfigured packages for `ml_model` Elasticseach assets and log a warning + skip their installation before continuing with setup.

WIP because I'd like to figure out adding tests for this before review. 