### PR TITLE
[7.17] Use kibana_system user for writing to Fleet system indices in Endpoint isolation (#120597)

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.test.ts
@@ -214,9 +214,10 @@ describe('Host Isolation', () => {
             Promise.resolve({ body: legacyMetadataSearchResponse(searchResponse) })
           );
         if (indexExists) {
-          ctx.core.elasticsearch.client.asInternalUser.index = mockIndexResponse;
+          ctx.core.elasticsearch.client.asCurrentUser.index = mockIndexResponse;
         }
-        ctx.core.elasticsearch.client.asCurrentUser.index = mockIndexResponse;
+
+        ctx.core.elasticsearch.client.asInternalUser.index = mockIndexResponse;
         ctx.core.elasticsearch.client.asCurrentUser.search = mockSearchResponse;
         const withLicense = license ? license : Platinum;
         licenseEmitter.next(withLicense);
@@ -268,7 +269,7 @@ describe('Host Isolation', () => {
         searchResponse: metadataResponse,
       });
       const actionDoc: EndpointAction = (
-        ctx.core.elasticsearch.client.asCurrentUser.index as jest.Mock
+        ctx.core.elasticsearch.client.asInternalUser.index as jest.Mock
       ).mock.calls[0][0].body;
       expect(actionDoc.agents).toContain(AgentID);
     });
@@ -279,7 +280,7 @@ describe('Host Isolation', () => {
         mockUser: testU,
       });
       const actionDoc: EndpointAction = (
-        ctx.core.elasticsearch.client.asCurrentUser.index as jest.Mock
+        ctx.core.elasticsearch.client.asInternalUser.index as jest.Mock
       ).mock.calls[0][0].body;
       expect(actionDoc.user_id).toEqual(testU.username);
     });
@@ -289,7 +290,7 @@ describe('Host Isolation', () => {
         body: { endpoint_ids: ['XYZ'], comment: CommentText },
       });
       const actionDoc: EndpointAction = (
-        ctx.core.elasticsearch.client.asCurrentUser.index as jest.Mock
+        ctx.core.elasticsearch.client.asInternalUser.index as jest.Mock
       ).mock.calls[0][0].body;
       expect(actionDoc.data.comment).toEqual(CommentText);
     });
@@ -298,7 +299,7 @@ describe('Host Isolation', () => {
         body: { endpoint_ids: ['XYZ'], comment: 'XYZ' },
       });
       const actionDoc: EndpointAction = (
-        ctx.core.elasticsearch.client.asCurrentUser.index as jest.Mock
+        ctx.core.elasticsearch.client.asInternalUser.index as jest.Mock
       ).mock.calls[0][0].body;
       const actionID = actionDoc.action_id;
       expect(mockResponse.ok).toBeCalled();
@@ -311,7 +312,7 @@ describe('Host Isolation', () => {
         body: { endpoint_ids: ['XYZ'] },
       });
       const actionDoc: EndpointAction = (
-        ctx.core.elasticsearch.client.asCurrentUser.index as jest.Mock
+        ctx.core.elasticsearch.client.asInternalUser.index as jest.Mock
       ).mock.calls[0][0].body;
       expect(actionDoc.timeout).toEqual(300);
     });
@@ -324,7 +325,7 @@ describe('Host Isolation', () => {
         searchResponse: doc,
       });
       const actionDoc: EndpointAction = (
-        ctx.core.elasticsearch.client.asCurrentUser.index as jest.Mock
+        ctx.core.elasticsearch.client.asInternalUser.index as jest.Mock
       ).mock.calls[0][0].body;
       expect(actionDoc.agents).toContain(AgentID);
     });
@@ -334,7 +335,7 @@ describe('Host Isolation', () => {
         body: { endpoint_ids: ['XYZ'] },
       });
       const actionDoc: EndpointAction = (
-        ctx.core.elasticsearch.client.asCurrentUser.index as jest.Mock
+        ctx.core.elasticsearch.client.asInternalUser.index as jest.Mock
       ).mock.calls[0][0].body;
       expect(actionDoc.data.command).toEqual('isolate');
     });
@@ -343,7 +344,7 @@ describe('Host Isolation', () => {
         body: { endpoint_ids: ['XYZ'] },
       });
       const actionDoc: EndpointAction = (
-        ctx.core.elasticsearch.client.asCurrentUser.index as jest.Mock
+        ctx.core.elasticsearch.client.asInternalUser.index as jest.Mock
       ).mock.calls[0][0].body;
       expect(actionDoc.data.command).toEqual('unisolate');
     });

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.ts
@@ -209,13 +209,9 @@ export const isolationRequestHandler = function (
     }
 
     try {
-      let esClient = context.core.elasticsearch.client.asCurrentUser;
-      if (doesLogsEndpointActionsDsExist) {
-        // create action request record as system user with user in .fleet-actions
-        esClient = context.core.elasticsearch.client.asInternalUser;
-      }
-      // write as the current user if the new indices do not exist
-      // <v7.16 requires the current user to be super user
+      const esClient = context.core.elasticsearch.client.asInternalUser;
+      // write as the internal user if the new indices do not exist
+      // 8.0+ requires internal user to write to system indices
       fleetActionIndexResult = await esClient.index<EndpointAction>({
         index: AGENT_ACTIONS_INDEX,
         body: {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Use kibana_system user for writing to Fleet system indices in Endpoint isolation (#120597)