### PR TITLE
[Fleet] Add package service to fleet plugin

### DIFF
--- a/x-pack/plugins/apm/server/routes/fleet/get_apm_package_policy_definition.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/get_apm_package_policy_definition.ts
@@ -61,9 +61,10 @@ async function getApmPackageVersion(
 ) {
   if (fleetPluginStart && isPrereleaseVersion(kibanaVersion)) {
     try {
-      const latestApmPackage = await fleetPluginStart.fetchFindLatestPackage(
-        'apm'
-      );
+      const latestApmPackage =
+        await fleetPluginStart.packageService.asInternalUser.fetchFindLatestPackage(
+          'apm'
+        );
       return latestApmPackage.version;
     } catch (error) {
       return SUPPORTED_APM_PACKAGE_VERSION;

--- a/x-pack/plugins/fleet/server/index.ts
+++ b/x-pack/plugins/fleet/server/index.ts
@@ -22,6 +22,7 @@ export type {
   AgentClient,
   ESIndexPatternService,
   PackageService,
+  PackageClient,
   AgentPolicyServiceInterface,
   ArtifactsClientInterface,
   Artifact,

--- a/x-pack/plugins/fleet/server/mocks/index.ts
+++ b/x-pack/plugins/fleet/server/mocks/index.ts
@@ -18,12 +18,13 @@ import { licensingMock } from '../../../../plugins/licensing/server/mocks';
 import { encryptedSavedObjectsMock } from '../../../encrypted_saved_objects/server/mocks';
 import { securityMock } from '../../../security/server/mocks';
 import type { PackagePolicyServiceInterface } from '../services/package_policy';
-import type { AgentPolicyServiceInterface, PackageService } from '../services';
+import type { AgentPolicyServiceInterface } from '../services';
 import type { FleetAppContext } from '../plugin';
 import { createMockTelemetryEventsSender } from '../telemetry/__mocks__';
 import { createFleetAuthzMock } from '../../common';
 import { agentServiceMock } from '../services/agents/agent_service.mock';
 import type { FleetRequestHandlerContext } from '../types';
+import { packageServiceMock } from '../services/epm/package_service.mock';
 
 // Export all mocks from artifacts
 export * from '../services/artifacts/mocks';
@@ -142,9 +143,7 @@ export const createMockAgentService = () => agentServiceMock.create();
  */
 export const createMockAgentClient = () => agentServiceMock.createClient();
 
-export const createMockPackageService = (): PackageService => {
-  return {
-    getInstallation: jest.fn(),
-    ensureInstalledPackage: jest.fn(),
-  };
-};
+/**
+ * Creates a mock PackageService
+ */
+export const createMockPackageService = () => packageServiceMock.create();

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -19,6 +19,7 @@ import type {
   KibanaRequest,
   ServiceStatus,
   ElasticsearchClient,
+  SavedObjectsClientContract,
 } from 'kibana/server';
 import type { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 
@@ -445,7 +446,7 @@ export class FleetPlugin
 
   private setupPackageService(
     internalEsClient: ElasticsearchClient,
-    internalSoClient: any
+    internalSoClient: SavedObjectsClientContract
   ): PackageService {
     if (this.packageService) {
       return this.packageService;

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -80,15 +80,14 @@ import {
   agentPolicyService,
   packagePolicyService,
   AgentServiceImpl,
+  PackageServiceImpl,
 } from './services';
 import { registerFleetUsageCollector } from './collectors/register';
-import { getInstallation, ensureInstalledPackage } from './services/epm/packages';
 import { getAuthzFromRequest, makeRouterWithFleetAuthz } from './routes/security';
 import { FleetArtifactsClient } from './services/artifacts';
 import type { FleetRouter } from './types/request_context';
 import { TelemetryEventsSender } from './telemetry/sender';
 import { setupFleet } from './services/setup';
-import { fetchFindLatestPackage } from './services/epm/registry';
 
 export interface FleetSetupDeps {
   licensing: LicensingPluginSetup;
@@ -170,8 +169,6 @@ export interface FleetStartContract {
    * @param packageName
    */
   createArtifactsClient: (packageName: string) => FleetArtifactsClient;
-
-  fetchFindLatestPackage: typeof fetchFindLatestPackage;
 }
 
 export class FleetPlugin
@@ -193,6 +190,7 @@ export class FleetPlugin
   private readonly fleetStatus$: BehaviorSubject<ServiceStatus>;
 
   private agentService?: AgentService;
+  private packageService?: PackageService;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.config$ = this.initializerContext.config.create<FleetConfigType>();
@@ -407,10 +405,10 @@ export class FleetPlugin
       },
       fleetSetupCompleted: () => fleetSetupPromise,
       esIndexPatternService: new ESIndexPatternSavedObjectService(),
-      packageService: {
-        getInstallation,
-        ensureInstalledPackage,
-      },
+      packageService: this.setupPackageService(
+        core.elasticsearch.client.asInternalUser,
+        new SavedObjectsClient(core.savedObjects.createInternalRepository())
+      ),
       agentService: this.setupAgentService(core.elasticsearch.client.asInternalUser),
       agentPolicyService: {
         get: agentPolicyService.get,
@@ -426,7 +424,6 @@ export class FleetPlugin
       createArtifactsClient(packageName: string) {
         return new FleetArtifactsClient(core.elasticsearch.client.asInternalUser, packageName);
       },
-      fetchFindLatestPackage,
     };
   }
 
@@ -444,5 +441,29 @@ export class FleetPlugin
 
     this.agentService = new AgentServiceImpl(internalEsClient);
     return this.agentService;
+  }
+
+  private setupPackageService(
+    internalEsClient: ElasticsearchClient,
+    internalSoClient: any
+  ): PackageService {
+    if (this.packageService) {
+      return this.packageService;
+    }
+
+    this.packageService = new PackageServiceImpl(
+      internalEsClient,
+      internalSoClient,
+      this.getLogger()
+    );
+    return this.packageService;
+  }
+
+  private getLogger(): Logger {
+    if (!this.logger) {
+      this.logger = this.initializerContext.logger.get();
+    }
+
+    return this.logger;
   }
 }

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/install.ts
@@ -112,7 +112,7 @@ export const installTransform = async (
   return installedTransforms;
 };
 
-const isTransform = (path: string) => {
+export const isTransform = (path: string) => {
   const pathParts = getPathParts(path);
   return !path.endsWith('/') && pathParts.type === ElasticsearchAssetType.transform;
 };

--- a/x-pack/plugins/fleet/server/services/epm/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { PackageServiceImpl } from './package_service';
+
+export type { PackageService, PackageClient } from './package_service';

--- a/x-pack/plugins/fleet/server/services/epm/package_service.mock.ts
+++ b/x-pack/plugins/fleet/server/services/epm/package_service.mock.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PackageClient, PackageService } from './package_service';
+
+const createClientMock = (): jest.Mocked<PackageClient> => ({
+  getInstallation: jest.fn(),
+  ensureInstalledPackage: jest.fn(),
+  fetchFindLatestPackage: jest.fn(),
+  getRegistryPackage: jest.fn(),
+  reinstallEsAssets: jest.fn(),
+});
+
+const createServiceMock = (): jest.Mocked<PackageService> => ({
+  asScoped: jest.fn().mockReturnValue(createClientMock()),
+  asInternalUser: createClientMock(),
+});
+
+export const packageServiceMock = {
+  createClient: createClientMock,
+  create: createServiceMock,
+};

--- a/x-pack/plugins/fleet/server/services/epm/package_service.mock.ts
+++ b/x-pack/plugins/fleet/server/services/epm/package_service.mock.ts
@@ -15,8 +15,8 @@ const createClientMock = (): jest.Mocked<PackageClient> => ({
   reinstallEsAssets: jest.fn(),
 });
 
-const createServiceMock = (): jest.Mocked<PackageService> => ({
-  asScoped: jest.fn().mockReturnValue(createClientMock()),
+const createServiceMock = (): PackageService => ({
+  asScoped: jest.fn(createClientMock),
   asInternalUser: createClientMock(),
 });
 

--- a/x-pack/plugins/fleet/server/services/epm/package_service.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/package_service.test.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+jest.mock('../../routes/security');
+
+import type { MockedLogger } from '@kbn/logging/target_types/mocks';
+
+import type {
+  ElasticsearchClient,
+  SavedObjectsClientContract,
+} from '../../../../../../src/core/server';
+import {
+  elasticsearchServiceMock,
+  httpServerMock,
+  loggingSystemMock,
+  savedObjectsClientMock,
+} from '../../../../../../src/core/server/mocks';
+
+import { FleetUnauthorizedError } from '../../errors';
+import type { InstallablePackage } from '../../types';
+
+import type { PackageClient, PackageService } from './package_service';
+import { PackageServiceImpl } from './package_service';
+import * as epmPackagesGet from './packages/get';
+import * as epmPackagesInstall from './packages/install';
+import * as epmRegistry from './registry';
+import * as epmTransformsInstall from './elasticsearch/transform/install';
+
+const testKeys = [
+  'getInstallation',
+  'ensureInstalledPackage',
+  'fetchFindLatestPackage',
+  'getRegistryPackage',
+  'reinstallEsAssets',
+];
+
+function getTest(
+  mocks: {
+    packageClient: PackageClient;
+    esClient?: ElasticsearchClient;
+    soClient?: SavedObjectsClientContract;
+    logger?: MockedLogger;
+  },
+  testKey: string
+) {
+  let test: {
+    method: Function;
+    args: any[];
+    spy: jest.SpyInstance;
+    spyArgs: any[];
+    spyResponse: any;
+  };
+
+  switch (testKey) {
+    case testKeys[0]:
+      test = {
+        method: mocks.packageClient.getInstallation.bind(mocks.packageClient),
+        args: ['package name'],
+        spy: jest.spyOn(epmPackagesGet, 'getInstallation'),
+        spyArgs: [
+          {
+            pkgName: 'package name',
+            savedObjectsClient: mocks.soClient,
+          },
+        ],
+        spyResponse: { name: 'getInstallation test' },
+      };
+      break;
+    case testKeys[1]:
+      test = {
+        method: mocks.packageClient.ensureInstalledPackage.bind(mocks.packageClient),
+        args: [{ pkgName: 'package name', pkgVersion: '8.0.0', spaceId: 'spaceId' }],
+        spy: jest.spyOn(epmPackagesInstall, 'ensureInstalledPackage'),
+        spyArgs: [
+          {
+            pkgName: 'package name',
+            pkgVersion: '8.0.0',
+            spaceId: 'spaceId',
+            esClient: mocks.esClient,
+            savedObjectsClient: mocks.soClient,
+          },
+        ],
+        spyResponse: { name: 'ensureInstalledPackage test' },
+      };
+      break;
+    case testKeys[2]:
+      test = {
+        method: mocks.packageClient.fetchFindLatestPackage.bind(mocks.packageClient),
+        args: ['package name'],
+        spy: jest.spyOn(epmRegistry, 'fetchFindLatestPackage'),
+        spyArgs: ['package name'],
+        spyResponse: { name: 'fetchFindLatestPackage test' },
+      };
+      break;
+    case testKeys[3]:
+      test = {
+        method: mocks.packageClient.getRegistryPackage.bind(mocks.packageClient),
+        args: ['package name', '8.0.0'],
+        spy: jest.spyOn(epmRegistry, 'getRegistryPackage'),
+        spyArgs: ['package name', '8.0.0'],
+        spyResponse: {
+          packageInfo: { name: 'getRegistryPackage test' },
+          paths: ['/some/test/path'],
+        },
+      };
+      break;
+    case testKeys[4]:
+      const pkg: InstallablePackage = {
+        format_version: '1.0.0',
+        name: 'package name',
+        title: 'package title',
+        description: 'package description',
+        version: '8.0.0',
+        release: 'ga',
+        owner: { github: 'elastic' },
+      };
+      const paths = ['some/test/transform/path'];
+
+      test = {
+        method: mocks.packageClient.reinstallEsAssets.bind(mocks.packageClient),
+        args: [pkg, paths],
+        spy: jest.spyOn(epmTransformsInstall, 'installTransform'),
+        spyArgs: [pkg, paths, mocks.esClient, mocks.soClient, mocks.logger],
+        spyResponse: [
+          {
+            name: 'package name',
+          },
+        ],
+      };
+      break;
+    default:
+      throw new Error('invalid test key');
+  }
+
+  return test;
+}
+
+describe('PackageService', () => {
+  let mockPackageService: PackageService;
+  let mockEsClient: ElasticsearchClient;
+  let mockSoClient: SavedObjectsClientContract;
+  let mockLogger: MockedLogger;
+
+  beforeEach(() => {
+    mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
+    mockSoClient = savedObjectsClientMock.create();
+    mockLogger = loggingSystemMock.createLogger();
+    mockPackageService = new PackageServiceImpl(mockEsClient, mockSoClient, mockLogger);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('asScoped', () => {
+    describe.each(testKeys)('without required privileges', (testKey: string) => {
+      const unauthError = new FleetUnauthorizedError(
+        `User does not have adequate permissions to access Fleet packages.`
+      );
+
+      it(`rejects on ${testKey}`, async () => {
+        const { method, args } = getTest(
+          { packageClient: mockPackageService.asScoped(httpServerMock.createKibanaRequest()) },
+          testKey
+        );
+        await expect(method(...args)).rejects.toThrowError(unauthError);
+      });
+    });
+
+    describe.each(testKeys)('with required privileges', (testKey: string) => {
+      it(`calls ${testKey} and returns results`, async () => {
+        const mockClients = {
+          packageClient: mockPackageService.asInternalUser,
+          esClient: mockEsClient,
+          soClient: mockSoClient,
+          logger: mockLogger,
+        };
+        const { method, args, spy, spyArgs, spyResponse } = getTest(mockClients, testKey);
+        spy.mockResolvedValue(spyResponse);
+
+        await expect(method(...args)).resolves.toEqual(spyResponse);
+        expect(spy).toHaveBeenCalledWith(...spyArgs);
+      });
+    });
+  });
+
+  describe.each(testKeys)('asInternalUser', (testKey: string) => {
+    it(`calls ${testKey} and returns results`, async () => {
+      const mockClients = {
+        packageClient: mockPackageService.asInternalUser,
+        esClient: mockEsClient,
+        soClient: mockSoClient,
+        logger: mockLogger,
+      };
+      const { method, args, spy, spyArgs, spyResponse } = getTest(mockClients, testKey);
+      spy.mockResolvedValue(spyResponse);
+
+      await expect(method(...args)).resolves.toEqual(spyResponse);
+      expect(spy).toHaveBeenCalledWith(...spyArgs);
+    });
+  });
+});

--- a/x-pack/plugins/fleet/server/services/epm/package_service.ts
+++ b/x-pack/plugins/fleet/server/services/epm/package_service.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable max-classes-per-file */
+
+import type {
+  KibanaRequest,
+  ElasticsearchClient,
+  SavedObjectsClientContract,
+  Logger,
+} from 'kibana/server';
+
+import type {
+  EsAssetReference,
+  InstallablePackage,
+  Installation,
+  RegistryPackage,
+  RegistrySearchResult,
+} from '../../types';
+import { checkSuperuser } from '../../routes/security';
+import { FleetUnauthorizedError } from '../../errors';
+
+import { installTransform, isTransform } from './elasticsearch/transform/install';
+import { fetchFindLatestPackage, getRegistryPackage } from './registry';
+import { ensureInstalledPackage, getInstallation } from './packages';
+
+export type InstalledAssetType = EsAssetReference;
+
+export interface PackageService {
+  asScoped(request: KibanaRequest): PackageClient;
+  asInternalUser: PackageClient;
+}
+
+export interface PackageClient {
+  getInstallation(pkgName: string): Promise<Installation | undefined>;
+
+  ensureInstalledPackage(options: {
+    pkgName: string;
+    pkgVersion?: string;
+    spaceId?: string;
+  }): Promise<Installation | undefined>;
+
+  fetchFindLatestPackage(packageName: string): Promise<RegistrySearchResult>;
+
+  getRegistryPackage(
+    packageName: string,
+    packageVersion: string
+  ): Promise<{ packageInfo: RegistryPackage; paths: string[] }>;
+
+  reinstallEsAssets(
+    packageInfo: InstallablePackage,
+    assetPaths: string[]
+  ): Promise<InstalledAssetType[]>;
+}
+
+export class PackageServiceImpl implements PackageService {
+  constructor(
+    private readonly internalEsClient: ElasticsearchClient,
+    private readonly internalSoClient: SavedObjectsClientContract,
+    private readonly logger: Logger
+  ) {}
+
+  public asScoped(request: KibanaRequest) {
+    const preflightCheck = () => {
+      if (!checkSuperuser(request)) {
+        throw new FleetUnauthorizedError(
+          `User does not have adequate permissions to access Fleet packages.`
+        );
+      }
+    };
+
+    return new PackageClientImpl(
+      this.internalEsClient,
+      this.internalSoClient,
+      this.logger,
+      preflightCheck
+    );
+  }
+
+  public get asInternalUser() {
+    return new PackageClientImpl(this.internalEsClient, this.internalSoClient, this.logger);
+  }
+}
+
+class PackageClientImpl implements PackageClient {
+  constructor(
+    private readonly internalEsClient: ElasticsearchClient,
+    private readonly internalSoClient: SavedObjectsClientContract,
+    private readonly logger: Logger,
+    private readonly preflightCheck?: () => void | Promise<void>
+  ) {}
+
+  public async getInstallation(pkgName: string) {
+    await this.#runPreflight();
+    return getInstallation({
+      pkgName,
+      savedObjectsClient: this.internalSoClient,
+    });
+  }
+
+  public async ensureInstalledPackage(options: {
+    pkgName: string;
+    pkgVersion?: string;
+    spaceId?: string;
+  }): Promise<Installation | undefined> {
+    await this.#runPreflight();
+    return ensureInstalledPackage({
+      ...options,
+      esClient: this.internalEsClient,
+      savedObjectsClient: this.internalSoClient,
+    });
+  }
+
+  public async fetchFindLatestPackage(packageName: string) {
+    await this.#runPreflight();
+    return fetchFindLatestPackage(packageName);
+  }
+
+  public async getRegistryPackage(packageName: string, packageVersion: string) {
+    await this.#runPreflight();
+    return getRegistryPackage(packageName, packageVersion);
+  }
+
+  public async reinstallEsAssets(
+    packageInfo: InstallablePackage,
+    assetPaths: string[]
+  ): Promise<InstalledAssetType[]> {
+    await this.#runPreflight();
+    let installedAssets: InstalledAssetType[] = [];
+
+    const transformPaths = assetPaths.filter(isTransform);
+
+    if (transformPaths.length !== assetPaths.length) {
+      throw new Error('reinstallEsAssets is currently only implemented for transform assets');
+    }
+
+    if (transformPaths.length) {
+      const installedTransformAssets = await this.#reinstallTransforms(packageInfo, transformPaths);
+      installedAssets = [...installedAssets, ...installedTransformAssets];
+    }
+
+    return installedAssets;
+  }
+
+  #reinstallTransforms(packageInfo: InstallablePackage, paths: string[]) {
+    return installTransform(
+      packageInfo,
+      paths,
+      this.internalEsClient,
+      this.internalSoClient,
+      this.logger
+    );
+  }
+
+  #runPreflight() {
+    if (this.preflightCheck) {
+      return this.preflightCheck();
+    }
+  }
+}

--- a/x-pack/plugins/fleet/server/services/index.ts
+++ b/x-pack/plugins/fleet/server/services/index.ts
@@ -9,7 +9,6 @@ import type { SavedObjectsClientContract } from 'kibana/server';
 
 import type { agentPolicyService } from './agent_policy';
 import * as settingsService from './settings';
-import type { getInstallation, ensureInstalledPackage } from './epm/packages';
 
 export { ESIndexPatternSavedObjectService } from './es_index_pattern';
 export { getRegistryUrl } from './epm/registry/registry_url';
@@ -28,11 +27,6 @@ export interface ESIndexPatternService {
 /**
  * Service that provides exported function that return information about EPM packages
  */
-
-export interface PackageService {
-  getInstallation: typeof getInstallation;
-  ensureInstalledPackage: typeof ensureInstalledPackage;
-}
 
 export interface AgentPolicyServiceInterface {
   get: typeof agentPolicyService['get'];
@@ -61,3 +55,7 @@ export * from './artifacts';
 
 // Policy preconfiguration functions
 export { ensurePreconfiguredPackagesAndPolicies } from './preconfiguration';
+
+// Package Services
+export { PackageServiceImpl } from './epm';
+export type { PackageService, PackageClient } from './epm';

--- a/x-pack/plugins/osquery/server/routes/status/create_status_route.ts
+++ b/x-pack/plugins/osquery/server/routes/status/create_status_route.ts
@@ -31,14 +31,11 @@ export const createStatusRoute = (router: IRouter, osqueryContext: OsqueryAppCon
       const internalSavedObjectsClient = await getInternalSavedObjectsClient(
         osqueryContext.getStartServices
       );
-      const packageService = osqueryContext.service.getPackageService();
+      const packageService = osqueryContext.service.getPackageService()?.asInternalUser;
       const packagePolicyService = osqueryContext.service.getPackagePolicyService();
       const agentPolicyService = osqueryContext.service.getAgentPolicyService();
 
-      const packageInfo = await osqueryContext.service.getPackageService()?.getInstallation({
-        savedObjectsClient: internalSavedObjectsClient,
-        pkgName: OSQUERY_INTEGRATION_NAME,
-      });
+      const packageInfo = await packageService?.getInstallation(OSQUERY_INTEGRATION_NAME);
 
       if (packageInfo?.install_version && satisfies(packageInfo?.install_version, '<0.6.0')) {
         try {
@@ -102,8 +99,6 @@ export const createStatusRoute = (router: IRouter, osqueryContext: OsqueryAppCon
           );
 
           await packageService?.ensureInstalledPackage({
-            esClient,
-            savedObjectsClient: internalSavedObjectsClient,
             pkgName: OSQUERY_INTEGRATION_NAME,
           });
 

--- a/x-pack/plugins/security_solution/server/endpoint/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/mocks.ts
@@ -11,12 +11,13 @@ import { listMock } from '../../../lists/server/mocks';
 import { securityMock } from '../../../security/server/mocks';
 import { alertsMock } from '../../../alerting/server/mocks';
 import { xpackMocks } from '../fixtures';
-import { FleetStartContract, ExternalCallback, PackageService } from '../../../fleet/server';
+import { FleetStartContract, ExternalCallback } from '../../../fleet/server';
 import {
   createPackagePolicyServiceMock,
   createMockAgentPolicyService,
   createMockAgentService,
   createArtifactsClientMock,
+  createMockPackageService,
 } from '../../../fleet/server/mocks';
 import { createMockConfig, requestContextMock } from '../lib/detection_engine/routes/__mocks__';
 import {
@@ -136,17 +137,6 @@ export const createMockEndpointAppContextServiceStartContract =
   };
 
 /**
- * Create mock PackageService
- */
-
-export const createMockPackageService = (): jest.Mocked<PackageService> => {
-  return {
-    getInstallation: jest.fn(),
-    ensureInstalledPackage: jest.fn(),
-  };
-};
-
-/**
  * Creates a mock IndexPatternService for use in tests that need to interact with the Fleet's
  * ESIndexPatternService.
  *
@@ -168,7 +158,6 @@ export const createMockFleetStartContract = (indexPattern: string): FleetStartCo
     registerExternalCallback: jest.fn((...args: ExternalCallback) => {}),
     packagePolicyService: createPackagePolicyServiceMock(),
     createArtifactsClient: jest.fn().mockReturnValue(createArtifactsClientMock()),
-    fetchFindLatestPackage: jest.fn().mockReturnValue('8.0.0'),
   };
 };
 

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.test.ts
@@ -20,7 +20,6 @@ import { EndpointAppContextService } from '../../endpoint_app_context_services';
 import {
   createMockEndpointAppContextServiceSetupContract,
   createMockEndpointAppContextServiceStartContract,
-  createMockPackageService,
   createRouteHandlerContext,
 } from '../../mocks';
 import { HostIsolationRequestSchema } from '../../../../common/endpoint/schema/actions';
@@ -49,6 +48,8 @@ import { legacyMetadataSearchResponseMock } from '../metadata/support/test_suppo
 import { AGENT_ACTIONS_INDEX, ElasticsearchAssetType } from '../../../../../fleet/common';
 import { CasesClientMock } from '../../../../../cases/server/client/mocks';
 import { EndpointAuthz } from '../../../../common/endpoint/types/authz';
+import type { PackageClient } from '../../../../../fleet/server';
+import { createMockPackageService } from '../../../../../fleet/server/mocks';
 
 interface CallRouteInterface {
   body?: HostIsolationRequestBody;
@@ -135,31 +136,29 @@ describe('Host Isolation', () => {
       endpointAppContextService = new EndpointAppContextService();
       const mockSavedObjectClient = savedObjectsClientMock.create();
       const mockPackageService = createMockPackageService();
-      mockPackageService.getInstallation.mockReturnValue(
-        Promise.resolve({
-          installed_kibana: [],
-          package_assets: [],
-          es_index_patterns: {},
-          name: '',
-          version: '',
-          install_status: 'installed',
-          install_version: '',
-          install_started_at: '',
-          install_source: 'registry',
-          installed_es: [
-            {
-              dupa: true,
-              id: 'logs-endpoint.events.security',
-              type: ElasticsearchAssetType.indexTemplate,
-            },
-            {
-              id: `${metadataTransformPrefix}-0.16.0-dev.0`,
-              type: ElasticsearchAssetType.transform,
-            },
-          ],
-          keep_policies_up_to_date: false,
-        })
-      );
+      const mockedPackageClient = mockPackageService.asInternalUser as jest.Mocked<PackageClient>;
+      mockedPackageClient.getInstallation.mockResolvedValue({
+        installed_kibana: [],
+        package_assets: [],
+        es_index_patterns: {},
+        name: '',
+        version: '',
+        install_status: 'installed',
+        install_version: '',
+        install_started_at: '',
+        install_source: 'registry',
+        installed_es: [
+          {
+            id: 'logs-endpoint.events.security',
+            type: ElasticsearchAssetType.indexTemplate,
+          },
+          {
+            id: `${metadataTransformPrefix}-0.16.0-dev.0`,
+            type: ElasticsearchAssetType.transform,
+          },
+        ],
+        keep_policies_up_to_date: false,
+      });
 
       licenseEmitter = new Subject();
       licenseService = new LicenseService();

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
@@ -75,7 +75,7 @@ describe('test endpoint routes', () => {
   let mockClusterClient: ClusterClientMock;
   let mockScopedClient: ScopedClusterClientMock;
   let mockSavedObjectClient: jest.Mocked<SavedObjectsClientContract>;
-  let mockPackageService: jest.Mocked<PackageService>;
+  let mockPackageService: PackageService;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let routeHandler: RequestHandler<any, any, any, any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
@@ -24,7 +24,6 @@ import { registerEndpointRoutes } from './index';
 import {
   createMockEndpointAppContextServiceSetupContract,
   createMockEndpointAppContextServiceStartContract,
-  createMockPackageService,
   createRouteHandlerContext,
 } from '../../mocks';
 import {
@@ -38,7 +37,7 @@ import {
   legacyMetadataSearchResponseMock,
   unitedMetadataSearchResponseMock,
 } from './support/test_support';
-import { AgentClient, PackageService } from '../../../../../fleet/server/services';
+import type { AgentClient, PackageService, PackageClient } from '../../../../../fleet/server';
 import {
   HOST_METADATA_GET_ROUTE,
   HOST_METADATA_LIST_ROUTE,
@@ -57,7 +56,7 @@ import {
 } from '../../../../../../../src/core/server/elasticsearch/client/mocks';
 import { EndpointHostNotFoundError } from '../../services/metadata';
 import { FleetAgentGenerator } from '../../../../common/endpoint/data_generators/fleet_agent_generator';
-import { createMockAgentClient } from '../../../../../fleet/server/mocks';
+import { createMockAgentClient, createMockPackageService } from '../../../../../fleet/server/mocks';
 import { TransformGetTransformStatsResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { getEndpointAuthzInitialStateMock } from '../../../../common/endpoint/service/authz';
 
@@ -121,30 +120,29 @@ describe('test endpoint routes', () => {
 
     endpointAppContextService = new EndpointAppContextService();
     mockPackageService = createMockPackageService();
-    mockPackageService.getInstallation.mockReturnValue(
-      Promise.resolve({
-        installed_kibana: [],
-        package_assets: [],
-        es_index_patterns: {},
-        name: '',
-        version: '',
-        install_status: 'installed',
-        install_version: '',
-        install_started_at: '',
-        install_source: 'registry',
-        installed_es: [
-          {
-            id: 'logs-endpoint.events.security',
-            type: ElasticsearchAssetType.indexTemplate,
-          },
-          {
-            id: `${metadataTransformPrefix}-0.16.0-dev.0`,
-            type: ElasticsearchAssetType.transform,
-          },
-        ],
-        keep_policies_up_to_date: false,
-      })
-    );
+    const mockPackageClient = mockPackageService.asInternalUser as jest.Mocked<PackageClient>;
+    mockPackageClient.getInstallation.mockResolvedValue({
+      installed_kibana: [],
+      package_assets: [],
+      es_index_patterns: {},
+      name: '',
+      version: '',
+      install_status: 'installed',
+      install_version: '',
+      install_started_at: '',
+      install_source: 'registry',
+      installed_es: [
+        {
+          id: 'logs-endpoint.events.security',
+          type: ElasticsearchAssetType.indexTemplate,
+        },
+        {
+          id: `${metadataTransformPrefix}-0.16.0-dev.0`,
+          type: ElasticsearchAssetType.transform,
+        },
+      ],
+      keep_policies_up_to_date: false,
+    });
     endpointAppContextService.setup(createMockEndpointAppContextServiceSetupContract());
     endpointAppContextService.start({ ...startContract, packageService: mockPackageService });
     mockAgentService = startContract.agentService!;

--- a/x-pack/plugins/security_solution/server/endpoint/services/endpoint_fleet_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/endpoint_fleet_services.ts
@@ -11,7 +11,7 @@ import type {
   AgentPolicyServiceInterface,
   FleetStartContract,
   PackagePolicyServiceInterface,
-  PackageService,
+  PackageClient,
 } from '../../../../fleet/server';
 
 export interface EndpointFleetServicesFactoryInterface {
@@ -33,13 +33,13 @@ export class EndpointFleetServicesFactory implements EndpointFleetServicesFactor
       agentPolicyService: agentPolicy,
       packagePolicyService: packagePolicy,
       agentService,
-      packageService: packages,
+      packageService,
     } = this.fleetDependencies;
 
     return {
       agent: agentService.asScoped(req),
       agentPolicy,
-      packages,
+      packages: packageService.asScoped(req),
       packagePolicy,
 
       asInternal: this.asInternalUser.bind(this),
@@ -51,13 +51,13 @@ export class EndpointFleetServicesFactory implements EndpointFleetServicesFactor
       agentPolicyService: agentPolicy,
       packagePolicyService: packagePolicy,
       agentService,
-      packageService: packages,
+      packageService,
     } = this.fleetDependencies;
 
     return {
       agent: agentService.asInternalUser,
       agentPolicy,
-      packages,
+      packages: packageService.asInternalUser,
       packagePolicy,
 
       asScoped: this.asScoped.bind(this),
@@ -71,7 +71,7 @@ export class EndpointFleetServicesFactory implements EndpointFleetServicesFactor
 export interface EndpointFleetServicesInterface {
   agent: AgentClient;
   agentPolicy: AgentPolicyServiceInterface;
-  packages: PackageService;
+  packages: PackageClient;
   packagePolicy: PackagePolicyServiceInterface;
 }
 

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
@@ -7,12 +7,7 @@
 
 /* eslint-disable max-classes-per-file */
 
-import {
-  CoreStart,
-  KibanaRequest,
-  Logger,
-  SavedObjectsClient,
-} from '../../../../../../src/core/server';
+import { KibanaRequest, Logger } from '../../../../../../src/core/server';
 import {
   ConcreteTaskInstance,
   TaskManagerSetupContract,
@@ -62,7 +57,7 @@ export class SyntheticsService {
     this.esHosts = getEsHosts({ config: this.config, cloud: server.cloud });
   }
 
-  public init(coreStart: CoreStart) {
+  public init() {
     // TODO: Figure out fake kibana requests to handle API keys on start up
     // getAPIKeyForSyntheticsService({ server: this.server }).then((apiKey) => {
     //   if (apiKey) {
@@ -70,20 +65,11 @@ export class SyntheticsService {
     //   }
     // });
 
-    this.setupIndexTemplates(coreStart);
+    this.setupIndexTemplates();
   }
 
-  private setupIndexTemplates(coreStart: CoreStart) {
-    const esClient = coreStart.elasticsearch.client.asInternalUser;
-    const savedObjectsClient = new SavedObjectsClient(
-      coreStart.savedObjects.createInternalRepository()
-    );
-
-    installSyntheticsIndexTemplates({
-      esClient,
-      server: this.server,
-      savedObjectsClient,
-    }).then(
+  private setupIndexTemplates() {
+    installSyntheticsIndexTemplates(this.server).then(
       (result) => {
         if (result.name === 'synthetics' && result.install_status === 'installed') {
           this.logger.info('Installed synthetics index templates');

--- a/x-pack/plugins/uptime/server/plugin.ts
+++ b/x-pack/plugins/uptime/server/plugin.ts
@@ -112,7 +112,7 @@ export class Plugin implements PluginType {
     }
 
     if (this.server?.config?.unsafe?.service.enabled) {
-      this.syntheticService?.init(coreStart);
+      this.syntheticService?.init();
       this.syntheticService?.scheduleSyncTask(plugins.taskManager);
       if (this.server && this.syntheticService) {
         this.server.syntheticsService = this.syntheticService;

--- a/x-pack/plugins/uptime/server/rest_api/synthetics_service/install_index_templates.ts
+++ b/x-pack/plugins/uptime/server/rest_api/synthetics_service/install_index_templates.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { ElasticsearchClient, SavedObjectsClientContract } from 'kibana/server';
+
 import { UMRestApiRouteFactory } from '../types';
 import { API_URLS } from '../../../common/constants';
 import { UptimeServerSetup } from '../../lib/adapters';
@@ -13,31 +13,23 @@ export const installIndexTemplatesRoute: UMRestApiRouteFactory = () => ({
   method: 'GET',
   path: API_URLS.INDEX_TEMPLATES,
   validate: {},
-  handler: async ({ server, request, savedObjectsClient, uptimeEsClient }): Promise<any> => {
-    return installSyntheticsIndexTemplates({
-      server,
-      savedObjectsClient,
-      esClient: uptimeEsClient.baseESClient,
-    });
+  handler: async ({ server }): Promise<any> => {
+    return installSyntheticsIndexTemplates(server);
   },
 });
 
-export async function installSyntheticsIndexTemplates({
-  esClient,
-  server,
-  savedObjectsClient,
-}: {
-  server: UptimeServerSetup;
-  esClient: ElasticsearchClient;
-  savedObjectsClient: SavedObjectsClientContract;
-}) {
+export async function installSyntheticsIndexTemplates(server: UptimeServerSetup) {
   // no need to add error handling here since fleetSetupCompleted is already wrapped in try/catch and will log
   // warning if setup fails to complete
   await server.fleet.fleetSetupCompleted();
 
-  return await server.fleet.packageService.ensureInstalledPackage({
-    esClient,
-    savedObjectsClient,
+  const installation = await server.fleet.packageService.asInternalUser.ensureInstalledPackage({
     pkgName: 'synthetics',
   });
+
+  if (!installation) {
+    return Promise.reject('No package installation found.');
+  }
+
+  return installation;
 }


### PR DESCRIPTION
## Summary

Adds new PackageService to the fleet plugin that newly exposes the `reinstallEsAssets` and `getRegistryPackage` methods. Also pulls in previously directly exposed functions: `getInstallation`, `ensureInstalledPackage`, and `fetchFindLatestPackage`.

Spawned from discussion in https://github.com/elastic/kibana/pull/121366.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
