### PR TITLE
[Lens][Canvas] PoC make panels aware of container style of accessibility

### DIFF
--- a/src/plugins/expressions/common/expression_renderers/types.ts
+++ b/src/plugins/expressions/common/expression_renderers/types.ts
@@ -90,6 +90,7 @@ export interface IInterpreterRenderHandlers {
   isInteractive(): boolean;
 
   isSyncColorsEnabled(): boolean;
+  getContainerStyle(): Record<string, string>;
   /**
    * This uiState interface is actually `PersistedState` from the visualizations plugin,
    * but expressions cannot know about vis or it creates a mess of circular dependencies.

--- a/src/plugins/expressions/public/loader.ts
+++ b/src/plugins/expressions/public/loader.ts
@@ -57,6 +57,7 @@ export class ExpressionLoader {
       onRenderError: params && params.onRenderError,
       renderMode: params?.renderMode,
       syncColors: params?.syncColors,
+      containerStyle: params?.containerStyle,
       hasCompatibleActions: params?.hasCompatibleActions,
     });
     this.render$ = this.renderHandler.render$;

--- a/src/plugins/expressions/public/react_expression_renderer.tsx
+++ b/src/plugins/expressions/public/react_expression_renderer.tsx
@@ -40,7 +40,7 @@ export interface ReactExpressionRendererProps extends IExpressionLoaderParams {
   reload$?: Observable<unknown>;
   onRender$?: (item: number) => void;
   debounce?: number;
-  containerStyle?: React.CSSProperties;
+  containerStyle?: { backgroundColor: string };
 }
 
 export type ReactExpressionRendererType = React.ComponentType<ReactExpressionRendererProps>;
@@ -177,6 +177,7 @@ export default function ReactExpressionRenderer({
     expressionLoaderOptions.interactive,
     expressionLoaderOptions.renderMode,
     expressionLoaderOptions.syncColors,
+    expressionLoaderOptions.containerStyle,
   ]);
 
   useEffect(() => {

--- a/src/plugins/expressions/public/react_expression_renderer.tsx
+++ b/src/plugins/expressions/public/react_expression_renderer.tsx
@@ -40,6 +40,7 @@ export interface ReactExpressionRendererProps extends IExpressionLoaderParams {
   reload$?: Observable<unknown>;
   onRender$?: (item: number) => void;
   debounce?: number;
+  containerStyle?: React.CSSProperties;
 }
 
 export type ReactExpressionRendererType = React.ComponentType<ReactExpressionRendererProps>;

--- a/src/plugins/expressions/public/render.ts
+++ b/src/plugins/expressions/public/render.ts
@@ -29,6 +29,7 @@ export interface ExpressionRenderHandlerParams {
   renderMode?: RenderMode;
   syncColors?: boolean;
   interactive?: boolean;
+  containerStyle?: { backgroundColor: string };
   hasCompatibleActions?: (event: ExpressionRendererEvent) => Promise<boolean>;
 }
 
@@ -55,6 +56,7 @@ export class ExpressionRenderHandler {
       renderMode,
       syncColors,
       interactive,
+      containerStyle,
       hasCompatibleActions = async () => false,
     }: ExpressionRenderHandlerParams = {}
   ) {
@@ -87,6 +89,9 @@ export class ExpressionRenderHandler {
       },
       event: (data) => {
         this.eventsSubject.next(data);
+      },
+      getContainerStyle: () => {
+        return containerStyle || {};
       },
       getRenderMode: () => {
         return renderMode || 'view';

--- a/src/plugins/expressions/public/types/index.ts
+++ b/src/plugins/expressions/public/types/index.ts
@@ -50,6 +50,7 @@ export interface IExpressionLoaderParams {
   searchSessionId?: string;
   renderMode?: RenderMode;
   syncColors?: boolean;
+  containerStyle?: { backgroundColor: string };
   hasCompatibleActions?: ExpressionRenderHandlerParams['hasCompatibleActions'];
   executionContext?: KibanaExecutionContext;
 

--- a/x-pack/plugins/canvas/public/components/element_content/element_content.tsx
+++ b/x-pack/plugins/canvas/public/components/element_content/element_content.tsx
@@ -77,7 +77,7 @@ export const ElementContent = (props: Props) => {
             ...renderable.value,
             input: {
               ...(renderable.value as Record<string, any>).input,
-              containerStyle: { backgroundColor, ...containerStyle },
+              containerStyle: { backgroundColor: backgroundColor ?? '#fff', ...containerStyle },
             },
           }}
           css={renderable.css} // This is an actual CSS stylesheet string, it will be scoped by RenderElement

--- a/x-pack/plugins/canvas/public/components/element_content/element_content.tsx
+++ b/x-pack/plugins/canvas/public/components/element_content/element_content.tsx
@@ -73,7 +73,13 @@ export const ElementContent = (props: Props) => {
           name={renderFunction.name}
           renderFn={renderFunction.render}
           reuseNode={renderFunction.reuseDomNode}
-          config={renderable.value}
+          config={{
+            ...renderable.value,
+            input: {
+              ...(renderable.value as Record<string, any>).input,
+              containerStyle: { backgroundColor, ...containerStyle },
+            },
+          }}
           css={renderable.css} // This is an actual CSS stylesheet string, it will be scoped by RenderElement
           width={width}
           height={height}

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -89,6 +89,7 @@ interface LensBaseEmbeddableInput extends EmbeddableInput {
   onLoad?: (isLoading: boolean) => void;
   onFilter?: (data: LensFilterEvent['data']) => void;
   onTableRowClick?: (data: LensTableRowContextMenuEvent['data']) => void;
+  containerStyle?: Record<string, string>;
 }
 
 export type LensByValueInput = {
@@ -424,7 +425,7 @@ export class Embeddable
           syncColors={input.syncColors}
           hasCompatibleActions={this.hasCompatibleActions}
           className={input.className}
-          style={input.style}
+          style={{ ...input.containerStyle, ...input.style }}
           executionContext={executionContext}
           canEdit={this.getIsEditable() && input.viewMode === 'edit'}
           onRuntimeError={() => {

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -232,8 +232,16 @@ export class Embeddable
         .pipe(
           distinctUntilChanged((a, b) =>
             fastIsEqual(
-              ['attributes' in a && a.attributes, 'savedObjectId' in a && a.savedObjectId],
-              ['attributes' in b && b.attributes, 'savedObjectId' in b && b.savedObjectId]
+              [
+                'attributes' in a && a.attributes,
+                'savedObjectId' in a && a.savedObjectId,
+                'containerStyle' in a && a.containerStyle,
+              ],
+              [
+                'attributes' in b && b.attributes,
+                'savedObjectId' in b && b.savedObjectId,
+                'containerStyle' in b && b.containerStyle,
+              ]
             )
           ),
           skip(1)

--- a/x-pack/plugins/lens/public/embeddable/expression_wrapper.tsx
+++ b/x-pack/plugins/lens/public/embeddable/expression_wrapper.tsx
@@ -139,6 +139,7 @@ export function ExpressionWrapper({
             renderMode={renderMode}
             syncColors={syncColors}
             executionContext={executionContext}
+            containerStyle={style}
             renderError={(errorMessage, error) => {
               onRuntimeError();
               return (

--- a/x-pack/plugins/lens/public/embeddable/expression_wrapper.tsx
+++ b/x-pack/plugins/lens/public/embeddable/expression_wrapper.tsx
@@ -139,7 +139,9 @@ export function ExpressionWrapper({
             renderMode={renderMode}
             syncColors={syncColors}
             executionContext={executionContext}
-            containerStyle={style}
+            containerStyle={
+              style?.backgroundColor ? { backgroundColor: style.backgroundColor } : undefined
+            }
             renderError={(errorMessage, error) => {
               onRuntimeError();
               return (

--- a/x-pack/plugins/lens/public/pie_visualization/expression.tsx
+++ b/x-pack/plugins/lens/public/pie_visualization/expression.tsx
@@ -51,6 +51,7 @@ export const getPieRenderer = (dependencies: {
             onClickValue={onClickValue}
             renderMode={handlers.getRenderMode()}
             syncColors={handlers.isSyncColorsEnabled()}
+            containerStyle={handlers.getContainerStyle()}
           />
         </I18nProvider>
       </KibanaThemeProvider>,


### PR DESCRIPTION
## Summary

This is a PoC of what would be required to make Lens aware of the background color in order to make better decisions for chart labels.

This PR currently addresses the Pie outside labels.

![canvas_background_labels](https://user-images.githubusercontent.com/924948/148064967-27e98b67-a37f-49ef-bf85-7c29790565fe.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
