### PR TITLE
[Security Solution][Endpoint] Add authz check to `/api/endpoint/policy` API

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/routes/policy/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/policy/index.ts
@@ -61,6 +61,10 @@ export function registerPolicyRoutes(router: IRouter, endpointAppContext: Endpoi
       validate: GetEndpointPackagePolicyRequestSchema,
       options: { authRequired: true },
     },
-    getPolicyListHandler(endpointAppContext)
+    withEndpointAuthz(
+      { all: ['canAccessEndpointManagement'] },
+      logger,
+      getPolicyListHandler(endpointAppContext)
+    )
   );
 }

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
@@ -63,6 +63,11 @@ export default function ({ getService }: FtrProviderContext) {
         body: undefined,
       },
       {
+        method: 'get',
+        path: '/api/endpoint/policy',
+        body: undefined,
+      },
+      {
         method: 'post',
         path: '/api/endpoint/isolate',
         body: { endpoint_ids: ['one'] },


### PR DESCRIPTION
## Summary

- Adds authorization check to the new `/api/endpint/policy` API
- Updates FTR test to include this API

GIF with APIs being called with user `elastic` and `t1_analyst`:

![olm-add-authz-to-policy-api](https://user-images.githubusercontent.com/56442535/146209614-c1cb87b5-1911-4b71-8f79-a50a8730540a.gif)


