### PR TITLE
Update Github Action for backport

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -41,5 +41,6 @@
     "^v(\\d+).(\\d+).\\d+$": "$1.$2"
   },
   "autoMerge": true,
-  "autoMergeMethod": "squash"
+  "autoMergeMethod": "squash",
+  "backportBinary": "node scripts/backport"
 }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -41,4 +41,3 @@ jobs:
           commit_email: 42973632+kibanamachine@users.noreply.github.com
           auto_merge: 'true'
           auto_merge_method: 'squash'
-          manual_backport_command_template: 'node scripts/backport --pr %pullNumber%'

--- a/package.json
+++ b/package.json
@@ -711,7 +711,7 @@
     "babel-plugin-require-context-hook": "^1.0.0",
     "babel-plugin-styled-components": "^2.0.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "backport": "^6.1.1",
+    "backport": "^6.1.3",
     "callsites": "^3.1.0",
     "chai": "3.5.0",
     "chance": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8656,10 +8656,10 @@ bach@^1.0.0:
     async-settle "^1.0.0"
     now-and-later "^2.0.0"
 
-backport@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/backport/-/backport-6.1.1.tgz#bf511fe2f26b8b85c25165a5bc6f390517bc39e5"
-  integrity sha512-J0U6bWckG655Wf9/u5Q7rl/urJ4JIWrQD6hXKdq03lDX/RfqPKqhWvWgPhOGAKssb5Y0A2g4AonWQhn0MOwdYQ==
+backport@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/backport/-/backport-6.1.3.tgz#48a0a8b8eadf422c475f816199390ef06fad16e0"
+  integrity sha512-LMSXgUOFI9G/Eu4hZDaC7uQwmpedGSxihxVpVcQYwxfdKgMAsYLRwf2R0uQZaWWzTepbpyN9SXvTR5FnacVSFA==
   dependencies:
     "@octokit/rest" "^18.12.0"
     axios "^0.24.0"


### PR DESCRIPTION
Related #122119 

 - The Backport Github Action was updated in https://github.com/elastic/kibana-github-actions/pull/15 where the `manual_backport_command_template` option was removed (replaced by `backportBinary`)
 - Bump Backport to 6.1.3

