### PR TITLE
[Security Solution] [Endpoint] Clean comments structure on event filters service

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/service/index.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/service/index.ts
@@ -134,6 +134,11 @@ export class EventFiltersHttpService implements EventFiltersService {
       delete exceptionToUpdateCleaned[field as keyof UpdateExceptionListItemSchema];
     });
 
+    exceptionToUpdateCleaned.comments = exceptionToUpdateCleaned.comments?.map((comment) => ({
+      comment: comment.comment,
+      id: comment.id,
+    }));
+
     return exceptionToUpdateCleaned as UpdateExceptionListItemSchema;
   }
 }

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/store/middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/store/middleware.ts
@@ -136,11 +136,6 @@ const eventFiltersUpdate = async (
       getNewComment(store.getState())
     ) as UpdateExceptionListItemSchema;
 
-    updatedCommentsEntry.comments = updatedCommentsEntry.comments?.map((comment) => ({
-      comment: comment.comment,
-      id: comment.id,
-    }));
-
     const exception = await eventFiltersService.updateOne(updatedCommentsEntry);
     store.dispatch({
       type: 'eventFiltersUpdateSuccess',


### PR DESCRIPTION
## Summary

There was an error adding event filters to a policy from the policy details page when the event filter had comments. This was already fixed on the middleware but the new event filters list in policy details view is not using the middleware so that fix has been moved to the service.
### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
