### PR TITLE
[8.0] Improve session cleanup tests stability. (#121961)

### DIFF
--- a/x-pack/test/security_api_integration/session_idle.config.ts
+++ b/x-pack/test/security_api_integration/session_idle.config.ts
@@ -41,13 +41,13 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ...xPackAPITestsConfig.get('kbnTestServer'),
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
-        '--xpack.security.session.idleTimeout=5s',
-        '--xpack.security.session.cleanupInterval=10s',
+        '--xpack.security.session.idleTimeout=10s',
+        '--xpack.security.session.cleanupInterval=20s',
         `--xpack.security.authc.providers=${JSON.stringify({
           basic: { basic1: { order: 0 } },
           saml: {
             saml_fallback: { order: 1, realm: 'saml1' },
-            saml_override: { order: 2, realm: 'saml1', session: { idleTimeout: '1m' } },
+            saml_override: { order: 2, realm: 'saml1', session: { idleTimeout: '2m' } },
             saml_disable: { order: 3, realm: 'saml1', session: { idleTimeout: 0 } },
           },
         })}`,

--- a/x-pack/test/security_api_integration/session_lifespan.config.ts
+++ b/x-pack/test/security_api_integration/session_lifespan.config.ts
@@ -41,13 +41,13 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ...xPackAPITestsConfig.get('kbnTestServer'),
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
-        '--xpack.security.session.lifespan=5s',
-        '--xpack.security.session.cleanupInterval=10s',
+        '--xpack.security.session.lifespan=10s',
+        '--xpack.security.session.cleanupInterval=20s',
         `--xpack.security.authc.providers=${JSON.stringify({
           basic: { basic1: { order: 0 } },
           saml: {
             saml_fallback: { order: 1, realm: 'saml1' },
-            saml_override: { order: 2, realm: 'saml1', session: { lifespan: '1m' } },
+            saml_override: { order: 2, realm: 'saml1', session: { lifespan: '2m' } },
             saml_disable: { order: 3, realm: 'saml1', session: { lifespan: 0 } },
           },
         })}`,

--- a/x-pack/test/security_api_integration/tests/session_idle/cleanup.ts
+++ b/x-pack/test/security_api_integration/tests/session_idle/cleanup.ts
@@ -28,11 +28,13 @@ export default function ({ getService }: FtrProviderContext) {
     username: string,
     provider: AuthenticationProvider
   ) {
+    log.debug(`Verifying session cookie for ${username}.`);
     const apiResponse = await supertest
       .get('/internal/security/me')
       .set('kbn-xsrf', 'xxx')
       .set('Cookie', sessionCookie.cookieString())
       .expect(200);
+    log.debug(`Session cookie for ${username} is valid.`);
 
     expect(apiResponse.body.username).to.be(username);
     expect(apiResponse.body.authentication_provider).to.eql(provider);
@@ -81,8 +83,9 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should properly clean up session expired because of idle timeout', async function () {
-      this.timeout(60000);
+      this.timeout(100000);
 
+      log.debug(`Log in as ${basicUsername} using ${basicPassword} password.`);
       const response = await supertest
         .post('/internal/security/login')
         .set('kbn-xsrf', 'xxx')
@@ -98,13 +101,16 @@ export default function ({ getService }: FtrProviderContext) {
       await checkSessionCookie(sessionCookie, basicUsername, { type: 'basic', name: 'basic1' });
       expect(await getNumberOfSessionDocuments()).to.be(1);
 
-      // Cleanup routine runs every 10s, and idle timeout threshold is three times larger than 5s
-      // idle timeout, let's wait for 40s to make sure cleanup routine runs when idle timeout
+      // Cleanup routine runs every 20s, and idle timeout threshold is three times larger than 10s
+      // idle timeout, let's wait for 60s to make sure cleanup routine runs when idle timeout
       // threshold is exceeded.
-      await delay(40000);
+      log.debug('Waiting for cleanup job to run...');
+      await delay(60000);
 
       // Session info is removed from the index and cookie isn't valid anymore
       expect(await getNumberOfSessionDocuments()).to.be(0);
+
+      log.debug(`Authenticating as ${basicUsername} with invalid session cookie.`);
       await supertest
         .get('/internal/security/me')
         .set('kbn-xsrf', 'xxx')
@@ -113,7 +119,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should properly clean up session expired because of idle timeout when providers override global session config', async function () {
-      this.timeout(60000);
+      this.timeout(100000);
 
       const [samlDisableSessionCookie, samlOverrideSessionCookie, samlFallbackSessionCookie] =
         await Promise.all([
@@ -140,10 +146,11 @@ export default function ({ getService }: FtrProviderContext) {
       });
       expect(await getNumberOfSessionDocuments()).to.be(4);
 
-      // Cleanup routine runs every 10s, and idle timeout threshold is three times larger than 5s
-      // idle timeout, let's wait for 40s to make sure cleanup routine runs when idle timeout
+      // Cleanup routine runs every 20s, and idle timeout threshold is three times larger than 10s
+      // idle timeout, let's wait for 60s to make sure cleanup routine runs when idle timeout
       // threshold is exceeded.
-      await delay(40000);
+      log.debug('Waiting for cleanup job to run...');
+      await delay(60000);
 
       // Session for basic and SAML that used global session settings should not be valid anymore.
       expect(await getNumberOfSessionDocuments()).to.be(2);
@@ -170,7 +177,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should not clean up session if user is active', async function () {
-      this.timeout(60000);
+      this.timeout(100000);
 
       const response = await supertest
         .post('/internal/security/login')
@@ -187,17 +194,17 @@ export default function ({ getService }: FtrProviderContext) {
       await checkSessionCookie(sessionCookie, basicUsername, { type: 'basic', name: 'basic1' });
       expect(await getNumberOfSessionDocuments()).to.be(1);
 
-      // Run 20 consequent requests with 1.5s delay, during this time cleanup procedure should run at
+      // Run 20 consequent requests with 3s delay, during this time cleanup procedure should run at
       // least twice.
       for (const counter of [...Array(20).keys()]) {
-        // Session idle timeout is 15s, let's wait 10s and make a new request that would extend the session.
-        await delay(1500);
+        // Session idle timeout is 10s, let's wait 3s and make a new request that would extend the session.
+        await delay(3000);
 
         sessionCookie = (await checkSessionCookie(sessionCookie, basicUsername, {
           type: 'basic',
           name: 'basic1',
         }))!;
-        log.debug(`Session is still valid after ${(counter + 1) * 1.5}s`);
+        log.debug(`Session is still valid after ${(counter + 1) * 3}s`);
       }
 
       // Session document should still be present.

--- a/x-pack/test/security_api_integration/tests/session_lifespan/cleanup.ts
+++ b/x-pack/test/security_api_integration/tests/session_lifespan/cleanup.ts
@@ -76,7 +76,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should properly clean up session expired because of lifespan', async function () {
-      this.timeout(60000);
+      this.timeout(100000);
 
       const response = await supertest
         .post('/internal/security/login')
@@ -96,9 +96,9 @@ export default function ({ getService }: FtrProviderContext) {
       });
       expect(await getNumberOfSessionDocuments()).to.be(1);
 
-      // Cleanup routine runs every 10s, let's wait for 40s to make sure it runs multiple times and
+      // Cleanup routine runs every 20s, let's wait for 60s to make sure it runs multiple times and
       // when lifespan is exceeded.
-      await delay(40000);
+      await delay(60000);
 
       // Session info is removed from the index and cookie isn't valid anymore
       expect(await getNumberOfSessionDocuments()).to.be(0);
@@ -110,7 +110,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should properly clean up session expired because of lifespan when providers override global session config', async function () {
-      this.timeout(60000);
+      this.timeout(100000);
 
       const [samlDisableSessionCookie, samlOverrideSessionCookie, samlFallbackSessionCookie] =
         await Promise.all([
@@ -136,9 +136,9 @@ export default function ({ getService }: FtrProviderContext) {
       });
       expect(await getNumberOfSessionDocuments()).to.be(4);
 
-      // Cleanup routine runs every 10s, let's wait for 40s to make sure it runs multiple times and
+      // Cleanup routine runs every 20s, let's wait for 40s to make sure it runs multiple times and
       // when lifespan is exceeded.
-      await delay(40000);
+      await delay(60000);
 
       // Session for basic and SAML that used global session settings should not be valid anymore.
       expect(await getNumberOfSessionDocuments()).to.be(2);


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Improve session cleanup tests stability. (#121961)