### PR TITLE
chore(NA): splits types from code on @kbn/field-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -571,6 +571,7 @@
     "@types/kbn__docs-utils": "link:bazel-bin/packages/kbn-docs-utils/npm_module_types",
     "@types/kbn__es-archiver": "link:bazel-bin/packages/kbn-es-archiver/npm_module_types",
     "@types/kbn__es-query": "link:bazel-bin/packages/kbn-es-query/npm_module_types",
+    "@types/kbn__field-types": "link:bazel-bin/packages/kbn-field-types/npm_module_types",
     "@types/kbn__i18n": "link:bazel-bin/packages/kbn-i18n/npm_module_types",
     "@types/kbn__i18n-react": "link:bazel-bin/packages/kbn-i18n-react/npm_module_types",
     "@types/license-checker": "15.0.0",

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -90,6 +90,7 @@ filegroup(
       "//packages/kbn-docs-utils:build_types",
       "//packages/kbn-es-archiver:build_types",
       "//packages/kbn-es-query:build_types",
+      "//packages/kbn-field-types:build_types",
       "//packages/kbn-i18n:build_types",
       "//packages/kbn-i18n-react:build_types",
   ],

--- a/packages/kbn-field-types/BUILD.bazel
+++ b/packages/kbn-field-types/BUILD.bazel
@@ -1,10 +1,11 @@
 
-load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
-load("//src/dev/bazel:index.bzl", "jsts_transpiler")
+load("@npm//@bazel/typescript:index.bzl", "ts_config")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library",)
+load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types", "ts_project")
 
 PKG_BASE_NAME = "kbn-field-types"
 PKG_REQUIRE_NAME = "@kbn/field-types"
+TYPES_PKG_REQUIRE_NAME = "@types/kbn__field-types"
 
 SOURCE_FILES = glob(
   [
@@ -74,7 +75,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
+  deps = RUNTIME_DEPS + [":target_node"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )
@@ -90,6 +91,23 @@ filegroup(
   name = "build",
   srcs = [
     ":npm_module",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+pkg_npm_types(
+  name = "npm_module_types",
+  srcs = SRCS,
+  deps = [":tsc_types"],
+  package_name = TYPES_PKG_REQUIRE_NAME,
+  tsconfig = ":tsconfig",
+  visibility = ["//visibility:public"],
+)
+
+filegroup(
+  name = "build_types",
+  srcs = [
+    ":npm_module_types",
   ],
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-field-types/package.json
+++ b/packages/kbn-field-types/package.json
@@ -3,6 +3,5 @@
   "version": "1.0.0",
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target_node/index.js",
-  "types": "./target_types/index.d.ts"
+  "main": "./target_node/index.js"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5853,6 +5853,10 @@
   version "0.0.0"
   uid ""
 
+"@types/kbn__field-types@link:bazel-bin/packages/kbn-field-types/npm_module_types":
+  version "0.0.0"
+  uid ""
+
 "@types/kbn__i18n-react@link:bazel-bin/packages/kbn-i18n-react/npm_module_types":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
This PR is a step forward on #104519

It splits the the types build from the code transpilation.