### PR TITLE
[Vega] dark mode not respected on initial load for maps

### DIFF
--- a/src/plugins/vis_types/vega/public/vega_view/vega_map_view/map_service_settings.ts
+++ b/src/plugins/vis_types/vega/public/vega_view/vega_map_view/map_service_settings.ts
@@ -58,6 +58,8 @@ export class MapServiceSettings {
   }
 
   private async initialize() {
+    this.isDarkMode = getUISettings().get('theme:darkMode');
+
     this.emsClient = await initEmsClientAsync({
       appVersion: this.appVersion,
       fileApiUrl: this.config.emsFileApiUrl,

--- a/src/plugins/vis_types/vega/public/vega_view/vega_map_view/map_service_settings.ts
+++ b/src/plugins/vis_types/vega/public/vega_view/vega_map_view/map_service_settings.ts
@@ -35,7 +35,7 @@ const initEmsClientAsync = async (config: Partial<EmsClientConfig>) => {
 
 export class MapServiceSettings {
   private emsClient?: EMSClient;
-  private isDarkMode: boolean = false;
+  private isDarkMode: boolean = getUISettings().get('theme:darkMode');
 
   constructor(public config: MapsEmsConfig, private appVersion: string) {}
 
@@ -58,8 +58,6 @@ export class MapServiceSettings {
   }
 
   private async initialize() {
-    this.isDarkMode = getUISettings().get('theme:darkMode');
-
     this.emsClient = await initEmsClientAsync({
       appVersion: this.appVersion,
       fileApiUrl: this.config.emsFileApiUrl,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/116913

## Summary

Update `isDarkMode` default value to use `theme:darkMode` setting from UI settings.

![vega map dark theme](https://user-images.githubusercontent.com/54894989/147943204-13f99111-664b-490a-b30a-d82bd5668802.gif)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
