### PR TITLE
[data views] remove addScriptedField

### DIFF
--- a/src/plugins/data_views/common/data_views/data_view.test.ts
+++ b/src/plugins/data_views/common/data_views/data_view.test.ts
@@ -10,7 +10,7 @@ import { map, last } from 'lodash';
 
 import { IndexPattern } from './data_view';
 
-import { CharacterNotAllowedInField, DuplicateField } from '../../../kibana_utils/common';
+import { CharacterNotAllowedInField } from '../../../kibana_utils/common';
 
 import { IndexPatternField } from '../fields';
 

--- a/src/plugins/data_views/common/data_views/data_view.test.ts
+++ b/src/plugins/data_views/common/data_views/data_view.test.ts
@@ -77,9 +77,6 @@ describe('IndexPattern', () => {
     test('should have expected properties', () => {
       expect(indexPattern).toHaveProperty('getScriptedFields');
       expect(indexPattern).toHaveProperty('getNonScriptedFields');
-      expect(indexPattern).toHaveProperty('addScriptedField');
-      expect(indexPattern).toHaveProperty('removeScriptedField');
-      expect(indexPattern).toHaveProperty('addScriptedField');
       expect(indexPattern).toHaveProperty('removeScriptedField');
       expect(indexPattern).toHaveProperty('addRuntimeField');
       expect(indexPattern).toHaveProperty('removeRuntimeField');
@@ -173,11 +170,17 @@ describe('IndexPattern', () => {
         type: 'boolean',
       };
 
-      await indexPattern.addScriptedField(
-        scriptedField.name,
-        scriptedField.script,
-        scriptedField.type
-      );
+      indexPattern.fields.add({
+        name: scriptedField.name,
+        script: scriptedField.script,
+        type: scriptedField.type,
+        scripted: true,
+        lang: 'painless',
+        aggregatable: true,
+        searchable: true,
+        count: 0,
+        readFromDocValues: false,
+      });
 
       const scriptedFields = indexPattern.getScriptedFields();
       expect(scriptedFields).toHaveLength(oldCount + 1);

--- a/src/plugins/data_views/common/data_views/data_view.test.ts
+++ b/src/plugins/data_views/common/data_views/data_view.test.ts
@@ -199,25 +199,6 @@ describe('IndexPattern', () => {
       expect(indexPattern.getScriptedFields().length).toEqual(oldCount - 1);
       expect(indexPattern.fields.getByName(scriptedField.name)).toEqual(undefined);
     });
-
-    test('should not allow duplicate names', async () => {
-      const scriptedFields = indexPattern.getScriptedFields();
-      const scriptedField = last(scriptedFields) as any;
-      expect.assertions(1);
-      try {
-        await indexPattern.addScriptedField(scriptedField.name, "'new script'", 'string');
-      } catch (e) {
-        expect(e).toBeInstanceOf(DuplicateField);
-      }
-    });
-
-    test('should not allow scripted field with * in name', async () => {
-      try {
-        await indexPattern.addScriptedField('test*123', "'new script'", 'string');
-      } catch (e) {
-        expect(e).toBeInstanceOf(CharacterNotAllowedInField);
-      }
-    });
   });
 
   describe('setFieldFormat and deleteFieldFormaat', () => {

--- a/src/plugins/data_views/common/data_views/data_view.ts
+++ b/src/plugins/data_views/common/data_views/data_view.ts
@@ -13,7 +13,7 @@ import { castEsToKbnFieldTypeName, ES_FIELD_TYPES, KBN_FIELD_TYPES } from '@kbn/
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { FieldAttrs, FieldAttrSet, DataViewAttributes } from '..';
 import type { RuntimeField } from '../types';
-import { CharacterNotAllowedInField, DuplicateField } from '../../../kibana_utils/common';
+import { CharacterNotAllowedInField } from '../../../kibana_utils/common';
 
 import { IIndexPattern, IFieldType } from '../../common';
 import { DataViewField, IIndexPatternFieldList, fieldList } from '../fields';
@@ -229,40 +229,6 @@ export class DataView implements IIndexPattern {
     return {
       excludes: (this.sourceFilters && this.sourceFilters.map((filter) => filter.value)) || [],
     };
-  }
-
-  /**
-   * Add scripted field to field list
-   *
-   * @param name field name
-   * @param script script code
-   * @param fieldType
-   * @param lang
-   * @deprecated use runtime field instead
-   */
-  async addScriptedField(name: string, script: string, fieldType: string = 'string') {
-    const scriptedFields = this.getScriptedFields();
-    const names = _.map(scriptedFields, 'name');
-
-    if (name.includes('*')) {
-      throw new CharacterNotAllowedInField('*', name);
-    }
-
-    if (_.includes(names, name)) {
-      throw new DuplicateField(name);
-    }
-
-    this.fields.add({
-      name,
-      script,
-      type: fieldType,
-      scripted: true,
-      lang: 'painless',
-      aggregatable: true,
-      searchable: true,
-      count: 0,
-      readFromDocValues: false,
-    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Scripted fields are deprecated and replaced by runtime fields. Scripted fields can still be added via `dataView.fields.add` which is used by `dataViewManagement`. The `addScriptedField` convenience method can be removed.