### PR TITLE
[Maps] Remove redundant categories from field-meta type

### DIFF
--- a/x-pack/plugins/maps/common/descriptor_types/style_property_descriptor_types.ts
+++ b/x-pack/plugins/maps/common/descriptor_types/style_property_descriptor_types.ts
@@ -215,10 +215,6 @@ export type Category = {
   count: number;
 };
 
-export type CategoryFieldMeta = {
-  categories: Category[];
-};
-
 export type GeometryTypes = {
   isPointsOnly: boolean;
   isLinesOnly: boolean;
@@ -228,7 +224,7 @@ export type GeometryTypes = {
 export type FieldMeta = {
   [key: string]: {
     range?: RangeFieldMeta;
-    categories?: CategoryFieldMeta;
+    categories: Category[];
   };
 };
 

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_color_property.test.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_color_property.test.tsx
@@ -233,13 +233,11 @@ test('Should pluck the categorical style-meta', async () => {
   const features = makeFeatures(['CN', 'CN', 'US', 'CN', 'US', 'IN']);
   const meta = colorStyle.pluckCategoricalStyleMetaFromFeatures(features);
 
-  expect(meta).toEqual({
-    categories: [
-      { key: 'CN', count: 3 },
-      { key: 'US', count: 2 },
-      { key: 'IN', count: 1 },
-    ],
-  });
+  expect(meta).toEqual([
+    { key: 'CN', count: 3 },
+    { key: 'US', count: 2 },
+    { key: 'IN', count: 1 },
+  ]);
 });
 
 test('Should pluck the categorical style-meta from fieldmeta', async () => {
@@ -262,13 +260,11 @@ test('Should pluck the categorical style-meta from fieldmeta', async () => {
     },
   });
 
-  expect(meta).toEqual({
-    categories: [
-      { key: 'CN', count: 3 },
-      { key: 'US', count: 2 },
-      { key: 'IN', count: 1 },
-    ],
-  });
+  expect(meta).toEqual([
+    { key: 'CN', count: 3 },
+    { key: 'US', count: 2 },
+    { key: 'IN', count: 1 },
+  ]);
 });
 
 describe('supportsFieldMeta', () => {

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_color_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_color_property.tsx
@@ -263,8 +263,8 @@ export class DynamicColorProperty extends DynamicStyleProperty<ColorDynamicOptio
       };
     }
 
-    const fieldMeta = this.getCategoryFieldMeta();
-    if (!fieldMeta || !fieldMeta.categories) {
+    const categories = this.getCategoryFieldMeta();
+    if (categories.length === 0) {
       return EMPTY_STOPS;
     }
 
@@ -275,14 +275,14 @@ export class DynamicColorProperty extends DynamicStyleProperty<ColorDynamicOptio
       return EMPTY_STOPS;
     }
 
-    const maxLength = Math.min(colors.length, fieldMeta.categories.length + 1);
+    const maxLength = Math.min(colors.length, categories.length + 1);
     const stops = [];
 
     for (let i = 0; i < maxLength - 1; i++) {
       stops.push({
-        stop: fieldMeta.categories[i].key,
+        stop: categories[i].key,
         color: this._chartsPaletteServiceGetColor
-          ? this._chartsPaletteServiceGetColor(fieldMeta.categories[i].key)
+          ? this._chartsPaletteServiceGetColor(categories[i].key)
           : colors[i],
       });
     }

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_icon_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_icon_property.tsx
@@ -63,7 +63,7 @@ export class DynamicIconProperty extends DynamicStyleProperty<IconDynamicOptions
     }
 
     return assignCategoriesToPalette({
-      categories: _.get(this.getCategoryFieldMeta(), 'categories', []),
+      categories: this.getCategoryFieldMeta(),
       paletteValues: getIconPalette(this._options.iconPaletteId),
     });
   }

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
@@ -193,7 +193,7 @@ export class DynamicStyleProperty<T>
     }
 
     const categoricalFieldMetaFromServer = this._getCategoryFieldMetaFromStyleMetaRequest();
