### PR TITLE
[Security Solution] [Endpoint] Display empty state when there are no assigned event filters to policy

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/index.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { PolicyEventFiltersEmptyUnassigned } from './policy_event_filters_empty_unassigned';
+export { PolicyEventFiltersEmptyUnexisting } from './policy_event_filters_empty_unexisting';

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/policy_event_filters_empty_unassigned.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/policy_event_filters_empty_unassigned.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { EuiEmptyPrompt, EuiPageTemplate, EuiLink } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+// TODO: Uncomment this when assign functionality through the flyout is done
+// import { usePolicyDetailsNavigateCallback } from '../../policy_hooks';
+import { useGetLinkTo } from './use_policy_event_filters_empty_hooks';
+import { useUserPrivileges } from '../../../../../../common/components/user_privileges';
+
+interface CommonProps {
+  policyId: string;
+  policyName: string;
+}
+
+export const PolicyEventFiltersEmptyUnassigned = memo<CommonProps>(({ policyId, policyName }) => {
+  const { canCreateArtifactsByPolicy } = useUserPrivileges().endpointPrivileges;
+  const { onClickHandler, toRouteUrl } = useGetLinkTo(policyId, policyName);
+
+  // TODO: Uncomment this when assign functionality through the flyout is done
+  // const navigateCallback = usePolicyDetailsNavigateCallback();
+  // const onClickPrimaryButtonHandler = useCallback(
+  //   () =>
+  //     navigateCallback({
+  //       show: 'list',
+  //     }),
+  //   [navigateCallback]
+  // );
+  return (
+    <EuiPageTemplate template="centeredContent">
+      <EuiEmptyPrompt
+        iconType="plusInCircle"
+        data-test-subj="policy-event-filters-empty-unassigned"
+        title={
+          <h2>
+            <FormattedMessage
+              id="xpack.securitySolution.endpoint.policy.eventFilters.empty.unassigned.title"
+              defaultMessage="No assigned event filters"
+            />
+          </h2>
+        }
+        body={
+          <FormattedMessage
+            id="xpack.securitySolution.endpoint.policy.eventFilters.empty.unassigned.content"
+            defaultMessage="There are currently no event filters assigned to {policyName}. Assign event filters now or add and manage them on the event filters page."
+            values={{ policyName }}
+          />
+        }
+        actions={[
+          ...(canCreateArtifactsByPolicy
+            ? [
+                // TODO: Uncomment this when assign functionality through the flyout is done
+                // <EuiButton
+                //   color="primary"
+                //   fill
+                //   onClick={onClickPrimaryButtonHandler}
+                //   data-test-subj="assign-ta-button"
+                // >
+                //   <FormattedMessage
+                //     id="xpack.securitySolution.endpoint.policy.eventFilters.empty.unassigned.primaryAction"
+                //     defaultMessage="Assign event filters"
+                //   />
+                // </EuiButton>,
+              ]
+            : []),
+          // eslint-disable-next-line @elastic/eui/href-or-on-click
+          <EuiLink onClick={onClickHandler} href={toRouteUrl}>
+            <FormattedMessage
+              id="xpack.securitySolution.endpoint.policy.eventFilters.empty.unassigned.secondaryAction"
+              defaultMessage="Manage event filters"
+            />
+          </EuiLink>,
+        ]}
+      />
+    </EuiPageTemplate>
+  );
+});
+
+PolicyEventFiltersEmptyUnassigned.displayName = 'PolicyEventFiltersEmptyUnassigned';

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/policy_event_filters_empty_unexisting.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/policy_event_filters_empty_unexisting.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { EuiEmptyPrompt, EuiButton, EuiPageTemplate } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useGetLinkTo } from './use_policy_event_filters_empty_hooks';
+
+interface CommonProps {
+  policyId: string;
+  policyName: string;
+}
+
+export const PolicyEventFiltersEmptyUnexisting = memo<CommonProps>(({ policyId, policyName }) => {
+  const { onClickHandler, toRouteUrl } = useGetLinkTo(policyId, policyName);
+  return (
+    <EuiPageTemplate template="centeredContent">
+      <EuiEmptyPrompt
+        iconType="plusInCircle"
+        data-test-subj="policy-event-filters-empty-unexisting"
+        title={
+          <h2>
+            <FormattedMessage
+              id="xpack.securitySolution.endpoint.policy.eventFilters.empty.unexisting.title"
+              defaultMessage="No event filters exist"
+            />
+          </h2>
+        }
+        body={
+          <FormattedMessage
+            id="xpack.securitySolution.endpoint.policy.eventFilters.empty.unexisting.content"
+            defaultMessage="There are currently no event filters applied to your endpoints."
+          />
+        }
+        actions={
+          // eslint-disable-next-line @elastic/eui/href-or-on-click
+          <EuiButton color="primary" fill onClick={onClickHandler} href={toRouteUrl}>
+            <FormattedMessage
+              id="xpack.securitySolution.endpoint.policy.eventFilters.empty.unexisting.action"
+              defaultMessage="Add event filter"
+            />
+          </EuiButton>
+        }
+      />
+    </EuiPageTemplate>
+  );
+});
+
+PolicyEventFiltersEmptyUnexisting.displayName = 'PolicyEventFiltersEmptyUnexisting';

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/use_policy_event_filters_empty_hooks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/use_policy_event_filters_empty_hooks.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import { useNavigateToAppEventHandler } from '../../../../../../common/hooks/endpoint/use_navigate_to_app_event_handler';
+import { useAppUrl } from '../../../../../../common/lib/kibana/hooks';
+import { getPolicyEventFiltersPath, getEventFiltersListPath } from '../../../../../common/routing';
+import { APP_UI_ID } from '../../../../../../../common/constants';
+
+export const useGetLinkTo = (policyId: string, policyName: string) => {
+  const { getAppUrl } = useAppUrl();
+  const { toRoutePath, toRouteUrl } = useMemo(() => {
+    const path = getEventFiltersListPath();
+    return {
+      toRoutePath: path,
+      toRouteUrl: getAppUrl({ path }),
+    };
+  }, [getAppUrl]);
+
+  const policyEventFiltersPath = useMemo(() => getPolicyEventFiltersPath(policyId), [policyId]);
+  const policyEventFilterRouteState = useMemo(() => {
+    return {
+      backButtonLabel: i18n.translate(
+        'xpack.securitySolution.endpoint.policy.eventFilters.empty.unassigned.backButtonLabel',
+        {
+          defaultMessage: 'Back to {policyName} policy',
+          values: {
+            policyName,
+          },
+        }
+      ),
+      onBackButtonNavigateTo: [
+        APP_UI_ID,
+        {
+          path: policyEventFiltersPath,
+        },
+      ],
+      backButtonUrl: getAppUrl({
+        appId: APP_UI_ID,
+        path: policyEventFiltersPath,
+      }),
+    };
+  }, [getAppUrl, policyName, policyEventFiltersPath]);
+
+  const onClickHandler = useNavigateToAppEventHandler(APP_UI_ID, {
+    state: policyEventFilterRouteState,
+    path: toRoutePath,
+  });
+
+  return {
+    onClickHandler,
+    toRouteUrl,
+  };
+};

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/hooks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/hooks.ts
@@ -9,6 +9,8 @@ import { QueryObserverResult, useQuery } from 'react-query';
 import { ServerApiError } from '../../../../../common/types';
 import { useHttp } from '../../../../../common/lib/kibana/hooks';
 import { EventFiltersHttpService } from '../../../event_filters/service';
