### PR TITLE
[ML] Functional tests - stabilize anomaly explorer tests

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/dashboard_controls/add_to_dashboard_controls.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/dashboard_controls/add_to_dashboard_controls.tsx
@@ -86,6 +86,9 @@ export const AddToDashboardControl: FC<AddToDashboardControlProps> = ({
             pagination={true}
             sorting={true}
             data-test-subj={`mlDashboardSelectionTable${isLoading ? ' loading' : ' loaded'}`}
+            rowProps={(item) => ({
+              'data-test-subj': `mlDashboardSelectionTableRow row-${item.id}`,
+            })}
           />
         </EuiFormRow>
       </EuiModalBody>

--- a/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
@@ -142,7 +142,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.anomaliesTable.assertTableNotEmpty();
         });
 
-        it.skip('renders Overall swim lane', async () => {
+        it('renders Overall swim lane', async () => {
           await ml.testExecution.logTestStep('has correct axes labels');
           await ml.swimLane.assertAxisLabels(overallSwimLaneTestSubj, 'x', [
             '2016-02-07 00:00',
@@ -155,7 +155,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.swimLane.assertAxisLabels(overallSwimLaneTestSubj, 'y', ['Overall']);
         });
 
-        it.skip('renders View By swim lane', async () => {
+        it('renders View By swim lane', async () => {
           await ml.testExecution.logTestStep('has correct axes labels');
           await ml.swimLane.assertAxisLabels(viewBySwimLaneTestSubj, 'x', [
             '2016-02-07 00:00',
@@ -179,7 +179,7 @@ export default function ({ getService }: FtrProviderContext) {
           ]);
         });
 
-        it.skip('supports cell selection by click on Overall swim lane', async () => {
+        it('supports cell selection by click on Overall swim lane', async () => {
           await ml.testExecution.logTestStep('checking page state before the cell selection');
           await ml.anomalyExplorer.assertClearSelectionButtonVisible(false);
           await ml.anomaliesTable.assertTableRowsCount(25);
@@ -230,7 +230,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.anomalyExplorer.assertAnomalyExplorerChartsCount(0);
         });
 
-        it.skip('allows to change the swim lane pagination', async () => {
+        it('allows to change the swim lane pagination', async () => {
           await ml.testExecution.logTestStep('checks default pagination');
           await ml.swimLane.assertPageSize(viewBySwimLaneTestSubj, 10);
           await ml.swimLane.assertActivePage(viewBySwimLaneTestSubj, 1);
@@ -247,7 +247,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.swimLane.assertActivePage(viewBySwimLaneTestSubj, 1);
         });
 
-        it.skip('supports cell selection by click on View By swim lane', async () => {
+        it('supports cell selection by click on View By swim lane', async () => {
           await ml.testExecution.logTestStep('checking page state before the cell selection');
           await ml.anomalyExplorer.assertClearSelectionButtonVisible(false);
           await ml.anomaliesTable.assertTableRowsCount(25);
@@ -288,7 +288,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.anomalyExplorer.assertAnomalyExplorerChartsCount(0);
         });
 
-        it.skip('supports cell selection by brush action', async () => {
+        it('supports cell selection by brush action', async () => {
           await ml.testExecution.logTestStep('checking page state before the cell selection');
           await ml.anomalyExplorer.assertClearSelectionButtonVisible(false);
           await ml.anomaliesTable.assertTableRowsCount(25);
@@ -328,7 +328,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.anomalyExplorer.assertAnomalyExplorerChartsCount(0);
         });
 
-        it.skip('allows to change the anomalies table pagination', async () => {
+        it('allows to change the anomalies table pagination', async () => {
           await ml.testExecution.logTestStep('displays the anomalies table with default config');
           await ml.anomaliesTable.assertTableExists();
           await ml.anomaliesTable.assertRowsNumberPerPage(25);

--- a/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
@@ -63,8 +63,7 @@ export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
   const elasticChart = getService('elasticChart');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/118584
-  describe.skip('anomaly explorer', function () {
+  describe('anomaly explorer', function () {
     this.tags(['mlqa']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
@@ -143,7 +142,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.anomaliesTable.assertTableNotEmpty();
         });
 
-        it('renders Overall swim lane', async () => {
+        it.skip('renders Overall swim lane', async () => {
           await ml.testExecution.logTestStep('has correct axes labels');
           await ml.swimLane.assertAxisLabels(overallSwimLaneTestSubj, 'x', [
             '2016-02-07 00:00',
@@ -156,7 +155,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.swimLane.assertAxisLabels(overallSwimLaneTestSubj, 'y', ['Overall']);
         });
 
-        it('renders View By swim lane', async () => {
+        it.skip('renders View By swim lane', async () => {
           await ml.testExecution.logTestStep('has correct axes labels');
           await ml.swimLane.assertAxisLabels(viewBySwimLaneTestSubj, 'x', [
             '2016-02-07 00:00',
@@ -180,7 +179,7 @@ export default function ({ getService }: FtrProviderContext) {
           ]);
         });
 
-        it('supports cell selection by click on Overall swim lane', async () => {
+        it.skip('supports cell selection by click on Overall swim lane', async () => {
           await ml.testExecution.logTestStep('checking page state before the cell selection');
           await ml.anomalyExplorer.assertClearSelectionButtonVisible(false);
           await ml.anomaliesTable.assertTableRowsCount(25);
@@ -231,7 +230,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.anomalyExplorer.assertAnomalyExplorerChartsCount(0);
         });
 
-        it('allows to change the swim lane pagination', async () => {
+        it.skip('allows to change the swim lane pagination', async () => {
           await ml.testExecution.logTestStep('checks default pagination');
           await ml.swimLane.assertPageSize(viewBySwimLaneTestSubj, 10);
           await ml.swimLane.assertActivePage(viewBySwimLaneTestSubj, 1);
@@ -248,7 +247,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.swimLane.assertActivePage(viewBySwimLaneTestSubj, 1);
         });
 
-        it('supports cell selection by click on View By swim lane', async () => {
+        it.skip('supports cell selection by click on View By swim lane', async () => {
           await ml.testExecution.logTestStep('checking page state before the cell selection');
           await ml.anomalyExplorer.assertClearSelectionButtonVisible(false);
           await ml.anomaliesTable.assertTableRowsCount(25);
@@ -289,7 +288,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.anomalyExplorer.assertAnomalyExplorerChartsCount(0);
         });
 
-        it('supports cell selection by brush action', async () => {
+        it.skip('supports cell selection by brush action', async () => {
           await ml.testExecution.logTestStep('checking page state before the cell selection');
           await ml.anomalyExplorer.assertClearSelectionButtonVisible(false);
           await ml.anomaliesTable.assertTableRowsCount(25);
@@ -329,7 +328,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.anomalyExplorer.assertAnomalyExplorerChartsCount(0);
         });
 
-        it('allows to change the anomalies table pagination', async () => {
+        it.skip('allows to change the anomalies table pagination', async () => {
           await ml.testExecution.logTestStep('displays the anomalies table with default config');
           await ml.anomaliesTable.assertTableExists();
           await ml.anomaliesTable.assertRowsNumberPerPage(25);

--- a/x-pack/test/functional/services/ml/anomaly_explorer.ts
+++ b/x-pack/test/functional/services/ml/anomaly_explorer.ts
@@ -121,13 +121,21 @@ export function MachineLearningAnomalyExplorerProvider({
       });
     },
 
-    async filterDashboardSearchWithSearchString(filter: string) {
-      await this.waitForDashboardsToLoad();
-      const searchBarInput = await testSubjects.find('mlDashboardsSearchBox');
-      await searchBarInput.clearValueWithKeyboard();
-      await searchBarInput.type(filter);
-      await this.assertDashboardSearchInputValue(filter);
-      await this.waitForDashboardsToLoad();
+    async filterDashboardSearchWithSearchString(filter: string, expectedRowCount: number = 1) {
+      await retry.tryForTime(20 * 1000, async () => {
+        await this.waitForDashboardsToLoad();
+        const searchBarInput = await testSubjects.find('mlDashboardsSearchBox');
+        await searchBarInput.clearValueWithKeyboard();
+        await searchBarInput.type(filter);
+        await this.assertDashboardSearchInputValue(filter);
+        await this.waitForDashboardsToLoad();
+
+        const dashboardRows = await testSubjects.findAll('~mlDashboardSelectionTableRow', 2000);
+        expect(dashboardRows.length).to.eql(
+          expectedRowCount,
+          `Dashboadr table should have ${expectedRowCount} rows, got ${dashboardRows.length}`
+        );
+      });
     },
 
     async assertDashboardSearchInputValue(expectedSearchValue: string) {

--- a/x-pack/test/functional/services/ml/anomaly_explorer.ts
+++ b/x-pack/test/functional/services/ml/anomaly_explorer.ts
@@ -133,7 +133,7 @@ export function MachineLearningAnomalyExplorerProvider({
         const dashboardRows = await testSubjects.findAll('~mlDashboardSelectionTableRow', 2000);
         expect(dashboardRows.length).to.eql(
           expectedRowCount,
-          `Dashboadr table should have ${expectedRowCount} rows, got ${dashboardRows.length}`
+          `Dashboard table should have ${expectedRowCount} rows, got ${dashboardRows.length}`
         );
       });
     },


### PR DESCRIPTION
## Summary

This PR stabilizes the anomaly explorer tests for adding a swim lane to a dashboard by validating the dashboard table row count after filtering.

Closes #118584
