### PR TITLE
[Security Solution][Investigations] Fix incorrect height of alert table

### DIFF
--- a/x-pack/plugins/timelines/public/components/t_grid/body/height_hack.ts
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/height_hack.ts
@@ -51,7 +51,9 @@ export const useDataGridHeightHack = (pageSize: number, rowCount: number) => {
         setHeight(DATA_GRID_HEIGHT_BY_PAGE_SIZE[pageSize]);
       } else if (rowCount <= pageSize) {
         // This is unnecessary if we add rowCount > pageSize below
-        setHeight(dataGridRowHeight * rowCount + (headerSectionHeight + additionalFiltersHeight));
+        setHeight(
+          dataGridRowHeight * (rowCount + 1) + (headerSectionHeight + additionalFiltersHeight)
+        );
       } else if (
         // rowCount > pageSize && // This will fix the issue but is always full height so has a lot of empty state
         gridVirtualized &&


### PR DESCRIPTION
## Summary

There was an issue where when going from a full page to a page with only one item, the height of the table was not tall enough. That meant the single row was hidden. (https://github.com/elastic/kibana/issues/122111)

I tried out several ways to prevent this issue but most of them were rather brittle. In the end I decided to add an extra row's height to the hacked height when the actual data is less than the page size.

Keep in mind that the module that contains the change is likely to be retired in 8.1. That version will contain a new version of EUI data grid which makes the height hack obsolete. (https://github.com/elastic/kibana/pull/122386)

https://user-images.githubusercontent.com/68591/148779845-f1487d62-21aa-44fe-8d2a-f8c60e3ddbbc.mov


