### PR TITLE
[Expressions] Add support of comments

### DIFF
--- a/docs/canvas/canvas-expression-lifecycle.asciidoc
+++ b/docs/canvas/canvas-expression-lifecycle.asciidoc
@@ -14,6 +14,7 @@ To use demo dataset available in Canvas to produce a table, run the following ex
 
 [source,text]
 ----
+/* Simple demo table */
 filters
 | demodata
 | table
@@ -24,6 +25,7 @@ This expression starts out with the <<filters_fn, filters>> function, which prov
 
 The filtered <<demodata_fn, demo data>> becomes the _context_ of the next function, <<table_fn, table>>, which creates a table visualization from this data set. The <<table_fn, table>> function isn’t strictly required, but by being explicit, you have the option of providing arguments to control things like the font used in the table. The output of the <<table_fn, table>> function becomes the _context_ of the <<render_fn, render>> function. Like the <<table_fn, table>>, the <<render_fn, render>> function isn’t required either, but it allows access to other arguments, such as styling the border of the element or injecting custom CSS.
 
+It is possible to add comments to the expression by starting them with a `//` sequence or by using `/*` and `*/` to enclose multi-line comments.
 
 [[canvas-function-arguments]]
 === Function arguments

--- a/docs/developer/plugin-list.asciidoc
+++ b/docs/developer/plugin-list.asciidoc
@@ -140,6 +140,9 @@ All the arguments to expression functions need to be serializable, as well as in
 Expression functions should try to stay 'pure'. This makes functions easy to reuse and also 
 make it possible to serialize the whole chain as well as output at every step of execution.
 
+It is possible to add comments to expressions by starting them with a `//` sequence
+or by using `/*` and `*/` to enclose multi-line comments.
+
 Expressions power visualizations in Dashboard and Lens, as well as, every
 *element* in Canvas is backed by an expression.
 

--- a/packages/kbn-interpreter/grammar/grammar.peggy
+++ b/packages/kbn-interpreter/grammar/grammar.peggy
@@ -23,7 +23,7 @@ start
   = expression
 
 expression
