### PR TITLE
[7.17] Capture user logout events in audit log (#121455)

### DIFF
--- a/docs/user/security/audit-logging.asciidoc
+++ b/docs/user/security/audit-logging.asciidoc
@@ -81,6 +81,9 @@ Refer to the corresponding {es} logs for potential write errors.
 | `success` | User has logged in successfully.
 | `failure` | Failed login attempt (e.g. due to invalid credentials).
 
+| `user_logout`
+| `unknown` | User is logging out.
+
 3+a|
 ===== Category: database
 ====== Type: creation

--- a/x-pack/plugins/security/server/audit/audit_events.test.ts
+++ b/x-pack/plugins/security/server/audit/audit_events.test.ts
@@ -18,6 +18,7 @@ import {
   SpaceAuditAction,
   spaceAuditEvent,
   userLoginEvent,
+  userLogoutEvent,
 } from './audit_events';
 
 describe('#savedObjectEvent', () => {
@@ -294,6 +295,57 @@ describe('#userLoginEvent', () => {
           "space_id": undefined,
         },
         "message": "Failed attempt to login using basic provider [name=basic1]",
+        "user": undefined,
+      }
+    `);
+  });
+});
+
+describe('#userLogoutEvent', () => {
+  test('creates event with `unknown` outcome', () => {
+    expect(
+      userLogoutEvent({
+        username: 'elastic',
+        provider: { name: 'basic1', type: 'basic' },
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "event": Object {
+          "action": "user_logout",
+          "category": Array [
+            "authentication",
+          ],
+          "outcome": "unknown",
+        },
+        "kibana": Object {
+          "authentication_provider": "basic1",
+          "authentication_type": "basic",
+        },
+        "message": "User [elastic] is logging out using basic provider [name=basic1]",
+        "user": Object {
+          "name": "elastic",
+        },
+      }
+    `);
+
+    expect(
+      userLogoutEvent({
+        provider: { name: 'basic1', type: 'basic' },
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "event": Object {
+          "action": "user_logout",
+          "category": Array [
+            "authentication",
+          ],
+          "outcome": "unknown",
+        },
+        "kibana": Object {
+          "authentication_provider": "basic1",
+          "authentication_type": "basic",
+        },
+        "message": "User [undefined] is logging out using basic provider [name=basic1]",
         "user": undefined,
       }
     `);

--- a/x-pack/plugins/security/server/audit/audit_events.ts
+++ b/x-pack/plugins/security/server/audit/audit_events.ts
@@ -7,6 +7,7 @@
 
 import type { EcsEventOutcome, EcsEventType, KibanaRequest, LogMeta } from 'src/core/server';
 
+import type { AuthenticationProvider } from '../../common/model';
 import type { AuthenticationResult } from '../authentication/authentication_result';
 
 /**
@@ -126,6 +127,31 @@ export function userLoginEvent({
     error: authenticationResult.error && {
       code: authenticationResult.error.name,
       message: authenticationResult.error.message,
+    },
+  };
+}
+
+export interface UserLogoutParams {
+  username?: string;
+  provider: AuthenticationProvider;
+}
+
+export function userLogoutEvent({ username, provider }: UserLogoutParams): AuditEvent {
+  return {
+    message: `User [${username}] is logging out using ${provider.type} provider [name=${provider.name}]`,
+    event: {
+      action: 'user_logout',
+      category: ['authentication'],
+      outcome: 'unknown',
+    },
+    user: username
+      ? {
+          name: username,
+        }
+      : undefined,
+    kibana: {
+      authentication_provider: provider.name,
+      authentication_type: provider.type,
     },
   };
 }

--- a/x-pack/plugins/security/server/audit/index.ts
+++ b/x-pack/plugins/security/server/audit/index.ts
@@ -10,7 +10,7 @@ export { AuditService } from './audit_service';
 export type { AuditEvent } from './audit_events';
 export {
   userLoginEvent,
-  httpRequestEvent,
+  userLogoutEvent,
   savedObjectEvent,
   spaceAuditEvent,
   SavedObjectAction,

--- a/x-pack/plugins/security/server/authentication/authenticator.ts
+++ b/x-pack/plugins/security/server/authentication/authenticator.ts
@@ -21,7 +21,7 @@ import type { SecurityLicense } from '../../common/licensing';
 import type { AuthenticatedUser, AuthenticationProvider } from '../../common/model';
 import { shouldProviderUseLoginForm } from '../../common/model';
 import type { AuditServiceSetup, SecurityAuditLogger } from '../audit';
-import { userLoginEvent } from '../audit';
+import { userLoginEvent, userLogoutEvent } from '../audit';
 import type { ConfigType } from '../config';
 import { getErrorStatusCode } from '../errors';
 import type { SecurityFeatureUsageServiceStart } from '../feature_usage';
@@ -419,7 +419,7 @@ export class Authenticator {
       sessionValue?.provider.name ??
       request.url.searchParams.get(LOGOUT_PROVIDER_QUERY_STRING_PARAMETER);
     if (suggestedProviderName) {
-      await this.invalidateSessionValue(request);
+      await this.invalidateSessionValue(request, sessionValue);
 
       // Provider name may be passed in a query param and sourced from the browser's local storage;
       // hence, we can't assume that this provider exists, so we have to check it.
@@ -565,7 +565,7 @@ export class Authenticator {
       this.logger.warn(
         `Attempted to retrieve session for the "${existingSessionValue.provider.type}/${existingSessionValue.provider.name}" provider, but it is not configured.`
       );
-      await this.invalidateSessionValue(request);
+      await this.invalidateSessionValue(request, existingSessionValue);
       return null;
     }
 
@@ -599,7 +599,7 @@ export class Authenticator {
     // attempt didn't fail.
     if (authenticationResult.shouldClearState()) {
       this.logger.debug('Authentication provider requested to invalidate existing session.');
-      await this.invalidateSessionValue(request);
+      await this.invalidateSessionValue(request, existingSessionValue);
       return null;
     }
 
@@ -613,7 +613,7 @@ export class Authenticator {
     if (authenticationResult.failed()) {
       if (ownsSession && getErrorStatusCode(authenticationResult.error) === 401) {
         this.logger.debug('Authentication attempt failed, existing session will be invalidated.');
-        await this.invalidateSessionValue(request);
+        await this.invalidateSessionValue(request, existingSessionValue);
       }
       return null;
     }
@@ -651,17 +651,17 @@ export class Authenticator {
       this.logger.debug(
         'Authentication provider has changed, existing session will be invalidated.'
       );
-      await this.invalidateSessionValue(request);
+      await this.invalidateSessionValue(request, existingSessionValue);
       existingSessionValue = null;
     } else if (sessionHasBeenAuthenticated) {
       this.logger.debug(
         'Session is authenticated, existing unauthenticated session will be invalidated.'
       );
-      await this.invalidateSessionValue(request);
+      await this.invalidateSessionValue(request, existingSessionValue);
       existingSessionValue = null;
     } else if (usernameHasChanged) {
       this.logger.debug('Username has changed, existing session will be invalidated.');
-      await this.invalidateSessionValue(request);
+      await this.invalidateSessionValue(request, existingSessionValue);
       existingSessionValue = null;
     }
 
@@ -697,8 +697,19 @@ export class Authenticator {
   /**
    * Invalidates session value associated with the specified request.
    * @param request Request instance.
+   * @param sessionValue Value of the existing session if any.
    */
-  private async invalidateSessionValue(request: KibanaRequest) {
+  private async invalidateSessionValue(request: KibanaRequest, sessionValue: SessionValue | null) {
+    if (sessionValue) {
+      const auditLogger = this.options.audit.asScoped(request);
+      auditLogger.log(
+        userLogoutEvent({
+          username: sessionValue.username,
+          provider: sessionValue.provider,
+        })
+      );
+    }
+
     await this.session.invalidate(request, { match: 'current' });
   }
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Capture user logout events in audit log (#121455)