### PR TITLE
[Fleet] added fleet setup before installing integration

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/install_button.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/install_button.tsx
@@ -17,6 +17,8 @@ import {
   useInstallPackage,
 } from '../../../../../hooks';
 
+import { sendPostFleetSetup } from '../../../../../../../hooks/use_request/setup';
+
 import { ConfirmPackageInstall } from './confirm_package_install';
 
 type InstallationButtonProps = Pick<PackageInfo, 'name' | 'title' | 'version'> & {
@@ -35,16 +37,21 @@ export function InstallButton(props: InstallationButtonProps) {
   const getPackageInstallStatus = useGetPackageInstallStatus();
   const { status: installationStatus } = getPackageInstallStatus(name);
 
-  const isInstalling = installationStatus === InstallStatus.installing;
+  const [isFleetSetupInProgress, setFleetSetupInProgress] = useState<boolean>(false);
+
+  const isInstalling = installationStatus === InstallStatus.installing || isFleetSetupInProgress;
   const [isInstallModalVisible, setIsInstallModalVisible] = useState<boolean>(false);
 
   const toggleInstallModal = useCallback(() => {
     setIsInstallModalVisible(!isInstallModalVisible);
   }, [isInstallModalVisible]);
 
-  const handleClickInstall = useCallback(() => {
-    installPackage({ name, version, title });
+  const handleClickInstall = useCallback(async () => {
+    setFleetSetupInProgress(true);
     toggleInstallModal();
+    await sendPostFleetSetup({ forceRecreate: false });
+    setFleetSetupInProgress(false);
+    installPackage({ name, version, title });
   }, [installPackage, name, title, toggleInstallModal, version]);
 
   const installModal = (

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/install_button.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/install_button.tsx
@@ -53,14 +53,17 @@ export function InstallButton(props: InstallationButtonProps) {
   const handleClickInstall = useCallback(async () => {
     setFleetSetupInProgress(true);
     toggleInstallModal();
-    const res = await sendPostFleetSetup({ forceRecreate: false });
-    if (res.error) {
+    try {
+      const res = await sendPostFleetSetup({ forceRecreate: false });
+      if (res.error) {
+        throw res.error;
+      }
+    } catch (e) {
       notifications.toasts.addWarning({
         title: toMountPoint(
           <FormattedMessage
             id="xpack.fleet.integrations.fleetSetupErrorTitle"
             defaultMessage="Failed to setup Fleet"
-            values={{ title }}
           />
         ),
         text: toMountPoint(


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/120358

Calling setup fleet first when clicking on integration install button.
- if fleet setup hasn't been done yet, the setup takes some time, so showing disabled "Installing" button.
- If fleet setup has been done already, the call returns quickly

Steps to verify:

1. Start Kibana and ES 7.16.0 without Fleet Server, do not go to Fleet app
2. Go directly to an Integration detail settings tab, such as http://localhost:5601/app/integrations/detail/nginx-1.2.3/settings
3. Click install button
4. Verify on Network tab that fleet setup is called, and during that time, cannot click Install button again.
5. After setup returns, install should be completing successfully

Repeat the above with another integration and verify that setup is called and returning quickly.

![image](https://user-images.githubusercontent.com/90178898/146341504-48cfc74d-b776-4db6-a7e0-28db5b173507.png)

![image](https://user-images.githubusercontent.com/90178898/146341724-1cfc46cf-7306-451a-9f6d-13ed66ab96ef.png)

What is alarming though is that first time the setup call takes almost 2 mins, and I see a few errors in kibana logs as well:
```
server    log   [10:04:43.409] [warning][fleet][plugins] Failure to install package [elastic_agent]: [{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"component template [metrics-elastic_agent.osquerybeat@custom] already exists"}],"type":"illegal_argument_exception","reason":"component template [metrics-elastic_agent.osquerybeat@custom] already exists"},"status":400}]
server    log   [10:04:43.410] [error][fleet][plugins] uninstalling elastic_agent-1.3.0 after error installing: [{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"component template [metrics-elastic_agent.osquerybeat@custom] already exists"}],"type":"illegal_argument_exception","reason":"component template [metrics-elastic_agent.osquerybeat@custom] already exists"},"status":400}]
server    log   [10:04:43.413] [error][fleet][plugins] failed to uninstall or rollback package after installation error Error: elastic_agent is installed by default and cannot be removed
server    log   [10:05:24.737] [warning][fleet][plugins] Failed installing package [elastic_agent] due to error: [{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"component template [metrics-elastic_agent.osquerybeat@custom] already exists"}],"type":"illegal_argument_exception","reason":"component template [metrics-elastic_agent.osquerybeat@custom] already exists"},"status":400}]
```

The same errors come when I navigate to Fleet to trigger setup first (on 7.16 branch)