### PR TITLE
[8.0] Normalize apm transaction names (#119740)

### DIFF
--- a/dev_docs/contributing/standards.mdx
+++ b/dev_docs/contributing/standards.mdx
@@ -67,6 +67,14 @@ Every public API should have a release tag specified at the top of it’s docume
 
 Every team should be collecting telemetry metrics on it’s public API usage. This will be important for knowing when it’s safe to make breaking changes. The Core team will be looking into ways to make this easier and an automatic part of registration (see [#112291](https://github.com/elastic/kibana/issues/112291)).
 
+### APM
+
+Kibana server and client are instrumented with APM node and APM RUM clients respectively, tracking serveral types of transactions by default, such as `page-load`, `request`, etc.
+You may introduce custom transactions. Please refer to the [APM documentation](https://www.elastic.co/guide/en/apm/get-started/current/index.html) and follow these guidelines when doing so:
+
+- Use dashed syntax for transaction types and names: `my-transaction-type` and `my-transaction-name`
+- [Refrain from adding too many custom labels](https://www.elastic.co/guide/en/apm/get-started/current/metadata.html)
+
 ### Documentation
 
 Every public API should be documented inside the [docs/api](https://github.com/elastic/kibana/tree/main/docs/api) folder in asciidoc (this content will eventually be migrated to mdx to support the new docs system). If a public REST API is undocumented, you should either document it, or make it internal.

--- a/src/core/public/apm_system.ts
+++ b/src/core/public/apm_system.ts
@@ -71,7 +71,7 @@ export class ApmSystem {
     start.application.currentAppId$.subscribe((appId) => {
       if (appId && this.apm) {
         this.closePageLoadTransaction();
-        this.apm.startTransaction(`/app/${appId}`, 'route-change', {
+        this.apm.startTransaction(appId, 'app-change', {
           managed: true,
           canReuse: true,
         });

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -128,7 +128,7 @@ export class Server {
 
   public async preboot() {
     this.log.debug('prebooting server');
-    const prebootTransaction = apm.startTransaction('server_preboot', 'kibana_platform');
+    const prebootTransaction = apm.startTransaction('server-preboot', 'kibana-platform');
 
     const environmentPreboot = await this.environment.preboot();
 
@@ -184,7 +184,7 @@ export class Server {
 
   public async setup() {
     this.log.debug('setting up server');
-    const setupTransaction = apm.startTransaction('server_setup', 'kibana_platform');
+    const setupTransaction = apm.startTransaction('server-setup', 'kibana-platform');
 
     const environmentSetup = this.environment.setup();
 
@@ -291,7 +291,7 @@ export class Server {
 
   public async start() {
     this.log.debug('starting server');
-    const startTransaction = apm.startTransaction('server_start', 'kibana_platform');
+    const startTransaction = apm.startTransaction('server-start', 'kibana-platform');
 
     const executionContextStart = this.executionContext.start();
     const elasticsearchStart = await this.elasticsearch.start();

--- a/x-pack/plugins/reporting/common/constants.ts
+++ b/x-pack/plugins/reporting/common/constants.ts
@@ -7,6 +7,8 @@
 
 export const PLUGIN_ID = 'reporting';
 
+export const REPORTING_TRANSACTION_TYPE = PLUGIN_ID;
+
 export const REPORTING_SYSTEM_INDEX = '.reporting';
 
 export const JOB_COMPLETION_NOTIFICATIONS_SESSION_KEY =

--- a/x-pack/plugins/reporting/server/export_types/common/generate_png.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/generate_png.ts
@@ -9,6 +9,7 @@ import apm from 'elastic-apm-node';
 import * as Rx from 'rxjs';
 import { finalize, map, tap } from 'rxjs/operators';
 import { LayoutTypes } from '../../../../screenshotting/common';
+import { REPORTING_TRANSACTION_TYPE } from '../../../common/constants';
 import { ReportingCore } from '../../';
 import { ScreenshotOptions } from '../../types';
 import { LevelLogger } from '../../lib';
@@ -18,8 +19,8 @@ export function generatePngObservable(
   logger: LevelLogger,
   options: ScreenshotOptions
 ): Rx.Observable<{ buffer: Buffer; warnings: string[] }> {
-  const apmTrans = apm.startTransaction('reporting generate_png', 'reporting');
-  const apmLayout = apmTrans?.startSpan('create_layout', 'setup');
+  const apmTrans = apm.startTransaction('generate-png', REPORTING_TRANSACTION_TYPE);
+  const apmLayout = apmTrans?.startSpan('create-layout', 'setup');
   if (!options.layout.dimensions) {
     throw new Error(`LayoutParams.Dimensions is undefined.`);
   }
@@ -40,7 +41,7 @@ export function generatePngObservable(
         apmTrans?.setLabel('memory', memory, false);
       });
       apmScreenshots?.end();
-      apmBuffer = apmTrans?.startSpan('get_buffer', 'output') ?? null;
+      apmBuffer = apmTrans?.startSpan('get-buffer', 'output') ?? null;
     }),
     map(({ results }) => ({
       buffer: results[0].screenshots[0].data,

--- a/x-pack/plugins/reporting/server/export_types/png/execute_job/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/png/execute_job/index.ts
@@ -8,7 +8,7 @@
 import apm from 'elastic-apm-node';
 import * as Rx from 'rxjs';
 import { finalize, map, mergeMap, takeUntil, tap } from 'rxjs/operators';
-import { PNG_JOB_TYPE } from '../../../../common/constants';
+import { PNG_JOB_TYPE, REPORTING_TRANSACTION_TYPE } from '../../../../common/constants';
 import { TaskRunResult } from '../../../lib/tasks';
 import { RunTaskFn, RunTaskFnFactory } from '../../../types';
 import {
@@ -26,8 +26,8 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPNG>> =
     const encryptionKey = config.get('encryptionKey');
 
     return function runTask(jobId, job, cancellationToken, stream) {
-      const apmTrans = apm.startTransaction('reporting execute_job png', 'reporting');
-      const apmGetAssets = apmTrans?.startSpan('get_assets', 'setup');
+      const apmTrans = apm.startTransaction('execute-job-png', REPORTING_TRANSACTION_TYPE);
+      const apmGetAssets = apmTrans?.startSpan('get-assets', 'setup');
       let apmGeneratePng: { end: () => void } | null | undefined;
 
       const jobLogger = parentLogger.clone([PNG_JOB_TYPE, 'execute', jobId]);
@@ -39,7 +39,7 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPNG>> =
           const [url] = getFullUrls(config, job);
 
           apmGetAssets?.end();
-          apmGeneratePng = apmTrans?.startSpan('generate_png_pipeline', 'execute');
+          apmGeneratePng = apmTrans?.startSpan('generate-png-pipeline', 'execute');
 
           return generatePngObservable(reporting, jobLogger, {
             conditionalHeaders,

--- a/x-pack/plugins/reporting/server/export_types/png_v2/execute_job.ts
+++ b/x-pack/plugins/reporting/server/export_types/png_v2/execute_job.ts
@@ -8,7 +8,7 @@
 import apm from 'elastic-apm-node';
 import * as Rx from 'rxjs';
 import { finalize, map, mergeMap, takeUntil, tap } from 'rxjs/operators';
-import { PNG_JOB_TYPE_V2 } from '../../../common/constants';
+import { PNG_JOB_TYPE_V2, REPORTING_TRANSACTION_TYPE } from '../../../common/constants';
 import { TaskRunResult } from '../../lib/tasks';
 import { RunTaskFn, RunTaskFnFactory } from '../../types';
 import {
@@ -26,8 +26,8 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPNGV2>> =
     const encryptionKey = config.get('encryptionKey');
 
     return function runTask(jobId, job, cancellationToken, stream) {
-      const apmTrans = apm.startTransaction('reporting execute_job pngV2', 'reporting');
-      const apmGetAssets = apmTrans?.startSpan('get_assets', 'setup');
+      const apmTrans = apm.startTransaction('execute-job-png-v2', REPORTING_TRANSACTION_TYPE);
+      const apmGetAssets = apmTrans?.startSpan('get-assets', 'setup');
       let apmGeneratePng: { end: () => void } | null | undefined;
 
       const jobLogger = parentLogger.clone([PNG_JOB_TYPE_V2, 'execute', jobId]);
@@ -40,7 +40,7 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPNGV2>> =
           const [locatorParams] = job.locatorParams;
 
           apmGetAssets?.end();
-          apmGeneratePng = apmTrans?.startSpan('generate_png_pipeline', 'execute');
+          apmGeneratePng = apmTrans?.startSpan('generate-png-pipeline', 'execute');
 
           return generatePngObservable(reporting, jobLogger, {
             conditionalHeaders,

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf/execute_job/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf/execute_job/index.ts
@@ -8,7 +8,7 @@
 import apm from 'elastic-apm-node';
 import * as Rx from 'rxjs';
 import { catchError, map, mergeMap, takeUntil, tap } from 'rxjs/operators';
-import { PDF_JOB_TYPE } from '../../../../common/constants';
+import { PDF_JOB_TYPE, REPORTING_TRANSACTION_TYPE } from '../../../../common/constants';
 import { TaskRunResult } from '../../../lib/tasks';
 import { RunTaskFn, RunTaskFnFactory } from '../../../types';
 import {
@@ -28,8 +28,8 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPDF>> =
 
     return async function runTask(jobId, job, cancellationToken, stream) {
       const jobLogger = parentLogger.clone([PDF_JOB_TYPE, 'execute-job', jobId]);
-      const apmTrans = apm.startTransaction('reporting execute_job pdf', 'reporting');
-      const apmGetAssets = apmTrans?.startSpan('get_assets', 'setup');
+      const apmTrans = apm.startTransaction('execute-job-pdf', REPORTING_TRANSACTION_TYPE);
+      const apmGetAssets = apmTrans?.startSpan('get-assets', 'setup');
       let apmGeneratePdf: { end: () => void } | null | undefined;
 
       const process$: Rx.Observable<TaskRunResult> = Rx.of(1).pipe(
@@ -45,7 +45,7 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPDF>> =
           const { browserTimezone, layout, title } = job;
           apmGetAssets?.end();
 
-          apmGeneratePdf = apmTrans?.startSpan('generate_pdf_pipeline', 'execute');
+          apmGeneratePdf = apmTrans?.startSpan('generate-pdf-pipeline', 'execute');
           return generatePdfObservable(
             reporting,
             jobLogger,

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf/lib/tracker.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf/lib/tracker.ts
@@ -6,6 +6,7 @@
  */
 
 import apm from 'elastic-apm-node';
+import { REPORTING_TRANSACTION_TYPE } from '../../../../common/constants';
 
 interface PdfTracker {
   setByteLength: (byteLength: number) => void;
@@ -32,7 +33,7 @@ interface ApmSpan {
 }
 
 export function getTracker(): PdfTracker {
-  const apmTrans = apm.startTransaction('reporting generate_pdf', 'reporting');
+  const apmTrans = apm.startTransaction('generate-pdf', REPORTING_TRANSACTION_TYPE);
 
   let apmScreenshots: ApmSpan | null = null;
   let apmSetup: ApmSpan | null = null;
@@ -42,37 +43,37 @@ export function getTracker(): PdfTracker {
 
   return {
     startScreenshots() {
-      apmScreenshots = apmTrans?.startSpan('screenshots_pipeline', SPANTYPE_SETUP) || null;
+      apmScreenshots = apmTrans?.startSpan('screenshots-pipeline', SPANTYPE_SETUP) || null;
     },
     endScreenshots() {
       if (apmScreenshots) apmScreenshots.end();
     },
     startSetup() {
-      apmSetup = apmTrans?.startSpan('setup_pdf', SPANTYPE_SETUP) || null;
+      apmSetup = apmTrans?.startSpan('setup-pdf', SPANTYPE_SETUP) || null;
     },
     endSetup() {
       if (apmSetup) apmSetup.end();
     },
     startAddImage() {
-      apmAddImage = apmTrans?.startSpan('add_pdf_image', SPANTYPE_OUTPUT) || null;
+      apmAddImage = apmTrans?.startSpan('add-pdf-image', SPANTYPE_OUTPUT) || null;
     },
     endAddImage() {
       if (apmAddImage) apmAddImage.end();
     },
     startCompile() {
-      apmCompilePdf = apmTrans?.startSpan('compile_pdf', SPANTYPE_OUTPUT) || null;
+      apmCompilePdf = apmTrans?.startSpan('compile-pdf', SPANTYPE_OUTPUT) || null;
     },
     endCompile() {
       if (apmCompilePdf) apmCompilePdf.end();
     },
     startGetBuffer() {
-      apmGetBuffer = apmTrans?.startSpan('get_buffer', SPANTYPE_OUTPUT) || null;
+      apmGetBuffer = apmTrans?.startSpan('get-buffer', SPANTYPE_OUTPUT) || null;
     },
     endGetBuffer() {
       if (apmGetBuffer) apmGetBuffer.end();
     },
     setByteLength(byteLength: number) {
-      apmTrans?.setLabel('byte_length', byteLength, false);
+      apmTrans?.setLabel('byte-length', byteLength, false);
     },
     setCpuUsage(cpu: number) {
       apmTrans?.setLabel('cpu', cpu, false);

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/execute_job.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/execute_job.ts
@@ -8,7 +8,7 @@
 import apm from 'elastic-apm-node';
 import * as Rx from 'rxjs';
 import { catchError, map, mergeMap, takeUntil, tap } from 'rxjs/operators';
-import { PDF_JOB_TYPE_V2 } from '../../../common/constants';
+import { PDF_JOB_TYPE_V2, REPORTING_TRANSACTION_TYPE } from '../../../common/constants';
 import { TaskRunResult } from '../../lib/tasks';
 import { RunTaskFn, RunTaskFnFactory } from '../../types';
 import {
@@ -27,8 +27,8 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPDFV2>> =
 
     return async function runTask(jobId, job, cancellationToken, stream) {
       const jobLogger = parentLogger.clone([PDF_JOB_TYPE_V2, 'execute-job', jobId]);
-      const apmTrans = apm.startTransaction('reporting execute_job pdf_v2', 'reporting');
-      const apmGetAssets = apmTrans?.startSpan('get_assets', 'setup');
+      const apmTrans = apm.startTransaction('execute-job-pdf-v2', REPORTING_TRANSACTION_TYPE);
+      const apmGetAssets = apmTrans?.startSpan('get-assets', 'setup');
       let apmGeneratePdf: { end: () => void } | null | undefined;
 
       const process$: Rx.Observable<TaskRunResult> = Rx.of(1).pipe(
@@ -42,7 +42,7 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPDFV2>> =
           const { browserTimezone, layout, title, locatorParams } = job;
           apmGetAssets?.end();
 
-          apmGeneratePdf = apmTrans?.startSpan('generate_pdf_pipeline', 'execute');
+          apmGeneratePdf = apmTrans?.startSpan('generate-pdf-pipeline', 'execute');
           return generatePdfObservable(
             reporting,
             jobLogger,

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/lib/tracker.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/lib/tracker.ts
@@ -6,6 +6,7 @@
  */
 
 import apm from 'elastic-apm-node';
+import { REPORTING_TRANSACTION_TYPE } from '../../../../common/constants';
 
 interface PdfTracker {
   setByteLength: (byteLength: number) => void;
@@ -32,7 +33,7 @@ interface ApmSpan {
 }
 
 export function getTracker(): PdfTracker {
-  const apmTrans = apm.startTransaction('reporting generate_pdf', 'reporting');
+  const apmTrans = apm.startTransaction('generate-pdf', REPORTING_TRANSACTION_TYPE);
 
   let apmScreenshots: ApmSpan | null = null;
   let apmSetup: ApmSpan | null = null;
@@ -42,37 +43,37 @@ export function getTracker(): PdfTracker {
 
   return {
     startScreenshots() {
-      apmScreenshots = apmTrans?.startSpan('screenshots_pipeline', SPANTYPE_SETUP) || null;
+      apmScreenshots = apmTrans?.startSpan('screenshots-pipeline', SPANTYPE_SETUP) || null;
     },
     endScreenshots() {
       if (apmScreenshots) apmScreenshots.end();
     },
     startSetup() {
-      apmSetup = apmTrans?.startSpan('setup_pdf', SPANTYPE_SETUP) || null;
+      apmSetup = apmTrans?.startSpan('setup-pdf', SPANTYPE_SETUP) || null;
     },
     endSetup() {
       if (apmSetup) apmSetup.end();
     },
     startAddImage() {
-      apmAddImage = apmTrans?.startSpan('add_pdf_image', SPANTYPE_OUTPUT) || null;
+      apmAddImage = apmTrans?.startSpan('add-pdf-image', SPANTYPE_OUTPUT) || null;
     },
     endAddImage() {
       if (apmAddImage) apmAddImage.end();
     },
     startCompile() {
-      apmCompilePdf = apmTrans?.startSpan('compile_pdf', SPANTYPE_OUTPUT) || null;
+      apmCompilePdf = apmTrans?.startSpan('compile-pdf', SPANTYPE_OUTPUT) || null;
     },
     endCompile() {
       if (apmCompilePdf) apmCompilePdf.end();
     },
     startGetBuffer() {
-      apmGetBuffer = apmTrans?.startSpan('get_buffer', SPANTYPE_OUTPUT) || null;
+      apmGetBuffer = apmTrans?.startSpan('get-buffer', SPANTYPE_OUTPUT) || null;
     },
     endGetBuffer() {
       if (apmGetBuffer) apmGetBuffer.end();
     },
     setByteLength(byteLength: number) {
-      apmTrans?.setLabel('byte_length', byteLength, false);
+      apmTrans?.setLabel('byte-length', byteLength, false);
     },
     setCpuUsage(cpu: number) {
       apmTrans?.setLabel('cpu', cpu, false);

--- a/x-pack/plugins/task_manager/server/queries/task_claiming.test.ts
+++ b/x-pack/plugins/task_manager/server/queries/task_claiming.test.ts
@@ -17,10 +17,16 @@ import { asOk, asErr } from '../lib/result_type';
 import { TaskTypeDictionary } from '../task_type_dictionary';
 import type { MustNotCondition } from '../queries/query_clauses';
 import { mockLogger } from '../test_utils';
-import { TaskClaiming, OwnershipClaimingOpts, TaskClaimingOpts } from './task_claiming';
+import {
+  TaskClaiming,
+  OwnershipClaimingOpts,
+  TaskClaimingOpts,
+  TASK_MANAGER_MARK_AS_CLAIMED,
+} from './task_claiming';
 import { Observable } from 'rxjs';
 import { taskStoreMock } from '../task_store.mock';
 import apm from 'elastic-apm-node';
+import { TASK_MANAGER_TRANSACTION_TYPE } from '../task_running';
 
 const taskManagerLogger = mockLogger();
 
@@ -190,8 +196,8 @@ describe('TaskClaiming', () => {
       const results = await getAllAsPromise(taskClaiming.claimAvailableTasks(claimingOpts));
 
       expect(apm.startTransaction).toHaveBeenCalledWith(
-        'markAvailableTasksAsClaimed',
-        'taskManager markAvailableTasksAsClaimed'
+        TASK_MANAGER_MARK_AS_CLAIMED,
+        TASK_MANAGER_TRANSACTION_TYPE
       );
       expect(mockApmTrans.end).toHaveBeenCalledWith('success');
 
@@ -250,8 +256,8 @@ describe('TaskClaiming', () => {
       ).rejects.toMatchInlineSnapshot(`[Error: Oh no]`);
 
       expect(apm.startTransaction).toHaveBeenCalledWith(
-        'markAvailableTasksAsClaimed',
-        'taskManager markAvailableTasksAsClaimed'
+        TASK_MANAGER_MARK_AS_CLAIMED,
+        TASK_MANAGER_TRANSACTION_TYPE
       );
       expect(mockApmTrans.end).toHaveBeenCalledWith('failure');
     });

--- a/x-pack/plugins/task_manager/server/queries/task_claiming.ts
+++ b/x-pack/plugins/task_manager/server/queries/task_claiming.ts
@@ -52,6 +52,7 @@ import {
   SearchOpts,
 } from '../task_store';
 import { FillPoolResult } from '../lib/fill_pool';
+import { TASK_MANAGER_TRANSACTION_TYPE } from '../task_running';
 
 export interface TaskClaimingOpts {
   logger: Logger;
@@ -105,6 +106,8 @@ interface TaskClaimingBatch<Concurrency extends BatchConcurrency, TaskType> {
 }
 type UnlimitedBatch = TaskClaimingBatch<BatchConcurrency.Unlimited, Set<string>>;
 type LimitedBatch = TaskClaimingBatch<BatchConcurrency.Limited, string>;
+
+export const TASK_MANAGER_MARK_AS_CLAIMED = 'mark-available-tasks-as-claimed';
 
 export class TaskClaiming {
   public readonly errors$ = new Subject<Error>();
@@ -412,9 +415,10 @@ export class TaskClaiming {
     );
 
     const apmTrans = apm.startTransaction(
-      'markAvailableTasksAsClaimed',
-      `taskManager markAvailableTasksAsClaimed`
+      TASK_MANAGER_MARK_AS_CLAIMED,
+      TASK_MANAGER_TRANSACTION_TYPE
     );
+
     try {
       const result = await this.taskStore.updateByQuery(
         {

--- a/x-pack/plugins/task_manager/server/task_running/ephemeral_task_runner.ts
+++ b/x-pack/plugins/task_manager/server/task_running/ephemeral_task_runner.ts
@@ -47,6 +47,9 @@ import {
   TaskRunner,
   TaskRunningInstance,
   TaskRunResult,
+  TASK_MANAGER_RUN_TRANSACTION_TYPE,
+  TASK_MANAGER_TRANSACTION_TYPE,
+  TASK_MANAGER_TRANSACTION_TYPE_MARK_AS_RUNNING,
 } from './task_runner';
 
 type Opts = {
@@ -188,9 +191,11 @@ export class EphemeralTaskManagerRunner implements TaskRunner {
       );
     }
     this.logger.debug(`Running ephemeral task ${this}`);
-    const apmTrans = apm.startTransaction(this.taskType, 'taskManager ephemeral run', {
+    const apmTrans = apm.startTransaction(this.taskType, TASK_MANAGER_RUN_TRANSACTION_TYPE, {
       childOf: this.instance.task.traceparent,
     });
+    apmTrans?.addLabels({ ephemeral: true });
+
     const modifiedContext = await this.beforeRun({
       taskInstance: asConcreteInstance(this.instance.task),
     });
@@ -243,7 +248,11 @@ export class EphemeralTaskManagerRunner implements TaskRunner {
       );
     }
 
-    const apmTrans = apm.startTransaction('taskManager', 'taskManager markTaskAsRunning');
+    const apmTrans = apm.startTransaction(
+      TASK_MANAGER_TRANSACTION_TYPE_MARK_AS_RUNNING,
+      TASK_MANAGER_TRANSACTION_TYPE
+    );
+    apmTrans?.addLabels({ entityId: this.taskType });
 
     const now = new Date();
     try {

--- a/x-pack/plugins/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/plugins/task_manager/server/task_running/task_runner.test.ts
@@ -26,6 +26,11 @@ import { throwUnrecoverableError } from './errors';
 import { taskStoreMock } from '../task_store.mock';
 import apm from 'elastic-apm-node';
 import { executionContextServiceMock } from '../../../../../src/core/server/mocks';
+import {
+  TASK_MANAGER_RUN_TRANSACTION_TYPE,
+  TASK_MANAGER_TRANSACTION_TYPE,
+  TASK_MANAGER_TRANSACTION_TYPE_MARK_AS_RUNNING,
+} from './task_runner';
 
 const executionContext = executionContextServiceMock.createSetupContract();
 const minutesFromNow = (mins: number): Date => secondsFromNow(mins * 60);
@@ -43,6 +48,8 @@ describe('TaskManagerRunner', () => {
   const readyToRunStageSetup = (opts: TestOpts) => testOpts(TaskRunningStage.READY_TO_RUN, opts);
   const mockApmTrans = {
     end: jest.fn(),
+    addLabels: jest.fn(),
+    setLabel: jest.fn(),
   };
 
   describe('Pending Stage', () => {
@@ -71,8 +78,8 @@ describe('TaskManagerRunner', () => {
       });
       await runner.markTaskAsRunning();
       expect(apm.startTransaction).toHaveBeenCalledWith(
-        'taskManager',
-        'taskManager markTaskAsRunning'
+        TASK_MANAGER_TRANSACTION_TYPE_MARK_AS_RUNNING,
+        TASK_MANAGER_TRANSACTION_TYPE
       );
       expect(mockApmTrans.end).toHaveBeenCalledWith('success');
     });
@@ -100,8 +107,8 @@ describe('TaskManagerRunner', () => {
       );
       // await runner.markTaskAsRunning();
       expect(apm.startTransaction).toHaveBeenCalledWith(
-        'taskManager',
-        'taskManager markTaskAsRunning'
+        TASK_MANAGER_TRANSACTION_TYPE_MARK_AS_RUNNING,
+        TASK_MANAGER_TRANSACTION_TYPE
       );
       expect(mockApmTrans.end).toHaveBeenCalledWith('failure');
     });
@@ -689,7 +696,7 @@ describe('TaskManagerRunner', () => {
         },
       });
       await runner.run();
-      expect(apm.startTransaction).toHaveBeenCalledWith('bar', 'taskManager run', {
+      expect(apm.startTransaction).toHaveBeenCalledWith('bar', TASK_MANAGER_RUN_TRANSACTION_TYPE, {
         childOf: 'apmTraceparent',
       });
       expect(mockApmTrans.end).toHaveBeenCalledWith('success');
@@ -712,7 +719,7 @@ describe('TaskManagerRunner', () => {
         },
       });
       await runner.run();
-      expect(apm.startTransaction).toHaveBeenCalledWith('bar', 'taskManager run', {
+      expect(apm.startTransaction).toHaveBeenCalledWith('bar', TASK_MANAGER_RUN_TRANSACTION_TYPE, {
         childOf: 'apmTraceparent',
       });
       expect(mockApmTrans.end).toHaveBeenCalledWith('failure');

--- a/x-pack/plugins/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/plugins/task_manager/server/task_running/task_runner.ts
@@ -59,6 +59,10 @@ import { isUnrecoverableError } from './errors';
 const defaultBackoffPerFailure = 5 * 60 * 1000;
 export const EMPTY_RUN_RESULT: SuccessfulRunResult = { state: {} };
 
+export const TASK_MANAGER_RUN_TRANSACTION_TYPE = 'task-run';
+export const TASK_MANAGER_TRANSACTION_TYPE = 'task-manager';
+export const TASK_MANAGER_TRANSACTION_TYPE_MARK_AS_RUNNING = 'mark-task-as-running';
+
 export interface TaskRunner {
   isExpired: boolean;
   expiration: Date;
@@ -256,7 +260,7 @@ export class TaskManagerRunner implements TaskRunner {
     }
     this.logger.debug(`Running task ${this}`);
 
-    const apmTrans = apm.startTransaction(this.taskType, 'taskManager run', {
+    const apmTrans = apm.startTransaction(this.taskType, TASK_MANAGER_RUN_TRANSACTION_TYPE, {
       childOf: this.instance.task.traceparent,
     });
 
@@ -313,7 +317,11 @@ export class TaskManagerRunner implements TaskRunner {
       );
     }
 
-    const apmTrans = apm.startTransaction('taskManager', 'taskManager markTaskAsRunning');
+    const apmTrans = apm.startTransaction(
+      TASK_MANAGER_TRANSACTION_TYPE_MARK_AS_RUNNING,
+      TASK_MANAGER_TRANSACTION_TYPE
+    );
+    apmTrans?.addLabels({ entityId: this.taskType });
 
     const now = new Date();
     try {


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Normalize apm transaction names (#119740)