### PR TITLE
[ML] Replace deprecated query imports in ml and transform plugins

### DIFF
--- a/x-pack/plugins/ml/public/application/app.tsx
+++ b/x-pack/plugins/ml/public/application/app.tsx
@@ -122,9 +122,8 @@ export const renderApp = (
   appMountParams: AppMountParameters
 ) => {
   setDependencyCache({
-    indexPatterns: deps.data.indexPatterns,
     timefilter: deps.data.query.timefilter,
-    fieldFormats: deps.data.fieldFormats,
+    fieldFormats: deps.fieldFormats,
     autocomplete: deps.data.autocomplete,
     config: coreStart.uiSettings!,
     chrome: coreStart.chrome!,

--- a/x-pack/plugins/ml/public/application/components/import_export_jobs/import_jobs_flyout/import_jobs_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/components/import_export_jobs/import_jobs_flyout/import_jobs_flyout.tsx
@@ -52,7 +52,7 @@ export const ImportJobsFlyout: FC<Props> = ({ isDisabled }) => {
   const {
     services: {
       data: {
-        indexPatterns: { getTitles: getIndexPatternTitles },
+        dataViews: { getTitles: getIndexPatternTitles },
       },
       notifications: { toasts },
       mlServices: { mlUsageCollection },

--- a/x-pack/plugins/ml/public/application/components/import_export_jobs/import_jobs_flyout/import_jobs_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/components/import_export_jobs/import_jobs_flyout/import_jobs_flyout.tsx
@@ -52,7 +52,7 @@ export const ImportJobsFlyout: FC<Props> = ({ isDisabled }) => {
   const {
     services: {
       data: {
-        dataViews: { getTitles: getIndexPatternTitles },
+        dataViews: { getTitles: getDataViewTitles },
       },
       notifications: { toasts },
       mlServices: { mlUsageCollection },
@@ -131,7 +131,7 @@ export const ImportJobsFlyout: FC<Props> = ({ isDisabled }) => {
       const validatedJobs = await jobImportService.validateJobs(
         loadedFile.jobs,
         loadedFile.jobType,
-        getIndexPatternTitles,
+        getDataViewTitles,
         getFilters
       );
 

--- a/x-pack/plugins/ml/public/application/components/import_export_jobs/import_jobs_flyout/jobs_import_service.ts
+++ b/x-pack/plugins/ml/public/application/components/import_export_jobs/import_jobs_flyout/jobs_import_service.ts
@@ -127,10 +127,10 @@ export class JobImportService {
   public async validateJobs(
     jobs: ImportedAdJob[] | DataFrameAnalyticsConfig[],
     type: JobType,
-    getIndexPatternTitles: (refresh?: boolean) => Promise<string[]>,
+    getDataViewTitles: (refresh?: boolean) => Promise<string[]>,
     getFilters: () => Promise<Filter[]>
   ) {
-    const existingIndexPatterns = new Set(await getIndexPatternTitles());
+    const existingDataViews = new Set(await getDataViewTitles());
     const existingFilters = new Set((await getFilters()).map((f) => f.filter_id));
     const tempJobs: Array<{ jobId: string; destIndex?: string }> = [];
     const skippedJobs: SkippedJobs[] = [];
@@ -154,7 +154,7 @@ export class JobImportService {
           }));
 
     commonJobs.forEach(({ jobId, indices, filters = [], destIndex }) => {
-      const missingIndices = indices.filter((i) => existingIndexPatterns.has(i) === false);
+      const missingIndices = indices.filter((i) => existingDataViews.has(i) === false);
       const missingFilters = filters.filter((i) => existingFilters.has(i) === false);
 
       if (missingIndices.length === 0 && missingFilters.length === 0) {

--- a/x-pack/plugins/ml/public/application/util/dependency_cache.ts
+++ b/x-pack/plugins/ml/public/application/util/dependency_cache.ts
@@ -22,6 +22,7 @@ import type {
 } from 'kibana/public';
 import type { DataPublicPluginStart } from 'src/plugins/data/public';
 import type { SharePluginStart } from 'src/plugins/share/public';
+import { FieldFormatsStart } from 'src/plugins/field_formats/public';
 import type { DataViewsContract } from '../../../../../../src/plugins/data_views/public';
 import type { SecurityPluginSetup } from '../../../../security/public';
 import type { MapsStartApi } from '../../../../maps/public';
@@ -30,14 +31,13 @@ import type { DataVisualizerPluginStart } from '../../../../data_visualizer/publ
 export interface DependencyCache {
   timefilter: DataPublicPluginSetup['query']['timefilter'] | null;
   config: IUiSettingsClient | null;
-  indexPatterns: DataViewsContract | null;
   chrome: ChromeStart | null;
   docLinks: DocLinksStart | null;
   toastNotifications: ToastsStart | null;
   overlays: OverlayStart | null;
   theme: ThemeServiceStart | null;
   recentlyAccessed: ChromeRecentlyAccessed | null;
-  fieldFormats: DataPublicPluginStart['fieldFormats'] | null;
+  fieldFormats: FieldFormatsStart | null;
   autocomplete: DataPublicPluginStart['autocomplete'] | null;
   basePath: IBasePath | null;
   savedObjectsClient: SavedObjectsClientContract | null;
@@ -54,7 +54,6 @@ export interface DependencyCache {
 const cache: DependencyCache = {
   timefilter: null,
   config: null,
-  indexPatterns: null,
   chrome: null,
   docLinks: null,
   toastNotifications: null,
@@ -79,7 +78,6 @@ export function setDependencyCache(deps: Partial<DependencyCache>) {
   cache.timefilter = deps.timefilter || null;
   cache.config = deps.config || null;
   cache.chrome = deps.chrome || null;
-  cache.indexPatterns = deps.indexPatterns || null;
   cache.docLinks = deps.docLinks || null;
   cache.toastNotifications = deps.toastNotifications || null;
   cache.overlays = deps.overlays || null;

--- a/x-pack/plugins/ml/public/application/util/dependency_cache.ts
+++ b/x-pack/plugins/ml/public/application/util/dependency_cache.ts
@@ -22,7 +22,7 @@ import type {
 } from 'kibana/public';
 import type { DataPublicPluginStart } from 'src/plugins/data/public';
 import type { SharePluginStart } from 'src/plugins/share/public';
-import { FieldFormatsStart } from 'src/plugins/field_formats/public';
+import type { FieldFormatsStart } from 'src/plugins/field_formats/public';
 import type { DataViewsContract } from '../../../../../../src/plugins/data_views/public';
 import type { SecurityPluginSetup } from '../../../../security/public';
 import type { MapsStartApi } from '../../../../maps/public';

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/anomaly_charts_embeddable.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/anomaly_charts_embeddable.tsx
@@ -63,14 +63,14 @@ export class AnomalyChartsEmbeddable extends Embeddable<
 
     try {
       const jobs = await anomalyExplorerService.getCombinedJobs(jobIds);
-      const indexPatternsService = this.services[1].data.indexPatterns;
+      const dataViewsService = this.services[1].data.dataViews;
 
       // First get list of unique indices from the selected jobs
       const indices = new Set(jobs.map((j) => j.datafeed_config.indices).flat());
       // Then find the data view assuming the data view title matches the index name
       const indexPatterns: Record<string, DataView> = {};
       for (const indexName of indices) {
-        const response = await indexPatternsService.find(`"${indexName}"`);
+        const response = await dataViewsService.find(`"${indexName}"`);
 
         const indexPattern = response.find(
           (obj) => obj.title.toLowerCase() === indexName.toLowerCase()

--- a/x-pack/plugins/ml/public/ui_actions/apply_entity_filters_action.tsx
+++ b/x-pack/plugins/ml/public/ui_actions/apply_entity_filters_action.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
+import { Filter } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { createAction } from '../../../../../src/plugins/ui_actions/public';
 import { MlCoreSetup } from '../plugin';
-import { Filter, FilterStateStore } from '../../../../../src/plugins/data/common';
+import { FilterStateStore } from '../../../../../src/plugins/data/common';
 import {
   ANOMALY_EXPLORER_CHARTS_EMBEDDABLE_TYPE,
   AnomalyChartsFieldSelectionContext,

--- a/x-pack/plugins/ml/public/ui_actions/apply_influencer_filters_action.tsx
+++ b/x-pack/plugins/ml/public/ui_actions/apply_influencer_filters_action.tsx
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
+import { Filter } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { createAction } from '../../../../../src/plugins/ui_actions/public';
 import { MlCoreSetup } from '../plugin';
 import { SWIMLANE_TYPE, VIEW_BY_JOB_LABEL } from '../application/explorer/explorer_constants';
-import { Filter, FilterStateStore } from '../../../../../src/plugins/data/common';
+import { FilterStateStore } from '../../../../../src/plugins/data/common';
 import { ANOMALY_SWIMLANE_EMBEDDABLE_TYPE, SwimLaneDrilldownContext } from '../embeddables';
 import { CONTROLLED_BY_SWIM_LANE_FILTER } from './constants';
 

--- a/x-pack/plugins/transform/public/app/hooks/use_search_items/common.ts
+++ b/x-pack/plugins/transform/public/app/hooks/use_search_items/common.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
+import { buildEsQuery } from '@kbn/es-query';
 import { SavedObjectsClientContract, SimpleSavedObject, IUiSettingsClient } from 'src/core/public';
 import {
   IndexPattern,
-  esQuery,
+  getEsQueryConfig,
   IndexPatternsContract,
   IndexPatternAttributes,
 } from '../../../../../../../src/plugins/data/public';
@@ -111,8 +112,8 @@ export function createSearchItems(
 
     const filters = fs.length ? fs : [];
 
-    const esQueryConfigs = esQuery.getEsQueryConfig(config);
-    combinedQuery = esQuery.buildEsQuery(indexPattern, [query], filters, esQueryConfigs);
+    const esQueryConfigs = getEsQueryConfig(config);
+    combinedQuery = buildEsQuery(indexPattern, [query], filters, esQueryConfigs);
   }
 
   if (!isIndexPattern(indexPattern)) {

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/hooks/use_search_bar.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/hooks/use_search_bar.ts
@@ -7,7 +7,8 @@
 
 import { useState } from 'react';
 
-import { esKuery, esQuery, Query } from '../../../../../../../../../../src/plugins/data/public';
+import { toElasticsearchQuery, fromKueryExpression, luceneStringToDsl } from '@kbn/es-query';
+import { Query } from '../../../../../../../../../../src/plugins/data/public';
 
 import { getPivotQuery } from '../../../../../common';
 
@@ -52,14 +53,11 @@ export const useSearchBar = (
       switch (query.language) {
         case QUERY_LANGUAGE_KUERY:
           setSearchQuery(
-            esKuery.toElasticsearchQuery(
-              esKuery.fromKueryExpression(query.query as string),
-              indexPattern
-            )
+            toElasticsearchQuery(fromKueryExpression(query.query as string), indexPattern)
           );
           return;
         case QUERY_LANGUAGE_LUCENE:
-          setSearchQuery(esQuery.luceneStringToDsl(query.query as string));
+          setSearchQuery(luceneStringToDsl(query.query as string));
           return;
       }
     } catch (e) {


### PR DESCRIPTION
## Summary

Removes usage of deprecated `Filter`, `esKuery` and `esQuery` imports from the `ml` and `transform` plugins and replaces them with the corresponding imports from `@kbn/es-query` and the `data` plugin instead.

Also replaces the deprecated `indexPatterns` and `fieldFormats` imports from `ml`.

Relates to #119356

Fixes #120221

