### PR TITLE
[Security Solution] [Endpoint] Add by policy to event filters generator

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/event_filter_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/event_filter_generator.ts
@@ -10,6 +10,7 @@ import { ENDPOINT_EVENT_FILTERS_LIST_ID } from '@kbn/securitysolution-list-const
 import { BaseDataGenerator } from './base_data_generator';
 import { getCreateExceptionListItemSchemaMock } from '../../../../lists/common/schemas/request/create_exception_list_item_schema.mock';
 
+const EFFECT_SCOPE_TYPES = ['policy:', 'policy:all'];
 export class EventFilterGenerator extends BaseDataGenerator<CreateExceptionListItemSchema> {
   generate(): CreateExceptionListItemSchema {
     const overrides: Partial<CreateExceptionListItemSchema> = {
@@ -17,7 +18,7 @@ export class EventFilterGenerator extends BaseDataGenerator<CreateExceptionListI
       list_id: ENDPOINT_EVENT_FILTERS_LIST_ID,
       item_id: `generator_endpoint_event_filter_${this.randomUUID()}`,
       os_types: [this.randomOSFamily()] as CreateExceptionListItemSchema['os_types'],
-      tags: ['policy:all'],
+      tags: [this.randomChoice(EFFECT_SCOPE_TYPES)],
       namespace_type: 'agnostic',
       meta: undefined,
     };

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/random_policy_id_generator.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/random_policy_id_generator.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolingLog } from '@kbn/dev-utils';
+import { KbnClient } from '@kbn/test';
+import { AxiosResponse } from 'axios';
+import { indexFleetEndpointPolicy } from '../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
+import {
+  PACKAGE_POLICY_API_ROUTES,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+} from '../../../../fleet/common/constants';
+import { setupFleetForEndpoint } from '../../../common/endpoint/data_loaders/setup_fleet_for_endpoint';
+import { GetPolicyListResponse } from '../../../public/management/pages/policy/types';
+
+const fetchEndpointPolicies = (
+  kbnClient: KbnClient
+): Promise<AxiosResponse<GetPolicyListResponse>> => {
+  return kbnClient.request<GetPolicyListResponse>({
+    method: 'GET',
+    path: PACKAGE_POLICY_API_ROUTES.LIST_PATTERN,
+    query: {
+      perPage: 100,
+      kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`,
+    },
+  });
+};
+
+// Setup a list of real endpoint policies and return a method to randomly select one
+export const randomPolicyIdGenerator: (
+  kbn: KbnClient,
+  log: ToolingLog
+) => Promise<() => string> = async (kbn, log) => {
+  log.info('Setting up fleet');
+  const fleetResponse = await setupFleetForEndpoint(kbn);
+
+  log.info('Generarting test policies...');
+  const randomN = (max: number): number => Math.floor(Math.random() * max);
+  const policyIds: string[] =
+    (await fetchEndpointPolicies(kbn)).data.items.map((policy) => policy.id) || [];
+
+  // If the number of existing policies is less than 5, then create some more policies
+  if (policyIds.length < 5) {
+    for (let i = 0, t = 5 - policyIds.length; i < t; i++) {
+      policyIds.push(
+        (
+          await indexFleetEndpointPolicy(
+            kbn,
+            `Policy for exceptions assignment ${i + 1}`,
+            fleetResponse.endpointPackage.version
+          )
+        ).integrationPolicies[0].id
+      );
+    }
+  }
+
+  return () => policyIds[randomN(policyIds.length)];
+};

--- a/x-pack/plugins/security_solution/scripts/endpoint/event_filters/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/event_filters/index.ts
@@ -18,6 +18,7 @@ import {
   EXCEPTION_LIST_URL,
 } from '@kbn/securitysolution-list-constants';
 import { EventFilterGenerator } from '../../../common/endpoint/data_generators/event_filter_generator';
+import { randomPolicyIdGenerator } from '../common/random_policy_id_generator';
 
 export const cli = () => {
   run(
@@ -70,16 +71,26 @@ const createEventFilters: RunFn = async ({ flags, log }) => {
 
   await ensureCreateEndpointEventFiltersList(kbn);
 
+  const randomPolicyId = await randomPolicyIdGenerator(kbn, log);
+
   await pMap(
     Array.from({ length: flags.count as unknown as number }),
-    () =>
-      kbn
+    () => {
+      const body = eventGenerator.generate();
+      if (body.tags?.length && body.tags[0] !== 'policy:all') {
+        const nmExceptions = Math.floor(Math.random() * 3) || 1;
+        body.tags = Array.from({ length: nmExceptions }, () => {
+          return `policy:${randomPolicyId()}`;
+        });
+      }
+      return kbn
         .request({
           method: 'POST',
           path: EXCEPTION_LIST_ITEM_URL,
-          body: eventGenerator.generate(),
+          body,
         })
-        .catch((e) => handleThrowAxiosHttpError(e)),
+        .catch((e) => handleThrowAxiosHttpError(e));
+    },
     { concurrency: 10 }
   );
 };

--- a/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
@@ -16,13 +16,11 @@ import {
 } from '@kbn/securitysolution-list-constants';
 import { KbnClient } from '@kbn/test';
 import { AxiosError, AxiosResponse } from 'axios';
-import { indexFleetEndpointPolicy } from '../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
 import {
   PACKAGE_POLICY_API_ROUTES,
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
 } from '../../../../fleet/common/constants';
 import { HostIsolationExceptionGenerator } from '../../../common/endpoint/data_generators/host_isolation_exception_generator';
-import { setupFleetForEndpoint } from '../../../common/endpoint/data_loaders/setup_fleet_for_endpoint';
 import { GetPolicyListResponse } from '../../../public/management/pages/policy/types';
 import { randomPolicyIdGenerator } from '../common/random_policy_id_generator';
 

--- a/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
@@ -127,16 +127,3 @@ const ensureCreateEndpointHostIsolationExceptionList = async (kbn: KbnClient) =>
       }
     });
 };
-
-const fetchEndpointPolicies = (
-  kbnClient: KbnClient
-): Promise<AxiosResponse<GetPolicyListResponse>> => {
-  return kbnClient.request<GetPolicyListResponse>({
-    method: 'GET',
-    path: PACKAGE_POLICY_API_ROUTES.LIST_PATTERN,
-    query: {
-      perPage: 100,
-      kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`,
-    },
-  });
-};

--- a/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
@@ -15,13 +15,8 @@ import {
   EXCEPTION_LIST_URL,
 } from '@kbn/securitysolution-list-constants';
 import { KbnClient } from '@kbn/test';
-import { AxiosError, AxiosResponse } from 'axios';
-import {
-  PACKAGE_POLICY_API_ROUTES,
-  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
-} from '../../../../fleet/common/constants';
+import { AxiosError } from 'axios';
 import { HostIsolationExceptionGenerator } from '../../../common/endpoint/data_generators/host_isolation_exception_generator';
-import { GetPolicyListResponse } from '../../../public/management/pages/policy/types';
 import { randomPolicyIdGenerator } from '../common/random_policy_id_generator';
 
 export const cli = () => {

--- a/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
@@ -24,6 +24,7 @@ import {
 import { HostIsolationExceptionGenerator } from '../../../common/endpoint/data_generators/host_isolation_exception_generator';
 import { setupFleetForEndpoint } from '../../../common/endpoint/data_loaders/setup_fleet_for_endpoint';
 import { GetPolicyListResponse } from '../../../public/management/pages/policy/types';
+import { randomPolicyIdGenerator } from '../common/random_policy_id_generator';
 
 export const cli = () => {
   run(
@@ -74,36 +75,10 @@ const createHostIsolationException: RunFn = async ({ flags, log }) => {
   const exceptionGenerator = new HostIsolationExceptionGenerator();
   const kbn = new KbnClient({ log, url: flags.kibana as string });
 
-  log.info('Setting up fleet');
-  const fleetResponse = await setupFleetForEndpoint(kbn);
-
   log.info('Creating Host isolation exceptions list');
   await ensureCreateEndpointHostIsolationExceptionList(kbn);
 
-  // Setup a list of real endpoint policies and return a method to randomly select one
-  const randomPolicyId: () => string = await (async () => {
-    log.info('Generarting test policies...');
-    const randomN = (max: number): number => Math.floor(Math.random() * max);
-    const policyIds: string[] =
-      (await fetchEndpointPolicies(kbn)).data.items.map((policy) => policy.id) || [];
-
-    // If the number of existing policies is less than 5, then create some more policies
-    if (policyIds.length < 5) {
-      for (let i = 0, t = 5 - policyIds.length; i < t; i++) {
-        policyIds.push(
-          (
-            await indexFleetEndpointPolicy(
-              kbn,
-              `Policy for Host Isolation Exceptions assignment ${i + 1}`,
-              fleetResponse.endpointPackage.version
-            )
-          ).integrationPolicies[0].id
-        );
-      }
-    }
-
-    return () => policyIds[randomN(policyIds.length)];
-  })();
+  const randomPolicyId = await randomPolicyIdGenerator(kbn, log);
 
   log.info('Generating exceptions....');
   await Promise.all(

--- a/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/index.ts
@@ -10,7 +10,6 @@ import { ToolingLog } from '@kbn/dev-utils';
 import { KbnClient } from '@kbn/test';
 import pMap from 'p-map';
 import { basename } from 'path';
-import { AxiosResponse } from 'axios';
 import {
   ENDPOINT_TRUSTED_APPS_LIST_DESCRIPTION,
   ENDPOINT_TRUSTED_APPS_LIST_ID,
@@ -21,13 +20,7 @@ import {
 import { CreateExceptionListSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { TrustedApp } from '../../../common/endpoint/types';
 import { TrustedAppGenerator } from '../../../common/endpoint/data_generators/trusted_app_generator';
-import { indexFleetEndpointPolicy } from '../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
-import { setupFleetForEndpoint } from '../../../common/endpoint/data_loaders/setup_fleet_for_endpoint';
-import { GetPolicyListResponse } from '../../../public/management/pages/policy/types';
-import {
-  PACKAGE_POLICY_API_ROUTES,
-  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
-} from '../../../../fleet/common';
+
 import { newTrustedAppToCreateExceptionListItem } from '../../../public/management/pages/trusted_apps/service/mappers';
 import { randomPolicyIdGenerator } from '../common/random_policy_id_generator';
 
@@ -140,19 +133,6 @@ const createRunLogger = () => {
           }
         }
       },
-    },
-  });
-};
-
-const fetchEndpointPolicies = (
-  kbnClient: KbnClient
-): Promise<AxiosResponse<GetPolicyListResponse>> => {
-  return kbnClient.request<GetPolicyListResponse>({
-    method: 'GET',
-    path: PACKAGE_POLICY_API_ROUTES.LIST_PATTERN,
-    query: {
-      perPage: 100,
-      kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`,
     },
   });
 };


### PR DESCRIPTION
## Summary

Includes by policy feature to the Event Filters data generator. Also unified code to generate policy id's

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
