### PR TITLE
[8.0] Remove CentOS (#121128)

### DIFF
--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -139,7 +139,7 @@ Specifies the browser to use to capture screenshots. This setting exists for bac
 When <<xpack-reporting-browser, `xpack.reporting.capture.browser.type`>> is set to `chromium` (default) you can also specify the following settings.
 
 `xpack.reporting.capture.browser.chromium.disableSandbox`::
-It is recommended that you research the feasibility of enabling unprivileged user namespaces. An exception is if you are running {kib} in Docker because the container runs in a user namespace with the built-in seccomp/bpf filters. For more information, refer to <<reporting-chromium-sandbox>>. Defaults to `false` for all operating systems except Debian, Red Hat Linux, and CentOS, which use `true`.
+It is recommended that you research the feasibility of enabling unprivileged user namespaces. An exception is if you are running {kib} in Docker because the container runs in a user namespace with the built-in seccomp/bpf filters. For more information, refer to <<reporting-chromium-sandbox>>. Defaults to `false` for all operating systems except Debian and Red Hat Linux, which use `true`.
 
 `xpack.reporting.capture.browser.chromium.proxy.enabled`::
 Enables the proxy for Chromium to use. When set to `true`, you must also specify the `xpack.reporting.capture.browser.chromium.proxy.server` setting. Defaults to `false`.

--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -14,7 +14,7 @@ To enable users to manually and automatically generate reports, install the repo
 
 Make sure the {kib} server operating system has the appropriate packages installed for the distribution.
 
-If you are using CentOS/RHEL systems, install the following packages:
+If you are using RHEL operating systems, install the following packages:
 
 * `ipa-gothic-fonts`
 * `xorg-x11-fonts-100dpi`

--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -1,11 +1,11 @@
 [[docker]]
 === Install {kib} with Docker
 ++++
-<titleabbrev>Install with Docker </titleabbrev>
+<titleabbrev>Install with Docker</titleabbrev>
 ++++
 
-Docker images for Kibana are available from the Elastic Docker registry. The
-base image is https://hub.docker.com/_/centos/[centos:7].
+Docker images for {kib} are available from the Elastic Docker registry. The
+base image is https://hub.docker.com/_/kibana[kibana].
 
 A list of all published Docker images and tags is available at
 https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in
@@ -126,9 +126,9 @@ docker rm kib-01
 
 [discrete]
 [[configuring-kibana-docker]]
-=== Configure Kibana on Docker
+=== Configure {kib} on Docker
 
-The Docker images provide several methods for configuring Kibana. The
+The Docker images provide several methods for configuring {kib}. The
 conventional approach is to provide a `kibana.yml` file as described in
 {kibana-ref}/settings.html[Configuring Kibana], but it's also possible to use
 environment variables to define settings.
@@ -137,7 +137,7 @@ environment variables to define settings.
 [[bind-mount-config]]
 ==== Bind-mounted configuration
 
-One way to configure Kibana on Docker is to provide `kibana.yml` via bind-mounting.
+One way to configure {kib} on Docker is to provide `kibana.yml` via bind-mounting.
 With `docker-compose`, the bind-mount can be specified like this:
 
 ["source","yaml",subs="attributes"]

--- a/docs/setup/install.asciidoc
+++ b/docs/setup/install.asciidoc
@@ -33,7 +33,7 @@ our Debian repository.
 
 `rpm`::
 
-The `rpm` package is suitable for installation on Red Hat, Centos, SLES,
+The `rpm` package is suitable for installation on Red Hat, SLES,
 OpenSuSE and other RPM-based systems.  RPMs may be downloaded from the
 Elastic website or from our RPM repository.
 +

--- a/docs/setup/install/rpm.asciidoc
+++ b/docs/setup/install/rpm.asciidoc
@@ -7,11 +7,11 @@
 
 The RPM for Kibana can be <<install-rpm,downloaded from our website>>
 or from our <<rpm-repo,RPM repository>>. It can be used to install
-Kibana on any RPM-based system such as OpenSuSE, SLES, Centos, Red Hat,
+Kibana on any RPM-based system such as OpenSuSE, SLES, Red Hat,
 and Oracle Enterprise.
 
 NOTE: RPM install is not supported on distributions with old versions of RPM,
-such as SLES 11 and CentOS 5.  Please see <<targz>> instead.
+such as SLES 11. Refer to <<targz>> instead.
 
 This package contains both free and subscription features.
 <<managing-licenses,Start a 30-day trial>> to try out all of the features.
@@ -85,7 +85,7 @@ sudo yum install kibana <1>
 sudo dnf install kibana <2>
 sudo zypper install kibana <3>
 --------------------------------------------------
-<1> Use `yum` on CentOS and older Red Hat based distributions.
+<1> Use `yum` on older Red Hat based distributions.
 <2> Use `dnf` on Fedora and other newer Red Hat distributions.
 <3> Use `zypper` on OpenSUSE based distributions
 

--- a/docs/user/production-considerations/reporting-production-considerations.asciidoc
+++ b/docs/user/production-considerations/reporting-production-considerations.asciidoc
@@ -20,7 +20,7 @@ For an additional layer of security, use the sandbox. The Chromium sandbox uses 
 ==== Linux sandbox
 The Linux sandbox depends on user namespaces, which were introduced with the 3.8 Linux kernel. However, many
 distributions don't have user namespaces enabled by default, or they require the CAP_SYS_ADMIN capability. The {report-features}
-automatically disable the sandbox when it is running on Debian and CentOS, as additional steps are required to enable
+automatically disable the sandbox when it is running on Debian because additional steps are required to enable
 unprivileged usernamespaces. In these situations, you'll see the following message in your {kib} startup logs:
 `Chromium sandbox provides an additional layer of protection, but is not supported for your OS.
 Automatically setting 'xpack.reporting.capture.browser.chromium.disableSandbox: true'.`

--- a/docs/user/reporting/reporting-troubleshooting.asciidoc
+++ b/docs/user/reporting/reporting-troubleshooting.asciidoc
@@ -154,7 +154,7 @@ In this case, try increasing the memory for the {kib} instance to 2GB.
 [[reporting-troubleshooting-arm-systems]]
 === ARM systems
 
-Chromium is not compatible with ARM RHEL/CentOS.
+Chromium is not compatible with ARM RHEL.
 
 [float]
 [[reporting-troubleshooting-maps-ems]]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Remove CentOS (#121128)