### PR TITLE
[8.0] chore: Refactors alerts search bar (#119104)

### DIFF
--- a/x-pack/plugins/observability/public/config/translations.ts
+++ b/x-pack/plugins/observability/public/config/translations.ts
@@ -101,4 +101,9 @@ export const translations = {
       defaultMessage: 'View in app',
     }),
   },
+  alertsSearchBar: {
+    placeholder: i18n.translate('xpack.observability.alerts.searchBarPlaceholder', {
+      defaultMessage: 'Search alerts (e.g. kibana.alert.evaluation.threshold > 75)',
+    }),
+  },
 };

--- a/x-pack/plugins/observability/public/pages/alerts/components/alerts_search_bar.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/components/alerts_search_bar.tsx
@@ -6,10 +6,12 @@
  */
 
 import { IndexPatternBase } from '@kbn/es-query';
-import { i18n } from '@kbn/i18n';
 import React, { useMemo, useState } from 'react';
 import { SearchBar, TimeHistory } from '../../../../../../../src/plugins/data/public';
 import { Storage } from '../../../../../../../src/plugins/kibana_utils/public';
+import { translations } from '../../../config';
+
+type QueryLanguageType = 'lucene' | 'kuery';
 
 export function AlertsSearchBar({
   dynamicIndexPatterns,
@@ -30,7 +32,7 @@ export function AlertsSearchBar({
   const timeHistory = useMemo(() => {
     return new TimeHistory(new Storage(localStorage));
   }, []);
-  const [queryLanguage, setQueryLanguage] = useState<'lucene' | 'kuery'>('kuery');
+  const [queryLanguage, setQueryLanguage] = useState<QueryLanguageType>('kuery');
 
   const compatibleIndexPatterns = useMemo(
     () =>
@@ -45,9 +47,7 @@ export function AlertsSearchBar({
   return (
     <SearchBar
       indexPatterns={compatibleIndexPatterns}
-      placeholder={i18n.translate('xpack.observability.alerts.searchBarPlaceholder', {
-        defaultMessage: 'Search alerts (e.g. kibana.alert.evaluation.threshold > 75)',
-      })}
+      placeholder={translations.alertsSearchBar.placeholder}
       query={{ query: query ?? '', language: queryLanguage }}
       timeHistory={timeHistory}
       dateRangeFrom={rangeFrom}
@@ -60,7 +60,7 @@ export function AlertsSearchBar({
           dateRange,
           query: typeof nextQuery?.query === 'string' ? nextQuery.query : '',
         });
-        setQueryLanguage((nextQuery?.language || 'kuery') as 'kuery' | 'lucene');
+        setQueryLanguage((nextQuery?.language ?? 'kuery') as QueryLanguageType);
       }}
       displayStyle="inPage"
     />


### PR DESCRIPTION
## Summary

Refactors the alerts search bar to use the nullish coalescing operator `??`, extract i18n strings to the newly created translations module, and defining a query language type to avoid repetition.

The UI renders fine as before, tests still pass.

**Note:** this is a manual backport of #119104 to 8.0 as the auto backport failed for merge conflicts.
Related: #121165

<img width="1904" alt="Screenshot 2021-11-18 at 22 18 31" src="https://user-images.githubusercontent.com/860099/142498315-0e5fb572-f483-4fd7-9b98-ae3d91ae365c.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))