### PR TITLE
[8.0] [Rule Registry][Security Solution] Populate kibana.alert.rule.tags by default (#121480)

### DIFF
--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
@@ -33,6 +33,7 @@ import {
   ALERT_WORKFLOW_STATUS,
   EVENT_ACTION,
   EVENT_KIND,
+  TAGS,
   TIMESTAMP,
   VERSION,
 } from '../../common/technical_rule_data_field_names';
@@ -267,6 +268,7 @@ export const createLifecycleExecutor =
           [EVENT_KIND]: 'signal',
           [EVENT_ACTION]: isNew ? 'open' : isActive ? 'active' : 'close',
           [VERSION]: ruleDataClient.kibanaVersion,
+          [TAGS]: options.tags,
           ...(isRecovered ? { [ALERT_END]: commonRuleFields[TIMESTAMP] } : {}),
         };
 

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
@@ -204,6 +204,9 @@ describe('createLifecycleRuleTypeFactory', () => {
               "kibana.alert.rule.name": "name",
               "kibana.alert.rule.producer": "producer",
               "kibana.alert.rule.rule_type_id": "ruleTypeId",
+              "kibana.alert.rule.tags": Array [
+                "tags",
+              ],
               "kibana.alert.rule.uuid": "alertId",
               "kibana.alert.start": "2021-06-16T09:01:00.000Z",
               "kibana.alert.status": "active",
@@ -228,6 +231,9 @@ describe('createLifecycleRuleTypeFactory', () => {
               "kibana.alert.rule.name": "name",
               "kibana.alert.rule.producer": "producer",
               "kibana.alert.rule.rule_type_id": "ruleTypeId",
+              "kibana.alert.rule.tags": Array [
+                "tags",
+              ],
               "kibana.alert.rule.uuid": "alertId",
               "kibana.alert.start": "2021-06-16T09:01:00.000Z",
               "kibana.alert.status": "active",

--- a/x-pack/plugins/rule_registry/server/utils/get_common_alert_fields.ts
+++ b/x-pack/plugins/rule_registry/server/utils/get_common_alert_fields.ts
@@ -16,7 +16,7 @@ import {
   ALERT_RULE_TYPE_ID,
   ALERT_RULE_UUID,
   SPACE_IDS,
-  TAGS,
+  ALERT_RULE_TAGS,
   TIMESTAMP,
 } from '@kbn/rule-data-utils/technical_field_names';
 
@@ -31,7 +31,7 @@ const commonAlertFieldNames = [
   ALERT_RULE_TYPE_ID,
   ALERT_RULE_UUID,
   SPACE_IDS,
-  TAGS,
+  ALERT_RULE_TAGS,
   TIMESTAMP,
 ];
 export type CommonAlertFieldName = Values<typeof commonAlertFieldNames>;
@@ -52,7 +52,7 @@ export const getCommonAlertFields = (
     [ALERT_RULE_TYPE_ID]: options.rule.ruleTypeId,
     [ALERT_RULE_UUID]: options.alertId,
     [SPACE_IDS]: [options.spaceId],
-    [TAGS]: options.tags,
+    [ALERT_RULE_TAGS]: options.tags,
     [TIMESTAMP]: options.startedAt.toISOString(),
   };
 };

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_ml.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_ml.ts
@@ -17,7 +17,6 @@ import {
   ALERT_UUID,
   ALERT_WORKFLOW_STATUS,
   SPACE_IDS,
-  TAGS,
   VERSION,
 } from '@kbn/rule-data-utils';
 import { flattenWithPrefix } from '@kbn/securitysolution-rules';
@@ -159,7 +158,6 @@ export default ({ getService }: FtrProviderContext) => {
         [ALERT_WORKFLOW_STATUS]: 'open',
         [ALERT_STATUS]: 'active',
         [SPACE_IDS]: ['default'],
-        [TAGS]: [`__internal_rule_id:${createdRule.rule_id}`, '__internal_immutable:false'],
         [ALERT_SEVERITY]: 'critical',
         [ALERT_RISK_SCORE]: 50,
         [ALERT_RULE_PARAMETERS]: {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_threat_matching.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_threat_matching.ts
@@ -17,7 +17,6 @@ import {
   ALERT_WORKFLOW_STATUS,
   SPACE_IDS,
   VERSION,
-  TAGS,
 } from '@kbn/rule-data-utils';
 import { flattenWithPrefix } from '@kbn/securitysolution-rules';
 
@@ -285,7 +284,6 @@ export default ({ getService }: FtrProviderContext) => {
           [ALERT_WORKFLOW_STATUS]: 'open',
           [SPACE_IDS]: ['default'],
           [VERSION]: fullSignal[VERSION],
-          [TAGS]: [`__internal_rule_id:${createdRule.rule_id}`, '__internal_immutable:false'],
           threat: {
             enrichments: get(fullSignal, 'threat.enrichments'),
           },

--- a/x-pack/test/rule_registry/spaces_only/tests/trial/__snapshots__/create_rule.snap
+++ b/x-pack/test/rule_registry/spaces_only/tests/trial/__snapshots__/create_rule.snap
@@ -38,6 +38,10 @@ Object {
   "kibana.alert.rule.rule_type_id": Array [
     "apm.transaction_error_rate",
   ],
+  "kibana.alert.rule.tags": Array [
+    "apm",
+    "service.name:opbeans-go",
+  ],
   "kibana.alert.status": Array [
     "active",
   ],
@@ -97,6 +101,10 @@ Object {
   ],
   "kibana.alert.rule.rule_type_id": Array [
     "apm.transaction_error_rate",
+  ],
+  "kibana.alert.rule.tags": Array [
+    "apm",
+    "service.name:opbeans-go",
   ],
   "kibana.alert.status": Array [
     "recovered",


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Rule Registry][Security Solution] Populate kibana.alert.rule.tags by default (#121480)