### PR TITLE
[ML] APM Correlations: Re-enable latency correlations API integration tests.

### DIFF
--- a/x-pack/test/apm_api_integration/tests/correlations/latency.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/latency.spec.ts
@@ -211,10 +211,10 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         expect(finalRawResponse?.overallHistogram?.length).to.be(101);
         expect(finalRawResponse?.fieldStats?.length).to.be(fieldsToSample.size);
 
-        // Identified 13 significant correlations out of 379 field/value pairs.
-        expect(finalRawResponse?.latencyCorrelations?.length).to.eql(
-          13,
-          `Expected 13 identified correlations, got ${finalRawResponse?.latencyCorrelations?.length}.`
+        // Identified more than 10 significant correlations out of 379 field/value pairs.
+        expect(finalRawResponse?.latencyCorrelations?.length).to.greaterThan(
+          10,
+          `Expected more than 10 identified correlations, got ${finalRawResponse?.latencyCorrelations?.length}.`
         );
 
         const correlation = finalRawResponse?.latencyCorrelations?.sort(

--- a/x-pack/test/apm_api_integration/tests/correlations/latency.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/latency.spec.ts
@@ -5,10 +5,15 @@
  * 2.0.
  */
 
+import { chunk } from 'lodash';
+
 import expect from '@kbn/expect';
 
 import { FtrProviderContext } from '../../common/ftr_provider_context';
-import type { LatencyCorrelationsResponse } from '../../../../plugins/apm/common/correlations/latency_correlations/types';
+import type {
+  LatencyCorrelation,
+  LatencyCorrelationsResponse,
+} from '../../../../plugins/apm/common/correlations/latency_correlations/types';
 
 // These tests go through the full sequence of queries required
 // to get the final results for a latency correlation analysis.
@@ -160,30 +165,54 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           `Expected field value pairs length to be '379', got '${fieldValuePairsResponse.body?.fieldValuePairs.length}'`
         );
 
-        const significantCorrelationsResponse = await apmApiClient.readUser({
-          endpoint: 'POST /internal/apm/correlations/significant_correlations',
-          params: {
-            body: {
-              ...getOptions(),
-              fieldValuePairs: fieldValuePairsResponse.body?.fieldValuePairs,
+        // This replicates the code used in the `useLatencyCorrelations` hook to chunk requests for correlation analysis.
+        // Tests turned out to be flaky and occasionally overload ES with a `search_phase_execution_exception`
+        // when all 379 field value pairs from above are queried in parallel.
+        // The chunking sends 10 field value pairs with each request to the Kibana API endpoint.
+        // Kibana itself will then run those 10 requests in parallel against ES.
+        const latencyCorrelations: LatencyCorrelation[] = [];
+        let ccsWarning = false;
+        const chunkSize = 10;
+
+        const fieldValuePairChunks = chunk(
+          fieldValuePairsResponse.body?.fieldValuePairs,
+          chunkSize
+        );
+
+        for (const fieldValuePairChunk of fieldValuePairChunks) {
+          const significantCorrelations = await apmApiClient.readUser({
+            endpoint: 'POST /internal/apm/correlations/significant_correlations',
+            params: {
+              body: {
+                ...getOptions(),
+                fieldValuePairs: fieldValuePairChunk,
+              },
             },
-          },
-        });
+          });
 
-        expect(significantCorrelationsResponse.status).to.eql(
-          200,
-          `Expected status to be '200', got '${significantCorrelationsResponse.status}'`
-        );
+          expect(significantCorrelations.status).to.eql(
+            200,
+            `Expected status to be '200', got '${significantCorrelations.status}'`
+          );
 
-        // Loaded fractions and totalDocCount of 1244.
-        expect(significantCorrelationsResponse.body?.totalDocCount).to.eql(
-          1244,
-          `Expected 1244 total doc count, got ${significantCorrelationsResponse.body?.totalDocCount}.`
-        );
+          // Loaded fractions and totalDocCount of 1244.
+          expect(significantCorrelations.body?.totalDocCount).to.eql(
+            1244,
+            `Expected 1244 total doc count, got ${significantCorrelations.body?.totalDocCount}.`
+          );
+
+          if (significantCorrelations.body?.latencyCorrelations.length > 0) {
+            latencyCorrelations.push(...significantCorrelations.body?.latencyCorrelations);
+          }
+
+          if (significantCorrelations.body?.ccsWarning) {
+            ccsWarning = true;
+          }
+        }
 
         const fieldsToSample = new Set<string>();
-        if (significantCorrelationsResponse.body?.latencyCorrelations.length > 0) {
-          significantCorrelationsResponse.body?.latencyCorrelations.forEach((d) => {
+        if (latencyCorrelations.length > 0) {
+          latencyCorrelations.forEach((d) => {
             fieldsToSample.add(d.fieldName);
           });
         }
@@ -199,10 +228,10 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
 
         const finalRawResponse: LatencyCorrelationsResponse = {
-          ccsWarning: significantCorrelationsResponse.body?.ccsWarning,
+          ccsWarning,
           percentileThresholdValue: overallDistributionResponse.body?.percentileThresholdValue,
           overallHistogram: overallDistributionResponse.body?.overallHistogram,
-          latencyCorrelations: significantCorrelationsResponse.body?.latencyCorrelations,
+          latencyCorrelations,
           fieldStats: failedtransactionsFieldStats.body?.stats,
         };
 
@@ -211,10 +240,10 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         expect(finalRawResponse?.overallHistogram?.length).to.be(101);
         expect(finalRawResponse?.fieldStats?.length).to.be(fieldsToSample.size);
 
-        // Identified more than 10 significant correlations out of 379 field/value pairs.
-        expect(finalRawResponse?.latencyCorrelations?.length).to.greaterThan(
-          10,
-          `Expected more than 10 identified correlations, got ${finalRawResponse?.latencyCorrelations?.length}.`
+        // Identified 13 significant correlations out of 379 field/value pairs.
+        expect(finalRawResponse?.latencyCorrelations?.length).to.eql(
+          13,
+          `Expected 13 identified correlations, got ${finalRawResponse?.latencyCorrelations?.length}.`
         );
 
         const correlation = finalRawResponse?.latencyCorrelations?.sort(

--- a/x-pack/test/apm_api_integration/tests/correlations/latency.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/latency.spec.ts
@@ -105,8 +105,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     { config: 'trial', archives: ['8.0.0'] },
     () => {
       // putting this into a single `it` because the responses depend on each other
-      // flaky: https://github.com/elastic/kibana/issues/118023
-      it.skip('runs queries and returns results', async () => {
+      it('runs queries and returns results', async () => {
         const overallDistributionResponse = await apmApiClient.readUser({
           endpoint: 'POST /internal/apm/latency/overall_distribution',
           params: {


### PR DESCRIPTION
## Summary

Fixes #118023.

The tests have been adapted to be less flaky, re-enabling with this PR.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
