### PR TITLE
[RAC][Refactoring] Rename alerting types in Infra

### DIFF
--- a/x-pack/plugins/infra/common/alerting/logs/log_threshold/types.ts
+++ b/x-pack/plugins/infra/common/alerting/logs/log_threshold/types.ts
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 import * as rt from 'io-ts';
 import { commonSearchSuccessResponseFieldsRT } from '../../../utils/elasticsearch_runtime_types';
 
-export const LOG_DOCUMENT_COUNT_ALERT_TYPE_ID = 'logs.alert.document.count';
+export const LOG_DOCUMENT_COUNT_RULE_TYPE_ID = 'logs.alert.document.count';
 
 const ThresholdTypeRT = rt.keyof({
   count: null,
@@ -143,7 +143,7 @@ export type TimeUnit = rt.TypeOf<typeof timeUnitRT>;
 export const timeSizeRT = rt.number;
 export const groupByRT = rt.array(rt.string);
 
-const RequiredAlertParamsRT = rt.type({
+const RequiredRuleParamsRT = rt.type({
   // NOTE: "count" would be better named as "threshold", but this would require a
   // migration of encrypted saved objects, so we'll keep "count" until it's problematic.
   count: ThresholdRT,
@@ -151,72 +151,69 @@ const RequiredAlertParamsRT = rt.type({
   timeSize: timeSizeRT,
 });
 
-const partialRequiredAlertParamsRT = rt.partial(RequiredAlertParamsRT.props);
-export type PartialRequiredAlertParams = rt.TypeOf<typeof partialRequiredAlertParamsRT>;
+const partialRequiredRuleParamsRT = rt.partial(RequiredRuleParamsRT.props);
+export type PartialRequiredRuleParams = rt.TypeOf<typeof partialRequiredRuleParamsRT>;
 
-const OptionalAlertParamsRT = rt.partial({
+const OptionalRuleParamsRT = rt.partial({
   groupBy: groupByRT,
 });
 
-export const countAlertParamsRT = rt.intersection([
+export const countRuleParamsRT = rt.intersection([
   rt.type({
     criteria: countCriteriaRT,
-    ...RequiredAlertParamsRT.props,
+    ...RequiredRuleParamsRT.props,
   }),
   rt.partial({
-    ...OptionalAlertParamsRT.props,
+    ...OptionalRuleParamsRT.props,
   }),
 ]);
-export type CountAlertParams = rt.TypeOf<typeof countAlertParamsRT>;
+export type CountRuleParams = rt.TypeOf<typeof countRuleParamsRT>;
 
-export const partialCountAlertParamsRT = rt.intersection([
+export const partialCountRuleParamsRT = rt.intersection([
   rt.type({
     criteria: partialCountCriteriaRT,
-    ...RequiredAlertParamsRT.props,
+    ...RequiredRuleParamsRT.props,
   }),
   rt.partial({
-    ...OptionalAlertParamsRT.props,
+    ...OptionalRuleParamsRT.props,
   }),
 ]);
-export type PartialCountAlertParams = rt.TypeOf<typeof partialCountAlertParamsRT>;
+export type PartialCountRuleParams = rt.TypeOf<typeof partialCountRuleParamsRT>;
 
-export const ratioAlertParamsRT = rt.intersection([
+export const ratioRuleParamsRT = rt.intersection([
   rt.type({
     criteria: ratioCriteriaRT,
-    ...RequiredAlertParamsRT.props,
+    ...RequiredRuleParamsRT.props,
   }),
   rt.partial({
-    ...OptionalAlertParamsRT.props,
+    ...OptionalRuleParamsRT.props,
   }),
 ]);
-export type RatioAlertParams = rt.TypeOf<typeof ratioAlertParamsRT>;
+export type RatioRuleParams = rt.TypeOf<typeof ratioRuleParamsRT>;
 
-export const partialRatioAlertParamsRT = rt.intersection([
+export const partialRatioRuleParamsRT = rt.intersection([
   rt.type({
     criteria: partialRatioCriteriaRT,
-    ...RequiredAlertParamsRT.props,
+    ...RequiredRuleParamsRT.props,
   }),
   rt.partial({
-    ...OptionalAlertParamsRT.props,
+    ...OptionalRuleParamsRT.props,
   }),
 ]);
-export type PartialRatioAlertParams = rt.TypeOf<typeof partialRatioAlertParamsRT>;
+export type PartialRatioRuleParams = rt.TypeOf<typeof partialRatioRuleParamsRT>;
 
-export const alertParamsRT = rt.union([countAlertParamsRT, ratioAlertParamsRT]);
-export type AlertParams = rt.TypeOf<typeof alertParamsRT>;
+export const ruleParamsRT = rt.union([countRuleParamsRT, ratioRuleParamsRT]);
+export type RuleParams = rt.TypeOf<typeof ruleParamsRT>;
 
-export const partialAlertParamsRT = rt.union([
-  partialCountAlertParamsRT,
-  partialRatioAlertParamsRT,
-]);
-export type PartialAlertParams = rt.TypeOf<typeof partialAlertParamsRT>;
+export const partialRuleParamsRT = rt.union([partialCountRuleParamsRT, partialRatioRuleParamsRT]);
+export type PartialRuleParams = rt.TypeOf<typeof partialRuleParamsRT>;
 
-export const isRatioAlert = (criteria: PartialCriteria): criteria is PartialRatioCriteria => {
+export const isRatioRule = (criteria: PartialCriteria): criteria is PartialRatioCriteria => {
   return criteria.length > 0 && Array.isArray(criteria[0]) ? true : false;
 };
 
-export const isRatioAlertParams = (params: AlertParams): params is RatioAlertParams => {
-  return isRatioAlert(params.criteria);
+export const isRatioRuleParams = (params: RuleParams): params is RatioRuleParams => {
+  return isRatioRule(params.criteria);
 };
 
 export const getNumerator = <C extends RatioCriteria | PartialRatioCriteria>(criteria: C): C[0] => {
@@ -229,8 +226,8 @@ export const getDenominator = <C extends RatioCriteria | PartialRatioCriteria>(
   return criteria[1];
 };
 
-export const hasGroupBy = (alertParams: AlertParams) => {
-  const { groupBy } = alertParams;
+export const hasGroupBy = (params: RuleParams) => {
+  const { groupBy } = params;
   return groupBy && groupBy.length > 0 ? true : false;
 };
 
@@ -339,8 +336,8 @@ export const isOptimizedGroupedSearchQueryResponse = (
 };
 
 export const isOptimizableGroupedThreshold = (
-  selectedComparator: AlertParams['count']['comparator'],
-  selectedValue?: AlertParams['count']['value']
+  selectedComparator: RuleParams['count']['comparator'],
+  selectedValue?: RuleParams['count']['value']
 ) => {
   if (selectedComparator === Comparator.GT) {
     return true;

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_flyout.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_flyout.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useContext, useMemo } from 'react';
 import { TriggerActionsContext } from '../../../utils/triggers_actions_context';
-import { LOG_DOCUMENT_COUNT_ALERT_TYPE_ID } from '../../../../common/alerting/logs/log_threshold/types';
+import { LOG_DOCUMENT_COUNT_RULE_TYPE_ID } from '../../../../common/alerting/logs/log_threshold/types';
 
 interface Props {
   visible?: boolean;
@@ -25,7 +25,7 @@ export const AlertFlyout = (props: Props) => {
         consumer: 'logs',
         onClose: onCloseFlyout,
         canChangeTrigger: false,
-        alertTypeId: LOG_DOCUMENT_COUNT_ALERT_TYPE_ID,
+        alertTypeId: LOG_DOCUMENT_COUNT_RULE_TYPE_ID,
         metadata: {
           isInternal: true,
         },

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criteria.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criteria.tsx
@@ -12,12 +12,12 @@ import { i18n } from '@kbn/i18n';
 import { IFieldType } from 'src/plugins/data/public';
 import { Criterion } from './criterion';
 import {
-  PartialAlertParams,
+  PartialRuleParams,
   PartialCountCriteria as PartialCountCriteriaType,
   PartialCriteria as PartialCriteriaType,
   PartialCriterion as PartialCriterionType,
   PartialRatioCriteria as PartialRatioCriteriaType,
-  isRatioAlert,
+  isRatioRule,
   getNumerator,
   getDenominator,
 } from '../../../../../common/alerting/logs/log_threshold/types';
@@ -38,7 +38,7 @@ interface SharedProps {
   criteria?: PartialCriteriaType;
   defaultCriterion: PartialCriterionType;
   errors: Errors['criteria'];
-  alertParams: PartialAlertParams;
+  ruleParams: PartialRuleParams;
   sourceId: string;
   updateCriteria: (criteria: PartialCriteriaType) => void;
 }
@@ -49,7 +49,7 @@ export const Criteria: React.FC<CriteriaProps> = (props) => {
   const { criteria, errors } = props;
   if (!criteria || criteria.length === 0) return null;
 
-  return !isRatioAlert(criteria) ? (
+  return !isRatioRule(criteria) ? (
     <CountCriteria {...props} criteria={criteria} errors={errors} />
   ) : (
     <RatioCriteria {...props} criteria={criteria} errors={errors} />
@@ -57,7 +57,7 @@ export const Criteria: React.FC<CriteriaProps> = (props) => {
 };
 
 interface CriteriaWrapperProps {
-  alertParams: SharedProps['alertParams'];
+  ruleParams: SharedProps['ruleParams'];
   fields: SharedProps['fields'];
   updateCriterion: (idx: number, params: PartialCriterionType) => void;
   removeCriterion: (idx: number) => void;
@@ -76,7 +76,7 @@ const CriteriaWrapper: React.FC<CriteriaWrapperProps> = (props) => {
     criteria,
     fields,
     errors,
-    alertParams,
+    ruleParams,
     sourceId,
     isRatio = false,
   } = props;
@@ -103,7 +103,7 @@ const CriteriaWrapper: React.FC<CriteriaWrapperProps> = (props) => {
               arrowDisplay="right"
             >
               <CriterionPreview
-                alertParams={alertParams}
+                ruleParams={ruleParams}
                 chartCriterion={criterion}
                 sourceId={sourceId}
                 showThreshold={!isRatio}

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criterion_preview_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criterion_preview_chart.tsx
@@ -35,7 +35,7 @@ import {
   NUM_BUCKETS,
 } from '../../../common/criterion_preview_chart/criterion_preview_chart';
 import {
-  PartialAlertParams,
+  PartialRuleParams,
   Threshold,
   Criterion,
   Comparator,
@@ -51,14 +51,14 @@ import { decodeOrThrow } from '../../../../../common/runtime_types';
 const GROUP_LIMIT = 5;
 
 interface Props {
-  alertParams: PartialAlertParams;
+  ruleParams: PartialRuleParams;
   chartCriterion: Partial<Criterion>;
   sourceId: string;
   showThreshold: boolean;
 }
 
 export const CriterionPreview: React.FC<Props> = ({
-  alertParams,
+  ruleParams,
   chartCriterion,
   sourceId,
   showThreshold,
@@ -69,12 +69,12 @@ export const CriterionPreview: React.FC<Props> = ({
     const params = {
       criteria,
       count: {
-        comparator: alertParams.count.comparator,
-        value: alertParams.count.value,
+        comparator: ruleParams.count.comparator,
+        value: ruleParams.count.value,
       },
-      timeSize: alertParams.timeSize,
-      timeUnit: alertParams.timeUnit,
-      groupBy: alertParams.groupBy,
+      timeSize: ruleParams.timeSize,
+      timeUnit: ruleParams.timeUnit,
+      groupBy: ruleParams.groupBy,
     };
 
     try {
@@ -83,11 +83,11 @@ export const CriterionPreview: React.FC<Props> = ({
       return null;
     }
   }, [
-    alertParams.timeSize,
-    alertParams.timeUnit,
-    alertParams.groupBy,
-    alertParams.count.comparator,
-    alertParams.count.value,
+    ruleParams.timeSize,
+    ruleParams.timeUnit,
+    ruleParams.groupBy,
+    ruleParams.count.comparator,
+    ruleParams.count.value,
     chartCriterion,
   ]);
 
@@ -102,7 +102,7 @@ export const CriterionPreview: React.FC<Props> = ({
           : NUM_BUCKETS / 4
       } // Display less data for groups due to space limitations
       sourceId={sourceId}
-      threshold={alertParams.count}
+      threshold={ruleParams.count}
       chartAlertParams={chartAlertParams}
       showThreshold={showThreshold}
     />

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/editor.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/editor.tsx
@@ -16,11 +16,11 @@ import {
 } from '../../../../../../triggers_actions_ui/public';
 import {
   Comparator,
-  isRatioAlert,
-  PartialAlertParams,
-  PartialCountAlertParams,
+  isRatioRule,
+  PartialRuleParams,
+  PartialCountRuleParams,
   PartialCriteria as PartialCriteriaType,
-  PartialRatioAlertParams,
+  PartialRatioRuleParams,
   ThresholdType,
   timeUnitRT,
   isOptimizableGroupedThreshold,
@@ -64,9 +64,9 @@ const createDefaultCriterion = (
     ? { field: DEFAULT_FIELD, comparator: Comparator.EQ, value }
     : { field: undefined, comparator: undefined, value: undefined };
 
-const createDefaultCountAlertParams = (
+const createDefaultCountRuleParams = (
   availableFields: LogIndexField[]
-): PartialCountAlertParams => ({
+): PartialCountRuleParams => ({
   ...DEFAULT_BASE_EXPRESSION,
   count: {
     value: 75,
@@ -75,9 +75,9 @@ const createDefaultCountAlertParams = (
   criteria: [createDefaultCriterion(availableFields, 'error')],
 });
 
-const createDefaultRatioAlertParams = (
+const createDefaultRatioRuleParams = (
   availableFields: LogIndexField[]
-): PartialRatioAlertParams => ({
+): PartialRatioRuleParams => ({
   ...DEFAULT_BASE_EXPRESSION,
   count: {
     value: 2,
@@ -90,7 +90,7 @@ const createDefaultRatioAlertParams = (
 });
 
 export const ExpressionEditor: React.FC<
-  AlertTypeParamsExpressionProps<PartialAlertParams, LogsContextMeta>
+  AlertTypeParamsExpressionProps<PartialRuleParams, LogsContextMeta>
 > = (props) => {
   const isInternal = props.metadata?.isInternal ?? false;
   const [sourceId] = useSourceId();
@@ -159,7 +159,7 @@ export const SourceStatusWrapper: React.FC = ({ children }) => {
   );
 };
 
-export const Editor: React.FC<AlertTypeParamsExpressionProps<PartialAlertParams, LogsContextMeta>> =
+export const Editor: React.FC<AlertTypeParamsExpressionProps<PartialRuleParams, LogsContextMeta>> =
   (props) => {
     const { setAlertParams, alertParams, errors } = props;
     const [hasSetDefaults, setHasSetDefaults] = useState<boolean>(false);
@@ -231,7 +231,7 @@ export const Editor: React.FC<AlertTypeParamsExpressionProps<PartialAlertParams,
     );
 
     const defaultCountAlertParams = useMemo(
-      () => createDefaultCountAlertParams(supportedFields),
+      () => createDefaultCountRuleParams(supportedFields),
       [supportedFields]
     );
 
@@ -240,7 +240,7 @@ export const Editor: React.FC<AlertTypeParamsExpressionProps<PartialAlertParams,
         const defaults =
           type === 'count'
             ? defaultCountAlertParams
-            : createDefaultRatioAlertParams(supportedFields);
+            : createDefaultRatioRuleParams(supportedFields);
         // Reset properties that don't make sense switching from one context to the other
         setAlertParams('count', defaults.count);
         setAlertParams('criteria', defaults.criteria);
@@ -276,7 +276,7 @@ export const Editor: React.FC<AlertTypeParamsExpressionProps<PartialAlertParams,
         criteria={alertParams.criteria}
         defaultCriterion={defaultCountAlertParams.criteria[0]}
         errors={criteriaErrors}
-        alertParams={alertParams}
+        ruleParams={alertParams}
         sourceId={sourceId}
         updateCriteria={updateCriteria}
       />
@@ -286,7 +286,7 @@ export const Editor: React.FC<AlertTypeParamsExpressionProps<PartialAlertParams,
       <>
         <TypeSwitcher criteria={alertParams.criteria || []} updateType={updateType} />
 
-        {alertParams.criteria && !isRatioAlert(alertParams.criteria) && criteriaComponent}
+        {alertParams.criteria && !isRatioRule(alertParams.criteria) && criteriaComponent}
 
         <Threshold
           comparator={alertParams.count?.comparator}
@@ -309,7 +309,7 @@ export const Editor: React.FC<AlertTypeParamsExpressionProps<PartialAlertParams,
           fields={groupByFields}
         />
 
-        {alertParams.criteria && isRatioAlert(alertParams.criteria) && criteriaComponent}
+        {alertParams.criteria && isRatioRule(alertParams.criteria) && criteriaComponent}
 
         {shouldShowGroupByOptimizationWarning && (
           <>

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/threshold.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/threshold.tsx
@@ -23,7 +23,7 @@ import { IErrorObject } from '../../../../../../triggers_actions_ui/public/types
 import {
   Comparator,
   ComparatorToi18nMap,
-  AlertParams,
+  RuleParams,
 } from '../../../../../common/alerting/logs/log_threshold/types';
 
 const thresholdPrefix = i18n.translate('xpack.infra.logs.alertFlyout.thresholdPrefix', {
@@ -49,7 +49,7 @@ const getComparatorOptions = (): Array<{
 interface Props {
   comparator?: Comparator;
   value?: number;
-  updateThreshold: (params: Partial<AlertParams['count']>) => void;
+  updateThreshold: (params: Partial<RuleParams['count']>) => void;
   errors: IErrorObject;
 }
 

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/type_switcher.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/type_switcher.tsx
@@ -11,7 +11,7 @@ import { EuiFlexItem, EuiFlexGroup, EuiPopover, EuiSelect, EuiExpression } from 
 import {
   PartialCriteria,
   ThresholdType,
-  isRatioAlert,
+  isRatioRule,
 } from '../../../../../common/alerting/logs/log_threshold/types';
 import { ExpressionLike } from './editor';
 
@@ -51,7 +51,7 @@ interface Props {
 }
 
 const getThresholdType = (criteria: PartialCriteria): ThresholdType => {
-  return isRatioAlert(criteria) ? 'ratio' : 'count';
+  return isRatioRule(criteria) ? 'ratio' : 'count';
 };
 
 export const TypeSwitcher: React.FC<Props> = ({ criteria, updateType }) => {

--- a/x-pack/plugins/infra/public/alerting/log_threshold/log_threshold_rule_type.ts
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/log_threshold_rule_type.ts
@@ -9,15 +9,15 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { ObservabilityRuleTypeModel } from '../../../../observability/public';
 import {
-  LOG_DOCUMENT_COUNT_ALERT_TYPE_ID,
-  PartialAlertParams,
+  LOG_DOCUMENT_COUNT_RULE_TYPE_ID,
+  PartialRuleParams,
 } from '../../../common/alerting/logs/log_threshold';
 import { formatRuleData } from './rule_data_formatters';
 import { validateExpression } from './validation';
 
-export function createLogThresholdRuleType(): ObservabilityRuleTypeModel<PartialAlertParams> {
+export function createLogThresholdRuleType(): ObservabilityRuleTypeModel<PartialRuleParams> {
   return {
-    id: LOG_DOCUMENT_COUNT_ALERT_TYPE_ID,
+    id: LOG_DOCUMENT_COUNT_RULE_TYPE_ID,
     description: i18n.translate('xpack.infra.logs.alertFlyout.alertDescription', {
       defaultMessage: 'Alert when the log aggregation exceeds the threshold.',
     }),

--- a/x-pack/plugins/infra/public/alerting/log_threshold/validation.ts
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/validation.ts
@@ -11,10 +11,10 @@ import { isNumber, isFinite } from 'lodash';
 import { IErrorObject, ValidationResult } from '../../../../triggers_actions_ui/public';
 import {
   PartialCountCriteria,
-  isRatioAlert,
+  isRatioRule,
   getNumerator,
   getDenominator,
-  PartialRequiredAlertParams,
+  PartialRequiredRuleParams,
   PartialCriteria,
 } from '../../../common/alerting/logs/log_threshold/types';
 
@@ -50,7 +50,7 @@ export function validateExpression({
   count,
   criteria,
   timeSize,
-}: PartialRequiredAlertParams & {
+}: PartialRequiredRuleParams & {
   criteria: PartialCriteria;
 }): ValidationResult {
   const validationResult = { errors: {} };
@@ -122,7 +122,7 @@ export function validateExpression({
       return _errors;
     };
 
-    if (!isRatioAlert(criteria)) {
+    if (!isRatioRule(criteria)) {
       const criteriaErrors = getCriterionErrors(criteria);
       errors.criteria[0] = criteriaErrors;
     } else {

--- a/x-pack/plugins/infra/server/features.ts
+++ b/x-pack/plugins/infra/server/features.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { LOG_DOCUMENT_COUNT_ALERT_TYPE_ID } from '../common/alerting/logs/log_threshold/types';
+import { LOG_DOCUMENT_COUNT_RULE_TYPE_ID } from '../common/alerting/logs/log_threshold/types';
 import { METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID } from './lib/alerting/inventory_metric_threshold/types';
 import { METRIC_THRESHOLD_ALERT_TYPE_ID } from './lib/alerting/metric_threshold/types';
 import { DEFAULT_APP_CATEGORIES } from '../../../../src/core/server';
@@ -83,7 +83,7 @@ export const LOGS_FEATURE = {
   management: {
     insightsAndAlerting: ['triggersActions'],
   },
-  alerting: [LOG_DOCUMENT_COUNT_ALERT_TYPE_ID],
+  alerting: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
   privileges: {
     all: {
       app: ['infra', 'logs', 'kibana'],
@@ -95,10 +95,10 @@ export const LOGS_FEATURE = {
       },
       alerting: {
         rule: {
-          all: [LOG_DOCUMENT_COUNT_ALERT_TYPE_ID],
+          all: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
         },
         alert: {
-          all: [LOG_DOCUMENT_COUNT_ALERT_TYPE_ID],
+          all: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
         },
       },
       management: {
@@ -112,10 +112,10 @@ export const LOGS_FEATURE = {
       api: ['infra'],
       alerting: {
         rule: {
-          read: [LOG_DOCUMENT_COUNT_ALERT_TYPE_ID],
+          read: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
         },
         alert: {
-          read: [LOG_DOCUMENT_COUNT_ALERT_TYPE_ID],
+          read: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
         },
       },
       management: {

--- a/x-pack/plugins/infra/server/lib/alerting/log_threshold/log_threshold_executor.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/log_threshold/log_threshold_executor.ts
@@ -22,11 +22,11 @@ import {
   AlertTypeState as RuleTypeState,
 } from '../../../../../alerting/server';
 import {
-  AlertParams,
-  alertParamsRT,
+  RuleParams,
+  ruleParamsRT,
   AlertStates,
   Comparator,
-  CountAlertParams,
+  CountRuleParams,
   CountCriteria,
   Criterion,
   getDenominator,
@@ -36,8 +36,8 @@ import {
   hasGroupBy,
   isOptimizableGroupedThreshold,
   isOptimizedGroupedSearchQueryResponse,
-  isRatioAlertParams,
-  RatioAlertParams,
+  isRatioRuleParams,
+  RatioRuleParams,
   UngroupedSearchQueryResponse,
   UngroupedSearchQueryResponseRT,
 } from '../../../../common/alerting/logs/log_threshold';
@@ -54,7 +54,7 @@ import {
 } from './reason_formatters';
 
 export type LogThresholdActionGroups = ActionGroupIdsOf<typeof FIRED_ACTIONS>;
-export type LogThresholdRuleTypeParams = AlertParams;
+export type LogThresholdRuleTypeParams = RuleParams;
 export type LogThresholdRuleTypeState = RuleTypeState; // no specific state used
 export type LogThresholdAlertState = AlertState; // no specific state used
 export type LogThresholdAlertContext = AlertContext; // no specific instance context used
@@ -116,9 +116,9 @@ export const createLogThresholdExecutor = (libs: InfraBackendLibs) =>
     );
 
     try {
-      const validatedParams = decodeOrThrow(alertParamsRT)(params);
+      const validatedParams = decodeOrThrow(ruleParamsRT)(params);
 
-      if (!isRatioAlertParams(validatedParams)) {
+      if (!isRatioRuleParams(validatedParams)) {
         await executeAlert(
           validatedParams,
           timestampField,
@@ -143,7 +143,7 @@ export const createLogThresholdExecutor = (libs: InfraBackendLibs) =>
   });
 
 async function executeAlert(
-  alertParams: CountAlertParams,
+  alertParams: CountRuleParams,
   timestampField: string,
   indexPattern: string,
   runtimeMappings: estypes.MappingRuntimeFields,
@@ -174,7 +174,7 @@ async function executeAlert(
 }
 
 async function executeRatioAlert(
-  alertParams: RatioAlertParams,
+  alertParams: RatioRuleParams,
   timestampField: string,
   indexPattern: string,
   runtimeMappings: estypes.MappingRuntimeFields,
@@ -182,12 +182,12 @@ async function executeRatioAlert(
   alertFactory: LogThresholdAlertFactory
 ) {
   // Ratio alert params are separated out into two standard sets of alert params
-  const numeratorParams: AlertParams = {
+  const numeratorParams: RuleParams = {
     ...alertParams,
     criteria: getNumerator(alertParams.criteria),
   };
 
-  const denominatorParams: AlertParams = {
+  const denominatorParams: RuleParams = {
     ...alertParams,
     criteria: getDenominator(alertParams.criteria),
   };
@@ -228,7 +228,7 @@ async function executeRatioAlert(
 }
 
 const getESQuery = (
-  alertParams: Omit<AlertParams, 'criteria'> & { criteria: CountCriteria },
+  alertParams: Omit<RuleParams, 'criteria'> & { criteria: CountCriteria },
   timestampField: string,
   indexPattern: string,
   runtimeMappings: estypes.MappingRuntimeFields
@@ -240,7 +240,7 @@ const getESQuery = (
 
 export const processUngroupedResults = (
   results: UngroupedSearchQueryResponse,
-  params: CountAlertParams,
+  params: CountRuleParams,
   alertFactory: LogThresholdAlertFactory,
   alertUpdater: AlertUpdater
 ) => {
@@ -271,7 +271,7 @@ export const processUngroupedResults = (
 export const processUngroupedRatioResults = (
   numeratorResults: UngroupedSearchQueryResponse,
   denominatorResults: UngroupedSearchQueryResponse,
-  params: RatioAlertParams,
+  params: RatioRuleParams,
   alertFactory: LogThresholdAlertFactory,
   alertUpdater: AlertUpdater
 ) => {
@@ -344,7 +344,7 @@ const getReducedGroupByResults = (
 
 export const processGroupByResults = (
   results: GroupedSearchQueryResponse['aggregations']['groups']['buckets'],
-  params: CountAlertParams,
+  params: CountRuleParams,
   alertFactory: LogThresholdAlertFactory,
   alertUpdater: AlertUpdater
 ) => {
@@ -385,7 +385,7 @@ export const processGroupByResults = (
 export const processGroupByRatioResults = (
   numeratorResults: GroupedSearchQueryResponse['aggregations']['groups']['buckets'],
   denominatorResults: GroupedSearchQueryResponse['aggregations']['groups']['buckets'],
-  params: RatioAlertParams,
+  params: RatioRuleParams,
   alertFactory: LogThresholdAlertFactory,
   alertUpdater: AlertUpdater
 ) => {
@@ -457,7 +457,7 @@ export const updateAlert: AlertUpdater = (alert, state, actions) => {
 };
 
 export const buildFiltersFromCriteria = (
-  params: Pick<AlertParams, 'timeSize' | 'timeUnit'> & { criteria: CountCriteria },
+  params: Pick<RuleParams, 'timeSize' | 'timeUnit'> & { criteria: CountCriteria },
   timestampField: string
 ) => {
   const { timeSize, timeUnit, criteria } = params;
@@ -508,11 +508,11 @@ export const buildFiltersFromCriteria = (
 };
 
 export const getGroupedESQuery = (
-  params: Pick<AlertParams, 'timeSize' | 'timeUnit' | 'groupBy'> & {
+  params: Pick<RuleParams, 'timeSize' | 'timeUnit' | 'groupBy'> & {
     criteria: CountCriteria;
     count: {
-      comparator: AlertParams['count']['comparator'];
-      value?: AlertParams['count']['value'];
+      comparator: RuleParams['count']['comparator'];
+      value?: RuleParams['count']['value'];
     };
   },
   timestampField: string,
@@ -619,7 +619,7 @@ export const getGroupedESQuery = (
 };
 
 export const getUngroupedESQuery = (
-  params: Pick<AlertParams, 'timeSize' | 'timeUnit'> & { criteria: CountCriteria },
+  params: Pick<RuleParams, 'timeSize' | 'timeUnit'> & { criteria: CountCriteria },
   timestampField: string,
   index: string,
   runtimeMappings: estypes.MappingRuntimeFields

--- a/x-pack/plugins/infra/server/lib/alerting/log_threshold/register_log_threshold_rule_type.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/log_threshold/register_log_threshold_rule_type.ts
@@ -9,8 +9,8 @@ import { i18n } from '@kbn/i18n';
 import { PluginSetupContract } from '../../../../../alerting/server';
 import { createLogThresholdExecutor, FIRED_ACTIONS } from './log_threshold_executor';
 import {
-  LOG_DOCUMENT_COUNT_ALERT_TYPE_ID,
-  alertParamsRT,
+  LOG_DOCUMENT_COUNT_RULE_TYPE_ID,
+  ruleParamsRT,
 } from '../../../../common/alerting/logs/log_threshold';
 import { InfraBackendLibs } from '../../infra_types';
 import { decodeOrThrow } from '../../../../common/runtime_types';
@@ -82,13 +82,13 @@ export async function registerLogThresholdRuleType(
   }
 
   alertingPlugin.registerType({
-    id: LOG_DOCUMENT_COUNT_ALERT_TYPE_ID,
+    id: LOG_DOCUMENT_COUNT_RULE_TYPE_ID,
     name: i18n.translate('xpack.infra.logs.alertName', {
       defaultMessage: 'Log threshold',
     }),
     validate: {
       params: {
-        validate: (params) => decodeOrThrow(alertParamsRT)(params),
+        validate: (params) => decodeOrThrow(ruleParamsRT)(params),
       },
     },
     defaultActionGroupId: FIRED_ACTIONS.id,


### PR DESCRIPTION
Fixes: #120486

Remaining refactoring in Infra plugin.
Renamed alerting types as per the [alerting terminology](https://github.com/elastic/kibana/tree/main/x-pack/plugins/alerting#terminology)