### PR TITLE
[ML] Add model_prune_window to job summary API expected response

### DIFF
--- a/x-pack/test/api_integration/apis/ml/jobs/jobs_summary.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/jobs_summary.ts
@@ -134,6 +134,7 @@ export default ({ getService }: FtrProviderContext) => {
                   },
                 ],
                 influencers: [],
+                model_prune_window: '30d',
               },
             },
           },
@@ -196,8 +197,7 @@ export default ({ getService }: FtrProviderContext) => {
     return groupIds.sort();
   }
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/121686
-  describe.skip('jobs_summary', function () {
+  describe('jobs_summary', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await ml.testResources.setKibanaTimeZoneToUTC();


### PR DESCRIPTION
## Summary

For new anomaly detection jobs, when the analysis config field `model_prune_window` is not set, a default value of 30 days is now supplied - see https://github.com/elastic/elasticsearch/pull/81377.

This corrects the expected response for the jobs_summary API integration test to include the default `model_prune_window` of `30d`

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

Fixes #121686 
