### PR TITLE
[8.0] [DOCS] Moves encryption key doc to tools section (#121021)

### DIFF
--- a/docs/user/commands/cli-commands.asciidoc
+++ b/docs/user/commands/cli-commands.asciidoc
@@ -3,6 +3,8 @@
 
 {kib} provides the following tools for configuring security and performing other tasks from the command line:
 
+* <<kibana-encryption-keys,`kibana-encryption-keys`>>
 * <<kibana-verification-code,`kibana-verification-code`>>
 
+include::encryption-keys/index.asciidoc[]
 include::kibana-verification-code.asciidoc[]

--- a/docs/user/commands/encryption-keys/index.asciidoc
+++ b/docs/user/commands/encryption-keys/index.asciidoc
@@ -1,5 +1,5 @@
 [[kibana-encryption-keys]]
-=== Set up encryption keys to protect sensitive information
+=== kibana-encryption-keys
 
 The `kibana-encryption-keys` command helps you set up encryption keys that {kib} uses
 to protect sensitive information.

--- a/docs/user/security/index.asciidoc
+++ b/docs/user/security/index.asciidoc
@@ -37,7 +37,7 @@ see {ref}/authorization.html[User authorization].
 
 [NOTE]
 ============================================================================
-Managing roles that grant <<kibana-privileges>> using the {es} 
+Managing roles that grant <<kibana-privileges>> using the {es}
 {ref}/security-api.html#security-role-apis[role management APIs] is not supported. Doing so will likely
 cause Kibana's authorization to behave unexpectedly.
 ============================================================================
@@ -45,5 +45,4 @@ cause Kibana's authorization to behave unexpectedly.
 include::authorization/index.asciidoc[]
 include::authorization/kibana-privileges.asciidoc[]
 include::api-keys/index.asciidoc[]
-include::encryption-keys/index.asciidoc[]
 include::role-mappings/index.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Moves encryption key doc to tools section (#121021)