### PR TITLE
read from correct kibana property paths

### DIFF
--- a/x-pack/plugins/monitoring/common/types/es.ts
+++ b/x-pack/plugins/monitoring/common/types/es.ts
@@ -41,6 +41,7 @@ export interface ElasticsearchSourceKibanaStats {
     };
     transport_address?: string;
     host?: string;
+    version?: string;
   };
   os?: {
     memory?: {
@@ -417,6 +418,7 @@ export interface ElasticsearchMetricbeatSource {
   '@timestamp'?: string;
   service?: {
     address?: string;
+    version?: string;
   };
   elasticsearch?: {
     node?: ElasticsearchLegacySource['source_node'] & ElasticsearchMetricbeatNode;

--- a/x-pack/plugins/monitoring/server/lib/kibana/get_kibana_info.ts
+++ b/x-pack/plugins/monitoring/server/lib/kibana/get_kibana_info.ts
@@ -16,7 +16,7 @@ import { ElasticsearchResponse } from '../../../common/types/es';
 export function handleResponse(resp: ElasticsearchResponse) {
   const legacySource = resp.hits?.hits[0]?._source.kibana_stats;
   const mbSource = resp.hits?.hits[0]?._source.kibana?.stats;
-  const kibana = resp.hits?.hits[0]?._source.kibana?.kibana ?? legacySource?.kibana;
+  const kibana = mbSource ?? legacySource?.kibana;
   const availabilityTimestamp =
     resp.hits?.hits[0]?._source['@timestamp'] ?? legacySource?.timestamp;
   if (!availabilityTimestamp) {
@@ -26,6 +26,7 @@ export function handleResponse(resp: ElasticsearchResponse) {
     availability: calculateAvailability(availabilityTimestamp),
     os_memory_free: mbSource?.os?.memory?.free_in_bytes ?? legacySource?.os?.memory?.free_in_bytes,
     uptime: mbSource?.process?.uptime?.ms ?? legacySource?.process?.uptime_in_millis,
+    version: resp.hits?.hits[0]?._source.service?.version ?? legacySource?.kibana?.version,
   });
 }
 
@@ -42,13 +43,14 @@ export function getKibanaInfo(
     ignore_unavailable: true,
     filter_path: [
       'hits.hits._source.kibana_stats.kibana',
-      'hits.hits._source.kibana.kibana',
+      'hits.hits._source.kibana.stats',
       'hits.hits._source.kibana_stats.os.memory.free_in_bytes',
       'hits.hits._source.kibana.stats.os.memory.free_in_bytes',
       'hits.hits._source.kibana_stats.process.uptime_in_millis',
       'hits.hits._source.kibana.stats.process.uptime.ms',
       'hits.hits._source.kibana_stats.timestamp',
       'hits.hits._source.@timestamp',
+      'hits.hits._source.service.version',
     ],
     body: {
       query: {


### PR DESCRIPTION
Small tweaks to stack monitoring.kibana queries that have outdated assumptions about the data structure. It seems that the inner `kibana` object does not exist anymore.