### PR TITLE
[7.16] Update dependency broadcast-channel to ^4.8.0 (#121481)

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "base64-js": "^1.3.1",
     "bluebird": "3.5.5",
     "brace": "0.11.1",
-    "broadcast-channel": "^4.7.1",
+    "broadcast-channel": "^4.8.0",
     "chalk": "^4.1.0",
     "cheerio": "^1.0.0-rc.10",
     "chokidar": "^3.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8746,10 +8746,10 @@ broadcast-channel@^3.4.1:
     rimraf "3.0.2"
     unload "2.2.0"
 
-broadcast-channel@^4.7.1:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.7.1.tgz#f2a5129cf4bf69c9f944b34e777a4fc907be407e"
-  integrity sha512-liKNu7gwUtBVyTzqx3Thg//7ZooKXfnXxFm/pjLPaxG3t8CquwqnobH8jtFe2FQenFduC2dUzkL1bIrld7auqg==
+broadcast-channel@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.8.0.tgz#1f2c1f1fd97e186c26793b044218ed44a9d4d7d8"
+  integrity sha512-Ei6MylH1YfQQql52zNyZaLu8UvD+BeWNUKcKc8KrqyA7z3Ap2tb6A8KQJm0EBO0SDiKKNaAyzrnkRHhrtG9pYQ==
   dependencies:
     "@babel/runtime" "^7.16.0"
     detect-node "^2.1.0"


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Update dependency broadcast-channel to ^4.8.0 (#121481)