### PR TITLE
[build/docker] Use /tmp to store kibana archive

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -16,7 +16,7 @@ RUN {{packageManager}} install -y findutils tar gzip
 {{/ubi}}
 
 {{#usePublicArtifact}}
-RUN cd /opt && \
+RUN cd /tmp && \
   curl --retry 8 -s -L \
     --output kibana.tar.gz \
      https://artifacts.elastic.co/downloads/kibana/{{artifactPrefix}}-$(arch).tar.gz && \


### PR DESCRIPTION
When introducing the cloud docker variant we started installing archives from /tmp instead of /opt.  This was mistakenly not updated in our docker build contexts, which download the public archives post release.