### PR TITLE
[Fleet] Fix updateCurrentWriteIndices to work with datastream with prefix

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -839,6 +839,33 @@ describe('EPM template', () => {
   });
 
   describe('updateCurrentWriteIndices', () => {
+    it('update all the index matching, index template index pattern', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.indices.getDataStream.mockResolvedValue({
+        body: {
+          data_streams: [{ name: 'test.prefix1-default' }],
+        },
+      } as any);
+      const logger = loggerMock.create();
+      await updateCurrentWriteIndices(esClient, logger, [
+        {
+          templateName: 'test',
+          indexTemplate: {
+            index_patterns: ['test.*-*'],
+            template: {
+              settings: { index: {} },
+              mappings: { properties: {} },
+            },
+          } as any,
+        },
+      ]);
+      expect(esClient.indices.getDataStream).toBeCalledWith({
+        name: 'test.*-*',
+      });
+      const putMappingsCall = esClient.indices.putMapping.mock.calls.map(([{ index }]) => index);
+      expect(putMappingsCall).toHaveLength(1);
+      expect(putMappingsCall[0]).toBe('test.prefix1-default');
+    });
     it('update non replicated datastream', async () => {
       const esClient = elasticsearchServiceMock.createElasticsearchClient();
       esClient.indices.getDataStream.mockResolvedValue({
@@ -854,6 +881,7 @@ describe('EPM template', () => {
         {
           templateName: 'test',
           indexTemplate: {
+            index_patterns: ['test-*'],
             template: {
               settings: { index: {} },
               mappings: { properties: {} },

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -468,8 +468,11 @@ const getDataStreams = async (
   esClient: ElasticsearchClient,
   template: IndexTemplateEntry
 ): Promise<CurrentDataStream[] | undefined> => {
-  const { templateName, indexTemplate } = template;
-  const { body } = await esClient.indices.getDataStream({ name: `${templateName}-*` });
+  const { indexTemplate } = template;
+
+  const { body } = await esClient.indices.getDataStream({
+    name: indexTemplate.index_patterns.join(','),
+  });
 
   const dataStreams = body.data_streams;
   if (!dataStreams.length) return;


### PR DESCRIPTION
## Description 

Resolve #121873

We allow datastream to have dataset as prefix in this case we generate an indexPattern looking like this `indexName.*-*`. In this scenario our code to update existing indices does not work.

That PR fix that by using the indextTemplate index pattern instead of an hardcoded value.

I tried to look at other place where we will not use the correct index pattern but found nothing.
