### PR TITLE
[ML] Fix Maps layer type name to new convention for File upload 

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/common/components/expanded_row/geo_point_content/format_utils.ts
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/expanded_row/geo_point_content/format_utils.ts
@@ -8,7 +8,7 @@
 import { Feature, Point } from 'geojson';
 import { euiPaletteColorBlind } from '@elastic/eui';
 import { DEFAULT_GEO_REGEX } from './geo_point_content';
-import { SOURCE_TYPES } from '../../../../../../../maps/common';
+import { LAYER_TYPE, SOURCE_TYPES } from '../../../../../../../maps/common';
 
 export const convertWKTGeoToLonLat = (
   value: string | number
@@ -72,6 +72,6 @@ export const getGeoPointsLayer = (
         },
       },
     },
-    type: 'VECTOR',
+    type: LAYER_TYPE.GEOJSON_VECTOR,
   };
 };


### PR DESCRIPTION
## Summary

This PR fixes the maps in the file upload table not showing correctly because the layer type is outdated (the types were named [here](https://github.com/elastic/kibana/pull/118617/files)) 

Before
![image](https://user-images.githubusercontent.com/43350163/146053687-a195d31c-d2d8-499e-b923-10412040d6f2.png)

After
<img width="1792" alt="Screen Shot 2021-12-14 at 11 57 39" src="https://user-images.githubusercontent.com/43350163/146053760-8fd6b68f-dcb5-424f-8884-af74f0781782.png">

