### PR TITLE
[Maps] fix drawings do not show when there is a global filter

### DIFF
--- a/x-pack/plugins/maps/public/classes/layers/wizards/new_vector_layer_wizard/wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/new_vector_layer_wizard/wizard.tsx
@@ -126,6 +126,7 @@ export class NewVectorLayerEditor extends Component<RenderWizardArguments, State
       indexPatternId,
       geoField: 'coordinates',
       filterByMapBounds: false,
+      applyGlobalQuery: false,
     });
     const layerDescriptor = GeoJsonVectorLayer.createDescriptor(
       { sourceDescriptor },

--- a/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.tsx
+++ b/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.tsx
@@ -84,13 +84,14 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
 
   async _getIsFeatureEditingEnabled(): Promise<boolean> {
     const vectorLayer = this.props.layer as IVectorLayer;
-    const layerSource = this.props.layer.getSource();
-    if (!(layerSource instanceof ESSearchSource)) {
+    const source = this.props.layer.getSource();
+    if (!(source instanceof ESSearchSource)) {
       return false;
     }
 
     if (
-      (layerSource as ESSearchSource).getSyncMeta().scalingType === SCALING_TYPES.CLUSTERS ||
+      (source as ESSearchSource).getApplyGlobalQuery() ||
+      (source as ESSearchSource).getSyncMeta().scalingType === SCALING_TYPES.CLUSTERS ||
       (await vectorLayer.isFilteredByGlobalTime()) ||
       vectorLayer.isPreviewLayer() ||
       !vectorLayer.isVisible() ||
@@ -191,9 +192,9 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
           'data-test-subj': 'editLayerButton',
           toolTipContent: this.state.isFeatureEditingEnabled
             ? null
-            : i18n.translate('xpack.maps.layerTocActions.editLayerTooltip', {
+            : i18n.translate('xpack.maps.layerTocActions.editFeaturesTooltip.disabledMessage', {
                 defaultMessage:
-                  'Edit features only supported for document layers without clustering, joins, or time filtering',
+                  'Edit features only supported for document layers without clustering, term joins, time filtering, or global search.',
               }),
           disabled: !this.state.isFeatureEditingEnabled || this.props.editModeActiveForLayer,
           onClick: async () => {

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -15075,7 +15075,6 @@
     "xpack.maps.layers.newVectorLayerWizard.indexPrivsErrorTitle": "インデックス権限がありません",
     "xpack.maps.layerSettings.attributionLegend": "属性",
     "xpack.maps.layerTocActions.cloneLayerTitle": "レイヤーおクローンを作成",
-    "xpack.maps.layerTocActions.editLayerTooltip": "クラスタリング、結合、または時間フィルタリングなしで、ドキュメントレイヤーでのサポートされている機能を編集",
     "xpack.maps.layerTocActions.fitToDataTitle": "データに合わせる",
     "xpack.maps.layerTocActions.hideLayerTitle": "レイヤーの非表示",
     "xpack.maps.layerTocActions.layerActionsTitle": "レイヤー操作",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -15273,7 +15273,6 @@
     "xpack.maps.layers.newVectorLayerWizard.indexPrivsErrorTitle": "缺少索引权限",
     "xpack.maps.layerSettings.attributionLegend": "归因",
     "xpack.maps.layerTocActions.cloneLayerTitle": "克隆图层",
-    "xpack.maps.layerTocActions.editLayerTooltip": "编辑在没有集群、联接或时间筛选的情况下文档图层仅支持的特征",
     "xpack.maps.layerTocActions.fitToDataTitle": "适应数据",
     "xpack.maps.layerTocActions.hideLayerTitle": "隐藏图层",
     "xpack.maps.layerTocActions.layerActionsTitle": "图层操作",


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/108587

* set applyGlobalQuery to false when creating a new index
* Do not enable "Edit features" action if applyGlobalQuery is true.