### PR TITLE
[Fleet] Handle error correctly in fleet server host input on prem instructions

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
@@ -295,20 +295,15 @@ export const useFleetServerInstructions = (policyId?: string) => {
 
   const addFleetServerHost = useCallback(
     async (host: string) => {
-      try {
-        await sendPutSettings({
-          fleet_server_hosts: [host, ...(settings?.item.fleet_server_hosts || [])],
-        });
-        await refreshSettings();
-      } catch (err) {
-        notifications.toasts.addError(err, {
-          title: i18n.translate('xpack.fleet.fleetServerSetup.errorAddingFleetServerHostTitle', {
-            defaultMessage: 'Error adding Fleet Server host',
-          }),
-        });
+      const res = await sendPutSettings({
+        fleet_server_hosts: [host, ...(settings?.item.fleet_server_hosts || [])],
+      });
+      if (res.error) {
+        throw res.error;
       }
+      await refreshSettings();
     },
-    [refreshSettings, notifications.toasts, settings?.item.fleet_server_hosts]
+    [refreshSettings, settings?.item.fleet_server_hosts]
   );
 
   return {
@@ -427,6 +422,7 @@ export const AddFleetServerHostStepContent = ({
   const [isLoading, setIsLoading] = useState(false);
   const [fleetServerHost, setFleetServerHost] = useState('');
   const [error, setError] = useState<undefined | string>();
+  const { notifications } = useStartServices();
 
   const { getHref } = useLink();
 
@@ -457,10 +453,16 @@ export const AddFleetServerHostStepContent = ({
       } else {
         setCalloutHost('');
       }
+    } catch (err) {
+      notifications.toasts.addError(err, {
+        title: i18n.translate('xpack.fleet.fleetServerSetup.errorAddingFleetServerHostTitle', {
+          defaultMessage: 'Error adding Fleet Server host',
+        }),
+      });
     } finally {
       setIsLoading(false);
     }
-  }, [fleetServerHost, addFleetServerHost, validate]);
+  }, [fleetServerHost, addFleetServerHost, validate, notifications.toasts]);
 
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Description 

Resolve #122228

In the fleet server on prem instructions we were not handling errors correctly that PR fix that.

## UI Changes and how to test

Try to add an http fleet server host than an https fleet server hosts you should see an error.

<img width="1283" alt="Screen Shot 2022-01-05 at 9 28 57 AM" src="https://user-images.githubusercontent.com/1336873/148234869-151c8e68-dcf6-4f64-a7aa-3fc5b9adef9b.png">
