### PR TITLE
Bump backport to 6.1.5

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -39,5 +39,3 @@ jobs:
           github_token: ${{secrets.KIBANAMACHINE_TOKEN}}
           commit_user: kibanamachine
           commit_email: 42973632+kibanamachine@users.noreply.github.com
-          auto_merge: 'true'
-          auto_merge_method: 'squash'

--- a/package.json
+++ b/package.json
@@ -712,7 +712,7 @@
     "babel-plugin-require-context-hook": "^1.0.0",
     "babel-plugin-styled-components": "^2.0.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "backport": "^6.1.3",
+    "backport": "6.1.5",
     "callsites": "^3.1.0",
     "chai": "3.5.0",
     "chance": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8656,10 +8656,10 @@ bach@^1.0.0:
     async-settle "^1.0.0"
     now-and-later "^2.0.0"
 
-backport@^6.1.3:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/backport/-/backport-6.1.3.tgz#48a0a8b8eadf422c475f816199390ef06fad16e0"
-  integrity sha512-LMSXgUOFI9G/Eu4hZDaC7uQwmpedGSxihxVpVcQYwxfdKgMAsYLRwf2R0uQZaWWzTepbpyN9SXvTR5FnacVSFA==
+backport@6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/backport/-/backport-6.1.5.tgz#2e8da121cd7ac89a51003f33fdd7febaa0a34202"
+  integrity sha512-fEn50S9P8mU3odGYZXNaj4LMTpio+zB2Vwq92wlu6u/fOQmkGvSxklp78NoAwSi8UBC3+vPa7G5zFp1uFLD6jg==
   dependencies:
     "@octokit/rest" "^18.12.0"
     axios "^0.24.0"


### PR DESCRIPTION
Bump `backport` to 6.1.5 and remove unnecessary defaults