### PR TITLE
[Lens] Fixes metrics test flakiness by using the Lens waitForVisualization function

### DIFF
--- a/x-pack/test/functional/apps/lens/metrics.ts
+++ b/x-pack/test/functional/apps/lens/metrics.ts
@@ -37,7 +37,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.setValue('lnsPalettePanel_dynamicColoring_stop_value_1', '21000', {
         clearWithKeyboard: true,
       });
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.lens.waitForVisualization();
       const styleObj = await PageObjects.lens.getMetricStyle();
       expect(styleObj.color).to.be('rgb(32, 146, 128)');
     });

--- a/x-pack/test/functional/apps/lens/metrics.ts
+++ b/x-pack/test/functional/apps/lens/metrics.ts
@@ -44,14 +44,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should change the color when reverting the palette', async () => {
       await testSubjects.click('lnsPalettePanel_dynamicColoring_reverse');
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.lens.waitForVisualization();
       const styleObj = await PageObjects.lens.getMetricStyle();
       expect(styleObj.color).to.be('rgb(204, 86, 66)');
     });
 
     it('should reset the color stops when changing palette to a predefined one', async () => {
       await PageObjects.lens.changePaletteTo('temperature');
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.lens.waitForVisualization();
       const styleObj = await PageObjects.lens.getMetricStyle();
       expect(styleObj.color).to.be('rgb(235, 239, 245)');
     });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/122489

From the CI screenshot we can see that the color has been updated correctly. This must be a race-condition. By waiting for the actual visualization to load first and then get the metricStyle, must fix this flakiness.

![image](https://user-images.githubusercontent.com/17003240/148775254-84f8bd2b-1bcf-44d5-a93b-ca628098cbf3.png)

CI run 50 times https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/73#cd10b996-e954-4b94-b8fc-c04b2739f205
Ci run 50 times https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/75#b0d5a525-b06a-41c8-bbc7-66dad484f24f

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios