### PR TITLE
[Exploratory View] Allow parsing time ranges when the user hasn't yet chosen report definitions

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_time_range.test.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_time_range.test.tsx
@@ -12,7 +12,10 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useExpViewTimeRange } from './use_time_range';
 import { ReportTypes } from '../configurations/constants';
 import { createKbnUrlStateStorage } from '../../../../../../../../src/plugins/kibana_utils/public';
-import { TRANSACTION_DURATION } from '../configurations/constants/elasticsearch_fieldnames';
+import {
+  TRANSACTION_DURATION,
+  METRIC_SYSTEM_MEMORY_USAGE,
+} from '../configurations/constants/elasticsearch_fieldnames';
 
 const mockSingleSeries = [
   {
@@ -73,6 +76,31 @@ describe('useExpViewTimeRange', function () {
 
   it('should return expected result when there are multiple distribution series with relative dates', async function () {
     await storage.set(allSeriesKey, mockMultipleSeries);
+    await storage.set(reportTypeKey, ReportTypes.DISTRIBUTION);
+
+    const { result } = renderHook(() => useExpViewTimeRange(), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current).toEqual({
+      from: 'now-30m',
+      to: 'now',
+    });
+  });
+
+  it("should correctly parse dates when last series doesn't have a report definition", async function () {
+    const mockSeriesWithoutDefinitions = [
+      ...mockSingleSeries,
+      {
+        dataType: 'mobile',
+        name: 'mobile-series-1',
+        reportDefinitions: undefined,
+        selectedMetricField: METRIC_SYSTEM_MEMORY_USAGE,
+        time: { from: 'now-30m', to: 'now' },
+      },
+    ];
+
+    await storage.set(allSeriesKey, mockSeriesWithoutDefinitions);
     await storage.set(reportTypeKey, ReportTypes.DISTRIBUTION);
 
     const { result } = renderHook(() => useExpViewTimeRange(), {

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_time_range.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_time_range.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { isEmpty } from 'lodash';
 import { useMemo } from 'react';
 import {
   AllSeries,
@@ -31,12 +30,7 @@ export const combineTimeRanges = (
   }
 
   allSeries.forEach((series) => {
-    if (
-      series.dataType &&
-      series.selectedMetricField &&
-      !isEmpty(series.reportDefinitions) &&
-      series.time
-    ) {
+    if (series.dataType && series.selectedMetricField && series.time) {
       const seriesFrom = parseRelativeDate(series.time.from)!;
       const seriesTo = parseRelativeDate(series.time.to, { roundUp: true })!;
 


### PR DESCRIPTION
## Summary

This PR addresses a page crash which would happen when the user would try to "Apply Changes" in the exploratory view without having chosen time-ranges yet.

Fixes https://github.com/elastic/kibana/issues/121653.
Fixes https://github.com/elastic/kibana/issues/119989.

The problem here was that we were starting with empty `to` and `from` fields and we'd skip any metrics for which the user hadn't yet defined "Report Definitions". Because of that, the hook would return `undefined` values when dates were parsed as relative dates, and thus we couldn't transform them to an `ISO` format [here](https://github.com/elastic/kibana/blob/2150e74224ac4f81de99dafd3244053664d0dc9b/x-pack/plugins/observability/public/components/shared/exploratory_view/header/add_to_case_action.tsx#L57), as the `toISOString` function would be called on `undefined`.

**The functionality working after this PR:**

![working_no_details](https://user-images.githubusercontent.com/6868147/146811485-305d8305-9bfd-4d30-9fc8-ba30c61a263a.gif)


## How to test this PR

### Locally (Performance Distribution report type as per https://github.com/elastic/kibana/issues/121653)

1. Download these two files and place them in the same folder, let's say `/tmp/example-ios-data`. They contain data to help you investigate and reproduce this bug.
    [data.json.gz](https://github.com/elastic/kibana/files/7620470/data.json.gz)
    [mappings.json.txt](https://github.com/elastic/kibana/files/7620473/mappings.json.txt)
2. Start the Elastic Stack using `elastic-package up` (or whichever other way you prefer, but this is the easiest)
3. Start a new instance of `Kibana` at the tip of `8.0` or `main` (in my case, I used `SHA 8406b9aa88a53a3cbfb86f838583421d0d0476da` for `8.0`)
4. Load the files you downloaded from step 1 into `/tmp/example-ios-data` using:
    ```
    $ node scripts/es_archiver.js load /tmp/example-ios-data --es-url="http://elastic:changeme@localhost:9200" --kibana-url="http://elastic:changeme@localhost:5602" --use-create
    $ node scripts/es_archiver.js load /tmp/example-ios-data --es-url="http://elastic:changeme@localhost:9200" --kibana-url="http://elastic:changeme@localhost:5602" --docs-only
    ```
4. Confirm that the documents have been loaded into the appropriate indices
   ```
   $ curl -u elastic:changeme -X GET "http://localhost:9200/apm-7.16.0-*/_count?q=*" -H 'Content-Type: application/json'
   {"count":721, ... }
   ```
5. Open the exploratory view, select the `Performance distribution` report type, then, select "Mobile Experience" as the "Data Type", then "Memory Usage" as the report metric, and click "apply" without adding any filters (the bug in the GIF below should _not_ appear).
    ![mobile_data_no_filters_bug](https://user-images.githubusercontent.com/6868147/146923424-fcf9cecb-3f51-4948-bb12-43e73fa15ead.gif)


### Locally (Core Web Vitals report type as per Fixes https://github.com/elastic/kibana/issues/119989)

1. Create a cluster configured for CCS against `edge` using [the `oblt-cli` tool](https://github.com/elastic/observability-test-environments/tree/master/tools/oblt_cli).
2. Checkout this branch and use the configurations sent to you on Slack so that your local Kibana version connects to the cluster configured for CCS you created in step 1
3. Log into ES using the credentials you were sent
4. Go to Uptime > Explore data and select the "Core Web Vitals" report type. Then, select RUM as the data type and LCP as the report metric.
5. Click to "Apply changes" without filling any further filters.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)) ➡️  This whole view doesn't change on mobile so I would say this is out of scope for this PR, which is a fix.
- [X] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

* There is a risk that this if condition was used for a particular reason which I couldn't find. I did try to test with a bunch of different report types and look through the code to see how `reportDefinitions` is used, but I couldn't find a case where we would have problems if it wasn't defined and we were still setting time ranges. **I'd appreciate input from others on whether I missed anything here, as I'm not as familiar with the codebase yet.**
    Perhaps @dominiqueclarke would be the best person to review this PR given she reviewed the PR in which Shahzad initially added this hook.
* **Can anyone advise on whether I should also backport this PR for 7.16.2 through that label or should I use a different one?**

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release Note

Fixes an issue where the exploratory view would crash on some types of reports if no filters were chosen for a series.