### PR TITLE
Fix savedObjectsTagging FTR test flakiness

### DIFF
--- a/x-pack/test/api_integration/services/usage_api.ts
+++ b/x-pack/test/api_integration/services/usage_api.ts
@@ -40,6 +40,7 @@ export function UsageAPIProvider({ getService }: FtrProviderContext) {
      */
     async getTelemetryStats(payload: {
       unencrypted?: boolean;
+      refreshCache?: boolean;
     }): Promise<ReturnType<TelemetryCollectionManagerPlugin['getStats']>> {
       const { body } = await supertest
         .post('/api/telemetry/v2/clusters/_stats')

--- a/x-pack/test/api_integration/services/usage_api.ts
+++ b/x-pack/test/api_integration/services/usage_api.ts
@@ -45,7 +45,7 @@ export function UsageAPIProvider({ getService }: FtrProviderContext) {
       const { body } = await supertest
         .post('/api/telemetry/v2/clusters/_stats')
         .set('kbn-xsrf', 'xxx')
-        .send(payload)
+        .send({ refreshCache: true, ...payload })
         .expect(200);
       return body;
     },

--- a/x-pack/test/saved_object_tagging/api_integration/tagging_api/apis/usage_collection.ts
+++ b/x-pack/test/saved_object_tagging/api_integration/tagging_api/apis/usage_collection.ts
@@ -42,6 +42,7 @@ export default function ({ getService }: FtrProviderContext) {
     it('collects the expected data', async () => {
       const [{ stats: telemetryStats }] = (await usageAPI.getTelemetryStats({
         unencrypted: true,
+        refreshCache: true,
       })) as any;
 
       const taggingStats = telemetryStats.stack_stats.kibana.plugins.saved_objects_tagging;


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/121492 by refreshing cache when retrieving the SOT telemetry data we assert against

