### PR TITLE
[7.17] [Telemetry] Ensure `refreshCache: true` in tests and helpers (#121913)

### DIFF
--- a/x-pack/dev-tools/api_debug/apis/telemetry/index.js
+++ b/x-pack/dev-tools/api_debug/apis/telemetry/index.js
@@ -10,4 +10,4 @@ export const description = 'Get the clusters stats from the Kibana server';
 export const method = 'POST';
 export const path = '/api/telemetry/v2/clusters/_stats';
 
-export const body = { unencrypted: true };
+export const body = { unencrypted: true, refreshCache: true };


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [Telemetry] Ensure `refreshCache: true` in tests and helpers (#121913)