### PR TITLE
[Uptime] Fix step detail table on mobile resolutions

### DIFF
--- a/x-pack/plugins/uptime/public/apps/uptime_page_template.tsx
+++ b/x-pack/plugins/uptime/public/apps/uptime_page_template.tsx
@@ -39,6 +39,10 @@ export const UptimePageTemplateComponent: React.FC<Props & EuiPageTemplateProps>
       .euiPageHeaderContent > .euiFlexGroup {
         flex-wrap: wrap;
       }
+
+      .euiPageHeaderContent > .euiFlexGroup > .euiFlexItem {
+        align-items: center;
+      }
     `;
   }, [PageTemplateComponent]);
 

--- a/x-pack/plugins/uptime/public/components/synthetics/check_steps/step_image.tsx
+++ b/x-pack/plugins/uptime/public/components/synthetics/check_steps/step_image.tsx
@@ -16,14 +16,14 @@ interface Props {
 
 export const StepImage = ({ step }: Props) => {
   return (
-    <EuiFlexGroup alignItems="center" gutterSize="s">
+    <EuiFlexGroup alignItems="center" gutterSize="s" wrap>
       <EuiFlexItem grow={false}>
         <PingTimestamp
           checkGroup={step.monitor.check_group}
           initialStepNo={step.synthetics?.step?.index}
         />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem grow={false} style={{ minWidth: 80 }}>
         <EuiText>{step.synthetics?.step?.name}</EuiText>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/plugins/uptime/public/components/synthetics/check_steps/steps_list.test.tsx
+++ b/x-pack/plugins/uptime/public/components/synthetics/check_steps/steps_list.test.tsx
@@ -8,7 +8,8 @@
 import React from 'react';
 import { JourneyStep } from '../../../../common/runtime_types/ping';
 import { StepsList } from './steps_list';
-import { render } from '../../../lib/helper/rtl_helpers';
+import { render, forDesktopOnly, forMobileOnly } from '../../../lib/helper/rtl_helpers';
+import { VIEW_PERFORMANCE } from '../../monitor/synthetics/translations';
 
 describe('StepList component', () => {
   let steps: JourneyStep[];
@@ -80,7 +81,7 @@ describe('StepList component', () => {
   it('renders a link to the step detail view', () => {
     const { getByTitle, getByTestId } = render(<StepsList data={[steps[0]]} loading={false} />);
     expect(getByTestId('step-detail-link')).toHaveAttribute('href', '/journey/fake-group/step/1');
-    expect(getByTitle(`Failed`));
+    expect(forDesktopOnly(getByTitle, 'title')(`Failed`));
   });
 
   it.each([
@@ -91,7 +92,7 @@ describe('StepList component', () => {
     const step = steps[0];
     step.synthetics!.payload!.status = status;
     const { getByText } = render(<StepsList data={[step]} loading={false} />);
-    expect(getByText(expectedStatus));
+    expect(forDesktopOnly(getByText)(expectedStatus));
   });
 
   it('creates expected message for all succeeded', () => {
@@ -148,5 +149,32 @@ describe('StepList component', () => {
     const { getByTestId } = render(<StepsList data={steps} loading={false} />);
     expect(getByTestId('row-fake-group'));
     expect(getByTestId('row-fake-group-1'));
+  });
+
+  describe('Mobile Designs', () => {
+    // We don't need to resize the window here because EUI
+    // does all the manipulation of what is displayed through
+    // CSS. Therefore, it's enough to check what's actually
+    // rendered and its classes.
+
+    it('renders the step name and index', () => {
+      const { getByText } = render(<StepsList data={steps} loading={false} />);
+      expect(forMobileOnly(getByText)('1. load page')).toBeInTheDocument();
+      expect(forMobileOnly(getByText)('2. go to login')).toBeInTheDocument();
+    });
+
+    it('does not render the link to view step details', async () => {
+      const { queryByText } = render(<StepsList data={steps} loading={false} />);
+      expect(forMobileOnly(queryByText)(VIEW_PERFORMANCE)).not.toBeInTheDocument();
+    });
+
+    it('renders the status label', () => {
+      steps[0].synthetics!.payload!.status = 'succeeded';
+      steps[1].synthetics!.payload!.status = 'skipped';
+
+      const { getByText } = render(<StepsList data={steps} loading={false} />);
+      expect(forMobileOnly(getByText)('Succeeded')).toBeInTheDocument();
+      expect(forMobileOnly(getByText)('Skipped')).toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/plugins/uptime/public/components/synthetics/check_steps/steps_list.tsx
+++ b/x-pack/plugins/uptime/public/components/synthetics/check_steps/steps_list.tsx
@@ -5,7 +5,15 @@
  * 2.0.
  */
 
-import { EuiBasicTable, EuiBasicTableColumn, EuiButtonIcon, EuiTitle } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiButtonIcon,
+  EuiTitle,
+  EuiFlexItem,
+  EuiText,
+  RIGHT_ALIGNMENT,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { MouseEvent, useState } from 'react';
 import styled from 'styled-components';
@@ -89,12 +97,37 @@ export const StepsList = ({ data, error, loading }: Props) => {
       render: (pingStatus: string, item) => (
         <StatusBadge status={pingStatus} stepNo={item.synthetics?.step?.index!} />
       ),
+      mobileOptions: {
+        render: (item) => (
+          <EuiFlexItem grow={false}>
+            <StatusBadge
+              isMobile={true}
+              status={item.synthetics?.payload?.status}
+              stepNo={item.synthetics?.step?.index!}
+            />
+          </EuiFlexItem>
+        ),
+        width: '20%',
+        header: STATUS_LABEL,
+        enlarge: false,
+      },
     },
     {
       align: 'left',
       field: 'timestamp',
       name: STEP_NAME_LABEL,
       render: (_timestamp: string, item) => <StepImage step={item} />,
+      mobileOptions: {
+        render: (item: JourneyStep) => (
+          <EuiText>
+            <strong>
+              {item.synthetics?.step?.index!}. {item.synthetics?.step?.name}
+            </strong>
+          </EuiText>
+        ),
+        header: 'Step',
+        enlarge: true,
+      },
     },
     {
       name: 'Step duration',
@@ -106,6 +139,12 @@ export const StepsList = ({ data, error, loading }: Props) => {
             setDurationPopoverOpenIndex={setDurationPopoverOpenIndex}
           />
         );
+      },
+      mobileOptions: {
+        header: i18n.translate('xpack.uptime.pingList.stepDurationHeader', {
+          defaultMessage: 'Step duration',
+        }),
+        show: true,
       },
     },
     {
@@ -120,11 +159,12 @@ export const StepsList = ({ data, error, loading }: Props) => {
           {VIEW_PERFORMANCE}
         </StepDetailLink>
       ),
+      mobileOptions: { show: false },
     },
 
     {
-      align: 'right',
-      width: '24px',
+      width: '40px',
+      align: RIGHT_ALIGNMENT,
       isExpander: true,
       render: (journeyStep: JourneyStep) => {
         return (
@@ -143,7 +183,6 @@ export const StepsList = ({ data, error, loading }: Props) => {
     const { monitor } = item;
 
     return {
-      height: '85px',
       'data-test-subj': `row-${monitor.check_group}`,
       onClick: (evt: MouseEvent) => {
         const targetElem = evt.target as HTMLElement;

--- a/x-pack/plugins/uptime/public/components/synthetics/status_badge.test.tsx
+++ b/x-pack/plugins/uptime/public/components/synthetics/status_badge.test.tsx
@@ -30,4 +30,10 @@ describe('StatusBadge', () => {
     expect(getByText('3.'));
     expect(getByText('Skipped'));
   });
+
+  it('hides the step number on mobile', () => {
+    const { queryByText } = render(<StatusBadge status="skipped" stepNo={3} isMobile />);
+    expect(queryByText('3.')).not.toBeInTheDocument();
+    expect(queryByText('Skipped')).toBeInTheDocument();
+  });
 });

--- a/x-pack/plugins/uptime/public/components/synthetics/status_badge.tsx
+++ b/x-pack/plugins/uptime/public/components/synthetics/status_badge.tsx
@@ -12,6 +12,7 @@ import { UptimeAppColors } from '../../apps/uptime_app';
 import { UptimeThemeContext } from '../../contexts';
 
 interface StatusBadgeProps {
+  isMobile?: boolean;
   status?: string;
   stepNo: number;
 }
@@ -46,15 +47,17 @@ export function textFromStatus(status?: string) {
   }
 }
 
-export const StatusBadge: FC<StatusBadgeProps> = ({ status, stepNo }) => {
+export const StatusBadge: FC<StatusBadgeProps> = ({ status, stepNo, isMobile }) => {
   const theme = useContext(UptimeThemeContext);
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s">
-      <EuiFlexItem grow={false}>
-        <EuiText>
-          <strong>{stepNo}.</strong>
-        </EuiText>
-      </EuiFlexItem>
+      {!isMobile && (
+        <EuiFlexItem grow={false}>
+          <EuiText>
+            <strong>{stepNo}.</strong>
+          </EuiText>
+        </EuiFlexItem>
+      )}
       <EuiFlexItem grow={false}>
         <EuiBadge color={colorFromStatus(theme.colors, status)}>{textFromStatus(status)}</EuiBadge>
       </EuiFlexItem>

--- a/x-pack/plugins/uptime/public/lib/helper/rtl_helpers.tsx
+++ b/x-pack/plugins/uptime/public/lib/helper/rtl_helpers.tsx
@@ -277,3 +277,38 @@ export const makeUptimePermissionsCore = (
     },
   };
 };
+
+// This function filters out the queried elements which appear only
+// either on mobile or desktop.
+//
+// It does so by filtering those with the class passed as the `classWrapper`.
+// For mobile, we filter classes which tell elements to be hidden on desktop.
+// For desktop, we do the opposite.
+//
+// We have this function because EUI will manipulate the visibility of some
+// elements through pure CSS, which we can't assert on tests. Therefore,
+// we look for the corresponding class wrapper.
+const finderWithClassWrapper =
+  (classWrapper: string) =>
+  (
+    getterFn: (f: MatcherFunction) => HTMLElement | null,
+    customAttribute?: keyof Element | keyof HTMLElement
+  ) =>
+  (text: string): HTMLElement | null =>
+    getterFn((_content: string, node: Nullish<Element>) => {
+      if (!node) return false;
+      // There are actually properties that are not in Element but which
+      // appear on the `node`, so we must cast the customAttribute as a keyof Element
+      const content = node[(customAttribute as keyof Element) ?? 'innerHTML'];
+      if (content === text && wrappedInClass(node, classWrapper)) return true;
+      return false;
+    });
+
+const wrappedInClass = (element: HTMLElement | Element, classWrapper: string): boolean => {
+  if (element.className.includes(classWrapper)) return true;
+  if (element.parentElement) return wrappedInClass(element.parentElement, classWrapper);
+  return false;
+};
+
+export const forMobileOnly = finderWithClassWrapper('hideForDesktop');
+export const forDesktopOnly = finderWithClassWrapper('hideForMobile');

--- a/x-pack/plugins/uptime/public/pages/synthetics/checks_navigation.tsx
+++ b/x-pack/plugins/uptime/public/pages/synthetics/checks_navigation.tsx
@@ -12,6 +12,7 @@ import { useHistory } from 'react-router-dom';
 import moment from 'moment';
 import { SyntheticsJourneyApiResponse } from '../../../common/runtime_types/ping';
 import { getShortTimeStamp } from '../../components/overview/monitor_list/columns/monitor_status_column';
+import { useBreakpoints } from '../../../public/hooks/use_breakpoints';
 
 interface Props {
   timestamp: string;
@@ -20,11 +21,15 @@ interface Props {
 
 export const ChecksNavigation = ({ timestamp, details }: Props) => {
   const history = useHistory();
+  const { down } = useBreakpoints();
+
+  const isMobile = down('s');
 
   return (
-    <EuiFlexGroup alignItems="center">
-      <EuiFlexItem>
+    <EuiFlexGroup alignItems="center" responsive={false} gutterSize="none">
+      <EuiFlexItem grow={false}>
         <EuiButtonEmpty
+          size={isMobile ? 'xs' : 'm'}
           iconType="arrowLeft"
           isDisabled={!details?.previous}
           onClick={() => {
@@ -37,11 +42,14 @@ export const ChecksNavigation = ({ timestamp, details }: Props) => {
           />
         </EuiButtonEmpty>
       </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiText className="eui-textNoWrap">{getShortTimeStamp(moment(timestamp))}</EuiText>
+      <EuiFlexItem grow={false}>
+        <EuiText size={isMobile ? 'xs' : 'm'} className="eui-textNoWrap">
+          {getShortTimeStamp(moment(timestamp))}
+        </EuiText>
       </EuiFlexItem>
-      <EuiFlexItem>
+      <EuiFlexItem grow={false}>
         <EuiButtonEmpty
+          size={isMobile ? 'xs' : 'm'}
           iconType="arrowRight"
           iconSide="right"
           isDisabled={!details?.next}


### PR DESCRIPTION
## Summary

This PR fixes #121919.

It adjusts the table in the page which shows detailed information about a check group's steps so that it works on mobile and intermediary resolutions.

For this PR, I've had to use [EUI's responsive tables](https://elastic.github.io/eui/#/tabular-content/tables#responsive-tables). The options for making tables responsive allowed me to hide the desired fields, and format them appropriately.

The most interesting part of this PR, however, are its tests. To be able to test whether the behaviour was correct on mobile and desktop, I've had to check for elements whose wrapper would contain classes which excluded it for `desktop` or `mobile`.

I've had to find elements this way because EUI does render these components to the DOM, but it duplicates elements and attaches `hideForDesktop` or `hideForMobile` classes to them. The display of the elements is them controlled in pure CSS, so I can't simply assert on whether an element is visible (as that depends on inline style properties to work).

You can see below how the page looks like on iPad and iPhone X resolutions after my changes.

![Screenshot 2021-12-30 at 16 08 05](https://user-images.githubusercontent.com/6868147/148250716-00506649-d0d0-4063-a1aa-db693aeb6ac4.png)

![Screenshot 2022-01-05 at 16 07 24](https://user-images.githubusercontent.com/6868147/148250363-da6c85d8-c23b-4ddd-ba49-e79ba1da81bb.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release Note

Make a monitor's steps details page work on mobile resolutions.