### PR TITLE
[data views] Remove data view intervalName

### DIFF
--- a/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
+++ b/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
@@ -775,7 +775,6 @@ Object {
     },
   },
   "id": "test-pattern",
-  "intervalName": undefined,
   "runtimeFieldMap": Object {
     "runtime_field": Object {
       "script": Object {

--- a/src/plugins/data_views/common/data_views/__snapshots__/data_views.test.ts.snap
+++ b/src/plugins/data_views/common/data_views/__snapshots__/data_views.test.ts.snap
@@ -40,7 +40,6 @@ Object {
   },
   "fields": Object {},
   "id": "id",
-  "intervalName": undefined,
   "runtimeFieldMap": Object {
     "aRuntimeField": Object {
       "script": Object {

--- a/src/plugins/data_views/common/data_views/data_view.ts
+++ b/src/plugins/data_views/common/data_views/data_view.ts
@@ -36,7 +36,6 @@ interface SavedObjectBody {
   fieldAttrs?: string;
   title?: string;
   timeFieldName?: string;
-  intervalName?: string;
   fields?: string;
   sourceFilters?: string;
   fieldFormatMap?: string;
@@ -62,12 +61,6 @@ export class DataView implements IIndexPattern {
   public typeMeta?: TypeMeta;
   public fields: IIndexPatternFieldList & { toSpec: () => DataViewFieldMap };
   public timeFieldName: string | undefined;
-  /**
-   * @deprecated Used by time range index patterns
-   * @removeBy 8.1
-   *
-   */
-  public intervalName: string | undefined;
   /**
    * Type is used to identify rollup index patterns
    */
@@ -117,7 +110,6 @@ export class DataView implements IIndexPattern {
     this.type = spec.type;
     this.typeMeta = spec.typeMeta;
     this.fieldAttrs = spec.fieldAttrs || {};
-    this.intervalName = spec.intervalName;
     this.allowNoIndex = spec.allowNoIndex || false;
     this.runtimeFieldMap = spec.runtimeFieldMap || {};
   }
@@ -217,7 +209,6 @@ export class DataView implements IIndexPattern {
       fieldFormats: this.fieldFormatMap,
       runtimeFieldMap: this.runtimeFieldMap,
       fieldAttrs: this.fieldAttrs,
-      intervalName: this.intervalName,
       allowNoIndex: this.allowNoIndex,
     };
   }
@@ -331,7 +322,6 @@ export class DataView implements IIndexPattern {
       fieldAttrs: fieldAttrs ? JSON.stringify(fieldAttrs) : undefined,
       title: this.title,
       timeFieldName: this.timeFieldName,
-      intervalName: this.intervalName,
       sourceFilters: this.sourceFilters ? JSON.stringify(this.sourceFilters) : undefined,
       fields: JSON.stringify(this.fields?.filter((field) => field.scripted) ?? []),
       fieldFormatMap,

--- a/src/plugins/data_views/common/data_views/data_views.ts
+++ b/src/plugins/data_views/common/data_views/data_views.ts
@@ -383,7 +383,6 @@ export class DataViewsService {
       attributes: {
         title,
         timeFieldName,
-        intervalName,
         fields,
         sourceFilters,
         fieldFormatMap,
@@ -408,7 +407,6 @@ export class DataViewsService {
       id,
       version,
       title,
-      intervalName,
       timeFieldName,
       sourceFilters: parsedSourceFilters,
       fields: this.fieldArrayToMap(parsedFields, parsedFieldAttrs),

--- a/src/plugins/data_views/common/types.ts
+++ b/src/plugins/data_views/common/types.ts
@@ -59,7 +59,6 @@ export interface DataViewAttributes {
   type?: string;
   typeMeta?: string;
   timeFieldName?: string;
-  intervalName?: string;
   sourceFilters?: string;
   fieldFormatMap?: string;
   fieldAttrs?: string;
@@ -249,11 +248,6 @@ export interface DataViewSpec {
    */
   version?: string;
   title?: string;
-  /**
-   * @deprecated
-   * Deprecated. Was used by time range based index patterns
-   */
-  intervalName?: string;
   timeFieldName?: string;
   sourceFilters?: SourceFilter[];
   fields?: DataViewFieldMap;

--- a/src/plugins/data_views/server/routes/update_index_pattern.ts
+++ b/src/plugins/data_views/server/routes/update_index_pattern.ts
@@ -21,7 +21,6 @@ const indexPatternUpdateSchema = schema.object({
   type: schema.maybe(schema.string()),
   typeMeta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
   timeFieldName: schema.maybe(schema.string()),
-  intervalName: schema.maybe(schema.string()),
   sourceFilters: schema.maybe(
     schema.arrayOf(
       schema.object({
@@ -81,7 +80,6 @@ export const registerUpdateIndexPatternRoute = (
           index_pattern: {
             title,
             timeFieldName,
-            intervalName,
             sourceFilters,
             fieldFormats,
             type,
@@ -102,11 +100,6 @@ export const registerUpdateIndexPatternRoute = (
         if (timeFieldName !== undefined && timeFieldName !== indexPattern.timeFieldName) {
           changeCount++;
           indexPattern.timeFieldName = timeFieldName;
-        }
-
-        if (intervalName !== undefined && intervalName !== indexPattern.intervalName) {
-          changeCount++;
-          indexPattern.intervalName = intervalName;
         }
 
         if (sourceFilters !== undefined) {

--- a/src/plugins/discover/public/application/main/components/sidebar/__snapshots__/discover_index_pattern_management.test.tsx.snap
+++ b/src/plugins/discover/public/application/main/components/sidebar/__snapshots__/discover_index_pattern_management.test.tsx.snap
@@ -619,7 +619,6 @@ exports[`Discover IndexPattern Management renders correctly 1`] = `
       "getFieldAttrs": [Function],
       "getOriginalSavedObjectBody": [Function],
       "id": "logstash-*",
-      "intervalName": undefined,
       "metaFields": Array [
         "_id",
         "_type",

--- a/test/api_integration/apis/index_patterns/index_pattern_crud/update_index_pattern/main.ts
+++ b/test/api_integration/apis/index_patterns/index_pattern_crud/update_index_pattern/main.ts
@@ -63,30 +63,6 @@ export default function ({ getService }: FtrProviderContext) {
       expect(response3.body.index_pattern.timeFieldName).to.be('timeFieldName2');
     });
 
-    it('can update index_pattern intervalName', async () => {
-      const title = `foo-${Date.now()}-${Math.random()}*`;
-      const response1 = await supertest.post('/api/index_patterns/index_pattern').send({
-        index_pattern: {
-          title,
-        },
-      });
-
-      expect(response1.body.index_pattern.intervalName).to.be(undefined);
-
-      const id = response1.body.index_pattern.id;
-      const response2 = await supertest.post('/api/index_patterns/index_pattern/' + id).send({
-        index_pattern: {
-          intervalName: 'intervalName2',
-        },
-      });
-
-      expect(response2.body.index_pattern.intervalName).to.be('intervalName2');
-
-      const response3 = await supertest.get('/api/index_patterns/index_pattern/' + id);
-
-      expect(response3.body.index_pattern.intervalName).to.be('intervalName2');
-    });
-
     it('can update index_pattern sourceFilters', async () => {
       const title = `foo-${Date.now()}-${Math.random()}*`;
       const response1 = await supertest.post('/api/index_patterns/index_pattern').send({

--- a/test/api_integration/apis/index_patterns/index_pattern_crud/update_index_pattern/main.ts
+++ b/test/api_integration/apis/index_patterns/index_pattern_crud/update_index_pattern/main.ts
@@ -238,26 +238,22 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       expect(response1.body.index_pattern.timeFieldName).to.be('timeFieldName1');
-      expect(response1.body.index_pattern.intervalName).to.be(undefined);
       expect(response1.body.index_pattern.typeMeta.foo).to.be('bar');
 
       const id = response1.body.index_pattern.id;
       const response2 = await supertest.post('/api/index_patterns/index_pattern/' + id).send({
         index_pattern: {
           timeFieldName: 'timeFieldName2',
-          intervalName: 'intervalName2',
           typeMeta: { baz: 'qux' },
         },
       });
 
       expect(response2.body.index_pattern.timeFieldName).to.be('timeFieldName2');
-      expect(response2.body.index_pattern.intervalName).to.be('intervalName2');
       expect(response2.body.index_pattern.typeMeta.baz).to.be('qux');
 
       const response3 = await supertest.get('/api/index_patterns/index_pattern/' + id);
 
       expect(response3.body.index_pattern.timeFieldName).to.be('timeFieldName2');
-      expect(response3.body.index_pattern.intervalName).to.be('intervalName2');
       expect(response3.body.index_pattern.typeMeta.baz).to.be('qux');
     });
 


### PR DESCRIPTION
## Summary

Removes `dataView.intervalName` which was used by time based index patterns which were deprecated in 6.x and removed in 7.x