### PR TITLE
[7.17] [Security Solution][Investigations] Don't show the empty label in charts for number values (#121274)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/charts/barchart.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/charts/barchart.tsx
@@ -8,7 +8,7 @@
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { Chart, BarSeries, Axis, Position, ScaleType, Settings } from '@elastic/charts';
-import { getOr, get, isNumber, isEmpty } from 'lodash/fp';
+import { getOr, get, isNumber } from 'lodash/fp';
 import deepmerge from 'deepmerge';
 import uuid from 'uuid';
 import styled from 'styled-components';
@@ -18,6 +18,7 @@ import { escapeDataProviderId } from '../drag_and_drop/helpers';
 import { useTimeZone } from '../../lib/kibana';
 import { defaultLegendColors } from '../matrix_histogram/utils';
 import { useThrottledResizeObserver } from '../utils';
+import { hasValueToDisplay } from '../../utils/validators';
 import { EMPTY_VALUE_LABEL } from '../charts/translation';
 
 import { ChartPlaceHolder } from './chart_place_holder';
@@ -53,7 +54,7 @@ const checkIfAnyValidSeriesExist = (
 
 const yAccessors = ['y'];
 const splitSeriesAccessors = [
-  (datum: ChartData) => (isEmpty(datum.g) ? EMPTY_VALUE_LABEL : datum.g),
+  (datum: ChartData) => (hasValueToDisplay(datum.g) ? datum.g : EMPTY_VALUE_LABEL),
 ];
 
 // Bar chart rotation: https://ela.st/chart-rotations

--- a/x-pack/plugins/security_solution/public/common/components/charts/draggable_legend_item.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/charts/draggable_legend_item.test.tsx
@@ -68,4 +68,13 @@ describe('DraggableLegendItem', () => {
     );
     expect(wrapper.find('[data-test-subj="value-wrapper-empty"]').first().exists()).toBeTruthy();
   });
+
+  it('does not render the empty value label when the value is a number', () => {
+    wrapper = mount(
+      <TestProviders>
+        <DraggableLegendItem legendItem={{ ...legendItem, value: 0 }} />
+      </TestProviders>
+    );
+    expect(wrapper.find('[data-test-subj="value-wrapper-empty"]').first().exists()).toBeFalsy();
+  });
 });

--- a/x-pack/plugins/security_solution/public/common/components/charts/draggable_legend_item.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/charts/draggable_legend_item.tsx
@@ -7,24 +7,28 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiHealth, EuiText } from '@elastic/eui';
 import React from 'react';
-import { isEmpty } from 'lodash/fp';
 
 import { DefaultDraggable } from '../draggables';
 import { EMPTY_VALUE_LABEL } from './translation';
+import { hasValueToDisplay } from '../../utils/validators';
 
 export interface LegendItem {
   color?: string;
   dataProviderId: string;
   field: string;
   timelineId?: string;
-  value: string;
+  value: string | number;
 }
 
 /**
  * Renders the value or a placeholder in case the value is empty
  */
