### PR TITLE
[8.0] [Alerting] Fixed Telemetry task: "Cannot read properties of undefined" due to the missing shard on Kibana start (#120438)

### DIFF
--- a/x-pack/plugins/actions/server/plugin.ts
+++ b/x-pack/plugins/actions/server/plugin.ts
@@ -263,13 +263,16 @@ export class ActionsPlugin implements Plugin<PluginSetupContract, PluginStartCon
       this.createRouteHandlerContext(core, this.kibanaIndex)
     );
     if (usageCollection) {
+      const eventLogIndex = this.eventLogService.getIndexPattern();
+      const kibanaIndex = this.kibanaIndex;
+
       initializeActionsTelemetry(
         this.telemetryLogger,
         plugins.taskManager,
         core,
-        this.kibanaIndex,
+        kibanaIndex,
         this.preconfiguredActions,
-        this.eventLogService
+        eventLogIndex
       );
     }
 
@@ -422,7 +425,9 @@ export class ActionsPlugin implements Plugin<PluginSetupContract, PluginStartCon
         this.getUnsecuredSavedObjectsClient(core.savedObjects, request),
     });
 
-    scheduleActionsTelemetry(this.telemetryLogger, plugins.taskManager);
+    this.eventLogService!.isEsContextReady().then(() => {
+      scheduleActionsTelemetry(this.telemetryLogger, plugins.taskManager);
+    });
 
     if (this.actionsConfig.preconfiguredAlertHistoryEsIndex) {
       createAlertHistoryIndexTemplate({

--- a/x-pack/plugins/actions/server/usage/task.ts
+++ b/x-pack/plugins/actions/server/usage/task.ts
@@ -7,7 +7,6 @@
 
 import { Logger, CoreSetup } from 'kibana/server';
 import moment from 'moment';
-import { IEventLogService } from '../../../event_log/server';
 import {
   RunContext,
   TaskManagerSetupContract,
@@ -26,7 +25,7 @@ export function initializeActionsTelemetry(
   core: CoreSetup,
   kibanaIndex: string,
   preconfiguredActions: PreConfiguredAction[],
-  eventLog: IEventLogService
+  eventLogIndex: string
 ) {
   registerActionsTelemetryTask(
     logger,
@@ -34,7 +33,7 @@ export function initializeActionsTelemetry(
     core,
     kibanaIndex,
     preconfiguredActions,
-    eventLog
+    eventLogIndex
   );
 }
 
@@ -48,7 +47,7 @@ function registerActionsTelemetryTask(
   core: CoreSetup,
   kibanaIndex: string,
   preconfiguredActions: PreConfiguredAction[],
-  eventLog: IEventLogService
+  eventLogIndex: string
 ) {
   taskManager.registerTaskDefinitions({
     [TELEMETRY_TASK_TYPE]: {
@@ -59,7 +58,7 @@ function registerActionsTelemetryTask(
         core,
         kibanaIndex,
         preconfiguredActions,
-        eventLog
+        eventLogIndex
       ),
     },
   });
@@ -83,11 +82,10 @@ export function telemetryTaskRunner(
   core: CoreSetup,
   kibanaIndex: string,
   preconfiguredActions: PreConfiguredAction[],
-  eventLog: IEventLogService
+  eventLogIndex: string
 ) {
   return ({ taskInstance }: RunContext) => {
     const { state } = taskInstance;
-    const eventLogIndex = eventLog.getIndexPattern();
     const getEsClient = () =>
       core.getStartServices().then(
         ([

--- a/x-pack/plugins/alerting/server/plugin.ts
+++ b/x-pack/plugins/alerting/server/plugin.ts
@@ -211,12 +211,13 @@ export class AlertingPlugin {
         usageCollection,
         core.getStartServices().then(([_, { taskManager }]) => taskManager)
       );
+      const eventLogIndex = this.eventLogService.getIndexPattern();
       initializeAlertingTelemetry(
         this.telemetryLogger,
         core,
         plugins.taskManager,
         kibanaIndex,
-        this.eventLogService
+        eventLogIndex
       );
     }
 
@@ -423,7 +424,9 @@ export class AlertingPlugin {
           : Promise.resolve([]);
     });
 
-    scheduleAlertingTelemetry(this.telemetryLogger, plugins.taskManager);
+    this.eventLogService!.isEsContextReady().then(() => {
+      scheduleAlertingTelemetry(this.telemetryLogger, plugins.taskManager);
+    });
 
     scheduleAlertingHealthCheck(this.logger, this.config, plugins.taskManager);
     scheduleApiKeyInvalidatorTask(this.telemetryLogger, this.config, plugins.taskManager);

--- a/x-pack/plugins/alerting/server/usage/task.ts
+++ b/x-pack/plugins/alerting/server/usage/task.ts
@@ -7,7 +7,6 @@
 
 import { Logger, CoreSetup } from 'kibana/server';
 import moment from 'moment';
-import { IEventLogService } from '../../../event_log/server';
 import {
   RunContext,
   TaskManagerSetupContract,
@@ -29,9 +28,9 @@ export function initializeAlertingTelemetry(
   core: CoreSetup,
   taskManager: TaskManagerSetupContract,
   kibanaIndex: string,
-  eventLog: IEventLogService
+  eventLogIndex: string
 ) {
-  registerAlertingTelemetryTask(logger, core, taskManager, kibanaIndex, eventLog);
+  registerAlertingTelemetryTask(logger, core, taskManager, kibanaIndex, eventLogIndex);
 }
 
 export function scheduleAlertingTelemetry(logger: Logger, taskManager?: TaskManagerStartContract) {
@@ -45,13 +44,13 @@ function registerAlertingTelemetryTask(
   core: CoreSetup,
   taskManager: TaskManagerSetupContract,
   kibanaIndex: string,
-  eventLog: IEventLogService
+  eventLogIndex: string
 ) {
   taskManager.registerTaskDefinitions({
     [TELEMETRY_TASK_TYPE]: {
       title: 'Alerting usage fetch task',
       timeout: '5m',
-      createTaskRunner: telemetryTaskRunner(logger, core, kibanaIndex, eventLog),
+      createTaskRunner: telemetryTaskRunner(logger, core, kibanaIndex, eventLogIndex),
     },
   });
 }
@@ -73,11 +72,10 @@ export function telemetryTaskRunner(
   logger: Logger,
   core: CoreSetup,
   kibanaIndex: string,
-  eventLog: IEventLogService
+  eventLogIndex: string
 ) {
   return ({ taskInstance }: RunContext) => {
     const { state } = taskInstance;
-    const eventLogIndex = eventLog.getIndexPattern();
     const getEsClient = () =>
       core.getStartServices().then(
         ([

--- a/x-pack/plugins/event_log/server/event_log_service.mock.ts
+++ b/x-pack/plugins/event_log/server/event_log_service.mock.ts
@@ -18,6 +18,7 @@ const createEventLogServiceMock = () => {
     registerSavedObjectProvider: jest.fn(),
     getLogger: jest.fn().mockReturnValue(eventLoggerMock.create()),
     getIndexPattern: jest.fn(),
+    isEsContextReady: jest.fn().mockResolvedValue(true),
   };
   return mock;
 };

--- a/x-pack/plugins/event_log/server/event_log_service.ts
+++ b/x-pack/plugins/event_log/server/event_log_service.ts
@@ -92,6 +92,10 @@ export class EventLogService implements IEventLogService {
     return this.savedObjectProviderRegistry.registerProvider(type, provider);
   }
 
+  async isEsContextReady() {
+    return await this.esContext.waitTillReady();
+  }
+
   getIndexPattern() {
     return this.esContext.esNames.indexPattern;
   }

--- a/x-pack/plugins/event_log/server/types.ts
+++ b/x-pack/plugins/event_log/server/types.ts
@@ -35,6 +35,7 @@ export interface IEventLogService {
   registerSavedObjectProvider(type: string, provider: SavedObjectProvider): void;
   getLogger(properties: IEvent): IEventLogger;
   getIndexPattern(): string;
+  isEsContextReady(): Promise<boolean>;
 }
 
 export interface IEventLogClientService {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Alerting] Fixed Telemetry task: "Cannot read properties of undefined" due to the missing shard on Kibana start (#120438)