### PR TITLE
[ML] Fixing model bounds in new job wizard

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/anomaly_chart/model_bounds.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/anomaly_chart/model_bounds.tsx
@@ -41,7 +41,6 @@ export const ModelBounds: FC<Props> = ({ modelData }) => {
       yAccessors={['modelUpper']}
       y0Accessors={['modelLower']}
       data={model}
-      stackAccessors={['time']}
       curve={CurveType.CURVE_MONOTONE_X}
       areaSeriesStyle={areaSeriesStyle}
       color={MODEL_COLOR}


### PR DESCRIPTION
The model bounds shown in the single metric wizard are incorrectly missing their minimum values and are being drawn to the bottom of the chart:

![image](https://user-images.githubusercontent.com/22172091/148802127-686a58b7-3ce5-4520-8dae-fc2ca8173f55.png)

It should look like this:

![image](https://user-images.githubusercontent.com/22172091/148802150-600b0d5f-b8ba-4b9b-90a6-956077d312af.png)


