### PR TITLE
[Lens] [Gauge] Show invalid dimension indicators when minimum value is equal or bigger to maximum value

### DIFF
--- a/src/plugins/chart_expressions/expression_gauge/public/components/index.scss
+++ b/src/plugins/chart_expressions/expression_gauge/public/components/index.scss
@@ -4,7 +4,7 @@
   width: 100%;
   // the FocusTrap is adding extra divs which are making the visualization redraw twice
   // with a visible glitch. This make the chart library resilient to this extra reflow
-  overflow: auto hidden;
+  overflow: hidden;
   user-select: text;
   padding: $euiSizeS;
 }

--- a/src/plugins/chart_expressions/expression_gauge/public/components/utils.test.ts
+++ b/src/plugins/chart_expressions/expression_gauge/public/components/utils.test.ts
@@ -51,7 +51,7 @@ describe('expression gauge utils', () => {
       expect(getMaxValue({ metric: 10 }, localState)).toEqual(15);
       expect(getMaxValue({ min: 0, metric: 2 }, localState)).toEqual(4);
       expect(getMaxValue({ min: -100, metric: 2 }, localState)).toEqual(50);
-      expect(getMaxValue({ min: -0.001, metric: 0 }, localState)).toEqual(0.001);
+      expect(getMaxValue({ min: -0.001, metric: 0 }, localState)).toEqual(1);
       expect(getMaxValue({ min: -2000, metric: -1000 }, localState)).toEqual(-500);
       expect(getMaxValue({ min: 0.5, metric: 1.5 }, localState)).toEqual(2);
     });

--- a/src/plugins/chart_expressions/expression_gauge/public/components/utils.ts
+++ b/src/plugins/chart_expressions/expression_gauge/public/components/utils.ts
@@ -40,7 +40,7 @@ function getNiceRange(min: number, max: number) {
   const tickSpacing = getNiceNumber(range / (maxTicks - 1));
   return {
     min: Math.floor(min / tickSpacing) * tickSpacing,
-    max: Math.ceil(offsetMax / tickSpacing) * tickSpacing,
+    max: Math.ceil(Math.ceil(offsetMax / tickSpacing) * tickSpacing),
   };
 }
 

--- a/src/plugins/chart_expressions/expression_gauge/public/index.ts
+++ b/src/plugins/chart_expressions/expression_gauge/public/index.ts
@@ -12,5 +12,5 @@ export function plugin() {
   return new ExpressionGaugePlugin();
 }
 
-export { getGoalValue, getMaxValue, getMinValue } from './components/utils';
+export { getGoalValue, getMaxValue, getMinValue, getValueFromAccessor } from './components/utils';
 export { GaugeIconVertical, GaugeIconHorizontal } from './components/gauge_icon';

--- a/x-pack/plugins/lens/public/visualizations/gauge/visualization.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/gauge/visualization.test.ts
@@ -280,6 +280,87 @@ describe('gauge', () => {
         ],
       });
     });
