### PR TITLE
[Uptime] Avoid duplicate requests when loading monitor steps

### DIFF
--- a/x-pack/plugins/uptime/public/components/synthetics/check_steps/use_check_steps.ts
+++ b/x-pack/plugins/uptime/public/components/synthetics/check_steps/use_check_steps.ts
@@ -5,25 +5,34 @@
  * 2.0.
  */
 
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { FETCH_STATUS, useFetcher } from '../../../../../observability/public';
-import { fetchJourneySteps } from '../../../state/api/journey';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppState } from '../../../state';
+import { getJourneySteps } from '../../../state/actions/journey';
 import { JourneyState } from '../../../state/reducers/journey';
 
 export const useCheckSteps = (): JourneyState => {
   const { checkGroupId } = useParams<{ checkGroupId: string }>();
+  const dispatch = useDispatch();
 
-  const { data, status, error } = useFetcher(() => {
-    return fetchJourneySteps({
-      checkGroup: checkGroupId,
-    });
-  }, [checkGroupId]);
+  useEffect(() => {
+    dispatch(
+      getJourneySteps({
+        checkGroup: checkGroupId,
+      })
+    );
+  }, [checkGroupId, dispatch]);
+
+  const checkGroup = useSelector((state: AppState) => {
+    return state.journeys[checkGroupId];
+  });
 
   return {
-    error,
     checkGroup: checkGroupId,
-    steps: data?.steps ?? [],
-    details: data?.details,
-    loading: status === FETCH_STATUS.LOADING || status === FETCH_STATUS.PENDING,
+    steps: checkGroup?.steps ?? [],
+    details: checkGroup?.details,
+    loading: checkGroup?.loading ?? false,
+    error: checkGroup?.error,
   };
 };

--- a/x-pack/plugins/uptime/public/lib/helper/helper_with_redux.tsx
+++ b/x-pack/plugins/uptime/public/lib/helper/helper_with_redux.tsx
@@ -6,19 +6,37 @@
  */
 
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
-import { AppState } from '../../state';
+import type { Store } from 'redux';
+import { createStore as createReduxStore, applyMiddleware } from 'redux';
 
-export const MountWithReduxProvider: React.FC<{ state?: AppState }> = ({ children, state }) => (
-  <ReduxProvider
-    store={{
-      dispatch: jest.fn(),
-      getState: jest.fn().mockReturnValue(state || { selectedFilters: null }),
-      subscribe: jest.fn(),
-      replaceReducer: jest.fn(),
-      [Symbol.observable]: jest.fn(),
-    }}
-  >
-    {children}
-  </ReduxProvider>
-);
+import { Provider as ReduxProvider } from 'react-redux';
+import createSagaMiddleware from 'redux-saga';
+
+import { AppState } from '../../state';
+import { rootReducer } from '../../state/reducers';
+import { rootEffect } from '../../state/effects';
+
+const createRealStore = (): Store => {
+  const sagaMW = createSagaMiddleware();
+  const store = createReduxStore(rootReducer, applyMiddleware(sagaMW));
+  sagaMW.run(rootEffect);
+  return store;
+};
+
+export const MountWithReduxProvider: React.FC<{ state?: AppState; useRealStore?: boolean }> = ({
+  children,
+  state,
+  useRealStore,
+}) => {
+  const store = useRealStore
+    ? createRealStore()
+    : {
+        dispatch: jest.fn(),
+        getState: jest.fn().mockReturnValue(state || { selectedFilters: null }),
+        subscribe: jest.fn(),
+        replaceReducer: jest.fn(),
+        [Symbol.observable]: jest.fn(),
+      };
+
+  return <ReduxProvider store={store}>{children}</ReduxProvider>;
+};

--- a/x-pack/plugins/uptime/public/lib/helper/rtl_helpers.tsx
+++ b/x-pack/plugins/uptime/public/lib/helper/rtl_helpers.tsx
@@ -14,7 +14,7 @@ import {
   RenderOptions,
   Nullish,
 } from '@testing-library/react';
