### PR TITLE
Fix data does not wrap on alert details inside enriched data block

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -47,6 +47,7 @@ const getDescription = ({
         linkValue={linkValue}
         timelineId={timelineId}
         values={values}
+        applyWidthAndPadding={false}
       />
     )}
   </>

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/enrichment_summary.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/enrichment_summary.tsx
@@ -36,9 +36,24 @@ export interface ThreatSummaryDescription {
 }
 
 const EnrichmentFieldFeedName = styled.span`
-  margin-left: ${({ theme }) => theme.eui.paddingSizes.xs};
   white-space: nowrap;
   font-style: italic;
+`;
+
+export const StyledEuiFlexGroup = styled(EuiFlexGroup)`
+  .hoverActions-active {
+    .timelines__hoverActionButton,
+    .securitySolution__hoverActionButton {
+      opacity: 1;
+    }
+  }
+
+  &:hover {
+    .timelines__hoverActionButton,
+    .securitySolution__hoverActionButton {
+      opacity: 1;
+    }
+  }
 `;
 
 const EnrichmentDescription: React.FC<ThreatSummaryDescription> = ({
@@ -54,9 +69,9 @@ const EnrichmentDescription: React.FC<ThreatSummaryDescription> = ({
   if (!data || !value) return null;
   const key = `alert-details-value-formatted-field-value-${timelineId}-${eventId}-${data.field}-${value}-${index}-${feedName}`;
   return (
-    <EuiFlexGroup key={key} direction="row" gutterSize="none" alignItems="center">
+    <StyledEuiFlexGroup key={key} direction="row" gutterSize="xs" alignItems="center">
       <EuiFlexItem grow={false}>
-        <div className="eui-textBreakAll">
+        <div>
           <FormattedFieldValue
             contextId={timelineId}
             eventId={key}
@@ -66,9 +81,11 @@ const EnrichmentDescription: React.FC<ThreatSummaryDescription> = ({
             isDraggable={isDraggable}
             isObjectArray={data.isObjectArray}
             value={value}
+            truncate={false}
           />
           {feedName && (
             <EnrichmentFieldFeedName>
+              {' '}
               {i18n.FEED_NAME_PREPOSITION} {feedName}
             </EnrichmentFieldFeedName>
           )}
@@ -83,10 +100,11 @@ const EnrichmentDescription: React.FC<ThreatSummaryDescription> = ({
             fieldFromBrowserField={browserField}
             timelineId={timelineId}
             values={[value]}
+            applyWidthAndPadding={false}
           />
         )}
       </EuiFlexItem>
-    </EuiFlexGroup>
+    </StyledEuiFlexGroup>
   );
 };
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
@@ -84,7 +84,7 @@ export const EnrichedDataRow: React.FC<{ field: string | undefined; value: React
     <EuiFlexItem style={{ flexShrink: 0 }} grow={false}>
       <EnrichmentFieldTitle title={field} />
     </EuiFlexItem>
-    <EuiFlexItem>{value}</EuiFlexItem>
+    <EuiFlexItem className="eui-textBreakWord">{value}</EuiFlexItem>
   </StyledEuiFlexGroup>
 );
 


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/119418
## Summary

* Add `eui-textBreakWord` utility class to enforce the field content to break.
* Add `applyWidthAndPadding` prop to `ActionCell`  to make more space for the content
* Overwrite `hoverActions` style to display ActionCell on hovering and make it consistent with other flyout fields.


**Before fix**
<img width="888" alt="Screenshot 2021-12-15 at 13 40 50" src="https://user-images.githubusercontent.com/1490444/146189543-6573ed2d-dc6f-408c-9759-3f45954e18a0.png">

**After fix**
<img width="887" alt="Screenshot 2021-12-20 at 14 38 52" src="https://user-images.githubusercontent.com/1490444/146781142-430a2b2c-cb19-40a1-ae91-63b739944377.png">
<img width="889" alt="Screenshot 2021-12-20 at 14 39 07" src="https://user-images.githubusercontent.com/1490444/146781144-ace0fd0d-2463-4732-b65f-b54f8fb6f807.png">
<img width="445" alt="Screenshot 2021-12-20 at 14 38 39" src="https://user-images.githubusercontent.com/1490444/146781141-aef0f400-d1b7-4782-9ac7-b407d57c9498.png">
<img width="443" alt="Screenshot 2021-12-20 at 14 38 10" src="https://user-images.githubusercontent.com/1490444/146781135-79a266a0-3aff-4f79-ae15-d982ed03ff40.png">