+
+    test('resolves configuration when with group error when max < minimum', () => {
+      const state: GaugeVisualizationState = {
+        ...exampleState(),
+        layerId: 'first',
+        metricAccessor: 'metric-accessor',
+        minAccessor: 'min-accessor',
+        maxAccessor: 'max-accessor',
+        goalAccessor: 'goal-accessor',
+      };
+      frame.activeData = {
+        first: {
+          type: 'datatable',
+          columns: [],
+          rows: [{ 'min-accessor': 10, 'max-accessor': 0 }],
+        },
+      };
+
+      expect(
+        getGaugeVisualization({
+          paletteService,
+        }).getConfiguration({ state, frame, layerId: 'first' })
+      ).toEqual({
+        groups: [
+          {
+            layerId: 'first',
+            groupId: GROUP_ID.METRIC,
+            groupLabel: 'Metric',
+            accessors: [{ columnId: 'metric-accessor', triggerIcon: 'none' }],
+            filterOperations: isNumericDynamicMetric,
+            supportsMoreColumns: false,
+            required: true,
+            dataTestSubj: 'lnsGauge_metricDimensionPanel',
+            enableDimensionEditor: true,
+            supportFieldFormat: true,
+          },
+          {
+            layerId: 'first',
+            groupId: GROUP_ID.MIN,
+            groupLabel: 'Minimum value',
+            accessors: [{ columnId: 'min-accessor' }],
+            filterOperations: isNumericMetric,
+            supportsMoreColumns: false,
+            dataTestSubj: 'lnsGauge_minDimensionPanel',
+            prioritizedOperation: 'min',
+            suggestedValue: expect.any(Function),
+            supportFieldFormat: false,
+            supportStaticValue: true,
+            invalid: true,
+            invalidMessage: 'Minimum value may not be greater than maximum value',
+          },
+          {
+            layerId: 'first',
+            groupId: GROUP_ID.MAX,
+            groupLabel: 'Maximum value',
+            accessors: [{ columnId: 'max-accessor' }],
+            filterOperations: isNumericMetric,
+            supportsMoreColumns: false,
+            dataTestSubj: 'lnsGauge_maxDimensionPanel',
+            prioritizedOperation: 'max',
+            suggestedValue: expect.any(Function),
+            supportFieldFormat: false,
+            supportStaticValue: true,
+            invalid: true,
+            invalidMessage: 'Minimum value may not be greater than maximum value',
+          },
+          {
+            layerId: 'first',
+            groupId: GROUP_ID.GOAL,
+            groupLabel: 'Goal value',
+            accessors: [{ columnId: 'goal-accessor' }],
+            filterOperations: isNumericMetric,
+            supportsMoreColumns: false,
+            required: false,
+            dataTestSubj: 'lnsGauge_goalDimensionPanel',
+            supportFieldFormat: false,
+            supportStaticValue: true,
+          },
+        ],
+      });
+    });
   });
 
   describe('#setDimension', () => {

--- a/x-pack/plugins/lens/public/visualizations/gauge/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/gauge/visualization.tsx
@@ -19,6 +19,7 @@ import {
   getGoalValue,
   getMaxValue,
   getMinValue,
+  getValueFromAccessor,
   GaugeIconVertical,
   GaugeIconHorizontal,
 } from '../../../../../../src/plugins/chart_expressions/expression_gauge/public';
@@ -195,6 +196,31 @@ export const getGaugeVisualization = ({
       palette = getStopsForFixedMode(displayStops, state?.palette?.params?.colorStops);
     }
 
+    let invalidProps: { invalid?: boolean; invalidMessage?: string } = {};
+    const minValue = getValueFromAccessor('minAccessor', row, state);
+    const maxValue = getValueFromAccessor('maxAccessor', row, state);
+    if (maxValue != null && minValue != null) {
+      if (maxValue < minValue) {
+        invalidProps = {
+          invalid: true,
+          invalidMessage: i18n.translate(
+            'xpack.lens.guageVisualization.chartCannotRenderMinGreaterMax',
+            {
+              defaultMessage: 'Minimum value may not be greater than maximum value',
+            }
+          ),
+        };
+      }
+      if (maxValue === minValue) {
+        invalidProps = {
+          invalid: true,
+          invalidMessage: i18n.translate('xpack.lens.guageVisualization.chartCannotRenderEqual', {
+            defaultMessage: 'Minimum and maximum values may not be equal',
+          }),
+        };
+      }
+    }
+
     return {
       groups: [
         {
@@ -238,6 +264,7 @@ export const getGaugeVisualization = ({
           dataTestSubj: 'lnsGauge_minDimensionPanel',
           prioritizedOperation: 'min',
           suggestedValue: () => (state.metricAccessor ? getMinValue(row, state) : undefined),
+          ...invalidProps,
         },
         {
           supportStaticValue: true,
@@ -253,6 +280,7 @@ export const getGaugeVisualization = ({
           dataTestSubj: 'lnsGauge_maxDimensionPanel',
           prioritizedOperation: 'max',
           suggestedValue: () => (state.metricAccessor ? getMaxValue(row, state) : undefined),
+          ...invalidProps,
         },
         {
           supportStaticValue: true,


### PR DESCRIPTION
## Summary

Highlights dimensions for gauge when 
a. min === max:
<img width="279" alt="Screenshot 2021-12-14 at 17 14 02" src="https://user-images.githubusercontent.com/4283304/146036362-34cbf090-623c-43ba-9b00-3209ed75346b.png">


b. min > max:
<img width="892" alt="Screenshot 2021-12-14 at 17 13 32" src="https://user-images.githubusercontent.com/4283304/146036262-19bf6752-b7f3-467b-8f79-56b1b81dbe84.png">

<img width="271" alt="Screenshot 2021-12-14 at 17 13 42" src="https://user-images.githubusercontent.com/4283304/146036291-28d0702b-c7dc-4fef-a97c-2838591931b9.png">

