### PR TITLE
fix `<CodeEditor/>` font glitches

### DIFF
--- a/src/plugins/kibana_react/public/code_editor/code_editor.tsx
+++ b/src/plugins/kibana_react/public/code_editor/code_editor.tsx
@@ -15,6 +15,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import classNames from 'classnames';
 import './register_languages';
+import './remeasure_fonts';
 
 import {
   DARK_THEME,

--- a/src/plugins/kibana_react/public/code_editor/remeasure_fonts.ts
+++ b/src/plugins/kibana_react/public/code_editor/remeasure_fonts.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { monaco } from '@kbn/monaco';
+
+/**
+ * When using custom fonts with monaco need to call `monaco.editor.remeasureFonts()` when custom fonts finished loading
+ * Otherwise initial measurements on fallback font are used which causes visual glitches in the editor
+ */
+if ('fonts' in window.document && 'ready' in window.document.fonts) {
+  window.document.fonts.ready
+    .then(() => {
+      monaco.editor.remeasureFonts();
+    })
+    .catch((e) => {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to remeasureFonts in <CodeEditor/>');
+      // eslint-disable-next-line no-console
+      console.warn(e);
+    });
+}


### PR DESCRIPTION
## Summary

Fix `<CodeEditor/>` font related glitches: 

Example:

Before when selecting text: 

https://user-images.githubusercontent.com/7784120/146366355-164385fc-3e58-4626-8940-e71b62fd018a.mov

After: 

https://user-images.githubusercontent.com/7784120/146366367-8a9a9a7c-9faa-4ff9-9962-73498185a9d6.mov


The problem is that we are using custom font (`Roboto Mont`) and we need to ask Monaco to remeasure font for its layout engine when it is finished loaded 

cc @DziyanaDzeraviankina @flash1293 @pgayvallet @alexwizp as this came up in https://github.com/elastic/kibana/pull/119605


## Release Notes

Fix font glitches in code editor



