### PR TITLE
[7.17] [Logging]metrics ops logs include event loop delay histogram data (#120451)

### DIFF
--- a/src/core/server/metrics/metrics_service.test.ts
+++ b/src/core/server/metrics/metrics_service.test.ts
@@ -203,6 +203,7 @@ describe('MetricsService', () => {
             },
             "process": Object {
               "eventLoopDelay": undefined,
+              "eventLoopDelayHistogram": undefined,
               "memory": Object {
                 "heap": Object {
                   "usedInBytes": undefined,


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [Logging]metrics ops logs include event loop delay histogram data (#120451)