### PR TITLE
[Security Solution] [Endpoint] Fixes wrong empty state when filtering by policy

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.test.tsx
@@ -169,11 +169,10 @@ describe('When on the host isolation exceptions page', () => {
         // wait for the page render
         await waitFor(() =>
           expect(getHostIsolationExceptionItemsMock).toHaveBeenLastCalledWith({
-            filter:
-              '(exception-list-agnostic.attributes.item_id:(*this*does*not*exists*) OR exception-list-agnostic.attributes.name:(*this*does*not*exists*) OR exception-list-agnostic.attributes.description:(*this*does*not*exists*) OR exception-list-agnostic.attributes.entries.value:(*this*does*not*exists*))',
             http: mockedContext.coreStart.http,
+            filter: undefined,
             page: 1,
-            perPage: 10,
+            perPage: 1,
           })
         );
 
@@ -203,13 +202,13 @@ describe('When on the host isolation exceptions page', () => {
         );
         userEvent.click(option);
 
-        // wait for the page render and request
+        // wait for the page render
         await waitFor(() =>
           expect(getHostIsolationExceptionItemsMock).toHaveBeenLastCalledWith({
-            filter: `((exception-list-agnostic.attributes.tags:"policy:${firstPolicy.id}"))`,
             http: mockedContext.coreStart.http,
+            filter: undefined,
             page: 1,
-            perPage: 10,
+            perPage: 1,
           })
         );
 

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.tsx
@@ -70,6 +70,12 @@ export const HostIsolationExceptionsList = () => {
         : undefined,
   });
 
+  const { isLoading: isLoadingAll, data: allData } = useFetchHostIsolationExceptionsList({
+    page: 0,
+    perPage: 1,
+    enabled: data && !data.total,
+  });
+
   const toasts = useToasts();
 
   // load the list of policies>
@@ -87,10 +93,10 @@ export const HostIsolationExceptionsList = () => {
   };
 
   const listItems = data?.data || [];
-  const totalCountListItems = data?.total || 0;
+  const allListItems = allData?.data || [];
 
   const showFlyout = privileges.canIsolateHost && !!location.show;
-  const hasDataToShow = !!location.filter || listItems.length > 0;
+  const hasDataToShow = allListItems.length > 0 || listItems.length > 0;
 
   useEffect(() => {
     if (!isLoading && listItems.length === 0 && !privileges.canIsolateHost) {
@@ -181,7 +187,7 @@ export const HostIsolationExceptionsList = () => {
     [navigateCallback]
   );
 
-  if (isLoading && !hasDataToShow) {
+  if ((isLoading || isLoadingAll) && !hasDataToShow) {
     return <ManagementPageLoader data-test-subj="hostIsolationExceptionListLoader" />;
   }
 
@@ -234,7 +240,7 @@ export const HostIsolationExceptionsList = () => {
             defaultValue={location.filter}
             onSearch={handleOnSearch}
             policyList={policiesRequest.data?.items}
-            hasPolicyFilter={true}
+            hasPolicyFilter
             defaultIncludedPolicies={location.included_policies}
             placeholder={i18n.translate(
               'xpack.securitySolution.hostIsolationExceptions.search.placeholder',
@@ -248,7 +254,7 @@ export const HostIsolationExceptionsList = () => {
             <FormattedMessage
               id="xpack.securitySolution.hostIsolationExceptions.list.totalCount"
               defaultMessage="Showing {total, plural, one {# exception} other {# exceptions}}"
-              values={{ total: totalCountListItems }}
+              values={{ total: listItems.length }}
             />
           </EuiText>
           <EuiSpacer size="s" />

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/list.tsx
@@ -179,7 +179,7 @@ export const PolicyHostIsolationExceptionsList = ({
         placeholder={i18n.translate(
           'xpack.securitySolution.endpoint.policy.hostIsolationExceptions.list.search.placeholder',
           {
-            defaultMessage: 'Search on the fields below: name, description, value, ip',
+            defaultMessage: 'Search on the fields below: name, description, ip',
           }
         )}
         defaultValue={urlParams.filter}


### PR DESCRIPTION
## Summary

Also fix wrong placeholder for search bar and fix unit tests.
![fix host isolation exception filter by policy](https://user-images.githubusercontent.com/15727784/148760375-9986a757-e732-4529-a2a7-d8abc956585c.gif)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
