### PR TITLE
[Reporting] Ensure uniform enablement of the plugin

### DIFF
--- a/x-pack/plugins/reporting/server/plugin.ts
+++ b/x-pack/plugins/reporting/server/plugin.ts
@@ -12,6 +12,7 @@ import { buildConfig, registerUiSettings, ReportingConfigType } from './config';
 import { registerDeprecations } from './deprecations';
 import { LevelLogger, ReportingStore } from './lib';
 import { registerRoutes } from './routes';
+import { reportingStatusSavedObject } from './saved_objects';
 import { setFieldFormats } from './services';
 import type {
   ReportingRequestHandlerContext,
@@ -20,7 +21,6 @@ import type {
   ReportingStart,
   ReportingStartDeps,
 } from './types';
-import { reportingStatusSavedObject } from './saved_objects';
 import { registerReportingUsageCollector } from './usage';
 
 export class ReportingPlugin

--- a/x-pack/plugins/reporting/server/plugin.ts
+++ b/x-pack/plugins/reporting/server/plugin.ts
@@ -20,6 +20,7 @@ import type {
   ReportingStart,
   ReportingStartDeps,
 } from './types';
+import { reportingStatusSavedObject } from './saved_objects';
 import { registerReportingUsageCollector } from './usage';
 
 export class ReportingPlugin
@@ -33,6 +34,8 @@ export class ReportingPlugin
   }
 
   public setup(core: CoreSetup, plugins: ReportingSetupDeps) {
+    core.savedObjects.registerType(reportingStatusSavedObject.type);
+
     const { http } = core;
     const { features, licensing, security, spaces, taskManager } = plugins;
 
@@ -95,6 +98,7 @@ export class ReportingPlugin
     // async background start
     (async () => {
       await reportingCore.pluginSetsUp();
+      await reportingStatusSavedObject.setStatus(core.savedObjects);
 
       const store = new ReportingStore(reportingCore, this.logger);
 

--- a/x-pack/plugins/reporting/server/saved_objects/index.ts
+++ b/x-pack/plugins/reporting/server/saved_objects/index.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SavedObjectsServiceStart, SavedObjectsType } from 'kibana/server';
+import { PLUGIN_ID } from '../../common/constants';
+
+const SAVED_OBJECT_ID = 'reporting-status';
+
+interface Attributes {
+  enabled: true;
+}
+
+export const reportingStatusSavedObject = {
+  get type() {
+    const reportingStatusSavedObjectType: SavedObjectsType<Attributes> = {
+      name: PLUGIN_ID,
+      namespaceType: 'agnostic',
+      hidden: true,
+      mappings: {
+        properties: {
+          enabled: { type: 'boolean' },
+        },
+      },
+    };
+    return reportingStatusSavedObjectType;
+  },
+
+  async setStatus(savedObjects: SavedObjectsServiceStart) {
+    const scopedClient = savedObjects.createInternalRepository([PLUGIN_ID]);
+    const reportingStatus: Attributes = { enabled: true };
+    await scopedClient.update<Attributes>(PLUGIN_ID, SAVED_OBJECT_ID, reportingStatus, {
+      upsert: reportingStatus,
+    });
+  },
+};

--- a/x-pack/plugins/reporting/server/saved_objects/index.ts
+++ b/x-pack/plugins/reporting/server/saved_objects/index.ts
@@ -8,6 +8,24 @@
 import { SavedObjectsServiceStart, SavedObjectsType } from 'kibana/server';
 import { PLUGIN_ID } from '../../common/constants';
 
+/*
+ * The purpose of this saved object is to ensure that if Reporting is disabled in
+ * a Kibana, it is disabled in every Kibana instance.
+ *
+ * Reporting creates this saved object as a safety check from instances that
+ * have the Reporting plugin disabled. Those instances should fail to start up
+ * since this saved object type isn't registered. The unknown type of object is
+ * meant to cause Kibana to fail to start.
+ *
+ * If an administrator wishes to disable Reporting, they should use
+ * `xpack.reporting.queue.pollEnabled: false` from simply stopping the
+ * Reporting plugin from doing any processing work.
+ *
+ * If they wish to completely disable Reporting, but Reporting has been run on
+ * a previous instance, they will have to manually remove this saved object
+ * from the Kibana instance to clear the "unknown" object.
+ */
+
 const SAVED_OBJECT_ID = 'reporting-status';
 
 interface Attributes {
@@ -32,6 +50,9 @@ export const reportingStatusSavedObject = {
   async setStatus(savedObjects: SavedObjectsServiceStart) {
     const scopedClient = savedObjects.createInternalRepository([PLUGIN_ID]);
     const reportingStatus: Attributes = { enabled: true };
+
+    // Reporting creates the object to raise a flag in instances that have
+    // disabled Reporting.
     await scopedClient.update<Attributes>(PLUGIN_ID, SAVED_OBJECT_ID, reportingStatus, {
       upsert: reportingStatus,
     });


### PR DESCRIPTION
## Summary

Addresses the first part of https://github.com/elastic/kibana/issues/120995 

Kibana has safety checks built into the Saved Objects system to ensure that an instance doesn't start if there is an unknown SO type in the data ([`CHECK_UNKNOWN_DOCUMENTS`](https://github.com/elastic/kibana/pull/118300)). This PR gives the Reporting plugin a new saved object type to take advantage of that safety check.

Having a mixed configuration, where Reporting is completely disabled on some instance(s) of Kibana but not others, is not supported because it corrupts the reporting task instances. Today, there is no way for the user to know if they are inadvertently creating that situation - they must resolve the data corruption manually after noticing that Reporting is broken.

Reporting can still be disabled for the most part by setting `xpack.reporting.queue.pollEnabled: false` in the kibana.yml. This setting does not need to be uniformly set across all Kibana instances.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
