### PR TITLE
[7.16] Re-enable Basic login functional tests.

### DIFF
--- a/x-pack/test/security_functional/tests/login_selector/basic_functionality.ts
+++ b/x-pack/test/security_functional/tests/login_selector/basic_functionality.ts
@@ -17,8 +17,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const deployment = getService('deployment');
   const PageObjects = getPageObjects(['security', 'common']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/98562
-  describe.skip('Basic functionality', function () {
+  describe('Basic functionality', function () {
     this.tags('includeFirefox');
 
     const testCredentials = { username: 'admin_user', password: 'change_me' };


### PR DESCRIPTION
## Summary

Follow-up for https://github.com/elastic/kibana/pull/119909#issuecomment-982164815

__Flaky Test Runner:__ https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/296 (x30 runs, :heavy_check_mark:)