### PR TITLE
[data views] remove _timestamp field overrides

### DIFF
--- a/src/plugins/data_views/server/fetcher/lib/field_capabilities/overrides.ts
+++ b/src/plugins/data_views/server/fetcher/lib/field_capabilities/overrides.ts
@@ -14,11 +14,6 @@ const OVERRIDES: Record<string, Partial<FieldDescriptor>> = {
   _index: { type: 'string' },
   _type: { type: 'string' },
   _id: { type: 'string' },
-  _timestamp: {
-    type: 'date',
-    searchable: true,
-    aggregatable: true,
-  },
   _score: {
     type: 'number',
     searchable: false,


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/pull/111238 - allowed fields that start with an underscore (aside form meta fields) to be part of a data view but there was existing code that overrode the type of any field named `_timestamp` which is fine if its a date field but breaks most searches if its anything else.

`_timestamp` field was removed from ES quite a while ago so we can simply stop overriding its type - https://github.com/elastic/elasticsearch/pull/18980

closes: https://github.com/elastic/kibana/issues/121710

Release notes: bug fix

Allow fields named `_timestamp` to be non-date types