### PR TITLE
[Cases] Migrating alerts schema to object format

### DIFF
--- a/x-pack/plugins/cases/common/api/cases/comment.ts
+++ b/x-pack/plugins/cases/common/api/cases/comment.ts
@@ -64,6 +64,24 @@ export const AlertCommentRequestRt = rt.type({
   owner: rt.string,
 });
 
+// TODO: rename
+export const AlertCommentRequestRt810 = rt.type({
+  type: rt.union([rt.literal(CommentType.generatedAlert), rt.literal(CommentType.alert)]),
+  alerts: rt.array(
+    rt.type({
+      id: rt.string,
+      index: rt.string,
+      rule: rt.type({
+        // TODO: it'd be great if we could enforce not allowing the user to pass in null for the rule information
+        // but allow it to be null in the backend because of previous alerts that did not have the rule info
+        id: rt.union([rt.string, rt.null]),
+        name: rt.union([rt.string, rt.null]),
+      }),
+    })
+  ),
+  owner: rt.string,
+});
+
 export const ActionsCommentRequestRt = rt.type({
   type: rt.literal(CommentType.actions),
   comment: rt.string,
@@ -84,6 +102,12 @@ export const AttributesTypeAlertsRt = rt.intersection([
   AlertCommentRequestRt,
   CommentAttributesBasicRt,
 ]);
+
+export const AttributesTypeAlertsRt810 = rt.intersection([
+  AlertCommentRequestRt810,
+  CommentAttributesBasicRt,
+]);
+
 const AttributesTypeActionsRt = rt.intersection([
   ActionsCommentRequestRt,
   CommentAttributesBasicRt,
@@ -91,6 +115,7 @@ const AttributesTypeActionsRt = rt.intersection([
 const CommentAttributesRt = rt.union([
   AttributesTypeUserRt,
   AttributesTypeAlertsRt,
+  AttributesTypeAlertsRt810,
   AttributesTypeActionsRt,
 ]);
 
@@ -166,6 +191,8 @@ export const FindQueryParamsRt = rt.partial({
 export type FindQueryParams = rt.TypeOf<typeof FindQueryParamsRt>;
 export type AttributesTypeActions = rt.TypeOf<typeof AttributesTypeActionsRt>;
 export type AttributesTypeAlerts = rt.TypeOf<typeof AttributesTypeAlertsRt>;
+// TODO: rename
+export type AttributesTypeAlerts810 = rt.TypeOf<typeof AttributesTypeAlertsRt810>;
 export type AttributesTypeUser = rt.TypeOf<typeof AttributesTypeUserRt>;
 export type CommentAttributes = rt.TypeOf<typeof CommentAttributesRt>;
 export type CommentRequest = rt.TypeOf<typeof CommentRequestRt>;

--- a/x-pack/plugins/cases/common/api/cases/comment.ts
+++ b/x-pack/plugins/cases/common/api/cases/comment.ts
@@ -80,7 +80,10 @@ export const ActionsCommentRequestRt = rt.type({
 });
 
 const AttributesTypeUserRt = rt.intersection([ContextTypeUserRt, CommentAttributesBasicRt]);
-const AttributesTypeAlertsRt = rt.intersection([AlertCommentRequestRt, CommentAttributesBasicRt]);
+export const AttributesTypeAlertsRt = rt.intersection([
+  AlertCommentRequestRt,
+  CommentAttributesBasicRt,
+]);
 const AttributesTypeActionsRt = rt.intersection([
   ActionsCommentRequestRt,
   CommentAttributesBasicRt,

--- a/x-pack/plugins/cases/server/saved_object_types/comments.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/comments.ts
@@ -44,11 +44,26 @@ export const createCaseCommentSavedObjectType = ({
           type: { type: 'keyword' },
         },
       },
-      alertId: {
-        type: 'keyword',
-      },
-      index: {
-        type: 'keyword',
+      alerts: {
+        type: 'nested',
+        properties: {
+          id: {
+            type: 'keyword',
+          },
+          index: {
+            type: 'keyword',
+          },
+          rule: {
+            properties: {
+              id: {
+                type: 'keyword',
+              },
+              name: {
+                type: 'keyword',
+              },
+            },
+          },
+        },
       },
       created_at: {
         type: 'date',
@@ -78,16 +93,6 @@ export const createCaseCommentSavedObjectType = ({
             type: 'keyword',
           },
           email: {
-            type: 'keyword',
-          },
-        },
-      },
-      rule: {
-        properties: {
-          id: {
-            type: 'keyword',
-          },
-          name: {
             type: 'keyword',
           },
         },

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/utils.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/utils.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { isString } from 'lodash';
 import { LogMeta, SavedObjectMigrationContext } from '../../../../../../src/core/server';
 
 interface MigrationLogMeta extends LogMeta {
@@ -24,12 +25,14 @@ export function logError({
 }: {
   id: string;
   context: SavedObjectMigrationContext;
-  error: Error;
+  error: Error | string;
   docType: string;
   docKey: string;
 }) {
+  const errorString = getErrorString(error);
+
   context.log.error<MigrationLogMeta>(
-    `Failed to migrate ${docType} with doc id: ${id} version: ${context.migrationVersion} error: ${error.message}`,
+    `Failed to migrate ${docType} with doc id: ${id} version: ${context.migrationVersion} error: ${errorString}`,
     {
       migrations: {
         [docKey]: {
@@ -38,4 +41,12 @@ export function logError({
       },
     }
   );
+}
+
+function getErrorString(error: Error | string): string {
+  if (isString(error)) {
+    return error;
+  }
+
+  return error.message;
 }

--- a/x-pack/plugins/cases/server/services/attachments/index.ts
+++ b/x-pack/plugins/cases/server/services/attachments/index.ts
@@ -96,6 +96,7 @@ export class AttachmentService {
     }
   }
 
+  // TODO: switch to new alerts object
   private buildCountAlertsAggs(): Record<string, estypes.AggregationsAggregationContainer> {
     return {
       alerts: {

--- a/x-pack/plugins/cases/server/services/cases/index.ts
+++ b/x-pack/plugins/cases/server/services/cases/index.ts
@@ -261,6 +261,7 @@ export class CasesService {
     try {
       this.log.debug(`Attempting to GET all cases for alert id ${alertId}`);
       const combinedFilter = combineFilters([
+        // TODO: switch to new alerts object
         nodeBuilder.is(`${CASE_COMMENT_SAVED_OBJECT}.attributes.alertId`, alertId),
         filter,
       ]);

--- a/x-pack/test/cases_api_integration/common/lib/elasticsearch.ts
+++ b/x-pack/test/cases_api_integration/common/lib/elasticsearch.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { TransportResult, Client } from '@elastic/elasticsearch';
+
+import {
+  AttributesTypeAlerts810,
+  AttributesTypeUser,
+  ConnectorMappings,
+} from '../../../../plugins/cases/common/api';
+
+import { ESCasesConfigureAttributes } from '../../../../plugins/cases/server/services/configure/types';
+import { ESCaseAttributes } from '../../../../plugins/cases/server/services/cases/types';
+
+/**
+ * Returns connector mappings saved objects from Elasticsearch directly.
+ */
+export const getConnectorMappingsFromES = async ({ es }: { es: Client }) => {
+  const mappings: TransportResult<
+    estypes.SearchResponse<{
+      'cases-connector-mappings': ConnectorMappings;
+    }>,
+    unknown
+  > = await es.search(
+    {
+      index: '.kibana',
+      body: {
+        query: {
+          term: {
+            type: {
+              value: 'cases-connector-mappings',
+            },
+          },
+        },
+      },
+    },
+    { meta: true }
+  );
+
+  return mappings;
+};
+
+/**
+ * Returns configure saved objects from Elasticsearch directly.
+ */
+export const getConfigureSavedObjectsFromES = async ({ es }: { es: Client }) => {
+  const configure: TransportResult<
+    estypes.SearchResponse<{
+      'cases-configure': ESCasesConfigureAttributes;
+    }>,
+    unknown
+  > = await es.search(
+    {
+      index: '.kibana',
+      body: {
+        query: {
+          term: {
+            type: {
+              value: 'cases-configure',
+            },
+          },
+        },
+      },
+    },
+    { meta: true }
+  );
+
+  return configure;
+};
+
+export const getCaseSavedObjectsFromES = async ({ es }: { es: Client }) => {
+  const configure: TransportResult<
+    estypes.SearchResponse<{ cases: ESCaseAttributes }>,
+    unknown
+  > = await es.search(
+    {
+      index: '.kibana',
+      body: {
+        query: {
+          term: {
+            type: {
+              value: 'cases',
+            },
+          },
+        },
+      },
+    },
+    { meta: true }
+  );
+
+  return configure;
+};
+
+export const findAlertAttachmentsSavedObjectsFromES = async ({ es }: { es: Client }) => {
+  const alerts: TransportResult<
+    estypes.SearchResponse<{ 'cases-comments': AttributesTypeAlerts810 }>
+  > = await es.search(
+    {
+      index: '.kibana',
+      body: {
+        query: {
+          bool: {
+            filter: [
+              {
+                term: {
+                  type: {
+                    value: 'cases-comments',
+                  },
+                },
+              },
+              {
+                term: {
+                  'cases-comments.type': {
+                    value: 'alert',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    { meta: true }
+  );
+
+  return alerts;
+};
+
+export const getAlertAttachmentSavedObjectFromES = async ({
+  es,
+  id,
+}: {
+  es: Client;
+  id: string;
+}) => {
+  const alert: TransportResult<estypes.GetResponse<{ 'cases-comments': AttributesTypeAlerts810 }>> =
+    await es.get(
+      {
+        id,
+        index: '.kibana',
+      },
+      { meta: true }
+    );
+
+  return alert;
+};
+
+export const getUserAttachmentSavedObjectFromES = async ({
+  es,
+  id,
+}: {
+  es: Client;
+  id: string;
+}) => {
+  const alert: TransportResult<estypes.GetResponse<{ 'cases-comments': AttributesTypeUser }>> =
+    await es.get(
+      {
+        id,
+        index: '.kibana',
+      },
+      { meta: true }
+    );
+
+  return alert;
+};

--- a/x-pack/test/cases_api_integration/common/lib/utils.ts
+++ b/x-pack/test/cases_api_integration/common/lib/utils.ts
@@ -49,7 +49,6 @@ import {
   CasesConfigurationsResponse,
   CaseUserActionsResponse,
   AlertResponse,
-  ConnectorMappings,
   CasesByAlertId,
   CaseResolveResponse,
   CaseMetricsResponse,
@@ -61,8 +60,6 @@ import { SignalHit } from '../../../../plugins/security_solution/server/lib/dete
 import { ActionResult, FindActionResult } from '../../../../plugins/actions/server/types';
 import { User } from './authentication/types';
 import { superUser } from './authentication/users';
-import { ESCasesConfigureAttributes } from '../../../../plugins/cases/server/services/configure/types';
-import { ESCaseAttributes } from '../../../../plugins/cases/server/services/cases/types';
 import { getServiceNowServer } from '../../../alerting_api_integration/common/fixtures/plugins/actions_simulators/server/plugin';
 
 function toArray<T>(input: T | T[]): T[] {
@@ -592,89 +589,6 @@ export const ensureSavedObjectIsAuthorized = (
 ) => {
   expect(entities.length).to.eql(numberOfExpectedCases);
   entities.forEach((entity) => expect(owners.includes(entity.owner)).to.be(true));
-};
-
-interface ConnectorMappingsSavedObject {
-  'cases-connector-mappings': ConnectorMappings;
-}
-
-/**
- * Returns connector mappings saved objects from Elasticsearch directly.
- */
-export const getConnectorMappingsFromES = async ({ es }: { es: Client }) => {
-  const mappings: TransportResult<
-    estypes.SearchResponse<ConnectorMappingsSavedObject>,
-    unknown
-  > = await es.search(
-    {
-      index: '.kibana',
-      body: {
-        query: {
-          term: {
-            type: {
-              value: 'cases-connector-mappings',
-            },
-          },
-        },
-      },
-    },
-    { meta: true }
-  );
-
-  return mappings;
-};
-
-interface ConfigureSavedObject {
-  'cases-configure': ESCasesConfigureAttributes;
-}
-
-/**
- * Returns configure saved objects from Elasticsearch directly.
- */
-export const getConfigureSavedObjectsFromES = async ({ es }: { es: Client }) => {
-  const configure: TransportResult<
-    estypes.SearchResponse<ConfigureSavedObject>,
-    unknown
-  > = await es.search(
-    {
-      index: '.kibana',
-      body: {
-        query: {
-          term: {
-            type: {
-              value: 'cases-configure',
-            },
-          },
-        },
-      },
-    },
-    { meta: true }
-  );
-
-  return configure;
-};
-
-export const getCaseSavedObjectsFromES = async ({ es }: { es: Client }) => {
-  const configure: TransportResult<
-    estypes.SearchResponse<{ cases: ESCaseAttributes }>,
-    unknown
-  > = await es.search(
-    {
-      index: '.kibana',
-      body: {
-        query: {
-          term: {
-            type: {
-              value: 'cases',
-            },
-          },
-        },
-      },
-    },
-    { meta: true }
-  );
-
-  return configure;
 };
 
 export const createCaseWithConnector = async ({

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/migrations.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/migrations.ts
@@ -11,7 +11,8 @@ import {
   CASES_URL,
   SECURITY_SOLUTION_OWNER,
 } from '../../../../../../plugins/cases/common/constants';
-import { getCase, getCaseSavedObjectsFromES, resolveCase } from '../../../../common/lib/utils';
+import { getCase, resolveCase } from '../../../../common/lib/utils';
+import { getCaseSavedObjectsFromES } from '../../../../common/lib/elasticsearch';
 import { superUser } from '../../../../common/lib/authentication/users';
 import { AttributesTypeUser } from '../../../../../../plugins/cases/common/api';
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/migrations.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/migrations.ts
@@ -11,11 +11,11 @@ import {
   CASE_CONFIGURE_URL,
   SECURITY_SOLUTION_OWNER,
 } from '../../../../../../plugins/cases/common/constants';
+import { getConfiguration } from '../../../../common/lib/utils';
 import {
-  getConfiguration,
   getConfigureSavedObjectsFromES,
   getConnectorMappingsFromES,
-} from '../../../../common/lib/utils';
+} from '../../../../common/lib/elasticsearch';
 
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService }: FtrProviderContext) {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/push_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/push_case.ts
@@ -32,10 +32,10 @@ import {
   createCaseWithConnector,
   createConnector,
   getServiceNowConnector,
-  getConnectorMappingsFromES,
   getCase,
   getServiceNowSimulationServer,
 } from '../../../../common/lib/utils';
+import { getConnectorMappingsFromES } from '../../../../common/lib/elasticsearch';
 import {
   CaseConnector,
   CaseStatuses,

--- a/x-pack/test/functional/fixtures/kbn_archiver/cases/7.13.2/alerts.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/cases/7.13.2/alerts.json
@@ -1,0 +1,249 @@
+{
+  "attributes": {
+    "closed_at": null,
+    "closed_by": null,
+    "connector": {
+      "fields": [
+        {
+          "key": "issueType",
+          "value": "10002"
+        },
+        {
+          "key": "parent",
+          "value": null
+        },
+        {
+          "key": "priority",
+          "value": null
+        }
+      ],
+      "id": "d68508f0-cf9d-11eb-a603-13e7747d215c",
+      "name": "Test Jira",
+      "type": ".jira"
+    },
+    "created_at": "2021-06-17T18:57:41.682Z",
+    "created_by": {
+      "email": null,
+      "full_name": "j@j.com",
+      "username": "711621466"
+    },
+    "description": "asdf",
+    "external_service": {
+      "connector_id": "d68508f0-cf9d-11eb-a603-13e7747d215c",
+      "connector_name": "Test Jira",
+      "external_id": "10106",
+      "external_title": "TPN-99",
+      "external_url": "https://cases-testing.atlassian.net/browse/TPN-99",
+      "pushed_at": "2021-06-17T18:57:45.524Z",
+      "pushed_by": {
+        "email": null,
+        "full_name": "j@j.com",
+        "username": "711621466"
+      }
+    },
+    "settings": {
+      "syncAlerts": true
+    },
+    "status": "open",
+    "tags": [
+      "some tag"
+    ],
+    "title": "A case",
+    "type": "individual",
+    "updated_at": "2021-06-17T18:57:58.037Z",
+    "updated_by": {
+      "email": null,
+      "full_name": "j@j.com",
+      "username": "711621466"
+    }
+  },
+  "id": "e49ad6e0-cf9d-11eb-a603-13e7747d215c",
+  "coreMigrationVersion": "7.13.2",
+  "migrationVersion": {
+    "cases": "7.12.0"
+  },
+  "references": [
+  ],
+  "type": "cases",
+  "updated_at": "2021-06-17T18:57:58.076Z"
+}
+
+{
+  "attributes": {
+    "associationType": "case",
+    "alertId": "123",
+    "index": "123",
+    "rule": {
+      "id": "id",
+      "name": "name"
+    },
+    "created_at": "2021-06-17T18:57:58.037Z",
+    "created_by": {
+      "email": null,
+      "full_name": "j@j.com",
+      "username": "711621466"
+    },
+    "pushed_at": null,
+    "pushed_by": null,
+    "type": "alert",
+    "updated_at": null,
+    "updated_by": null
+  },
+  "coreMigrationVersion": "7.13.2",
+  "migrationVersion": {
+    "cases-comments": "7.12.0"
+  },
+  "id": "ee59cdd0-cf9d-11eb-a603-13e7747d215c",
+  "references": [
+    {
+      "id": "e49ad6e0-cf9d-11eb-a603-13e7747d215c",
+      "name": "associated-cases",
+      "type": "cases"
+    }
+  ],
+  "type": "cases-comments",
+  "updated_at": "2021-06-17T18:57:58.087Z"
+}
+
+{
+  "attributes": {
+    "associationType": "case",
+    "alertId": ["123", "456"],
+    "index": ["123", "456"],
+    "rule": {
+      "id": null,
+      "name": null
+    },
+    "created_at": "2021-06-17T18:57:58.037Z",
+    "created_by": {
+      "email": null,
+      "full_name": "j@j.com",
+      "username": "711621466"
+    },
+    "pushed_at": null,
+    "pushed_by": null,
+    "type": "alert",
+    "updated_at": null,
+    "updated_by": null
+  },
+  "coreMigrationVersion": "7.13.2",
+  "migrationVersion": {
+    "cases-comments": "7.12.0"
+  },
+  "id": "ae59cdd0-cf9d-11eb-a603-13e7747d215c",
+  "references": [
+    {
+      "id": "e49ad6e0-cf9d-11eb-a603-13e7747d215c",
+      "name": "associated-cases",
+      "type": "cases"
+    }
+  ],
+  "type": "cases-comments",
+  "updated_at": "2021-06-17T18:57:58.087Z"
+}
+
+{
+  "attributes": {
+    "associationType": "case",
+    "comment": "A comment",
+    "created_at": "2021-06-17T18:57:58.037Z",
+    "created_by": {
+      "email": null,
+      "full_name": "j@j.com",
+      "username": "711621466"
+    },
+    "pushed_at": null,
+    "pushed_by": null,
+    "type": "user",
+    "updated_at": null,
+    "updated_by": null
+  },
+  "coreMigrationVersion": "7.13.2",
+  "migrationVersion": {
+    "cases-comments": "7.12.0"
+  },
+  "id": "be59cdd0-cf9d-11eb-a603-13e7747d215c",
+  "references": [
+    {
+      "id": "e49ad6e0-cf9d-11eb-a603-13e7747d215c",
+      "name": "associated-cases",
+      "type": "cases"
+    }
+  ],
+  "type": "cases-comments",
+  "updated_at": "2021-06-17T18:57:58.087Z"
+}
+
+{
+  "attributes": {
+    "associationType": "case",
+    "alertId": ["123", "456"],
+    "index": "123",
+    "rule": {
+      "id": null,
+      "name": null
+    },
+    "created_at": "2021-06-17T18:57:58.037Z",
+    "created_by": {
+      "email": null,
+      "full_name": "j@j.com",
+      "username": "711621466"
+    },
+    "pushed_at": null,
+    "pushed_by": null,
+    "type": "alert",
+    "updated_at": null,
+    "updated_by": null
+  },
+  "coreMigrationVersion": "7.13.2",
+  "migrationVersion": {
+    "cases-comments": "7.12.0"
+  },
+  "id": "ce59cdd0-cf9d-11eb-a603-13e7747d215c",
+  "references": [
+    {
+      "id": "e49ad6e0-cf9d-11eb-a603-13e7747d215c",
+      "name": "associated-cases",
+      "type": "cases"
+    }
+  ],
+  "type": "cases-comments",
+  "updated_at": "2021-06-17T18:57:58.087Z"
+}
+
+{
+  "attributes": {
+    "associationType": "case",
+    "alertId": ["123"],
+    "index": ["123", "456"],
+    "rule": {
+      "id": null,
+      "name": null
+    },
+    "created_at": "2021-06-17T18:57:58.037Z",
+    "created_by": {
+      "email": null,
+      "full_name": "j@j.com",
+      "username": "711621466"
+    },
+    "pushed_at": null,
+    "pushed_by": null,
+    "type": "alert",
+    "updated_at": null,
+    "updated_by": null
+  },
+  "coreMigrationVersion": "7.13.2",
+  "migrationVersion": {
+    "cases-comments": "7.12.0"
+  },
+  "id": "de59cdd0-cf9d-11eb-a603-13e7747d215c",
+  "references": [
+    {
+      "id": "e49ad6e0-cf9d-11eb-a603-13e7747d215c",
+      "name": "associated-cases",
+      "type": "cases"
+    }
+  ],
+  "type": "cases-comments",
+  "updated_at": "2021-06-17T18:57:58.087Z"
+}


### PR DESCRIPTION
WIP

This PR refactors the alerts schema from being separated arrays for the ids and indices to arrays of objects:

## Current format
```
{
  alertId: string | string[];
  index: string | string[];
  rule: { id: string | null; index: string | null; };
}
```

## New format
```
{
  alerts: {
    id: string;
    index: string;
    rule: { id: string | null; index: string | null; };
  };
}
```