### PR TITLE
[APM] disable fleet depreaction warning

### DIFF
--- a/x-pack/plugins/apm/server/plugin.ts
+++ b/x-pack/plugins/apm/server/plugin.ts
@@ -47,7 +47,6 @@ import {
   TRANSACTION_TYPE,
 } from '../common/elasticsearch_fieldnames';
 import { tutorialProvider } from './tutorial';
-import { getDeprecations } from './deprecations';
 
 export class APMPlugin
   implements
@@ -195,14 +194,6 @@ export class APMPlugin
       config: currentConfig,
       logger: this.logger,
       kibanaVersion: this.initContext.env.packageInfo.version,
-    });
-
-    core.deprecations.registerDeprecations({
-      getDeprecations: getDeprecations({
-        cloudSetup: plugins.cloud,
-        fleet: resourcePlugins.fleet,
-        branch: this.initContext.env.packageInfo.branch,
-      }),
     });
 
     return {


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/120987

This PR removes the apm integration deprecation warning