### PR TITLE
[8.0] Allow wrapping of text for PDF generation. (#121360)

### DIFF
--- a/x-pack/plugins/reporting/server/export_types/common/pdf/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/pdf/index.ts
@@ -76,7 +76,7 @@ export class PdfMaker {
         text: title,
         style: 'heading',
         font: getFont(title),
-        noWrap: true,
+        noWrap: false,
       });
     }
 
@@ -85,7 +85,7 @@ export class PdfMaker {
         text: description,
         style: 'subheading',
         font: getFont(description),
-        noWrap: true,
+        noWrap: false,
       });
     }
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Allow wrapping of text for PDF generation. (#121360)