### PR TITLE
[Lens] add ticks on bands tooltip for gauge

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/gauge/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/visualizations/gauge/dimension_editor.tsx
@@ -202,7 +202,7 @@ export function GaugeDimensionEditor(
                 position="top"
                 tooltipContent={i18n.translate('xpack.lens.shared.ticksPositionOptionsTooltip', {
                   defaultMessage:
-                    'Places ticks on color borders instead of distributing them evenly',
+                    'Places ticks on each band border instead of distributing them evenly',
                 })}
                 condition={true}
                 delay="regular"

--- a/x-pack/plugins/lens/public/visualizations/gauge/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/visualizations/gauge/dimension_editor.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlexItem,
   EuiSwitchEvent,
   EuiSwitch,
+  EuiIcon,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -33,6 +34,7 @@ import {
   FIXED_PROGRESSION,
   getStopsForFixedMode,
   PalettePanelContainer,
+  TooltipWrapper,
 } from '../../shared_components/';
 import type { VisualizationDimensionEditorProps } from '../../types';
 import './dimension_editor.scss';
@@ -193,11 +195,32 @@ export function GaugeDimensionEditor(
             </EuiFlexGroup>
           </EuiFormRow>
           <EuiFormRow
-            fullWidth
             display="columnCompressedSwitch"
-            label={i18n.translate('xpack.lens.shared.ticksPositionOptions', {
-              defaultMessage: 'Ticks on bands',
-            })}
+            fullWidth
+            label={
+              <TooltipWrapper
+                position="top"
+                tooltipContent={i18n.translate('xpack.lens.shared.ticksPositionOptionsTooltip', {
+                  defaultMessage:
+                    'Places ticks on color borders instead of distributing them evenly',
+                })}
+                condition={true}
+                delay="regular"
+              >
+                <span>
+                  {i18n.translate('xpack.lens.shared.ticksPositionOptions', {
+                    defaultMessage: 'Ticks on bands',
+                  })}
+
+                  <EuiIcon
+                    type="questionInCircle"
+                    color="subdued"
+                    size="s"
+                    className="eui-alignTop"
+                  />
+                </span>
+              </TooltipWrapper>
+            }
           >
             <EuiSwitch
               compressed


### PR DESCRIPTION
## Summary

Adds tooltip to explain the setting to the user. @KOTungseth, could you help with a copy? 
<img width="309" alt="Screenshot 2021-12-15 at 15 00 33" src="https://user-images.githubusercontent.com/4283304/146200164-0bca4495-55df-4c14-a596-54c17d4da865.png">


What it does is placing the ticks on the edges of the color instead spreading 4 of them in equal distance.

Setting on:
<img width="630" alt="Screenshot 2021-12-15 at 14 59 51" src="https://user-images.githubusercontent.com/4283304/146200087-567400f8-aa44-4bb6-97b6-76a32a603c9f.png">

Setting off:
<img width="630" alt="Screenshot 2021-12-15 at 14 59 55" src="https://user-images.githubusercontent.com/4283304/146200076-9a0cd926-384c-4a18-829a-e0738daad161.png">

