### PR TITLE
[Uptime][Monitor Management] Add locations column to the monitor management table

### DIFF
--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
@@ -5,11 +5,13 @@
  * 2.0.
  */
 import React, { useContext, useMemo, useCallback } from 'react';
+import { i18n } from '@kbn/i18n';
 import { EuiBasicTable, EuiPanel, EuiSpacer, EuiLink } from '@elastic/eui';
 import { MonitorManagementList as MonitorManagementListState } from '../../../state/reducers/monitor_management';
 import { MonitorFields } from '../../../../common/runtime_types';
 import { UptimeSettingsContext } from '../../../contexts';
 import { Actions } from './actions';
+import { MonitorLocations } from './monitor_locations';
 import { MonitorTags } from './tags';
 import * as labels from '../../overview/monitor_list/translations';
 
@@ -57,7 +59,9 @@ export const MonitorManagementList = ({
   const columns = [
     {
       align: 'left' as const,
-      name: 'Monitor name',
+      name: i18n.translate('xpack.uptime.monitorManagement.monitorList.monitorName', {
+        defaultMessage: 'Monitor name',
+      }),
       render: ({
         attributes: { name },
         id,
@@ -77,33 +81,52 @@ export const MonitorManagementList = ({
     {
       align: 'left' as const,
       field: 'attributes',
-      name: 'Monitor type',
+      name: i18n.translate('xpack.uptime.monitorManagement.monitorList.monitorType', {
+        defaultMessage: 'Monitor type',
+      }),
       render: ({ type }: Partial<MonitorFields>) => type,
     },
     {
       align: 'left' as const,
       field: 'attributes',
-      name: 'Tags',
+      name: i18n.translate('xpack.uptime.monitorManagement.monitorList.tags', {
+        defaultMessage: 'Tags',
+      }),
       render: ({ tags }: Partial<MonitorFields>) => (tags ? <MonitorTags tags={tags} /> : null),
     },
     {
       align: 'left' as const,
       field: 'attributes',
-      name: 'Schedule',
+      name: i18n.translate('xpack.uptime.monitorManagement.monitorList.locations', {
+        defaultMessage: 'Locations',
+      }),
+      render: ({ locations }: Partial<MonitorFields>) =>
+        locations ? <MonitorLocations locations={locations} /> : null,
+    },
+    {
+      align: 'left' as const,
+      field: 'attributes',
+      name: i18n.translate('xpack.uptime.monitorManagement.monitorList.schedule', {
+        defaultMessage: 'Schedule',
+      }),
       render: ({ schedule }: Partial<MonitorFields>) =>
         `@every ${schedule?.number}${schedule?.unit}`,
     },
     {
       align: 'left' as const,
       field: 'attributes',
-      name: 'URL',
+      name: i18n.translate('xpack.uptime.monitorManagement.monitorList.URL', {
+        defaultMessage: 'URL',
+      }),
       render: (attributes: Partial<MonitorFields>) => attributes.urls || attributes.hosts,
       truncateText: true,
     },
     {
       align: 'left' as const,
       field: 'id',
-      name: 'Actions',
+      name: i18n.translate('xpack.uptime.monitorManagement.monitorList.actions', {
+        defaultMessage: 'Actions',
+      }),
       render: (id: string) => <Actions id={id} setRefresh={setRefresh} />,
     },
   ];
@@ -112,7 +135,9 @@ export const MonitorManagementList = ({
     <EuiPanel hasBorder>
       <EuiSpacer size="m" />
       <EuiBasicTable
-        aria-label={'Monitor management list'}
+        aria-label={i18n.translate('xpack.uptime.monitorManagement.monitorList.title', {
+          defaultMessage: 'Monitor management list',
+        })}
         error={error?.message}
         loading={loading}
         isExpandable={true}

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_locations.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_locations.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { EuiBadge, EuiBadgeGroup } from '@elastic/eui';
+import { ServiceLocations, ServiceLocation } from '../../../../common/runtime_types';
+import { EXPAND_LOCATIONS_LABEL } from '../../overview/monitor_list/columns/translations';
+
+interface Props {
+  locations: ServiceLocations;
+}
+
+const INITIAL_LIMIT = 3;
+
+export const MonitorLocations = ({ locations }: Props) => {
+  const [toDisplay, setToDisplay] = useState(INITIAL_LIMIT);
+
+  const locationsToDisplay = locations.slice(0, toDisplay);
+
+  return (
+    <EuiBadgeGroup>
+      {locationsToDisplay.map((location: ServiceLocation) => (
+        <EuiBadge
+          key={location.id}
+          color="hollow"
+          className="eui-textTruncate"
+          style={{ maxWidth: 120 }}
+        >
+          {location.label}
+        </EuiBadge>
+      ))}
+      {locations.length > toDisplay && (
+        <EuiBadge
+          color="hollow"
+          onClick={() => {
+            setToDisplay(locations.length);
+          }}
+          onClickAriaLabel={EXPAND_LOCATIONS_LABEL}
+        >
+          +{locations.length - INITIAL_LIMIT}
+        </EuiBadge>
+      )}
+    </EuiBadgeGroup>
+  );
+};

--- a/x-pack/plugins/uptime/public/components/overview/monitor_list/columns/translations.ts
+++ b/x-pack/plugins/uptime/public/components/overview/monitor_list/columns/translations.ts
@@ -18,3 +18,7 @@ export const DISABLE_STATUS_ALERT = i18n.translate('xpack.uptime.monitorList.dis
 export const EXPAND_TAGS_LABEL = i18n.translate('xpack.uptime.monitorList.tags.expand', {
   defaultMessage: 'Click to view remaining tags',
 });
+
+export const EXPAND_LOCATIONS_LABEL = i18n.translate('xpack.uptime.monitorList.locations.expand', {
+  defaultMessage: 'Click to view remaining locations',
+});


### PR DESCRIPTION
Closes #121006 

## Summary

Adds **Locations** column to the monitor managements monitors list table.
- Will show 3 locations at most initially and will trim others
- A button indicating number of trimmed locations will reveal all the locations in the column

Screenshots:
![121006-Add-Locations-To-Monitor-Management-table](https://user-images.githubusercontent.com/2748376/146446426-380ff5fd-8923-47a3-adf6-58ae53d2a8e6.png)

Videos:
https://user-images.githubusercontent.com/2748376/146446606-77853eab-0472-4681-9995-dd74671d82a7.mov


## How to test this PR locally

- Go through [this](https://gist.github.com/awahab07/8456a2b1854ed9c5dcd30fb4e733ae1c) and enable monitor management.
- Add or Edit a monitor and confirm the PR implements the said behavior.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~[] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
