### PR TITLE
[Security Solution][Investigations] - Link to flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/index.tsx
@@ -50,7 +50,7 @@ const HomePageComponent: React.FC<HomePageProps> = ({
     <SecuritySolutionAppWrapper className="kbnAppWrapper">
       <GlobalHeader setHeaderActionMenu={setHeaderActionMenu} />
       <DragDropContextWrapper browserFields={browserFields}>
-        <UseUrlState indexPattern={indexPattern} navTabs={navTabs} pathName={pathname} />
+        <UseUrlState indexPattern={indexPattern} navTabs={navTabs} currentPath={pathname} />
         <SecuritySolutionTemplateWrapper onAppLeave={onAppLeave}>
           {children}
         </SecuritySolutionTemplateWrapper>

--- a/x-pack/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/index.tsx
@@ -50,7 +50,7 @@ const HomePageComponent: React.FC<HomePageProps> = ({
     <SecuritySolutionAppWrapper className="kbnAppWrapper">
       <GlobalHeader setHeaderActionMenu={setHeaderActionMenu} />
       <DragDropContextWrapper browserFields={browserFields}>
-        <UseUrlState indexPattern={indexPattern} navTabs={navTabs} />
+        <UseUrlState indexPattern={indexPattern} navTabs={navTabs} pathName={pathname} />
         <SecuritySolutionTemplateWrapper onAppLeave={onAppLeave}>
           {children}
         </SecuritySolutionTemplateWrapper>

--- a/x-pack/plugins/security_solution/public/common/components/navigation/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/helpers.ts
@@ -21,6 +21,7 @@ import {
 
 import { SearchNavTab } from './types';
 import { SourcererUrlState } from '../../store/sourcerer/model';
+import { ToggleDetailPanel } from '../../../../common/types';
 
 export const getSearch = (tab: SearchNavTab, urlState: UrlState): string => {
   if (tab && tab.urlKey != null && !isAdministration(tab.urlKey)) {
@@ -32,6 +33,7 @@ export const getSearch = (tab: SearchNavTab, urlState: UrlState): string => {
           | SourcererUrlState
           | TimelineUrl
           | UrlInputsModel
+          | ToggleDetailPanel
           | string = '';
 
         if (urlKey === CONSTANTS.appQuery && urlState.query != null) {
@@ -56,6 +58,13 @@ export const getSearch = (tab: SearchNavTab, urlState: UrlState): string => {
             urlStateToReplace = '';
           } else {
             urlStateToReplace = timeline;
+          }
+        } else if (urlKey === CONSTANTS.detailPanel && urlState[CONSTANTS.detailPanel] != null) {
+          const detailPanel = urlState[CONSTANTS.detailPanel];
+          if (!detailPanel?.panelView) {
+            urlStateToReplace = '';
+          } else {
+            urlStateToReplace = detailPanel;
           }
         }
         return replaceQueryStringInLocation(

--- a/x-pack/plugins/security_solution/public/common/components/navigation/tab_navigation/types.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/tab_navigation/types.ts
@@ -13,12 +13,14 @@ import { TimelineUrl } from '../../../../timelines/store/timeline/model';
 
 import { SecuritySolutionTabNavigationProps } from '../types';
 import { SiemRouteType } from '../../../utils/route/types';
+import { ToggleDetailPanel } from '../../../../../common/types';
 
 export interface TabNavigationProps extends SecuritySolutionTabNavigationProps {
   pathName: string;
   pageName: string;
   tabName: SiemRouteType | undefined;
   [CONSTANTS.appQuery]?: Query;
+  [CONSTANTS.detailPanel]?: ToggleDetailPanel;
   [CONSTANTS.filters]?: Filter[];
   [CONSTANTS.savedQuery]?: string;
   [CONSTANTS.sourcerer]: SourcererUrlState;

--- a/x-pack/plugins/security_solution/public/common/components/url_state/constants.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/constants.ts
@@ -10,6 +10,7 @@ export enum CONSTANTS {
   alertsPage = 'alerts.page',
   caseDetails = 'case.details',
   casePage = 'case.page',
+  detailPanel = 'detailPanel',
   filters = 'filters',
   hostsDetails = 'hosts.details',
   hostsPage = 'hosts.page',

--- a/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
@@ -192,7 +192,7 @@ export const makeMapStateToProps = () => {
           }
         : { id: '', isOpen: false, activeTab: TimelineTabs.query, graphEventId: '' };
 
-    const timelineId = getTimelineIdForPathname(ownProps?.pathName, flyoutTimeline?.show);
+    const timelineId = getTimelineIdForPathname(ownProps?.currentPath, flyoutTimeline?.show);
     let detailPanel = {};
 
     if (timelineId) {

--- a/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
@@ -29,7 +29,6 @@ import {
   ValueUrlState,
   UrlState,
   UrlStateProps,
-  UrlStateStateToPropsType,
 } from './types';
 import { sourcererSelectors } from '../../store/sourcerer';
 import { SourcererScopeName, SourcererUrlState } from '../../store/sourcerer/model';

--- a/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
@@ -238,24 +238,24 @@ export const makeMapStateToProps = () => {
         {}
       );
 
-    return {
-      urlState: {
-        ...searchAttr,
-        [CONSTANTS.sourcerer]: selectedPatterns,
-        [CONSTANTS.timerange]: {
-          global: {
-            [CONSTANTS.timerange]: globalTimerange,
-            linkTo: globalLinkTo,
-          },
-          timeline: {
-            [CONSTANTS.timerange]: timelineTimerange,
-            linkTo: timelineLinkTo,
-          },
+    const urlState: UrlState = {
+      ...searchAttr,
+      [CONSTANTS.sourcerer]: selectedPatterns,
+      [CONSTANTS.timerange]: {
+        global: {
+          [CONSTANTS.timerange]: globalTimerange,
+          linkTo: globalLinkTo,
         },
-        [CONSTANTS.timeline]: timeline,
-        ...(detailPanel != null ? { [CONSTANTS.detailPanel]: detailPanel } : undefined),
+        timeline: {
+          [CONSTANTS.timerange]: timelineTimerange,
+          linkTo: timelineLinkTo,
+        },
       },
+      [CONSTANTS.timeline]: timeline,
+      ...(detailPanel != null ? { [CONSTANTS.detailPanel]: detailPanel } : undefined),
     };
+
+    return { urlState };
   };
 
   return mapStateToProps;

--- a/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
@@ -177,7 +177,7 @@ export const makeMapStateToProps = () => {
   const getGlobalSavedQuerySelector = inputsSelectors.globalSavedQuerySelector();
   const getTimeline = timelineSelectors.getTimelineByIdSelector();
   const getSourcererScopes = sourcererSelectors.scopesSelector();
-  const mapStateToProps = (state: State, ownProps?: UrlStateProps & UrlStateStateToPropsType) => {
+  const mapStateToProps = (state: State, ownProps?: UrlStateProps) => {
     const inputState = getInputsSelector(state);
     const { linkTo: globalLinkTo, timerange: globalTimerange } = inputState.global;
     const { linkTo: timelineLinkTo, timerange: timelineTimerange } = inputState.timeline;

--- a/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
@@ -92,7 +92,7 @@ export const decodeRisonUrlState = <T>(value: string | undefined): T | null => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const encodeRisonUrlState = (state: any) => encode(state);
 
-export const getQueryStringFromLocation = (search: string) => search.substring(1);
+export const getQueryStringFromLocation = (search: string) => search?.substring(1);
 
 export const getParamFromQueryString = (queryString: string, key: string) => {
   const parsedQueryString = parse(queryString, { sort: false });
@@ -122,6 +122,12 @@ export const replaceStateKeyInQueryString =
           };
     return stringify(url.encodeQuery(newValue), { sort: false, encode: false });
   };
+
+export const getUrlStateKeyValue = (urlState: UrlState, urlKey: KeyUrlState) =>
+  isQueryStateEmpty(urlState[urlKey], urlKey) ? '' : urlState[urlKey];
+
+export const getQueryStringKeyValue = ({ search, urlKey }: { search: string; urlKey: string }) =>
+  getParamFromQueryString(getQueryStringFromLocation(search), urlKey);
 
 export const replaceQueryStringInLocation = (
   location: H.Location,

--- a/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
@@ -238,25 +238,24 @@ export const makeMapStateToProps = () => {
         {}
       );
 
-    const urlState: UrlState = {
-      ...searchAttr,
-      [CONSTANTS.sourcerer]: selectedPatterns,
-      [CONSTANTS.timerange]: {
-        global: {
-          [CONSTANTS.timerange]: globalTimerange,
-          linkTo: globalLinkTo,
+    return {
+      urlState: {
+        ...searchAttr,
+        [CONSTANTS.sourcerer]: selectedPatterns,
+        [CONSTANTS.timerange]: {
+          global: {
+            [CONSTANTS.timerange]: globalTimerange,
+            linkTo: globalLinkTo,
+          },
+          timeline: {
+            [CONSTANTS.timerange]: timelineTimerange,
+            linkTo: timelineLinkTo,
+          },
         },
-        timeline: {
-          [CONSTANTS.timerange]: timelineTimerange,
-          linkTo: timelineLinkTo,
-        },
+        [CONSTANTS.timeline]: timeline,
+        ...(detailPanel != null ? { [CONSTANTS.detailPanel]: detailPanel } : undefined),
       },
-      [CONSTANTS.timeline]: timeline,
     };
-
-    if (detailPanel != null) urlState[CONSTANTS.detailPanel] = detailPanel;
-
-    return { urlState };
   };
 
   return mapStateToProps;

--- a/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
@@ -193,7 +193,7 @@ export const makeMapStateToProps = () => {
         : { id: '', isOpen: false, activeTab: TimelineTabs.query, graphEventId: '' };
 
     const timelineId = getTimelineIdForPathname(ownProps?.currentPath, flyoutTimeline?.show);
-    let detailPanel = {};
+    let detailPanel = null;
 
     if (timelineId) {
       const activeTimelineById =
@@ -238,24 +238,25 @@ export const makeMapStateToProps = () => {
         {}
       );
 
-    return {
-      urlState: {
-        ...searchAttr,
-        [CONSTANTS.sourcerer]: selectedPatterns,
-        [CONSTANTS.timerange]: {
-          global: {
-            [CONSTANTS.timerange]: globalTimerange,
-            linkTo: globalLinkTo,
-          },
-          timeline: {
-            [CONSTANTS.timerange]: timelineTimerange,
-            linkTo: timelineLinkTo,
-          },
+    const urlState: UrlState = {
+      ...searchAttr,
+      [CONSTANTS.sourcerer]: selectedPatterns,
+      [CONSTANTS.timerange]: {
+        global: {
+          [CONSTANTS.timerange]: globalTimerange,
+          linkTo: globalLinkTo,
         },
-        [CONSTANTS.timeline]: timeline,
-        [CONSTANTS.detailPanel]: detailPanel,
-      } as UrlState,
+        timeline: {
+          [CONSTANTS.timerange]: timelineTimerange,
+          linkTo: timelineLinkTo,
+        },
+      },
+      [CONSTANTS.timeline]: timeline,
     };
+
+    if (detailPanel != null) urlState[CONSTANTS.detailPanel] = detailPanel;
+
+    return { urlState };
   };
 
   return mapStateToProps;

--- a/x-pack/plugins/security_solution/public/common/components/url_state/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/index.test.tsx
@@ -319,7 +319,7 @@ describe('UrlStateContainer', () => {
 
         if (CONSTANTS.alertsPage === page) {
           await waitFor(() => {
-            expect(mockSetRelativeRangeDatePicker.mock.calls[3][0]).toEqual({
+            expect(mockSetRelativeRangeDatePicker.mock.calls[1][0]).toEqual({
               from: '2020-01-01T00:00:00.000Z',
               fromStr: 'now-1d/d',
               kind: 'relative',
@@ -328,11 +328,11 @@ describe('UrlStateContainer', () => {
               id: 'global',
             });
 
-            expect(mockSetRelativeRangeDatePicker.mock.calls[2][0]).toEqual({
-              from: 1558732849370,
+            expect(mockSetRelativeRangeDatePicker.mock.calls[0][0]).toEqual({
+              from: '2020-01-01T00:00:00.000Z',
               fromStr: 'now-15m',
               kind: 'relative',
-              to: 1558733749370,
+              to: '2020-01-01T00:00:00.000Z',
               toStr: 'now',
               id: 'timeline',
             });

--- a/x-pack/plugins/security_solution/public/common/components/url_state/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/index.test.tsx
@@ -35,6 +35,15 @@ const mockRouteSpy: RouteSpyState = {
   search: '',
   pathName: '/network',
 };
+
+jest.mock('../../hooks/use_selector', () => {
+  const original = jest.requireActual('../../hooks/use_selector');
+  return {
+    ...original,
+    useDeepEqualSelector: jest.fn(),
+  };
+});
+
 jest.mock('../../utils/route/use_route_spy', () => ({
   useRouteSpy: () => [mockRouteSpy],
 }));
@@ -200,7 +209,7 @@ describe('UrlStateContainer', () => {
             ).toEqual({
               hash: '',
               pathname: examplePath,
-              search: `?query=(language:kuery,query:'host.name:%22siem-es%22')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))`,
+              search: `?query=(language:kuery,query:'host.name:%22siem-es%22')&detailPanel=(tabType:query,timelineId:'')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))`,
               state: '',
             });
           }
@@ -208,7 +217,7 @@ describe('UrlStateContainer', () => {
       });
     });
 
-    it("it doesn't update URL state when pathName and browserPAth are out of sync", () => {
+    it("it doesn't update URL state when pathName and browserPath are out of sync", () => {
       mockProps = getMockPropsObj({
         page: CONSTANTS.networkPage,
         examplePath: '/network',

--- a/x-pack/plugins/security_solution/public/common/components/url_state/index_mocked.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/index_mocked.test.tsx
@@ -44,6 +44,13 @@ jest.mock('react-redux', () => {
     useDispatch: () => jest.fn(),
   };
 });
+jest.mock('../../hooks/use_selector', () => {
+  const original = jest.requireActual('../../hooks/use_selector');
+  return {
+    ...original,
+    useDeepEqualSelector: jest.fn(),
+  };
+});
 
 describe('UrlStateContainer - lodash.throttle mocked to test update url', () => {
   afterEach(() => {
@@ -101,7 +108,7 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
         hash: '',
         pathname: '/network',
         search:
-          "?query=(language:kuery,query:'host.name:%22siem-es%22')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)))",
+          "?query=(language:kuery,query:'host.name:%22siem-es%22')&detailPanel=(tabType:query,timelineId:'')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)))",
         state: '',
       });
     });
@@ -135,7 +142,7 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
         hash: '',
         pathname: '/network',
         search:
-          "?query=(language:kuery,query:'host.name:%22siem-es%22')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))",
+          "?query=(language:kuery,query:'host.name:%22siem-es%22')&detailPanel=(tabType:query,timelineId:'')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))",
         state: '',
       });
     });
@@ -170,7 +177,7 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
         hash: '',
         pathname: '/network',
         search:
-          "?sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))&timeline=(id:hello_timeline_id,isOpen:!t)",
+          "?detailPanel=(tabType:query,timelineId:'')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))&timeline=(id:hello_timeline_id,isOpen:!t)",
         state: '',
       });
     });
@@ -205,7 +212,7 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
         hash: '',
         pathname: '/network',
         search:
-          "?sourcerer=!(cool,patterns)&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))",
+          "?detailPanel=(tabType:query,timelineId:'')&sourcerer=!(cool,patterns)&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))",
         state: '',
       });
     });
@@ -306,7 +313,7 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
               hash: '',
               pathname: examplePath,
               search:
-                "?sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))",
+                "?detailPanel=(tabType:query,timelineId:'')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))",
               state: '',
             });
           }
@@ -337,7 +344,7 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
           );
 
           expect(mockHistory.replace.mock.calls[0][0].search).toEqual(
-            "?sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))"
+            "?detailPanel=(tabType:query,timelineId:'')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))"
           );
 
           (useLocation as jest.Mock).mockReturnValue({
@@ -349,7 +356,7 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
           wrapper.update();
 
           expect(mockHistory.replace.mock.calls[1][0].search).toEqual(
-            "?query=(language:kuery,query:'host.name:%22siem-es%22')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))"
+            "?query=(language:kuery,query:'host.name:%22siem-es%22')&detailPanel=(tabType:query,timelineId:'')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))"
           );
         });
 
@@ -382,7 +389,7 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
           );
 
           expect(mockHistory.replace.mock.calls[0][0].search).toEqual(
-            "?sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))"
+            "?detailPanel=(tabType:query,timelineId:'')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))"
           );
 
           (useLocation as jest.Mock).mockReturnValue({

--- a/x-pack/plugins/security_solution/public/common/components/url_state/initialize_redux_by_url.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/initialize_redux_by_url.tsx
@@ -10,9 +10,7 @@ import { Dispatch } from 'redux';
 
 import { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
-import { useLocation } from 'react-router-dom';
 import type { Filter, Query } from '@kbn/es-query';
-import { ToggleDetailPanel } from '../../../../common/types/timeline';
 import { inputsActions, sourcererActions } from '../../store/actions';
 import { InputsModelId, TimeRangeKinds } from '../../store/inputs/constants';
 import {
@@ -23,12 +21,7 @@ import {
 } from '../../store/inputs/model';
 import { TimelineUrl } from '../../../timelines/store/timeline/model';
 import { CONSTANTS } from './constants';
-import {
-  decodeRisonUrlState,
-  getParamFromQueryString,
-  getQueryStringFromLocation,
-  isDetectionsPages,
-} from './helpers';
+import { decodeRisonUrlState, isDetectionsPages } from './helpers';
 import { normalizeTimeRange } from './normalize_time_range';
 import { SetInitialStateFromUrl } from './types';
 import {
@@ -36,29 +29,8 @@ import {
   dispatchUpdateTimeline,
 } from '../../../timelines/components/open_timeline/helpers';
 import { SourcererScopeName, SourcererUrlState } from '../../store/sourcerer/model';
-import { timelineActions, timelineSelectors } from '../../../timelines/store/timeline';
-import { useDeepEqualSelector } from '../../hooks/use_selector';
-
-const getQueryStringKeyValue = ({ search, urlKey }: { search: string; urlKey: string }) =>
-  getParamFromQueryString(getQueryStringFromLocation(search), urlKey);
-
-const useInitializeDetailPanel = () => {
-  const { search } = useLocation();
-  const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
-  const urlDetailPanel = useMemo(
-    () =>
-      decodeRisonUrlState<ToggleDetailPanel>(
-        getQueryStringKeyValue({
-          search,
-          urlKey: CONSTANTS.detailPanel,
-        }) ?? undefined
-      ),
-    [search]
-  );
-  const timelineId = urlDetailPanel?.timelineId ?? '';
-  const existingTimeline = useDeepEqualSelector((state) => getTimeline(state, timelineId));
-  return { detailPanel: urlDetailPanel, wasTimelineCreated: existingTimeline != null };
-};
+import { timelineActions } from '../../../timelines/store/timeline';
+import { useInitializeDetailPanel } from './use_initialize_detail_panel';
 
 export const useSetInitialStateFromUrl = () => {
   const dispatch = useDispatch();

--- a/x-pack/plugins/security_solution/public/common/components/url_state/query_timeline_by_id_on_url_change.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/query_timeline_by_id_on_url_change.ts
@@ -9,16 +9,9 @@ import { Action } from 'typescript-fsa';
 import { DispatchUpdateTimeline } from '../../../timelines/components/open_timeline/types';
 import { queryTimelineById } from '../../../timelines/components/open_timeline/helpers';
 import { TimelineTabs } from '../../../../common/types/timeline';
-import {
-  decodeRisonUrlState,
-  getQueryStringFromLocation,
-  getParamFromQueryString,
-} from './helpers';
+import { decodeRisonUrlState, getQueryStringKeyValue } from './helpers';
 import { TimelineUrl } from '../../../timelines/store/timeline/model';
 import { CONSTANTS } from './constants';
-
-const getQueryStringKeyValue = ({ search, urlKey }: { search: string; urlKey: string }) =>
-  getParamFromQueryString(getQueryStringFromLocation(search), urlKey);
 
 interface QueryTimelineIdOnUrlChange {
   oldSearch?: string;

--- a/x-pack/plugins/security_solution/public/common/components/url_state/test_dependencies.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/test_dependencies.ts
@@ -121,6 +121,10 @@ export const defaultProps: UrlStateContainerPropTypes = {
       isOpen: false,
     },
     [CONSTANTS.sourcerer]: {},
+    [CONSTANTS.detailPanel]: {
+      tabType: TimelineTabs.query,
+      timelineId: '',
+    },
   },
   history: {
     ...mockHistory,
@@ -190,7 +194,7 @@ export const getMockPropsObj = ({ page, examplePath, pageName, detailName }: Get
       {
         hash: '',
         pathname: examplePath,
-        search: `?query=(language:kuery,query:'host.name:%22siem-es%22')&timerange=(global:(linkTo:!(),timerange:(from:1558591200000,fromStr:now-1d%2Fd,kind:relative,to:1558677599999,toStr:now-1d%2Fd)),timeline:(linkTo:!(),timerange:(from:1558732849370,fromStr:now-15m,kind:relative,to:1558733749370,toStr:now)))`,
+        search: `?query=(language:kuery,query:'host.name:%22siem-es%22')&timerange=(global:(linkTo:!(),timerange:(from:1558591200000,fromStr:now-1d%2Fd,kind:relative,to:1558677599999,toStr:now-1d%2Fd)),timeline:(linkTo:!(),timerange:(from:1558732849370,fromStr:now-15m,kind:relative,to:1558733749370,toStr:now)))&detailPanel=(panelView:eventDetail,params:(eventId:%27049edacba26686023c363340861669eaa94ffa0fd7b7b8f47371e7504c8b4c66%27,indexName:.internal.alerts-security.alerts-default-000001),tabType:query,timelineId:detections-page)`,
         state: '',
       },
       page,
@@ -202,7 +206,7 @@ export const getMockPropsObj = ({ page, examplePath, pageName, detailName }: Get
       {
         hash: '',
         pathname: examplePath,
-        search: `?query=(language:kuery,query:'host.name:%22siem-es%22')&timerange=(global:(linkTo:!(),timerange:(from:1558591200000,fromStr:now-1d%2Fd,kind:relative,to:1558677599999,toStr:now-1d%2Fd)),timeline:(linkTo:!(),timerange:(from:1558732849370,fromStr:now-15m,kind:relative,to:1558733749370,toStr:now)))`,
+        search: `?query=(language:kuery,query:'host.name:%22siem-es%22')&timerange=(global:(linkTo:!(),timerange:(from:1558591200000,fromStr:now-1d%2Fd,kind:relative,to:1558677599999,toStr:now-1d%2Fd)),timeline:(linkTo:!(),timerange:(from:1558732849370,fromStr:now-15m,kind:relative,to:1558733749370,toStr:now)))&detailPanel=(panelView:eventDetail,params:(eventId:%27049edacba26686023c363340861669eaa94ffa0fd7b7b8f47371e7504c8b4c66%27,indexName:.internal.alerts-security.alerts-default-000001),tabType:query,timelineId:detections-page)`,
         state: '',
       },
       page,
@@ -214,7 +218,7 @@ export const getMockPropsObj = ({ page, examplePath, pageName, detailName }: Get
       {
         hash: '',
         pathname: examplePath,
-        search: `?query=(language:kuery,query:'host.name:%22siem-es%22')&timerange=(global:(linkTo:!(timeline),timerange:(from:1558591200000,fromStr:now-1d%2Fd,kind:relative,to:1558677599999,toStr:now-1d%2Fd)),timeline:(linkTo:!(global),timerange:(from:1558732849370,fromStr:now-15m,kind:relative,to:1558733749370,toStr:now)))`,
+        search: `?query=(language:kuery,query:'host.name:%22siem-es%22')&timerange=(global:(linkTo:!(timeline),timerange:(from:1558591200000,fromStr:now-1d%2Fd,kind:relative,to:1558677599999,toStr:now-1d%2Fd)),timeline:(linkTo:!(global),timerange:(from:1558732849370,fromStr:now-15m,kind:relative,to:1558733749370,toStr:now)))&detailPanel=(panelView:eventDetail,params:(eventId:%27049edacba26686023c363340861669eaa94ffa0fd7b7b8f47371e7504c8b4c66%27,indexName:.internal.alerts-security.alerts-default-000001),tabType:query,timelineId:detections-page)`,
         state: '',
       },
       page,
@@ -229,7 +233,7 @@ export const getMockPropsObj = ({ page, examplePath, pageName, detailName }: Get
         hash: '',
         pathname: examplePath,
         search:
-          '?timerange=(global:(linkTo:!(timeline),timerange:(from:1556736012685,kind:absolute,to:1556822416082)),timeline:(linkTo:!(global),timerange:(from:1556736012685,kind:absolute,to:1556822416082)))',
+          '?timerange=(global:(linkTo:!(timeline),timerange:(from:1556736012685,kind:absolute,to:1556822416082)),timeline:(linkTo:!(global),timerange:(from:1556736012685,kind:absolute,to:1556822416082)))&detailPanel=(panelView:eventDetail,params:(eventId:%27049edacba26686023c363340861669eaa94ffa0fd7b7b8f47371e7504c8b4c66%27,indexName:.internal.alerts-security.alerts-default-000001),tabType:query,timelineId:detections-page)',
         state: '',
       },
       page,
@@ -242,7 +246,7 @@ export const getMockPropsObj = ({ page, examplePath, pageName, detailName }: Get
         hash: '',
         pathname: examplePath,
         search:
-          '?timerange=(global:(linkTo:!(timeline),timerange:(from:1556736012685,kind:absolute,to:1556822416082)),timeline:(linkTo:!(global),timerange:(from:1556736012685,kind:absolute,to:1556822416082)))',
+          '?timerange=(global:(linkTo:!(timeline),timerange:(from:1556736012685,kind:absolute,to:1556822416082)),timeline:(linkTo:!(global),timerange:(from:1556736012685,kind:absolute,to:1556822416082)))&detailPanel=(panelView:eventDetail,params:(eventId:%27049edacba26686023c363340861669eaa94ffa0fd7b7b8f47371e7504c8b4c66%27,indexName:.internal.alerts-security.alerts-default-000001),tabType:query,timelineId:detections-page)',
         state: '',
       },
       page,
@@ -256,7 +260,7 @@ export const getMockPropsObj = ({ page, examplePath, pageName, detailName }: Get
       {
         hash: '',
         pathname: examplePath,
-        search: `?query=(query:'host.name:%22siem-es%22',language:kuery)&timerange=(global:(linkTo:!(),timerange:(from:1558591200000,fromStr:now-1d%2Fd,kind:relative,to:1558677599999,toStr:now-1d%2Fd)),timeline:(linkTo:!(),timerange:(from:1558732849370,fromStr:now-15m,kind:relative,to:1558733749370,toStr:now)))`,
+        search: `?query=(query:'host.name:%22siem-es%22',language:kuery)&timerange=(global:(linkTo:!(),timerange:(from:1558591200000,fromStr:now-1d%2Fd,kind:relative,to:1558677599999,toStr:now-1d%2Fd)),timeline:(linkTo:!(),timerange:(from:1558732849370,fromStr:now-15m,kind:relative,to:1558733749370,toStr:now)))&detailPanel=(panelView:eventDetail,params:(eventId:%27049edacba26686023c363340861669eaa94ffa0fd7b7b8f47371e7504c8b4c66%27,indexName:.internal.alerts-security.alerts-default-000001),tabType:query,timelineId:detections-page)`,
         state: '',
       },
       page,
@@ -324,6 +328,15 @@ export const testCases: Array<
     /* pathName */ '/timeline',
     /* type */ null,
     /* pageName */ SecurityPageName.timelines,
+    /* detailName */ undefined,
+  ],
+  [
+    /* page */ CONSTANTS.alertsPage,
+    /* namespaceLower */ 'alerts',
+    /* namespaceUpper */ 'Alerts',
+    /* pathName */ '/alerts',
+    /* type */ null,
+    /* pageName */ SecurityPageName.alerts,
     /* detailName */ undefined,
   ],
 ];

--- a/x-pack/plugins/security_solution/public/common/components/url_state/types.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/types.ts
@@ -14,9 +14,11 @@ import { SecurityNav } from '../navigation/types';
 
 import { CONSTANTS, UrlStateType } from './constants';
 import { SourcererUrlState } from '../../store/sourcerer/model';
+import { ToggleDetailPanel } from '../../../../common/types';
 
 export const ALL_URL_STATE_KEYS: KeyUrlState[] = [
   CONSTANTS.appQuery,
+  CONSTANTS.detailPanel,
   CONSTANTS.filters,
   CONSTANTS.savedQuery,
   CONSTANTS.sourcerer,
@@ -40,6 +42,7 @@ export type LocationTypes =
 
 export interface UrlState {
   [CONSTANTS.appQuery]?: Query;
+  [CONSTANTS.detailPanel]?: ToggleDetailPanel;
   [CONSTANTS.filters]?: Filter[];
   [CONSTANTS.savedQuery]?: string;
   [CONSTANTS.sourcerer]: SourcererUrlState;
@@ -51,6 +54,7 @@ export type KeyUrlState = keyof UrlState;
 export type ValueUrlState = UrlState[keyof UrlState];
 
 export interface UrlStateProps {
+  pathName?: string;
   navTabs: SecurityNav;
   indexPattern?: DataViewBase;
   mapToUrlState?: (value: string) => UrlState;

--- a/x-pack/plugins/security_solution/public/common/components/url_state/types.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/types.ts
@@ -54,7 +54,7 @@ export type KeyUrlState = keyof UrlState;
 export type ValueUrlState = UrlState[keyof UrlState];
 
 export interface UrlStateProps {
-  pathName?: string;
+  currentPath?: string;
   navTabs: SecurityNav;
   indexPattern?: DataViewBase;
   mapToUrlState?: (value: string) => UrlState;

--- a/x-pack/plugins/security_solution/public/common/components/url_state/use_initialize_detail_panel.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/use_initialize_detail_panel.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useLocation } from 'react-router-dom';
+import { useInitializeDetailPanel } from './use_initialize_detail_panel';
+import { renderHook } from '@testing-library/react-hooks';
+import { useDeepEqualSelector } from '../../hooks/use_selector';
+import { timelineSelectors } from '../../../timelines/store/timeline';
+
+jest.mock('../../hooks/use_selector');
+jest.mock('../../../timelines/store/timeline', () => {
+  const original = jest.requireActual('../../../timelines/store/timeline');
+  return {
+    ...original,
+    timelineSelectors: {
+      ...original.timelineSelectors,
+      getTimelineByIdSelector: jest.fn(),
+    },
+  };
+});
+jest.mock('react-router-dom', () => {
+  const original = jest.requireActual('react-router-dom');
+  return {
+    ...original,
+    useLocation: jest.fn(),
+  };
+});
+
+describe('useInitializeDetailPanel', () => {
+  beforeEach(() => {
+    (useDeepEqualSelector as jest.Mock).mockImplementation((cb) => {
+      return cb();
+    });
+    (timelineSelectors.getTimelineByIdSelector as jest.Mock).mockImplementation((cb) => {
+      return jest.fn().mockReturnValue(undefined);
+    });
+  });
+  afterEach(() => {
+    (useDeepEqualSelector as jest.Mock).mockClear();
+    (timelineSelectors.getTimelineByIdSelector as jest.Mock).mockClear();
+  });
+
+  describe('detail panel is not set', () => {
+    test('should return an undefined detail panel', () => {
+      (useLocation as jest.Mock).mockReturnValue({
+        search: '',
+      });
+      const { result } = renderHook(() => useInitializeDetailPanel());
+      expect(result.current.detailPanel).toEqual(null);
+    });
+  });
+
+  describe('detail panel is set', () => {
+    test('should return an undefined detail panel', () => {
+      (useLocation as jest.Mock).mockReturnValue({
+        search:
+          '?detailPanel=(panelView:eventDetail,params:(eventId:%27049edacba26686023c363340861669eaa94ffa0fd7b7b8f47371e7504c8b4c66%27,indexName:.internal.alerts-security.alerts-default-000001),tabType:query,timelineId:detections-page)',
+      });
+      const { result } = renderHook(() => useInitializeDetailPanel());
+      expect(result.current.detailPanel).toEqual({
+        panelView: 'eventDetail',
+        params: {
+          eventId: '049edacba26686023c363340861669eaa94ffa0fd7b7b8f47371e7504c8b4c66',
+          indexName: '.internal.alerts-security.alerts-default-000001',
+        },
+        tabType: 'query',
+        timelineId: 'detections-page',
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/components/url_state/use_initialize_detail_panel.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/use_initialize_detail_panel.test.tsx
@@ -45,7 +45,7 @@ describe('useInitializeDetailPanel', () => {
   });
 
   describe('detail panel is not set', () => {
-    test('should return an undefined detail panel', () => {
+    test('should return null', () => {
       (useLocation as jest.Mock).mockReturnValue({
         search: '',
       });
@@ -55,7 +55,7 @@ describe('useInitializeDetailPanel', () => {
   });
 
   describe('detail panel is set', () => {
-    test('should return an undefined detail panel', () => {
+    test('should return an event detail panel', () => {
       (useLocation as jest.Mock).mockReturnValue({
         search:
           '?detailPanel=(panelView:eventDetail,params:(eventId:%27049edacba26686023c363340861669eaa94ffa0fd7b7b8f47371e7504c8b4c66%27,indexName:.internal.alerts-security.alerts-default-000001),tabType:query,timelineId:detections-page)',

--- a/x-pack/plugins/security_solution/public/common/components/url_state/use_initialize_detail_panel.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/use_initialize_detail_panel.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { CONSTANTS } from './constants';
+import { decodeRisonUrlState, getQueryStringKeyValue } from './helpers';
+import { ToggleDetailPanel } from '../../../../common/types/timeline';
+import { timelineSelectors } from '../../../timelines/store/timeline';
+import { useDeepEqualSelector } from '../../hooks/use_selector';
+
+interface UseInitializeDetailPanel {
+  detailPanel: ToggleDetailPanel | null;
+  wasTimelineCreated: boolean;
+}
+export const useInitializeDetailPanel = (): UseInitializeDetailPanel => {
+  const { search } = useLocation();
+  const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
+  const urlDetailPanel = useMemo(
+    () =>
+      decodeRisonUrlState<ToggleDetailPanel>(
+        getQueryStringKeyValue({
+          search,
+          urlKey: CONSTANTS.detailPanel,
+        }) ?? undefined
+      ),
+    [search]
+  );
+  const timelineId = urlDetailPanel?.timelineId ?? '';
+  const existingTimeline = useDeepEqualSelector((state) => getTimeline(state, timelineId));
+  return { detailPanel: urlDetailPanel, wasTimelineCreated: existingTimeline != null };
+};

--- a/x-pack/plugins/security_solution/public/common/components/url_state/use_url_state.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/use_url_state.tsx
@@ -15,8 +15,6 @@ import { useSetInitialStateFromUrl } from './initialize_redux_by_url';
 import { useKibana } from '../../lib/kibana';
 import { CONSTANTS, UrlStateType } from './constants';
 import {
-  getQueryStringFromLocation,
-  getParamFromQueryString,
   getUrlType,
   getTitle,
   replaceStatesInLocation,
@@ -25,6 +23,8 @@ import {
   encodeRisonUrlState,
   isQueryStateEmpty,
   updateTimerangeUrl,
+  getQueryStringKeyValue,
+  getUrlStateKeyValue,
 } from './helpers';
 import {
   UrlStateContainerPropTypes,
@@ -33,7 +33,6 @@ import {
   KeyUrlState,
   ALL_URL_STATE_KEYS,
   UrlStateToRedux,
-  UrlState,
   isAdministration,
   ValueUrlState,
 } from './types';
@@ -204,12 +203,6 @@ export const useUrlStateHooks = ({
 
   return null;
 };
-
-const getUrlStateKeyValue = (urlState: UrlState, urlKey: KeyUrlState) =>
-  isQueryStateEmpty(urlState[urlKey], urlKey) ? '' : urlState[urlKey];
-
-const getQueryStringKeyValue = ({ search, urlKey }: { search: string; urlKey: string }) =>
-  getParamFromQueryString(getQueryStringFromLocation(search), urlKey);
 
 export const getUpdateToFormatUrlStateString = ({
   isFirstPageLoad,

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/helpers.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/helpers.ts
@@ -163,6 +163,7 @@ export const addTimelineToStore = ({
       filterManager: timelineById[id].filterManager,
       isLoading: timelineById[id].isLoading,
       initialized: timelineById[id].initialized,
+      expandedDetail: timelineById[id].expandedDetail ?? {},
       resolveTimelineConfig,
       dateRange:
         timeline.status === TimelineStatus.immutable &&
@@ -207,6 +208,7 @@ export const addNewTimeline = ({
       ...timelineDefaults,
       ...timelineProps,
       dateRange,
+      expandedDetail: timeline?.expandedDetail ?? {},
       savedObjectId: null,
       version: null,
       isSaving: false,
@@ -254,7 +256,6 @@ export const updateTimelineShowTimeline = ({
   timelineById,
 }: UpdateShowTimelineProps): TimelineById => {
   const timeline = timelineById[id];
-
   return {
     ...timelineById,
     [id]: {

--- a/x-pack/plugins/timelines/public/store/t_grid/reducer.ts
+++ b/x-pack/plugins/timelines/public/store/t_grid/reducer.ts
@@ -78,9 +78,9 @@ export const tGridReducer = reducerWithInitialState(initialTGridState)
     timelineById: {
       ...state.timelineById,
       [action.timelineId]: {
-        ...state.timelineById[action.timelineId],
+        ...(state.timelineById[action.timelineId] ?? {}),
         expandedDetail: {
-          ...state.timelineById[action.timelineId].expandedDetail,
+          ...(state.timelineById[action.timelineId]?.expandedDetail ?? {}),
           ...updateTimelineDetailsPanel(action),
         },
       },


### PR DESCRIPTION
## Summary

The goal of this PR was to make it easier for users to be able to quickly share details regarding a specific alert or event with each other. Before this change the only way users could potentially do this was by either attaching an event to a case or creating a timeline / pinning an event in a timeline. That ability still remains, but to allow users to share specific details without going through those extra steps, this PR provides users the ability to link directly to the details flyout . The three different detail flyouts users can now link directly to are:

1. Alert details / event details flyout 
2. Host details flyout
3. Finally, the IP details flyout.

This functionality works in all pages where these panels are accessible as well as the timeline flyout. Examples from some of these views are included below:

**Alerts Page**

https://user-images.githubusercontent.com/17211684/151003970-e7642aa9-d6b3-4224-b148-7f820dd0232a.mov

**Cases Page**

https://user-images.githubusercontent.com/17211684/151004021-94318b15-84d3-4646-bba1-722415f71fec.mov

**Host Events and External Alerts Pages**

https://user-images.githubusercontent.com/17211684/151004072-16e184a1-06ad-48dd-968a-b9ff64f28395.mov

**Network External Alerts Page**

https://user-images.githubusercontent.com/17211684/151004135-51c97475-70d1-458e-96ef-eeabb1d44d88.mov

**Timeline Query Tab**

https://user-images.githubusercontent.com/17211684/151004254-251224b2-024e-4b34-9d53-5a28bc082a77.mov


**Timeline Pinned Events Tab**

https://user-images.githubusercontent.com/17211684/151004320-872e6258-b28e-448a-9c5a-6872688db7b4.mov
 