### PR TITLE
[Security Solution][Investigations] Don't show the empty label in charts for number values

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/charts/barchart.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/charts/barchart.tsx
@@ -8,7 +8,7 @@
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { Chart, BarSeries, Axis, Position, ScaleType, Settings } from '@elastic/charts';
-import { getOr, get, isNumber, isEmpty } from 'lodash/fp';
+import { getOr, get, isNumber } from 'lodash/fp';
 import deepmerge from 'deepmerge';
 import uuid from 'uuid';
 import styled from 'styled-components';
@@ -18,6 +18,7 @@ import { escapeDataProviderId } from '../drag_and_drop/helpers';
 import { useTimeZone } from '../../lib/kibana';
 import { defaultLegendColors } from '../matrix_histogram/utils';
 import { useThrottledResizeObserver } from '../utils';
+import { hasValueToDisplay } from '../../utils/validators';
 import { EMPTY_VALUE_LABEL } from '../charts/translation';
 
 import { ChartPlaceHolder } from './chart_place_holder';
@@ -53,7 +54,7 @@ const checkIfAnyValidSeriesExist = (
 
 const yAccessors = ['y'];
 const splitSeriesAccessors = [
-  (datum: ChartData) => (isEmpty(datum.g) ? EMPTY_VALUE_LABEL : datum.g),
+  (datum: ChartData) => (hasValueToDisplay(datum.g) ? datum.g : EMPTY_VALUE_LABEL),
 ];
 
 // Bar chart rotation: https://ela.st/chart-rotations

--- a/x-pack/plugins/security_solution/public/common/components/charts/draggable_legend_item.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/charts/draggable_legend_item.test.tsx
@@ -68,4 +68,13 @@ describe('DraggableLegendItem', () => {
     );
     expect(wrapper.find('[data-test-subj="value-wrapper-empty"]').first().exists()).toBeTruthy();
   });
+
+  it('does not render the value label when the value is a number', () => {
+    wrapper = mount(
+      <TestProviders>
+        <DraggableLegendItem legendItem={{ ...legendItem, value: 0 }} />
+      </TestProviders>
+    );
+    expect(wrapper.find('[data-test-subj="value-wrapper-empty"]').first().exists()).toBeFalsy();
+  });
 });

--- a/x-pack/plugins/security_solution/public/common/components/charts/draggable_legend_item.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/charts/draggable_legend_item.test.tsx
@@ -69,7 +69,7 @@ describe('DraggableLegendItem', () => {
     expect(wrapper.find('[data-test-subj="value-wrapper-empty"]').first().exists()).toBeTruthy();
   });
 
