### PR TITLE
[Cases] Show only english choices in the ServiceNow connectors

### DIFF
--- a/x-pack/plugins/actions/server/builtin_action_types/servicenow/service.test.ts
+++ b/x-pack/plugins/actions/server/builtin_action_types/servicenow/service.test.ts
@@ -701,7 +701,7 @@ describe('ServiceNow service', () => {
         axios,
         logger,
         configurationUtilities,
-        url: 'https://example.com/api/now/table/sys_choice?sysparm_query=name=task^ORname=incident^element=priority^ORelement=category&sysparm_fields=label,value,dependent_value,element',
+        url: 'https://example.com/api/now/table/sys_choice?sysparm_query=name=task^ORname=incident^element=priority^ORelement=category^language=en&sysparm_fields=label,value,dependent_value,element',
       });
     });
 
@@ -734,7 +734,7 @@ describe('ServiceNow service', () => {
         axios,
         logger,
         configurationUtilities,
-        url: 'https://example.com/api/now/table/sys_choice?sysparm_query=name=task^ORname=sn_si_incident^element=priority^ORelement=category&sysparm_fields=label,value,dependent_value,element',
+        url: 'https://example.com/api/now/table/sys_choice?sysparm_query=name=task^ORname=sn_si_incident^element=priority^ORelement=category^language=en&sysparm_fields=label,value,dependent_value,element',
       });
     });
 

--- a/x-pack/plugins/actions/server/builtin_action_types/servicenow/service.ts
+++ b/x-pack/plugins/actions/server/builtin_action_types/servicenow/service.ts
@@ -74,7 +74,7 @@ export const createExternalService: ServiceFactory = (
       .slice(1)
       .reduce((acc, field) => `${acc}^ORelement=${field}`, `element=${fields[0]}`);
 
-    return `${choicesUrl}?sysparm_query=name=task^ORname=${table}^${elements}&sysparm_fields=label,value,dependent_value,element`;
+    return `${choicesUrl}?sysparm_query=name=task^ORname=${table}^${elements}^language=en&sysparm_fields=label,value,dependent_value,element`;
   };
 
   const checkInstance = (res: AxiosResponse) => {

--- a/x-pack/plugins/actions/server/builtin_action_types/servicenow/service_itom.test.ts
+++ b/x-pack/plugins/actions/server/builtin_action_types/servicenow/service_itom.test.ts
@@ -83,7 +83,7 @@ describe('ServiceNow SIR service', () => {
         axios,
         logger,
         configurationUtilities,
-        url: 'https://example.com/api/now/table/sys_choice?sysparm_query=name=task^ORname=em_event^element=severity&sysparm_fields=label,value,dependent_value,element',
+        url: 'https://example.com/api/now/table/sys_choice?sysparm_query=name=task^ORname=em_event^element=severity^language=en&sysparm_fields=label,value,dependent_value,element',
       });
     });
   });


### PR DESCRIPTION
## Summary

If the internalization application is installed in ServiceNow the `api/now/v2/table/sys_choice` will return all choices for all languages. This PR fixes the issue by returning only the English choices.

Fixes: https://github.com/elastic/kibana/issues/118610

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
