### PR TITLE
[Uptime] Fix report crashing when no report dates exist

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/components/date_range_picker.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/components/date_range_picker.tsx
@@ -15,9 +15,10 @@ import { useUiSetting } from '../../../../../../../../src/plugins/kibana_react/p
 import { SeriesUrl } from '../types';
 import { ReportTypes } from '../configurations/constants';
 
-export const parseRelativeDate = (date: string, options = {}) => {
+export const parseRelativeDate = (date: string, options = {}): Moment | void => {
   return DateMath.parse(date, options)!;
 };
+
 export function DateRangePicker({ seriesId, series }: { seriesId: number; series: SeriesUrl }) {
   const { firstSeries, setSeries, reportType } = useSeriesStorage();
   const dateFormat = useUiSetting<string>('dateFormat');

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.ts
@@ -635,11 +635,17 @@ export class LensAttributes {
       time: { from },
     } = layerConfig;
 
-    const inDays = Math.abs(parseRelativeDate(mainFrom).diff(parseRelativeDate(from), 'days'));
+    const parsedMainFrom = parseRelativeDate(mainFrom);
+    const parsedFrom = parseRelativeDate(from);
+
+    const inDays =
+      parsedMainFrom && parsedFrom ? Math.abs(parsedMainFrom.diff(parsedFrom, 'days')) : 0;
     if (inDays > 1) {
       return inDays + 'd';
     }
-    const inHours = Math.abs(parseRelativeDate(mainFrom).diff(parseRelativeDate(from), 'hours'));
+
+    const inHours =
+      parsedMainFrom && parsedFrom ? Math.abs(parsedMainFrom?.diff(parsedFrom, 'hours')) : 0;
     if (inHours === 0) {
       return null;
     }

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/header/add_to_case_action.test.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/header/add_to_case_action.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '../rtl_helpers';
+import { render, forNearestButton } from '../rtl_helpers';
 import { fireEvent } from '@testing-library/dom';
 import { AddToCaseAction } from './add_to_case_action';
 import * as useCaseHook from '../hooks/use_add_to_case';
@@ -14,6 +14,10 @@ import * as datePicker from '../components/date_range_picker';
 import moment from 'moment';
 
 describe('AddToCaseAction', function () {
+  beforeEach(() => {
+    jest.spyOn(datePicker, 'parseRelativeDate').mockRestore();
+  });
+
   it('should render properly', async function () {
     const { findByText } = render(
       <AddToCaseAction
@@ -44,6 +48,26 @@ describe('AddToCaseAction', function () {
         timeRange: {
           from: '2021-11-10T10:52:06.091Z',
           to: '2021-11-10T10:52:06.091Z',
+        },
+      })
+    );
+  });
+
+  it('should use an empty time-range when timeRanges are empty', async function () {
+    const useAddToCaseHook = jest.spyOn(useCaseHook, 'useAddToCase');
+
+    const { getByText } = render(
+      <AddToCaseAction lensAttributes={null} timeRange={{ to: '', from: '' }} />
+    );
+
+    expect(await forNearestButton(getByText)('Add to case')).toBeDisabled();
+
+    expect(useAddToCaseHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lensAttributes: null,
+        timeRange: {
+          from: '',
+          to: '',
         },
       })
     );

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/header/add_to_case_action.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/header/add_to_case_action.tsx
@@ -54,7 +54,10 @@ export function AddToCaseAction({ lensAttributes, timeRange }: AddToCaseProps) {
   const { onCaseClicked, isCasesOpen, setIsCasesOpen, isSaving } = useAddToCase({
     lensAttributes,
     getToastText,
-    timeRange: { from: absoluteFromDate.toISOString(), to: absoluteToDate.toISOString() },
+    timeRange: {
+      from: absoluteFromDate?.toISOString() ?? '',
+      to: absoluteToDate?.toISOString() ?? '',
+    },
   });
 
   const getAllCasesSelectorModalProps: GetAllCasesSelectorModalProps = {

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/header/last_updated.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/header/last_updated.tsx
@@ -14,8 +14,8 @@ import { ChartCreationInfo } from './chart_creation_info';
 
 export interface ChartTimeRange {
   lastUpdated: number;
-  to: number;
-  from: number;
+  to?: number;
+  from?: number;
 }
 
 interface Props {

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/lens_embeddable.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/lens_embeddable.tsx
@@ -45,8 +45,8 @@ export function LensEmbeddable(props: Props) {
 
       setChartTimeRangeContext({
         lastUpdated: timeLoaded,
-        to: parseRelativeDate(timeRange?.to || '').valueOf(),
-        from: parseRelativeDate(timeRange?.from || '').valueOf(),
+        to: parseRelativeDate(timeRange?.to || '')?.valueOf(),
+        from: parseRelativeDate(timeRange?.from || '')?.valueOf(),
       });
 
       if (!isLoading) {

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/rtl_helpers.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/rtl_helpers.tsx
@@ -9,7 +9,12 @@ import { of } from 'rxjs';
 import React, { ReactElement } from 'react';
 import { stringify } from 'query-string';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { render as reactTestLibRender, RenderOptions } from '@testing-library/react';
+import {
+  render as reactTestLibRender,
+  RenderOptions,
+  Nullish,
+  MatcherFunction,
+} from '@testing-library/react';
 import { Route, Router } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
 import { CoreStart } from 'kibana/public';
@@ -370,3 +375,18 @@ export const mockIndexPattern = createStubIndexPattern({
     fields: JSON.parse(indexPatternData.attributes.fields),
   },
 });
+
+// This function allows us to query for the nearest button with test
+// no matter whether it has nested tags or not (as EuiButton elements do).
+export const forNearestButton =
+  (getByText: (f: MatcherFunction) => HTMLElement | null) =>
+  (text: string): HTMLElement | null =>
+    getByText((_content: string, node: Nullish<Element>) => {
+      if (!node) return false;
+      const noOtherButtonHasText = Array.from(node.children).every(
+        (child) => child && (child.textContent !== text || child.tagName.toLowerCase() !== 'button')
+      );
+      return (
+        noOtherButtonHasText && node.textContent === text && node.tagName.toLowerCase() === 'button'
+      );
+    });


### PR DESCRIPTION
## Summary

This PR fixes #122086.

The problem described in #122086 was indeed similar to #119989 and #121653. It happened because when trying to apply the settings to generate the graphs, we didn't have any dates available to parse and call `toISOString` in.

Previously, I've done a fix which just makes that function be called with the correct settings for other reports (https://github.com/elastic/kibana/pull/121671), but, in this case, we don't have any dates to pass down, and thus the `toISOString` call causes a crash as it's called on `undefined`.

This fix should be more resilient as it's more "defensive" than the previous, which was a small precise fix.

## The fix

In my fix, I have updated the types to reflect the fact that `parseRelativeDate` can return `void` values. Then, I updated the function which does the parsing so that it doesn't try to call `toISOString` on `undefined` values.

Also, you don't have to worry about these values being empty because when they are the `lensAttributes` will also be `null`, meaning a report can't be rendered. In that case, we show the empty view you expect.

https://github.com/elastic/kibana/blob/cf81ece986d49e0e86a9a34ef7f0a55cd6c8e7f8/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.tsx#L117-L124

In that case, the `Add to Case` button will also be disabled:

https://github.com/elastic/kibana/blob/cf81ece986d49e0e86a9a34ef7f0a55cd6c8e7f8/x-pack/plugins/observability/public/components/shared/exploratory_view/header/add_to_case_action.tsx#L71-L83

## How to test this PR

Testing instructions can be found in #122086.

Besides following those instructions, please also try choosing different types of reports and keep applying configurations for all of them with as few bits of data selected as possible, to make sure nothing will cause the exploratory view to crash.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


## Release note

Fixes a problem in which the exploratory view would crash if no date ranges were selected.