### PR TITLE
[8.0] [UA] Remove deprecation logs created by Elastic products (#121174)

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -282,6 +282,7 @@ export class DocLinksService {
           migrationApiDeprecation: `${ELASTICSEARCH_DOCS}migration-api-deprecation.html`,
           nodeRoles: `${ELASTICSEARCH_DOCS}modules-node.html#node-roles`,
           releaseHighlights: `${ELASTICSEARCH_DOCS}release-highlights.html`,
+          version8ReleaseHighlights: `${ELASTIC_WEBSITE_URL}guide/en/elastic-stack/8.0/elastic-stack-highlights.html`,
           remoteClusters: `${ELASTICSEARCH_DOCS}remote-clusters.html`,
           remoteClustersProxy: `${ELASTICSEARCH_DOCS}remote-clusters.html#proxy-mode`,
           remoteClusersProxySettings: `${ELASTICSEARCH_DOCS}remote-clusters-settings.html#remote-cluster-proxy-settings`,

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/app_context.mock.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/app_context.mock.ts
@@ -22,10 +22,29 @@ import { breadcrumbService } from '../../../public/application/lib/breadcrumbs';
 import { dataPluginMock } from '../../../../../../src/plugins/data/public/mocks';
 import { cloudMock } from '../../../../../../x-pack/plugins/cloud/public/mocks';
 
+const data = dataPluginMock.createStartContract();
+const dataViews = { ...data.dataViews };
+const findDataView = (id: string) =>
+  Promise.resolve([
+    {
+      id,
+      title: id,
+      getFieldByName: jest.fn((name: string) => ({
+        name,
+      })),
+    },
+  ]);
+
 const servicesMock = {
   api: apiService,
   breadcrumbs: breadcrumbService,
-  data: dataPluginMock.createStartContract(),
+  data: {
+    ...data,
+    dataViews: {
+      ...dataViews,
+      find: findDataView,
+    },
+  },
 };
 
 // We'll mock these values to avoid testing the locators themselves.

--- a/x-pack/plugins/upgrade_assistant/common/constants.ts
+++ b/x-pack/plugins/upgrade_assistant/common/constants.ts
@@ -41,3 +41,23 @@ export const CLUSTER_UPGRADE_STATUS_POLL_INTERVAL_MS = 45000;
 export const CLOUD_BACKUP_STATUS_POLL_INTERVAL_MS = 60000;
 export const DEPRECATION_LOGS_COUNT_POLL_INTERVAL_MS = 15000;
 export const SYSTEM_INDICES_MIGRATION_POLL_INTERVAL_MS = 15000;
+
+/**
+ * List of Elastic apps that potentially can generate deprecation logs.
+ * We want to filter those out for our users so they only see deprecation logs
+ * that _they_ are generating.
+ */
+export const APPS_WITH_DEPRECATION_LOGS = [
+  'kibana',
+  'cloud',
+  'logstash',
+  'beats',
+  'fleet',
+  'ml',
+  'security',
+  'observability',
+  'enterprise-search',
+];
+
+// The field that will indicate which elastic product generated the deprecation log
+export const DEPRECATION_LOGS_ORIGIN_FIELD = 'elasticsearch.elastic_product_origin';

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/external_links.test.ts
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/external_links.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getDeprecationIndexPatternId } from './external_links';
+import { getDeprecationDataView } from './external_links';
 
 import { DEPRECATION_LOGS_INDEX_PATTERN } from '../../../../../common/constants';
 import { dataPluginMock, Start } from '../../../../../../../../src/plugins/data/public/mocks';
@@ -17,14 +17,14 @@ describe('External Links', () => {
     dataService = dataPluginMock.createStartContract();
   });
 
-  describe('getDeprecationIndexPatternId', () => {
-    it('creates new index pattern if doesnt exist', async () => {
+  describe('getDeprecationDataView', () => {
+    it('creates new data view if doesnt exist', async () => {
       dataService.dataViews.find = jest.fn().mockResolvedValue([]);
       dataService.dataViews.createAndSave = jest.fn().mockResolvedValue({ id: '123-456' });
 
-      const indexPatternId = await getDeprecationIndexPatternId(dataService);
+      const dataViewId = (await getDeprecationDataView(dataService)).id;
 
-      expect(indexPatternId).toBe('123-456');
+      expect(dataViewId).toBe('123-456');
       // prettier-ignore
       expect(dataService.dataViews.createAndSave).toHaveBeenCalledWith({
         title: DEPRECATION_LOGS_INDEX_PATTERN,
@@ -32,7 +32,7 @@ describe('External Links', () => {
       }, false, true);
     });
 
-    it('uses existing index pattern if it already exists', async () => {
+    it('uses existing data view if it already exists', async () => {
       dataService.dataViews.find = jest.fn().mockResolvedValue([
         {
           id: '123-456',
@@ -40,9 +40,9 @@ describe('External Links', () => {
         },
       ]);
 
-      const indexPatternId = await getDeprecationIndexPatternId(dataService);
+      const dataViewId = await (await getDeprecationDataView(dataService)).id;
 
-      expect(indexPatternId).toBe('123-456');
+      expect(dataViewId).toBe('123-456');
       expect(dataService.dataViews.find).toHaveBeenCalledWith(DEPRECATION_LOGS_INDEX_PATTERN);
     });
   });

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/overview.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/overview.tsx
@@ -88,7 +88,7 @@ export const Overview = withRouter(({ history }: RouteComponentProps) => {
           ]}
         >
           <EuiText data-test-subj="whatsNewLink">
-            <EuiLink href={docLinks.links.elasticsearch.releaseHighlights} target="_blank">
+            <EuiLink href={docLinks.links.elasticsearch.version8ReleaseHighlights} target="_blank">
               <FormattedMessage
                 id="xpack.upgradeAssistant.overview.whatsNewLink"
                 defaultMessage="What's new in 8.x?"

--- a/x-pack/test/api_integration/apis/upgrade_assistant/es_deprecation_logs.helpers.ts
+++ b/x-pack/test/api_integration/apis/upgrade_assistant/es_deprecation_logs.helpers.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Chance from 'chance';
+
+import {
+  DEPRECATION_LOGS_INDEX,
+  DEPRECATION_LOGS_ORIGIN_FIELD,
+} from '../../../../plugins/upgrade_assistant/common/constants';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+const chance = new Chance();
+const CHARS_POOL = 'abcdefghijklmnopqrstuvwxyz';
+const getRandomString = () => `${chance.string({ pool: CHARS_POOL })}-${Date.now()}`;
+
+const deprecationMock = {
+  'event.dataset': 'deprecation.elasticsearch',
+  '@timestamp': '2021-12-06T16:28:11,104Z',
+  'log.level': 'CRITICAL',
+  'log.logger':
+    'org.elasticsearch.deprecation.rest.action.admin.indices.RestGetIndexTemplateAction',
+  'elasticsearch.cluster.name': 'es-test-cluster',
+  'elasticsearch.cluster.uuid': 'PBE1syg4ToKCA0DcD2nKEw',
+  'elasticsearch.node.id': '_0gaVTs5TIO_JWuFl9URJA',
+  'elasticsearch.node.name': 'node-01',
+  message:
+    '[types removal] Specifying include_type_name in get index template requests is deprecated.',
+  'data_stream.type': 'logs',
+  'data_stream.dataset': 'deprecation.elasticsearch',
+  'data_stream.namespace': 'default',
+  'ecs.version': '1.7',
+  'elasticsearch.event.category': 'types',
+  'event.code': 'get_index_template_include_type_name',
+  'elasticsearch.http.request.x_opaque_id': 'd17e37e2-d41f-49cc-8186-35bcdcd99770',
+};
+
+export const initHelpers = (getService: FtrProviderContext['getService']) => {
+  const es = getService('es');
+
+  const createDeprecationLog = async (isElasticProduct = false) => {
+    const id = getRandomString();
+
+    const body = {
+      ...deprecationMock,
+    };
+
+    if (isElasticProduct) {
+      (body as any)[DEPRECATION_LOGS_ORIGIN_FIELD] = 'kibana';
+    }
+
+    await es.index({
+      id,
+      index: DEPRECATION_LOGS_INDEX,
+      op_type: 'create',
+      refresh: true,
+      body,
+    });
+
+    return id;
+  };
+
+  const deleteDeprecationLogs = async (docIds: string[]) => {
+    return await es.deleteByQuery({
+      index: DEPRECATION_LOGS_INDEX,
+      refresh: true,
+      body: {
+        query: {
+          ids: { values: docIds },
+        },
+      },
+    });
+  };
+
+  return {
+    createDeprecationLog,
+    deleteDeprecationLogs,
+  };
+};

--- a/x-pack/test/api_integration/apis/upgrade_assistant/es_deprecation_logs.ts
+++ b/x-pack/test/api_integration/apis/upgrade_assistant/es_deprecation_logs.ts
@@ -38,7 +38,7 @@ export default function ({ getService }: FtrProviderContext) {
               index: DEPRECATION_LOGS_INDEX,
               size: 10000,
             })
-          ).body.hits.hits;
+          ).hits.hits;
 
           const nonElasticProductDeprecations = allDeprecations.filter(
             (deprecation) =>

--- a/x-pack/test/api_integration/apis/upgrade_assistant/es_deprecation_logs.ts
+++ b/x-pack/test/api_integration/apis/upgrade_assistant/es_deprecation_logs.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import expect from '@kbn/expect';
+
+import {
+  DEPRECATION_LOGS_INDEX,
+  DEPRECATION_LOGS_ORIGIN_FIELD,
+  APPS_WITH_DEPRECATION_LOGS,
+  API_BASE_PATH,
+} from '../../../../plugins/upgrade_assistant/common/constants';
+import { FtrProviderContext } from '../../ftr_provider_context';
+import { initHelpers } from './es_deprecation_logs.helpers';
+
+export default function ({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const supertest = getService('supertest');
+
+  const { createDeprecationLog, deleteDeprecationLogs } = initHelpers(getService);
+
+  describe('Elasticsearch deprecation logs', () => {
+    describe('GET /api/upgrade_assistant/deprecation_logging', () => {
+      describe('/count', () => {
+        it('should filter out the deprecation from Elastic products', async () => {
+          // We add a custom deprecation to make sure our filter is working
+          // and make sure that the count of deprecation without filter is greater
+          // than the total of deprecations
+          const IS_ELASTIC_PRODUCT = true;
+          const doc1 = await createDeprecationLog();
+          const doc2 = await createDeprecationLog(IS_ELASTIC_PRODUCT);
+          const checkpoint = '2000-01-01T00:00:00.000Z';
+
+          const allDeprecations = (
+            await es.search({
+              index: DEPRECATION_LOGS_INDEX,
+              size: 10000,
+            })
+          ).body.hits.hits;
+
+          const nonElasticProductDeprecations = allDeprecations.filter(
+            (deprecation) =>
+              !APPS_WITH_DEPRECATION_LOGS.includes(
+                (deprecation._source as any)[DEPRECATION_LOGS_ORIGIN_FIELD]
+              )
+          );
+
+          const { body: apiRequestResponse } = await supertest
+            .get(`${API_BASE_PATH}/deprecation_logging/count`)
+            .query({
+              from: checkpoint,
+            })
+            .set('kbn-xsrf', 'xxx')
+            .expect(200);
+
+          expect(nonElasticProductDeprecations.length).be.below(allDeprecations.length);
+          expect(apiRequestResponse.count).be(nonElasticProductDeprecations.length);
+
+          await deleteDeprecationLogs([doc1, doc2]);
+        });
+      });
+    });
+  });
+}

--- a/x-pack/test/api_integration/apis/upgrade_assistant/index.ts
+++ b/x-pack/test/api_integration/apis/upgrade_assistant/index.ts
@@ -13,5 +13,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./cloud_backup_status'));
     loadTestFile(require.resolve('./privileges'));
     loadTestFile(require.resolve('./es_deprecations'));
+    loadTestFile(require.resolve('./es_deprecation_logs'));
   });
 }


### PR DESCRIPTION
Backports the following commits to 8.0 (https://github.com/elastic/kibana/pull/121174):

* [UA] Filter out elastic products deprecation logs (https://github.com/elastic/kibana/pull/121174/commits/99f442048584e3df7fdf62fbea077f40038dc34a)