-  = space? first:function? rest:('|' space? fn:function { return fn; })* {
+  = blank? first:function? rest:('|' blank? fn:function { return fn; })* {
     return addMeta({
       type: 'expression',
       chain: first ? [first].concat(rest) : []
@@ -44,7 +44,7 @@ function "function"
 /* ----- Arguments ----- */
 
 argument_assignment
-  = name:identifier space? '=' space? value:argument {
+  = name:identifier blank? '=' blank? value:argument {
     return { name, value };
   }
   / value:argument {
@@ -58,7 +58,7 @@ argument
   }
 
 arg_list
-  = args:(space arg:argument_assignment { return arg; })* space? {
+  = args:(blank arg:argument_assignment { return arg; })* blank? {
     return args.reduce((accumulator, { name, value }) => ({
       ...accumulator,
       [name]: (accumulator[name] || []).concat(value)
@@ -82,7 +82,7 @@ phrase
 
 unquoted_string_or_number
   // Make sure we're not matching the beginning of a search
-  = string:unquoted+ { // this also matches nulls, booleans, and numbers
+  = !comment string:unquoted+ { // this also matches nulls, booleans, and numbers
     var result = string.join('');
     // Sort of hacky, but PEG doesn't have backtracking so
     // a null/boolean/number rule is hard to read, and performs worse
@@ -93,8 +93,20 @@ unquoted_string_or_number
     return Number(result);
   }
 
+blank
+  = (space / comment)+
+
 space
-  = [\ \t\r\n]+
+  = [\ \t\r\n]
+
+comment
+  = inline_comment / multiline_comment
+
+inline_comment
+  = "//" [^\n]*
+
+multiline_comment
+  = "/*" (!"*/" .)* "*/"?
 
 unquoted
   = "\\" sequence:([\"'(){}<>\[\]$`|=\ \t\n\r] / "\\") { return sequence; }

--- a/packages/kbn-interpreter/src/common/index.ts
+++ b/packages/kbn-interpreter/src/common/index.ts
@@ -15,7 +15,13 @@ export type {
   AstArgumentWithMeta,
   AstFunctionWithMeta,
 } from './lib/ast';
-export { fromExpression, toExpression, safeElementFromExpression } from './lib/ast';
+export {
+  fromExpression,
+  isAst,
+  isAstWithMeta,
+  toExpression,
+  safeElementFromExpression,
+} from './lib/ast';
 export { Fn } from './lib/fn';
 export { getType } from './lib/get_type';
 export { castProvider } from './lib/cast';

--- a/packages/kbn-interpreter/src/common/index.ts
+++ b/packages/kbn-interpreter/src/common/index.ts
@@ -7,6 +7,7 @@
  */
 
 export type { Ast, AstArgument, AstFunction, AstNode } from './lib/ast';
+export type { AstWithMeta, AstArgumentWithMeta, AstFunctionWithMeta } from './lib/ast_with_meta';
 export { fromExpression, toExpression, safeElementFromExpression } from './lib/ast';
 export { Fn } from './lib/fn';
 export { getType } from './lib/get_type';

--- a/packages/kbn-interpreter/src/common/index.ts
+++ b/packages/kbn-interpreter/src/common/index.ts
@@ -6,8 +6,15 @@
  * Side Public License, v 1.
  */
 
-export type { Ast, AstArgument, AstFunction, AstNode } from './lib/ast';
-export type { AstWithMeta, AstArgumentWithMeta, AstFunctionWithMeta } from './lib/ast_with_meta';
+export type {
+  Ast,
+  AstArgument,
+  AstFunction,
+  AstNode,
+  AstWithMeta,
+  AstArgumentWithMeta,
+  AstFunctionWithMeta,
+} from './lib/ast';
 export { fromExpression, toExpression, safeElementFromExpression } from './lib/ast';
 export { Fn } from './lib/fn';
 export { getType } from './lib/get_type';

--- a/packages/kbn-interpreter/src/common/index.ts
+++ b/packages/kbn-interpreter/src/common/index.ts
@@ -6,14 +6,12 @@
  * Side Public License, v 1.
  */
 
-export type { Ast, ExpressionFunctionAST } from './lib/ast';
+export type { Ast, AstArgument, AstFunction, AstNode } from './lib/ast';
 export { fromExpression, toExpression, safeElementFromExpression } from './lib/ast';
 export { Fn } from './lib/fn';
 export { getType } from './lib/get_type';
 export { castProvider } from './lib/cast';
-// @ts-expect-error
-// @internal
-export { parse } from '../../grammar';
+export { parse } from './lib/parse';
 export { getByAlias } from './lib/get_by_alias';
 export { Registry } from './lib/registry';
 export { addRegistries, register, registryFactory } from './registries';

--- a/packages/kbn-interpreter/src/common/lib/ast/ast.ts
+++ b/packages/kbn-interpreter/src/common/lib/ast/ast.ts
@@ -54,3 +54,11 @@ export type AstWithMeta = WithMeta<
     }
   >
 >;
+
+export function isAstWithMeta(value: any): value is AstWithMeta {
+  return typeof value?.node === 'object';
+}
+
+export function isAst(value: any): value is Ast {
+  return typeof value === 'object' && value?.type === 'expression';
+}

--- a/packages/kbn-interpreter/src/common/lib/ast/ast.ts
+++ b/packages/kbn-interpreter/src/common/lib/ast/ast.ts
@@ -6,7 +6,22 @@
  * Side Public License, v 1.
  */
 
-import type { Ast, AstArgument, AstFunction } from './ast';
+export type AstNode = Ast | AstFunction | AstArgument;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type Ast = {
+  type: 'expression';
+  chain: AstFunction[];
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type AstFunction = {
+  type: 'function';
+  function: string;
+  arguments: Record<string, AstArgument[]>;
+};
+
+export type AstArgument = string | boolean | number | Ast;
 
 interface WithMeta<T> {
   start: number;

--- a/packages/kbn-interpreter/src/common/lib/ast/compare.ts
+++ b/packages/kbn-interpreter/src/common/lib/ast/compare.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { forEach, xor, zip } from 'lodash';
+import { parse } from '../parse';
+import type {
+  Ast,
+  AstArgument,
+  AstArgumentWithMeta,
+  AstWithMeta,
+  AstFunction,
+  AstFunctionWithMeta,
+} from './ast';
+import { isAst, isAstWithMeta } from './ast';
+
+export interface ValueChange {
+  type: 'value';
+  source: AstArgumentWithMeta;
+  target: AstArgument;
+}
+
+export type Change = ValueChange;
+
+export function isValueChange(value: any): value is ValueChange {
+  return value?.type === 'value';
+}
+
+export function compare(expression: string, ast: Ast): Change[] {
+  const astWithMeta = parse(expression, { addMeta: true });
+  const queue = [[astWithMeta, ast]] as Array<[typeof astWithMeta, typeof ast]>;
+  const changes = [] as Change[];
+
+  function compareExpression(source: AstWithMeta, target: Ast) {
+    zip(source.node.chain, target.chain).forEach(([fnWithMeta, fn]) => {
+      if (!fnWithMeta || !fn || fnWithMeta?.node.function !== fn?.function) {
+        throw Error('Expression changes are not supported.');
+      }
+
+      compareFunction(fnWithMeta, fn);
+    });
+  }
+
+  function compareFunction(source: AstFunctionWithMeta, target: AstFunction) {
+    if (xor(Object.keys(source.node.arguments), Object.keys(target.arguments)).length) {
+      throw Error('Function changes are not supported.');
+    }
+
+    forEach(source.node.arguments, (valuesWithMeta, argument) => {
+      const values = target.arguments[argument];
+
+      compareArgument(valuesWithMeta, values);
+    });
+  }
+
+  function compareArgument(source: AstArgumentWithMeta[], target: AstArgument[]) {
+    if (source.length !== target.length) {
+      throw Error('Arguments changes are not supported.');
+    }
+
+    zip(source, target).forEach(([valueWithMeta, value]) => compareValue(valueWithMeta!, value!));
+  }
+
+  function compareValue(source: AstArgumentWithMeta, target: AstArgument) {
+    if (isAstWithMeta(source) && isAst(target)) {
+      compareExpression(source, target);
+
+      return;
+    }
+
+    if (source.node !== target) {
+      changes.push({ type: 'value', source, target });
+    }
+  }
+
+  while (queue.length) {
+    compareExpression(...queue.shift()!);
+  }
+
+  return changes;
+}

--- a/packages/kbn-interpreter/src/common/lib/ast/from_expression.test.js
+++ b/packages/kbn-interpreter/src/common/lib/ast/from_expression.test.js
@@ -7,9 +7,9 @@
  */
 
 import { fromExpression } from '@kbn/interpreter';
-import { getType } from './get_type';
+import { getType } from '../get_type';
 
-describe('ast fromExpression', () => {
+describe('fromExpression', () => {
   describe('invalid expression', () => {
     it('throws with invalid expression', () => {
       const check = () => fromExpression('wat!');

--- a/packages/kbn-interpreter/src/common/lib/ast/from_expression.ts
+++ b/packages/kbn-interpreter/src/common/lib/ast/from_expression.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Ast } from './ast';
+import { parse } from '../parse';
+
+export function fromExpression(expression: string, type = 'expression'): Ast {
+  try {
+    return parse(String(expression), { startRule: type });
+  } catch (e) {
+    throw new Error(`Unable to parse expression: ${e.message}`);
+  }
+}

--- a/packages/kbn-interpreter/src/common/lib/ast/index.ts
+++ b/packages/kbn-interpreter/src/common/lib/ast/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export * from './ast';
+export * from './from_expression';
+export * from './safe_element_from_expression';
+export * from './to_expression';

--- a/packages/kbn-interpreter/src/common/lib/ast/patch.ts
+++ b/packages/kbn-interpreter/src/common/lib/ast/patch.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Ast } from './ast';
+import { isAstWithMeta } from './ast';
+import type { Change, ValueChange } from './compare';
+import { compare, isValueChange } from './compare';
+import { toExpression } from './to_expression';
+
+export function patch(expression: string, ast: Ast): string {
+  let result = '';
+  let position = 0;
+
+  function apply(change: Change) {
+    if (isValueChange(change)) {
+      return void patchValue(change);
+    }
+
+    throw new Error('Cannot apply patch for the change.');
+  }
+
+  function patchValue(change: ValueChange) {
+    if (isAstWithMeta(change.source)) {
+      throw new Error('Patching sub-expressions is not supported.');
+    }
+
+    result += `${expression.substring(position, change.source.start)}${toExpression(
+      change.target,
+      'argument'
+    )}`;
+
+    position = change.source.end;
+  }
+
+  compare(expression, ast)
+    .sort(({ source: source1 }, { source: source2 }) => source1.start - source2.start)
+    .forEach(apply);
+
+  result += expression.substring(position);
+
+  return result;
+}

--- a/packages/kbn-interpreter/src/common/lib/ast/safe_element_from_expression.ts
+++ b/packages/kbn-interpreter/src/common/lib/ast/safe_element_from_expression.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { fromExpression } from './from_expression';
+
+// TODO: OMG This is so bad, we need to talk about the right way to handle bad expressions since some are element based and others not
+export function safeElementFromExpression(expression: string) {
+  try {
+    return fromExpression(expression);
+  } catch (e) {
+    return fromExpression(
+      `markdown
+"## Crud.
+Canvas could not parse this element's expression. I am so sorry this error isn't more useful. I promise it will be soon.
+
+Thanks for understanding,
+#### Management
+"`
+    );
+  }
+}

--- a/packages/kbn-interpreter/src/common/lib/ast/to_expression.test.js
+++ b/packages/kbn-interpreter/src/common/lib/ast/to_expression.test.js
@@ -8,7 +8,7 @@
 
 import { toExpression } from '@kbn/interpreter';
 
-describe('ast toExpression', () => {
+describe('toExpression', () => {
   describe('single expression', () => {
     it('throws if no type included', () => {
       const errMsg = 'Objects must have a type property';

--- a/packages/kbn-interpreter/src/common/lib/ast/to_expression.ts
+++ b/packages/kbn-interpreter/src/common/lib/ast/to_expression.ts
@@ -6,25 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { getType } from './get_type';
-import { parse } from './parse';
-
-export type AstNode = Ast | AstFunction | AstArgument;
-
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type Ast = {
-  type: 'expression';
-  chain: AstFunction[];
-};
-
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type AstFunction = {
-  type: 'function';
-  function: string;
-  arguments: Record<string, AstArgument[]>;
-};
-
-export type AstArgument = string | boolean | number | Ast;
+import { getType } from '../get_type';
+import type { Ast, AstArgument, AstFunction, AstNode } from './ast';
 
 function getArgumentString(arg: AstArgument, argKey?: string, level = 0): string {
   const type = getType(arg);
@@ -112,31 +95,6 @@ function getExpression(chain: AstFunction[], level = 0) {
       return fnWithArgs(fn, expressionArgs);
     })
     .join(separator);
-}
-
-export function fromExpression(expression: string, type = 'expression'): Ast {
-  try {
-    return parse(String(expression), { startRule: type });
-  } catch (e) {
-    throw new Error(`Unable to parse expression: ${e.message}`);
-  }
-}
-
-// TODO: OMG This is so bad, we need to talk about the right way to handle bad expressions since some are element based and others not
-export function safeElementFromExpression(expression: string) {
-  try {
-    return fromExpression(expression);
-  } catch (e) {
-    return fromExpression(
-      `markdown
-"## Crud.
-Canvas could not parse this element's expression. I am so sorry this error isn't more useful. I promise it will be soon.
-
-Thanks for understanding,
-#### Management
-"`
-    );
-  }
 }
 
 // TODO: Respect the user's existing formatting

--- a/packages/kbn-interpreter/src/common/lib/ast/to_expression.ts
+++ b/packages/kbn-interpreter/src/common/lib/ast/to_expression.ts
@@ -8,6 +8,21 @@
 
 import { getType } from '../get_type';
 import type { Ast, AstArgument, AstFunction, AstNode } from './ast';
+import { isAst } from './ast';
+import { patch } from './patch';
+
+interface Options {
+  /**
+   * Node type.
+   */
+  type?: 'argument' | 'expression' | 'function';
+
+  /**
+   * Original expression to apply the new AST to.
+   * At the moment, only arguments values changes are supported.
+   */
+  source?: string;
+}
 
 function getArgumentString(arg: AstArgument, argKey?: string, level = 0): string {
   const type = getType(arg);
@@ -97,8 +112,13 @@ function getExpression(chain: AstFunction[], level = 0) {
     .join(separator);
 }
 
-// TODO: Respect the user's existing formatting
-export function toExpression(ast: AstNode, type = 'expression'): string {
+export function toExpression(ast: AstNode, options: string | Options = 'expression'): string {
+  const { type, source } = typeof options === 'string' ? ({ type: options } as Options) : options;
+
+  if (source && isAst(ast)) {
+    return patch(source, ast);
+  }
+
   if (type === 'argument') {
     return getArgumentString(ast as AstArgument);
   }

--- a/packages/kbn-interpreter/src/common/lib/ast_with_meta.ts
+++ b/packages/kbn-interpreter/src/common/lib/ast_with_meta.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Ast, AstArgument, AstFunction } from './ast';
+
+interface WithMeta<T> {
+  start: number;
+  end: number;
+  text: string;
+  node: T;
+}
+
+type Replace<T, R> = Pick<T, Exclude<keyof T, keyof R>> & R;
+
+type WrapAstArgumentWithMeta<T> = T extends Ast ? AstWithMeta : WithMeta<T>;
+export type AstArgumentWithMeta = WrapAstArgumentWithMeta<AstArgument>;
+
+export type AstFunctionWithMeta = WithMeta<
+  Replace<
+    AstFunction,
+    {
+      arguments: {
+        [key: string]: AstArgumentWithMeta[];
+      };
+    }
+  >
+>;
+
+export type AstWithMeta = WithMeta<
+  Replace<
+    Ast,
+    {
+      chain: AstFunctionWithMeta[];
+    }
+  >
+>;

--- a/packages/kbn-interpreter/src/common/lib/grammar.d.ts
+++ b/packages/kbn-interpreter/src/common/lib/grammar.d.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+declare module '*/grammar' {
+  export const parse: import('./parse').Parse;
+}

--- a/packages/kbn-interpreter/src/common/lib/parse.ts
+++ b/packages/kbn-interpreter/src/common/lib/parse.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Ast } from './ast';
+import { parse } from '../../../grammar';
+
+interface Options {
+  startRule?: string;
+}
+
+interface OptionsWithMeta extends Options {
+  addMeta: true;
+}
+
+export interface Parse {
+  (input: string, options?: Options): Ast;
+  (input: string, options: OptionsWithMeta): any;
+}
+
+const typedParse = parse;
+
+export { typedParse as parse };

--- a/packages/kbn-interpreter/src/common/lib/parse.ts
+++ b/packages/kbn-interpreter/src/common/lib/parse.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Ast } from './ast';
+import type { AstWithMeta } from './ast_with_meta';
 import { parse } from '../../../grammar';
 
 interface Options {
@@ -19,7 +20,7 @@ interface OptionsWithMeta extends Options {
 
 export interface Parse {
   (input: string, options?: Options): Ast;
-  (input: string, options: OptionsWithMeta): any;
+  (input: string, options: OptionsWithMeta): AstWithMeta;
 }
 
 const typedParse = parse;

--- a/packages/kbn-interpreter/src/common/lib/parse.ts
+++ b/packages/kbn-interpreter/src/common/lib/parse.ts
@@ -6,8 +6,7 @@
  * Side Public License, v 1.
  */
 
-import type { Ast } from './ast';
-import type { AstWithMeta } from './ast_with_meta';
+import type { Ast, AstWithMeta } from './ast';
 import { parse } from '../../../grammar';
 
 interface Options {

--- a/src/plugins/expressions/README.asciidoc
+++ b/src/plugins/expressions/README.asciidoc
@@ -10,6 +10,9 @@ All the arguments to expression functions need to be serializable, as well as in
 Expression functions should try to stay 'pure'. This makes functions easy to reuse and also 
 make it possible to serialize the whole chain as well as output at every step of execution.
 
+It is possible to add comments to expressions by starting them with a `//` sequence
+or by using `/*` and `*/` to enclose multi-line comments.
+
 Expressions power visualizations in Dashboard and Lens, as well as, every
 *element* in Canvas is backed by an expression.
 
@@ -30,7 +33,8 @@ filters
   query="SELECT COUNT(timestamp) as total_errors
     FROM kibana_sample_data_logs
     WHERE tags LIKE '%warning%' OR tags LIKE '%error%'"
-| math "total_errors"
+| math "total_errors" // take "total_errors" column
+/* Represent as a number over a label */
 | metric "TOTAL ISSUES"
   metricFont={font family="'Open Sans', Helvetica, Arial, sans-serif" size=48 align="left" color="#FFFFFF" weight="normal" underline=false italic=false}
   labelFont={font family="'Open Sans', Helvetica, Arial, sans-serif" size=30 align="left" color="#FFFFFF" weight="lighter" underline=false italic=false}

--- a/src/plugins/expressions/common/ast/types.ts
+++ b/src/plugins/expressions/common/ast/types.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import type { Ast, AstFunction } from '@kbn/interpreter';
 import { ExpressionValue, ExpressionValueError } from '../expression_types';
 
 export type ExpressionAstNode =
@@ -13,14 +14,11 @@ export type ExpressionAstNode =
   | ExpressionAstFunction
   | ExpressionAstArgument;
 
-export type ExpressionAstExpression = {
-  type: 'expression';
+export type ExpressionAstExpression = Omit<Ast, 'chain'> & {
   chain: ExpressionAstFunction[];
 };
 
-export type ExpressionAstFunction = {
-  type: 'function';
-  function: string;
+export type ExpressionAstFunction = Omit<AstFunction, 'arguments'> & {
   arguments: Record<string, ExpressionAstArgument[]>;
 
   /**

--- a/src/plugins/presentation_util/public/components/expression_input/autocomplete.ts
+++ b/src/plugins/presentation_util/public/components/expression_input/autocomplete.ts
@@ -7,12 +7,9 @@
  */
 
 import { uniq } from 'lodash';
-// @ts-expect-error untyped library
+import type { Ast, AstArgument, AstFunction } from '@kbn/interpreter';
 import { parse } from '@kbn/interpreter';
 import {
-  ExpressionAstExpression,
-  ExpressionAstFunction,
-  ExpressionAstArgument,
   ExpressionFunction,
   ExpressionFunctionParameter,
   getByAlias,
@@ -67,18 +64,16 @@ interface ASTMetaInformation<T> {
   node: T;
 }
 
-// Wraps ExpressionArg with meta or replace ExpressionAstExpression with ExpressionASTWithMeta
-type WrapExpressionArgWithMeta<T> = T extends ExpressionAstExpression
-  ? ExpressionASTWithMeta
-  : ASTMetaInformation<T>;
+// Wraps ExpressionArg with meta or replace Ast with ExpressionASTWithMeta
+type WrapExpressionArgWithMeta<T> = T extends Ast ? ExpressionASTWithMeta : ASTMetaInformation<T>;
 
-type ExpressionArgASTWithMeta = WrapExpressionArgWithMeta<ExpressionAstArgument>;
+type ExpressionArgASTWithMeta = WrapExpressionArgWithMeta<AstArgument>;
 
 type Modify<T, R> = Pick<T, Exclude<keyof T, keyof R>> & R;
 
 // Wrap ExpressionFunctionAST with meta and modify arguments to be wrapped with meta
 type ExpressionFunctionASTWithMeta = Modify<
-  ExpressionAstFunction,
+  AstFunction,
   {
     arguments: {
       [key: string]: ExpressionArgASTWithMeta[];
@@ -89,7 +84,7 @@ type ExpressionFunctionASTWithMeta = Modify<
 // Wrap ExpressionFunctionAST with meta and modify chain to be wrapped with meta
 type ExpressionASTWithMeta = ASTMetaInformation<
   Modify<
-    ExpressionAstExpression,
+    Ast,
     {
       chain: Array<ASTMetaInformation<ExpressionFunctionASTWithMeta>>;
     }

--- a/src/plugins/presentation_util/public/components/expression_input/autocomplete.ts
+++ b/src/plugins/presentation_util/public/components/expression_input/autocomplete.ts
@@ -8,6 +8,7 @@
 
 import { uniq } from 'lodash';
 import type { AstWithMeta, AstArgumentWithMeta } from '@kbn/interpreter';
+import { isAstWithMeta } from '@kbn/interpreter';
 import { parse } from '@kbn/interpreter';
 import {
   ExpressionFunction,
@@ -60,11 +61,6 @@ export interface FunctionSuggestion extends BaseSuggestion {
 }
 
 export type AutocompleteSuggestion = FunctionSuggestion | ArgSuggestion | ValueSuggestion;
-
-// Typeguard for checking if ExpressionArg is a new expression
-function isExpression(maybeExpression: any): maybeExpression is AstWithMeta {
-  return typeof maybeExpression.node === 'object';
-}
 
 /**
  * Generates the AST with the given expression and then returns the function and argument definitions
@@ -178,7 +174,7 @@ function getFnArgAtPosition(ast: AstWithMeta, position: number): FnArgAtPosition
 
         // If the arg value is an expression, expand our start and end position
         // to include the opening and closing braces
-        if (value.node !== null && isExpression(value)) {
+        if (value.node !== null && isAstWithMeta(value)) {
           argStart--;
           argEnd++;
         }
@@ -189,7 +185,7 @@ function getFnArgAtPosition(ast: AstWithMeta, position: number): FnArgAtPosition
         // argument name (`font=` for example), recurse within the expression
         if (
           value.node !== null &&
-          isExpression(value) &&
+          isAstWithMeta(value) &&
           (argName === '_' || !(argStart <= position && position <= argStart + argName.length + 1))
         ) {
           const result = getFnArgAtPosition(value, position);

--- a/src/plugins/presentation_util/public/components/expression_input/language.ts
+++ b/src/plugins/presentation_util/public/components/expression_input/language.ts
@@ -72,6 +72,9 @@ const expressionsLanguage: ExpressionsLanguage = {
       [/'/, 'string', '@string_single'],
 
       [/@symbols/, 'delimiter'],
+
+      [/\/\*/, 'comment', '@multiline_comment'],
+      [/\/\/.*$/, 'comment'],
     ],
 
     string_double: [
@@ -92,6 +95,12 @@ const expressionsLanguage: ExpressionsLanguage = {
       [/\{/, 'delimiter.bracket', '@bracketCounting'],
       [/\}/, 'delimiter.bracket', '@pop'],
       { include: 'common' },
+    ],
+
+    multiline_comment: [
+      [/[^\/*]+/, 'comment'],
+      ['\\*/', 'comment', '@pop'],
+      [/[\/*]/, 'comment'],
     ],
   },
 };

--- a/x-pack/plugins/canvas/public/components/workpad_filters/hooks/use_canvas_filters.ts
+++ b/x-pack/plugins/canvas/public/components/workpad_filters/hooks/use_canvas_filters.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ExpressionFunctionAST, fromExpression } from '@kbn/interpreter';
+import { AstFunction, fromExpression } from '@kbn/interpreter';
 import { shallowEqual, useSelector } from 'react-redux';
 import { State } from '../../../../types';
 import { getFiltersByFilterExpressions } from '../../../lib/filter';
@@ -14,7 +14,7 @@ import { useFiltersService } from '../../../services';
 
 const extractExpressionAST = (filters: string[]) => fromExpression(filters.join(' | '));
 
-export function useCanvasFilters(filterExprsToGroupBy: ExpressionFunctionAST[] = []) {
+export function useCanvasFilters(filterExprsToGroupBy: AstFunction[] = []) {
   const filtersService = useFiltersService();
   const filterExpressions = useSelector(
     (state: State) => filtersService.getFilters(state),

--- a/x-pack/plugins/canvas/public/lib/filter.ts
+++ b/x-pack/plugins/canvas/public/lib/filter.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Ast, ExpressionFunctionAST, fromExpression, toExpression } from '@kbn/interpreter';
+import { Ast, AstFunction, fromExpression, toExpression } from '@kbn/interpreter';
 import { flowRight, get, groupBy } from 'lodash';
 import {
   Filter as FilterType,
@@ -63,7 +63,7 @@ export const groupFiltersBy = (filters: FilterType[], groupByField: FilterField)
   }));
 };
 
-const excludeFiltersByGroups = (filters: Ast[], filterExprAst: ExpressionFunctionAST) => {
+const excludeFiltersByGroups = (filters: Ast[], filterExprAst: AstFunction) => {
   const groupsToExclude = filterExprAst.arguments.group ?? [];
   const removeUngrouped = filterExprAst.arguments.ungrouped?.[0] ?? false;
   return filters.filter((filter) => {
@@ -85,7 +85,7 @@ const excludeFiltersByGroups = (filters: Ast[], filterExprAst: ExpressionFunctio
 
 const includeFiltersByGroups = (
   filters: Ast[],
-  filterExprAst: ExpressionFunctionAST,
+  filterExprAst: AstFunction,
   ignoreUngroupedIfGroups: boolean = false
 ) => {
   const groupsToInclude = filterExprAst.arguments.group ?? [];
@@ -109,7 +109,7 @@ const includeFiltersByGroups = (
 
 export const getFiltersByFilterExpressions = (
   filters: string[],
-  filterExprsAsts: ExpressionFunctionAST[]
+  filterExprsAsts: AstFunction[]
 ) => {
   const filtersAst = filters.map((filter) => fromExpression(filter));
   const matchedFiltersAst = filterExprsAsts.reduce((includedFilters, filter) => {

--- a/x-pack/plugins/canvas/public/lib/filter_adapters.test.ts
+++ b/x-pack/plugins/canvas/public/lib/filter_adapters.test.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-import { ExpressionFunctionAST } from '@kbn/interpreter';
+import { AstFunction } from '@kbn/interpreter';
 import { adaptCanvasFilter } from './filter_adapters';
 
 describe('adaptCanvasFilter', () => {
-  const filterAST: ExpressionFunctionAST = {
+  const filterAST: AstFunction = {
     type: 'function',
     function: 'exactly',
     arguments: {

--- a/x-pack/plugins/canvas/public/lib/filter_adapters.ts
+++ b/x-pack/plugins/canvas/public/lib/filter_adapters.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ExpressionFunctionAST } from '@kbn/interpreter';
+import type { AstFunction } from '@kbn/interpreter';
 import { identity } from 'lodash';
 import { ExpressionAstArgument, Filter, FilterType } from '../../types';
 
@@ -23,7 +23,7 @@ const argToValue = (
 
 const convertFunctionToFilterType = (func: string) => functionToFilter[func] ?? FilterType.exactly;
 
-const collectArgs = (args: ExpressionFunctionAST['arguments']) => {
+const collectArgs = (args: AstFunction['arguments']) => {
   const argsKeys = Object.keys(args);
 
   if (!argsKeys.length) {
@@ -36,7 +36,7 @@ const collectArgs = (args: ExpressionFunctionAST['arguments']) => {
   );
 };
 
-export function adaptCanvasFilter(filter: ExpressionFunctionAST): Filter {
+export function adaptCanvasFilter(filter: AstFunction): Filter {
   const { function: type, arguments: args } = filter;
   const { column, filterGroup, value: valueArg, type: typeArg, ...rest } = args ?? {};
   return {

--- a/x-pack/plugins/canvas/server/collectors/collector_helpers.ts
+++ b/x-pack/plugins/canvas/server/collectors/collector_helpers.ts
@@ -10,19 +10,13 @@
  * @param cb: callback to do something with a function that has been found
  */
 
-import {
-  ExpressionAstExpression,
-  ExpressionAstNode,
-} from '../../../../../src/plugins/expressions/common';
-
-function isExpression(
-  maybeExpression: ExpressionAstNode
-): maybeExpression is ExpressionAstExpression {
-  return typeof maybeExpression === 'object' && maybeExpression.type === 'expression';
-}
+import { isAst } from '@kbn/interpreter';
+import { ExpressionAstNode } from '../../../../../src/plugins/expressions/common';
 
 export function collectFns(ast: ExpressionAstNode, cb: (functionName: string) => void) {
-  if (!isExpression(ast)) return;
+  if (!isAst(ast)) {
+    return;
+  }
 
   ast.chain.forEach(({ function: cFunction, arguments: cArguments }) => {
     cb(cFunction);

--- a/x-pack/plugins/canvas/server/saved_objects/workpad_references.ts
+++ b/x-pack/plugins/canvas/server/saved_objects/workpad_references.ts
@@ -31,7 +31,10 @@ export const extractReferences = (
         }))
       );
 
-      return { ...element, expression: toExpression(extract.state) };
+      return {
+        ...element,
+        expression: toExpression(extract.state, { source: element.expression }),
+      };
     });
 
     return { ...page, elements };
@@ -59,7 +62,7 @@ export const injectReferences = (
         referencesForElement
       );
 
-      return { ...element, expression: toExpression(injectedAst) };
+      return { ...element, expression: toExpression(injectedAst, { source: element.expression }) };
     });
 
     return { ...page, elements };

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/expression_helpers.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/expression_helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Ast, fromExpression, ExpressionFunctionAST } from '@kbn/interpreter';
+import { Ast, AstFunction, fromExpression } from '@kbn/interpreter';
 import { DatasourceStates } from '../../state_management';
 import { Visualization, DatasourcePublicAPI, DatasourceMap } from '../../types';
 
@@ -35,7 +35,7 @@ export function prependDatasourceExpression(
     ([layerId, expr]) => [layerId, typeof expr === 'string' ? fromExpression(expr) : expr]
   );
 
-  const datafetchExpression: ExpressionFunctionAST = {
+  const datafetchExpression: AstFunction = {
     type: 'function',
     function: 'lens_merge_tables',
     arguments: {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/utils.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { ExpressionFunctionAST } from '@kbn/interpreter';
+import type { AstFunction } from '@kbn/interpreter';
 import memoizeOne from 'memoize-one';
 import { LayerType, layerTypes } from '../../../../../common';
 import type { TimeScaleUnit } from '../../../../../common/expressions';
@@ -143,7 +143,7 @@ export function dateBasedOperationToExpression(
   columnId: string,
   functionName: string,
   additionalArgs: Record<string, unknown[]> = {}
-): ExpressionFunctionAST[] {
+): AstFunction[] {
   const currentColumn = layer.columns[columnId] as unknown as ReferenceBasedIndexPatternColumn;
   const buckets = layer.columnOrder.filter((colId) => layer.columns[colId].isBucketed);
   const dateColumnIndex = buckets.findIndex(
@@ -174,7 +174,7 @@ export function optionallHistogramBasedOperationToExpression(
   columnId: string,
   functionName: string,
   additionalArgs: Record<string, unknown[]> = {}
-): ExpressionFunctionAST[] {
+): AstFunction[] {
   const currentColumn = layer.columns[columnId] as unknown as ReferenceBasedIndexPatternColumn;
   const buckets = layer.columnOrder.filter((colId) => layer.columns[colId].isBucketed);
   const nonHistogramColumns = buckets.filter(

--- a/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts
@@ -6,7 +6,7 @@
  */
 
 import { cloneDeep, mergeWith } from 'lodash';
-import { fromExpression, toExpression, Ast, ExpressionFunctionAST } from '@kbn/interpreter';
+import { fromExpression, toExpression, Ast, AstFunction } from '@kbn/interpreter';
 import {
   SavedObjectMigrationMap,
   SavedObjectMigrationFn,
@@ -141,7 +141,7 @@ const removeLensAutoDate: SavedObjectMigrationFn<LensDocShapePre710, LensDocShap
   }
   try {
     const ast = fromExpression(expression);
-    const newChain: ExpressionFunctionAST[] = ast.chain.map((topNode) => {
+    const newChain: AstFunction[] = ast.chain.map((topNode) => {
       if (topNode.function !== 'lens_merge_tables') {
         return topNode;
       }
@@ -202,7 +202,7 @@ const addTimeFieldToEsaggs: SavedObjectMigrationFn<LensDocShapePre710, LensDocSh
 
   try {
     const ast = fromExpression(expression);
-    const newChain: ExpressionFunctionAST[] = ast.chain.map((topNode) => {
+    const newChain: AstFunction[] = ast.chain.map((topNode) => {
       if (topNode.function !== 'lens_merge_tables') {
         return topNode;
       }


### PR DESCRIPTION
## Summary

This PR resolves #42829, and namely adds the following:
- support of inline comments (`// something`);
- support of multiline comments (`/* something */`);
- syntax highlighting in the code editor;
- fixes canvas to preserve the original formatting of the expression.

The comments do not end up in the AST so that there are no changes in the interpreter.

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
