### PR TITLE
[Security Solution][Investigations] Fixes rendering issue of last element of a task list when empty

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/notes/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/notes/helpers.test.tsx
@@ -9,10 +9,10 @@ import { createNote } from './helpers';
 
 describe('createNote', () => {
   it(`does not trim the note's text content`, () => {
-    // A note with two todo items.
+    // A note with two empty todo items.
     // Notice the required trailing whitespace which is required otherwise
     // markdown renderers will not render the list correctly
-    const note = '- [ ] todo item \n\n- [ ] todo item ';
+    const note = '- [ ] \n\n- [ ] ';
     expect(createNote({ newNote: note })).toEqual(
       expect.objectContaining({
         note,

--- a/x-pack/plugins/security_solution/public/timelines/components/notes/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/notes/helpers.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createNote } from './helpers';
+
+describe('createNote', () => {
+  it(`does not trim the note's text content`, () => {
+    // A note with two todo items.
+    // Notice the required trailing whitespace which is required otherwise
+    // markdown renderers will not render the list correctly
+    const note = '- [ ] todo item \n\n- [ ] todo item ';
+    expect(createNote({ newNote: note })).toEqual(
+      expect.objectContaining({
+        note,
+      })
+    );
+  });
+});

--- a/x-pack/plugins/security_solution/public/timelines/components/notes/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/notes/helpers.tsx
@@ -79,7 +79,7 @@ export const createNote = ({ newNote }: { newNote: string }): Note => ({
   created: moment.utc().toDate(),
   id: uuid.v4(),
   lastEdit: null,
-  note: newNote.trim(),
+  note: newNote,
   saveObjectId: null,
   user: 'elastic', // TODO: get the logged-in Kibana user
   version: null,


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/121986 describes an issue where the last element of a task list does not render properly.

I compared the implementation of the note editor with the one of the comment editor of the cases plugin. The one significant difference I saw was that in the timeline comment editor we trim the note's content. Removing the triming fixes the issue. It should be noted that the original issue only occurs for empty tasks. 



https://user-images.githubusercontent.com/68591/148053363-0728ee1f-b6d6-4ee6-a642-3e52677b08ec.mov



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
