### PR TITLE
[Infra UI] Replace IFieldType references

### DIFF
--- a/x-pack/plugins/infra/common/inventory_models/shared/components/metrics_and_groupby_toolbar_items.tsx
+++ b/x-pack/plugins/infra/common/inventory_models/shared/components/metrics_and_groupby_toolbar_items.tsx
@@ -43,7 +43,7 @@ export const MetricsAndGroupByToolbarItems = (props: Props) => {
     <>
       <EuiFlexItem grow={false}>
         <WaffleMetricControls
-          fields={props.createDerivedIndexPattern('metrics').fields}
+          fields={props.createDerivedIndexPattern().fields}
           options={metricOptions}
           metric={props.metric}
           onChange={props.changeMetric}
@@ -57,7 +57,7 @@ export const MetricsAndGroupByToolbarItems = (props: Props) => {
           groupBy={props.groupBy}
           nodeType={props.nodeType}
           onChange={props.changeGroupBy}
-          fields={props.createDerivedIndexPattern('metrics').fields}
+          fields={props.createDerivedIndexPattern().fields}
           onChangeCustomOptions={props.changeCustomOptions}
           customOptions={props.customOptions}
         />

--- a/x-pack/plugins/infra/public/alerting/common/group_by_expression/group_by_expression.tsx
+++ b/x-pack/plugins/infra/public/alerting/common/group_by_expression/group_by_expression.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useMemo } from 'react';
-import { IFieldType } from 'src/plugins/data/public';
+import { DataViewField } from 'src/plugins/data_views/common';
 import { i18n } from '@kbn/i18n';
 import {
   EuiPopoverTitle,
@@ -19,7 +19,7 @@ import { GroupBySelector } from './selector';
 
 interface Props {
   selectedGroups?: string[];
-  fields: IFieldType[];
+  fields: DataViewField[];
   onChange: (groupBy: string[]) => void;
   label?: string;
 }

--- a/x-pack/plugins/infra/public/alerting/common/group_by_expression/selector.tsx
+++ b/x-pack/plugins/infra/public/alerting/common/group_by_expression/selector.tsx
@@ -7,12 +7,12 @@
 
 import { EuiComboBox } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
-import { IFieldType } from 'src/plugins/data/public';
+import { DataViewField } from 'src/plugins/data_views/common';
 
 interface Props {
   selectedGroups?: string[];
   onChange: (groupBy: string[]) => void;
-  fields: IFieldType[];
+  fields: DataViewField[];
   label: string;
   placeholder: string;
 }

--- a/x-pack/plugins/infra/public/alerting/inventory/components/expression.test.tsx
+++ b/x-pack/plugins/infra/public/alerting/inventory/components/expression.test.tsx
@@ -171,7 +171,15 @@ describe('ExpressionRow', () => {
           metric: [],
         }}
         expression={expression}
-        fields={[{ name: 'some.system.field', type: 'bzzz' }]}
+        fields={[
+          {
+            name: 'some.system.field',
+            type: 'bzzz',
+            searchable: true,
+            aggregatable: true,
+            displayable: true,
+          },
+        ]}
       />
     );
 

--- a/x-pack/plugins/infra/public/alerting/inventory/components/expression.tsx
+++ b/x-pack/plugins/infra/public/alerting/inventory/components/expression.tsx
@@ -5,10 +5,8 @@
  * 2.0.
  */
 
-import { debounce, omit } from 'lodash';
 import { Unit } from '@elastic/datemath';
 import React, { useCallback, useMemo, useEffect, useState, ChangeEvent } from 'react';
-import { IFieldType } from 'src/plugins/data/public';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -25,6 +23,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { debounce, omit } from 'lodash';
 import { toMetricOpt } from '../../../../common/snapshot_metric_i18n';
 import {
   Comparator,
@@ -67,6 +66,7 @@ import {
 } from '../../../../common/http_api/snapshot_api';
 
 import { useKibanaContextForPlugin } from '../../../hooks/use_kibana';
+import { DerivedIndexPattern } from '../../../containers/metrics_source';
 
 import { ExpressionChart } from './expression_chart';
 const FILTER_TYPING_DEBOUNCE_MS = 500;
@@ -417,7 +417,7 @@ interface ExpressionRowProps {
   addExpression(): void;
   remove(id: number): void;
   setAlertParams(id: number, params: Partial<InventoryMetricConditions>): void;
-  fields: IFieldType[];
+  fields: DerivedIndexPattern['fields'];
 }
 
 const NonCollapsibleExpression = euiStyled.div`

--- a/x-pack/plugins/infra/public/alerting/inventory/components/metric.tsx
+++ b/x-pack/plugins/infra/public/alerting/inventory/components/metric.tsx
@@ -4,11 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import React, { useState, useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { debounce } from 'lodash';
 import {
   EuiExpression,
   EuiPopover,
@@ -22,8 +20,8 @@ import {
   EuiText,
   EuiFieldText,
 } from '@elastic/eui';
-import { IFieldType } from 'src/plugins/data/public';
 import { EuiPopoverTitle, EuiButtonIcon } from '@elastic/eui';
+import { debounce } from 'lodash';
 import { getCustomMetricLabel } from '../../../../common/formatters/get_custom_metric_label';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { IErrorObject } from '../../../../../triggers_actions_ui/public/types';
@@ -34,6 +32,7 @@ import {
   SNAPSHOT_CUSTOM_AGGREGATIONS,
   SnapshotCustomAggregationRT,
 } from '../../../../common/http_api/snapshot_api';
+import { DerivedIndexPattern } from '../../../containers/metrics_source';
 
 interface Props {
   metric?: { value: string; text: string };
@@ -42,7 +41,7 @@ interface Props {
   onChange: (metric?: string) => void;
   onChangeCustom: (customMetric?: SnapshotCustomMetricInput) => void;
   customMetric?: SnapshotCustomMetricInput;
-  fields: IFieldType[];
+  fields: DerivedIndexPattern['fields'];
   popupPosition?:
     | 'upCenter'
     | 'upLeft'

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criteria.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criteria.tsx
@@ -9,7 +9,7 @@ import React, { useCallback } from 'react';
 import { EuiFlexItem, EuiFlexGroup, EuiButtonEmpty, EuiAccordion, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import { IFieldType } from 'src/plugins/data/public';
+import { DataViewField } from 'src/plugins/data_views/common';
 import { Criterion } from './criterion';
 import {
   PartialRuleParams,
@@ -34,7 +34,7 @@ const QueryBText = i18n.translate('xpack.infra.logs.alerting.threshold.ratioCrit
 });
 
 interface SharedProps {
-  fields: IFieldType[];
+  fields: DataViewField[];
   criteria?: PartialCriteriaType;
   defaultCriterion: PartialCriterionType;
   errors: Errors['criteria'];

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criterion.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criterion.tsx
@@ -20,8 +20,8 @@ import {
   EuiComboBox,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { DataViewField } from 'src/plugins/data_views/common';
 import { isNumber, isFinite } from 'lodash';
-import { IFieldType } from 'src/plugins/data/public';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { IErrorObject } from '../../../../../../triggers_actions_ui/public/types';
 import {
@@ -55,7 +55,7 @@ const criterionComparatorValueTitle = i18n.translate(
   }
 );
 
-const getCompatibleComparatorsForField = (fieldInfo: IFieldType | undefined) => {
+const getCompatibleComparatorsForField = (fieldInfo: DataViewField | undefined) => {
   if (fieldInfo?.type === 'number') {
     return [
       { value: Comparator.GT, text: ComparatorToi18nMap[Comparator.GT] },
@@ -83,7 +83,7 @@ const getCompatibleComparatorsForField = (fieldInfo: IFieldType | undefined) => 
   }
 };
 
-const getFieldInfo = (fields: IFieldType[], fieldName: string): IFieldType | undefined => {
+const getFieldInfo = (fields: DataViewField[], fieldName: string): DataViewField | undefined => {
   return fields.find((field) => {
     return field.name === fieldName;
   });
@@ -91,7 +91,7 @@ const getFieldInfo = (fields: IFieldType[], fieldName: string): IFieldType | und
 
 interface Props {
   idx: number;
-  fields: IFieldType[];
+  fields: DataViewField[];
   criterion: Partial<CriterionType>;
   updateCriterion: (idx: number, params: Partial<CriterionType>) => void;
   removeCriterion: (idx: number) => void;
@@ -117,7 +117,7 @@ export const Criterion: React.FC<Props> = ({
     });
   }, [fields]);
 
-  const fieldInfo: IFieldType | undefined = useMemo(() => {
+  const fieldInfo: DataViewField | undefined = useMemo(() => {
     if (criterion.field) {
       return getFieldInfo(fields, criterion.field);
     } else {

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { debounce } from 'lodash';
 import { Unit } from '@elastic/datemath';
 import React, { ChangeEvent, useCallback, useMemo, useEffect, useState } from 'react';
 import {
@@ -23,6 +22,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { debounce } from 'lodash';
 import { Comparator, Aggregators } from '../../../../common/alerting/metrics';
 import { ForLastExpression } from '../../../../../triggers_actions_ui/public';
 import {

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_row.test.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_row.test.tsx
@@ -26,8 +26,20 @@ describe('ExpressionRow', () => {
       <ExpressionRow
         canDelete={false}
         fields={[
-          { name: 'system.cpu.user.pct', type: 'test' },
-          { name: 'system.load.1', type: 'test' },
+          {
+            name: 'system.cpu.user.pct',
+            type: 'test',
+            searchable: true,
+            aggregatable: true,
+            displayable: true,
+          },
+          {
+            name: 'system.load.1',
+            type: 'test',
+            searchable: true,
+            aggregatable: true,
+            displayable: true,
+          },
         ]}
         remove={() => {}}
         addExpression={() => {}}

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_row.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_row.tsx
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { omit } from 'lodash';
 import React, { useCallback, useState, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -18,7 +17,7 @@ import {
   EuiHealth,
   EuiButtonEmpty,
 } from '@elastic/eui';
-import { IFieldType } from 'src/plugins/data/public';
+import { omit } from 'lodash';
 import { pctToDecimal, decimalToPct } from '../../../../common/utils/corrected_percent_convert';
 import {
   WhenExpression,
@@ -33,6 +32,7 @@ import {
   // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 } from '../../../../server/lib/alerting/metric_threshold/types';
 import { builtInComparators } from '../../../../../triggers_actions_ui/public';
+import { DerivedIndexPattern } from '../../../containers/metrics_source';
 
 const customComparators = {
   ...builtInComparators,
@@ -46,7 +46,7 @@ const customComparators = {
 };
 
 interface ExpressionRowProps {
-  fields: IFieldType[];
+  fields: DerivedIndexPattern['fields'];
   expressionId: number;
   expression: MetricExpression;
   errors: IErrorObject;

--- a/x-pack/plugins/infra/public/containers/metrics_source/source.tsx
+++ b/x-pack/plugins/infra/public/containers/metrics_source/source.tsx
@@ -100,10 +100,10 @@ export const useSource = ({ sourceId }: { sourceId: string }) => {
     [fetchService, sourceId]
   );
 
-  const createDerivedIndexPattern = (type: 'metrics') => {
+  const createDerivedIndexPattern = () => {
     return {
       fields: source?.status ? source.status.indexFields : [],
-      title: pickIndexPattern(source, type),
+      title: pickIndexPattern(source, 'metrics'),
     };
   };
 

--- a/x-pack/plugins/infra/public/containers/metrics_source/types.ts
+++ b/x-pack/plugins/infra/public/containers/metrics_source/types.ts
@@ -5,5 +5,11 @@
  * 2.0.
  */
 
-export * from './source';
-export * from './types';
+import { MetricsSourceStatus } from '../../../common/metrics_sources';
+
+export interface DerivedIndexPattern {
+  fields: MetricsSourceStatus['indexFields'];
+  title: string;
+}
+
+export type CreateDerivedIndexPattern = () => DerivedIndexPattern;

--- a/x-pack/plugins/infra/public/containers/with_source/with_source.tsx
+++ b/x-pack/plugins/infra/public/containers/with_source/with_source.tsx
@@ -7,13 +7,13 @@
 
 import React, { useContext } from 'react';
 
-import { DataViewBase } from '@kbn/es-query';
 import {
   MetricsSourceConfigurationProperties,
   PartialMetricsSourceConfigurationProperties,
 } from '../../../common/metrics_sources';
 import { RendererFunction } from '../../utils/typed_react';
 import { Source } from '../metrics_source';
+import { CreateDerivedIndexPattern } from '../../containers/metrics_source';
 
 interface WithSourceProps {
   children: RendererFunction<{
@@ -21,7 +21,7 @@ interface WithSourceProps {
     create: (
       sourceProperties: PartialMetricsSourceConfigurationProperties
     ) => Promise<any> | undefined;
-    createDerivedIndexPattern: (type: 'metrics') => DataViewBase;
+    createDerivedIndexPattern: CreateDerivedIndexPattern;
     exists?: boolean;
     hasFailed: boolean;
     isLoading: boolean;

--- a/x-pack/plugins/infra/public/pages/metrics/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/index.tsx
@@ -11,7 +11,6 @@ import React, { useContext } from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 
 import { EuiErrorBoundary, EuiHeaderLinks, EuiHeaderLink } from '@elastic/eui';
-import { DataViewBase } from '@kbn/es-query';
 import { MetricsSourceConfigurationProperties } from '../../../common/metrics_sources';
 import { DocumentTitle } from '../../components/document_title';
 import { HelpCenterContent } from '../../components/help_center_content';
@@ -41,6 +40,7 @@ import { AnomalyDetectionFlyout } from './inventory_view/components/ml/anomaly_d
 import { HeaderMenuPortal } from '../../../../observability/public';
 import { HeaderActionMenuContext } from '../../utils/header_action_menu_provider';
 import { useLinkProps } from '../../hooks/use_link_props';
+import { CreateDerivedIndexPattern } from '../../containers/metrics_source';
 
 const ADD_DATA_LABEL = i18n.translate('xpack.infra.metricsHeaderAddDataButtonLabel', {
   defaultMessage: 'Add data',
@@ -139,7 +139,7 @@ export const InfrastructurePage = ({ match }: RouteComponentProps) => {
 
 const PageContent = (props: {
   configuration: MetricsSourceConfigurationProperties;
-  createDerivedIndexPattern: (type: 'metrics') => DataViewBase;
+  createDerivedIndexPattern: CreateDerivedIndexPattern;
 }) => {
   const { createDerivedIndexPattern, configuration } = props;
   const { options } = useContext(MetricsExplorerOptionsContainer.Context);
@@ -151,7 +151,7 @@ const PageContent = (props: {
       defaultViewState={DEFAULT_METRICS_EXPLORER_VIEW_STATE}
     >
       <MetricsExplorerPage
-        derivedIndexPattern={createDerivedIndexPattern('metrics')}
+        derivedIndexPattern={createDerivedIndexPattern()}
         source={configuration}
         {...props}
       />

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/metrics/metrics.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/metrics/metrics.tsx
@@ -6,10 +6,10 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { first, last } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { Chart, niceTimeFormatter, PointerEvent } from '@elastic/charts';
 import { EuiLoadingChart, EuiSpacer, EuiFlexGrid, EuiFlexItem } from '@elastic/eui';
+import { first, last } from 'lodash';
 import { TabContent, TabProps } from '../shared';
 import { useSnapshot } from '../../../../hooks/use_snaphot';
 import { useWaffleOptionsContext } from '../../../../hooks/use_waffle_options';
@@ -73,7 +73,7 @@ const TabComponent = (props: TabProps) => {
   const { nodeType, accountId, region, customMetrics } = useWaffleOptionsContext();
   const { currentTime, node } = props;
   const derivedIndexPattern = useMemo(
-    () => createDerivedIndexPattern('metrics'),
+    () => createDerivedIndexPattern(),
     [createDerivedIndexPattern]
   );
   let filter = `${findInventoryFields(nodeType).id}: "${node.id}"`;

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/search_bar.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/search_bar.tsx
@@ -21,7 +21,7 @@ export const SearchBar = () => {
     setFilterQueryDraftFromKueryExpression,
   } = useWaffleFiltersContext();
   return (
-    <WithKueryAutocompletion indexPattern={createDerivedIndexPattern('metrics')}>
+    <WithKueryAutocompletion indexPattern={createDerivedIndexPattern()}>
       {({ isLoadingSuggestions, loadSuggestions, suggestions }) => (
         <AutocompleteField
           isLoadingSuggestions={isLoadingSuggestions}

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/toolbars/toolbar.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/toolbars/toolbar.tsx
@@ -7,7 +7,6 @@
 
 import React, { FunctionComponent } from 'react';
 import { EuiFlexItem } from '@elastic/eui';
-import { DataViewBase } from '@kbn/es-query';
 import { useSourceContext } from '../../../../../containers/metrics_source';
 import {
   SnapshotMetricInput,
@@ -22,9 +21,9 @@ import { InfraGroupByOptions } from '../../../../../lib/lib';
 import { InventoryItemType } from '../../../../../../common/inventory_models/types';
 import { WaffleOptionsState, WaffleSortOption } from '../../hooks/use_waffle_options';
 import { useInventoryMeta } from '../../hooks/use_inventory_meta';
-
+import { CreateDerivedIndexPattern } from '../../../../../containers/metrics_source';
 export interface ToolbarProps extends Omit<WaffleOptionsState, 'boundsOverride' | 'autoBounds'> {
-  createDerivedIndexPattern: (type: 'metrics') => DataViewBase;
+  createDerivedIndexPattern: CreateDerivedIndexPattern;
   changeMetric: (payload: SnapshotMetricInput) => void;
   changeGroupBy: (payload: SnapshotGroupBy) => void;
   changeCustomOptions: (payload: InfraGroupByOptions[]) => void;

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/custom_field_panel.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/custom_field_panel.tsx
@@ -8,12 +8,11 @@
 import { EuiButton, EuiComboBox, EuiForm, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { IFieldType } from 'src/plugins/data/public';
 import { InfraGroupByOptions } from '../../../../../lib/lib';
-
+import { DerivedIndexPattern } from '../../../../../containers/metrics_source';
 interface Props {
   onSubmit: (field: string) => void;
-  fields: IFieldType[];
+  fields: DerivedIndexPattern['fields'];
   currentOptions: InfraGroupByOptions[];
 }
 

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/custom_metric_form.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/custom_metric_form.tsx
@@ -20,7 +20,6 @@ import {
   EuiText,
   EuiPopoverTitle,
 } from '@elastic/eui';
-import { IFieldType } from 'src/plugins/data/public';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -30,6 +29,7 @@ import {
   SnapshotCustomAggregationRT,
 } from '../../../../../../../common/http_api/snapshot_api';
 import { EuiTheme, withTheme } from '../../../../../../../../../../src/plugins/kibana_react/common';
+import { DerivedIndexPattern } from '../../../../../../containers/metrics_source';
 
 interface SelectedOption {
   label: string;
@@ -53,7 +53,7 @@ const AGGREGATION_LABELS = {
 interface Props {
   theme: EuiTheme | undefined;
   metric?: SnapshotCustomMetricInput;
-  fields: IFieldType[];
+  fields: DerivedIndexPattern['fields'];
   customMetrics: SnapshotCustomMetricInput[];
   onChange: (metric: SnapshotCustomMetricInput) => void;
   onCancel: () => void;

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/index.tsx
@@ -8,7 +8,6 @@
 import { EuiPopover } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState, useCallback } from 'react';
-import { IFieldType } from 'src/plugins/data/public';
 import { getCustomMetricLabel } from '../../../../../../../common/formatters/get_custom_metric_label';
 import {
   SnapshotMetricInput,
@@ -22,11 +21,12 @@ import { MetricsEditMode } from './metrics_edit_mode';
 import { CustomMetricMode } from './types';
 import { SnapshotMetricType } from '../../../../../../../common/inventory_models/types';
 import { DropdownButton } from '../../dropdown_button';
+import { DerivedIndexPattern } from '../../../../../../containers/metrics_source';
 
 interface Props {
   options: Array<{ text: string; value: string }>;
   metric: SnapshotMetricInput;
-  fields: IFieldType[];
+  fields: DerivedIndexPattern['fields'];
   onChange: (metric: SnapshotMetricInput) => void;
   onChangeCustomMetrics: (metrics: SnapshotCustomMetricInput[]) => void;
   customMetrics: SnapshotCustomMetricInput[];

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_group_by_controls.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_group_by_controls.tsx
@@ -15,21 +15,20 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
-import { IFieldType } from 'src/plugins/data/public';
 import { InfraGroupByOptions } from '../../../../../lib/lib';
 import { CustomFieldPanel } from './custom_field_panel';
 import { euiStyled } from '../../../../../../../../../src/plugins/kibana_react/common';
 import { InventoryItemType } from '../../../../../../common/inventory_models/types';
 import { SnapshotGroupBy } from '../../../../../../common/http_api/snapshot_api';
 import { DropdownButton } from '../dropdown_button';
-
+import { DerivedIndexPattern } from '../../../../../containers/metrics_source';
 interface Props {
   options: Array<{ text: string; field: string; toolTipContent?: string }>;
   nodeType: InventoryItemType;
   groupBy: SnapshotGroupBy;
   onChange: (groupBy: SnapshotGroupBy) => void;
   onChangeCustomOptions: (options: InfraGroupByOptions[]) => void;
-  fields: IFieldType[];
+  fields: DerivedIndexPattern['fields'];
   customOptions: InfraGroupByOptions[];
 }
 

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/hooks/use_process_list.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/hooks/use_process_list.ts
@@ -27,7 +27,7 @@ export function useProcessList(
   searchFilter: object
 ) {
   const { createDerivedIndexPattern } = useSourceContext();
-  const indexPattern = createDerivedIndexPattern('metrics').title;
+  const indexPattern = createDerivedIndexPattern().title;
 
   const [inErrorState, setInErrorState] = useState(false);
   const decodeResponse = (response: any) => {
@@ -76,7 +76,7 @@ export function useProcessList(
 function useProcessListParams(props: { hostTerm: Record<string, string>; to: number }) {
   const { hostTerm, to } = props;
   const { createDerivedIndexPattern } = useSourceContext();
-  const indexPattern = createDerivedIndexPattern('metrics').title;
+  const indexPattern = createDerivedIndexPattern().title;
   return { hostTerm, indexPattern, to };
 }
 const ProcessListContext = createContainter(useProcessListParams);

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/hooks/use_waffle_filters.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/hooks/use_waffle_filters.ts
@@ -30,7 +30,7 @@ export const DEFAULT_WAFFLE_FILTERS_STATE: WaffleFiltersState = { kind: 'kuery',
 
 export const useWaffleFilters = () => {
   const { createDerivedIndexPattern } = useSourceContext();
-  const indexPattern = createDerivedIndexPattern('metrics');
+  const indexPattern = createDerivedIndexPattern();
 
   const [urlState, setUrlState] = useUrlState<WaffleFiltersState>({
     defaultState: DEFAULT_WAFFLE_FILTERS_STATE,

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/group_by.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/group_by.tsx
@@ -9,13 +9,13 @@ import { EuiComboBox } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import React, { useCallback } from 'react';
-import { IFieldType } from 'src/plugins/data/public';
 import { MetricsExplorerOptions } from '../hooks/use_metrics_explorer_options';
+import { DerivedIndexPattern } from '../../../../containers/metrics_source';
 
 interface Props {
   options: MetricsExplorerOptions;
   onChange: (groupBy: string | null | string[]) => void;
-  fields: IFieldType[];
+  fields: DerivedIndexPattern['fields'];
   errorOptions?: string[];
 }
 

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/metrics.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/metrics.tsx
@@ -9,16 +9,16 @@ import { EuiComboBox } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import React, { useCallback, useState } from 'react';
-import { IFieldType } from 'src/plugins/data/public';
 import { colorTransformer, Color } from '../../../../../common/color_palette';
 import { MetricsExplorerMetric } from '../../../../../common/http_api/metrics_explorer';
 import { MetricsExplorerOptions } from '../hooks/use_metrics_explorer_options';
+import { DerivedIndexPattern } from '../../../../containers/metrics_source';
 
 interface Props {
   autoFocus?: boolean;
   options: MetricsExplorerOptions;
   onChange: (metrics: MetricsExplorerMetric[]) => void;
-  fields: IFieldType[];
+  fields: DerivedIndexPattern['fields'];
 }
 
 interface SelectedOption {

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/toolbar.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/toolbar.tsx
@@ -8,7 +8,6 @@
 import { EuiFlexGroup, EuiFlexItem, EuiSuperDatePicker, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
-import { DataViewBase } from '@kbn/es-query';
 import { UI_SETTINGS } from '../../../../../../../../src/plugins/data/public';
 import {
   MetricsExplorerMetric,
@@ -26,9 +25,10 @@ import { MetricsExplorerAggregationPicker } from './aggregation';
 import { MetricsExplorerChartOptions as MetricsExplorerChartOptionsComponent } from './chart_options';
 import { useKibanaUiSetting } from '../../../../utils/use_kibana_ui_setting';
 import { mapKibanaQuickRangesToDatePickerRanges } from '../../../../utils/map_timepicker_quickranges_to_datepicker_ranges';
+import { DerivedIndexPattern } from '../../../../containers/metrics_source';
 
 interface Props {
-  derivedIndexPattern: DataViewBase;
+  derivedIndexPattern: DerivedIndexPattern;
   timeRange: MetricsExplorerTimeOptions;
   options: MetricsExplorerOptions;
   chartOptions: MetricsExplorerChartOptions;

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/index.tsx
@@ -8,7 +8,6 @@
 import { EuiErrorBoundary } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useContext } from 'react';
-import { DataViewBase } from '@kbn/es-query';
 import { MetricsSourceConfigurationProperties } from '../../../../common/metrics_sources';
 import { useTrackPageview } from '../../../../../observability/public';
 import { useMetricsBreadcrumbs } from '../../../hooks/use_metrics_breadcrumbs';
@@ -22,10 +21,10 @@ import { useSavedViewContext } from '../../../containers/saved_view/saved_view';
 import { MetricsPageTemplate } from '../page_template';
 import { metricsExplorerTitle } from '../../../translations';
 import { SavedViewsToolbarControls } from '../../../components/saved_views/toolbar_control';
-
+import { DerivedIndexPattern } from '../../../containers/metrics_source';
 interface MetricsExplorerPageProps {
   source: MetricsSourceConfigurationProperties;
-  derivedIndexPattern: DataViewBase;
+  derivedIndexPattern: DerivedIndexPattern;
 }
 
 export const MetricsExplorerPage = ({ source, derivedIndexPattern }: MetricsExplorerPageProps) => {


### PR DESCRIPTION
## Summary

Fixes #107885

Replaces all instances of `IFieldType` with suitable replacements. 

Due to the super permissible nature of the `IFieldType` interface there were some types that were just represented incorrectly. But, because `IFieldType` designated most fields as optional it didn't really surface the type mismatches. 

E.g. on the metrics side the derived index pattern was often designated as a `DataViewBase`, and in many ways it looks like one, the problem with the base type is it also expects the `fields` to be of the base version. However, we actually use a custom type for the representation there. It's not quite the "full" field, nor the base type, which is why it made more sense to introduce a new accurate type. 

Over on the logs side it may well make more sense for some sections of code to use `ResolvedLogSourceConfiguration['fields']` rather than relying on the underlying, backing types. However, I had issues getting that to play nicely where we use `supportedFields` in the alerting code (even though there should have been no type mismatch), so instead kept this as the `DataViewField` type.