### PR TITLE
[storybook] Fix Presentation Utility to use default setup; add README note

### DIFF
--- a/packages/kbn-storybook/README.md
+++ b/packages/kbn-storybook/README.md
@@ -46,7 +46,7 @@ You can also add a `manager.ts` file to customize various aspects of your Storyb
 addons.setConfig({
   theme: create({
     brandTitle: 'My Plugin',
-    brandUrl: 'https://github.com/elastic/kibana/tree/main/src/plugins/my_pluginl',
+    brandUrl: 'https://github.com/elastic/kibana/tree/main/src/plugins/my_plugin',
   }),
 });
 ```

--- a/packages/kbn-storybook/README.md
+++ b/packages/kbn-storybook/README.md
@@ -16,6 +16,7 @@ This package provides ability to add [Storybook](https://storybook.js.org/) to a
   ```
 
 - Add your plugin alias to `src/dev/storybook/aliases.ts` config.
+
 - Create sample Storybook stories. For example, in your plugin create a file at
   `src/plugins/<plugin>/public/components/hello_world/hello_world.stories.tsx` with
   the following [Component Story Format](https://storybook.js.org/docs/react/api/csf) contents:
@@ -34,8 +35,20 @@ This package provides ability to add [Storybook](https://storybook.js.org/) to a
   ```
 
 - Launch Storybook with `yarn storybook <plugin>`, or build a static site with `yarn storybook --site <plugin>`.
-
 ## Customizing configuration
 
-The `defaultConfig` object provided by the @kbn/storybook package should be all you need to get running, but you can
-override this in your .storybook/main.js. Using [Storybook's configuration options](https://storybook.js.org/docs/react/configure/overview).
+The `defaultConfig` object provided by the `@kbn/storybook` package should be all you need to get running, but you can
+override this in your `.storybook/main.js`. Using [Storybook's configuration options](https://storybook.js.org/docs/react/configure/overview).
+
+You can also add a `manager.ts` file to customize various aspects of your Storybook.  For example, to change the title and link of the Storybook sidebar, you could add:
+
+```ts
+addons.setConfig({
+  theme: create({
+    brandTitle: 'My Plugin',
+    brandUrl: 'https://github.com/elastic/kibana/tree/main/src/plugins/my_pluginl',
+  }),
+});
+```
+
+Refer to the [Storybook documentation](https://storybook.js.org/docs/react/configure/features-and-behavior) for more information. 

--- a/src/plugins/presentation_util/storybook/main.ts
+++ b/src/plugins/presentation_util/storybook/main.ts
@@ -6,11 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { defaultConfigWebFinal } from '@kbn/storybook';
+import { defaultConfig } from '@kbn/storybook';
 
-// We have to do this because the kbn/storybook preset overrides the manager entries,
-// so we can't customize the theme.
-module.exports = {
-  ...defaultConfigWebFinal,
-  addons: ['@storybook/addon-a11y', '@storybook/addon-essentials'],
-};
+module.exports = defaultConfig;

--- a/src/plugins/presentation_util/storybook/manager.ts
+++ b/src/plugins/presentation_util/storybook/manager.ts
@@ -10,9 +10,6 @@ import { addons } from '@storybook/addons';
 import { create } from '@storybook/theming';
 import { PANEL_ID } from '@storybook/addon-actions';
 
-// @ts-expect-error There's probably a better way to do this.
-import { registerThemeSwitcherAddon } from '@kbn/storybook/target_node/lib/register_theme_switcher_addon';
-
 addons.setConfig({
   theme: create({
     base: 'light',
@@ -22,5 +19,3 @@ addons.setConfig({
   showPanel: true.valueOf,
   selectedPanel: PANEL_ID,
 });
-
-registerThemeSwitcherAddon();


### PR DESCRIPTION
## Summary

The Presentation Utility plugin used a custom setup in order to alter the manager entries.  With #122093, this is no longer necessary.

This also adds a note to the `kbn-storybook` README on how to customize the manager and preview per-plugin.