### PR TITLE
[Security Solutions] Fixes telemetry to work with alerts on cases

### DIFF
--- a/x-pack/plugins/security_solution/server/usage/collector.ts
+++ b/x-pack/plugins/security_solution/server/usage/collector.ts
@@ -9,6 +9,7 @@ import { CoreSetup, SavedObjectsClientContract } from '../../../../../src/core/s
 import { CollectorFetchContext } from '../../../../../src/plugins/usage_collection/server';
 import { CollectorDependencies } from './types';
 import { fetchDetectionsMetrics } from './detections';
+import { SAVED_OBJECT_TYPES } from '../../../cases/common/constants';
 
 export type RegisterCollector = (deps: CollectorDependencies) => void;
 export interface UsageData {
@@ -17,7 +18,8 @@ export interface UsageData {
 
 export async function getInternalSavedObjectsClient(core: CoreSetup) {
   return core.getStartServices().then(async ([coreStart]) => {
-    return coreStart.savedObjects.createInternalRepository();
+    // note: we include the cases hidden types here otherwise we would not be able to query them. If at some point cases is not considered a hidden type this can be removed
+    return coreStart.savedObjects.createInternalRepository(SAVED_OBJECT_TYPES);
   });
 }
 


### PR DESCRIPTION
## Summary

One line fix to where we have to expose cases to the saved object client as hidden to work with telemetry. This one liner was broken out from:
https://github.com/elastic/kibana/pull/120809

So we could back-port easier to earlier versions.

Manual testing:
To see telemetry go to advanced settings -> Usage Data (and click cluster data):
<img width="2193" alt="Screen Shot 2021-12-08 at 4 14 43 PM" src="https://user-images.githubusercontent.com/1151048/145477392-8cab122c-cf7a-41c6-bac4-0aa389e9f914.png">


And you will see it like so:
<img width="420" alt="Screen Shot 2021-12-08 at 4 43 10 PM" src="https://user-images.githubusercontent.com/1151048/145477286-5dcdc3ef-1fde-4407-aaa8-2b7b5bece74d.png">

