### PR TITLE
Fix ticks deduplication on Y axis

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@elastic/apm-rum": "^5.9.1",
     "@elastic/apm-rum-react": "^1.3.1",
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
-    "@elastic/charts": "38.0.5",
+    "@elastic/charts": "38.1.0",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^7.16.0-canary.7",
     "@elastic/ems-client": "7.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,10 +1520,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@38.0.5":
-  version "38.0.5"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-38.0.5.tgz#b6ca7a41903a5b31589294d141f84134daa590d5"
-  integrity sha512-Utr1n+j71qQbscCucO7frnMC1j1TgftzqSLoUE0CezFRcwgcy1i3KhSCtdnSthXtvLUvh341WpkKOqp7UyOuhw==
+"@elastic/charts@38.1.0":
+  version "38.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-38.1.0.tgz#52146564c0e399da2267c10ec4536c33e50969e4"
+  integrity sha512-u2hQ8+daCvqapKQiFqN8QHWTz3OXby5Xf/ta1Dv59KTDTFIinCZD/M8PyD3MapbKx4b67hL7UxbErqr4rZ8jeA==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"
@@ -1534,6 +1534,7 @@
     d3-interpolate "^1.4.0"
     d3-scale "^1.0.7"
     d3-shape "^1.3.4"
+    luxon "^1.25.0"
     prop-types "^15.7.2"
     re-reselect "^3.4.0"
     react-redux "^7.1.0"
@@ -19088,6 +19089,11 @@ lru-queue@0.1:
   integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
   dependencies:
     es5-ext "~0.10.2"
+
+luxon@^1.25.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.0.tgz#e7f96daad3938c06a62de0fb027115d251251fbf"
+  integrity sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==
 
 lz-string@^1.4.4:
   version "1.4.4"


### PR DESCRIPTION
## Summary

This dependency upgrade fixes wrong tick deduplication applied to Y-axis.
In particular, within Lens, when a user manually configures a numeric formatter for the Y-axis with `0` decimals, the previously implemented deduplication logic wrongly displays the Y-axis values.
Version 38.1.0 corrects that behavior. 

From (note that all the ticks are shifted by 0.5 due to rounding and deduplication):
![](https://user-images.githubusercontent.com/1508364/145396901-827f6eaf-75b8-4a53-abe1-3f30c7049ef9.png)

To:
![](https://user-images.githubusercontent.com/1508364/145396932-10c0bb62-9ded-4214-bf49-9ebf0053d6a6.png)

fix https://github.com/elastic/kibana/issues/108260 