### PR TITLE
[Embeddable] fix customize time range displays auto-refresh option

### DIFF
--- a/x-pack/plugins/ui_actions_enhanced/public/customize_time_range_modal.test.tsx
+++ b/x-pack/plugins/ui_actions_enhanced/public/customize_time_range_modal.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CustomizeTimeRangeModal } from './customize_time_range_modal';
+import { Embeddable } from '../../../../src/plugins/embeddable/public';
+import { TimeRangeInput } from './custom_time_range_action';
+
+test("Doesn't display refresh interval options", () => {
+  render(
+    <CustomizeTimeRangeModal
+      embeddable={
+        {
+          getInput: () => ({ timerange: { from: 'now-7d', to: 'now' } }),
+        } as unknown as Embeddable<TimeRangeInput>
+      }
+      onClose={() => {}}
+      commonlyUsedRanges={[]}
+    />
+  );
+
+  expect(screen.getByTestId('superDatePickerToggleQuickMenuButton')).toBeInTheDocument();
+  expect(screen.queryByTitle(/auto refresh/gi)).not.toBeInTheDocument();
+});

--- a/x-pack/plugins/ui_actions_enhanced/public/customize_time_range_modal.tsx
+++ b/x-pack/plugins/ui_actions_enhanced/public/customize_time_range_modal.tsx
@@ -114,7 +114,6 @@ export class CustomizeTimeRangeModal extends Component<CustomizeTimeRangeProps, 
             <EuiSuperDatePicker
               start={this.state.timeRange ? this.state.timeRange.from : undefined}
               end={this.state.timeRange ? this.state.timeRange.to : undefined}
-              isPaused={false}
               onTimeChange={this.onTimeChange}
               showUpdateButton={false}
               dateFormat={this.props.dateFormat}


### PR DESCRIPTION
## Summary

close https://github.com/elastic/kibana/issues/122135

Before: 


![](https://user-images.githubusercontent.com/7784120/147671655-427e7001-ee4b-48f9-bd61-a900f4a1fc9c.png)


Fixed version: 

![Screen Shot 2021-12-30 at 13 53 43](https://user-images.githubusercontent.com/7784120/147753715-0a88aa55-7abf-4fbe-b1c7-f700b71163ec.png)

