### PR TITLE
Migrated ILM Tests to Use test_user

### DIFF
--- a/x-pack/test/functional/apps/index_lifecycle_management/feature_controls/ilm_security.ts
+++ b/x-pack/test/functional/apps/index_lifecycle_management/feature_controls/ilm_security.ts
@@ -60,7 +60,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('should render the "Data" section with ILM', async () => {
         await PageObjects.common.navigateToApp('management');
         const sections = await managementMenu.getSections();
-        expect(sections).to.have.length(1);
+        // Changed sections to have a length of 2 because of
+        // https://github.com/elastic/kibana/pull/121262
+        expect(sections).to.have.length(2);
         expect(sections[0]).to.eql({
           sectionId: 'data',
           sectionLinks: ['index_lifecycle_management'],

--- a/x-pack/test/functional/apps/index_lifecycle_management/home_page.ts
+++ b/x-pack/test/functional/apps/index_lifecycle_management/home_page.ts
@@ -16,9 +16,11 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const log = getService('log');
   const retry = getService('retry');
   const esClient = getService('es');
+  const security = getService('security');
 
   describe('Home page', function () {
     before(async () => {
+      await security.testUser.setRoles(['manage_ilm'], true);
       await esClient.snapshot.createRepository({
         name: repoName,
         body: {
@@ -30,11 +32,13 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         },
         verify: false,
       });
+
       await pageObjects.common.navigateToApp('indexLifecycleManagement');
     });
     after(async () => {
       await esClient.snapshot.deleteRepository({ name: repoName });
       await esClient.ilm.deleteLifecycle({ name: policyName });
+      await security.testUser.restoreDefaults();
     });
 
     it('Loads the app', async () => {

--- a/x-pack/test/functional/config.js
+++ b/x-pack/test/functional/config.js
@@ -516,6 +516,14 @@ export default async function ({ readConfigFile }) {
           elasticsearch: {
             cluster: ['manage_ilm'],
           },
+          kibana: [
+            {
+              feature: {
+                advancedSettings: ['read'],
+              },
+              spaces: ['default'],
+            },
+          ],
         },
 
         index_management_user: {


### PR DESCRIPTION
Summary

This PR is part of a [meta issue](https://github.com/elastic/kibana/issues/60815) to migrate all functional tests to using the test_user functionality within functional test runner. This PR in particular migrates the Index Lifecycle Management functional tests to do that.