-    return categoricalFieldMetaFromServer
+    return categoricalFieldMetaFromServer.length
       ? categoricalFieldMetaFromServer
       : categoryFieldMetaFromLocalFeatures;
   }

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
@@ -415,14 +415,14 @@ export class DynamicStyleProperty<T>
     };
   }
 
-  _pluckCategoricalStyleMetaFromFieldMetaData(styleMetaData: StyleMetaData): Category[] | null {
+  _pluckCategoricalStyleMetaFromFieldMetaData(styleMetaData: StyleMetaData): Category[] {
     if (!this.isCategorical() || !this._field) {
-      return null;
+      return [];
     }
 
     const fieldMeta = styleMetaData[`${this._field.getRootName()}_terms`];
     if (!fieldMeta || !('buckets' in fieldMeta)) {
-      return null;
+      return [];
     }
 
     return fieldMeta.buckets.map((bucket) => {

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
@@ -27,7 +27,7 @@ import {
   OrdinalDataMappingPopover,
 } from '../components/data_mapping';
 import {
-  CategoryFieldMeta,
+  Category,
   FieldMetaOptions,
   PercentilesFieldMeta,
   RangeFieldMeta,
@@ -47,7 +47,7 @@ export interface IDynamicStyleProperty<T> extends IStyleProperty<T> {
   getMbFieldName(): string;
   getFieldOrigin(): FIELD_ORIGIN | null;
   getRangeFieldMeta(): RangeFieldMeta | null;
-  getCategoryFieldMeta(): CategoryFieldMeta | null;
+  getCategoryFieldMeta(): Category[];
   /*
    * Returns hash that signals style meta needs to be re-fetched when value changes
    */
@@ -57,11 +57,9 @@ export interface IDynamicStyleProperty<T> extends IStyleProperty<T> {
   supportsFieldMeta(): boolean;
   getFieldMetaRequest(): Promise<unknown | null>;
   pluckOrdinalStyleMetaFromFeatures(features: Feature[]): RangeFieldMeta | null;
-  pluckCategoricalStyleMetaFromFeatures(features: Feature[]): CategoryFieldMeta | null;
+  pluckCategoricalStyleMetaFromFeatures(features: Feature[]): Category[];
   pluckOrdinalStyleMetaFromTileMetaFeatures(metaFeatures: TileMetaFeature[]): RangeFieldMeta | null;
-  pluckCategoricalStyleMetaFromTileMetaFeatures(
-    features: TileMetaFeature[]
-  ): CategoryFieldMeta | null;
+  pluckCategoricalStyleMetaFromTileMetaFeatures(features: TileMetaFeature[]): Category[];
   getValueSuggestions(query: string): Promise<string[]>;
   enrichGeoJsonAndMbFeatureState(
     featureCollection: FeatureCollection,
@@ -175,19 +173,19 @@ export class DynamicStyleProperty<T>
   _getCategoryFieldMetaFromStyleMetaRequest() {
     const dataRequestId = this._getStyleMetaDataRequestId(this.getFieldName());
     if (!dataRequestId) {
-      return null;
+      return [];
     }
 
     const styleMetaDataRequest = this._layer.getDataRequest(dataRequestId);
     if (!styleMetaDataRequest || !styleMetaDataRequest.hasData()) {
-      return null;
+      return [];
     }
 
     const data = styleMetaDataRequest.getData() as StyleMetaData;
     return this._pluckCategoricalStyleMetaFromFieldMetaData(data);
   }
 
-  getCategoryFieldMeta(): CategoryFieldMeta | null {
+  getCategoryFieldMeta(): Category[] {
     const categoryFieldMetaFromLocalFeatures = this._getCategoryFieldMetaFromLocalFeatures();
 
     if (!this.isFieldMetaEnabled()) {
@@ -332,10 +330,8 @@ export class DynamicStyleProperty<T>
         };
   }
 
-  pluckCategoricalStyleMetaFromTileMetaFeatures(
-    metaFeatures: TileMetaFeature[]
-  ): CategoryFieldMeta | null {
-    return null;
+  pluckCategoricalStyleMetaFromTileMetaFeatures(metaFeatures: TileMetaFeature[]): Category[] {
+    return [];
   }
 
   pluckOrdinalStyleMetaFromFeatures(features: Feature[]): RangeFieldMeta | null {
@@ -364,10 +360,10 @@ export class DynamicStyleProperty<T>
         };
   }
 
-  pluckCategoricalStyleMetaFromFeatures(features: Feature[]): CategoryFieldMeta | null {
+  pluckCategoricalStyleMetaFromFeatures(features: Feature[]): Category[] {
     const size = this.getNumberOfCategories();
     if (!this.isCategorical() || size <= 0) {
-      return null;
+      return [];
     }
 
     const counts = new Map();
@@ -384,7 +380,7 @@ export class DynamicStyleProperty<T>
       }
     }
 
-    const ordered = [];
+    const ordered: Category[] = [];
     for (const [key, value] of counts) {
       ordered.push({ key, count: value });
     }
@@ -392,10 +388,7 @@ export class DynamicStyleProperty<T>
     ordered.sort((a, b) => {
       return b.count - a.count;
     });
-    const truncated = ordered.slice(0, size);
-    return {
-      categories: truncated,
-    } as CategoryFieldMeta;
+    return ordered.slice(0, size);
   }
 
   _pluckOrdinalStyleMetaFromFieldMetaData(styleMetaData: StyleMetaData): RangeFieldMeta | null {
@@ -422,9 +415,7 @@ export class DynamicStyleProperty<T>
     };
   }
 
-  _pluckCategoricalStyleMetaFromFieldMetaData(
-    styleMetaData: StyleMetaData
-  ): CategoryFieldMeta | null {
+  _pluckCategoricalStyleMetaFromFieldMetaData(styleMetaData: StyleMetaData): Category[] | null {
     if (!this.isCategorical() || !this._field) {
       return null;
     }
@@ -434,14 +425,12 @@ export class DynamicStyleProperty<T>
       return null;
     }
 
-    return {
-      categories: fieldMeta.buckets.map((bucket) => {
-        return {
-          key: bucket.key,
-          count: bucket.doc_count,
-        };
-      }),
-    };
+    return fieldMeta.buckets.map((bucket) => {
+      return {
+        key: bucket.key,
+        count: bucket.doc_count,
+      };
+    });
   }
 
   formatField(value: RawValue): string | number {

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/test_helpers/test_util.ts
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/test_helpers/test_util.ts
@@ -8,12 +8,6 @@
 // eslint-disable-next-line max-classes-per-file
 import { FIELD_ORIGIN, LAYER_STYLE_TYPE } from '../../../../../../common/constants';
 import { StyleMeta } from '../../style_meta';
-import {
-  CategoryFieldMeta,
-  GeometryTypes,
-  RangeFieldMeta,
-  StyleMetaDescriptor,
-} from '../../../../../../common/descriptor_types';
 import { AbstractField, IField } from '../../../../fields/field';
 import { IStyle } from '../../../style';
 
@@ -77,40 +71,32 @@ export class MockStyle implements IStyle {
   }
 
   getStyleMeta(): StyleMeta {
-    const geomTypes: GeometryTypes = {
-      isPointsOnly: false,
-      isLinesOnly: false,
-      isPolygonsOnly: false,
-    };
-    const rangeFieldMeta: RangeFieldMeta = {
-      min: this._min,
-      max: this._max,
-      delta: this._max - this._min,
-    };
-    const catFieldMeta: CategoryFieldMeta = {
-      categories: [
-        {
-          key: 'US',
-          count: 10,
-        },
-        {
-          key: 'CN',
-          count: 8,
-        },
-      ],
-    };
-
-    const styleMetaDescriptor: StyleMetaDescriptor = {
-      geometryTypes: geomTypes,
+    return new StyleMeta({
+      geometryTypes: {
+        isPointsOnly: false,
+        isLinesOnly: false,
+        isPolygonsOnly: false,
+      },
       fieldMeta: {
         foobar: {
-          range: rangeFieldMeta,
-          categories: catFieldMeta,
+          range: {
+            min: this._min,
+            max: this._max,
+            delta: this._max - this._min,
+          },
+          categories: [
+            {
+              key: 'US',
+              count: 10,
+            },
+            {
+              key: 'CN',
+              count: 8,
+            },
+          ],
         },
       },
-    };
-
-    return new StyleMeta(styleMetaDescriptor);
+    });
   }
 }
 

--- a/x-pack/plugins/maps/public/classes/styles/vector/style_meta.ts
+++ b/x-pack/plugins/maps/public/classes/styles/vector/style_meta.ts
@@ -5,11 +5,7 @@
  * 2.0.
  */
 
-import {
-  StyleMetaDescriptor,
-  RangeFieldMeta,
-  CategoryFieldMeta,
-} from '../../../../common/descriptor_types';
+import { StyleMetaDescriptor, RangeFieldMeta, Category } from '../../../../common/descriptor_types';
 
 export class StyleMeta {
   private readonly _descriptor: StyleMetaDescriptor;
@@ -23,10 +19,8 @@ export class StyleMeta {
       : null;
   }
 
-  getCategoryFieldMetaDescriptor(fieldName: string): CategoryFieldMeta | null {
-    return this._descriptor.fieldMeta[fieldName] && this._descriptor.fieldMeta[fieldName].categories
-      ? this._descriptor.fieldMeta[fieldName].categories!
-      : null;
+  getCategoryFieldMetaDescriptor(fieldName: string): Category[] {
+    return this._descriptor.fieldMeta[fieldName].categories;
   }
 
   isPointsOnly(): boolean {

--- a/x-pack/plugins/maps/public/classes/styles/vector/vector_style.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/vector_style.tsx
@@ -511,19 +511,15 @@ export class VectorStyle implements IVectorStyle {
     }
 
     dynamicProperties.forEach((dynamicProperty) => {
-      const ordinalStyleMeta =
-        dynamicProperty.pluckOrdinalStyleMetaFromTileMetaFeatures(metaFeatures);
-      const categoricalStyleMeta =
-        dynamicProperty.pluckCategoricalStyleMetaFromTileMetaFeatures(metaFeatures);
-
       const name = dynamicProperty.getFieldName();
       if (!styleMeta.fieldMeta[name]) {
-        styleMeta.fieldMeta[name] = {};
+        styleMeta.fieldMeta[name] = { categories: [] };
       }
-      if (categoricalStyleMeta) {
-        styleMeta.fieldMeta[name].categories = categoricalStyleMeta;
-      }
+      styleMeta.fieldMeta[name].categories =
+        dynamicProperty.pluckCategoricalStyleMetaFromTileMetaFeatures(metaFeatures);
 
+      const ordinalStyleMeta =
+        dynamicProperty.pluckOrdinalStyleMetaFromTileMetaFeatures(metaFeatures);
       if (ordinalStyleMeta) {
         styleMeta.fieldMeta[name].range = ordinalStyleMeta;
       }
@@ -595,17 +591,13 @@ export class VectorStyle implements IVectorStyle {
 
     dynamicProperties.forEach(
       (dynamicProperty: IDynamicStyleProperty<DynamicStylePropertyOptions>) => {
-        const categoricalStyleMeta =
-          dynamicProperty.pluckCategoricalStyleMetaFromFeatures(features);
-        const ordinalStyleMeta = dynamicProperty.pluckOrdinalStyleMetaFromFeatures(features);
         const name = dynamicProperty.getFieldName();
         if (!styleMeta.fieldMeta[name]) {
-          styleMeta.fieldMeta[name] = {};
+          styleMeta.fieldMeta[name] = { categories: [] };
         }
-        if (categoricalStyleMeta) {
-          styleMeta.fieldMeta[name].categories = categoricalStyleMeta;
-        }
-
+        styleMeta.fieldMeta[name].categories =
+          dynamicProperty.pluckCategoricalStyleMetaFromFeatures(features);
+        const ordinalStyleMeta = dynamicProperty.pluckOrdinalStyleMetaFromFeatures(features);
         if (ordinalStyleMeta) {
           styleMeta.fieldMeta[name].range = ordinalStyleMeta;
         }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/104097

PR replaces `CategoryFieldMeta` with  `Category[]`

```
export type Category = {
  key: string;
  count: number;
};

export type FieldMeta = {
  [key: string]: {
    range?: RangeFieldMeta;
    categories: Category[];
  };
};
```