### PR TITLE
[Maps] fix Missing data outline not visible for shapes

### DIFF
--- a/x-pack/plugins/maps/public/classes/styles/vector/components/legend/line_icon.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/components/legend/line_icon.tsx
@@ -8,7 +8,7 @@
 import React, { CSSProperties } from 'react';
 
 export const LineIcon = ({ style }: { style: CSSProperties }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-    <line x1="0" y1="6" x2="16" y2="6" style={style} />
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" style={style}>
+    <line x1="0" y1="6" x2="16" y2="6" />
   </svg>
 );

--- a/x-pack/plugins/maps/public/classes/styles/vector/components/legend/polygon_icon.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/components/legend/polygon_icon.tsx
@@ -8,7 +8,7 @@
 import React, { CSSProperties } from 'react';
 
 export const PolygonIcon = ({ style }: { style: CSSProperties }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-    <rect width="15" height="15" x=".5" y=".5" style={style} rx="4" />
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" style={style}>
+    <rect width="15" height="15" x=".5" y=".5" rx="4" />
   </svg>
 );


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/121565

Move style property from rect and line element to svg element so border is displayed.

<img width="200" alt="Screen Shot 2022-01-04 at 1 07 58 PM" src="https://user-images.githubusercontent.com/373691/148104777-2ad90219-8a32-41ac-84c0-b5fd3e90a569.png">

<img width="86" alt="Screen Shot 2022-01-04 at 1 09 57 PM" src="https://user-images.githubusercontent.com/373691/148104786-24c38f83-2925-4299-af84-65cc356007d5.png">
