### PR TITLE
fixes #117448: button styles in exploratory view header

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/components/action_menu/action_menu.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/components/action_menu/action_menu.tsx
@@ -69,6 +69,7 @@ export function ExpViewActionMenuContent({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButton
+            fill={true}
             iconType="save"
             fullWidth={false}
             isDisabled={!lens.canUseEditor() || lensAttributes === null}

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/header/add_to_case_action.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/header/add_to_case_action.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback } from 'react';
 import { toMountPoint, useKibana } from '../../../../../../../../src/plugins/kibana_react/public';
@@ -68,10 +68,9 @@ export function AddToCaseAction({ lensAttributes, timeRange }: AddToCaseProps) {
 
   return (
     <>
-      <EuiButton
+      <EuiButtonEmpty
         size="s"
         isLoading={isSaving}
-        fullWidth={false}
         isDisabled={lensAttributes === null}
         onClick={() => {
           if (lensAttributes) {
@@ -82,7 +81,7 @@ export function AddToCaseAction({ lensAttributes, timeRange }: AddToCaseProps) {
         {i18n.translate('xpack.observability.expView.heading.addToCase', {
           defaultMessage: 'Add to case',
         })}
-      </EuiButton>
+      </EuiButtonEmpty>
       {isCasesOpen &&
         lensAttributes &&
         cases.getAllCasesSelectorModal(getAllCasesSelectorModalProps)}


### PR DESCRIPTION
## Summary

<img width="1440" alt="Screenshot 2022-01-04 at 11 27 12" src="https://user-images.githubusercontent.com/20965076/148045674-1d76d2a5-4d1b-4de2-90fb-fe0d12c1b112.png">

This is purely a visual change.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
