### PR TITLE
chore(NA): use internal pkg_npm on @kbn/spec-to-console

### DIFF
--- a/packages/kbn-spec-to-console/BUILD.bazel
+++ b/packages/kbn-spec-to-console/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//src/dev/bazel:index.bzl", "pkg_npm")
 
 PKG_BASE_NAME = "kbn-spec-to-console"
 PKG_REQUIRE_NAME = "@kbn/spec-to-console"
@@ -27,14 +28,14 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md",
 ]
 
-DEPS = []
+RUNTIME_DEPS = []
 
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES + [
     ":srcs",
   ],
-  deps = DEPS,
+  deps = RUNTIME_DEPS,
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This PR is a step forward on #104519

It changes the package build to use the internal macro for pkg_npm