### PR TITLE
On Week: reusable ServiceInventory

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/index.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiEmptyPrompt } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useEffect } from 'react';
+import uuid from 'uuid';
+import { useKibana } from '../../../../../../../../src/plugins/kibana_react/public';
+import { CoreStart } from '../../../../../../../../src/core/public';
+import { useAnomalyDetectionJobsContext } from '../../../../context/anomaly_detection_jobs/use_anomaly_detection_jobs_context';
+import { useLocalStorage } from '../../../../hooks/useLocalStorage';
+import { FETCH_STATUS, useFetcher } from '../../../../hooks/use_fetcher';
+import { useTimeRange } from '../../../../hooks/use_time_range';
+import { createCallApmApi } from '../../../../services/rest/createCallApmApi';
+import { MLCallout, shouldDisplayMlCallout } from '../../../shared/ml_callout';
+import { getTimeRangeComparison } from '../../../shared/time_comparison/get_time_range_comparison';
+import { ServiceList } from './service_list';
+
+export interface ServiceInventoryProps {
+  comparisonEnabled?: boolean;
+  comparisonType?: 'week' | 'day' | 'period';
+  rangeFrom?: string;
+  rangeTo?: string;
+  environment?: string;
+  kuery?: string;
+}
+
+const initialData = {
+  requestId: '',
+  mainStatisticsData: {
+    items: [],
+    hasHistoricalData: true,
+    hasLegacyData: false,
+  },
+};
+
+function useServicesFetcherExternal({
+  comparisonEnabled,
+  comparisonType,
+  rangeFrom,
+  rangeTo,
+  environment,
+  kuery,
+}: ServiceInventoryProps) {
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
+  const { offset } = getTimeRangeComparison({
+    start,
+    end,
+    comparisonEnabled,
+    comparisonType,
+  });
+
+  const { data = initialData, status: mainStatisticsStatus } = useFetcher(
+    (callApmApi) => {
+      if (start && end) {
+        return callApmApi({
+          endpoint: 'GET /internal/apm/services',
+          params: {
+            query: {
+              environment,
+              kuery,
+              start,
+              end,
+            },
+          },
+        }).then((mainStatisticsData) => {
+          return {
+            requestId: uuid(),
+            mainStatisticsData,
+          };
+        });
+      }
+    },
+    [environment, kuery, start, end]
+  );
+
+  const { mainStatisticsData, requestId } = data;
+
+  const { data: comparisonData } = useFetcher(
+    (callApmApi) => {
+      if (start && end && mainStatisticsData.items.length) {
+        return callApmApi({
+          endpoint: 'GET /internal/apm/services/detailed_statistics',
+          params: {
+            query: {
+              environment,
+              kuery,
+              start,
+              end,
+              serviceNames: JSON.stringify(
+                mainStatisticsData.items
+                  .map(({ serviceName }) => serviceName)
+                  // Service name is sorted to guarantee the same order every time this API is called so the result can be cached.
+                  .sort()
+              ),
+              offset,
+            },
+          },
+        });
+      }
+    },
+    // only fetches detailed statistics when requestId is invalidated by main statistics api call or offset is changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [requestId, offset],
+    { preservePreviousData: false }
+  );
+
+  return {
+    mainStatisticsData,
+    mainStatisticsStatus,
+    comparisonData,
+  };
+}
+
+export function ServiceInventory({
+  comparisonEnabled,
+  comparisonType,
+  rangeFrom,
+  rangeTo,
+  environment,
+  kuery,
+}: ServiceInventoryProps) {
+  const { services } = useKibana();
+
+  const serviceParams = {
+    comparisonEnabled,
+    comparisonType,
+    rangeFrom,
+    rangeTo,
+    environment,
+    kuery,
+  };
+
+  useEffect(() => {
+    createCallApmApi(services as CoreStart);
+  }, [services]);
+
+  const { mainStatisticsData, mainStatisticsStatus, comparisonData } =
+    useServicesFetcherExternal({
+      comparisonEnabled,
+      comparisonType,
+      rangeFrom,
+      rangeTo,
+      environment,
+      kuery,
+    });
+
+  const { anomalyDetectionSetupState } = useAnomalyDetectionJobsContext();
+
+  const [userHasDismissedCallout, setUserHasDismissedCallout] = useLocalStorage(
+    `apm.userHasDismissedServiceInventoryMlCallout.${anomalyDetectionSetupState}`,
+    false
+  );
+
+  const displayMlCallout =
+    !userHasDismissedCallout &&
+    shouldDisplayMlCallout(anomalyDetectionSetupState);
+
+  const isLoading = mainStatisticsStatus === FETCH_STATUS.LOADING;
+  const isFailure = mainStatisticsStatus === FETCH_STATUS.FAILURE;
+  const noItemsMessage = (
+    <EuiEmptyPrompt
+      title={
+        <div>
+          {i18n.translate('xpack.apm.servicesTable.notFoundLabel', {
+            defaultMessage: 'No services found',
+          })}
+        </div>
+      }
+      titleSize="s"
+    />
+  );
+
+  return (
+    <>
+      <EuiFlexGroup direction="column" gutterSize="m">
+        {displayMlCallout && (
+          <EuiFlexItem>
+            <MLCallout
+              isOnSettingsPage={false}
+              anomalyDetectionSetupState={anomalyDetectionSetupState}
+              onDismiss={() => setUserHasDismissedCallout(true)}
+            />
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem>
+          <ServiceList
+            isLoading={isLoading}
+            isFailure={isFailure}
+            items={mainStatisticsData.items}
+            comparisonData={comparisonData}
+            noItemsMessage={noItemsMessage}
+            serviceParams={serviceParams}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+}
+
+// Allow for lazy loading
+// eslint-disable-next-line import/no-default-export
+export default ServiceInventory;

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/service_inventory_wrapper.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/service_inventory_wrapper.tsx
@@ -10,6 +10,7 @@ import type { ServiceInventoryProps } from './';
 
 const LazyServiceInventory = React.lazy(() => import('./'));
 
+// eslint-disable-next-line react/function-component-definition
 export const LazyServiceInventoryWrapper: React.FC<ServiceInventoryProps> = (
   props
 ) => (

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/service_inventory_wrapper.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/service_inventory_wrapper.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { ServiceInventoryProps } from './';
+
+const LazyServiceInventory = React.lazy(() => import('./'));
+
+export const LazyServiceInventoryWrapper: React.FC<ServiceInventoryProps> = (
+  props
+) => (
+  <React.Suspense fallback={<div />}>
+    <LazyServiceInventory {...props} />
+  </React.Suspense>
+);

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/service_list/HealthBadge.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/service_list/HealthBadge.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiBadge } from '@elastic/eui';
+import {
+  getServiceHealthStatusBadgeColor,
+  getServiceHealthStatusLabel,
+  ServiceHealthStatus,
+} from '../../../../../../common/service_health_status';
+import { useTheme } from '../../../../../hooks/use_theme';
+
+export function HealthBadge({
+  healthStatus,
+}: {
+  healthStatus: ServiceHealthStatus;
+}) {
+  const theme = useTheme();
+
+  return (
+    <EuiBadge color={getServiceHealthStatusBadgeColor(theme, healthStatus)}>
+      {getServiceHealthStatusLabel(healthStatus)}
+    </EuiBadge>
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/service_list/index.tsx
@@ -20,6 +20,7 @@ import React, { useMemo } from 'react';
 import { ValuesType } from 'utility-types';
 import { stringify } from 'query-string';
 import { euiStyled } from '../../../../../../../../../src/plugins/kibana_react/common';
+import { useKibana } from '../../../../../../../../../src/plugins/kibana_react/public';
 import { NOT_AVAILABLE_LABEL } from '../../../../../../common/i18n';
 import { ServiceHealthStatus } from '../../../../../../common/service_health_status';
 import {
@@ -79,12 +80,14 @@ export function getServiceColumns({
   breakpoints,
   showHealthStatusColumn,
   serviceParams,
+  http,
 }: {
   showTransactionTypeColumn: boolean;
   showHealthStatusColumn: boolean;
   breakpoints: Breakpoints;
   comparisonData?: ServicesDetailedStatisticsAPIResponse;
   serviceParams: ServiceParams;
+  http: HttpSetup;
 }): Array<ITableColumn<ServiceListItem>> {
   const { isSmall, isLarge, isXl } = breakpoints;
   const showWhenSmallOrGreaterThanLarge = isSmall || !isLarge;
@@ -123,7 +126,9 @@ export function getServiceColumns({
           content={
             <StyledLink
               data-test-subj={`serviceLink_${agentName}`}
-              href={`app/apm/services/${serviceName}/overview?${params}`}
+              href={http.basePath.prepend(
+                `/app/apm/services/${serviceName}/overview?${params}`
+              )}
             >
               <EuiFlexGroup
                 alignItems="center"
@@ -256,6 +261,10 @@ export function ServiceList({
   isFailure,
   serviceParams,
 }: Props) {
+  const {
+    services: { http },
+  } = useKibana();
+
   const breakpoints = useBreakpoints();
   const displayHealthStatus = items.some((item) => 'healthStatus' in item);
 
@@ -273,6 +282,7 @@ export function ServiceList({
         breakpoints,
         showHealthStatusColumn: displayHealthStatus,
         serviceParams,
+        http,
       }),
     [
       showTransactionTypeColumn,
@@ -280,6 +290,7 @@ export function ServiceList({
       breakpoints,
       displayHealthStatus,
       serviceParams,
+      http,
     ]
   );
 

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory_reusable/service_list/index.tsx
@@ -1,0 +1,371 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLink,
+  EuiText,
+  EuiToolTip,
+  RIGHT_ALIGNMENT,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { orderBy } from 'lodash';
+import React, { useMemo } from 'react';
+import { ValuesType } from 'utility-types';
+import { stringify } from 'query-string';
+import { euiStyled } from '../../../../../../../../../src/plugins/kibana_react/common';
+import { NOT_AVAILABLE_LABEL } from '../../../../../../common/i18n';
+import { ServiceHealthStatus } from '../../../../../../common/service_health_status';
+import {
+  TRANSACTION_PAGE_LOAD,
+  TRANSACTION_REQUEST,
+} from '../../../../../../common/transaction_types';
+import {
+  asMillisecondDuration,
+  asPercent,
+  asTransactionRate,
+} from '../../../../../../common/utils/formatters';
+import {
+  Breakpoints,
+  useBreakpoints,
+} from '../../../../../hooks/use_breakpoints';
+import { APIReturnType } from '../../../../../services/rest/createCallApmApi';
+import { unit, truncate } from '../../../../../utils/style';
+import { AgentIcon } from '../../../../shared/agent_icon';
+import { EnvironmentBadge } from '../../../../shared/EnvironmentBadge';
+import { ListMetric } from '../../../../shared/list_metric';
+import { ITableColumn, ManagedTable } from '../../../../shared/managed_table';
+import { TruncateWithTooltip } from '../../../../shared/truncate_with_tooltip';
+import { HealthBadge } from './HealthBadge';
+
+const StyledLink = euiStyled(EuiLink)`${truncate('100%')};`;
+
+interface ServiceParams {
+  comparisonEnabled?: boolean;
+  comparisonType?: 'week' | 'day' | 'period';
+  rangeFrom?: string;
+  rangeTo?: string;
+  environment?: string;
+  kuery?: string;
+}
+
+type ServiceListAPIResponse = APIReturnType<'GET /internal/apm/services'>;
+type Items = ServiceListAPIResponse['items'];
+type ServicesDetailedStatisticsAPIResponse =
+  APIReturnType<'GET /internal/apm/services/detailed_statistics'>;
+
+type ServiceListItem = ValuesType<Items>;
+
+function formatString(value?: string | null) {
+  return value || NOT_AVAILABLE_LABEL;
+}
+
+const SERVICE_HEALTH_STATUS_ORDER = [
+  ServiceHealthStatus.unknown,
+  ServiceHealthStatus.healthy,
+  ServiceHealthStatus.warning,
+  ServiceHealthStatus.critical,
+];
+
+export function getServiceColumns({
+  showTransactionTypeColumn,
+  comparisonData,
+  breakpoints,
+  showHealthStatusColumn,
+  serviceParams,
+}: {
+  showTransactionTypeColumn: boolean;
+  showHealthStatusColumn: boolean;
+  breakpoints: Breakpoints;
+  comparisonData?: ServicesDetailedStatisticsAPIResponse;
+  serviceParams: ServiceParams;
+}): Array<ITableColumn<ServiceListItem>> {
+  const { isSmall, isLarge, isXl } = breakpoints;
+  const showWhenSmallOrGreaterThanLarge = isSmall || !isLarge;
+  const showWhenSmallOrGreaterThanXL = isSmall || !isXl;
+  const params = stringify(serviceParams);
+  return [
+    ...(showHealthStatusColumn
+      ? [
+          {
+            field: 'healthStatus',
+            name: i18n.translate('xpack.apm.servicesTable.healthColumnLabel', {
+              defaultMessage: 'Health',
+            }),
+            width: `${unit * 6}px`,
+            sortable: true,
+            render: (_, { healthStatus }) => {
+              return (
+                <HealthBadge
+                  healthStatus={healthStatus ?? ServiceHealthStatus.unknown}
+                />
+              );
+            },
+          } as ITableColumn<ServiceListItem>,
+        ]
+      : []),
+    {
+      field: 'serviceName',
+      name: i18n.translate('xpack.apm.servicesTable.nameColumnLabel', {
+        defaultMessage: 'Name',
+      }),
+      sortable: true,
+      render: (_, { serviceName, agentName }) => (
+        <TruncateWithTooltip
+          data-test-subj="apmServiceListAppLink"
+          text={formatString(serviceName)}
+          content={
+            <StyledLink
+              data-test-subj={`serviceLink_${agentName}`}
+              href={`app/apm/services/${serviceName}/overview?${params}`}
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+                responsive={false}
+              >
+                <EuiFlexItem grow={false}>
+                  <AgentIcon agentName={agentName} />
+                </EuiFlexItem>
+                <EuiFlexItem>{serviceName}</EuiFlexItem>
+              </EuiFlexGroup>
+            </StyledLink>
+          }
+        />
+      ),
+    },
+    ...(showWhenSmallOrGreaterThanLarge
+      ? [
+          {
+            field: 'environments',
+            name: i18n.translate(
+              'xpack.apm.servicesTable.environmentColumnLabel',
+              {
+                defaultMessage: 'Environment',
+              }
+            ),
+            width: `${unit * 10}px`,
+            sortable: true,
+            render: (_, { environments }) => (
+              <EnvironmentBadge environments={environments ?? []} />
+            ),
+          } as ITableColumn<ServiceListItem>,
+        ]
+      : []),
+    ...(showTransactionTypeColumn && showWhenSmallOrGreaterThanXL
+      ? [
+          {
+            field: 'transactionType',
+            name: i18n.translate(
+              'xpack.apm.servicesTable.transactionColumnLabel',
+              { defaultMessage: 'Transaction type' }
+            ),
+            width: `${unit * 10}px`,
+            sortable: true,
+          },
+        ]
+      : []),
+    {
+      field: 'latency',
+      name: i18n.translate('xpack.apm.servicesTable.latencyAvgColumnLabel', {
+        defaultMessage: 'Latency (avg.)',
+      }),
+      sortable: true,
+      dataType: 'number',
+      render: (_, { serviceName, latency }) => (
+        <ListMetric
+          series={comparisonData?.currentPeriod[serviceName]?.latency}
+          comparisonSeries={
+            comparisonData?.previousPeriod[serviceName]?.latency
+          }
+          hideSeries={!showWhenSmallOrGreaterThanLarge}
+          color="euiColorVis1"
+          valueLabel={asMillisecondDuration(latency || 0)}
+        />
+      ),
+      align: RIGHT_ALIGNMENT,
+    },
+    {
+      field: 'throughput',
+      name: i18n.translate('xpack.apm.servicesTable.throughputColumnLabel', {
+        defaultMessage: 'Throughput',
+      }),
+      sortable: true,
+      dataType: 'number',
+      render: (_, { serviceName, throughput }) => (
+        <ListMetric
+          series={comparisonData?.currentPeriod[serviceName]?.throughput}
+          comparisonSeries={
+            comparisonData?.previousPeriod[serviceName]?.throughput
+          }
+          hideSeries={!showWhenSmallOrGreaterThanLarge}
+          color="euiColorVis0"
+          valueLabel={asTransactionRate(throughput)}
+        />
+      ),
+      align: RIGHT_ALIGNMENT,
+    },
+    {
+      field: 'transactionErrorRate',
+      name: i18n.translate('xpack.apm.servicesTable.transactionErrorRate', {
+        defaultMessage: 'Failed transaction rate',
+      }),
+      sortable: true,
+      dataType: 'number',
+      render: (_, { serviceName, transactionErrorRate }) => {
+        const valueLabel = asPercent(transactionErrorRate, 1);
+        return (
+          <ListMetric
+            series={
+              comparisonData?.currentPeriod[serviceName]?.transactionErrorRate
+            }
+            comparisonSeries={
+              comparisonData?.previousPeriod[serviceName]?.transactionErrorRate
+            }
+            hideSeries={!showWhenSmallOrGreaterThanLarge}
+            color="euiColorVis7"
+            valueLabel={valueLabel}
+          />
+        );
+      },
+      align: RIGHT_ALIGNMENT,
+    },
+  ];
+}
+
+interface Props {
+  items: Items;
+  comparisonData?: ServicesDetailedStatisticsAPIResponse;
+  noItemsMessage?: React.ReactNode;
+  isLoading: boolean;
+  isFailure?: boolean;
+  serviceParams: ServiceParams;
+}
+
+export function ServiceList({
+  items,
+  noItemsMessage,
+  comparisonData,
+  isLoading,
+  isFailure,
+  serviceParams,
+}: Props) {
+  const breakpoints = useBreakpoints();
+  const displayHealthStatus = items.some((item) => 'healthStatus' in item);
+
+  const showTransactionTypeColumn = items.some(
+    ({ transactionType }) =>
+      transactionType !== TRANSACTION_REQUEST &&
+      transactionType !== TRANSACTION_PAGE_LOAD
+  );
+
+  const serviceColumns = useMemo(
+    () =>
+      getServiceColumns({
+        showTransactionTypeColumn,
+        comparisonData,
+        breakpoints,
+        showHealthStatusColumn: displayHealthStatus,
+        serviceParams,
+      }),
+    [
+      showTransactionTypeColumn,
+      comparisonData,
+      breakpoints,
+      displayHealthStatus,
+      serviceParams,
+    ]
+  );
+
+  const initialSortField = displayHealthStatus
+    ? 'healthStatus'
+    : 'transactionsPerMinute';
+
+  return (
+    <EuiFlexGroup gutterSize="xs" direction="column" responsive={false}>
+      <EuiFlexItem>
+        <EuiFlexGroup
+          alignItems="center"
+          gutterSize="xs"
+          justifyContent="flexEnd"
+        >
+          <EuiFlexItem grow={false}>
+            <EuiToolTip
+              position="top"
+              content={i18n.translate(
+                'xpack.apm.servicesTable.tooltip.metricsExplanation',
+                {
+                  defaultMessage:
+                    'Service metrics are aggregated on transaction type "request", "page-load", or the top available transaction type.',
+                }
+              )}
+            >
+              <EuiIcon type="questionInCircle" color="subdued" />
+            </EuiToolTip>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color="subdued">
+              {i18n.translate(
+                'xpack.apm.servicesTable.metricsExplanationLabel',
+                { defaultMessage: 'What are these metrics?' }
+              )}
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <ManagedTable
+          isLoading={isLoading}
+          error={isFailure}
+          columns={serviceColumns}
+          items={items}
+          noItemsMessage={noItemsMessage}
+          initialSortField={initialSortField}
+          initialSortDirection="desc"
+          initialPageSize={50}
+          sortFn={(itemsToSort, sortField, sortDirection) => {
+            // For healthStatus, sort items by healthStatus first, then by TPM
+            return sortField === 'healthStatus'
+              ? orderBy(
+                  itemsToSort,
+                  [
+                    (item) => {
+                      return item.healthStatus
+                        ? SERVICE_HEALTH_STATUS_ORDER.indexOf(item.healthStatus)
+                        : -1;
+                    },
+                    (item) => item.throughput ?? 0,
+                  ],
+                  [sortDirection, sortDirection]
+                )
+              : orderBy(
+                  itemsToSort,
+                  (item) => {
+                    switch (sortField) {
+                      // Use `?? -1` here so `undefined` will appear after/before `0`.
+                      // In the table this will make the "N/A" items always at the
+                      // bottom/top.
+                      case 'latency':
+                        return item.latency ?? -1;
+                      case 'throughput':
+                        return item.throughput ?? -1;
+                      case 'transactionErrorRate':
+                        return item.transactionErrorRate ?? -1;
+                      default:
+                        return item[sortField as keyof typeof item];
+                    }
+                  },
+                  sortDirection
+                );
+          }}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/x-pack/plugins/apm/public/index.ts
+++ b/x-pack/plugins/apm/public/index.ts
@@ -24,3 +24,7 @@ export const plugin: PluginInitializer<ApmPluginSetup, ApmPluginStart> = (
 ) => new ApmPlugin(pluginInitializerContext);
 
 export type { ApmPluginSetup, ApmPluginStart };
+
+// Shared components
+export { LazyServiceInventoryWrapper as ServiceInventory } from './components/app/service_inventory/service_inventory_reusable/service_inventory_wrapper';
+export type { ServiceInventoryProps } from './components/app/service_inventory/service_inventory_reusable';

--- a/x-pack/plugins/apm/tsconfig.json
+++ b/x-pack/plugins/apm/tsconfig.json
@@ -40,6 +40,9 @@
     { "path": "../security/tsconfig.json" },
     { "path": "../task_manager/tsconfig.json" },
     { "path": "../triggers_actions_ui/tsconfig.json" },
-    { "path": "../fleet/tsconfig.json" }
+    { "path": "../fleet/tsconfig.json" },
+    {
+      "path": "../uptime/tsconfig.json"
+    }
   ]
 }

--- a/x-pack/plugins/uptime/kibana.json
+++ b/x-pack/plugins/uptime/kibana.json
@@ -24,7 +24,8 @@
     "security",
     "triggersActionsUi",
     "usageCollection",
-    "taskManager"
+    "taskManager",
+    "apm"
   ],
   "server": true,
   "ui": true,

--- a/x-pack/plugins/uptime/public/pages/overview.tsx
+++ b/x-pack/plugins/uptime/public/pages/overview.tsx
@@ -16,6 +16,7 @@ import { StatusPanel } from '../components/overview/status_panel';
 import { QueryBar } from '../components/overview/query_bar/query_bar';
 import { MONITORING_OVERVIEW_LABEL } from '../routes';
 import { FilterGroup } from '../components/overview/filter_group/filter_group';
+import { ServiceInventory } from '../../../apm/public';
 
 const EuiFlexItemStyled = styled(EuiFlexItem)`
   && {
@@ -45,6 +46,14 @@ export const OverviewPageComponent = () => {
       </EuiFlexGroup>
       <EuiSpacer size="xs" />
       <StatusPanel />
+      <ServiceInventory
+        comparisonEnabled={true}
+        comparisonType="period"
+        rangeFrom="now-30d/d"
+        rangeTo="now"
+        environment="ENVIRONMENT_ALL"
+        kuery=""
+      />
       <EuiSpacer size="s" />
       <MonitorList />
     </>

--- a/x-pack/plugins/uptime/tsconfig.json
+++ b/x-pack/plugins/uptime/tsconfig.json
@@ -30,6 +30,9 @@
     },
     {
       "path": "../fleet/tsconfig.json"
+    },
+    {
+      "path": "../apm/tsconfig.json"
     }
   ]
 }


### PR DESCRIPTION
https://github.com/elastic/apm-dev/issues/654

### What was done
- Create ServiceInventory and ServiceList components that can be reused by other plugins, to make this possible was needed to avoid the usage of some hooks that can be just be used within the apm plugin (i.e `useApmParams`, `useApmRouter`)
- The ServiceInventory needs to receive this 'params' as harcoded props
- Create a lazy wrapper for the ServiceInventory and export it so it can be consumed by other plugins
- Added apm as a required plugin to uptime, so we can import the apm components

![image](https://user-images.githubusercontent.com/31922082/149305298-46c00b7d-a487-4015-9e51-2edfe8eb78d7.png)
