### PR TITLE
[Fleet] Do not udpate or rollover replicated datastream

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -9,10 +9,11 @@ import { readFileSync } from 'fs';
 import path from 'path';
 
 import { safeLoad } from 'js-yaml';
+import { loggerMock } from '@kbn/logging/mocks';
+import { elasticsearchServiceMock } from 'src/core/server/mocks';
 
 import { createAppContextStartContractMock } from '../../../../mocks';
 import { appContextService } from '../../../../services';
-
 import type { RegistryDataStream } from '../../../../types';
 import { processFields } from '../../fields/field';
 import type { Field } from '../../fields/field';
@@ -22,6 +23,7 @@ import {
   getTemplate,
   getTemplatePriority,
   generateTemplateIndexPattern,
+  updateCurrentWriteIndices,
 } from './template';
 
 const FLEET_COMPONENT_TEMPLATE = '.fleet_component_template-1';
@@ -800,5 +802,35 @@ describe('EPM template', () => {
 
     expect(templateIndexPattern).toEqual(templateIndexPatternDatasetIsPrefixTrue);
     expect(templatePriority).toEqual(templatePriorityDatasetIsPrefixTrue);
+  });
+
+  describe('updateCurrentWriteIndices', () => {
+    it('update non replicated datastream', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.indices.getDataStream.mockResolvedValue({
+        body: {
+          data_streams: [
+            { name: 'test-non-replicated' },
+            { name: 'test-replicated', replicated: true },
+          ],
+        },
+      } as any);
+      const logger = loggerMock.create();
+      await updateCurrentWriteIndices(esClient, logger, [
+        {
+          templateName: 'test',
+          indexTemplate: {
+            template: {
+              settings: { index: {} },
+              mappings: { properties: {} },
+            },
+          } as any,
+        },
+      ]);
+
+      const putMappingsCall = esClient.indices.putMapping.mock.calls.map(([{ index }]) => index);
+      expect(putMappingsCall).toHaveLength(1);
+      expect(putMappingsCall[0]).toBe('test-non-replicated');
+    });
   });
 });

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -33,6 +33,7 @@ export interface IndexTemplateMapping {
 }
 export interface CurrentDataStream {
   dataStreamName: string;
+  replicated: boolean;
   indexTemplate: IndexTemplate;
 }
 const DEFAULT_SCALING_FACTOR = 1000;
@@ -415,8 +416,17 @@ export const updateCurrentWriteIndices = async (
   if (!templates.length) return;
 
   const allIndices = await queryDataStreamsFromTemplates(esClient, templates);
-  if (!allIndices.length) return;
-  return updateAllDataStreams(allIndices, esClient, logger);
+  const allUpdatablesIndices = allIndices.filter((indice) => {
+    if (indice.replicated) {
+      logger.warn(
+        `Datastream ${indice.dataStreamName} cannot be updated because this is a replicated datastream.`
+      );
+      return false;
+    }
+    return true;
+  });
+  if (!allUpdatablesIndices.length) return;
+  return updateAllDataStreams(allUpdatablesIndices, esClient, logger);
 };
 
 function isCurrentDataStream(item: CurrentDataStream[] | undefined): item is CurrentDataStream[] {
@@ -440,10 +450,12 @@ const getDataStreams = async (
 ): Promise<CurrentDataStream[] | undefined> => {
   const { templateName, indexTemplate } = template;
   const { body } = await esClient.indices.getDataStream({ name: `${templateName}-*` });
+
   const dataStreams = body.data_streams;
   if (!dataStreams.length) return;
   return dataStreams.map((dataStream: any) => ({
     dataStreamName: dataStream.name,
+    replicated: dataStream.replicated,
     indexTemplate,
   }));
 };
@@ -478,7 +490,6 @@ const updateExistingDataStream = async ({
   // to skip updating and assume the value in the index mapping is correct
   delete mappings.properties.stream;
   delete mappings.properties.data_stream;
-
   // try to update the mappings first
   try {
     await retryTransientEsErrors(


### PR DESCRIPTION
## Summary

Resolve #118899

Replicated datastream cannot be updated, so we should not update them.

We can know that a datastream is replicated with this elasticsearch change https://github.com/elastic/elasticsearch/pull/80988

That PR skip replicated datastream update and log a warning  like this 
<img width="1082" alt="Screen Shot 2021-12-14 at 2 22 01 PM" src="https://user-images.githubusercontent.com/1336873/146071697-db5c28be-e5fb-45f6-9452-35a202c9dc38.png">

## How to test

You need to setup a replicated cluster then the best way is to follow the instructions in #118899 

This scenario seems hard to cover with an integration test so I added a basic unit test to try to cover that feature.