### PR TITLE
[8.0] Update dependency broadcast-channel to ^4.9.0 (#122000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "base64-js": "^1.3.1",
     "bluebird": "3.5.5",
     "brace": "0.11.1",
-    "broadcast-channel": "^4.8.0",
+    "broadcast-channel": "^4.9.0",
     "chalk": "^4.1.0",
     "cheerio": "^1.0.0-rc.10",
     "chokidar": "^3.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8760,10 +8760,10 @@ broadcast-channel@^3.4.1:
     rimraf "3.0.2"
     unload "2.2.0"
 
-broadcast-channel@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.8.0.tgz#1f2c1f1fd97e186c26793b044218ed44a9d4d7d8"
-  integrity sha512-Ei6MylH1YfQQql52zNyZaLu8UvD+BeWNUKcKc8KrqyA7z3Ap2tb6A8KQJm0EBO0SDiKKNaAyzrnkRHhrtG9pYQ==
+broadcast-channel@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.9.0.tgz#8af337d4ea19aeb6b819ec2eb3dda942b28c724c"
+  integrity sha512-xWzFb3wrOZGJF2kOSs2D3KvHXdLDMVb+WypEIoNvwblcHgUBydVy65pDJ9RS4WN9Kyvs0UVQuCCzfKme0G6Qjw==
   dependencies:
     "@babel/runtime" "^7.16.0"
     detect-node "^2.1.0"


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Update dependency broadcast-channel to ^4.9.0 (#122000)