### PR TITLE
Fix [Explore] [90761] 'Error loading map features' on network page

### DIFF
--- a/x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts
+++ b/x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts
@@ -47,7 +47,7 @@ export interface RenderTooltipContentParams {
   }: {
     layerId: string;
     featureId?: string | number;
-    mbProperties: GeoJsonProperties;
+    mbProperties?: GeoJsonProperties;
   }) => Promise<ITooltipProperty[]>;
   loadFeatureGeometry: ({
     layerId,

--- a/x-pack/plugins/security_solution/public/network/components/embeddables/map_tool_tip/map_tool_tip.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/map_tool_tip/map_tool_tip.tsx
@@ -134,7 +134,7 @@ export const MapToolTipComponent = ({
         try {
           const featureGeo = loadFeatureGeometry({ layerId, featureId });
           const [featureProperties, layerNameString] = await Promise.all([
-            loadFeatureProperties({ layerId, featureId, mbProperties: {} }),
+            loadFeatureProperties({ layerId, featureId }),
             getLayerName(layerId),
           ]);
 


### PR DESCRIPTION
closes #90761

A tooltip was displaying an error instead of showing host information. This was due to mbProperties being passed as an empty object- overriding an id field leading to no data for the tooltip. This is being further investigated by @nreese :D.


Before:
<img width="466" alt="image" src="https://user-images.githubusercontent.com/28942857/148449551-f7bbf5ea-2b14-44b7-ad48-856f89595cca.png">

After:
<img width="326" alt="Screenshot 2022-01-06 at 16 39 32" src="https://user-images.githubusercontent.com/28942857/148450472-5a695730-ccd1-4ac7-9489-85f9e92f6051.png">

