### PR TITLE
[maps] fix x-pack/test/functional/apps/maps/documents_source/top_hits.js test

### DIFF
--- a/x-pack/test/functional/apps/maps/documents_source/top_hits.js
+++ b/x-pack/test/functional/apps/maps/documents_source/top_hits.js
@@ -14,6 +14,7 @@ export default function ({ getPageObjects, getService }) {
   const inspector = getService('inspector');
   const find = getService('find');
   const security = getService('security');
+  const retry = getService('retry');
 
   describe('geo top hits', () => {
     describe('split on string field', () => {
@@ -42,13 +43,23 @@ export default function ({ getPageObjects, getService }) {
       describe('configuration', () => {
         before(async () => {
           await PageObjects.maps.openLayerPanel('logstash');
-          // Can not use testSubjects because data-test-subj is placed range input and number input
-          const sizeInput = await find.byCssSelector(
-            `input[data-test-subj="layerPanelTopHitsSize"][type='number']`
-          );
-          await sizeInput.click();
-          await sizeInput.clearValue();
-          await sizeInput.type('3');
+
+          await retry.try(async () => {
+            // Can not use testSubjects because data-test-subj is placed range input and number input
+            const sizeInput = await find.byCssSelector(
+              `input[data-test-subj="layerPanelTopHitsSize"][type='number']`
+            );
+            await sizeInput.click();
+            await sizeInput.clearValue();
+            await sizeInput.type('3');
+
+            const sizeValue = await sizeInput.getAttribute('value');
+            if (sizeValue !== '3') {
+              throw new Error('layerPanelTopHitsSize not set to 3');
+            }
+          });
+
+          
           await PageObjects.maps.waitForLayersToLoad();
         });
 

--- a/x-pack/test/functional/apps/maps/documents_source/top_hits.js
+++ b/x-pack/test/functional/apps/maps/documents_source/top_hits.js
@@ -59,7 +59,6 @@ export default function ({ getPageObjects, getService }) {
             }
           });
 
-          
           await PageObjects.maps.waitForLayersToLoad();
         });
 


### PR DESCRIPTION
fixes https://github.com/elastic/kibana/issues/121363

Screen shot below shows failure in CI. Notice how "documents per entity" input is not set to 3, but instead set to 23. This is causing the test to fail. Added logic to retry setting input if its not set to 3.

![top_hits_size](https://user-images.githubusercontent.com/373691/148094982-d53b001d-37e6-4c42-873a-411da4a05757.png)
