### PR TITLE
[CI] Try to prevent npm/yarn problems from causing an agent to fail all future jobs

### DIFF
--- a/.buildkite/scripts/common/setup_node.sh
+++ b/.buildkite/scripts/common/setup_node.sh
@@ -60,6 +60,8 @@ echo "--- Setup Yarn"
 YARN_VERSION=$(node -e "console.log(String(require('./package.json').engines.yarn || '').replace(/^[^\d]+/,''))")
 export YARN_VERSION
 
+npm root -g
+ls -alh "$(npm root -g)"
 rm -rf "$(npm root -g)/yarn" # TODO remove me
 mkdir -p "$(npm root -g)/yarn/test" # TODO remove me after testing
 

--- a/.buildkite/scripts/common/setup_node.sh
+++ b/.buildkite/scripts/common/setup_node.sh
@@ -60,8 +60,16 @@ echo "--- Setup Yarn"
 YARN_VERSION=$(node -e "console.log(String(require('./package.json').engines.yarn || '').replace(/^[^\d]+/,''))")
 export YARN_VERSION
 
+mkdir -p "$(npm root -g)/yarn/test" # TODO remove me after testing
+
 if [[ ! $(which yarn) || $(yarn --version) != "$YARN_VERSION" ]]; then
-  npm install -g "yarn@^${YARN_VERSION}"
+  if [[ ! $(npm install -g "yarn@^${YARN_VERSION}") ]]; then
+    # Installing yarn fails once in a while
+    # if it fails at a bad time, a yarn directory is left behind that causes all subsequent installs to fail
+    rm -rf "$(npm root -g)/yarn"
+    echo "Trying again to install yarn..."
+    npm install -g "yarn@^${YARN_VERSION}"
+  fi
 fi
 
 yarn config set yarn-offline-mirror "$YARN_OFFLINE_CACHE"

--- a/.buildkite/scripts/common/setup_node.sh
+++ b/.buildkite/scripts/common/setup_node.sh
@@ -64,6 +64,7 @@ npm root -g
 ls -alh "$(npm root -g)"
 rm -rf "$(npm root -g)/yarn" # TODO remove me
 mkdir -p "$(npm root -g)/yarn/test" # TODO remove me after testing
+which yarn || true
 
 if [[ ! $(which yarn) || $(yarn --version) != "$YARN_VERSION" ]]; then
   if [[ ! $(npm install -g "yarn@^${YARN_VERSION}") ]]; then

--- a/.buildkite/scripts/common/setup_node.sh
+++ b/.buildkite/scripts/common/setup_node.sh
@@ -60,16 +60,11 @@ echo "--- Setup Yarn"
 YARN_VERSION=$(node -e "console.log(String(require('./package.json').engines.yarn || '').replace(/^[^\d]+/,''))")
 export YARN_VERSION
 
-npm root -g
-ls -alh "$(npm root -g)"
-rm -rf "$(npm root -g)/yarn" # TODO remove me
-mkdir -p "$(npm root -g)/yarn/test" # TODO remove me after testing
-which yarn || true
-
 if [[ ! $(which yarn) || $(yarn --version) != "$YARN_VERSION" ]]; then
+  rm -rf "$(npm root -g)/yarn" # in case the directory is in a bad state
   if [[ ! $(npm install -g "yarn@^${YARN_VERSION}") ]]; then
-    # Installing yarn fails once in a while
-    # if it fails at a bad time, a yarn directory is left behind that causes all subsequent installs to fail
+    # If this command is terminated early, e.g. because the build was cancelled in buildkite,
+    # a yarn directory is left behind in a bad state that can cause all subsequent installs to fail
     rm -rf "$(npm root -g)/yarn"
     echo "Trying again to install yarn..."
     npm install -g "yarn@^${YARN_VERSION}"

--- a/.buildkite/scripts/common/setup_node.sh
+++ b/.buildkite/scripts/common/setup_node.sh
@@ -60,6 +60,7 @@ echo "--- Setup Yarn"
 YARN_VERSION=$(node -e "console.log(String(require('./package.json').engines.yarn || '').replace(/^[^\d]+/,''))")
 export YARN_VERSION
 
+rm -rf "$(npm root -g)/yarn" # TODO remove me
 mkdir -p "$(npm root -g)/yarn/test" # TODO remove me after testing
 
 if [[ ! $(which yarn) || $(yarn --version) != "$YARN_VERSION" ]]; then

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -10,6 +10,9 @@ export BUILDKITE_TOKEN
 echo '--- Install buildkite dependencies'
 cd '.buildkite'
 
+# If this yarn install is terminated early, e.g. if the build is cancelled in buildkite,
+# A node module could end up in a bad state that can cause all future builds to fail
+# So, let's cache clean and try again to make sure that's not what caused the error
 install_deps() {
   yarn install --production --pure-lockfile
   EXIT=$?

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -21,7 +21,7 @@ install_deps() {
 
 retry 5 15 install_deps
 
-cd "$KIBANA_DIR"
+cd ..
 
 node .buildkite/scripts/lifecycle/print_agent_links.js || true
 

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -9,8 +9,19 @@ export BUILDKITE_TOKEN
 
 echo '--- Install buildkite dependencies'
 cd '.buildkite'
-retry 5 15 yarn install --production --pure-lockfile
-cd -
+
+install_deps() {
+  yarn install --production --pure-lockfile
+  EXIT=$?
+  if [[ "$EXIT" != "0" ]]; then
+    yarn cache clean
+  fi
+  return $EXIT
+}
+
+retry 5 15 install_deps
+
+cd "$KIBANA_DIR"
 
 node .buildkite/scripts/lifecycle/print_agent_links.js || true
 


### PR DESCRIPTION
Most steps in our Buildkite pipelines use one-time use agents. But, the really short steps that every build runs (pipeline upload, pre-build, post-build) use long-running agents. There are a few things related to node modules that can cause agents to start failing all jobs they run.

Here's an example of what happens:

1. A job is run for a PR that needs a different version of yarn than what is currently installed on the agent
2. The [job is cancelled](https://buildkite.com/elastic/kibana-pull-request/builds/15854#af26e2fb-963e-420b-bbd6-da5ee91f9f37/84-85) after someone pushes a new commit to the PR, and it happens to be in the middle of `npm install -g yarn`
3. The `yarn` global `node_modules` directory is in a bad state
4. [The next job](https://buildkite.com/elastic/kibana-macos-bazel-cache/builds/611#1d3a5a8b-8e24-4c85-8fc6-011fec069ea2/50-56) and all future ones on this agent will fail when trying to install yarn

The long-term goal would be to use something like containers to provide more isolation between jobs while keeping fast start times, but this should help in the short-term.