### PR TITLE
[ML] Anomaly detection explorer: Fix Maps layer type name to new convention

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/map_config.ts
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/map_config.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FIELD_ORIGIN, STYLE_TYPE } from '../../../../../maps/common';
+import { FIELD_ORIGIN, LAYER_TYPE, STYLE_TYPE } from '../../../../../maps/common';
 import { ANOMALY_THRESHOLD, SEVERITY_COLORS } from '../../../../common';
 import { AnomaliesTableData } from '../explorer_utils';
 
@@ -104,7 +104,7 @@ export const getMLAnomaliesTypicalLayer = (anomalies: AnomaliesTableData['anomal
         },
       },
     },
-    type: 'VECTOR',
+    type: LAYER_TYPE.GEOJSON_VECTOR,
   };
 };
 
@@ -161,6 +161,6 @@ export const getMLAnomaliesActualLayer = (anomalies: any) => {
         },
       },
     },
-    type: 'VECTOR',
+    type: LAYER_TYPE.GEOJSON_VECTOR,
   };
 };


### PR DESCRIPTION
## Summary

Fix for the maps in Anomaly Detection explorer view not showing up because the layer type is outdated and throws an error. (the types were named [here](https://github.com/elastic/kibana/pull/118617/files)) 

Before:

![image](https://user-images.githubusercontent.com/6446462/146102440-5f984c8c-9dcf-46d0-ad54-f267628fcb28.png)


After:

![image](https://user-images.githubusercontent.com/6446462/146101051-ced1c979-234f-4422-a0c8-6597383fb0a9.png)






