### PR TITLE
[Security Solution] [Endpoint] Display backbutton for artifact empty states

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/administration_list_page.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/administration_list_page.tsx
@@ -64,15 +64,15 @@ export const AdministrationListPage: FC<AdministrationListPageProps & CommonProp
     const getTestId = useTestIdGenerator(otherProps['data-test-subj']);
 
     const pageHeader = useMemo(
-      () => (
-        <>
-          {hideHeader ? (
-            <EuiFlexGroup direction="column" gutterSize="none" alignItems="flexStart">
-              <EuiFlexItem grow={false}>
-                {headerBackComponent && <>{headerBackComponent}</>}
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          ) : (
+      () =>
+        hideHeader ? (
+          <EuiFlexGroup direction="column" gutterSize="none" alignItems="flexStart">
+            <EuiFlexItem grow={false}>
+              {headerBackComponent && <>{headerBackComponent}</>}
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ) : (
+          <>
             <EuiPageHeader
               pageTitle={header}
               description={description}
@@ -81,10 +81,9 @@ export const AdministrationListPage: FC<AdministrationListPageProps & CommonProp
               restrictWidth={restrictWidth}
               data-test-subj={getTestId('header')}
             />
-          )}
-          <EuiSpacer size="l" />
-        </>
-      ),
+            <EuiSpacer size="l" />
+          </>
+        ),
       [
         actions,
         description,

--- a/x-pack/plugins/security_solution/public/management/components/administration_list_page.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/administration_list_page.tsx
@@ -63,10 +63,16 @@ export const AdministrationListPage: FC<AdministrationListPageProps & CommonProp
 
     const getTestId = useTestIdGenerator(otherProps['data-test-subj']);
 
-    return (
-      <div {...otherProps}>
-        {!hideHeader && (
-          <>
+    const pageHeader = useMemo(
+      () => (
+        <>
+          {hideHeader ? (
+            <EuiFlexGroup direction="column" gutterSize="none" alignItems="flexStart">
+              <EuiFlexItem grow={false}>
+                {headerBackComponent && <>{headerBackComponent}</>}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
             <EuiPageHeader
               pageTitle={header}
               description={description}
@@ -75,9 +81,25 @@ export const AdministrationListPage: FC<AdministrationListPageProps & CommonProp
               restrictWidth={restrictWidth}
               data-test-subj={getTestId('header')}
             />
-            <EuiSpacer size="l" />
-          </>
-        )}
+          )}
+          <EuiSpacer size="l" />
+        </>
+      ),
+      [
+        actions,
+        description,
+        getTestId,
+        hasBottomBorder,
+        header,
+        headerBackComponent,
+        hideHeader,
+        restrictWidth,
+      ]
+    );
+
+    return (
+      <div {...otherProps}>
+        {pageHeader}
 
         <EuiPageContent
           hasBorder={false}


### PR DESCRIPTION
## Summary

![backbutton displayed for empty states](https://user-images.githubusercontent.com/15727784/148057230-2e17fee2-198e-4a94-b96b-dfce31b12cbe.gif)



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