-import { Router } from 'react-router-dom';
+import { Router, Route } from 'react-router-dom';
 import { merge } from 'lodash';
 import { createMemoryHistory, History } from 'history';
 import { CoreStart } from 'kibana/public';
@@ -57,6 +57,7 @@ interface MockKibanaProviderProps<ExtraCore> extends KibanaProviderOptions<Extra
 
 interface MockRouterProps<ExtraCore> extends MockKibanaProviderProps<ExtraCore> {
   history?: History;
+  path?: string;
 }
 
 type Url =
@@ -71,6 +72,7 @@ interface RenderRouterOptions<ExtraCore> extends KibanaProviderOptions<ExtraCore
   renderOptions?: Omit<RenderOptions, 'queries'>;
   state?: Partial<AppState> | DeepPartial<AppState>;
   url?: Url;
+  path?: string;
 }
 
 function getSetting<T = any>(key: string): T {
@@ -121,6 +123,9 @@ const mockCore: () => Partial<CoreStart> = () => {
       get: getSetting,
       get$: setSetting$,
     },
+    usageCollection: {
+      reportUiCounter: () => {},
+    },
     triggersActionsUi: triggersActionsUiMock.createStart(),
     storage: createMockStore(),
     data: dataPluginMock.createStartContract(),
@@ -163,13 +168,14 @@ export function MockKibanaProvider<ExtraCore>({
 export function MockRouter<ExtraCore>({
   children,
   core,
+  path,
   history = createMemoryHistory(),
   kibanaProps,
 }: MockRouterProps<ExtraCore>) {
   return (
     <Router history={history}>
       <MockKibanaProvider core={core} kibanaProps={kibanaProps}>
-        {children}
+        <Route path={path}>{children}</Route>
       </MockKibanaProvider>
     </Router>
   );
@@ -180,10 +186,13 @@ export const MockRedux = ({
   state,
   history = createMemoryHistory(),
   children,
+  path,
 }: {
   state: Partial<AppState>;
   history?: History;
   children: React.ReactNode;
+  path?: string;
+  useRealStore?: boolean;
 }) => {
   const testState: AppState = {
     ...mockState,
@@ -192,7 +201,9 @@ export const MockRedux = ({
 
   return (
     <MountWithReduxProvider state={testState}>
-      <MockRouter history={history}>{children}</MockRouter>
+      <MockRouter path={path} history={history}>
+        {children}
+      </MockRouter>
     </MountWithReduxProvider>
   );
 };
@@ -207,7 +218,9 @@ export function render<ExtraCore>(
     renderOptions,
     state,
     url,
-  }: RenderRouterOptions<ExtraCore> = {}
+    path,
+    useRealStore,
+  }: RenderRouterOptions<ExtraCore> & { useRealStore?: boolean } = {}
 ) {
   const testState: AppState = merge({}, mockState, state);
 
@@ -217,8 +230,8 @@ export function render<ExtraCore>(
 
   return {
     ...reactTestLibRender(
-      <MountWithReduxProvider state={testState}>
-        <MockRouter history={history} kibanaProps={kibanaProps} core={core}>
+      <MountWithReduxProvider state={testState} useRealStore={useRealStore}>
+        <MockRouter path={path} history={history} kibanaProps={kibanaProps} core={core}>
           {ui}
         </MockRouter>
       </MountWithReduxProvider>,

--- a/x-pack/plugins/uptime/public/state/effects/journey.test.ts
+++ b/x-pack/plugins/uptime/public/state/effects/journey.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Store } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { createStore as createReduxStore, applyMiddleware } from 'redux';
+
+import { rootReducer } from '../reducers';
+import { fetchJourneyStepsEffect } from '../effects/journey';
+
+import { getJourneySteps } from '../actions/journey';
+
+import { fetchJourneySteps } from '../api/journey';
+
+jest.mock('../api/journey', () => ({
+  fetchJourneySteps: jest.fn(),
+}));
+
+const createTestStore = (): Store => {
+  const sagaMW = createSagaMiddleware();
+  const store = createReduxStore(rootReducer, applyMiddleware(sagaMW));
+  sagaMW.run(fetchJourneyStepsEffect);
+  return store;
+};
+
+describe('journey effect', () => {
+  afterEach(() => jest.resetAllMocks());
+  afterAll(() => jest.restoreAllMocks());
+
+  it('fetches only once when dispatching multiple getJourneySteps for a particular ID', () => {
+    (fetchJourneySteps as jest.Mock).mockResolvedValue({
+      checkGroup: 'saga-test',
+      details: {
+        journey: {
+          monitor: { name: 'test-name' },
+        },
+      },
+    });
+
+    const store = createTestStore();
+
+    // Actually dispatched
+    store.dispatch(getJourneySteps({ checkGroup: 'saga-test' }));
+
+    // Skipped
+    store.dispatch(getJourneySteps({ checkGroup: 'saga-test' }));
+
+    expect(fetchJourneySteps).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches multiple times for different IDs', () => {
+    (fetchJourneySteps as jest.Mock).mockResolvedValue({
+      checkGroup: 'saga-test',
+      details: {
+        journey: {
+          monitor: { name: 'test-name' },
+        },
+      },
+    });
+
+    const store = createTestStore();
+
+    // Actually dispatched
+    store.dispatch(getJourneySteps({ checkGroup: 'saga-test' }));
+
+    // Skipped
+    store.dispatch(getJourneySteps({ checkGroup: 'saga-test' }));
+
+    // Actually dispatched because it has a different ID
+    store.dispatch(getJourneySteps({ checkGroup: 'saga-test-second' }));
+
+    expect(fetchJourneySteps).toHaveBeenCalledTimes(2);
+  });
+
+  it('can re-fetch after an ID is fetched', async () => {
+    (fetchJourneySteps as jest.Mock).mockResolvedValue({
+      checkGroup: 'saga-test',
+      details: {
+        journey: {
+          monitor: { name: 'test-name' },
+        },
+      },
+    });
+
+    const store = createTestStore();
+
+    const waitForStateUpdate = (): Promise<void> =>
+      new Promise((resolve) => store.subscribe(() => resolve()));
+
+    // Actually dispatched
+    store.dispatch(getJourneySteps({ checkGroup: 'saga-test' }));
+
+    await waitForStateUpdate();
+
+    // Also dispatched given its initial request is not in-flight anymore
+    store.dispatch(getJourneySteps({ checkGroup: 'saga-test' }));
+
+    expect(fetchJourneySteps).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/120219.

This PR avoids duplicate requests on the route where we load and show monitor steps.

This bug happened because each of the components on the header, main page, and side, were fetching steps themselves. Given that each of these components were making their own requests, we ended up with plenty of unnecessary requests to the server, not just one.

⚠️ After speaking to @shahzad31 and reading @justinkambic's comment, **I've updated this PR** so that it doesn't use a context anymore. Instead, it uses an `effect` which is capable of keeping track of in-flight requests. That effect will _not_ try to fetch a journey for which we're currently fetching data.

Please notice that the majority of changes in this PR has been on testing files because:
* Testing the component by passing a state means the test will be too different from runtime, and thus it could not fail in situations we would need it to. Therefore, **I've updated our testing helpers to allow for implementers to use a real Redux store when appropriate**, as I've done here.
* I've added specific tests which create a Redux store and use the effect for fetching journey to ensure that it has the correct behaviour. I've seen we don't have many tests like this, and it's a pattern I like because it adds a lot of safety guarantees to our code given it resembles runtime quite closely.

## How to test this PR

1. Create a new browser monitor
2. Wait for the monitor to run at least once
3. Open `Uptime > Monitors` and access that monitor's details.
4. Open your dev tools and filter four `/journey`, so you can see the requests made
5. Click on a monitor instance and see it only fetches data for that check-group once

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release Note

Fixes a bug where the monitor step details would send more requests than necessary.