### PR TITLE
Line break before mathColumn's accepted data type

### DIFF
--- a/docs/canvas/canvas-function-reference.asciidoc
+++ b/docs/canvas/canvas-function-reference.asciidoc
@@ -1867,6 +1867,7 @@ Default: `"throw"`
 === `mathColumn`
 
 Adds a column by evaluating `TinyMath` on each row. This function is optimized for math, so it performs better than the <<mapColumn_fn>> with a <<math_fn>>.
+
 *Accepts:* `datatable`
 
 [cols="3*^<"]


### PR DESCRIPTION
## Summary

There is currently no line break after mathColumn's description and the bolded text that indicates what data type it accepts.

![image](https://user-images.githubusercontent.com/19675699/145481100-e1260f08-bb13-4b71-b408-7341daf1d6ec.png)

