### PR TITLE
[storybook][eui] Add EUIThemeProvider to kbn-storybook

### DIFF
--- a/packages/kbn-storybook/preset.js
+++ b/packages/kbn-storybook/preset.js
@@ -16,4 +16,7 @@ module.exports = {
   webpackFinal: (config) => {
     return webpackConfig({ config });
   },
+  config: (entry) => {
+    return [...entry, require.resolve('./target_node/lib/decorators')];
+  },
 };

--- a/packages/kbn-storybook/src/lib/decorators.tsx
+++ b/packages/kbn-storybook/src/lib/decorators.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { EuiProvider } from '@elastic/eui';
+import createCache from '@emotion/cache';
+import type { DecoratorFn } from '@storybook/react';
+
+/**
+ * Storybook decorator using the EUI provider. Uses the value from
+ * `globals` provided by the Storybook theme switcher.
+ */
+const EuiProviderDecorator: DecoratorFn = (storyFn, { globals }) => {
+  const colorMode = globals.euiTheme === 'v8.dark' ? 'dark' : 'light';
+  const emotionCache = createCache({
+    key: 'eui-styles',
+    container: document.querySelector(`meta[name="eui-styles-global"]`) as HTMLElement,
+  });
+
+  return (
+    <EuiProvider colorMode={colorMode} cache={emotionCache}>
+      {storyFn()}
+    </EuiProvider>
+  );
+};
+
+export const decorators = [EuiProviderDecorator];

--- a/packages/kbn-storybook/templates/index.ejs
+++ b/packages/kbn-storybook/templates/index.ejs
@@ -13,6 +13,7 @@
     <% } %>
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="eui-styles-global" />
 
     <!-- Added for Kibana shared dependencies -->
     <script>


### PR DESCRIPTION
## Summary

> This PR is a clean change derived from https://github.com/elastic/kibana/pull/121901

Fixes #121557 
Contributes to #121654
Closes #121901

This PR adds the `EuiThemeProvider` as a decorator to `kbn-storybook` preset.  This ensures all Kibana Storybooks will inherit the EUI theme without having to add the decorator manually to every plugin.  

Without this provider, all Storybooks appear to be broken due to lack of EUI styles.