### PR TITLE
[8.0] [Security Solution] Unskip test suite

### DIFF
--- a/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
@@ -12,8 +12,7 @@ import { getRegistryUrl as getRegistryUrlFromIngest } from '../../../plugins/fle
 export default function endpointAPIIntegrationTests(providerContext: FtrProviderContext) {
   const { loadTestFile, getService } = providerContext;
 
-  // failing: https://github.com/elastic/kibana/issues/116510
-  describe.skip('Endpoint plugin', function () {
+  describe('Endpoint plugin', function () {
     const ingestManager = getService('ingestManager');
 
     const log = getService('log');


### PR DESCRIPTION
## Summary

Unskip a set of tests that was only skipped on the 8.0 branch.  This looks like it was probably due to a package mismatch.  This PR is now passing and a successful flaky test runner is here: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/70

Addresses this issue: https://github.com/elastic/kibana/issues/116510

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
