### PR TITLE
[XY] Fixes the broken chart when an agg is placed in another axis and then is hidden

### DIFF
--- a/src/plugins/vis_types/xy/public/config/get_config.test.ts
+++ b/src/plugins/vis_types/xy/public/config/get_config.test.ts
@@ -41,4 +41,28 @@ describe('getConfig', () => {
     expect(config.yAxes[0].ticks?.formatter).toStrictEqual(config.aspects.y[1].formatter);
     expect(config.yAxes[1].ticks?.formatter).toStrictEqual(config.aspects.y[0].formatter);
   });
+
+  it('assigns the correct number of yAxes if the agg is hidden', () => {
+    // We have two axes but the one y dimension is hidden
+    const newVisParams = {
+      ...visParamsWithTwoYAxes,
+      dimensions: {
+        ...visParamsWithTwoYAxes.dimensions,
+        y: [
+          {
+            label: 'Average memory',
+            aggType: 'avg',
+            params: {},
+            accessor: 1,
+            format: {
+              id: 'number',
+              params: {},
+            },
+          },
+        ],
+      },
+    };
+    const config = getConfig(visData, newVisParams);
+    expect(config.yAxes.length).toBe(1);
+  });
 });

--- a/src/plugins/vis_types/xy/public/config/get_config.test.ts
+++ b/src/plugins/vis_types/xy/public/config/get_config.test.ts
@@ -38,8 +38,8 @@ describe('getConfig', () => {
   it('assigns the correct formatter per y axis', () => {
     const config = getConfig(visData, visParamsWithTwoYAxes);
     expect(config.yAxes.length).toBe(2);
-    expect(config.yAxes[0].ticks?.formatter).toStrictEqual(config.aspects.y[1].formatter);
-    expect(config.yAxes[1].ticks?.formatter).toStrictEqual(config.aspects.y[0].formatter);
+    expect(config.yAxes[0].ticks?.formatter).toStrictEqual(config.aspects.y[0].formatter);
+    expect(config.yAxes[1].ticks?.formatter).toStrictEqual(config.aspects.y[1].formatter);
   });
 
   it('assigns the correct number of yAxes if the agg is hidden', () => {

--- a/src/plugins/vis_types/xy/public/config/get_config.ts
+++ b/src/plugins/vis_types/xy/public/config/get_config.ts
@@ -48,15 +48,16 @@ export function getConfig(
   } = params;
   const aspects = getAspects(table.columns, params.dimensions);
   const tooltip = getTooltip(aspects, params);
-  const yAxes = params.valueAxes.map((a) => {
+
+  const yAxes: Array<AxisConfig<ScaleContinuousType>> = [];
+
+  params.valueAxes.map((a) => {
     // find the correct aspect for each value axis
     const aspectsIdx = params.seriesParams.findIndex((s) => s.valueAxis === a.id);
-    return getAxis<YScaleType>(
-      a,
-      params.grid,
-      aspects.y[aspectsIdx > -1 ? aspectsIdx : 0],
-      params.seriesParams
-    );
+    const aspect = aspects.y[aspectsIdx > -1 ? aspectsIdx : 0];
+    if (aspect) {
+      yAxes.push(getAxis<YScaleType>(a, params.grid, aspect, params.seriesParams));
+    }
   });
 
   const rotation = getRotation(params.categoryAxes[0]);

--- a/src/plugins/vis_types/xy/public/config/get_config.ts
+++ b/src/plugins/vis_types/xy/public/config/get_config.ts
@@ -51,12 +51,13 @@ export function getConfig(
 
   const yAxes: Array<AxisConfig<ScaleContinuousType>> = [];
 
-  params.valueAxes.map((a) => {
-    // find the correct aspect for each value axis
-    const aspectsIdx = params.seriesParams.findIndex((s) => s.valueAxis === a.id);
-    const aspect = aspects.y[aspectsIdx > -1 ? aspectsIdx : 0];
-    if (aspect) {
-      yAxes.push(getAxis<YScaleType>(a, params.grid, aspect, params.seriesParams));
+  params.dimensions.y.forEach((y) => {
+    const accessor = y.accessor;
+    const aspect = aspects.y.find(({ column }) => column === accessor);
+    const serie = params.seriesParams.find(({ data: { id } }) => id === aspect?.aggId);
+    const valueAxis = params.valueAxes.find(({ id }) => id === serie?.valueAxis);
+    if (aspect && valueAxis) {
+      yAxes.push(getAxis<YScaleType>(valueAxis, params.grid, aspect, params.seriesParams));
     }
   });
 


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/121268

There is a bug when you try to create a XY chart with two metrics on two y axes (one in the left and one in the right). If you hide one of the aggs, then the chart was failing with the error:
![image](https://user-images.githubusercontent.com/17003240/146515600-34bc96d3-a187-49ee-9411-1ff541a15050.png)

This PR fixes it:
![image](https://user-images.githubusercontent.com/17003240/146515651-5c469719-e71b-41c6-993f-0d7cc37e2e01.png)



### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios