### PR TITLE
[Fleet] Make response in stats endpoint consistent

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -866,15 +866,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "response": {
-                      "$ref": "#/components/schemas/package_usage_stats"
-                    }
-                  },
-                  "required": [
-                    "response"
-                  ]
+                  "$ref": "#/components/schemas/get_stats_response"
                 }
               }
             }
@@ -3504,6 +3496,22 @@
         },
         "required": [
           "agent_policy_count"
+        ]
+      },
+      "get_stats_response": {
+        "title": "Get stats response",
+        "type": "object",
+        "properties": {
+          "items": {
+            "$ref": "#/components/schemas/package_usage_stats"
+          },
+          "response": {
+            "deprecated": true,
+            "$ref": "#/components/schemas/package_usage_stats"
+          }
+        },
+        "required": [
+          "items"
         ]
       },
       "fleet_status_response": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -527,12 +527,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  response:
-                    $ref: '#/components/schemas/package_usage_stats'
-                required:
-                  - response
+                $ref: '#/components/schemas/get_stats_response'
       operationId: get-package-stats
       security:
         - basicAuth: []
@@ -2189,6 +2184,17 @@ components:
           type: integer
       required:
         - agent_policy_count
+    get_stats_response:
+      title: Get stats response
+      type: object
+      properties:
+        items:
+          $ref: '#/components/schemas/package_usage_stats'
+        response:
+          deprecated: true
+          $ref: '#/components/schemas/package_usage_stats'
+      required:
+        - items
     fleet_status_response:
       title: Fleet status response
       type: object

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/get_stats_response.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/get_stats_response.yaml
@@ -1,0 +1,10 @@
+title: Get stats response
+type: object
+properties:
+  items:
+    $ref: ./package_usage_stats.yaml
+  response:
+    deprecated: true
+    $ref: ./package_usage_stats.yaml
+required:
+  - items

--- a/x-pack/plugins/fleet/common/openapi/paths/epm@packages@{pkg_name}@stats.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/epm@packages@{pkg_name}@stats.yaml
@@ -7,12 +7,7 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              response:
-                $ref: ../components/schemas/package_usage_stats.yaml
-            required:
-              - response
+            $ref: ../components/schemas/get_stats_response.yaml
   operationId: get-package-stats
   security:
     - basicAuth: []

--- a/x-pack/plugins/fleet/common/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/epm.ts
@@ -94,7 +94,9 @@ export interface GetStatsRequest {
 }
 
 export interface GetStatsResponse {
-  response: PackageUsageStats;
+  items: PackageUsageStats;
+  // deprecated in 8.0
+  response?: PackageUsageStats;
 }
 
 export interface InstallPackageRequest {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/integration_agent_policy_count.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/integration_agent_policy_count.tsx
@@ -15,5 +15,5 @@ import { useGetPackageStats } from '../../../../../hooks';
 export const IntegrationAgentPolicyCount = memo<{ packageName: string }>(({ packageName }) => {
   const { data } = useGetPackageStats(packageName);
 
-  return <>{data?.response.agent_policy_count ?? 0}</>;
+  return <>{data?.items.agent_policy_count ?? 0}</>;
 });

--- a/x-pack/plugins/fleet/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/handlers.ts
@@ -239,8 +239,10 @@ export const getStatsHandler: FleetRequestHandler<
   try {
     const { pkgName } = request.params;
     const savedObjectsClient = context.fleet.epm.internalSoClient;
+    const stats = await getPackageUsageStats({ savedObjectsClient, pkgName })
     const body: GetStatsResponse = {
-      response: await getPackageUsageStats({ savedObjectsClient, pkgName }),
+      items: stats,
+      response: stats
     };
     return response.ok({ body });
   } catch (error) {


### PR DESCRIPTION
## Summary
Last small PR related to https://github.com/elastic/obs-dc-team/issues/655 to make fleet APIs responses consistent. 
In the `packages/stats` endpoint `response` is now replaced by `items` and marked as deprecated
This PR also updates the openApi specs.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
