### PR TITLE
[Fleet] Omit elasticsearch field for policy update API (partial backport of #119131)

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -348,7 +348,8 @@ export const EditPackagePolicyForm = memo<{
   const [formState, setFormState] = useState<PackagePolicyFormState>('INVALID');
   const savePackagePolicy = async () => {
     setFormState('LOADING');
-    const result = await sendUpdatePackagePolicy(packagePolicyId, packagePolicy);
+    const { elasticsearch, ...restPackagePolicy } = packagePolicy; // ignore 'elasticsearch' property since it fails route validation
+    const result = await sendUpdatePackagePolicy(packagePolicyId, restPackagePolicy);
     setFormState('SUBMITTED');
     return result;
   };


### PR DESCRIPTION
## Summary

Backport of the fleet fix from #119131.

Contributes to fixing https://github.com/elastic/kibana/issues/121238#issuecomment-995731268

Although the `elasticsearch` field is returned in the GET response, we do not allow it to be set through the policy update API, so it must be omitted first.

**Test steps**

- Add version 7.16.0 of the APM package to an agent policy
- From the agent policy, select "Edit integration"
- Edit the integration and save the edit
- (there should be no error)
