### PR TITLE
[Fleet] fix redudant copy in output & settings confirm dialog

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -49,7 +49,7 @@ const ConfirmDescription: React.FunctionComponent<ConfirmDescriptionProps> = ({
 }) => (
   <FormattedMessage
     id="xpack.fleet.settings.updateOutput.confirmModalText"
-    defaultMessage="This action will update {outputName} output. It will update {policies} agent policies and {agents}. This action can not be undone. Are you sure you wish to continue?"
+    defaultMessage="This action will update {outputName} output. It will update {policies} and {agents}. This action can not be undone. Are you sure you wish to continue?"
     values={{
       outputName: <strong>{output.name}</strong>,
       agents: (

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.tsx
@@ -35,7 +35,7 @@ const ConfirmDescription: React.FunctionComponent<ConfirmDescriptionProps> = ({
 }) => (
   <FormattedMessage
     id="xpack.fleet.settings.fleetServerHostsFlyout.confirmModalText"
-    defaultMessage="This action will update {policies} agent policies and {agents}. This action can not be undone. Are you sure you wish to continue?"
+    defaultMessage="This action will update {policies} and {agents}. This action can not be undone. Are you sure you wish to continue?"
     values={{
       agents: (
         <strong>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/hooks/use_delete_output.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/hooks/use_delete_output.tsx
@@ -35,7 +35,7 @@ const ConfirmDescription: React.FunctionComponent<ConfirmDescriptionProps> = ({
 }) => (
   <FormattedMessage
     id="xpack.fleet.settings.deleteOutput.confirmModalText"
-    defaultMessage="This action will delete {outputName} output. It will update {policies} agent policies and {agents}. This action can not be undone. Are you sure you wish to continue?"
+    defaultMessage="This action will delete {outputName} output. It will update {policies} and {agents}. This action can not be undone. Are you sure you wish to continue?"
     values={{
       outputName: <strong>{output.name}</strong>,
       agents: (


### PR DESCRIPTION
## Summary

Resolve #120740 

Fix a typo in the confirm dialog of the output and settings form.

### UI  changes

#### Before

<img src="https://user-images.githubusercontent.com/60252716/145192975-bcdb1f4b-284d-4bd3-b558-817eb703de9f.JPG" />

#### After

<img width="931" alt="Screen Shot 2021-12-14 at 9 51 59 AM" src="https://user-images.githubusercontent.com/1336873/146021803-382f47f1-bb12-42b9-8e80-d08bd48790fd.png">
