### PR TITLE
[ML] Fix model size stats for overview page and model management

### DIFF
--- a/x-pack/plugins/ml/common/types/trained_models.ts
+++ b/x-pack/plugins/ml/common/types/trained_models.ts
@@ -17,6 +17,11 @@ export interface IngestStats {
   failed: number;
 }
 
+export interface TrainedModelModelSizeStats {
+  model_size_bytes: number;
+  required_native_memory_bytes: number;
+}
+
 export interface TrainedModelStat {
   model_id?: string;
   pipeline_count?: number;
@@ -46,6 +51,7 @@ export interface TrainedModelStat {
     >;
   };
   deployment_stats?: Omit<TrainedModelDeploymentStatsResponse, 'model_id'>;
+  model_size_stats?: TrainedModelModelSizeStats;
 }
 
 type TreeNode = object;
@@ -126,7 +132,6 @@ export interface InferenceConfigResponse {
 
 export interface TrainedModelDeploymentStatsResponse {
   model_id: string;
-  model_size_bytes: number;
   inference_threads: number;
   model_threads: number;
   state: DeploymentState;
@@ -170,6 +175,7 @@ export interface AllocatedModel {
   state: string;
   model_threads: number;
   model_size_bytes: number;
+  required_native_memory_bytes: number;
   node: {
     /**
      * Not required for rendering in the Nodes overview

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
@@ -122,13 +122,15 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
     function updateModelItems() {
       (async function () {
         const deploymentStats = stats.deployment_stats;
+        const modelSizeStats = stats.model_size_stats;
 
-        if (!deploymentStats) return;
+        if (!deploymentStats || !modelSizeStats) return;
 
         const items: AllocatedModel[] = deploymentStats.nodes.map((n) => {
           const nodeName = Object.values(n.node)[0].name;
           return {
             ...deploymentStats,
+            ...modelSizeStats,
             node: {
               ...pick(n, [
                 'average_inference_time_ms',

--- a/x-pack/plugins/ml/public/application/trained_models/nodes_overview/allocated_models.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/nodes_overview/allocated_models.tsx
@@ -59,7 +59,7 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
       truncateText: true,
       'data-test-subj': 'mlAllocatedModelsTableSize',
       render: (v: AllocatedModel) => {
-        return bytesFormatter(v.model_size_bytes);
+        return bytesFormatter(v.required_native_memory_bytes);
       },
     },
     {

--- a/x-pack/plugins/ml/server/models/data_frame_analytics/__mocks__/mock_deployment_response.json
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/__mocks__/mock_deployment_response.json
@@ -1,355 +1,383 @@
 [
   {
     "model_id": "distilbert-base-uncased-finetuned-sst-2-english",
-    "model_size_bytes": 267386880,
-    "inference_threads": 1,
-    "model_threads": 1,
-    "state": "started",
-    "allocation_status": {
-      "allocation_count": 2,
-      "target_allocation_count": 3,
-      "state": "started"
+    "model_size_stats" : {
+      "model_size_bytes" : 267386880,
+      "required_native_memory_bytes" : 534773760
     },
-    "nodes": [
-      {
-        "node": {
-          "3qIoLFnbSi-DwVrYioUCdw": {
-            "name": "node3",
-            "ephemeral_id": "WeA49KLuRPmJM_ulLx0ANg",
-            "transport_address": "10.142.0.2:9353",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "ingest",
-              "master",
-              "ml",
-              "transform"
-            ]
-          }
-        },
-        "routing_state": {
-          "routing_state": "started"
-        },
-        "inference_count": 0,
-        "average_inference_time_ms": 0.0
+    "pipeline_count" : 0,
+    "deployment_stats": {
+      "model_id": "distilbert-base-uncased-finetuned-sst-2-english",
+      "inference_threads": 1,
+      "model_threads": 1,
+      "state": "started",
+      "allocation_status": {
+        "allocation_count": 2,
+        "target_allocation_count": 3,
+        "state": "started"
       },
-      {
-        "node": {
-          "DpCy7SOBQla3pu0Dq-tnYw": {
-            "name": "node2",
-            "ephemeral_id": "17qcsXsNTYqbJ6uwSvdl9g",
-            "transport_address": "10.142.0.2:9352",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "master",
-              "ml",
-              "transform"
-            ]
+      "nodes": [
+        {
+          "node": {
+            "3qIoLFnbSi-DwVrYioUCdw": {
+              "name": "node3",
+              "ephemeral_id": "WeA49KLuRPmJM_ulLx0ANg",
+              "transport_address": "10.142.0.2:9353",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "ingest",
+                "master",
+                "ml",
+                "transform"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "started"
+          },
+          "inference_count": 0,
+          "average_inference_time_ms": 0.0
+        },
+        {
+          "node": {
+            "DpCy7SOBQla3pu0Dq-tnYw": {
+              "name": "node2",
+              "ephemeral_id": "17qcsXsNTYqbJ6uwSvdl9g",
+              "transport_address": "10.142.0.2:9352",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "master",
+                "ml",
+                "transform"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "failed",
+            "reason": "The object cannot be set twice!"
           }
         },
-        "routing_state": {
-          "routing_state": "failed",
-          "reason": "The object cannot be set twice!"
+        {
+          "node": {
+            "pt7s6lKHQJaP4QHKtU-Q0Q": {
+              "name": "node1",
+              "ephemeral_id": "nMJBE9WSRQSWotk0zDPi_Q",
+              "transport_address": "10.142.0.2:9351",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "master",
+                "ml"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "started"
+          },
+          "inference_count": 0,
+          "average_inference_time_ms": 0.0
         }
-      },
-      {
-        "node": {
-          "pt7s6lKHQJaP4QHKtU-Q0Q": {
-            "name": "node1",
-            "ephemeral_id": "nMJBE9WSRQSWotk0zDPi_Q",
-            "transport_address": "10.142.0.2:9351",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "master",
-              "ml"
-            ]
-          }
-        },
-        "routing_state": {
-          "routing_state": "started"
-        },
-        "inference_count": 0,
-        "average_inference_time_ms": 0.0
-      }
-    ]
+      ]
+    }
   },
   {
     "model_id": "elastic__distilbert-base-cased-finetuned-conll03-english",
-    "model_size_bytes": 260947500,
-    "inference_threads": 1,
-    "model_threads": 1,
-    "state": "started",
-    "allocation_status": {
-      "allocation_count": 2,
-      "target_allocation_count": 3,
-      "state": "started"
+    "model_size_stats" : {
+      "model_size_bytes" : 260947500,
+      "required_native_memory_bytes" : 521895000
     },
-    "nodes": [
-      {
-        "node": {
-          "3qIoLFnbSi-DwVrYioUCdw": {
-            "name": "node3",
-            "ephemeral_id": "WeA49KLuRPmJM_ulLx0ANg",
-            "transport_address": "10.142.0.2:9353",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "ingest",
-              "master",
-              "ml",
-              "transform"
-            ]
-          }
-        },
-        "routing_state": {
-          "routing_state": "started"
-        },
-        "inference_count": 0,
-        "average_inference_time_ms": 0.0
+    "pipeline_count" : 0,
+    "deployment_stats": {
+      "model_id": "elastic__distilbert-base-cased-finetuned-conll03-english",
+      "inference_threads": 1,
+      "model_threads": 1,
+      "state": "started",
+      "allocation_status": {
+        "allocation_count": 2,
+        "target_allocation_count": 3,
+        "state": "started"
       },
-      {
-        "node": {
-          "DpCy7SOBQla3pu0Dq-tnYw": {
-            "name": "node2",
-            "ephemeral_id": "17qcsXsNTYqbJ6uwSvdl9g",
-            "transport_address": "10.142.0.2:9352",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "master",
-              "ml",
-              "transform"
-            ]
+      "nodes": [
+        {
+          "node": {
+            "3qIoLFnbSi-DwVrYioUCdw": {
+              "name": "node3",
+              "ephemeral_id": "WeA49KLuRPmJM_ulLx0ANg",
+              "transport_address": "10.142.0.2:9353",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "ingest",
+                "master",
+                "ml",
+                "transform"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "started"
+          },
+          "inference_count": 0,
+          "average_inference_time_ms": 0.0
+        },
+        {
+          "node": {
+            "DpCy7SOBQla3pu0Dq-tnYw": {
+              "name": "node2",
+              "ephemeral_id": "17qcsXsNTYqbJ6uwSvdl9g",
+              "transport_address": "10.142.0.2:9352",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "master",
+                "ml",
+                "transform"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "failed",
+            "reason": "The object cannot be set twice!"
           }
         },
-        "routing_state": {
-          "routing_state": "failed",
-          "reason": "The object cannot be set twice!"
+        {
+          "node": {
+            "pt7s6lKHQJaP4QHKtU-Q0Q": {
+              "name": "node1",
+              "ephemeral_id": "nMJBE9WSRQSWotk0zDPi_Q",
+              "transport_address": "10.142.0.2:9351",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "master",
+                "ml"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "started"
+          },
+          "inference_count": 0,
+          "average_inference_time_ms": 0.0
         }
-      },
-      {
-        "node": {
-          "pt7s6lKHQJaP4QHKtU-Q0Q": {
-            "name": "node1",
-            "ephemeral_id": "nMJBE9WSRQSWotk0zDPi_Q",
-            "transport_address": "10.142.0.2:9351",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "master",
-              "ml"
-            ]
-          }
-        },
-        "routing_state": {
-          "routing_state": "started"
-        },
-        "inference_count": 0,
-        "average_inference_time_ms": 0.0
-      }
-    ]
+      ]
+    }
   },
   {
     "model_id": "sentence-transformers__msmarco-minilm-l-12-v3",
-    "model_size_bytes": 133378867,
-    "inference_threads": 1,
-    "model_threads": 1,
-    "state": "started",
-    "allocation_status": {
-      "allocation_count": 2,
-      "target_allocation_count": 3,
-      "state": "started"
+    "model_size_stats" : {
+      "model_size_bytes" : 133378867,
+      "required_native_memory_bytes" : 266757734
     },
-    "nodes": [
-      {
-        "node": {
-          "3qIoLFnbSi-DwVrYioUCdw": {
-            "name": "node3",
-            "ephemeral_id": "WeA49KLuRPmJM_ulLx0ANg",
-            "transport_address": "10.142.0.2:9353",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "ingest",
-              "master",
-              "ml",
-              "transform"
-            ]
-          }
-        },
-        "routing_state": {
-          "routing_state": "started"
-        },
-        "inference_count": 0,
-        "average_inference_time_ms": 0.0
+    "pipeline_count" : 0,
+    "deployment_stats": {
+      "model_id": "sentence-transformers__msmarco-minilm-l-12-v3",
+      "inference_threads": 1,
+      "model_threads": 1,
+      "state": "started",
+      "allocation_status": {
+        "allocation_count": 2,
+        "target_allocation_count": 3,
+        "state": "started"
       },
-      {
-        "node": {
-          "DpCy7SOBQla3pu0Dq-tnYw": {
-            "name": "node2",
-            "ephemeral_id": "17qcsXsNTYqbJ6uwSvdl9g",
-            "transport_address": "10.142.0.2:9352",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "master",
-              "ml",
-              "transform"
-            ]
+      "nodes": [
+        {
+          "node": {
+            "3qIoLFnbSi-DwVrYioUCdw": {
+              "name": "node3",
+              "ephemeral_id": "WeA49KLuRPmJM_ulLx0ANg",
+              "transport_address": "10.142.0.2:9353",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "ingest",
+                "master",
+                "ml",
+                "transform"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "started"
+          },
+          "inference_count": 0,
+          "average_inference_time_ms": 0.0
+        },
+        {
+          "node": {
+            "DpCy7SOBQla3pu0Dq-tnYw": {
+              "name": "node2",
+              "ephemeral_id": "17qcsXsNTYqbJ6uwSvdl9g",
+              "transport_address": "10.142.0.2:9352",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "master",
+                "ml",
+                "transform"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "failed",
+            "reason": "The object cannot be set twice!"
           }
         },
-        "routing_state": {
-          "routing_state": "failed",
-          "reason": "The object cannot be set twice!"
+        {
+          "node": {
+            "pt7s6lKHQJaP4QHKtU-Q0Q": {
+              "name": "node1",
+              "ephemeral_id": "nMJBE9WSRQSWotk0zDPi_Q",
+              "transport_address": "10.142.0.2:9351",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "master",
+                "ml"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "started"
+          },
+          "inference_count": 0,
+          "average_inference_time_ms": 0.0
         }
-      },
-      {
-        "node": {
-          "pt7s6lKHQJaP4QHKtU-Q0Q": {
-            "name": "node1",
-            "ephemeral_id": "nMJBE9WSRQSWotk0zDPi_Q",
-            "transport_address": "10.142.0.2:9351",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "master",
-              "ml"
-            ]
-          }
-        },
-        "routing_state": {
-          "routing_state": "started"
-        },
-        "inference_count": 0,
-        "average_inference_time_ms": 0.0
-      }
-    ]
+      ]
+    }
   },
   {
     "model_id": "typeform__mobilebert-uncased-mnli",
-    "model_size_bytes": 100139008,
-    "inference_threads": 1,
-    "model_threads": 1,
-    "state": "started",
-    "allocation_status": {
-      "allocation_count": 2,
-      "target_allocation_count": 3,
-      "state": "started"
+    "model_size_stats" : {
+      "model_size_bytes" : 100139008,
+      "required_native_memory_bytes" : 200278016
     },
-    "nodes": [
-      {
-        "node": {
-          "3qIoLFnbSi-DwVrYioUCdw": {
-            "name": "node3",
-            "ephemeral_id": "WeA49KLuRPmJM_ulLx0ANg",
-            "transport_address": "10.142.0.2:9353",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "ingest",
-              "master",
-              "ml",
-              "transform"
-            ]
-          }
-        },
-        "routing_state": {
-          "routing_state": "started"
-        },
-        "inference_count": 0,
-        "average_inference_time_ms": 0.0
+    "pipeline_count" : 0,
+    "deployment_stats": {
+      "model_id": "typeform__mobilebert-uncased-mnli",
+      "inference_threads": 1,
+      "model_threads": 1,
+      "state": "started",
+      "allocation_status": {
+        "allocation_count": 2,
+        "target_allocation_count": 3,
+        "state": "started"
       },
-      {
-        "node": {
-          "DpCy7SOBQla3pu0Dq-tnYw": {
-            "name": "node2",
-            "ephemeral_id": "17qcsXsNTYqbJ6uwSvdl9g",
-            "transport_address": "10.142.0.2:9352",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "master",
-              "ml",
-              "transform"
-            ]
+      "nodes": [
+        {
+          "node": {
+            "3qIoLFnbSi-DwVrYioUCdw": {
+              "name": "node3",
+              "ephemeral_id": "WeA49KLuRPmJM_ulLx0ANg",
+              "transport_address": "10.142.0.2:9353",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "ingest",
+                "master",
+                "ml",
+                "transform"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "started"
+          },
+          "inference_count": 0,
+          "average_inference_time_ms": 0.0
+        },
+        {
+          "node": {
+            "DpCy7SOBQla3pu0Dq-tnYw": {
+              "name": "node2",
+              "ephemeral_id": "17qcsXsNTYqbJ6uwSvdl9g",
+              "transport_address": "10.142.0.2:9352",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "master",
+                "ml",
+                "transform"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "failed",
+            "reason": "The object cannot be set twice!"
           }
         },
-        "routing_state": {
-          "routing_state": "failed",
-          "reason": "The object cannot be set twice!"
+        {
+          "node": {
+            "pt7s6lKHQJaP4QHKtU-Q0Q": {
+              "name": "node1",
+              "ephemeral_id": "nMJBE9WSRQSWotk0zDPi_Q",
+              "transport_address": "10.142.0.2:9351",
+              "attributes": {
+                "ml.machine_memory": "15599742976",
+                "xpack.installed": "true",
+                "ml.max_jvm_size": "1073741824"
+              },
+              "roles": [
+                "data",
+                "master",
+                "ml"
+              ]
+            }
+          },
+          "routing_state": {
+            "routing_state": "started"
+          },
+          "inference_count": 0,
+          "average_inference_time_ms": 0.0
         }
-      },
-      {
-        "node": {
-          "pt7s6lKHQJaP4QHKtU-Q0Q": {
-            "name": "node1",
-            "ephemeral_id": "nMJBE9WSRQSWotk0zDPi_Q",
-            "transport_address": "10.142.0.2:9351",
-            "attributes": {
-              "ml.machine_memory": "15599742976",
-              "xpack.installed": "true",
-              "ml.max_jvm_size": "1073741824"
-            },
-            "roles": [
-              "data",
-              "master",
-              "ml"
-            ]
-          }
-        },
-        "routing_state": {
-          "routing_state": "started"
-        },
-        "inference_count": 0,
-        "average_inference_time_ms": 0.0
-      }
-    ]
+      ]
+    }
   }
 ]
 

--- a/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.test.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.test.ts
@@ -107,11 +107,7 @@ describe('Model service', () => {
     getTrainedModelsStats: jest.fn(() => {
       return Promise.resolve({
         body: {
-          trained_model_stats: mockResponse.map((v) => {
-            return {
-              deployment_stats: v,
-            };
-          }),
+          trained_model_stats: mockResponse,
         },
       });
     }),
@@ -149,6 +145,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'distilbert-base-uncased-finetuned-sst-2-english',
               model_size_bytes: 267386880,
+              required_native_memory_bytes: 534773760,
               model_threads: 1,
               state: 'started',
               node: {
@@ -168,6 +165,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'elastic__distilbert-base-cased-finetuned-conll03-english',
               model_size_bytes: 260947500,
+              required_native_memory_bytes: 521895000,
               model_threads: 1,
               state: 'started',
               node: {
@@ -187,6 +185,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'sentence-transformers__msmarco-minilm-l-12-v3',
               model_size_bytes: 133378867,
+              required_native_memory_bytes: 266757734,
               model_threads: 1,
               state: 'started',
               node: {
@@ -206,6 +205,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'typeform__mobilebert-uncased-mnli',
               model_size_bytes: 100139008,
+              required_native_memory_bytes: 200278016,
               model_threads: 1,
               state: 'started',
               node: {
@@ -237,22 +237,22 @@ describe('Model service', () => {
               by_model: [
                 {
                   model_id: 'distilbert-base-uncased-finetuned-sst-2-english',
-                  model_size: 267386880,
+                  model_size: 534773760,
                 },
                 {
                   model_id: 'elastic__distilbert-base-cased-finetuned-conll03-english',
-                  model_size: 260947500,
+                  model_size: 521895000,
                 },
                 {
                   model_id: 'sentence-transformers__msmarco-minilm-l-12-v3',
-                  model_size: 133378867,
+                  model_size: 266757734,
                 },
                 {
                   model_id: 'typeform__mobilebert-uncased-mnli',
-                  model_size: 100139008,
+                  model_size: 200278016,
                 },
               ],
-              total: 793309535,
+              total: 1555161790,
             },
           },
           roles: ['data', 'ingest', 'master', 'ml', 'transform'],
@@ -269,6 +269,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'distilbert-base-uncased-finetuned-sst-2-english',
               model_size_bytes: 267386880,
+              required_native_memory_bytes: 534773760,
               model_threads: 1,
               state: 'started',
               node: {
@@ -287,6 +288,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'elastic__distilbert-base-cased-finetuned-conll03-english',
               model_size_bytes: 260947500,
+              required_native_memory_bytes: 521895000,
               model_threads: 1,
               state: 'started',
               node: {
@@ -305,6 +307,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'sentence-transformers__msmarco-minilm-l-12-v3',
               model_size_bytes: 133378867,
+              required_native_memory_bytes: 266757734,
               model_threads: 1,
               state: 'started',
               node: {
@@ -323,6 +326,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'typeform__mobilebert-uncased-mnli',
               model_size_bytes: 100139008,
+              required_native_memory_bytes: 200278016,
               model_threads: 1,
               state: 'started',
               node: {
@@ -353,22 +357,22 @@ describe('Model service', () => {
               by_model: [
                 {
                   model_id: 'distilbert-base-uncased-finetuned-sst-2-english',
-                  model_size: 267386880,
+                  model_size: 534773760,
                 },
                 {
                   model_id: 'elastic__distilbert-base-cased-finetuned-conll03-english',
-                  model_size: 260947500,
+                  model_size: 521895000,
                 },
                 {
                   model_id: 'sentence-transformers__msmarco-minilm-l-12-v3',
-                  model_size: 133378867,
+                  model_size: 266757734,
                 },
                 {
                   model_id: 'typeform__mobilebert-uncased-mnli',
-                  model_size: 100139008,
+                  model_size: 200278016,
                 },
               ],
-              total: 793309535,
+              total: 1555161790,
             },
           },
           roles: ['data', 'master', 'ml', 'transform'],
@@ -384,6 +388,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'distilbert-base-uncased-finetuned-sst-2-english',
               model_size_bytes: 267386880,
+              required_native_memory_bytes: 534773760,
               model_threads: 1,
               state: 'started',
               node: {
@@ -403,6 +408,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'elastic__distilbert-base-cased-finetuned-conll03-english',
               model_size_bytes: 260947500,
+              required_native_memory_bytes: 521895000,
               model_threads: 1,
               state: 'started',
               node: {
@@ -422,6 +428,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'sentence-transformers__msmarco-minilm-l-12-v3',
               model_size_bytes: 133378867,
+              required_native_memory_bytes: 266757734,
               model_threads: 1,
               state: 'started',
               node: {
@@ -441,6 +448,7 @@ describe('Model service', () => {
               inference_threads: 1,
               model_id: 'typeform__mobilebert-uncased-mnli',
               model_size_bytes: 100139008,
+              required_native_memory_bytes: 200278016,
               model_threads: 1,
               state: 'started',
               node: {
@@ -472,22 +480,22 @@ describe('Model service', () => {
               by_model: [
                 {
                   model_id: 'distilbert-base-uncased-finetuned-sst-2-english',
-                  model_size: 267386880,
+                  model_size: 534773760,
                 },
                 {
                   model_id: 'elastic__distilbert-base-cased-finetuned-conll03-english',
-                  model_size: 260947500,
+                  model_size: 521895000,
                 },
                 {
                   model_id: 'sentence-transformers__msmarco-minilm-l-12-v3',
-                  model_size: 133378867,
+                  model_size: 266757734,
                 },
                 {
                   model_id: 'typeform__mobilebert-uncased-mnli',
-                  model_size: 100139008,
+                  model_size: 200278016,
                 },
               ],
-              total: 793309535,
+              total: 1555161790,
             },
           },
           name: 'node1',

--- a/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
@@ -7,7 +7,10 @@
 
 import type { IScopedClusterClient } from 'kibana/server';
 import { sumBy, pick } from 'lodash';
-import { NodesInfoNodeInfo } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import {
+  MlTrainedModelStats,
+  NodesInfoNodeInfo,
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type {
   NodeDeploymentStatsResponse,
   PipelineDefinition,
@@ -18,7 +21,10 @@ import {
   MemoryOverviewService,
   NATIVE_EXECUTABLE_CODE_OVERHEAD,
 } from '../memory_overview/memory_overview_service';
-import { TrainedModelDeploymentStatsResponse } from '../../../common/types/trained_models';
+import {
+  TrainedModelDeploymentStatsResponse,
+  TrainedModelModelSizeStats,
+} from '../../../common/types/trained_models';
 import { isDefined } from '../../../common/types/guards';
 import { isPopulatedObject } from '../../../common';
 
@@ -27,6 +33,11 @@ export type ModelService = ReturnType<typeof modelsProvider>;
 const NODE_FIELDS = ['attributes', 'name', 'roles', 'version'] as const;
 
 export type RequiredNodeFields = Pick<NodesInfoNodeInfo, typeof NODE_FIELDS[number]>;
+
+interface TrainedModelStatsResponse extends MlTrainedModelStats {
+  deployment_stats?: Omit<TrainedModelDeploymentStatsResponse, 'model_id'>;
+  model_size_stats?: TrainedModelModelSizeStats;
+}
 
 export function modelsProvider(
   client: IScopedClusterClient,
@@ -107,21 +118,30 @@ export function modelsProvider(
               )
             : nodeFields.attributes;
 
-          const allocatedModels = (
-            trainedModelStats
-              .map((v) => {
-                // @ts-ignore new prop
-                return v.deployment_stats;
-              })
-              .filter(isDefined) as TrainedModelDeploymentStatsResponse[]
-          )
-            .filter((v) => v.nodes.some((n) => Object.keys(n.node)[0] === nodeId))
-            .map(({ nodes, ...rest }) => {
+          const allocatedModels = (trainedModelStats as TrainedModelStatsResponse[])
+            .filter(
+              (d) =>
+                isDefined(d.deployment_stats) &&
+                isDefined(d.deployment_stats.nodes) &&
+                d.deployment_stats.nodes.some((n) => Object.keys(n.node)[0] === nodeId)
+            )
+            .map((d) => {
+              const modelSizeState = d.model_size_stats;
+              const deploymentStats = d.deployment_stats;
+
+              if (!deploymentStats || !modelSizeState) {
+                throw new Error('deploymentStats or modelSizeState not defined');
+              }
+
+              const { nodes, ...rest } = deploymentStats;
+
               const { node: tempNode, ...nodeRest } = nodes.find(
                 (v) => Object.keys(v.node)[0] === nodeId
               )!;
               return {
+                model_id: d.model_id,
                 ...rest,
+                ...modelSizeState,
                 node: nodeRest,
               };
             });
@@ -129,7 +149,7 @@ export function modelsProvider(
           const modelsMemoryUsage = allocatedModels.map((v) => {
             return {
               model_id: v.model_id,
-              model_size: v.model_size_bytes,
+              model_size: v.required_native_memory_bytes,
             };
           });
 


### PR DESCRIPTION
## Summary

Related to this ES PR https://github.com/elastic/elasticsearch/pull/82000

The API for model size stats change attributes and structure. This PR picks up the changes to fix the display of model sizes on the ML overview page and model management page.

Note the bulk of the diff is the adapted mock file to be aligned with the new structure returned by the API.

Screenshots with highlights showing the updated values:

Overview Page:

![image](https://user-images.githubusercontent.com/230104/147255287-2c5d3d07-7e65-428d-bed7-f94b32bbf4e4.png)

Model Management Page:

![image](https://user-images.githubusercontent.com/230104/147255151-44869bd6-0cbb-4879-8712-d0fa9391825a.png)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
