### PR TITLE
[7.17] [Fleet] Do not udpate or rollover replicated datastream (#121235)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -9,7 +9,6 @@ import { readFileSync } from 'fs';
 import path from 'path';
 
 import { safeLoad } from 'js-yaml';
-import { loggerMock } from '@kbn/logging/mocks';
 import { elasticsearchServiceMock } from 'src/core/server/mocks';
 
 import { createAppContextStartContractMock } from '../../../../mocks';
@@ -815,8 +814,7 @@ describe('EPM template', () => {
           ],
         },
       } as any);
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
+      await updateCurrentWriteIndices(esClient, [
         {
           templateName: 'test',
           indexTemplate: {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -9,10 +9,11 @@ import { readFileSync } from 'fs';
 import path from 'path';
 
 import { safeLoad } from 'js-yaml';
+import { loggerMock } from '@kbn/logging/mocks';
+import { elasticsearchServiceMock } from 'src/core/server/mocks';
 
 import { createAppContextStartContractMock } from '../../../../mocks';
 import { appContextService } from '../../../../services';
-
 import type { RegistryDataStream } from '../../../../types';
 import { processFields } from '../../fields/field';
 import type { Field } from '../../fields/field';
@@ -22,6 +23,7 @@ import {
   getTemplate,
   getTemplatePriority,
   generateTemplateIndexPattern,
+  updateCurrentWriteIndices,
 } from './template';
 
 const FLEET_COMPONENT_TEMPLATE = '.fleet_component_template-1';
@@ -800,5 +802,35 @@ describe('EPM template', () => {
 
     expect(templateIndexPattern).toEqual(templateIndexPatternDatasetIsPrefixTrue);
     expect(templatePriority).toEqual(templatePriorityDatasetIsPrefixTrue);
+  });
+
+  describe('updateCurrentWriteIndices', () => {
+    it('update non replicated datastream', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.indices.getDataStream.mockResolvedValue({
+        body: {
+          data_streams: [
+            { name: 'test-non-replicated' },
+            { name: 'test-replicated', replicated: true },
+          ],
+        },
+      } as any);
+      const logger = loggerMock.create();
+      await updateCurrentWriteIndices(esClient, logger, [
+        {
+          templateName: 'test',
+          indexTemplate: {
+            template: {
+              settings: { index: {} },
+              mappings: { properties: {} },
+            },
+          } as any,
+        },
+      ]);
+
+      const putMappingsCall = esClient.indices.putMapping.mock.calls.map(([{ index }]) => index);
+      expect(putMappingsCall).toHaveLength(1);
+      expect(putMappingsCall[0]).toBe('test-non-replicated');
+    });
   });
 });

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -31,6 +31,7 @@ export interface IndexTemplateMapping {
 }
 export interface CurrentDataStream {
   dataStreamName: string;
+  replicated: boolean;
   indexTemplate: IndexTemplate;
 }
 const DEFAULT_SCALING_FACTOR = 1000;
@@ -418,7 +419,13 @@ export const updateCurrentWriteIndices = async (
   if (!templates.length) return;
 
   const allIndices = await queryDataStreamsFromTemplates(esClient, templates);
-  if (!allIndices.length) return;
+  const allUpdatablesIndices = allIndices.filter((indice) => {
+    if (indice.replicated) {
+      return false;
+    }
+    return true;
+  });
+  if (!allUpdatablesIndices.length) return;
   return updateAllDataStreams(allIndices, esClient);
 };
 
@@ -443,10 +450,12 @@ const getDataStreams = async (
 ): Promise<CurrentDataStream[] | undefined> => {
   const { templateName, indexTemplate } = template;
   const { body } = await esClient.indices.getDataStream({ name: `${templateName}-*` });
+
   const dataStreams = body.data_streams;
   if (!dataStreams.length) return;
   return dataStreams.map((dataStream: any) => ({
     dataStreamName: dataStream.name,
+    replicated: dataStream.replicated,
     indexTemplate,
   }));
 };
@@ -478,7 +487,6 @@ const updateExistingDataStream = async ({
   // to skip updating and assume the value in the index mapping is correct
   delete mappings.properties.stream;
   delete mappings.properties.data_stream;
-
   // try to update the mappings first
   try {
     await esClient.indices.putMapping({

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -426,7 +426,7 @@ export const updateCurrentWriteIndices = async (
     return true;
   });
   if (!allUpdatablesIndices.length) return;
-  return updateAllDataStreams(allIndices, esClient);
+  return updateAllDataStreams(allUpdatablesIndices, esClient);
 };
 
 function isCurrentDataStream(item: CurrentDataStream[] | undefined): item is CurrentDataStream[] {
@@ -452,6 +452,7 @@ const getDataStreams = async (
   const { body } = await esClient.indices.getDataStream({ name: `${templateName}-*` });
 
   const dataStreams = body.data_streams;
+
   if (!dataStreams.length) return;
   return dataStreams.map((dataStream: any) => ({
     dataStreamName: dataStream.name,


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [Fleet] Do not udpate or rollover replicated datastream (#121235)