### PR TITLE
[Security Solution][Detections]Fix rule query overlapping timeline banner on rule edit page

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/query_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/query_bar/index.tsx
@@ -56,6 +56,9 @@ const StyledEuiFormRow = styled(EuiFormRow)`
       & > div:first-child {
         margin: 0px 0px 0px 4px;
       }
+      &__wrap {
+        z-index: 0;
+      }
     }
   }
 `;


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/117983
## Summary

Fixes rule query overlapping timeline banner on rule edit page by changing input query z-index

### Before
<img width="1525" alt="Screenshot 2021-12-13 at 19 10 59" src="https://user-images.githubusercontent.com/92328789/145873455-37073bc4-c04b-42ce-89c7-4dee64fa5b10.png">

### After

<img width="1533" alt="Screenshot 2021-12-13 at 19 10 36" src="https://user-images.githubusercontent.com/92328789/145873467-1f2aeb18-730c-4878-8a3d-7ac43d95ac54.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
