### PR TITLE
[Security Solution][Detections]Fix rule query input overlapping timeline banner

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/query_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/query_bar/index.tsx
@@ -56,7 +56,8 @@ const StyledEuiFormRow = styled(EuiFormRow)`
       & > div:first-child {
         margin: 0px 0px 0px 4px;
       }
-      &__wrap {
+      &__wrap,
+      &__textarea {
         z-index: 0;
       }
     }


### PR DESCRIPTION
- Issue: https://github.com/elastic/kibana/issues/117983

## Summary

Fixes overlapping timeline banner on rule edit page by changing textarea z-index.
Previous [fix](https://github.com/elastic/kibana/pull/121127) works fine for  **8.1** but doesn't for **8.0**
https://github.com/elastic/kibana/issues/117983#issuecomment-999528845.

Applying this fix for 8.1 as well to prevent it from happening in future

### Before
<img width="1260" alt="Screenshot 2021-12-23 at 17 20 11" src="https://user-images.githubusercontent.com/92328789/147273251-06d68e78-59b6-48fe-90ce-12278fcde382.png">


### After
<img width="1215" alt="Screenshot 2021-12-23 at 17 18 08" src="https://user-images.githubusercontent.com/92328789/147273089-e86e3dac-d1fe-40d5-9af3-a721a4e48eef.png">


Checked both for 8.0/8.1 and different browser, works fine