### PR TITLE
[7.17] Adds event loop delay percentiles to mean delay (#121052)

### DIFF
--- a/src/core/public/core_app/status/components/__snapshots__/metric_tiles.test.tsx.snap
+++ b/src/core/public/core_app/status/components/__snapshots__/metric_tiles.test.tsx.snap
@@ -4,17 +4,24 @@ exports[`MetricTile correct displays a byte metric 1`] = `
 <EuiCard
   data-test-subj="serverMetric-heap-total"
   description="Heap Total"
-  layout="horizontal"
+  textAlign="left"
   title="1.40 GB"
 />
 `;
 
 exports[`MetricTile correct displays a float metric 1`] = `
-<EuiCard
-  data-test-subj="serverMetric-load"
-  description="Load"
-  layout="horizontal"
-  title="4.05, 3.37, 3.12"
+<LoadMetricTile
+  metric={
+    Object {
+      "name": "Load",
+      "type": "float",
+      "value": Array [
+        4.0537109375,
+        3.36669921875,
+        3.1220703125,
+      ],
+    }
+  }
 />
 `;
 
@@ -22,7 +29,7 @@ exports[`MetricTile correct displays a time metric 1`] = `
 <EuiCard
   data-test-subj="serverMetric-response-time-max"
   description="Response Time Max"
-  layout="horizontal"
+  textAlign="left"
   title="1234.00 ms"
 />
 `;
@@ -31,7 +38,29 @@ exports[`MetricTile correct displays an untyped metric 1`] = `
 <EuiCard
   data-test-subj="serverMetric-a-metric"
   description="A metric"
-  layout="horizontal"
+  textAlign="left"
   title="1.80"
+/>
+`;
+
+exports[`MetricTile correctly displays a metric with metadata 1`] = `
+<DelayMetricTile
+  metric={
+    Object {
+      "meta": Object {
+        "description": "Percentiles",
+        "title": "",
+        "type": "time",
+        "value": Array [
+          1,
+          5,
+          10,
+        ],
+      },
+      "name": "Delay",
+      "type": "time",
+      "value": 1,
+    }
+  }
 />
 `;

--- a/src/core/public/core_app/status/components/metric_tiles.test.tsx
+++ b/src/core/public/core_app/status/components/metric_tiles.test.tsx
@@ -35,6 +35,18 @@ const timeMetric: Metric = {
   value: 1234,
 };
 
+const metricWithMeta: Metric = {
+  name: 'Delay',
+  type: 'time',
+  value: 1,
+  meta: {
+    description: 'Percentiles',
+    title: '',
+    value: [1, 5, 10],
+    type: 'time',
+  },
+};
+
 describe('MetricTile', () => {
   it('correct displays an untyped metric', () => {
     const component = shallow(<MetricTile metric={untypedMetric} />);
@@ -53,6 +65,11 @@ describe('MetricTile', () => {
 
   it('correct displays a time metric', () => {
     const component = shallow(<MetricTile metric={timeMetric} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('correctly displays a metric with metadata', () => {
+    const component = shallow(<MetricTile metric={metricWithMeta} />);
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/core/public/core_app/status/components/metric_tiles.tsx
+++ b/src/core/public/core_app/status/components/metric_tiles.tsx
@@ -7,22 +7,103 @@
  */
 
 import React, { FunctionComponent } from 'react';
-import { EuiFlexGrid, EuiFlexItem, EuiCard } from '@elastic/eui';
-import { formatNumber, Metric } from '../lib';
+import { EuiFlexGrid, EuiFlexItem, EuiCard, EuiStat } from '@elastic/eui';
+import { DataType, formatNumber, Metric } from '../lib';
+
+/*
+ * Displays metadata for a metric.
+ */
+const MetricCardFooter: FunctionComponent<{
+  title: string;
+  description: string;
+}> = ({ title, description }) => {
+  return (
+    <EuiStat
+      data-test-subj="serverMetricMeta"
+      title={title}
+      titleSize="xxs"
+      description={description}
+      reverse
+    />
+  );
+};
+
+const DelayMetricTile: FunctionComponent<{ metric: Metric }> = ({ metric }) => {
+  const { name, meta } = metric;
+  return (
+    <EuiCard
+      data-test-subj={`serverMetric-${formatMetricId(name)}`}
+      title={formatMetric(metric)}
+      textAlign="left"
+      description={`${name} avg`}
+      footer={
+        meta?.value && (
+          <MetricCardFooter
+            title={formatDelayFooterTitle(meta.value, meta.type)}
+            description={meta.description}
+          />
+        )
+      }
+    />
+  );
+};
+
+const LoadMetricTile: FunctionComponent<{ metric: Metric }> = ({ metric }) => {
+  const { name, meta } = metric;
+  return (
+    <EuiCard
+      data-test-subj={`serverMetric-${formatMetricId(name)}`}
+      title={formatMetric(metric)}
+      textAlign="left"
+      description={name}
+      footer={meta && <MetricCardFooter title={meta.title} description={meta.description} />}
+    />
+  );
+};
+
+const ResponseTimeMetric: FunctionComponent<{ metric: Metric }> = ({ metric }) => {
+  const { name, meta } = metric;
+  return (
+    <EuiCard
+      data-test-subj={`serverMetric-${formatMetricId(name)}`}
+      title={formatMetric(metric)}
+      textAlign="left"
+      description={name}
+      footer={
+        meta?.value &&
+        Array.isArray(meta.value) && (
+          <MetricCardFooter
+            title={formatNumber(meta.value[0], meta.type)}
+            description={meta.description}
+          />
+        )
+      }
+    />
+  );
+};
 
 /*
  * Displays a metric with the correct format.
  */
 export const MetricTile: FunctionComponent<{ metric: Metric }> = ({ metric }) => {
   const { name } = metric;
-  return (
-    <EuiCard
-      data-test-subj={`serverMetric-${formatMetricId(metric)}`}
-      layout="horizontal"
-      title={formatMetric(metric)}
-      description={name}
-    />
-  );
+  switch (name) {
+    case 'Delay':
+      return <DelayMetricTile metric={metric} />;
+    case 'Load':
+      return <LoadMetricTile metric={metric} />;
+    case 'Response time avg':
+      return <ResponseTimeMetric metric={metric} />;
+    default:
+      return (
+        <EuiCard
+          data-test-subj={`serverMetric-${formatMetricId(name)}`}
+          textAlign="left"
+          title={formatMetric(metric)}
+          description={name}
+        />
+      );
+  }
 };
 
 /*
@@ -38,11 +119,20 @@ export const MetricTiles: FunctionComponent<{ metrics: Metric[] }> = ({ metrics 
   </EuiFlexGrid>
 );
 
+// formatting helper functions
+
 const formatMetric = ({ value, type }: Metric) => {
   const metrics = Array.isArray(value) ? value : [value];
   return metrics.map((metric) => formatNumber(metric, type)).join(', ');
 };
 
-const formatMetricId = ({ name }: Metric) => {
+const formatMetricId = (name: Metric['name']) => {
   return name.toLowerCase().replace(/[ ]+/g, '-');
+};
+
+const formatDelayFooterTitle = (values: number[], type?: DataType) => {
+  return `
+  50: ${formatNumber(values[0], type)};
+  95: ${formatNumber(values[1], type)};
+  99: ${formatNumber(values[2], type)}`;
 };

--- a/src/core/public/core_app/status/lib/load_status.test.ts
+++ b/src/core/public/core_app/status/lib/load_status.test.ts
@@ -218,13 +218,23 @@ describe('response processing', () => {
     expect(names).toEqual([
       'Heap total',
       'Heap used',
-      'Load',
-      'Response time avg',
-      'Response time max',
       'Requests per second',
+      'Load',
+      'Delay',
+      'Response time avg',
     ]);
-
     const values = data.metrics.map((m) => m.value);
-    expect(values).toEqual([1000000, 100, [4.1, 2.1, 0.1], 4000, 8000, 400]);
+    expect(values).toEqual([1000000, 100, 400, [4.1, 2.1, 0.1], 1, 4000]);
+  });
+
+  test('adds meta details to Load, Delay and Response time', async () => {
+    const data = await loadStatus({ http, notifications });
+    const metricNames = data.metrics.filter((met) => met.meta);
+    expect(metricNames.map((item) => item.name)).toEqual(['Load', 'Delay', 'Response time avg']);
+    expect(metricNames.map((item) => item.meta!.description)).toEqual([
+      'Load interval',
+      'Percentiles',
+      'Response time max',
+    ]);
   });
 });

--- a/src/core/public/core_app/status/lib/load_status.ts
+++ b/src/core/public/core_app/status/lib/load_status.ts
@@ -13,10 +13,17 @@ import type { HttpSetup } from '../../../http';
 import type { NotificationsSetup } from '../../../notifications';
 import type { DataType } from '../lib';
 
+interface MetricMeta {
+  title: string;
+  description: string;
+  value?: number[];
+  type?: DataType;
+}
 export interface Metric {
   name: string;
   value: number | number[];
   type?: DataType;
+  meta?: MetricMeta;
 }
 
 export interface FormattedStatus {
@@ -58,11 +65,46 @@ function formatMetrics({ metrics }: StatusResponse): Metric[] {
       type: 'byte',
     },
     {
+      name: i18n.translate('core.statusPage.metricsTiles.columns.requestsPerSecHeader', {
+        defaultMessage: 'Requests per second',
+      }),
+      value: (metrics.requests.total * 1000) / metrics.collection_interval_in_millis,
+      type: 'float',
+    },
+    {
       name: i18n.translate('core.statusPage.metricsTiles.columns.loadHeader', {
         defaultMessage: 'Load',
       }),
       value: [metrics.os.load['1m'], metrics.os.load['5m'], metrics.os.load['15m']],
       type: 'float',
+      meta: {
+        description: i18n.translate('core.statusPage.metricsTiles.columns.load.metaHeader', {
+          defaultMessage: 'Load interval',
+        }),
+        title: Object.keys(metrics.os.load).join('; '),
+      },
+    },
+    {
+      name: i18n.translate('core.statusPage.metricsTiles.columns.processDelayHeader', {
+        defaultMessage: 'Delay',
+      }),
+      value: metrics.process.event_loop_delay,
+      type: 'time',
+      meta: {
+        description: i18n.translate(
+          'core.statusPage.metricsTiles.columns.processDelayDetailsHeader',
+          {
+            defaultMessage: 'Percentiles',
+          }
+        ),
+        title: '',
+        value: [
+          metrics.process.event_loop_delay_histogram?.percentiles['50'],
+          metrics.process.event_loop_delay_histogram?.percentiles['95'],
+          metrics.process.event_loop_delay_histogram?.percentiles['99'],
+        ],
+        type: 'time',
+      },
     },
     {
       name: i18n.translate('core.statusPage.metricsTiles.columns.resTimeAvgHeader', {
@@ -70,20 +112,14 @@ function formatMetrics({ metrics }: StatusResponse): Metric[] {
       }),
       value: metrics.response_times.avg_in_millis,
       type: 'time',
-    },
-    {
-      name: i18n.translate('core.statusPage.metricsTiles.columns.resTimeMaxHeader', {
-        defaultMessage: 'Response time max',
-      }),
-      value: metrics.response_times.max_in_millis,
-      type: 'time',
-    },
-    {
-      name: i18n.translate('core.statusPage.metricsTiles.columns.requestsPerSecHeader', {
-        defaultMessage: 'Requests per second',
-      }),
-      value: (metrics.requests.total * 1000) / metrics.collection_interval_in_millis,
-      type: 'float',
+      meta: {
+        description: i18n.translate('core.statusPage.metricsTiles.columns.resTimeMaxHeader', {
+          defaultMessage: 'Response time max',
+        }),
+        title: '',
+        value: [metrics.response_times.max_in_millis],
+        type: 'time',
+      },
     },
   ];
 }

--- a/test/functional/apps/status_page/index.ts
+++ b/test/functional/apps/status_page/index.ts
@@ -33,6 +33,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(metrics).to.have.length(6);
     });
 
+    it('should display the server metrics meta', async () => {
+      const metricsMetas = await testSubjects.findAll('serverMetricMeta');
+      expect(metricsMetas).to.have.length(3);
+    });
+
     it('should display the server status', async () => {
       const titleText = await testSubjects.getVisibleText('serverStatusTitle');
       expect(titleText).to.contain('Kibana status is');


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Adds event loop delay percentiles to mean delay (#121052)