### PR TITLE
[Workplace Search] Improve GitHub apps frontend validation

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/github_via_app.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/github_via_app.tsx
@@ -44,8 +44,13 @@ interface GithubViaAppProps {
 
 export const GitHubViaApp: React.FC<GithubViaAppProps> = ({ isGithubEnterpriseServer }) => {
   const { isOrganization } = useValues(AppLogic);
-  const { githubAppId, githubEnterpriseServerUrl, isSubmitButtonLoading, indexPermissionsValue } =
-    useValues(GithubViaAppLogic);
+  const {
+    githubAppId,
+    githubEnterpriseServerUrl,
+    stagedPrivateKey,
+    isSubmitButtonLoading,
+    indexPermissionsValue,
+  } = useValues(GithubViaAppLogic);
   const {
     setGithubAppId,
     setGithubEnterpriseServerUrl,
@@ -118,7 +123,12 @@ export const GitHubViaApp: React.FC<GithubViaAppProps> = ({ isGithubEnterpriseSe
           fill
           type="submit"
           isLoading={isSubmitButtonLoading}
-          isDisabled={!githubAppId || (isGithubEnterpriseServer && !githubEnterpriseServerUrl)}
+          isDisabled={
+            // disable submit button if any required fields are empty
+            !githubAppId ||
+            (isGithubEnterpriseServer && !githubEnterpriseServerUrl) ||
+            !stagedPrivateKey
+          }
         >
           {isSubmitButtonLoading ? 'Connecting…' : `Connect ${name}`}
         </EuiButton>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/workplace-search-team/issues/2232

Improve GitHub apps frontend validation by disabling the submit button 
if the private key has not been uploaded.

Note: the validation will not work if a user removes the file
from the file picker after uploading it, as the file picker doesn't call the
onChange callback on that action.

Before:

https://user-images.githubusercontent.com/11838280/145452500-64b23edd-30ed-4849-8cf2-386e2cbebac7.mp4

After:

https://user-images.githubusercontent.com/11838280/145452390-0baf894f-80cb-4ac5-9dc1-e7b406568ee2.mp4

### Checklist

Tests are intentionally omitted.

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
