### PR TITLE
[Uptime][Monitor Management] Make synthetics service monitors config sync task interval configurable

### DIFF
--- a/x-pack/plugins/uptime/common/config.ts
+++ b/x-pack/plugins/uptime/common/config.ts
@@ -37,6 +37,7 @@ export const config: PluginConfigDescriptor = {
               password: schema.string(),
               manifestUrl: schema.string(),
               hosts: schema.maybe(schema.arrayOf(schema.string())),
+              syncInterval: schema.maybe(schema.string()),
             })
           ),
         })

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
@@ -127,7 +127,9 @@ export class SyntheticsService {
     });
   }
 
-  public async scheduleSyncTask(taskManager: TaskManagerStartContract): Promise<TaskInstance> {
+  public async scheduleSyncTask(
+    taskManager: TaskManagerStartContract
+  ): Promise<TaskInstance | null> {
     const interval =
       this.config.unsafe.service.syncInterval ?? SYNTHETICS_SERVICE_SYNC_INTERVAL_DEFAULT;
 
@@ -154,6 +156,8 @@ export class SyntheticsService {
         `Error running task: ${SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_ID}, `,
         e?.message() ?? e
       );
+
+      return null;
     }
   }
 

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
@@ -37,6 +37,7 @@ import {
 const SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_TYPE =
   'UPTIME:SyntheticsService:Sync-Saved-Monitor-Objects';
 const SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_ID = 'UPTIME:SyntheticsService:sync-task';
+const SYNTHETICS_SERVICE_SYNC_INTERVAL_DEFAULT = '5m';
 
 export class SyntheticsService {
   private logger: Logger;
@@ -126,19 +127,23 @@ export class SyntheticsService {
   }
 
   public scheduleSyncTask(taskManager: TaskManagerStartContract) {
+    const interval =
+      this.config.unsafe.service.syncInterval ?? SYNTHETICS_SERVICE_SYNC_INTERVAL_DEFAULT;
     taskManager
       .ensureScheduled({
         id: SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_ID,
         taskType: SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_TYPE,
         schedule: {
-          interval: '1m',
+          interval,
         },
         params: {},
         state: {},
         scope: ['uptime'],
       })
       .then((_result) => {
-        this.logger?.info(`Task ${SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_ID} scheduled. `);
+        this.logger?.info(
+          `Task ${SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_ID} scheduled with interval ${interval}.`
+        );
       })
       .catch((e) => {
         this.logger?.error(


### PR DESCRIPTION
Closes #121233

## Summary

- Adds synthetics service config key `xpack.uptime.unsafe.service.syncInterval` to configure sync interval 
- On config update, Kibana will restart and sync task will be rescheduled (previous instance will be cancelled)
- Sets the default interval to sync monitor configs to `5m`

## How to test
- Go through [this](https://gist.github.com/awahab07/8456a2b1854ed9c5dcd30fb4e733ae1c#file-enable-monitor-mangement-locally-md) and enable Monitor Management
- Change the value of `xpack.uptime.unsafe.service.syncInterval` to some other interval e.g. `3m` or `60s`
- Wait for Kibana to restart
- Expect the message in Kibana logs (with the configured interval as above)
    ```
    [plugins.uptime] Task UPTIME:SyntheticsService:sync-task scheduled with interval 4m
    ```
- When `xpack.uptime.unsafe.service.syncInterval` is not configured, expect the log message with default interval `5m`
    ```
    [plugins.uptime] Task UPTIME:SyntheticsService:sync-task scheduled with interval 5m
    ```