### PR TITLE
[PluginService] Register all deprecations before running `isEnabledPath`

### DIFF
--- a/packages/kbn-config/src/config_service.test.ts
+++ b/packages/kbn-config/src/config_service.test.ts
@@ -340,7 +340,7 @@ test('throws if reading "enabled" when it is not present in the schema', async (
     })
   );
 
-  expect(
+  await expect(
     async () => await configService.isEnabledAtPath('foo')
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `"[config validation of [foo].enabled]: definition for this key is missing"`
@@ -357,7 +357,7 @@ test('throws if reading "enabled" when no schema exists', async () => {
   const rawConfigProvider = rawConfigServiceMock.create({ rawConfig: initialConfig });
   const configService = new ConfigService(rawConfigProvider, defaultEnv, logger);
 
-  expect(
+  await expect(
     async () => await configService.isEnabledAtPath('foo')
   ).rejects.toThrowErrorMatchingInlineSnapshot(`"No validation schema has been defined for [foo]"`);
 });
@@ -372,7 +372,7 @@ test('throws if reading any config value when no schema exists', async () => {
   const rawConfigProvider = rawConfigServiceMock.create({ rawConfig: initialConfig });
   const configService = new ConfigService(rawConfigProvider, defaultEnv, logger);
 
-  expect(
+  await expect(
     async () => await configService.isEnabledAtPath('foo')
   ).rejects.toThrowErrorMatchingInlineSnapshot(`"No validation schema has been defined for [foo]"`);
 });

--- a/src/core/server/plugins/plugins_service.test.ts
+++ b/src/core/server/plugins/plugins_service.test.ts
@@ -25,7 +25,7 @@ import { PluginsService } from './plugins_service';
 import { PluginsSystem } from './plugins_system';
 import { config } from './plugins_config';
 import { take } from 'rxjs/operators';
-import { DiscoveredPlugin, PluginType } from './types';
+import { DiscoveredPlugin, PluginConfigDescriptor, PluginType } from './types';
 
 const MockPluginsSystem: jest.Mock<PluginsSystem<PluginType>> = PluginsSystem as any;
 
@@ -1092,17 +1092,14 @@ describe('PluginsService', () => {
 
     jest.doMock(
       join(pluginB.path, 'server'),
-      () => ({
+      (): { config: PluginConfigDescriptor } => ({
         config: {
           schema: schema.object({
             enabled: schema.maybe(schema.boolean({ defaultValue: true })),
             renamed: schema.string(), // Mandatory string to make sure that the field is actually renamed by deprecations
           }),
-          deprecations: (toolkit: any) => [
-            toolkit.renameFromRoot(
-              'plugin-1-deprecations.toBeRenamed',
-              'plugin-2-deprecations.renamed'
-            ),
+          deprecations: ({ renameFromRoot }) => [
+            renameFromRoot('plugin-1-deprecations.toBeRenamed', 'plugin-2-deprecations.renamed'),
           ],
         },
       }),

--- a/src/core/server/plugins/plugins_service.ts
+++ b/src/core/server/plugins/plugins_service.ts
@@ -273,7 +273,7 @@ export class PluginsService implements CoreService<PluginsServiceSetup, PluginsS
     >();
     const plugins = await plugin$.pipe(toArray()).toPromise();
 
-    // 1. Register config descriptors and deprecations
+    // Register config descriptors and deprecations
     for (const plugin of plugins) {
       const configDescriptor = plugin.getConfigDescriptor();
       if (configDescriptor) {
@@ -294,7 +294,7 @@ export class PluginsService implements CoreService<PluginsServiceSetup, PluginsS
       }
     }
 
-    // 2. Validate config and handle enabled statuses.
+    // Validate config and handle enabled statuses.
     // NOTE: We can't do both in the same previous loop because some plugins' deprecations may affect others.
     // Hence, we need all the deprecations to be registered before accessing any config parameter.
     for (const plugin of plugins) {
@@ -320,7 +320,7 @@ export class PluginsService implements CoreService<PluginsServiceSetup, PluginsS
       pluginEnableStatuses.set(plugin.name, { plugin, isEnabled });
     }
 
-    // 3. Add the plugins to the Plugin System if enabled and its dependencies are met
+    // Add the plugins to the Plugin System if enabled and its dependencies are met
     for (const [pluginName, { plugin, isEnabled }] of pluginEnableStatuses) {
       this.validatePluginDependencies(plugin, pluginEnableStatuses);
 


### PR DESCRIPTION
## Summary

The Plugin Service needs to register all the config deprecations before checking if plugins are enabled.

The reasoning for this behaviour is:
1. We need to validate the config with the schema provided by the plugins so we know if `enabled` is allowed, and if they should default to `false`.
2. Validating the config without ensuring that all deprecations are registered/applied can cause bugs like #121058 due to race conditions (`reporting` fails to validate a key that is renamed by `screenshotting` only because the deprecations in the latter are not registered yet).

This PR also adds `await`s to some tests in `packages/kbn-config/src/config_service.test.ts` that should be awaited.

Resolves #121058.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
