### PR TITLE
[Fleet] Use uuidv5 value if preconfigured agent policy id is not provided

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -228,6 +228,7 @@ class AgentPolicyService {
     options?: { id?: string; user?: AuthenticatedUser }
   ): Promise<AgentPolicy> {
     await this.requireUniqueName(soClient, agentPolicy);
+
     const newSo = await soClient.create<AgentPolicySOAttributes>(
       SAVED_OBJECT_TYPE,
       {

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -206,7 +206,9 @@ class AgentPolicyService {
     if (agentPolicies.total === 0) {
       return {
         created: true,
-        policy: await this.create(soClient, esClient, newAgentPolicy, { id: String(id) }),
+        policy: await this.create(soClient, esClient, newAgentPolicy, {
+          id: id ? String(id) : uuidv5(newAgentPolicy.name, UUID_V5_NAMESPACE),
+        }),
       };
     }
 


### PR DESCRIPTION
## Summary

Fixes #122181

Fix issue with `undefined` coming through as the ID for the default policy. This is because there is no `id` set in the cloud config for the default agent policy. This regressed as part of https://github.com/elastic/kibana/pull/120776.

We default to a uuidv5 value seeded with the policy name now. 

## How to test

Mimic the cloud config in your `kibana.dev.yml` file, e.g.

```yml
server.basePath: /my-super-cool-base-path

xpack.fleet.agents.elasticsearch.host: http://localhost:9200
xpack.fleet.agents.kibana.host: http://localhost:5601

logging:
 loggers:
    - name: plugins.fleet
      appenders: [console]
      level: debug

# Cloud Agent policy
xpack.fleet.packages:
  - name: apm
    version: latest
  - name: fleet_server
    version: latest
  - name: system
    version: latest
xpack.fleet.outputs:
  - name: 'Elastic Cloud internal output'
    type: 'elasticsearch'
    id: 'es-containerhost'
    hosts: ["http://localhost:9200"]
xpack.fleet.agentPolicies:
  # Cloud Agent policy
  - name: Elastic Cloud agent policy
    description: Default agent policy for agents hosted on Elastic Cloud
    id: policy-elastic-agent-on-cloud

    # set the internal containerhost URL to ES
    data_output_id: es-containerhost
    monitoring_output_id: es-containerhost

    is_default: false
    is_managed: true
    is_default_fleet_server: false

    namespace: default
    monitoring_enabled: []
    # If a user scales up / down the Elastic Agent in Cloud, the old
    # instances will still be shown as offline for 24h
    # The reason for having a value such high is to prevent fleet-servers to self unenroll to soon
    # in case checkin cannot happen for a longer time period.
    unenroll_timeout: 86400 # 1 day TTL

    package_policies:
      - name: Fleet Server
        id: elastic-cloud-fleet-server
        package:
          name: fleet_server
        inputs:
          - type: fleet-server
            keep_enabled: true

            vars:
              - name: host
                value: 0.0.0.0
                frozen: true
              - name: port
                value: 8220
                frozen: true
              - name: custom
                value: |
                  server.runtime:
                    gc_percent: 20          # Force the GC to execute more frequently: see https://golang.org/pkg/runtime/debug/#SetGCPercent
      - name: Elastic APM
        id: elastic-cloud-apm
        package:
          name: apm
        inputs:
          - type: apm
            keep_enabled: true
            vars:
              - name: api_key_enabled
                value: true
              - name: host
                value: "0.0.0.0:8200"
                frozen: true
              - name: secret_token
                value: xxxx
              - name: tls_enabled
                value: true
                frozen: true
              - name: tls_certificate
                value: /app/config/certs/node.crt
                frozen: true
              - name: tls_key
                value: /app/config/certs/node.key
                frozen: true
              - name: url
                value: https://localhost:8200
                frozen: true

  # Default policy
  - name: Default policy
    description: Default agent policy created by Kibana

    is_default: true
    is_managed: false

    namespace: default
    monitoring_enabled:
      - logs
      - metrics

    package_policies:
      - name: system-1
        id: default-system
        package:
          name: system
```

Start a fresh ES/Kibana environment and observe that your default policy is created with an ID of `30d6f27e-7701-5057-8f0c-14511286ac8d`