### PR TITLE
Fix docker image building during demo environment creation

### DIFF
--- a/.buildkite/scripts/steps/demo_env/kibana.sh
+++ b/.buildkite/scripts/steps/demo_env/kibana.sh
@@ -9,7 +9,7 @@ source "$(dirname "${0}")/config.sh"
 export KIBANA_IMAGE="gcr.io/elastic-kibana-184716/demo/kibana:$DEPLOYMENT_NAME-$(git rev-parse HEAD)"
 
 echo '--- Build Kibana'
-node scripts/build --debug --docker-images --example-plugins --skip-os-packages --skip-docker-ubi
+node scripts/build --debug --docker-images --example-plugins --skip-docker-ubi
 
 echo '--- Build Docker image with example plugins'
 cd target/example_plugins


### PR DESCRIPTION
Not sure if something changed, but `--skip-os-packages` is keeping the docker image from being built during demo env creating/updating.