### PR TITLE
[7.17] [Canvas] Fixes Workpad element is breaking after changing the expression from expression editor and resizing.(#122154) (#122154)

### DIFF
--- a/x-pack/plugins/canvas/public/components/render_with_fn/render_with_fn.tsx
+++ b/x-pack/plugins/canvas/public/components/render_with_fn/render_with_fn.tsx
@@ -58,7 +58,7 @@ export const RenderWithFn: FC<Props> = ({
       return;
     }
 
-    if (!firstRender) {
+    if (!firstRender.current) {
       handlers.current.destroy();
     }
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [Canvas] Fixes Workpad element is breaking after changing the expression from expression editor and resizing.(#122154) (#122154)