### PR TITLE
[Cases] Improve text on all cases table

### DIFF
--- a/x-pack/plugins/cases/public/components/all_cases/translations.ts
+++ b/x-pack/plugins/cases/public/components/all_cases/translations.ts
@@ -10,18 +10,17 @@ import { i18n } from '@kbn/i18n';
 export * from '../../common/translations';
 
 export const NO_CASES = i18n.translate('xpack.cases.caseTable.noCases.title', {
-  defaultMessage: 'No Cases',
+  defaultMessage: 'No cases to display',
 });
 
 export const NO_CASES_BODY = i18n.translate('xpack.cases.caseTable.noCases.body', {
-  defaultMessage:
-    'There are no cases to display. Please create a new case or change your filter settings above.',
+  defaultMessage: 'Create a case or edit your filters.',
 });
 
 export const NO_CASES_BODY_READ_ONLY = i18n.translate(
   'xpack.cases.caseTable.noCases.readonly.body',
   {
-    defaultMessage: 'There are no cases to display. Please change your filter settings above.',
+    defaultMessage: 'Edit your filters.',
   }
 );
 

--- a/x-pack/plugins/cases/public/components/all_cases/translations.ts
+++ b/x-pack/plugins/cases/public/components/all_cases/translations.ts
@@ -20,7 +20,7 @@ export const NO_CASES_BODY = i18n.translate('xpack.cases.caseTable.noCases.body'
 export const NO_CASES_BODY_READ_ONLY = i18n.translate(
   'xpack.cases.caseTable.noCases.readonly.body',
   {
-    defaultMessage: 'Edit your filters.',
+    defaultMessage: 'Edit your filter settings.',
   }
 );
 


### PR DESCRIPTION
## Summary

In PR https://github.com/elastic/kibana/pull/121876, I forgot to change the text that is being shown when there are no cases in the all cases page table. This PR fixes this issue.

<img width="2298" alt="Screenshot 2021-12-22 at 7 33 37 PM" src="https://user-images.githubusercontent.com/7871006/147132855-2d7956f9-5e76-4d04-93f9-d200f7bd9384.png">

<img width="2287" alt="Screenshot 2021-12-22 at 8 31 00 PM" src="https://user-images.githubusercontent.com/7871006/147139012-adc5e8f0-d274-4aca-b405-5055756c4d34.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentnce case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
