### PR TITLE
[Lens] Wait for vis before asserting on it

### DIFF
--- a/x-pack/test/functional/apps/lens/smokescreen.ts
+++ b/x-pack/test/functional/apps/lens/smokescreen.ts
@@ -59,6 +59,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await listingTable.searchForItemWithName('Afancilenstest');
       await PageObjects.lens.clickVisualizeListItemTitle('Afancilenstest');
       await PageObjects.lens.goToTimeRange();
+      await PageObjects.lens.waitForVisualization();
 
       expect(await PageObjects.lens.getTitle()).to.eql('Afancilenstest');
 
@@ -80,6 +81,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         keepOpen: true,
       });
       await PageObjects.lens.addFilterToAgg(`geo.src : CN`);
+      await PageObjects.lens.waitForVisualization();
 
       // Verify that the field was persisted from the transition
       expect(await PageObjects.lens.getFiltersAggLabels()).to.eql([`ip : *`, `geo.src : CN`]);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/77969

In the screenshot you can see the filters are set correctly but the vis is not updated yet:
<img width="1288" alt="Screenshot 2021-12-13 at 14 53 29" src="https://user-images.githubusercontent.com/1508364/145824884-ba5927f7-d878-47f6-afca-8355ce38f17b.png">

This PR sets a `waitForVisualization` before asserting on the legend