### PR TITLE
[Fleet] Show missing fleet server host callout for fleet server policy

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -127,7 +127,6 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
       <EuiFlyoutBody
         banner={
           fleetStatus.isReady &&
-          !isFleetServerPolicySelected &&
           !isLoadingInitialRequest &&
           fleetServerHosts.length === 0 &&
           mode === 'managed' ? (


### PR DESCRIPTION
## Description 

Resolve #121952 

When clicking on the add Fleet server callout (when a fleet server has been added but is offline) we were displaying a blank flyout, that PR fix that by displaying the correct missing fleet server host callout.



### UI changes

#### Before 

<img width="952" alt="Screen Shot 2022-01-05 at 10 48 27 AM" src="https://user-images.githubusercontent.com/1336873/148251009-e8ead80e-cb99-4f17-a0e5-a159e4b86418.png">

#### After 
<img width="1038" alt="Screen Shot 2022-01-05 at 11 16 35 AM" src="https://user-images.githubusercontent.com/1336873/148251177-035f00ea-e9c2-43f7-9c2b-9fd969d62007.png">


### How to test?

1. Add a fleet server without setting the fleet server hosts 
I did it  with that command 
```
 docker run \
--add-host kibana:192.168.65.2 --add-host elasticsearch:192.168.65.2 --add-host fleetserver:127.0.0.1 \
-e KIBANA_HOST=http://kibana:5601 -e KIBANA_USERNAME=elastic -e KIBANA_PASSWORD=changeme \
-e ELASTICSEARCH_HOST=http://elasticsearch:9200 -e ELASTICSEARCH_USERNAME=elastic \
-e FLEET_INSECURE=1 -e ELASTICSEARCH_PASSWORD=changeme -e KIBANA_FLEET_SETUP=1 \
-e FLEET_SERVER_ENABLE=1 -e FLEET_SERVER_INSECURE_HTTP=1 \
-p 8220:8220 docker.elastic.co/beats/elastic-agent:8.0.0-SNAPSHOT
```

2. stop that fleet server you should see the add fleet server callout 

<img width="1385" alt="Screen Shot 2022-01-05 at 11 15 48 AM" src="https://user-images.githubusercontent.com/1336873/148251212-abd7beef-f4a7-4317-906b-5ec811ceddc4.png">

3. than click on Add Fleet server you should see the missing fleet server host callout (then if you set the host in the settings you should see the fleet server instructions)




