### PR TITLE
[Fleet] Fix policy count in output edit modal

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/services/agent_and_policies_count.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/services/agent_and_policies_count.tsx
@@ -7,7 +7,7 @@
 
 import { sendGetAgentPolicies, sendGetAgents } from '../../../hooks';
 import type { Output } from '../../../types';
-import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '../../../constants';
+import { AGENT_POLICY_SAVED_OBJECT_TYPE, SO_SEARCH_LIMIT } from '../../../constants';
 
 export async function getAgentAndPolicyCountForOutput(output: Output) {
   let kuery = `${AGENT_POLICY_SAVED_OBJECT_TYPE}.data_output_id:"${output.id}" or ${AGENT_POLICY_SAVED_OBJECT_TYPE}.monitoring_output_id:"${output.id}"`;
@@ -16,6 +16,8 @@ export async function getAgentAndPolicyCountForOutput(output: Output) {
   }
   const agentPolicies = await sendGetAgentPolicies({
     kuery,
+    page: 1,
+    perPage: SO_SEARCH_LIMIT,
   });
 
   if (agentPolicies.error) {


### PR DESCRIPTION
## Summary

Fix the policy count in the output edition modal, that confirm modal was retrieving the default limit perPage and was not returning more than 20 policies.

### UI Changes

#### Before 

<img width="1632" alt="Screen Shot 2022-01-04 at 10 50 57 AM" src="https://user-images.githubusercontent.com/1336873/148087056-5d9edf24-1370-4ac4-aa9c-a03e70589a4b.png">

#### After 

<img width="1634" alt="Screen Shot 2022-01-04 at 10 57 33 AM" src="https://user-images.githubusercontent.com/1336873/148087053-43d40dc2-0c2b-446e-b4b3-f481dac617cb.png">