### PR TITLE
[Security Solution][Endpoint] Adds description field to event filters

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/artifact_entry_card/artifact_entry_card.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_entry_card/artifact_entry_card.tsx
@@ -91,7 +91,7 @@ export const ArtifactEntryCard = memo<ArtifactEntryCardProps>(
 
           {!hideComments ? (
             <>
-              <EuiSpacer size="l" />
+              {hideDescription && <EuiSpacer size="l" />}
               <CardComments comments={artifact.comments} data-test-subj={getTestId('comments')} />
             </>
           ) : null}

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.test.tsx
@@ -162,6 +162,22 @@ describe('Event filter form', () => {
     expect(getState().form.hasNameError).toBeTruthy();
   });
 
+  it('should change description', async () => {
+    component = await renderWithData();
+
+    const nameInput = component.getByTestId('eventFilters-form-description-input');
+
+    act(() => {
+      fireEvent.change(nameInput, {
+        target: {
+          value: 'Exception description',
+        },
+      });
+    });
+
+    expect(getState().form.entry?.description).toBe('Exception description');
+  });
+
   it('should change comments', async () => {
     component = await renderWithData();
 

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
@@ -19,6 +19,7 @@ import {
   EuiSuperSelectOption,
   EuiText,
   EuiHorizontalRule,
+  EuiTextArea,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
@@ -36,7 +37,15 @@ import { getExceptionBuilderComponentLazy } from '../../../../../../../../lists/
 import type { OnChangeProps } from '../../../../../../../../lists/public';
 import { useEventFiltersSelector } from '../../hooks';
 import { getFormEntryStateMutable, getHasNameError, getNewComment } from '../../../store/selector';
-import { NAME_LABEL, NAME_ERROR, NAME_PLACEHOLDER, OS_LABEL, RULE_NAME } from './translations';
+import {
+  NAME_LABEL,
+  NAME_ERROR,
+  DESCRIPTION_LABEL,
+  DESCRIPTION_PLACEHOLDER,
+  NAME_PLACEHOLDER,
+  OS_LABEL,
+  RULE_NAME,
+} from './translations';
 import { OS_TITLES } from '../../../../../common/translations';
 import { ENDPOINT_EVENT_FILTERS_LIST_ID, EVENT_FILTER_LIST_TYPE } from '../../../constants';
 import { ABOUT_EVENT_FILTERS } from '../../translations';
@@ -134,6 +143,7 @@ export const EventFiltersForm: React.FC<EventFiltersFormProps> = memo(
                   entry: {
                     ...arg.exceptionItems[0],
                     name: exception?.name ?? '',
+                    description: exception?.description ?? '',
                     comments: exception?.comments ?? [],
                     os_types: exception?.os_types ?? [OperatingSystem.WINDOWS],
                     tags: exception?.tags ?? [],
@@ -159,6 +169,21 @@ export const EventFiltersForm: React.FC<EventFiltersFormProps> = memo(
           payload: {
             entry: { ...exception, name },
             hasNameError: !name,
+          },
+        });
+      },
+      [dispatch, exception]
+    );
+
+    const handleOnDescriptionChange = useCallback(
+      (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        if (!exception) return;
+        setHasFormChanged(true);
+        const description = e.target.value.toString().trim();
+        dispatch({
+          type: 'eventFiltersChangeForm',
+          payload: {
+            entry: { ...exception, description },
           },
         });
       },
@@ -229,6 +254,24 @@ export const EventFiltersForm: React.FC<EventFiltersFormProps> = memo(
       [hasNameError, exception?.name, handleOnChangeName, hasBeenInputNameVisited]
     );
 
+    const descriptionInputMemo = useMemo(
+      () => (
+        <EuiFormRow label={DESCRIPTION_LABEL} fullWidth>
+          <EuiTextArea
+            id="eventFiltersFormInputDescription"
+            placeholder={DESCRIPTION_PLACEHOLDER}
+            defaultValue={exception?.description ?? ''}
+            onChange={handleOnDescriptionChange}
+            fullWidth
+            data-test-subj="eventFilters-form-description-input"
+            aria-label={DESCRIPTION_PLACEHOLDER}
+            maxLength={256}
+          />
+        </EuiFormRow>
+      ),
+      [exception?.description, handleOnDescriptionChange]
+    );
+
     const osInputMemo = useMemo(
       () => (
         <EuiFormRow label={OS_LABEL} fullWidth>
@@ -285,9 +328,10 @@ export const EventFiltersForm: React.FC<EventFiltersFormProps> = memo(
           </EuiText>
           <EuiSpacer size="m" />
           {nameInputMemo}
+          {descriptionInputMemo}
         </>
       ),
-      [nameInputMemo]
+      [nameInputMemo, descriptionInputMemo]
     );
 
     const criteriaSection = useMemo(

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/translations.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/translations.ts
@@ -17,6 +17,19 @@ export const NAME_PLACEHOLDER = i18n.translate(
 export const NAME_LABEL = i18n.translate('xpack.securitySolution.eventFilter.form.name.label', {
   defaultMessage: 'Name your event filter',
 });
+export const DESCRIPTION_LABEL = i18n.translate(
+  'xpack.securitySolution.eventFilter.form.description.placeholder',
+  {
+    defaultMessage: 'Description',
+  }
+);
+
+export const DESCRIPTION_PLACEHOLDER = i18n.translate(
+  'xpack.securitySolution.eventFilter.form.description.label',
+  {
+    defaultMessage: 'Describe your event filter',
+  }
+);
 
 export const NAME_ERROR = i18n.translate('xpack.securitySolution.eventFilter.form.name.error', {
   defaultMessage: "The name can't be empty",

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/event_filters_list_page.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/event_filters_list_page.tsx
@@ -193,7 +193,6 @@ export const EventFiltersListPage = memo(() => {
       cachedCardProps[eventFilter.id] = {
         item: eventFilter as AnyArtifact,
         policies: artifactCardPolicies,
-        hideDescription: true,
         'data-test-subj': 'eventFilterCard',
         actions: [
           {


### PR DESCRIPTION

## Summary

It also adds unit test and displays description field on artifact entry card for event filters.
![description on event filters](https://user-images.githubusercontent.com/15727784/148743926-dcbf970a-fa13-4490-9a0e-1c872f80a966.gif)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
