### PR TITLE
Removing alerting's dependency on kibanaUtils

### DIFF
--- a/x-pack/plugins/alerting/kibana.json
+++ b/x-pack/plugins/alerting/kibana.json
@@ -14,7 +14,6 @@
     "encryptedSavedObjects",
     "eventLog",
     "features",
-    "kibanaUtils",
     "licensing",
     "taskManager"
   ],


### PR DESCRIPTION
Removing the alerting plugin's dependency on kibanaUtils because as far as I can tell, it's not used. CI will confirm my suspicion