### PR TITLE
Remove dashboard permissions check for disabling save and return

### DIFF
--- a/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
@@ -261,9 +261,7 @@ export const getTopNavConfig = (
         });
   const showSaveAndReturn = originatingApp && (savedVis?.id || allowByValue);
 
-  const showSaveButton =
-    visualizeCapabilities.save ||
-    (allowByValue && !showSaveAndReturn && dashboardCapabilities.showWriteControls);
+  const showSaveButton = visualizeCapabilities.save || (allowByValue && !showSaveAndReturn);
 
   const topNavMenu: TopNavMenuData[] = [
     {
@@ -556,7 +554,7 @@ export const getTopNavConfig = (
               }
             ),
             testId: 'visualizesaveAndReturnButton',
-            disableButton: hasUnappliedChanges || !dashboardCapabilities.showWriteControls,
+            disableButton: hasUnappliedChanges,
             tooltip() {
               if (hasUnappliedChanges) {
                 return i18n.translate(

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -38,7 +38,6 @@ function getLensTopNavConfig(options: {
   actions: LensTopNavActions;
   tooltips: LensTopNavTooltips;
   savingToLibraryPermitted: boolean;
-  savingToDashboardPermitted: boolean;
 }): TopNavMenuData[] {
   const {
     actions,
@@ -47,17 +46,13 @@ function getLensTopNavConfig(options: {
     enableExportToCSV,
     showSaveAndReturn,
     savingToLibraryPermitted,
-    savingToDashboardPermitted,
     tooltips,
   } = options;
   const topNavMenu: TopNavMenuData[] = [];
 
   const enableSaveButton =
     savingToLibraryPermitted ||
-    (allowByValue &&
-      savingToDashboardPermitted &&
-      !options.isByValueMode &&
-      !options.showSaveAndReturn);
+    (allowByValue && !options.isByValueMode && !options.showSaveAndReturn);
 
   const saveButtonLabel = options.isByValueMode
     ? i18n.translate('xpack.lens.app.addToLibrary', {
@@ -130,7 +125,6 @@ function getLensTopNavConfig(options: {
       iconType: 'checkInCircleFilled',
       run: actions.saveAndReturn,
       testId: 'lnsApp_saveAndReturnButton',
-      disableButton: !savingToDashboardPermitted,
       description: i18n.translate('xpack.lens.app.saveAndReturnButtonAriaLabel', {
         defaultMessage: 'Save the current lens visualization and return to the last app',
       }),
@@ -231,9 +225,6 @@ export const LensTopNavMenu = ({
   const { from, to } = data.query.timefilter.timefilter.getTime();
 
   const savingToLibraryPermitted = Boolean(isSaveable && application.capabilities.visualize.save);
-  const savingToDashboardPermitted = Boolean(
-    isSaveable && application.capabilities.dashboard?.showWriteControls
-  );
 
   const unsavedTitle = i18n.translate('xpack.lens.app.unsavedFilename', {
     defaultMessage: 'unsaved',
@@ -251,7 +242,6 @@ export const LensTopNavMenu = ({
         allowByValue: dashboardFeatureFlag.allowByValueEmbeddables,
         showCancel: Boolean(isLinkedToOriginatingApp),
         savingToLibraryPermitted,
-        savingToDashboardPermitted,
         tooltips: {
           showExportWarning: () => {
             if (activeData) {
@@ -301,27 +291,25 @@ export const LensTopNavMenu = ({
             }
           },
           saveAndReturn: () => {
-            if (savingToDashboardPermitted) {
-              // disabling the validation on app leave because the document has been saved.
-              onAppLeave((actions) => {
-                return actions.default();
-              });
-              runSave(
-                {
-                  newTitle: title || '',
-                  newCopyOnSave: false,
-                  isTitleDuplicateConfirmed: false,
-                  returnToOrigin: true,
-                },
-                {
-                  saveToLibrary:
-                    (initialInput && attributeService.inputIsRefType(initialInput)) ?? false,
-                }
-              );
-            }
+            // disabling the validation on app leave because the document has been saved.
+            onAppLeave((actions) => {
+              return actions.default();
+            });
+            runSave(
+              {
+                newTitle: title || '',
+                newCopyOnSave: false,
+                isTitleDuplicateConfirmed: false,
+                returnToOrigin: true,
+              },
+              {
+                saveToLibrary:
+                  (initialInput && attributeService.inputIsRefType(initialInput)) ?? false,
+              }
+            );
           },
           showSaveModal: () => {
-            if (savingToDashboardPermitted || savingToLibraryPermitted) {
+            if (savingToLibraryPermitted) {
               setIsSaveModalVisible(true);
             }
           },
@@ -345,7 +333,6 @@ export const LensTopNavMenu = ({
       onAppLeave,
       redirectToOrigin,
       runSave,
-      savingToDashboardPermitted,
       savingToLibraryPermitted,
       setIsSaveModalVisible,
       uiSettings,

--- a/x-pack/test/functional/apps/canvas/embeddables/visualization.ts
+++ b/x-pack/test/functional/apps/canvas/embeddables/visualization.ts
@@ -53,6 +53,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('by-value', () => {
       it('creates new tsvb embeddable', async () => {
+        await PageObjects.canvas.deleteSelectedElement();
         const originalEmbeddableCount = await PageObjects.canvas.getEmbeddableCount();
         await PageObjects.canvas.createNewVis('metrics');
         await PageObjects.visualize.saveVisualizationAndReturn();
@@ -71,10 +72,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const embeddableCount = await PageObjects.canvas.getEmbeddableCount();
           expect(embeddableCount).to.eql(originalEmbeddableCount);
         });
-        await PageObjects.canvas.deleteSelectedElement();
       });
 
       it('creates new vega embeddable', async () => {
+        await PageObjects.canvas.deleteSelectedElement();
         const originalEmbeddableCount = await PageObjects.canvas.getEmbeddableCount();
         await PageObjects.canvas.createNewVis('vega');
         await PageObjects.visualize.saveVisualizationAndReturn();

--- a/x-pack/test/functional/apps/canvas/index.js
+++ b/x-pack/test/functional/apps/canvas/index.js
@@ -17,8 +17,6 @@ export default function canvasApp({ loadTestFile, getService }) {
         'global_canvas_all',
         'global_discover_all',
         'global_maps_all',
-        // TODO: Fix permission check, save and return button is disabled when dashboard is disabled
-        'global_dashboard_all',
       ]);
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
     });


### PR DESCRIPTION
## Summary

Blocked by #120024.

I encountered this issue when testing Canvas with dashboard disabled. The save and return is disabled when dashboard is disabled even when the user has access to write to Canvas and editor apps.

Discussed with @ThomThomson and this check isn't necessary since the user shouldn't end up in this save and return state without an `originatingApp` if they don't have write permissions to Canvas or Dashboard.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
