### PR TITLE
[Cases] Fix flaky test on form submit

### DIFF
--- a/x-pack/plugins/cases/public/components/create/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.test.tsx
@@ -114,34 +114,22 @@ describe('CreateCaseForm', () => {
     expect(queryByText('Sync alert')).not.toBeInTheDocument();
   });
 
-  describe('CreateCaseFormFields', () => {
-    it('should render spinner when loading', async () => {
-      const wrapper = mount(
-        <MockHookWrapperComponent>
-          <CreateCaseFormFields
-            connectors={[]}
-            isLoadingConnectors={false}
-            hideConnectorServiceNowSir={false}
-            withSteps={true}
-          />
-        </MockHookWrapperComponent>
-      );
+  it('should render spinner when loading', async () => {
+    const wrapper = mount(
+      <MockHookWrapperComponent>
+        <CreateCaseForm {...casesFormProps} />
+      </MockHookWrapperComponent>
+    );
 
-      await act(async () => {
-        globalForm.setFieldValue('title', 'title');
-        globalForm.setFieldValue('description', 'description');
-        globalForm.submit();
-        // For some weird reason this is needed to pass the test.
-        // It does not do anything useful
-        await wrapper.find(`[data-test-subj="caseTitle"]`);
-        await wrapper.update();
-      });
+    expect(wrapper.find(`[data-test-subj="create-case-submit"]`).exists()).toBeTruthy();
 
-      await waitFor(() => {
-        expect(
-          wrapper.find(`[data-test-subj="create-case-loading-spinner"]`).exists()
-        ).toBeTruthy();
-      });
+    await act(async () => {
+      globalForm.setFieldValue('title', 'title');
+      globalForm.setFieldValue('description', 'description');
+      await wrapper.find(`button[data-test-subj="create-case-submit"]`).simulate('click');
+      wrapper.update();
     });
+    
+    expect(wrapper.find(`[data-test-subj="create-case-loading-spinner"]`).exists()).toBeTruthy();
   });
 });

--- a/x-pack/plugins/cases/public/components/create/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.test.tsx
@@ -129,7 +129,7 @@ describe('CreateCaseForm', () => {
       await wrapper.find(`button[data-test-subj="create-case-submit"]`).simulate('click');
       wrapper.update();
     });
-    
+
     expect(wrapper.find(`[data-test-subj="create-case-loading-spinner"]`).exists()).toBeTruthy();
   });
 });

--- a/x-pack/plugins/cases/public/components/create/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.test.tsx
@@ -7,14 +7,14 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import { useForm, Form, FormHook } from '../../common/shared_imports';
 import { useGetTags } from '../../containers/use_get_tags';
 import { useConnectors } from '../../containers/configure/use_connectors';
 import { connectorsMock } from '../../containers/mock';
 import { schema, FormProps } from './schema';
-import { CreateCaseForm, CreateCaseFormFields, CreateCaseFormProps } from './form';
+import { CreateCaseForm, CreateCaseFormProps } from './form';
 import { useCaseConfigure } from '../../containers/configure/use_configure';
 import { useCaseConfigureResponse } from '../configure_cases/__mock__';
 import { TestProviders } from '../../common/mock';


### PR DESCRIPTION
## Summary

Fixes a flaky jest test: https://github.com/elastic/kibana/issues/120243

## Changes

I could not make it fail locally with the original version. Nevertheless, this test case was doing weird things, such as this nonsense `find` that was needed to make the test pass:
```        
// For some weird reason this is needed to pass the test.
// It does not do anything useful
await wrapper.find(`[data-test-subj="caseTitle"]`);
```

I changed the way the tests submit the form using simulate and this line is no longer needed to prevent the test failure.