### PR TITLE
Fix elastic/fleet-server access to agent policies

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -39,11 +39,11 @@ import type {
 import { defaultIngestErrorHandler } from '../../errors';
 import { incrementPackageName } from '../../services/package_policy';
 
-export const getAgentPoliciesHandler: RequestHandler<
+export const getAgentPoliciesHandler: FleetRequestHandler<
   undefined,
   TypeOf<typeof GetAgentPoliciesRequestSchema.query>
 > = async (context, request, response) => {
-  const soClient = context.core.savedObjects.client;
+  const soClient = context.fleet.epm.internalSoClient;
   const esClient = context.core.elasticsearch.client.asInternalUser;
   const { full: withPackagePolicies = false, ...restOfQuery } = request.query;
   try {


### PR DESCRIPTION
## Summary

The `GET /api/fleet/agent_policies` API was still using the regular Saved Objects client which is preventing the `elastic/fleet-server` service account from retrieving agent policies. This switches to use the internal SO client which does not require the service account to have explicit SO privileges.