### PR TITLE
[Discover] Add i18n to no results screen

### DIFF
--- a/src/plugins/discover/public/application/main/components/no_results/no_results_helper.tsx
+++ b/src/plugins/discover/public/application/main/components/no_results/no_results_helper.tsx
@@ -57,7 +57,10 @@ export function AdjustSearch({ hasFilters, hasQuery, onDisableFilters }: AdjustS
               />
             </EuiDescriptionListTitle>
             <EuiDescriptionListDescription>
-              Try searching for a different combination of terms.
+              <FormattedMessage
+                id="discover.noResults.trySearchingForDifferentCombination"
+                defaultMessage="Try searching for a different combination of terms."
+              />
             </EuiDescriptionListDescription>
           </EuiDescriptionList>
         </>
@@ -69,11 +72,20 @@ export function AdjustSearch({ hasFilters, hasQuery, onDisableFilters }: AdjustS
             <EuiDescriptionListTitle data-test-subj="discoverNoResultsAdjustFilters">
               <FormattedMessage
                 id="discover.noResults.adjustFilters"
-                defaultMessage="Adjust your filters"
+                defaultMessage="Adjust your filters."
               />
             </EuiDescriptionListTitle>
             <EuiDescriptionListDescription>
-              Try removing or{' '}
+              <FormattedMessage
+                id="discover.noResults.tryRemovingOrDisablingFilters"
+                defaultMessage="Try removing or <link>temporarily disabling filters</link>."
+                values={
+                  {
+                    link: (content)=> (<EuiLink data-test-subj="discoverNoResultsDisableFilters" onClick={onDisableFilters}>{content}</EuiLink>) 
+                  }
+                } 
+              />
+             {' '}
               <EuiLink data-test-subj="discoverNoResultsDisableFilters" onClick={onDisableFilters}>
                 <FormattedMessage
                   id="discover.noResults.disableFilters"

--- a/src/plugins/discover/public/application/main/components/no_results/no_results_helper.tsx
+++ b/src/plugins/discover/public/application/main/components/no_results/no_results_helper.tsx
@@ -6,15 +6,15 @@
  * Side Public License, v 1.
  */
 
-import React, { Fragment } from "react";
-import { FormattedMessage } from "@kbn/i18n-react";
+import React, { Fragment } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import {
   EuiDescriptionList,
   EuiDescriptionListTitle,
   EuiLink,
   EuiDescriptionListDescription,
   EuiSpacer,
-} from "@elastic/eui";
+} from '@elastic/eui';
 
 export function getTimeFieldMessage() {
   return (
@@ -43,11 +43,7 @@ interface AdjustSearchProps {
   hasQuery?: boolean;
 }
 
-export function AdjustSearch({
-  hasFilters,
-  hasQuery,
-  onDisableFilters,
-}: AdjustSearchProps) {
+export function AdjustSearch({ hasFilters, hasQuery, onDisableFilters }: AdjustSearchProps) {
   return (
     <Fragment>
       {hasQuery && (

--- a/src/plugins/discover/public/application/main/components/no_results/no_results_helper.tsx
+++ b/src/plugins/discover/public/application/main/components/no_results/no_results_helper.tsx
@@ -78,14 +78,17 @@ export function AdjustSearch({ hasFilters, hasQuery, onDisableFilters }: AdjustS
             <EuiDescriptionListDescription>
               <FormattedMessage
                 id="discover.noResults.tryRemovingOrDisablingFilters"
-                defaultMessage="Try removing or <link>temporarily disabling filters</link>."
+                defaultMessage="Try removing or {disablingFiltersLink}."
                 values={{
-                  link: (content) => (
+                  disablingFiltersLink: (
                     <EuiLink
                       data-test-subj="discoverNoResultsDisableFilters"
                       onClick={onDisableFilters}
                     >
-                      {content}
+                      <FormattedMessage
+                        id="discover.noResults.temporaryDisablingFiltersLinkText"
+                        defaultMessage="temporarily disabling filters"
+                      />
                     </EuiLink>
                   ),
                 }}

--- a/src/plugins/discover/public/application/main/components/no_results/no_results_helper.tsx
+++ b/src/plugins/discover/public/application/main/components/no_results/no_results_helper.tsx
@@ -6,15 +6,15 @@
  * Side Public License, v 1.
  */
 
-import React, { Fragment } from 'react';
-import { FormattedMessage } from '@kbn/i18n-react';
+import React, { Fragment } from "react";
+import { FormattedMessage } from "@kbn/i18n-react";
 import {
   EuiDescriptionList,
   EuiDescriptionListTitle,
   EuiLink,
   EuiDescriptionListDescription,
   EuiSpacer,
-} from '@elastic/eui';
+} from "@elastic/eui";
 
 export function getTimeFieldMessage() {
   return (
@@ -43,7 +43,11 @@ interface AdjustSearchProps {
   hasQuery?: boolean;
 }
 
-export function AdjustSearch({ hasFilters, hasQuery, onDisableFilters }: AdjustSearchProps) {
+export function AdjustSearch({
+  hasFilters,
+  hasQuery,
+  onDisableFilters,
+}: AdjustSearchProps) {
   return (
     <Fragment>
       {hasQuery && (
@@ -79,20 +83,17 @@ export function AdjustSearch({ hasFilters, hasQuery, onDisableFilters }: AdjustS
               <FormattedMessage
                 id="discover.noResults.tryRemovingOrDisablingFilters"
                 defaultMessage="Try removing or <link>temporarily disabling filters</link>."
-                values={
-                  {
-                    link: (content)=> (<EuiLink data-test-subj="discoverNoResultsDisableFilters" onClick={onDisableFilters}>{content}</EuiLink>) 
-                  }
-                } 
+                values={{
+                  link: (content) => (
+                    <EuiLink
+                      data-test-subj="discoverNoResultsDisableFilters"
+                      onClick={onDisableFilters}
+                    >
+                      {content}
+                    </EuiLink>
+                  ),
+                }}
               />
-             {' '}
-              <EuiLink data-test-subj="discoverNoResultsDisableFilters" onClick={onDisableFilters}>
-                <FormattedMessage
-                  id="discover.noResults.disableFilters"
-                  defaultMessage="temporarily disabling filters"
-                />
-              </EuiLink>
-              .
             </EuiDescriptionListDescription>
           </EuiDescriptionList>
         </>

--- a/src/plugins/discover/public/application/main/components/no_results/no_results_helper.tsx
+++ b/src/plugins/discover/public/application/main/components/no_results/no_results_helper.tsx
@@ -72,7 +72,7 @@ export function AdjustSearch({ hasFilters, hasQuery, onDisableFilters }: AdjustS
             <EuiDescriptionListTitle data-test-subj="discoverNoResultsAdjustFilters">
               <FormattedMessage
                 id="discover.noResults.adjustFilters"
-                defaultMessage="Adjust your filters."
+                defaultMessage="Adjust your filters"
               />
             </EuiDescriptionListTitle>
             <EuiDescriptionListDescription>

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -1792,7 +1792,6 @@
     "discover.noMatchRoute.bannerTitleText": "ページが見つかりません",
     "discover.noResults.adjustFilters": "フィルターを調整",
     "discover.noResults.adjustSearch": "クエリを調整",
-    "discover.noResults.disableFilters": "フィルターを一時的に無効にしています",
     "discover.noResults.expandYourTimeRangeTitle": "時間範囲を拡大",
     "discover.noResults.queryMayNotMatchTitle": "期間を長くして検索を試してください。",
     "discover.noResults.searchExamples.noResultsBecauseOfError": "検索結果の取得中にエラーが発生しました",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -1806,7 +1806,6 @@
     "discover.noMatchRoute.bannerTitleText": "未找到页面",
     "discover.noResults.adjustFilters": "调整您的筛选",
     "discover.noResults.adjustSearch": "调整您的查询",
-    "discover.noResults.disableFilters": "正临时禁用筛选",
     "discover.noResults.expandYourTimeRangeTitle": "展开时间范围",
     "discover.noResults.queryMayNotMatchTitle": "尝试搜索更长的时间段。",
     "discover.noResults.searchExamples.noResultsBecauseOfError": "检索搜索结果时遇到问题",


### PR DESCRIPTION
## Summary

This PR adds i18n to parts of Discover's no results screen that were not translatable. 

<img width="648" alt="Bildschirmfoto 2021-12-15 um 10 47 04" src="https://user-images.githubusercontent.com/463851/146163407-4705d5b6-8102-457a-b0b6-8d65241e0e62.png">


