### PR TITLE
Re-enables legacy import saved objects functional tests

### DIFF
--- a/test/functional/apps/dashboard/bwc_import.ts
+++ b/test/functional/apps/dashboard/bwc_import.ts
@@ -13,8 +13,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['dashboard', 'header', 'settings', 'savedObjects', 'common']);
   const dashboardExpect = getService('dashboardExpect');
 
-  // https://github.com/elastic/kibana/issues/114053
-  describe.skip('bwc import', function describeIndexTests() {
+  describe('bwc import', function describeIndexTests() {
     before(async function () {
       await PageObjects.dashboard.initTests();
       await PageObjects.settings.navigateTo();

--- a/test/functional/apps/management/_import_objects.ts
+++ b/test/functional/apps/management/_import_objects.ts
@@ -211,8 +211,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    // https://github.com/elastic/kibana/issues/114053
-    describe.skip('.json file', () => {
+    describe('.json file', () => {
       beforeEach(async function () {
         await esArchiver.load('test/functional/fixtures/es_archiver/saved_objects_imports');
         await kibanaServer.uiSettings.replace({});

--- a/test/functional/apps/management/_mgmt_import_saved_objects.js
+++ b/test/functional/apps/management/_mgmt_import_saved_objects.js
@@ -16,8 +16,7 @@ export default function ({ getService, getPageObjects }) {
   //in 6.4.0 bug the Saved Search conflict would be resolved and get imported but the visualization
   //that referenced the saved search was not imported.( https://github.com/elastic/kibana/issues/22238)
 
-  // https://github.com/elastic/kibana/issues/114053
-  describe.skip('mgmt saved objects', function describeIndexTests() {
+  describe('mgmt saved objects', function describeIndexTests() {
     before(async () => {
       await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/discover');
       await PageObjects.settings.navigateTo();


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/114053

Re-enables skipped tests related to importing saved objects from legacy format files

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Functional tests start failing intermittently again due to race conditions | unknown | medium |  Investigate race conditions that might be causing flakiness |