### PR TITLE
[Uptime] Prevent event propagation on step_duration

### DIFF
--- a/x-pack/plugins/uptime/public/components/synthetics/check_steps/step_duration.tsx
+++ b/x-pack/plugins/uptime/public/components/synthetics/check_steps/step_duration.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { MouseEvent } from 'react';
+
 import * as React from 'react';
 import { EuiButtonEmpty, EuiPopover } from '@elastic/eui';
 import { useMemo } from 'react';
@@ -55,6 +57,7 @@ export const StepDuration = ({
 
   return (
     <EuiPopover
+      onClick={(evt: MouseEvent<HTMLDivElement>) => evt.stopPropagation()}
       isOpen={durationPopoverOpenIndex === step.synthetics.step?.index}
       button={button}
       closePopover={() => setDurationPopoverOpenIndex(null)}


### PR DESCRIPTION
## Summary

Fixes #122032.

Prevent click event propagation when interacting with step_duration popover.


### Checklist

- [X] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [X] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [X] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
