### PR TITLE
[Fleet] Fix increment package policy name

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -26,6 +26,7 @@ import {
   doesAgentPolicyAlreadyIncludePackage,
   validatePackagePolicy,
   validationHasErrors,
+  SO_SEARCH_LIMIT,
 } from '../../common';
 import type {
   DeletePackagePoliciesResponse,
@@ -1389,7 +1390,7 @@ export async function incrementPackageName(
 ) {
   // Fetch all packagePolicies having the package name
   const packagePolicyData = await packagePolicyService.list(soClient, {
-    perPage: 1,
+    perPage: SO_SEARCH_LIMIT,
     kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: "${packageName}"`,
   });
 

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -6,19 +6,38 @@
  */
 
 import expect from '@kbn/expect';
+import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../../../plugins/fleet/common';
 
-export default function ({ getService }: FtrProviderContext) {
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
 
   describe('fleet_agent_policies', () => {
+    skipIfNoDockerRegistry(providerContext);
     describe('POST /api/fleet/agent_policies', () => {
       before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
+        await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
       });
+      setupFleetAndAgents(providerContext);
+      const packagePoliciesToDeleteIds: string[] = [];
       after(async () => {
+        if (packagePoliciesToDeleteIds.length > 0) {
+          await kibanaServer.savedObjects.bulkDelete({
+            objects: packagePoliciesToDeleteIds.map((id) => ({
+              id,
+              type: PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            })),
+          });
+        }
+
         await esArchiver.unload('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
+        await esArchiver.unload('x-pack/test/functional/es_archives/empty_kibana');
       });
       it('should work with valid minimum required values', async () => {
         const {
@@ -112,6 +131,55 @@ export default function ({ getService }: FtrProviderContext) {
           .set('kbn-xsrf', 'xxxx')
           .send(sharedBody)
           .expect(409);
+      });
+
+      it('should allow to create policy with the system integration policy and increment correctly the name', async () => {
+        // load a bunch of fake system integration policy
+        await kibanaServer.savedObjects.create({
+          id: 'package-policy-1',
+          type: PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+          overwrite: true,
+          attributes: {
+            name: 'system-456',
+            package: {
+              name: 'system',
+            },
+          },
+        });
+        packagePoliciesToDeleteIds.push('package-policy-1');
+        await kibanaServer.savedObjects.create({
+          id: 'package-policy-2',
+          type: PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+          overwrite: true,
+          attributes: {
+            name: 'system-123',
+            package: {
+              name: 'system',
+            },
+          },
+        });
+        packagePoliciesToDeleteIds.push('package-policy-2');
+
+        // first one succeeds
+        const res = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .query({
+            sys_monitoring: true,
+          })
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Policy with system monitoring ${Date.now()}`,
+            namespace: 'default',
+          })
+          .expect(200);
+
+        const {
+          body: { items: policies },
+        } = await supertest.get(`/api/fleet/agent_policies?full=true`).expect(200);
+
+        const policy = policies.find((p: any) => (p.id = res.body.item.id));
+
+        expect(policy.package_policies[0].name).be('system-457');
       });
     });
 


### PR DESCRIPTION
## Summary

Resolve #121059 

Fix the package policy increment function to retrieve all the other existing package policy instead of only one.

What versions should we target for that fix?

## Work in progress

Trying to see if I can add some non regression test