### PR TITLE
[Fleet] added missing envvar

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -254,6 +254,7 @@ kibana_vars=(
     xpack.fleet.agents.kibana.host
     xpack.fleet.agents.tlsCheckDisabled
     xpack.fleet.packages
+    xpack.fleet.registryProxyUrl
     xpack.fleet.registryUrl
     xpack.graph.canEditDrillDownUrls
     xpack.graph.savePolicy


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/118145

Added missing `xpack.fleet.registryProxyUrl` docker var.
