### PR TITLE
[Security Solution] Create Field READ access of data view management bug fix

### DIFF
--- a/src/plugins/data_view_field_editor/public/plugin.ts
+++ b/src/plugins/data_view_field_editor/public/plugin.ts
@@ -54,11 +54,6 @@ export class IndexPatternFieldEditorPlugin
       openDeleteModal,
       userPermissions: {
         editIndexPattern: () => {
-          console.log('CAPS', {
-            'management.kibana.indexPatterns': capabilities.management.kibana.indexPatterns,
-            'indexPatterns.save': capabilities.indexPatterns.save,
-            capabilities,
-          });
           return capabilities.management.kibana.indexPatterns;
         },
       },

--- a/src/plugins/data_view_field_editor/public/plugin.ts
+++ b/src/plugins/data_view_field_editor/public/plugin.ts
@@ -54,6 +54,11 @@ export class IndexPatternFieldEditorPlugin
       openDeleteModal,
       userPermissions: {
         editIndexPattern: () => {
+          console.log('CAPS', {
+            'management.kibana.indexPatterns': capabilities.management.kibana.indexPatterns,
+            'indexPatterns.save': capabilities.indexPatterns.save,
+            capabilities,
+          });
           return capabilities.management.kibana.indexPatterns;
         },
       },

--- a/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.test.tsx
@@ -18,25 +18,26 @@ import { useKibana } from '../../../common/lib/kibana';
 import type { DataView } from '../../../../../../../src/plugins/data/common';
 import { TimelineId } from '../../../../common/types';
 
-const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
-
 let mockIndexPatternFieldEditor: Start;
 jest.mock('../../../common/lib/kibana');
+const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
 const runAllPromises = () => new Promise(setImmediate);
 
 describe('CreateFieldButton', () => {
   beforeEach(() => {
     mockIndexPatternFieldEditor = indexPatternFieldEditorPluginMock.createStartContract();
+    mockIndexPatternFieldEditor.userPermissions.editIndexPattern = () => true;
     useKibanaMock().services.dataViewFieldEditor = mockIndexPatternFieldEditor;
     useKibanaMock().services.data.dataViews.get = () => new Promise(() => undefined);
-    // @ts-ignore
-    useKibanaMock().services.application.capabilities.indexPatterns.save = true;
+
+    useKibanaMock().services.application.capabilities = {
+      ...useKibanaMock().services.application.capabilities,
+      indexPatterns: { save: true },
+    };
   });
-
-  it('displays the button when user has read permissions', () => {
-    mockIndexPatternFieldEditor.userPermissions.editIndexPattern = () => true;
-
+  // refactor below tests once resolved: https://github.com/elastic/kibana/issues/122462
+  it('displays the button when user has read permissions and write permissions', () => {
     render(
       <CreateFieldButton
         selectedDataViewId={'dataViewId'}
@@ -67,8 +68,26 @@ describe('CreateFieldButton', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
+  it("doesn't display the button when user doesn't have write permissions", () => {
+    useKibanaMock().services.application.capabilities = {
+      ...useKibanaMock().services.application.capabilities,
+      indexPatterns: { save: false },
+    };
+    render(
+      <CreateFieldButton
+        selectedDataViewId={'dataViewId'}
+        onClick={() => undefined}
+        timelineId={TimelineId.detectionsPage}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
   it("calls 'onClick' param when the button is clicked", async () => {
-    mockIndexPatternFieldEditor.userPermissions.editIndexPattern = () => true;
     useKibanaMock().services.data.dataViews.get = () => Promise.resolve({} as DataView);
 
     const onClickParam = jest.fn();

--- a/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.test.tsx
@@ -30,9 +30,11 @@ describe('CreateFieldButton', () => {
     mockIndexPatternFieldEditor = indexPatternFieldEditorPluginMock.createStartContract();
     useKibanaMock().services.dataViewFieldEditor = mockIndexPatternFieldEditor;
     useKibanaMock().services.data.dataViews.get = () => new Promise(() => undefined);
+    // @ts-ignore
+    useKibanaMock().services.application.capabilities.indexPatterns.save = true;
   });
 
-  it('displays the button when user has permissions', () => {
+  it('displays the button when user has read permissions', () => {
     mockIndexPatternFieldEditor.userPermissions.editIndexPattern = () => true;
 
     render(
@@ -49,7 +51,7 @@ describe('CreateFieldButton', () => {
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
-  it("doesn't display the button when user doesn't have permissions", () => {
+  it("doesn't display the button when user doesn't have read permissions", () => {
     mockIndexPatternFieldEditor.userPermissions.editIndexPattern = () => false;
     render(
       <CreateFieldButton

--- a/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
@@ -22,8 +22,6 @@ import { sourcererSelectors } from '../../../common/store';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../timeline/body/constants';
 import { defaultColumnHeaderType } from '../timeline/body/column_headers/default_headers';
-import { userHasPermissions } from '../../../detections/pages/detection_engine/rules/helpers';
-import { useUserData } from '../../../detections/components/user_info';
 
 interface CreateFieldButtonProps {
   selectedDataViewId: string;

--- a/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
@@ -22,6 +22,8 @@ import { sourcererSelectors } from '../../../common/store';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../timeline/body/constants';
 import { defaultColumnHeaderType } from '../timeline/body/column_headers/default_headers';
+import { userHasPermissions } from '../../../detections/pages/detection_engine/rules/helpers';
+import { useUserData } from '../../../detections/components/user_info';
 
 interface CreateFieldButtonProps {
   selectedDataViewId: string;
@@ -41,6 +43,7 @@ export const CreateFieldButton = React.memo<CreateFieldButtonProps>(
     const {
       dataViewFieldEditor,
       data: { dataViews },
+      application: { capabilities },
     } = useKibana().services;
 
     useEffect(() => {
@@ -83,7 +86,11 @@ export const CreateFieldButton = React.memo<CreateFieldButtonProps>(
       timelineId,
     ]);
 
-    if (!dataViewFieldEditor?.userPermissions.editIndexPattern()) {
+    if (
+      !dataViewFieldEditor?.userPermissions.editIndexPattern() ||
+      // remove below check once resolved: https://github.com/elastic/kibana/issues/122462
+      !capabilities.indexPatterns.save
+    ) {
       return null;
     }
 


### PR DESCRIPTION
## Summary

Fixes a[ bug in Security Solution](https://github.com/elastic/kibana/issues/122161) that left Create Field enabled when user has READ access of data view management. This is meant to be a hot fix, as the [permanent fix](https://github.com/elastic/kibana/issues/122462) is upstream and out of scope for the Security Solution team. Once the permanent fix is merged, we should revert these changes.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios