### PR TITLE
[APM] Fix trace sample pagination layout

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/index.tsx
@@ -88,8 +88,8 @@ export function WaterfallWithSummary({
 
   return (
     <>
-      <EuiFlexGroup>
-        <EuiFlexItem style={{ flexDirection: 'row', alignItems: 'center' }}>
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false}>
           <EuiTitle size="xs">
             <h5>
               {i18n.translate('xpack.apm.transactionDetails.traceSampleTitle', {
@@ -97,6 +97,8 @@ export function WaterfallWithSummary({
               })}
             </h5>
           </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem>
           {traceSamples && (
             <EuiPagination
               pageCount={traceSamples.length}


### PR DESCRIPTION
## Summary

The trace sample pagination component was updated to also feature first and last page options. The component itself was aligning up against the trace sample title, so this PR just adds more space between the items in the header.

**Before**

<img width="837" alt="CleanShot 2022-01-06 at 10 31 30@2x" src="https://user-images.githubusercontent.com/4104278/148361258-53d25d6b-69e1-49cb-8d7f-a024847e4fb8.png">

**After**

<img width="948" alt="CleanShot 2022-01-06 at 10 28 30@2x" src="https://user-images.githubusercontent.com/4104278/148361090-e6d12c75-0c37-4c7f-b8be-7111815e0793.png">