+import { parseQueryFilterToKQL } from '../../../../common/utils';
+import { SEARCHABLE_FIELDS } from '../../../event_filters/constants';
 
 export function useGetAllAssignedEventFilters(
   policyId?: string
@@ -27,6 +29,60 @@ export function useGetAllAssignedEventFilters(
       refetchIntervalInBackground: false,
       refetchOnWindowFocus: false,
       enabled: !!policyId,
+      refetchOnMount: true,
+    }
+  );
+}
+
+export function useSearchAssignedEventFilters(
+  policyId?: string,
+  filter?: string
+): QueryObserverResult<FoundExceptionListItemSchema, ServerApiError> {
+  const http = useHttp();
+  const eventFiltersService = new EventFiltersHttpService(http);
+
+  return useQuery<FoundExceptionListItemSchema, ServerApiError>(
+    ['eventFilters', 'assigned', policyId],
+    () => {
+      const kuery = [
+        `((exception-list-agnostic.attributes.tags:"policy:${policyId}") OR (exception-list-agnostic.attributes.tags:"policy:all"))`,
+      ];
+
+      if (filter) {
+        const filterKuery = parseQueryFilterToKQL(filter, SEARCHABLE_FIELDS) || undefined;
+        if (filterKuery) {
+          kuery.push(filterKuery);
+        }
+      }
+
+      return eventFiltersService.getList({
+        filter: kuery.join(' AND '),
+      });
+    },
+    {
+      refetchIntervalInBackground: false,
+      refetchOnWindowFocus: false,
+      enabled: !!policyId,
+      refetchOnMount: true,
+    }
+  );
+}
+
+export function useGetAllEventFilters(): QueryObserverResult<
+  FoundExceptionListItemSchema,
+  ServerApiError
+> {
+  const http = useHttp();
+  const eventFiltersService = new EventFiltersHttpService(http);
+
+  return useQuery<FoundExceptionListItemSchema, ServerApiError>(
+    ['eventFilters', 'all'],
+    () => {
+      return eventFiltersService.getList();
+    },
+    {
+      refetchIntervalInBackground: false,
+      refetchOnWindowFocus: false,
       refetchOnMount: true,
     }
   );

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/layout/policy_event_filters_layout.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/layout/policy_event_filters_layout.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { PolicyEventFiltersLayout } from './policy_event_filters_layout';
+import * as reactTestingLibrary from '@testing-library/react';
+import {
+  AppContextTestRender,
+  createAppRootMockRenderer,
+} from '../../../../../../common/mock/endpoint';
+import { EndpointDocGenerator } from '../../../../../../../common/endpoint/generate_data';
+import { EventFilterGenerator } from '../../../../../../../common/endpoint/data_generators/event_filter_generator';
+
+import { EventFiltersHttpService } from '../../../../event_filters/service';
+import { ImmutableObject, PolicyData } from '../../../../../../../common/endpoint/types';
+
+jest.mock('../../../../event_filters/service');
+const EventFiltersHttpServiceMock = EventFiltersHttpService as jest.Mock;
+
+let render: () => ReturnType<AppContextTestRender['render']>;
+let mockedContext: AppContextTestRender;
+let policyItem: ImmutableObject<PolicyData>;
+const generator = new EndpointDocGenerator();
+const eventFilterGenerator = new EventFilterGenerator();
+
+describe('Policy event filters layout', () => {
+  beforeEach(() => {
+    mockedContext = createAppRootMockRenderer();
+    policyItem = generator.generatePolicyPackagePolicy();
+    render = () => mockedContext.render(<PolicyEventFiltersLayout policyItem={policyItem} />);
+  });
+
+  afterEach(() => reactTestingLibrary.cleanup());
+
+  it('should renders layout with a loader', async () => {
+    const component = render();
+    expect(component.getByTestId('policy-event-filters-loading-spinner')).toBeTruthy();
+  });
+
+  it('should renders layout with no assigned event filters data when there are not event filters', async () => {
+    EventFiltersHttpServiceMock.mockImplementation(() => {
+      return {
+        getList: () => ({
+          total: 0,
+          data: [],
+        }),
+      };
+    });
+
+    const component = render();
+    expect(await component.findByTestId('policy-event-filters-empty-unexisting')).not.toBeNull();
+  });
+
+  it('should renders layout with no assigned event filters data when there are event filters', async () => {
+    EventFiltersHttpServiceMock.mockImplementation(() => {
+      return {
+        getList: (
+          params: Partial<{
+            filter: string;
+          }>
+        ) => {
+          if (
+            params &&
+            params.filter ===
+              `(exception-list-agnostic.attributes.tags:"policy:${policyItem.id}" OR exception-list-agnostic.attributes.tags:"policy:all")`
+          ) {
+            return {
+              total: 0,
+              data: [],
+            };
+          } else {
+            return {
+              total: 1,
+              data: [eventFilterGenerator.generate()],
+            };
+          }
+        },
+      };
+    });
+
+    const component = render();
+
+    expect(await component.findByTestId('policy-event-filters-empty-unassigned')).not.toBeNull();
+  });
+
+  it('should renders layout with data', async () => {
+    EventFiltersHttpServiceMock.mockImplementation(() => {
+      return {
+        getList: () => ({
+          total: 3,
+          data: Array.from({ length: 3 }, () => eventFilterGenerator.generate()),
+        }),
+      };
+    });
+    const component = render();
+    expect(await component.findByTestId('policy-event-filters-header-section')).not.toBeNull();
+    expect(await component.findByTestId('policy-event-filters-layout-about')).not.toBeNull();
+    expect((await component.findByTestId('policy-event-filters-layout-about')).textContent).toMatch(
+      '3 event filters'
+    );
+  });
+});

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/layout/policy_event_filters_layout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/layout/policy_event_filters_layout.tsx
@@ -21,8 +21,9 @@ import { useAppUrl } from '../../../../../../common/lib/kibana';
 import { APP_UI_ID } from '../../../../../../../common/constants';
 import { ImmutableObject, PolicyData } from '../../../../../../../common/endpoint/types';
 import { getEventFiltersListPath } from '../../../../../common/routing';
-import { useGetAllAssignedEventFilters } from '../hooks';
+import { useGetAllAssignedEventFilters, useGetAllEventFilters } from '../hooks';
 import { ManagementEmptyStateWraper } from '../../../../../components/management_empty_state_wraper';
+import { PolicyEventFiltersEmptyUnassigned, PolicyEventFiltersEmptyUnexisting } from '../empty';
 
 interface PolicyEventFiltersLayoutProps {
   policyItem?: ImmutableObject<PolicyData> | undefined;
@@ -36,6 +37,12 @@ export const PolicyEventFiltersLayout = React.memo<PolicyEventFiltersLayoutProps
       isLoading: isLoadingAllAssigned,
       isRefetching: isRefetchingAllAssigned,
     } = useGetAllAssignedEventFilters(policyItem?.id);
+
+    const {
+      data: allEventFilters,
+      isLoading: isLoadingAllEventFilters,
+      isRefetching: isRefetchingAllEventFilters,
+    } = useGetAllEventFilters();
 
     const aboutInfo = useMemo(() => {
       const link = (
@@ -63,44 +70,60 @@ export const PolicyEventFiltersLayout = React.memo<PolicyEventFiltersLayoutProps
     }, [getAppUrl, allAssigned]);
 
     const isGlobalLoading = useMemo(
-      () => isLoadingAllAssigned || isRefetchingAllAssigned,
-      [isLoadingAllAssigned, isRefetchingAllAssigned]
+      () =>
+        isLoadingAllAssigned ||
+        isRefetchingAllAssigned ||
+        isLoadingAllEventFilters ||
+        isRefetchingAllEventFilters,
+      [
+        isLoadingAllAssigned,
+        isLoadingAllEventFilters,
+        isRefetchingAllAssigned,
+        isRefetchingAllEventFilters,
+      ]
     );
 
     const isEmptyState = useMemo(() => allAssigned && allAssigned.total === 0, [allAssigned]);
 
-    return policyItem && !isGlobalLoading ? (
-      isEmptyState ? (
-        // TODO: Display empty state when needed
-        <></>
+    if (!policyItem || isGlobalLoading) {
+      return (
+        <ManagementEmptyStateWraper>
+          <EuiLoadingSpinner data-test-subj="policy-event-filters-loading-spinner" size="l" />
+        </ManagementEmptyStateWraper>
+      );
+    }
+
+    if (isEmptyState) {
+      return allEventFilters && allEventFilters.total !== 0 ? (
+        <PolicyEventFiltersEmptyUnassigned policyId={policyItem.id} policyName={policyItem.name} />
       ) : (
-        <div>
-          <EuiPageHeader alignItems="center">
-            <EuiPageHeaderSection>
-              <EuiTitle size="m">
-                <h2>
-                  {i18n.translate(
-                    'xpack.securitySolution.endpoint.policy.eventFilters.layout.title',
-                    {
-                      defaultMessage: 'Assigned event filters',
-                    }
-                  )}
-                </h2>
-              </EuiTitle>
+        <PolicyEventFiltersEmptyUnexisting policyId={policyItem.id} policyName={policyItem.name} />
+      );
+    }
 
-              <EuiSpacer size="s" />
+    return (
+      <div>
+        <EuiPageHeader alignItems="center">
+          <EuiPageHeaderSection data-test-subj="policy-event-filters-header-section">
+            <EuiTitle size="m">
+              <h2>
+                {i18n.translate(
+                  'xpack.securitySolution.endpoint.policy.eventFilters.layout.title',
+                  {
+                    defaultMessage: 'Assigned event filters',
+                  }
+                )}
+              </h2>
+            </EuiTitle>
 
-              <EuiText size="xs">
-                <p>{aboutInfo}</p>
-              </EuiText>
-            </EuiPageHeaderSection>
-          </EuiPageHeader>
-        </div>
-      )
-    ) : (
-      <ManagementEmptyStateWraper>
-        <EuiLoadingSpinner size="l" />
-      </ManagementEmptyStateWraper>
+            <EuiSpacer size="s" />
+
+            <EuiText size="xs" data-test-subj="policy-event-filters-layout-about">
+              <p>{aboutInfo}</p>
+            </EuiText>
+          </EuiPageHeaderSection>
+        </EuiPageHeader>
+      </div>
     );
   }
 );


### PR DESCRIPTION
## Summary

The commented code will be uncommented when the flyout to add more items to the policy is implemented.

![event filters empty state](https://user-images.githubusercontent.com/15727784/145970082-318fcca5-119c-416e-8c7f-902902b45f94.gif)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
