### PR TITLE
[Security Solution][Investigations] Show correct alert actions based on the alert's status

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
@@ -13,7 +13,18 @@ import React from 'react';
 import { Ecs } from '../../../../../common/ecs';
 import { mockTimelines } from '../../../../common/mock/mock_timelines_plugin';
 
-const ecsRowData: Ecs = { _id: '1', agent: { type: ['blah'] } };
+const ecsRowData: Ecs = {
+  _id: '1',
+  agent: { type: ['blah'] },
+  kibana: {
+    alert: {
+      workflow_status: ['open'],
+      rule: {
+        uuid: ['testId'],
+      },
+    },
+  },
+};
 
 const props = {
   ariaLabel:
@@ -47,9 +58,19 @@ jest.mock('../../../../common/lib/kibana', () => ({
   }),
 }));
 
+jest.mock(
+  '../../../../detections/containers/detection_engine/alerts/use_alerts_privileges',
+  () => ({
+    useAlertsPrivileges: jest.fn().mockReturnValue({ hasIndexWrite: true, hasKibanaCRUD: true }),
+  })
+);
+
 const actionMenuButton = '[data-test-subj="timeline-context-menu-button"] button';
 const addToExistingCaseButton = '[data-test-subj="add-to-existing-case-action"]';
 const addToNewCaseButton = '[data-test-subj="add-to-new-case-action"]';
+const markAsOpenButton = '[data-test-subj="open-alert-status"]';
+const markAsAcknowledgedButton = '[data-test-subj="acknowledged-alert-status"]';
+const markAsClosedButton = '[data-test-subj="close-alert-status"]';
 
 describe('InvestigateInResolverAction', () => {
   test('it render AddToCase context menu item if timelineId === TimelineId.detectionsPage', () => {
@@ -97,5 +118,17 @@ describe('InvestigateInResolverAction', () => {
     wrapper.find(actionMenuButton).simulate('click');
     expect(wrapper.find(addToExistingCaseButton).first().exists()).toEqual(false);
     expect(wrapper.find(addToNewCaseButton).first().exists()).toEqual(false);
+  });
+
+  test('it renders the correct status action buttons', () => {
+    const wrapper = mount(<AlertContextMenu {...props} timelineId={TimelineId.active} />, {
+      wrappingComponent: TestProviders,
+    });
+
+    wrapper.find(actionMenuButton).simulate('click');
+
+    expect(wrapper.find(markAsOpenButton).first().exists()).toEqual(false);
+    expect(wrapper.find(markAsAcknowledgedButton).first().exists()).toEqual(true);
+    expect(wrapper.find(markAsClosedButton).first().exists()).toEqual(true);
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
@@ -79,7 +79,7 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
     ariaLabel: ATTACH_ALERT_TO_CASE_FOR_ROW({ ariaRowindex, columnValues }),
   });
 
-  const alertStatus = get(0, ecsRowData?.['kibana.alert.workflow_status']) as Status;
+  const alertStatus = get(0, ecsRowData?.kibana?.alert?.workflow_status) as Status | undefined;
 
   const isEvent = useMemo(() => indexOf(ecsRowData.event?.kind, 'event') !== -1, [ecsRowData]);
 


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/117703 describes an issue in the alert table where the wrong set of alert actions are shown. The context menu should only contain actions that apply to the alert in its current status. The faulty behavior is shown in the following screenshot:

![image](https://user-images.githubusercontent.com/68591/146038689-407cee79-f63c-470d-b2c5-12f3e87863fb.png)

The context menu should not show `Mark as open` here since the alert is already open.

The fix in this PR corrects that behavior and only the applicable actions are shown:

<img width="890" alt="Screenshot 2021-12-14 at 17 17 54" src="https://user-images.githubusercontent.com/68591/146039842-969534ff-2b47-4793-92d1-270c9c6b0d44.png">
<img width="868" alt="Screenshot 2021-12-14 at 17 17 37" src="https://user-images.githubusercontent.com/68591/146039852-3ef89fae-0d10-4784-8771-f59f820bbfb4.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
