### PR TITLE
[Workplace Search] Remove credentials callout for non-custom sources

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -548,7 +548,6 @@ export const Overview: React.FC = () => {
                 {!indexPermissions && isOrganization && (
                   <EuiFlexItem>{documentPermissionsDisabled}</EuiFlexItem>
                 )}
-                {indexPermissions && <EuiFlexItem>{credentials}</EuiFlexItem>}
               </>
             )}
             {custom && (


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/2248

## Summary

This PR fixes a bug that was rendering a source identifier and links to custom source ingestion documentation for non-custom sources.

**Before**
![credentials-bug](https://user-images.githubusercontent.com/1869731/146834041-16c04612-ca78-42b8-8685-db8d59eb0f0d.png)

**After**
![credentials-fixed](https://user-images.githubusercontent.com/1869731/146834054-c132c3cc-2111-402c-9cb9-bf3dae8b3a8d.png)

For context, here is where the source identifier is supposed to be rendered (and still does) for a custom source:
![custom](https://user-images.githubusercontent.com/1869731/146834730-8ce63ad9-6d1d-47eb-9793-fe6f536734aa.png)
