### PR TITLE
[kbn-storybook] Add decorator for `EuiProvider`

### DIFF
--- a/packages/kbn-storybook/preset.js
+++ b/packages/kbn-storybook/preset.js
@@ -16,4 +16,7 @@ module.exports = {
   webpackFinal: (config) => {
     return webpackConfig({ config });
   },
+  config: (entry) => {
+    return [...entry, require.resolve('./target_node/lib/decorators')];
+  },
 };

--- a/packages/kbn-storybook/src/index.ts
+++ b/packages/kbn-storybook/src/index.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-export { EuiProviderDecorator } from './lib/decorators';
 export { defaultConfig, defaultConfigWebFinal, mergeWebpackFinal } from './lib/default_config';
 export { runStorybookCli } from './lib/run_storybook_cli';
 export { default as WebpackConfig } from './webpack.config';

--- a/packages/kbn-storybook/src/index.ts
+++ b/packages/kbn-storybook/src/index.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+export { EuiProviderDecorator } from './lib/decorators';
 export { defaultConfig, defaultConfigWebFinal, mergeWebpackFinal } from './lib/default_config';
 export { runStorybookCli } from './lib/run_storybook_cli';
 export { default as WebpackConfig } from './webpack.config';

--- a/packages/kbn-storybook/src/lib/decorators.tsx
+++ b/packages/kbn-storybook/src/lib/decorators.tsx
@@ -15,7 +15,7 @@ import type { DecoratorFn } from '@storybook/react';
  * Storybook decorator using the EUI provider. Uses the value from
  * `globals` provided by the Storybook theme switcher.
  */
