### PR TITLE
[Fleet] Add CA fingerprint field to the output form

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
@@ -136,6 +136,27 @@ export const EditOutputFlyout: React.FunctionComponent<EditOutputFlyoutProps> = 
             {...inputs.elasticsearchUrlInput.props}
           />
           <EuiFormRow
+            fullWidth
+            label={
+              <FormattedMessage
+                id="xpack.fleet.settings.editOutputFlyout.caTrustedFingerprintInputLabel"
+                defaultMessage="Elasticsearch CA trusted fingerprint (optional)"
+              />
+            }
+            {...inputs.caTrustedFingerprintInput.formRowProps}
+          >
+            <EuiFieldText
+              fullWidth
+              {...inputs.caTrustedFingerprintInput.props}
+              placeholder={i18n.translate(
+                'xpack.fleet.settings.editOutputFlyout.caTrustedFingerprintInputPlaceholder',
+                {
+                  defaultMessage: 'Specify Elasticsearch CA trusted fingerprint',
+                }
+              )}
+            />
+          </EuiFormRow>
+          <EuiFormRow
             label={i18n.translate('xpack.fleet.settings.editOutputFlyout.yamlConfigInputLabel', {
               defaultMessage: 'Advanced YAML configuration',
             })}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
@@ -71,3 +71,13 @@ export function validateName(value: string) {
     ];
   }
 }
+
+export function validateCATrustedFingerPrint(value: string) {
+  if (value !== '' && !value.match(/^[a-zA-Z0-9]$/)) {
+    return [
+      i18n.translate('xpack.fleet.settings.outputForm.caTrusterdFingerprintInvalidErrorMessage', {
+        defaultMessage: 'CA trusted fingerprint should be a base64 CA sha256 fingerprint',
+      }),
+    ];
+  }
+}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -22,7 +22,12 @@ import type { Output, PostOutputRequest } from '../../../../types';
 import { useConfirmModal } from '../../hooks/use_confirm_modal';
 import { getAgentAndPolicyCountForOutput } from '../../services/agent_and_policies_count';
 
-import { validateName, validateHosts, validateYamlConfig } from './output_form_validators';
+import {
+  validateName,
+  validateHosts,
+  validateYamlConfig,
+  validateCATrustedFingerPrint,
+} from './output_form_validators';
 
 const ConfirmTitle = () => (
   <FormattedMessage
@@ -111,6 +116,12 @@ export function useOutputForm(onSucess: () => void, output?: Output) {
     isPreconfigured
   );
 
+  const caTrustedFingerprintInput = useInput(
+    output?.ca_trusted_fingerprint ?? '',
+    validateCATrustedFingerPrint,
+    isPreconfigured
+  );
+
   const defaultOutputInput = useSwitchInput(
     output?.is_default ?? false,
     isPreconfigured || output?.is_default
@@ -127,6 +138,7 @@ export function useOutputForm(onSucess: () => void, output?: Output) {
     additionalYamlConfigInput,
     defaultOutputInput,
     defaultMonitoringOutputInput,
+    caTrustedFingerprintInput,
   };
 
   const hasChanged = Object.values(inputs).some((input) => input.hasChanged);
@@ -135,13 +147,19 @@ export function useOutputForm(onSucess: () => void, output?: Output) {
     const nameInputValid = nameInput.validate();
     const elasticsearchUrlsValid = elasticsearchUrlInput.validate();
     const additionalYamlConfigValid = additionalYamlConfigInput.validate();
+    const caTrustedFingerprintValid = caTrustedFingerprintInput.validate();
 
-    if (!elasticsearchUrlsValid || !additionalYamlConfigValid || !nameInputValid) {
+    if (
+      !elasticsearchUrlsValid ||
+      !additionalYamlConfigValid ||
+      !nameInputValid ||
+      !caTrustedFingerprintValid
+    ) {
       return false;
     }
 
     return true;
-  }, [nameInput, elasticsearchUrlInput, additionalYamlConfigInput]);
+  }, [nameInput, elasticsearchUrlInput, additionalYamlConfigInput, caTrustedFingerprintInput]);
 
   const submit = useCallback(async () => {
     try {
@@ -157,6 +175,7 @@ export function useOutputForm(onSucess: () => void, output?: Output) {
         is_default: defaultOutputInput.value,
         is_default_monitoring: defaultMonitoringOutputInput.value,
         config_yaml: additionalYamlConfigInput.value,
+        ca_trusted_fingerprint: caTrustedFingerprintInput.value,
       };
 
       if (output) {
@@ -195,6 +214,7 @@ export function useOutputForm(onSucess: () => void, output?: Output) {
     defaultMonitoringOutputInput.value,
     defaultOutputInput.value,
     elasticsearchUrlInput.value,
+    caTrustedFingerprintInput.value,
     nameInput.value,
     notifications.toasts,
     onSucess,


### PR DESCRIPTION
## Summary

Description show and allow user to edit the new ca trusted fingerprint field in the output UI 

## UI Changes

### For preconfigured policies

<img width="658" alt="Screen Shot 2021-12-09 at 12 47 34 PM" src="https://user-images.githubusercontent.com/1336873/145449313-839c1709-c329-4267-a6d0-289d3e5ca42e.png">


### For other policies

<img width="721" alt="Screen Shot 2021-12-09 at 12 43 07 PM" src="https://user-images.githubusercontent.com/1336873/145449318-7a1d87d6-6934-4d75-86ba-2afca19dfc14.png">


cc @mostlyjason 