### PR TITLE
[Upgrade Assistant] Fix ml model upgrade status check

### DIFF
--- a/x-pack/plugins/upgrade_assistant/server/routes/ml_snapshots.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/ml_snapshots.ts
@@ -248,7 +248,7 @@ export function registerMlSnapshotRoutes({ router, lib: { handleEsError } }: Rou
               });
             } else if (upgradeStatus.state === 'failed') {
               return response.customError({
-                statusCode: 404,
+                statusCode: 500,
                 body: {
                   message:
                     "The upgrade that was started for this model snapshot doesn't exist anymore.",

--- a/x-pack/plugins/upgrade_assistant/server/routes/ml_snapshots.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/ml_snapshots.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
 import { ResponseError } from '@elastic/elasticsearch/lib/errors';
 import { ApiResponse } from '@elastic/elasticsearch';
 import { schema } from '@kbn/config-schema';
 import { IScopedClusterClient, SavedObjectsClientContract } from 'kibana/server';
+
 import { API_BASE_PATH } from '../../common/constants';
 import { MlOperation, ML_UPGRADE_OP_TYPE } from '../../common/types';
 import { versionCheckHandlerWrapper } from '../lib/es_version_precheck';
@@ -250,8 +252,13 @@ export function registerMlSnapshotRoutes({ router, lib: { handleEsError } }: Rou
               return response.customError({
                 statusCode: 500,
                 body: {
-                  message:
-                    "The upgrade that was started for this model snapshot doesn't exist anymore.",
+                  message: i18n.translate(
+                    'xpack.upgradeAssistant.ml_snapshots.modelSnapshotUpgradeFailed',
+                    {
+                      defaultMessage:
+                        "The upgrade that was started for this model snapshot doesn't exist anymore.",
+                    }
+                  ),
                 },
               });
             } else {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/121313

### Summary
This PR uses a newly implemented api from ES (https://github.com/elastic/elasticsearch/pull/81641) in order to have a more accurate representation of the model snapshot upgrade. Nothing should be noticeable different from before, except that we now pull the status from a different api endpoint.

**How to test**
1. Start elasticsearch with `yarn es snapshot --license=trial -E path.data=./data-6.8.20` and kibana with `yarn start`. You can use this snapshot [data-6.8.20.zip](https://github.com/elastic/kibana/files/7745963/data-6.8.20.zip) I created that contains a ML deprecation that requires upgrading.
2. Navigate to `Stack Management` -> `Upgrade Assistant` -> `ES deprecations`
3. Verify that upgrading the ML deprecation in the table follows the usual flow.

Note: when this PR is merged, I'll create a new one for getting this change into main and 8.x