### PR TITLE
[7.17] [Console] Avoid generating extra deprecation logs when getting data for autocomplete (#121857)

### DIFF
--- a/src/plugins/console/public/lib/es/es.ts
+++ b/src/plugins/console/public/lib/es/es.ts
@@ -28,12 +28,15 @@ export function send(
   method: string,
   path: string,
   data: string | object,
-  { asSystemRequest }: SendOptions = {}
+  { asSystemRequest }: SendOptions = {},
+  withProductOrigin: boolean = false
 ) {
   const wrappedDfd = $.Deferred();
 
   const options: JQuery.AjaxSettings = {
-    url: '../api/console/proxy?' + stringify({ path, method }, { sort: false }),
+    url:
+      '../api/console/proxy?' +
+      stringify({ path, method, ...(withProductOrigin && { withProductOrigin }) }, { sort: false }),
     headers: {
       'kbn-xsrf': 'kibana',
       ...(asSystemRequest && { 'kbn-system-request': 'true' }),

--- a/src/plugins/console/public/lib/mappings/mappings.js
+++ b/src/plugins/console/public/lib/mappings/mappings.js
@@ -250,7 +250,8 @@ function retrieveSettings(settingsKey, settingsToRetrieve) {
 
   // Fetch autocomplete info if setting is set to true, and if user has made changes.
   if (settingsToRetrieve[settingsKey] === true) {
-    return es.send('GET', settingKeyToPathMap[settingsKey], null, true);
+    const WITH_PRODUCT_ORIGIN = true;
+    return es.send('GET', settingKeyToPathMap[settingsKey], null, true, WITH_PRODUCT_ORIGIN);
   } else {
     const settingsPromise = new $.Deferred();
     if (settingsToRetrieve[settingsKey] === false) {

--- a/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
@@ -116,7 +116,7 @@ export const createHandler =
   }: RouteDependencies): RequestHandler<unknown, Query, Body> =>
   async (ctx, request, response) => {
     const { body, query } = request;
-    const { path, method } = query;
+    const { path, method, withProductOrigin } = query;
 
     if (kibanaVersion.major < 8) {
       // The "console.proxyFilter" setting in kibana.yaml has been deprecated in 8.x
@@ -153,6 +153,11 @@ export const createHandler =
         const requestHeaders = {
           ...headers,
           ...getProxyHeaders(request),
+          // There are a few internal calls that console UI makes to ES in order to get mappings, aliases and templates
+          // in the autocomplete mechanism from the editor. At this particular time, those requests generate deprecation
+          // logs since they access system indices. With this header we can provide a way to the UI to determine which
+          // requests need to deprecation logs and which ones dont.
+          ...(withProductOrigin && { 'x-elastic-product-origin': 'kibana' }),
         };
 
         esIncomingMessage = await proxyRequest({

--- a/src/plugins/console/server/routes/api/console/proxy/headers.test.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/headers.test.ts
@@ -74,5 +74,24 @@ describe('Console Proxy Route', () => {
       expect(headers).toHaveProperty('x-forwarded-host');
       expect(headers['x-forwarded-host']).toBe('test');
     });
+
+    it('sends product-origin header when withProductOrigin query param is set', async () => {
+      await handler(
+        {} as any,
+        {
+          headers: {},
+          query: {
+            method: 'POST',
+            path: '/api/console/proxy?path=_aliases&method=GET',
+            withProductOrigin: true,
+          },
+        } as any,
+        kibanaResponseFactory
+      );
+
+      const [[{ headers }]] = (requestModule.proxyRequest as jest.Mock).mock.calls;
+      expect(headers).toHaveProperty('x-elastic-product-origin');
+      expect(headers['x-elastic-product-origin']).toBe('kibana');
+    });
   });
 });

--- a/src/plugins/console/server/routes/api/console/proxy/validation_config.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/validation_config.ts
@@ -29,6 +29,7 @@ export const routeValidationConfig = {
   query: schema.object({
     method: acceptedHttpVerb,
     path: nonEmptyString,
+    withProductOrigin: schema.maybe(schema.boolean()),
   }),
   body: schema.stream(),
 };


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [Console] Avoid generating extra deprecation logs when getting data for autocomplete (#121857)