### PR TITLE
[8.0] [Fleet] index templates - add support for wildcard multi-fields (#121088)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -383,6 +383,40 @@ describe('EPM template', () => {
     expect(mappings).toEqual(keywordWithMultiFieldsMapping);
   });
 
+  it('tests processing wildcard field with multi fields', () => {
+    const keywordWithMultiFieldsLiteralYml = `
+- name: keywordWithMultiFields
+  type: wildcard
+  multi_fields:
+    - name: raw
+      type: keyword
+    - name: indexed
+      type: text
+`;
+
+    const keywordWithMultiFieldsMapping = {
+      properties: {
+        keywordWithMultiFields: {
+          ignore_above: 1024,
+          type: 'wildcard',
+          fields: {
+            raw: {
+              ignore_above: 1024,
+              type: 'keyword',
+            },
+            indexed: {
+              type: 'text',
+            },
+          },
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(keywordWithMultiFieldsLiteralYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(keywordWithMultiFieldsMapping);
+  });
+
   it('tests processing object field with no other attributes', () => {
     const objectFieldLiteralYml = `
 - name: objectField

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -147,6 +147,13 @@ export function generateMappings(fields: Field[]): IndexTemplateMappings {
             fieldProps.fields = generateMultiFields(field.multi_fields);
           }
           break;
+        case 'wildcard':
+          const wildcardMapping = generateWildcardMapping(field);
+          fieldProps = { ...fieldProps, ...wildcardMapping, type: 'wildcard' };
+          if (field.multi_fields) {
+            fieldProps.fields = generateMultiFields(field.multi_fields);
+          }
+          break;
         case 'constant_keyword':
           fieldProps.type = field.type;
           if (field.value) {
@@ -267,6 +274,19 @@ function generateTextMapping(field: Field): IndexTemplateMapping {
   }
   if (field.search_analyzer) {
     mapping.search_analyzer = field.search_analyzer;
+  }
+  return mapping;
+}
+
+function generateWildcardMapping(field: Field): IndexTemplateMapping {
+  const mapping: IndexTemplateMapping = {
+    ignore_above: DEFAULT_IGNORE_ABOVE,
+  };
+  if (field.null_value) {
+    mapping.null_value = field.null_value;
+  }
+  if (field.ignore_above) {
+    mapping.ignore_above = field.ignore_above;
   }
   return mapping;
 }

--- a/x-pack/plugins/fleet/server/services/epm/fields/field.ts
+++ b/x-pack/plugins/fleet/server/services/epm/fields/field.ts
@@ -34,6 +34,7 @@ export interface Field {
   dynamic?: 'strict' | boolean;
   include_in_parent?: boolean;
   include_in_root?: boolean;
+  null_value?: string;
 
   // Meta fields
   metric_type?: string;


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Fleet] index templates - add support for wildcard multi-fields (#121088)