-const ValueWrapper = React.memo<{ value?: string | null }>(({ value }) =>
-  isEmpty(value) ? <em data-test-subj="value-wrapper-empty">{EMPTY_VALUE_LABEL}</em> : <>{value}</>
+const ValueWrapper = React.memo<{ value: LegendItem['value'] }>(({ value }) =>
+  hasValueToDisplay(value) ? (
+    <>{value}</>
+  ) : (
+    <em data-test-subj="value-wrapper-empty">{EMPTY_VALUE_LABEL}</em>
+  )
 );
 
 ValueWrapper.displayName = 'ValueWrapper';

--- a/x-pack/plugins/security_solution/public/common/components/draggables/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/draggables/index.tsx
@@ -24,7 +24,7 @@ export interface DefaultDraggableType {
   id: string;
   isDraggable?: boolean;
   field: string;
-  value?: string | null;
+  value?: string | number | null;
   name?: string | null;
   queryValue?: string | null;
   children?: React.ReactNode;
@@ -63,7 +63,7 @@ export const Content = React.memo<{
   field: string;
   tooltipContent?: React.ReactNode;
   tooltipPosition?: ToolTipPositions;
-  value?: string | null;
+  value?: string | number | null;
 }>(({ children, field, tooltipContent, tooltipPosition, value }) =>
   !tooltipContentIsExplicitlyNull(tooltipContent) ? (
     <EuiToolTip
@@ -115,7 +115,7 @@ export const DefaultDraggable = React.memo<DefaultDraggableType>(
         and: [],
         enabled: true,
         id: escapeDataProviderId(id),
-        name: name ? name : value ?? '',
+        name: name ? name : value?.toString() ?? '',
         excluded: false,
         kqlQuery: '',
         queryMatch: {

--- a/x-pack/plugins/security_solution/public/common/utils/validators/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/validators/index.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isUrlInvalid } from '.';
+import { isUrlInvalid, hasValueToDisplay } from '.';
 
 describe('helpers', () => {
   describe('isUrlInvalid', () => {
@@ -47,6 +47,20 @@ describe('helpers', () => {
 
     test('should verify as invalid url without //', () => {
       expect(isUrlInvalid('http:www.thisIsNotValid.com/foo')).toBeTruthy();
+    });
+  });
+
+  describe('hasValueToDisplay', () => {
+    test('identifies valid values', () => {
+      expect(hasValueToDisplay('test')).toBeTruthy();
+      expect(hasValueToDisplay(0)).toBeTruthy();
+      expect(hasValueToDisplay(100)).toBeTruthy();
+    });
+
+    test('identifies empty/invalid values', () => {
+      expect(hasValueToDisplay('')).toBeFalsy();
+      expect(hasValueToDisplay(null)).toBeFalsy();
+      expect(hasValueToDisplay(undefined)).toBeFalsy();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/common/utils/validators/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/validators/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { isEmpty, isNumber } from 'lodash/fp';
 export * from './is_endpoint_host_isolated';
 
 const allowedSchemes = ['http:', 'https:'];
@@ -29,3 +30,7 @@ export const isUrlInvalid = (url: string | null | undefined) => {
   }
   return true;
 };
+
+export function hasValueToDisplay(value: string | number | null | undefined) {
+  return isNumber(value) || !isEmpty(value);
+}

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/alerts_histogram.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/alerts_histogram.tsx
@@ -15,10 +15,10 @@ import {
 } from '@elastic/charts';
 import { EuiFlexGroup, EuiFlexItem, EuiProgress } from '@elastic/eui';
 import React, { useMemo } from 'react';
-import { isEmpty } from 'lodash/fp';
 
 import { useTheme, UpdateDateRange, ChartData } from '../../../../common/components/charts/common';
 import { histogramDateTimeFormatter } from '../../../../common/components/utils';
+import { hasValueToDisplay } from '../../../../common/utils/validators';
 import { DraggableLegend } from '../../../../common/components/charts/draggable_legend';
 import { LegendItem } from '../../../../common/components/charts/draggable_legend_item';
 import { EMPTY_VALUE_LABEL } from '../../../../common/components/charts/translation';
@@ -58,7 +58,7 @@ export const AlertsHistogram = React.memo<AlertsHistogramProps>(
     const id = 'alertsHistogram';
     const yAccessors = useMemo(() => ['y'], []);
     const splitSeriesAccessors = useMemo(
-      () => [(datum: ChartData) => (isEmpty(datum.g) ? EMPTY_VALUE_LABEL : datum.g)],
+      () => [(datum: ChartData) => (hasValueToDisplay(datum.g) ? datum.g : EMPTY_VALUE_LABEL)],
       []
     );
     const tickFormat = useMemo(() => histogramDateTimeFormatter([from, to]), [from, to]);


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [Security Solution][Investigations] Don't show the empty label in charts for number values (#121274)