### PR TITLE
chore(NA): splits types from code on @kbn/optimizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -575,6 +575,7 @@
     "@types/kbn__i18n": "link:bazel-bin/packages/kbn-i18n/npm_module_types",
     "@types/kbn__i18n-react": "link:bazel-bin/packages/kbn-i18n-react/npm_module_types",
     "@types/kbn__mapbox-gl": "link:bazel-bin/packages/kbn-mapbox-gl/npm_module_types",
+    "@types/kbn__optimizer": "link:bazel-bin/packages/kbn-optimizer/npm_module_types",
     "@types/license-checker": "15.0.0",
     "@types/listr": "^0.14.0",
     "@types/loader-utils": "^1.1.3",

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -94,6 +94,7 @@ filegroup(
       "//packages/kbn-i18n:build_types",
       "//packages/kbn-i18n-react:build_types",
       "//packages/kbn-mapbox-gl:build_types",
+      "//packages/kbn-optimizer:build_types",
   ],
 )
 

--- a/packages/kbn-cli-dev-mode/BUILD.bazel
+++ b/packages/kbn-cli-dev-mode/BUILD.bazel
@@ -52,7 +52,7 @@ TYPES_DEPS = [
   "//packages/kbn-config-schema:npm_module_types",
   "//packages/kbn-dev-utils:npm_module_types",
   "//packages/kbn-logging",
-  "//packages/kbn-optimizer",
+  "//packages/kbn-optimizer:npm_module_types",
   "//packages/kbn-server-http-tools",
   "//packages/kbn-std",
   "//packages/kbn-utils",

--- a/packages/kbn-optimizer/BUILD.bazel
+++ b/packages/kbn-optimizer/BUILD.bazel
@@ -1,9 +1,10 @@
-load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
-load("//src/dev/bazel:index.bzl", "jsts_transpiler")
+load("@npm//@bazel/typescript:index.bzl", "ts_config")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types", "ts_project")
 
 PKG_BASE_NAME = "kbn-optimizer"
 PKG_REQUIRE_NAME = "@kbn/optimizer"
+TYPES_PKG_REQUIRE_NAME = "@types/kbn__optimizer"
 
 SOURCE_FILES = glob(
   [
@@ -129,7 +130,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
+  deps = RUNTIME_DEPS + [":target_node"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )
@@ -145,6 +146,23 @@ filegroup(
   name = "build",
   srcs = [
     ":npm_module",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+pkg_npm_types(
+  name = "npm_module_types",
+  srcs = SRCS,
+  deps = [":tsc_types"],
+  package_name = TYPES_PKG_REQUIRE_NAME,
+  tsconfig = ":tsconfig",
+  visibility = ["//visibility:public"],
+)
+
+filegroup(
+  name = "build_types",
+  srcs = [
+    ":npm_module_types",
   ],
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-optimizer/package.json
+++ b/packages/kbn-optimizer/package.json
@@ -3,6 +3,5 @@
   "version": "1.0.0",
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target_node/index.js",
-  "types": "./target_types/index.d.ts"
+  "main": "./target_node/index.js"
 }

--- a/packages/kbn-plugin-helpers/BUILD.bazel
+++ b/packages/kbn-plugin-helpers/BUILD.bazel
@@ -43,7 +43,7 @@ RUNTIME_DEPS = [
 
 TYPES_DEPS = [
   "//packages/kbn-dev-utils:npm_module_types",
-  "//packages/kbn-optimizer",
+  "//packages/kbn-optimizer:npm_module_types",
   "//packages/kbn-utils",
   "@npm//del",
   "@npm//execa",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5869,6 +5869,10 @@
   version "0.0.0"
   uid ""
 
+"@types/kbn__optimizer@link:bazel-bin/packages/kbn-optimizer/npm_module_types":
+  version "0.0.0"
+  uid ""
+
 "@types/keyv@*":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"


### PR DESCRIPTION

This PR is a step forward on #104519

It splits the the types build from the code transpilation.