### PR TITLE
[Lens] don't update searchSession on start

### DIFF
--- a/x-pack/plugins/lens/public/state_management/context_middleware/index.test.ts
+++ b/x-pack/plugins/lens/public/state_management/context_middleware/index.test.ts
@@ -5,24 +5,24 @@
  * 2.0.
  */
 
-// /*
-//  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-//  * or more contributor license agreements. Licensed under the Elastic License
-//  * 2.0; you may not use this file except in compliance with the Elastic License
-//  * 2.0.
-//  */
-
-import { timeRangeMiddleware } from './time_range_middleware';
-
-import { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
-import moment from 'moment';
-import { initialState } from './lens_slice';
-import { LensAppState } from './types';
 import { PayloadAction } from '@reduxjs/toolkit';
-import { mockDataPlugin } from '../mocks';
+import moment from 'moment';
 
+import { contextMiddleware } from '.';
+import { DataPublicPluginStart } from '../../../../../../src/plugins/data/public';
+import { initialState } from '../lens_slice';
+import { LensAppState } from '../types';
+import { mockDataPlugin, mockStoreDeps } from '../../mocks';
+
+const storeDeps = mockStoreDeps();
 const createMiddleware = (data: DataPublicPluginStart) => {
-  const middleware = timeRangeMiddleware(data);
+  const middleware = contextMiddleware({
+    ...storeDeps,
+    lensServices: {
+      ...storeDeps.lensServices,
+      data,
+    },
+  });
   const store = {
     getState: jest.fn(() => ({ lens: initialState })),
     dispatch: jest.fn(),
@@ -34,7 +34,7 @@ const createMiddleware = (data: DataPublicPluginStart) => {
   return { store, next, invoke };
 };
 
-describe('timeRangeMiddleware', () => {
+describe('contextMiddleware', () => {
   describe('time update', () => {
     it('does update the searchSessionId when the state changes and too much time passed', () => {
       const data = mockDataPlugin();

--- a/x-pack/plugins/lens/public/state_management/context_middleware/index.ts
+++ b/x-pack/plugins/lens/public/state_management/context_middleware/index.ts
@@ -7,10 +7,30 @@
 
 import { Dispatch, MiddlewareAPI, PayloadAction } from '@reduxjs/toolkit';
 import moment from 'moment';
-import { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
-import { setState, LensDispatch } from '.';
-import { LensAppState } from './types';
-import { getResolvedDateRange, containsDynamicMath } from '../utils';
+import { DataPublicPluginStart } from '../../../../../../src/plugins/data/public';
+import { setState, LensDispatch } from '..';
+import { LensAppState } from '../types';
+import { getResolvedDateRange, containsDynamicMath } from '../../utils';
+import { LensStoreDeps } from '..';
+import { navigateAway } from '..';
+import { subscribeToExternalContext } from './subscribe_to_external_context';
+
+export const contextMiddleware = (storeDeps: LensStoreDeps) => (store: MiddlewareAPI) => {
+  const unsubscribeFromExternalContext = subscribeToExternalContext(
+    storeDeps.lensServices.data,
+    store.getState,
+    store.dispatch
+  );
+  return (next: Dispatch) => (action: PayloadAction<Partial<LensAppState>>) => {
+    if (!action.payload?.searchSessionId) {
+      updateTimeRange(storeDeps.lensServices.data, store.dispatch);
+    }
+    if (navigateAway.match(action)) {
+      return unsubscribeFromExternalContext();
+    }
+    next(action);
+  };
+};
 
 const TIME_LAG_PERCENTAGE_LIMIT = 0.02;
 const TIME_LAG_MIN_LIMIT = 10000; // for a small timerange to avoid infinite data refresh timelag minimum is TIME_LAG_ABSOLUTE ms
@@ -19,15 +39,6 @@ const TIME_LAG_MIN_LIMIT = 10000; // for a small timerange to avoid infinite dat
  * checks if TIME_LAG_PERCENTAGE_LIMIT passed to renew searchSessionId
  * and request new data.
  */
-export const timeRangeMiddleware = (data: DataPublicPluginStart) => (store: MiddlewareAPI) => {
-  return (next: Dispatch) => (action: PayloadAction<Partial<LensAppState>>) => {
-    if (!action.payload?.searchSessionId) {
-      updateTimeRange(data, store.dispatch);
-    }
-    next(action);
-  };
-};
-
 function updateTimeRange(data: DataPublicPluginStart, dispatch: LensDispatch) {
   const timefilter = data.query.timefilter.timefilter;
   const unresolvedTimeRange = timefilter.getTime();

--- a/x-pack/plugins/lens/public/state_management/context_middleware/index.ts
+++ b/x-pack/plugins/lens/public/state_management/context_middleware/index.ts
@@ -8,10 +8,9 @@
 import { Dispatch, MiddlewareAPI, PayloadAction } from '@reduxjs/toolkit';
 import moment from 'moment';
 import { DataPublicPluginStart } from '../../../../../../src/plugins/data/public';
-import { setState, LensDispatch } from '..';
+import { setState, LensDispatch, LensStoreDeps, navigateAway } from '..';
 import { LensAppState } from '../types';
 import { getResolvedDateRange, containsDynamicMath } from '../../utils';
-import { LensStoreDeps, navigateAway } from '..';
 import { subscribeToExternalContext } from './subscribe_to_external_context';
 
 export const contextMiddleware = (storeDeps: LensStoreDeps) => (store: MiddlewareAPI) => {

--- a/x-pack/plugins/lens/public/state_management/context_middleware/index.ts
+++ b/x-pack/plugins/lens/public/state_management/context_middleware/index.ts
@@ -11,8 +11,7 @@ import { DataPublicPluginStart } from '../../../../../../src/plugins/data/public
 import { setState, LensDispatch } from '..';
 import { LensAppState } from '../types';
 import { getResolvedDateRange, containsDynamicMath } from '../../utils';
-import { LensStoreDeps } from '..';
-import { navigateAway } from '..';
+import { LensStoreDeps, navigateAway } from '..';
 import { subscribeToExternalContext } from './subscribe_to_external_context';
 
 export const contextMiddleware = (storeDeps: LensStoreDeps) => (store: MiddlewareAPI) => {

--- a/x-pack/plugins/lens/public/state_management/context_middleware/subscribe_to_external_context.ts
+++ b/x-pack/plugins/lens/public/state_management/context_middleware/subscribe_to_external_context.ts
@@ -15,6 +15,9 @@ import {
 import { setState, LensGetState, LensDispatch } from '..';
 import { getResolvedDateRange } from '../../utils';
 
+/**
+ * subscribes to external changes for filters, searchSessionId, timerange and autorefresh
+ */
 export function subscribeToExternalContext(
   data: DataPublicPluginStart,
   getState: LensGetState,

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -9,10 +9,10 @@ import { configureStore, getDefaultMiddleware, PreloadedState } from '@reduxjs/t
 import { createLogger } from 'redux-logger';
 import { useDispatch, useSelector, TypedUseSelectorHook } from 'react-redux';
 import { makeLensReducer, lensActions } from './lens_slice';
-import { timeRangeMiddleware } from './time_range_middleware';
-import { optimizingMiddleware } from './optimizing_middleware';
 import { LensState, LensStoreDeps } from './types';
 import { initMiddleware } from './init_middleware';
+import { optimizingMiddleware } from './optimizing_middleware';
+import { contextMiddleware } from './context_middleware';
 export * from './types';
 export * from './selectors';
 
@@ -49,7 +49,7 @@ export const makeConfigureStore = (
     }),
     initMiddleware(storeDeps),
     optimizingMiddleware(),
-    timeRangeMiddleware(storeDeps.lensServices.data),
+    contextMiddleware(storeDeps),
   ];
   if (process.env.NODE_ENV === 'development') {
     middleware.push(

--- a/x-pack/plugins/lens/public/state_management/init_middleware/index.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/index.ts
@@ -7,21 +7,13 @@
 
 import { Dispatch, MiddlewareAPI, PayloadAction } from '@reduxjs/toolkit';
 import { LensStoreDeps } from '..';
-import { loadInitial as loadInitialAction, navigateAway } from '..';
+import { loadInitial as loadInitialAction } from '..';
 import { loadInitial } from './load_initial';
-import { subscribeToExternalContext } from './subscribe_to_external_context';
 
 export const initMiddleware = (storeDeps: LensStoreDeps) => (store: MiddlewareAPI) => {
-  const unsubscribeFromExternalContext = subscribeToExternalContext(
-    storeDeps.lensServices.data,
-    store.getState,
-    store.dispatch
-  );
   return (next: Dispatch) => (action: PayloadAction) => {
     if (loadInitialAction.match(action)) {
       return loadInitial(store, storeDeps, action.payload);
-    } else if (navigateAway.match(action)) {
-      return unsubscribeFromExternalContext();
     }
     next(action);
   };

--- a/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
@@ -99,8 +99,6 @@ export function loadInitial(
   const { resolvedDateRange, searchSessionId, isLinkedToOriginatingApp, ...emptyState } =
     getPreloadedState(storeDeps);
   const { attributeService, notifications, data, dashboardFeatureFlag } = lensServices;
-  const currentSessionId = data.search.session.getSessionId();
-
   const { lens } = store.getState();
   if (
     !initialInput ||
@@ -115,7 +113,7 @@ export function loadInitial(
           initEmpty({
             newState: {
               ...emptyState,
-              searchSessionId: currentSessionId || data.search.session.start(),
+              searchSessionId: data.search.session.getSessionId() || data.search.session.start(),
               datasourceStates: Object.entries(result).reduce(
                 (state, [datasourceId, datasourceState]) => ({
                   ...state,
@@ -178,6 +176,7 @@ export function loadInitial(
             }
           )
             .then((result) => {
+              const currentSessionId = data.search.session.getSessionId();
               store.dispatch(
                 setState({
                   isSaveable: true,


### PR DESCRIPTION
## Summary

Time update happens on start of the application and we subscribe to time updates (that updates the sessionId) before loading initial. That causes unnecessary update of searchSessionId at start.
This PR subscribes to time updates after the app is already initialised so the update doesn't happen. To check you could add `console.log(this.getSessionId())` in the start() method in file `src/plugins/data/public/search/session/session_service.ts`