-  it('does not render the value label when the value is a number', () => {
+  it('does not render the empty value label when the value is a number', () => {
     wrapper = mount(
       <TestProviders>
         <DraggableLegendItem legendItem={{ ...legendItem, value: 0 }} />

--- a/x-pack/plugins/security_solution/public/common/components/charts/draggable_legend_item.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/charts/draggable_legend_item.tsx
@@ -7,24 +7,28 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiHealth, EuiText } from '@elastic/eui';
 import React from 'react';
-import { isEmpty } from 'lodash/fp';
 
 import { DefaultDraggable } from '../draggables';
 import { EMPTY_VALUE_LABEL } from './translation';
+import { hasValueToDisplay } from '../../utils/validators';
 
 export interface LegendItem {
   color?: string;
   dataProviderId: string;
   field: string;
   timelineId?: string;
-  value: string;
+  value: string | number;
 }
 
 /**
  * Renders the value or a placeholder in case the value is empty
  */
-const ValueWrapper = React.memo<{ value?: string | null }>(({ value }) =>
-  isEmpty(value) ? <em data-test-subj="value-wrapper-empty">{EMPTY_VALUE_LABEL}</em> : <>{value}</>
+const ValueWrapper = React.memo<{ value: LegendItem['value'] }>(({ value }) =>
+  hasValueToDisplay(value) ? (
+    <>{value}</>
+  ) : (
+    <em data-test-subj="value-wrapper-empty">{EMPTY_VALUE_LABEL}</em>
+  )
 );
 
 ValueWrapper.displayName = 'ValueWrapper';

--- a/x-pack/plugins/security_solution/public/common/components/draggables/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/draggables/index.tsx
@@ -24,7 +24,7 @@ export interface DefaultDraggableType {
   id: string;
   isDraggable?: boolean;
   field: string;
-  value?: string | null;
+  value?: string | number | null;
   name?: string | null;
   queryValue?: string | null;
   children?: React.ReactNode;
@@ -63,7 +63,7 @@ export const Content = React.memo<{
   field: string;
   tooltipContent?: React.ReactNode;
   tooltipPosition?: ToolTipPositions;
-  value?: string | null;
+  value?: string | number | null;
 }>(({ children, field, tooltipContent, tooltipPosition, value }) =>
   !tooltipContentIsExplicitlyNull(tooltipContent) ? (
     <EuiToolTip
@@ -115,7 +115,7 @@ export const DefaultDraggable = React.memo<DefaultDraggableType>(
         and: [],
         enabled: true,
         id: escapeDataProviderId(id),
-        name: name ? name : value ?? '',
+        name: name ? name : value?.toString() ?? '',
         excluded: false,
         kqlQuery: '',
         queryMatch: {

--- a/x-pack/plugins/security_solution/public/common/utils/validators/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/validators/index.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isUrlInvalid } from '.';
+import { isUrlInvalid, hasValueToDisplay } from '.';
 
 describe('helpers', () => {
   describe('isUrlInvalid', () => {
@@ -47,6 +47,20 @@ describe('helpers', () => {
 
     test('should verify as invalid url without //', () => {
       expect(isUrlInvalid('http:www.thisIsNotValid.com/foo')).toBeTruthy();
+    });
+  });
+
+  describe('hasValueToDisplay', () => {
+    test('identifies valid values', () => {
+      expect(hasValueToDisplay('test')).toBeTruthy();
+      expect(hasValueToDisplay(0)).toBeTruthy();
+      expect(hasValueToDisplay(100)).toBeTruthy();
+    });
+
+    test('identifies empty/invalid values', () => {
+      expect(hasValueToDisplay('')).toBeFalsy();
+      expect(hasValueToDisplay(null)).toBeFalsy();
+      expect(hasValueToDisplay(undefined)).toBeFalsy();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/common/utils/validators/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/validators/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { isEmpty, isNumber } from 'lodash/fp';
 export * from './is_endpoint_host_isolated';
 
 const allowedSchemes = ['http:', 'https:'];
@@ -29,3 +30,7 @@ export const isUrlInvalid = (url: string | null | undefined) => {
   }
   return true;
 };
+
+export function hasValueToDisplay(value: string | number | null | undefined) {
+  return isNumber(value) || !isEmpty(value);
+}

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/alerts_histogram.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/alerts_histogram.tsx
@@ -16,10 +16,10 @@ import {
 } from '@elastic/charts';
 import { EuiFlexGroup, EuiFlexItem, EuiProgress } from '@elastic/eui';
 import React, { useMemo } from 'react';
-import { isEmpty } from 'lodash/fp';
 
 import { useTheme, UpdateDateRange, ChartData } from '../../../../common/components/charts/common';
 import { histogramDateTimeFormatter } from '../../../../common/components/utils';
+import { hasValueToDisplay } from '../../../../common/utils/validators';
 import { DraggableLegend } from '../../../../common/components/charts/draggable_legend';
 import { LegendItem } from '../../../../common/components/charts/draggable_legend_item';
 import { EMPTY_VALUE_LABEL } from '../../../../common/components/charts/translation';
@@ -59,7 +59,7 @@ export const AlertsHistogram = React.memo<AlertsHistogramProps>(
     const id = 'alertsHistogram';
     const yAccessors = useMemo(() => ['y'], []);
     const splitSeriesAccessors = useMemo(
-      () => [(datum: ChartData) => (isEmpty(datum.g) ? EMPTY_VALUE_LABEL : datum.g)],
+      () => [(datum: ChartData) => (hasValueToDisplay(datum.g) ? datum.g : EMPTY_VALUE_LABEL)],
       []
     );
     const tickFormat = useMemo(() => histogramDateTimeFormatter([from, to]), [from, to]);


### PR DESCRIPTION
## Summary

As described in https://github.com/elastic/kibana/issues/121265, the `empty value` label is shown too often, even when an actual value exists. When investigating the bug, I found that the types that we use for `value` in charts are not correct everywhere. In some places, a field's value is typed as `string | null` when in fact it should include `number` as well.

This is important, since the logic that decides whether to show an empty label uses lodash's [isEmpty](https://lodash.com/docs/4.17.15#isEmpty) function. When given a string or null, `isEmpty` works correctly and the empty label logic works fine. When given a `number` however, `isEmpty` will always return false and so the empty label logic will always show an empty label for numbers.

This PR introduces a new helper function `hasValueToDisplay` which is used instead of `isNumber`. Field labels of fields with integer values are no longer showing the `empty value` label:

<img width="572" alt="Screenshot 2021-12-15 at 10 52 25" src="https://user-images.githubusercontent.com/68591/146167273-b53751d8-f4c6-4335-873e-ab021c02706b.png">



### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

