### PR TITLE
[Controls] Fix flaky test #121826

### DIFF
--- a/test/functional/apps/dashboard/dashboard_controls_integration.ts
+++ b/test/functional/apps/dashboard/dashboard_controls_integration.ts
@@ -195,7 +195,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('Applies options list control options to dashboard', async () => {
-        expect(await pieChart.getPieSliceCount()).to.be(2);
+        await retry.try(async () => {
+          expect(await pieChart.getPieSliceCount()).to.be(2);
+        });
       });
 
       it('Applies options list control options to dashboard by default on open', async () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/121826

Adds a retry where one was missing. Strange that this test never failed before, as it checks immediately whether the filter had applied. Seems like it was susceptible to flakiness / the effects of a slow network.
