### PR TITLE
[8.0] Fix `import_saved_objects_between_versions` FTR test (#121498)

### DIFF
--- a/x-pack/test/functional/apps/saved_objects_management/import_saved_objects_between_versions.ts
+++ b/x-pack/test/functional/apps/saved_objects_management/import_saved_objects_between_versions.ts
@@ -20,19 +20,15 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
 
-  // Failing: See https://github.com/elastic/kibana/issues/116058
-  describe.skip('Export import saved objects between versions', function () {
+  describe('Export import saved objects between versions', function () {
     before(async function () {
-      await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
-      await esArchiver.load('x-pack/test/functional/es_archives/getting_started/shakespeare');
+      await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
       await kibanaServer.uiSettings.replace({});
       await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickKibanaSavedObjects();
     });
 
     after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
-      await esArchiver.unload('x-pack/test/functional/es_archives/getting_started/shakespeare');
       await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
     });
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix `import_saved_objects_between_versions` FTR test (#121498)