### PR TITLE
[Fleet] added kibana version to user-agent

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/registry/requests.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/requests.test.ts
@@ -6,9 +6,23 @@
  */
 
 import { RegistryError, RegistryConnectionError, RegistryResponseError } from '../../../errors';
+import { appContextService } from '../../app_context';
 
-import { fetchUrl } from './requests';
+import { fetchUrl, getResponse } from './requests';
 jest.mock('node-fetch');
+
+let mockRegistryProxyUrl: string | undefined;
+jest.mock('./proxy', () => ({
+  getProxyAgent: jest.fn().mockReturnValue('proxy agent'),
+  getRegistryProxyUrl: () => mockRegistryProxyUrl,
+}));
+
+jest.mock('../../app_context', () => ({
+  appContextService: {
+    getKibanaVersion: jest.fn(),
+    getLogger: jest.fn().mockReturnValue({ debug: jest.fn() }),
+  },
+}));
 
 const { Response, FetchError } = jest.requireActual('node-fetch');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -20,6 +34,35 @@ describe('Registry request', () => {
 
   afterEach(async () => {
     jest.clearAllMocks();
+  });
+
+  describe('fetch options', () => {
+    beforeEach(() => {
+      fetchMock.mockImplementationOnce(() => Promise.resolve(new Response('')));
+      (appContextService.getKibanaVersion as jest.Mock).mockReturnValue('8.0.0');
+    });
+    it('should set User-Agent header including kibana version', async () => {
+      getResponse('');
+
+      expect(fetchMock).toHaveBeenCalledWith('', {
+        headers: {
+          'User-Agent': 'Kibana/8.0.0 node-fetch',
+        },
+      });
+    });
+
+    it('should set User-Agent header including kibana version with agent', async () => {
+      mockRegistryProxyUrl = 'url';
+
+      getResponse('');
+
+      expect(fetchMock).toHaveBeenCalledWith('', {
+        agent: 'proxy agent',
+        headers: {
+          'User-Agent': 'Kibana/8.0.0 node-fetch',
+        },
+      });
+    });
   });
 
   describe('fetchUrl / getResponse errors', () => {

--- a/x-pack/plugins/fleet/server/services/epm/registry/requests.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/requests.ts
@@ -88,7 +88,7 @@ function isSystemError(error: FailedAttemptErrors): boolean {
 }
 
 export function getFetchOptions(targetUrl: string): RequestInit | undefined {
-  const options: { [key: string]: any } = {
+  const options: RequestInit = {
     headers: {
       'User-Agent': `Kibana/${appContextService.getKibanaVersion()} node-fetch`,
     },

--- a/x-pack/plugins/fleet/server/services/epm/registry/requests.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/requests.ts
@@ -88,15 +88,19 @@ function isSystemError(error: FailedAttemptErrors): boolean {
 }
 
 export function getFetchOptions(targetUrl: string): RequestInit | undefined {
+  const options: { [key: string]: any } = {
+    headers: {
+      'User-Agent': `Kibana/${appContextService.getKibanaVersion()} node-fetch`,
+    },
+  };
   const proxyUrl = getRegistryProxyUrl();
   if (!proxyUrl) {
-    return undefined;
+    return options;
   }
 
   const logger = appContextService.getLogger();
   logger.debug(`Using ${proxyUrl} as proxy for ${targetUrl}`);
 
-  return {
-    agent: getProxyAgent({ proxyUrl, targetUrl }),
-  };
+  options.agent = getProxyAgent({ proxyUrl, targetUrl });
+  return options;
 }


### PR DESCRIPTION
## Summary

Solves https://github.com/elastic/kibana/issues/116410

Added header `User-Agent` when calling epr API to include kibana version.

To verify manually:
- add log statement to `requests.ts` line 96: `console.log(JSON.stringify(options));`
- open Fleet locally
- check kibana output to see this: `{"headers":{"User-Agent":"Kibana/8.1.0 node-fetch"}}`


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
