### PR TITLE
[Security Solution][Hosts, Endpoint] Fix Host Details not showing endpoint related data for users without superuser role

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -36,6 +36,7 @@ import {
 } from './errors';
 import {
   EndpointFleetServicesFactory,
+  EndpointInternalFleetServicesInterface,
   EndpointScopedFleetServicesInterface,
 } from './services/endpoint_fleet_services';
 
@@ -138,6 +139,14 @@ export class EndpointAppContextService {
     }
 
     return this.fleetServicesFactory.asScoped(req);
+  }
+
+  public getInternalFleetServices(): EndpointInternalFleetServicesInterface {
+    if (this.fleetServicesFactory === null) {
+      throw new EndpointAppContentServicesNotStartedError();
+    }
+
+    return this.fleetServicesFactory.asInternalUser();
   }
 
   /** @deprecated use `getScopedFleetServices()` instead */

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helpers.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helpers.ts
@@ -188,11 +188,11 @@ export const getHostEndpoint = async (
     return null;
   }
 
-  const { esClient, endpointContext, request } = deps;
+  const { esClient, endpointContext } = deps;
   const logger = endpointContext.logFactory.get('metadata');
 
   try {
-    const fleetServices = endpointContext.service.getScopedFleetServices(request);
+    const fleetServices = endpointContext.service.getInternalFleetServices();
     const endpointMetadataService = endpointContext.service.getEndpointMetadataService();
 
     const endpointData = await endpointMetadataService

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_permissions.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_permissions.ts
@@ -62,8 +62,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await testSubjects.existOrFail('noIngestPermissions');
         });
 
-        // FIXME:PT skipped. need to fix security-team bug #1929
-        it.skip('should display endpoint data on Host Details', async () => {
+        it('should display endpoint data on Host Details', async () => {
           const endpoint = indexedData.hosts[0];
           await PageObjects.hosts.navigateToHostDetails(endpoint.host.name);
           const endpointSummary = await PageObjects.hosts.hostDetailsEndpointOverviewData();


### PR DESCRIPTION
## Summary

- Fix Host Details page not showing endpoint data when the user that is logged in does not have SuperUser role
- Adds a new method to the `EndpointAppContextServices` for retrieving an internal version of Fleet services

![image](https://user-images.githubusercontent.com/56442535/145830386-af542397-e9fb-400e-a291-865f6f59c2e8.png)

### Testing

This can be tested by using a User that does not have `superuser` role, but still has access to the Hosts pages in Security Solution. The `t1_analyst` role/user can be used for this by running the following scripts:

First - change directory (`cd`) to: `x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t1_analyst`

Then: 

```bash
ELASTICSEARCH_USERNAME=elastic ELASTICSEARCH_PASSWORD=changeme KIBANA_URL=http://127.0.0.1:5601 ELASTICSEARCH_URL=http://127.0.1:9200; export ELASTICSEARCH_USERNAME=elastic ELASTICSEARCH_PASSWORD=changeme KIBANA_URL=http://127.0.0.1:5601 ELASTI/127.0.0.1:5601p://127.0.1:9200; .http://127.0.1:9200le.sh && ./post_detections_user.sh
```

```bash
ELASTICSEARCH_USERNAME=elastic ELASTICSEARCH_PASSWORD=changeme KIBANA_URL=http://127.0.0.1:5601 ELASTICSEARCH_URL=http://127.0.1:9200; export ELASTICSEARCH_USERNAME=elastic ELASTICSEARCH_PASSWORD=changeme KIBANA_URL=http://127.0.0.1:5601 ELASTICSEARCH_URL=http://127.0.1:9200; ./post_detections_role.sh && ./post_detections_user.sh

```

