### PR TITLE
[ResponseOps] Change `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 /packages/kbn-docs-utils/ @elastic/kibana-tech-leads @elastic/kibana-operations
 
 # Virtual teams
-/x-pack/plugins/rule_registry/ @elastic/rac
+/x-pack/plugins/rule_registry/ @elastic/rac @elastic/response-ops
 
 # Data Discovery
 /src/plugins/discover/ @elastic/kibana-data-discovery

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -324,19 +324,21 @@
 /examples/preboot_example/ @elastic/kibana-security @elastic/kibana-core
 #CC# /x-pack/plugins/security/ @elastic/kibana-security
 
-# Kibana Alerting Services
-/x-pack/plugins/alerting/ @elastic/kibana-alerting-services
-/x-pack/plugins/actions/ @elastic/kibana-alerting-services
-/x-pack/plugins/event_log/ @elastic/kibana-alerting-services
-/x-pack/plugins/task_manager/ @elastic/kibana-alerting-services
-/x-pack/test/alerting_api_integration/ @elastic/kibana-alerting-services
-/x-pack/test/plugin_api_integration/test_suites/task_manager/ @elastic/kibana-alerting-services
-/x-pack/plugins/triggers_actions_ui/ @elastic/kibana-alerting-services
-/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/ @elastic/kibana-alerting-services
-/x-pack/test/functional_with_es_ssl/fixtures/plugins/alerts/ @elastic/kibana-alerting-services
-/docs/user/alerting/ @elastic/kibana-alerting-services
-/docs/management/connectors/ @elastic/kibana-alerting-services
-#CC# /x-pack/plugins/stack_alerts @elastic/kibana-alerting-services
+# Response Ops team
+/x-pack/plugins/alerting/ @elastic/response-ops
+/x-pack/plugins/actions/ @elastic/response-ops
+/x-pack/plugins/event_log/ @elastic/response-ops
+/x-pack/plugins/task_manager/ @elastic/response-ops
+/x-pack/test/alerting_api_integration/ @elastic/response-ops
+/x-pack/test/plugin_api_integration/test_suites/task_manager/ @elastic/response-ops
+/x-pack/plugins/triggers_actions_ui/ @elastic/response-ops
+/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/ @elastic/response-ops
+/x-pack/test/functional_with_es_ssl/fixtures/plugins/alerts/ @elastic/response-ops
+/docs/user/alerting/ @elastic/response-ops
+/docs/management/connectors/ @elastic/response-ops
+#CC# /x-pack/plugins/stack_alerts @elastic/response-ops
+/x-pack/plugins/cases @elastic/response-ops
+/x-pack/test/cases_api_integration @elastic/response-ops
 
 # Enterprise Search
 # Shared
@@ -403,9 +405,7 @@
 #CC# /x-pack/plugins/security_solution/ @elastic/security-solution
 
 # Security Solution sub teams
-/x-pack/plugins/cases @elastic/security-threat-hunting
 /x-pack/plugins/timelines @elastic/security-threat-hunting
-/x-pack/test/cases_api_integration @elastic/security-threat-hunting
 /x-pack/plugins/lists @elastic/security-detections-response
 
 ## Security Solution sub teams - security-onboarding-and-lifecycle-mgt


### PR DESCRIPTION
## Summary

Move the ownership of `alerting`, `actions`, `triggers_actions_ui`, and `cases` plugins to the @elastic/response-ops team.  