-export const EuiProviderDecorator: DecoratorFn = (storyFn, { globals }) => {
+const EuiProviderDecorator: DecoratorFn = (storyFn, { globals }) => {
   const colorMode = globals.euiTheme === 'v8.dark' ? 'dark' : 'light';
   const emotionCache = createCache({
     key: 'eui-styles',
@@ -28,3 +28,5 @@ export const EuiProviderDecorator: DecoratorFn = (storyFn, { globals }) => {
     </EuiProvider>
   );
 };
+
+export const decorators = [EuiProviderDecorator];

--- a/packages/kbn-storybook/src/lib/decorators.tsx
+++ b/packages/kbn-storybook/src/lib/decorators.tsx
@@ -6,10 +6,10 @@
  * Side Public License, v 1.
  */
 
-import type { DecoratorFn } from '@storybook/react';
 import React from 'react';
 import { EuiProvider } from '@elastic/eui';
 import createCache from '@emotion/cache';
+import type { DecoratorFn } from '@storybook/react';
 
 /**
  * Storybook decorator using the EUI provider. Uses the value from

--- a/packages/kbn-storybook/templates/index.ejs
+++ b/packages/kbn-storybook/templates/index.ejs
@@ -13,6 +13,7 @@
     <% } %>
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="eui-styles-global" />
 
     <!-- Added for Kibana shared dependencies -->
     <script>

--- a/src/plugins/kibana_react/common/eui_provider.tsx
+++ b/src/plugins/kibana_react/common/eui_provider.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { DecoratorFn } from '@storybook/react';
+import React from 'react';
+import { EuiProvider } from '@elastic/eui';
+import createCache from '@emotion/cache';
+
+/**
+ * Storybook decorator using the EUI provider. Uses the value from
+ * `globals` provided by the Storybook theme switcher.
+ */
+export const EuiProviderDecorator: DecoratorFn = (storyFn, { globals }) => {
+  const colorMode = globals.euiTheme === 'v8.dark' ? 'dark' : 'light';
+  const emotionCache = createCache({
+    key: 'eui-styles',
+    container: document.querySelector(`meta[name="eui-styles-global"]`) as HTMLElement,
+  });
+
+  return (
+    <EuiProvider colorMode={colorMode} cache={emotionCache}>
+      {storyFn()}
+    </EuiProvider>
+  );
+};

--- a/src/plugins/kibana_react/common/index.ts
+++ b/src/plugins/kibana_react/common/index.ts
@@ -9,5 +9,4 @@
 // TODO: https://github.com/elastic/kibana/issues/109898
 /* eslint-disable @kbn/eslint/no_export_all */
 
-export * from './eui_provider';
 export * from './eui_styled_components';

--- a/src/plugins/kibana_react/common/index.ts
+++ b/src/plugins/kibana_react/common/index.ts
@@ -9,4 +9,5 @@
 // TODO: https://github.com/elastic/kibana/issues/109898
 /* eslint-disable @kbn/eslint/no_export_all */
 
+export * from './eui_provider';
 export * from './eui_styled_components';

--- a/src/plugins/presentation_util/storybook/main.ts
+++ b/src/plugins/presentation_util/storybook/main.ts
@@ -6,11 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { defaultConfigWebFinal } from '@kbn/storybook';
+import { defaultConfig } from '@kbn/storybook';
 
 // We have to do this because the kbn/storybook preset overrides the manager entries,
 // so we can't customize the theme.
-module.exports = {
-  ...defaultConfigWebFinal,
-  addons: ['@storybook/addon-a11y', '@storybook/addon-essentials'],
-};
+module.exports = defaultConfig;

--- a/x-pack/plugins/apm/.storybook/preview.js
+++ b/x-pack/plugins/apm/.storybook/preview.js
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { EuiProviderDecorator } from '@kbn/storybook';
 import { EuiThemeProviderDecorator } from '../../../../src/plugins/kibana_react/common';
 
-export const decorators = [EuiProviderDecorator, EuiThemeProviderDecorator];
+export const decorators = [EuiThemeProviderDecorator];

--- a/x-pack/plugins/apm/.storybook/preview.js
+++ b/x-pack/plugins/apm/.storybook/preview.js
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
-import { EuiThemeProviderDecorator } from '../../../../src/plugins/kibana_react/common';
+import {
+  EuiProviderDecorator,
+  EuiThemeProviderDecorator,
+} from '../../../../src/plugins/kibana_react/common';
 
-export const decorators = [EuiThemeProviderDecorator];
+export const decorators = [EuiProviderDecorator, EuiThemeProviderDecorator];

--- a/x-pack/plugins/apm/.storybook/preview.js
+++ b/x-pack/plugins/apm/.storybook/preview.js
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-import {
-  EuiProviderDecorator,
-  EuiThemeProviderDecorator,
-} from '../../../../src/plugins/kibana_react/common';
+import { EuiProviderDecorator } from '@kbn/storybook';
+import { EuiThemeProviderDecorator } from '../../../../src/plugins/kibana_react/common';
 
 export const decorators = [EuiProviderDecorator, EuiThemeProviderDecorator];

--- a/x-pack/plugins/canvas/storybook/decorators/index.ts
+++ b/x-pack/plugins/canvas/storybook/decorators/index.ts
@@ -9,6 +9,7 @@ import { addDecorator } from '@storybook/react';
 import { routerContextDecorator } from './router_decorator';
 import { kibanaContextDecorator } from './kibana_decorator';
 import { servicesContextDecorator, legacyContextDecorator } from './services_decorator';
+import { EuiProviderDecorator } from '../../../../../src/plugins/kibana_react/common';
 
 export { reduxDecorator } from './redux_decorator';
 export { servicesContextDecorator } from './services_decorator';
@@ -19,6 +20,7 @@ export const addDecorators = () => {
     require('babel-plugin-require-context-hook/register')();
   }
 
+  addDecorator(EuiProviderDecorator);
   addDecorator(kibanaContextDecorator);
   addDecorator(routerContextDecorator);
   addDecorator(legacyContextDecorator());

--- a/x-pack/plugins/canvas/storybook/decorators/index.ts
+++ b/x-pack/plugins/canvas/storybook/decorators/index.ts
@@ -6,10 +6,10 @@
  */
 
 import { addDecorator } from '@storybook/react';
+import { EuiProviderDecorator } from '@kbn/storybook';
 import { routerContextDecorator } from './router_decorator';
 import { kibanaContextDecorator } from './kibana_decorator';
 import { servicesContextDecorator, legacyContextDecorator } from './services_decorator';
-import { EuiProviderDecorator } from '../../../../../src/plugins/kibana_react/common';
 
 export { reduxDecorator } from './redux_decorator';
 export { servicesContextDecorator } from './services_decorator';

--- a/x-pack/plugins/canvas/storybook/decorators/index.ts
+++ b/x-pack/plugins/canvas/storybook/decorators/index.ts
@@ -6,7 +6,6 @@
  */
 
 import { addDecorator } from '@storybook/react';
-import { EuiProviderDecorator } from '@kbn/storybook';
 import { routerContextDecorator } from './router_decorator';
 import { kibanaContextDecorator } from './kibana_decorator';
 import { servicesContextDecorator, legacyContextDecorator } from './services_decorator';
@@ -20,7 +19,6 @@ export const addDecorators = () => {
     require('babel-plugin-require-context-hook/register')();
   }
 
-  addDecorator(EuiProviderDecorator);
   addDecorator(kibanaContextDecorator);
   addDecorator(routerContextDecorator);
   addDecorator(legacyContextDecorator());


### PR DESCRIPTION
## Summary

Adds a global decorator for `EuiProvider` to ensure reset and global styles. Can expand consumption to all `.storybook/` instances if the approach looks correct.
