### PR TITLE
[Reporting] PoC `worker_thread`s for pdf generation

### DIFF
--- a/x-pack/plugins/reporting/server/export_types/common/pdf/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/pdf/index.ts
@@ -8,27 +8,48 @@
 import { i18n } from '@kbn/i18n';
 // @ts-ignore: no module definition
 import concat from 'concat-stream';
+import { Worker } from 'worker_threads';
 import _ from 'lodash';
 import path from 'path';
 import Printer from 'pdfmake';
+import { SerializableRecord } from '@kbn/utility-types';
 import { Content, ContentImage, ContentText } from 'pdfmake/interfaces';
 import type { Layout } from '../../../../../screenshotting/server';
+import type { LayoutParams } from '../../../../../screenshotting/common';
 import { getDocOptions, REPORTING_TABLE_LAYOUT } from './get_doc_options';
 import { getFont } from './get_font';
 import { getTemplate } from './get_template';
+import { TemplateLayout } from './get_template_copy';
+
+import { PdfWorkerData } from './worker';
+
+const pageMarginTop = 40;
+const pageMarginBottom = 80;
+const pageMarginWidth = 40;
+const headingFontSize = 14;
+const headingMarginTop = 10;
+const headingMarginBottom = 5;
+const headingHeight = headingFontSize * 1.5 + headingMarginTop + headingMarginBottom;
+const subheadingFontSize = 12;
+const subheadingMarginTop = 0;
+const subheadingMarginBottom = 5;
+const subheadingHeight = subheadingFontSize * 1.5 + subheadingMarginTop + subheadingMarginBottom;
 
 const assetPath = path.resolve(__dirname, '..', '..', 'common', 'assets');
 const tableBorderWidth = 1;
 
 export class PdfMaker {
   private _layout: Layout;
+  private _layoutParams: LayoutParams;
   private _logo: string | undefined;
   private _title: string;
   private _content: Content[];
   private _printer: Printer;
   private _pdfDoc: PDFKit.PDFDocument | undefined;
 
-  constructor(layout: Layout, logo: string | undefined) {
+  private worker?: Worker;
+
+  constructor(layout: Layout, layoutParams: LayoutParams, logo: string | undefined) {
     const fontPath = (filename: string) => path.resolve(assetPath, 'fonts', filename);
     const fonts = {
       Roboto: {
@@ -47,6 +68,7 @@ export class PdfMaker {
     };
 
     this._layout = layout;
+    this._layoutParams = layoutParams;
     this._logo = logo;
     this._title = '';
     this._content = [];
@@ -124,15 +146,44 @@ export class PdfMaker {
     this._title = title;
   }
 
-  generate() {
-    const docTemplate = _.assign(
-      getTemplate(this._layout, this._logo, this._title, tableBorderWidth, assetPath),
-      {
-        content: this._content,
-      }
-    );
-    this._pdfDoc = this._printer.createPdfKitDocument(docTemplate, getDocOptions(tableBorderWidth));
-    return this;
+  generate(): Promise<Buffer> {
+    // const docTemplate = _.assign(
+    //   getTemplate(this._layout, this._logo, this._title, tableBorderWidth, assetPath),
+    //   {
+    //     content: this._content,
+    //   }
+    // );
+    // this._pdfDoc = this._printer.createPdfKitDocument(docTemplate, getDocOptions(tableBorderWidth));
+    // return this;
+
+    if (this.worker) throw new Error('PDF generation already in progress!');
+    return new Promise((resolve, reject) => {
+      const workerData: PdfWorkerData = {
+        layout: {
+          hasFooter: this._layout.hasFooter,
+          hasHeader: this._layout.hasHeader,
+          orientation: this._layout.getPdfPageOrientation(),
+          useReportingBranding: this._layout.useReportingBranding,
+          pageSize: this._layout.getPdfPageSize({
+            pageMarginTop,
+            pageMarginBottom,
+            pageMarginWidth,
+            tableBorderWidth,
+            headingHeight,
+            subheadingHeight,
+          }),
+        },
+        title: this._title,
+        logo: this._logo,
+        content: this._content as unknown as SerializableRecord[],
+      };
+      this.worker = new Worker(path.resolve(__dirname, './worker'), { workerData });
+      this.worker.on('error', reject);
+      this.worker.on('message', (buffer: Buffer) => resolve(buffer));
+      this.worker.on('exit', () => {
+        this.worker = undefined;
+      });
+    });
   }
 
   getBuffer(): Promise<Buffer | null> {

--- a/x-pack/plugins/reporting/server/export_types/common/pdf/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/pdf/index.ts
@@ -5,21 +5,14 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
-// @ts-ignore: no module definition
-import concat from 'concat-stream';
 import { Worker } from 'worker_threads';
 import _ from 'lodash';
 import path from 'path';
-import Printer from 'pdfmake';
 import { SerializableRecord } from '@kbn/utility-types';
 import { Content, ContentImage, ContentText } from 'pdfmake/interfaces';
 import type { Layout } from '../../../../../screenshotting/server';
-import type { LayoutParams } from '../../../../../screenshotting/common';
-import { getDocOptions, REPORTING_TABLE_LAYOUT } from './get_doc_options';
+import { REPORTING_TABLE_LAYOUT } from './get_doc_options';
 import { getFont } from './get_font';
-import { getTemplate } from './get_template';
-import { TemplateLayout } from './get_template_copy';
 
 import { PdfWorkerData } from './worker';
 
@@ -35,44 +28,21 @@ const subheadingMarginTop = 0;
 const subheadingMarginBottom = 5;
 const subheadingHeight = subheadingFontSize * 1.5 + subheadingMarginTop + subheadingMarginBottom;
 
-const assetPath = path.resolve(__dirname, '..', '..', 'common', 'assets');
 const tableBorderWidth = 1;
 
 export class PdfMaker {
   private _layout: Layout;
-  private _layoutParams: LayoutParams;
   private _logo: string | undefined;
   private _title: string;
   private _content: Content[];
-  private _printer: Printer;
-  private _pdfDoc: PDFKit.PDFDocument | undefined;
 
   private worker?: Worker;
 
-  constructor(layout: Layout, layoutParams: LayoutParams, logo: string | undefined) {
-    const fontPath = (filename: string) => path.resolve(assetPath, 'fonts', filename);
-    const fonts = {
-      Roboto: {
-        normal: fontPath('roboto/Roboto-Regular.ttf'),
-        bold: fontPath('roboto/Roboto-Medium.ttf'),
-        italics: fontPath('roboto/Roboto-Italic.ttf'),
-        bolditalics: fontPath('roboto/Roboto-Italic.ttf'),
-      },
-      'noto-cjk': {
-        // Roboto does not support CJK characters, so we'll fall back on this font if we detect them.
-        normal: fontPath('noto/NotoSansCJKtc-Regular.ttf'),
-        bold: fontPath('noto/NotoSansCJKtc-Medium.ttf'),
-        italics: fontPath('noto/NotoSansCJKtc-Regular.ttf'),
-        bolditalics: fontPath('noto/NotoSansCJKtc-Medium.ttf'),
-      },
-    };
-
+  constructor(layout: Layout, logo: string | undefined) {
     this._layout = layout;
-    this._layoutParams = layoutParams;
     this._logo = logo;
     this._title = '';
     this._content = [];
-    this._printer = new Printer(fonts);
   }
 
   _addContents(contents: Content[]) {
@@ -146,66 +116,55 @@ export class PdfMaker {
     this._title = title;
   }
 
-  generate(): Promise<Buffer> {
-    // const docTemplate = _.assign(
-    //   getTemplate(this._layout, this._logo, this._title, tableBorderWidth, assetPath),
-    //   {
-    //     content: this._content,
-    //   }
-    // );
-    // this._pdfDoc = this._printer.createPdfKitDocument(docTemplate, getDocOptions(tableBorderWidth));
-    // return this;
-
-    if (this.worker) throw new Error('PDF generation already in progress!');
-    return new Promise((resolve, reject) => {
-      const workerData: PdfWorkerData = {
-        layout: {
-          hasFooter: this._layout.hasFooter,
-          hasHeader: this._layout.hasHeader,
-          orientation: this._layout.getPdfPageOrientation(),
-          useReportingBranding: this._layout.useReportingBranding,
-          pageSize: this._layout.getPdfPageSize({
-            pageMarginTop,
-            pageMarginBottom,
-            pageMarginWidth,
-            tableBorderWidth,
-            headingHeight,
-            subheadingHeight,
-          }),
-        },
-        title: this._title,
-        logo: this._logo,
-        content: this._content as unknown as SerializableRecord[],
-      };
-      this.worker = new Worker(path.resolve(__dirname, './worker.js'), { workerData });
-      this.worker.on('error', reject);
-      this.worker.on('message', (buffer: Buffer) => resolve(buffer));
-      this.worker.on('exit', () => {
-        this.worker = undefined;
-      });
-    });
+  private getWorkerData(): PdfWorkerData {
+    return {
+      layout: {
+        hasFooter: this._layout.hasFooter,
+        hasHeader: this._layout.hasHeader,
+        orientation: this._layout.getPdfPageOrientation(),
+        useReportingBranding: this._layout.useReportingBranding,
+        pageSize: this._layout.getPdfPageSize({
+          pageMarginTop,
+          pageMarginBottom,
+          pageMarginWidth,
+          tableBorderWidth,
+          headingHeight,
+          subheadingHeight,
+        }),
+      },
+      title: this._title,
+      logo: this._logo,
+      content: this._content as unknown as SerializableRecord[],
+    };
   }
 
-  getBuffer(): Promise<Buffer | null> {
-    return new Promise((resolve, reject) => {
-      if (!this._pdfDoc) {
-        throw new Error(
-          i18n.translate(
-            'xpack.reporting.exportTypes.printablePdf.documentStreamIsNotgeneratedErrorMessage',
-            {
-              defaultMessage: 'Document stream has not been generated',
-            }
-          )
-        );
-      }
+  generate(): Promise<Buffer> {
+    if (this.worker) throw new Error('PDF generation already in progress!');
 
-      const concatStream = concat(function (pdfBuffer: Buffer) {
-        resolve(pdfBuffer);
+    return new Promise<Buffer>((resolve, reject) => {
+      let buffer: undefined | Buffer;
+      this.worker = new Worker(path.resolve(__dirname, './worker.js'), {
+        resourceLimits: { maxOldGenerationSizeMb: 150 },
+        workerData: this.getWorkerData(),
       });
+      this.worker.on('error', reject);
 
-      this._pdfDoc.on('error', reject);
-      this._pdfDoc.pipe(concatStream);
-      this._pdfDoc.end();
+      // We expect one message from the work container the PDF buffer.
+      this.worker.on('message', (pdfBuffer: Buffer) => (buffer = pdfBuffer));
+
+      this.worker.on('exit', (code) => {
+        if (code !== 0) {
+          reject(new Error(`Worker exited with code ${code}`));
+          return;
+        }
+        if (buffer) {
+          resolve(buffer);
+          return;
+        }
+        reject(new Error('Worker exited without generating a PDF'));
+      });
+    }).finally(() => {
+      this.worker = undefined;
     });
   }
 }

--- a/x-pack/plugins/reporting/server/export_types/common/pdf/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/pdf/index.ts
@@ -144,7 +144,6 @@ export class PdfMaker {
     return new Promise<Buffer>((resolve, reject) => {
       let buffer: undefined | Buffer;
       this.worker = new Worker(path.resolve(__dirname, './worker.js'), {
-        resourceLimits: { maxOldGenerationSizeMb: 150 },
         workerData: this.getWorkerData(),
       });
       this.worker.on('error', reject);

--- a/x-pack/plugins/reporting/server/export_types/common/pdf/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/pdf/index.ts
@@ -177,7 +177,7 @@ export class PdfMaker {
         logo: this._logo,
         content: this._content as unknown as SerializableRecord[],
       };
-      this.worker = new Worker(path.resolve(__dirname, './worker'), { workerData });
+      this.worker = new Worker(path.resolve(__dirname, './worker.js'), { workerData });
       this.worker.on('error', reject);
       this.worker.on('message', (buffer: Buffer) => resolve(buffer));
       this.worker.on('exit', () => {

--- a/x-pack/plugins/reporting/server/export_types/common/pdf/worker.js
+++ b/x-pack/plugins/reporting/server/export_types/common/pdf/worker.js
@@ -1,0 +1,207 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable @typescript-eslint/no-var-requires*/
+const { i18n } = require('@kbn/i18n');
+const { workerData, parentPort, isMainThread } = require('worker_threads');
+const _ = require('lodash');
+const path = require('path');
+const PdfMake = require('pdfmake');
+// @ts-ignore: no module definition
+const concat = require('concat-stream');
+
+function getFont(text) {
+  // We are matching Han characters which is one of the supported unicode scripts
+  // (you can see the full list of supported scripts here: http://www.unicode.org/standard/supported.html).
+  // This will match Chinese, Japanese, Korean and some other Asian languages.
+  const isCKJ = /\p{Script=Han}/gu.test(text);
+  if (isCKJ) {
+    return 'noto-cjk';
+  } else {
+    return 'Roboto';
+  }
+}
+
+function getTemplate(layout, logo, title, tableBorderWidth, assetPath) {
+  const pageMarginTop = 40;
+  const pageMarginBottom = 80;
+  const pageMarginWidth = 40;
+  const headingFontSize = 14;
+  const headingMarginTop = 10;
+  const headingMarginBottom = 5;
+  const headingHeight = headingFontSize * 1.5 + headingMarginTop + headingMarginBottom;
+  const subheadingFontSize = 12;
+  const subheadingMarginTop = 0;
+  const subheadingMarginBottom = 5;
+  const subheadingHeight = subheadingFontSize * 1.5 + subheadingMarginTop + subheadingMarginBottom;
+
+  const getStyle = () => ({
+    heading: {
+      alignment: 'left',
+      fontSize: headingFontSize,
+      bold: true,
+      margin: [headingMarginTop, 0, headingMarginBottom, 0],
+    },
+    subheading: {
+      alignment: 'left',
+      fontSize: subheadingFontSize,
+      italics: true,
+      margin: [0, 0, subheadingMarginBottom, 20],
+    },
+    warning: {
+      color: '#f39c12', // same as @brand-warning in Kibana colors.less
+    },
+  });
+  const getHeader = () => ({
+    margin: [pageMarginWidth, pageMarginTop / 4, pageMarginWidth, 0],
+    text: title,
+    font: getFont(title),
+    style: {
+      color: '#aaa',
+    },
+    fontSize: 10,
+    alignment: 'center',
+  });
+  const getFooter = () => (currentPage, pageCount) => {
+    const logoPath = path.resolve(assetPath, 'img', 'logo-grey.png'); // Default Elastic Logo
+    return {
+      margin: [pageMarginWidth, pageMarginBottom / 4, pageMarginWidth, 0],
+      layout: 'noBorder',
+      table: {
+        widths: [100, '*', 100],
+        body: [
+          [
+            {
+              fit: [100, 35],
+              image: logo || logoPath,
+            },
+            {
+              alignment: 'center',
+              text: i18n.translate('xpack.reporting.exportTypes.printablePdf.pagingDescription', {
+                defaultMessage: 'Page {currentPage} of {pageCount}',
+                values: { currentPage: currentPage.toString(), pageCount },
+              }),
+              style: {
+                color: '#aaa',
+              },
+            },
+            '',
+          ],
+          [
+            logo
+              ? {
+                  text: i18n.translate('xpack.reporting.exportTypes.printablePdf.logoDescription', {
+                    defaultMessage: 'Powered by Elastic',
+                  }),
+                  fontSize: 10,
+                  style: {
+                    color: '#aaa',
+                  },
+                  margin: [0, 2, 0, 0],
+                }
+              : '',
+            '',
+            '',
+          ],
+        ],
+      },
+    };
+  };
+
+  return {
+    // define page size
+    pageOrientation: layout.orientation,
+    pageSize: layout.pageSize,
+    pageMargins: layout.useReportingBranding
+      ? [pageMarginWidth, pageMarginTop, pageMarginWidth, pageMarginBottom]
+      : [0, 0, 0, 0],
+
+    header: layout.hasHeader ? getHeader() : undefined,
+    footer: layout.hasFooter ? getFooter() : undefined,
+
+    styles: layout.useReportingBranding ? getStyle() : undefined,
+
+    defaultStyle: {
+      fontSize: 12,
+      font: 'Roboto',
+    },
+  };
+}
+
+console.log('current dir', __dirname);
+
+// const { getTemplate } = require('./get_template_copy');
+
+if (!isMainThread) {
+  const assetPath = path.resolve(__dirname, '..', '..', 'common', 'assets');
+  const tableBorderWidth = 1;
+
+  const fontPath = (filename) => path.resolve(assetPath, 'fonts', filename);
+
+  const fonts = {
+    Roboto: {
+      normal: fontPath('roboto/Roboto-Regular.ttf'),
+      bold: fontPath('roboto/Roboto-Medium.ttf'),
+      italics: fontPath('roboto/Roboto-Italic.ttf'),
+      bolditalics: fontPath('roboto/Roboto-Italic.ttf'),
+    },
+    'noto-cjk': {
+      // Roboto does not support CJK characters, so we'll fall back on this font if we detect them.
+      normal: fontPath('noto/NotoSansCJKtc-Regular.ttf'),
+      bold: fontPath('noto/NotoSansCJKtc-Medium.ttf'),
+      italics: fontPath('noto/NotoSansCJKtc-Regular.ttf'),
+      bolditalics: fontPath('noto/NotoSansCJKtc-Medium.ttf'),
+    },
+  };
+
+  const printer = new PdfMake(fonts);
+
+  const { layout, logo, title, content } = workerData;
+
+  (async function execute() {
+    const docDefinition = _.assign(getTemplate(layout, logo, title, tableBorderWidth, assetPath), {
+      content,
+    });
+
+    const pdfDoc = printer.createPdfKitDocument(docDefinition, {
+      tableLayouts: {
+        noBorder: {
+          // format is function (i, node) { ... };
+          hLineWidth: () => 0,
+          vLineWidth: () => 0,
+          paddingLeft: () => 0,
+          paddingRight: () => 0,
+          paddingTop: () => 0,
+          paddingBottom: () => 0,
+        },
+      },
+    });
+
+    const buffer = await new Promise((resolve, reject) => {
+      if (!pdfDoc) {
+        throw new Error(
+          i18n.translate(
+            'xpack.reporting.exportTypes.printablePdf.documentStreamIsNotgeneratedErrorMessage',
+            {
+              defaultMessage: 'Document stream has not been generated',
+            }
+          )
+        );
+      }
+
+      const concatStream = concat(function (pdfBuffer) {
+        resolve(pdfBuffer);
+      });
+
+      pdfDoc.on('error', reject);
+      pdfDoc.pipe(concatStream);
+      pdfDoc.end();
+    });
+
+    parentPort.postMessage(buffer);
+  })();
+}

--- a/x-pack/plugins/reporting/server/export_types/common/pdf/worker.js
+++ b/x-pack/plugins/reporting/server/export_types/common/pdf/worker.js
@@ -6,163 +6,162 @@
  */
 
 /* eslint-disable @typescript-eslint/no-var-requires*/
-const { i18n } = require('@kbn/i18n');
 const { workerData, parentPort, isMainThread } = require('worker_threads');
-const _ = require('lodash');
-const path = require('path');
-const PdfMake = require('pdfmake');
-// @ts-ignore: no module definition
-const concat = require('concat-stream');
 
-function getFont(text) {
-  // We are matching Han characters which is one of the supported unicode scripts
-  // (you can see the full list of supported scripts here: http://www.unicode.org/standard/supported.html).
-  // This will match Chinese, Japanese, Korean and some other Asian languages.
-  const isCKJ = /\p{Script=Han}/gu.test(text);
-  if (isCKJ) {
-    return 'noto-cjk';
-  } else {
-    return 'Roboto';
-  }
-}
+if (!isMainThread) {
+  (async function execute() {
+    const { i18n } = require('@kbn/i18n');
+    const _ = require('lodash');
+    const path = require('path');
+    const PdfMake = require('pdfmake');
+    // @ts-ignore: no module definition
+    const concat = require('concat-stream');
 
-function getTemplate(layout, logo, title, tableBorderWidth, assetPath) {
-  const pageMarginTop = 40;
-  const pageMarginBottom = 80;
-  const pageMarginWidth = 40;
-  const headingFontSize = 14;
-  const headingMarginTop = 10;
-  const headingMarginBottom = 5;
-  const headingHeight = headingFontSize * 1.5 + headingMarginTop + headingMarginBottom;
-  const subheadingFontSize = 12;
-  const subheadingMarginTop = 0;
-  const subheadingMarginBottom = 5;
-  const subheadingHeight = subheadingFontSize * 1.5 + subheadingMarginTop + subheadingMarginBottom;
+    function getFont(text) {
+      // We are matching Han characters which is one of the supported unicode scripts
+      // (you can see the full list of supported scripts here: http://www.unicode.org/standard/supported.html).
+      // This will match Chinese, Japanese, Korean and some other Asian languages.
+      const isCKJ = /\p{Script=Han}/gu.test(text);
+      if (isCKJ) {
+        return 'noto-cjk';
+      } else {
+        return 'Roboto';
+      }
+    }
 
-  const getStyle = () => ({
-    heading: {
-      alignment: 'left',
-      fontSize: headingFontSize,
-      bold: true,
-      margin: [headingMarginTop, 0, headingMarginBottom, 0],
-    },
-    subheading: {
-      alignment: 'left',
-      fontSize: subheadingFontSize,
-      italics: true,
-      margin: [0, 0, subheadingMarginBottom, 20],
-    },
-    warning: {
-      color: '#f39c12', // same as @brand-warning in Kibana colors.less
-    },
-  });
-  const getHeader = () => ({
-    margin: [pageMarginWidth, pageMarginTop / 4, pageMarginWidth, 0],
-    text: title,
-    font: getFont(title),
-    style: {
-      color: '#aaa',
-    },
-    fontSize: 10,
-    alignment: 'center',
-  });
-  const getFooter = () => (currentPage, pageCount) => {
-    const logoPath = path.resolve(assetPath, 'img', 'logo-grey.png'); // Default Elastic Logo
-    return {
-      margin: [pageMarginWidth, pageMarginBottom / 4, pageMarginWidth, 0],
-      layout: 'noBorder',
-      table: {
-        widths: [100, '*', 100],
-        body: [
-          [
-            {
-              fit: [100, 35],
-              image: logo || logoPath,
-            },
-            {
-              alignment: 'center',
-              text: i18n.translate('xpack.reporting.exportTypes.printablePdf.pagingDescription', {
-                defaultMessage: 'Page {currentPage} of {pageCount}',
-                values: { currentPage: currentPage.toString(), pageCount },
-              }),
-              style: {
-                color: '#aaa',
-              },
-            },
-            '',
-          ],
-          [
-            logo
-              ? {
-                  text: i18n.translate('xpack.reporting.exportTypes.printablePdf.logoDescription', {
-                    defaultMessage: 'Powered by Elastic',
-                  }),
-                  fontSize: 10,
+    function getTemplate(layout, logo, title, tableBorderWidth, assetPath) {
+      const pageMarginTop = 40;
+      const pageMarginBottom = 80;
+      const pageMarginWidth = 40;
+      const headingFontSize = 14;
+      const headingMarginTop = 10;
+      const headingMarginBottom = 5;
+      const subheadingFontSize = 12;
+      const subheadingMarginBottom = 5;
+
+      const getStyle = () => ({
+        heading: {
+          alignment: 'left',
+          fontSize: headingFontSize,
+          bold: true,
+          margin: [headingMarginTop, 0, headingMarginBottom, 0],
+        },
+        subheading: {
+          alignment: 'left',
+          fontSize: subheadingFontSize,
+          italics: true,
+          margin: [0, 0, subheadingMarginBottom, 20],
+        },
+        warning: {
+          color: '#f39c12', // same as @brand-warning in Kibana colors.less
+        },
+      });
+      const getHeader = () => ({
+        margin: [pageMarginWidth, pageMarginTop / 4, pageMarginWidth, 0],
+        text: title,
+        font: getFont(title),
+        style: {
+          color: '#aaa',
+        },
+        fontSize: 10,
+        alignment: 'center',
+      });
+      const getFooter = () => (currentPage, pageCount) => {
+        const logoPath = path.resolve(assetPath, 'img', 'logo-grey.png'); // Default Elastic Logo
+        return {
+          margin: [pageMarginWidth, pageMarginBottom / 4, pageMarginWidth, 0],
+          layout: 'noBorder',
+          table: {
+            widths: [100, '*', 100],
+            body: [
+              [
+                {
+                  fit: [100, 35],
+                  image: logo || logoPath,
+                },
+                {
+                  alignment: 'center',
+                  text: i18n.translate(
+                    'xpack.reporting.exportTypes.printablePdf.pagingDescription',
+                    {
+                      defaultMessage: 'Page {currentPage} of {pageCount}',
+                      values: { currentPage: currentPage.toString(), pageCount },
+                    }
+                  ),
                   style: {
                     color: '#aaa',
                   },
-                  margin: [0, 2, 0, 0],
-                }
-              : '',
-            '',
-            '',
-          ],
-        ],
+                },
+                '',
+              ],
+              [
+                logo
+                  ? {
+                      text: i18n.translate(
+                        'xpack.reporting.exportTypes.printablePdf.logoDescription',
+                        {
+                          defaultMessage: 'Powered by Elastic',
+                        }
+                      ),
+                      fontSize: 10,
+                      style: {
+                        color: '#aaa',
+                      },
+                      margin: [0, 2, 0, 0],
+                    }
+                  : '',
+                '',
+                '',
+              ],
+            ],
+          },
+        };
+      };
+
+      return {
+        // define page size
+        pageOrientation: layout.orientation,
+        pageSize: layout.pageSize,
+        pageMargins: layout.useReportingBranding
+          ? [pageMarginWidth, pageMarginTop, pageMarginWidth, pageMarginBottom]
+          : [0, 0, 0, 0],
+
+        header: layout.hasHeader ? getHeader() : undefined,
+        footer: layout.hasFooter ? getFooter() : undefined,
+
+        styles: layout.useReportingBranding ? getStyle() : undefined,
+
+        defaultStyle: {
+          fontSize: 12,
+          font: 'Roboto',
+        },
+      };
+    }
+    const assetPath = path.resolve(__dirname, '..', '..', 'common', 'assets');
+    const tableBorderWidth = 1;
+
+    const fontPath = (filename) => path.resolve(assetPath, 'fonts', filename);
+
+    const fonts = {
+      Roboto: {
+        normal: fontPath('roboto/Roboto-Regular.ttf'),
+        bold: fontPath('roboto/Roboto-Medium.ttf'),
+        italics: fontPath('roboto/Roboto-Italic.ttf'),
+        bolditalics: fontPath('roboto/Roboto-Italic.ttf'),
+      },
+      'noto-cjk': {
+        // Roboto does not support CJK characters, so we'll fall back on this font if we detect them.
+        normal: fontPath('noto/NotoSansCJKtc-Regular.ttf'),
+        bold: fontPath('noto/NotoSansCJKtc-Medium.ttf'),
+        italics: fontPath('noto/NotoSansCJKtc-Regular.ttf'),
+        bolditalics: fontPath('noto/NotoSansCJKtc-Medium.ttf'),
       },
     };
-  };
 
-  return {
-    // define page size
-    pageOrientation: layout.orientation,
-    pageSize: layout.pageSize,
-    pageMargins: layout.useReportingBranding
-      ? [pageMarginWidth, pageMarginTop, pageMarginWidth, pageMarginBottom]
-      : [0, 0, 0, 0],
+    const printer = new PdfMake(fonts);
 
-    header: layout.hasHeader ? getHeader() : undefined,
-    footer: layout.hasFooter ? getFooter() : undefined,
+    const { layout, logo, title, content } = workerData;
 
-    styles: layout.useReportingBranding ? getStyle() : undefined,
-
-    defaultStyle: {
-      fontSize: 12,
-      font: 'Roboto',
-    },
-  };
-}
-
-console.log('current dir', __dirname);
-
-// const { getTemplate } = require('./get_template_copy');
-
-if (!isMainThread) {
-  const assetPath = path.resolve(__dirname, '..', '..', 'common', 'assets');
-  const tableBorderWidth = 1;
-
-  const fontPath = (filename) => path.resolve(assetPath, 'fonts', filename);
-
-  const fonts = {
-    Roboto: {
-      normal: fontPath('roboto/Roboto-Regular.ttf'),
-      bold: fontPath('roboto/Roboto-Medium.ttf'),
-      italics: fontPath('roboto/Roboto-Italic.ttf'),
-      bolditalics: fontPath('roboto/Roboto-Italic.ttf'),
-    },
-    'noto-cjk': {
-      // Roboto does not support CJK characters, so we'll fall back on this font if we detect them.
-      normal: fontPath('noto/NotoSansCJKtc-Regular.ttf'),
-      bold: fontPath('noto/NotoSansCJKtc-Medium.ttf'),
-      italics: fontPath('noto/NotoSansCJKtc-Regular.ttf'),
-      bolditalics: fontPath('noto/NotoSansCJKtc-Medium.ttf'),
-    },
-  };
-
-  const printer = new PdfMake(fonts);
-
-  const { layout, logo, title, content } = workerData;
-
-  (async function execute() {
     const docDefinition = _.assign(getTemplate(layout, logo, title, tableBorderWidth, assetPath), {
       content,
     });

--- a/x-pack/plugins/reporting/server/export_types/common/pdf/worker.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/pdf/worker.ts
@@ -6,7 +6,22 @@
  */
 
 import { Ensure, SerializableRecord } from '@kbn/utility-types';
-import type { TemplateLayout } from './get_template_copy';
+
+export type TemplateLayout = Ensure<
+  {
+    orientation: 'landscape' | 'portrait' | undefined;
+    useReportingBranding: boolean;
+    hasHeader: boolean;
+    hasFooter: boolean;
+    pageSize:
+      | string
+      | {
+          width: number;
+          height: number | 'auto';
+        };
+  },
+  SerializableRecord
+>;
 
 export type PdfWorkerData = Ensure<
   {

--- a/x-pack/plugins/reporting/server/export_types/common/pdf/worker.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/pdf/worker.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Ensure, SerializableRecord } from '@kbn/utility-types';
+import type { TemplateLayout } from './get_template_copy';
+
+export type PdfWorkerData = Ensure<
+  {
+    layout: TemplateLayout;
+    title: string;
+    content: SerializableRecord[];
+
+    logo?: string;
+  },
+  SerializableRecord
+>;

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/execute_job.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/execute_job.ts
@@ -57,7 +57,7 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPDFV2>> =
             logo
           );
         }),
-        tap(({ buffer, warnings }) => {
+        tap(({ buffer }) => {
           apmGeneratePdf?.end();
 
           if (buffer) {

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/lib/generate_pdf.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/lib/generate_pdf.ts
@@ -57,7 +57,7 @@ export function generatePdfObservable(
       tracker.endScreenshots();
       tracker.startSetup();
 
-      const pdfOutput = new PdfMaker(layout, logo);
+      const pdfOutput = new PdfMaker(layout, options.layout, logo);
       if (title) {
         const timeRange = getTimeRange(results);
         title += timeRange ? ` - ${timeRange}` : '';
@@ -81,12 +81,12 @@ export function generatePdfObservable(
       try {
         tracker.startCompile();
         logger.debug(`Compiling PDF using "${layout.id}" layout...`);
-        pdfOutput.generate();
+        buffer = await pdfOutput.generate();
         tracker.endCompile();
 
         tracker.startGetBuffer();
         logger.debug(`Generating PDF Buffer...`);
-        buffer = await pdfOutput.getBuffer();
+        // buffer = await pdfOutput.getBuffer();
 
         const byteLength = buffer?.byteLength ?? 0;
         logger.debug(`PDF buffer byte length: ${byteLength}`);

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/lib/generate_pdf.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/lib/generate_pdf.ts
@@ -57,7 +57,7 @@ export function generatePdfObservable(
       tracker.endScreenshots();
       tracker.startSetup();
 
-      const pdfOutput = new PdfMaker(layout, options.layout, logo);
+      const pdfOutput = new PdfMaker(layout, logo);
       if (title) {
         const timeRange = getTimeRange(results);
         title += timeRange ? ` - ${timeRange}` : '';
@@ -86,7 +86,6 @@ export function generatePdfObservable(
 
         tracker.startGetBuffer();
         logger.debug(`Generating PDF Buffer...`);
-        // buffer = await pdfOutput.getBuffer();
 
         const byteLength = buffer?.byteLength ?? 0;
         logger.debug(`PDF buffer byte length: ${byteLength}`);

--- a/x-pack/plugins/reporting/tsconfig.json
+++ b/x-pack/plugins/reporting/tsconfig.json
@@ -6,15 +6,10 @@
     "declaration": true,
     "declarationMap": true
   },
-  "include": [
-    "common/**/*",
-    "public/**/*",
-    "server/**/*",
-    "../../../typings/**/*"
-  ],
+  "include": ["common/**/*", "public/**/*", "server/**/*", "../../../typings/**/*"],
   "references": [
     { "path": "../../../src/core/tsconfig.json" },
-    { "path": "../../../src/plugins/data/tsconfig.json"},
+    { "path": "../../../src/plugins/data/tsconfig.json" },
     { "path": "../../../src/plugins/discover/tsconfig.json" },
     { "path": "../../../src/plugins/embeddable/tsconfig.json" },
     { "path": "../../../src/plugins/kibana_react/tsconfig.json" },
@@ -28,6 +23,6 @@
     { "path": "../licensing/tsconfig.json" },
     { "path": "../screenshotting/tsconfig.json" },
     { "path": "../security/tsconfig.json" },
-    { "path": "../spaces/tsconfig.json" },
+    { "path": "../spaces/tsconfig.json" }
   ]
 }


### PR DESCRIPTION
## Summary

PoC for testing out how we might offload the PDF generation work from the main thread. This approach also allows for more aggressive memory management for generating reports.


Related
 * https://github.com/elastic/kibana/issues/118260