### PR TITLE
Automatically switch theme based on the user's OS setting.

### DIFF
--- a/src/core/public/injected_metadata/injected_metadata_service.mock.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.mock.ts
@@ -42,7 +42,7 @@ const createSetupContractMock = () => {
     },
   } as any);
   setupContract.getPlugins.mockReturnValue([]);
-  setupContract.getTheme.mockReturnValue({ theme: 'light', darkMode: false, version: 'v8' });
+  setupContract.getTheme.mockReturnValue({ theme: 'light', version: 'v8' });
   return setupContract;
 };
 

--- a/src/core/public/injected_metadata/injected_metadata_service.mock.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.mock.ts
@@ -42,7 +42,7 @@ const createSetupContractMock = () => {
     },
   } as any);
   setupContract.getPlugins.mockReturnValue([]);
-  setupContract.getTheme.mockReturnValue({ darkMode: false, version: 'v8' });
+  setupContract.getTheme.mockReturnValue({ theme: 'light', darkMode: false, version: 'v8' });
   return setupContract;
 };
 

--- a/src/core/public/injected_metadata/injected_metadata_service.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.ts
@@ -47,6 +47,7 @@ export interface InjectedMetadataParams {
       [key: string]: unknown;
     };
     theme: {
+      theme: string; // FIXME ThemeOptions
       darkMode: boolean;
       version: ThemeVersion;
     };
@@ -166,6 +167,7 @@ export interface InjectedMetadataSetup {
     policy: IExternalUrlPolicy[];
   };
   getTheme: () => {
+    theme: string; // FIXME ThemeOptions
     darkMode: boolean;
     version: ThemeVersion;
   };

--- a/src/core/public/injected_metadata/injected_metadata_service.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.ts
@@ -48,7 +48,6 @@ export interface InjectedMetadataParams {
     };
     theme: {
       theme: string; // FIXME ThemeOptions
-      darkMode: boolean;
       version: ThemeVersion;
     };
     env: {
@@ -168,7 +167,6 @@ export interface InjectedMetadataSetup {
   };
   getTheme: () => {
     theme: string; // FIXME ThemeOptions
-    darkMode: boolean;
     version: ThemeVersion;
   };
   /**

--- a/src/core/public/theme/theme_service.test.ts
+++ b/src/core/public/theme/theme_service.test.ts
@@ -21,7 +21,7 @@ describe('ThemeService', () => {
 
   describe('#setup', () => {
     it('exposes a `theme$` observable with the values provided by the injected metadata', async () => {
-      injectedMetadata.getTheme.mockReturnValue({ theme: 'dark', version: 'v8', darkMode: true });
+      injectedMetadata.getTheme.mockReturnValue({ theme: 'dark', version: 'v8' });
       const { theme$ } = themeService.setup({ injectedMetadata });
       const theme = await theme$.pipe(take(1)).toPromise();
       expect(theme).toEqual({
@@ -38,7 +38,7 @@ describe('ThemeService', () => {
     });
 
     it('exposes a `theme$` observable with the values provided by the injected metadata', async () => {
-      injectedMetadata.getTheme.mockReturnValue({ theme: 'dark', version: 'v8', darkMode: true });
+      injectedMetadata.getTheme.mockReturnValue({ theme: 'dark', version: 'v8' });
       themeService.setup({ injectedMetadata });
       const { theme$ } = themeService.start();
       const theme = await theme$.pipe(take(1)).toPromise();

--- a/src/core/public/theme/theme_service.test.ts
+++ b/src/core/public/theme/theme_service.test.ts
@@ -21,7 +21,7 @@ describe('ThemeService', () => {
 
   describe('#setup', () => {
     it('exposes a `theme$` observable with the values provided by the injected metadata', async () => {
-      injectedMetadata.getTheme.mockReturnValue({ version: 'v8', darkMode: true });
+      injectedMetadata.getTheme.mockReturnValue({ theme: 'dark', version: 'v8', darkMode: true });
       const { theme$ } = themeService.setup({ injectedMetadata });
       const theme = await theme$.pipe(take(1)).toPromise();
       expect(theme).toEqual({
@@ -38,7 +38,7 @@ describe('ThemeService', () => {
     });
 
     it('exposes a `theme$` observable with the values provided by the injected metadata', async () => {
-      injectedMetadata.getTheme.mockReturnValue({ version: 'v8', darkMode: true });
+      injectedMetadata.getTheme.mockReturnValue({ theme: 'dark', version: 'v8', darkMode: true });
       themeService.setup({ injectedMetadata });
       const { theme$ } = themeService.start();
       const theme = await theme$.pipe(take(1)).toPromise();

--- a/src/core/public/theme/theme_service.ts
+++ b/src/core/public/theme/theme_service.ts
@@ -18,10 +18,19 @@ export interface SetupDeps {
 export class ThemeService {
   private theme$?: Observable<CoreTheme>;
   private stop$ = new Subject<void>();
+  private mq = window.matchMedia('(prefers-color-scheme: dark)');
 
-  public setup({ injectedMetadata }: SetupDeps): ThemeServiceSetup {
+  setup({ injectedMetadata }: SetupDeps): ThemeServiceSetup {
     const theme = injectedMetadata.getTheme();
-    this.theme$ = of({ darkMode: theme.darkMode });
+    this.theme$ = of({
+      darkMode: theme.theme === 'system' ? this.mq.matches : theme.theme === 'dark',
+    });
+
+    if (theme.theme === 'system') {
+      this.mq.addEventListener('change', (e) => {
+        // FIXME Update theme$
+      });
+    }
 
     return {
       theme$: this.theme$.pipe(takeUntil(this.stop$), shareReplay(1)),

--- a/src/core/server/rendering/bootstrap/bootstrap_renderer.ts
+++ b/src/core/server/rendering/bootstrap/bootstrap_renderer.ts
@@ -51,20 +51,21 @@ export const bootstrapRendererFactory: BootstrapRendererFactory = ({
   };
 
   return async function bootstrapRenderer({ uiSettingsClient, request, isAnonymousPage = false }) {
-    let darkMode = false;
+    let theme = 'system';
     const themeVersion: ThemeVersion = 'v8';
 
     try {
       const authenticated = isAuthenticated(request);
-      darkMode = authenticated ? await uiSettingsClient.get('theme:darkMode') : false;
+      theme = authenticated ? await uiSettingsClient.get('theme') : 'system';
     } catch (e) {
       // just use the default values in case of connectivity issues with ES
     }
 
     const themeTag = getThemeTag({
       themeVersion,
-      darkMode,
+      theme,
     });
+
     const buildHash = packageInfo.buildNum;
     const regularBundlePath = `${serverBasePath}/${buildHash}/bundles`;
 

--- a/src/core/server/rendering/bootstrap/get_theme_tag.test.ts
+++ b/src/core/server/rendering/bootstrap/get_theme_tag.test.ts
@@ -9,20 +9,28 @@
 import { getThemeTag } from './get_theme_tag';
 
 describe('getThemeTag', () => {
-  it('returns the correct value for version:v8 and darkMode:false', () => {
+  it('returns the correct value for version:v8 and theme:light', () => {
     expect(
       getThemeTag({
         themeVersion: 'v8',
-        darkMode: false,
+        theme: 'light',
       })
     ).toEqual('v8light');
   });
-  it('returns the correct value for version:v8 and darkMode:true', () => {
+  it('returns the correct value for version:v8 and theme:dark', () => {
     expect(
       getThemeTag({
         themeVersion: 'v8',
-        darkMode: true,
+        theme: 'dark',
       })
     ).toEqual('v8dark');
+  });
+  it('returns the correct value for version:v8 and theme:system', () => {
+    expect(
+      getThemeTag({
+        themeVersion: 'v8',
+        theme: 'system',
+      })
+    ).toEqual('system');
   });
 });

--- a/src/core/server/rendering/bootstrap/get_theme_tag.ts
+++ b/src/core/server/rendering/bootstrap/get_theme_tag.ts
@@ -14,10 +14,10 @@ import type { ThemeVersion } from '@kbn/ui-shared-deps-npm';
  */
 export const getThemeTag = ({
   themeVersion,
-  darkMode,
+  theme,
 }: {
   themeVersion: ThemeVersion;
-  darkMode: boolean;
+  theme: string;
 }) => {
-  return `${themeVersion}${darkMode ? 'dark' : 'light'}`;
+  return `${themeVersion}${theme}`;
 };

--- a/src/core/server/rendering/bootstrap/render_template.ts
+++ b/src/core/server/rendering/bootstrap/render_template.ts
@@ -17,6 +17,16 @@ export const renderTemplate = ({
   jsDependencyPaths,
   publicPathMap,
 }: BootstrapTemplateData) => {
+  const __kbnThemeTag__ = themeTag.includes('system')
+    ? `Object.defineProperty(window, '__kbnThemeTag__', {
+      get: () => {
+        const prefix = '${themeTag.slice(0, themeTag.indexOf('system'))}';
+        const theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        return prefix + theme;
+      }
+    });`
+    : `window.__kbnThemeTag__ = ${themeTag};`;
+
   return `
 function kbnBundlesLoader() {
   var modules = {};
@@ -49,7 +59,7 @@ function kbnBundlesLoader() {
 
 var kbnCsp = JSON.parse(document.querySelector('kbn-csp').getAttribute('data'));
 window.__kbnStrictCsp__ = kbnCsp.strictCsp;
-window.__kbnThemeTag__ = "${themeTag}";
+${__kbnThemeTag__}
 window.__kbnPublicPath__ = ${publicPathMap};
 window.__kbnBundles__ = kbnBundlesLoader();
 

--- a/src/core/server/rendering/render_utils.test.ts
+++ b/src/core/server/rendering/render_utils.test.ts
@@ -9,46 +9,30 @@
 import { getStylesheetPaths } from './render_utils';
 
 describe('getStylesheetPaths', () => {
-  describe('when darkMode is `true`', () => {
-    describe('when themeVersion is `v8`', () => {
-      it('returns the correct list', () => {
-        expect(
-          getStylesheetPaths({
-            darkMode: true,
-            themeVersion: 'v8',
-            basePath: '/base-path',
-            buildNum: 17,
-          })
-        ).toMatchInlineSnapshot(`
-          Array [
+  describe('when themeVersion is `v8`', () => {
+    it('returns the correct list', () => {
+      expect(
+        getStylesheetPaths({
+          themeVersion: 'v8',
+          basePath: '/base-path',
+          buildNum: 17,
+        })
+      ).toMatchInlineSnapshot(`
+        Object {
+          "dark": Array [
             "/base-path/17/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.v8.dark.css",
             "/base-path/17/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.css",
             "/base-path/node_modules/@kbn/ui-framework/dist/kui_dark.css",
             "/base-path/ui/legacy_dark_theme.css",
-          ]
-        `);
-      });
-    });
-  });
-  describe('when darkMode is `false`', () => {
-    describe('when themeVersion is `v8`', () => {
-      it('returns the correct list', () => {
-        expect(
-          getStylesheetPaths({
-            darkMode: false,
-            themeVersion: 'v8',
-            basePath: '/base-path',
-            buildNum: 69,
-          })
-        ).toMatchInlineSnapshot(`
-          Array [
-            "/base-path/69/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.v8.light.css",
-            "/base-path/69/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.css",
+          ],
+          "light": Array [
+            "/base-path/17/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.v8.light.css",
+            "/base-path/17/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.css",
             "/base-path/node_modules/@kbn/ui-framework/dist/kui_light.css",
             "/base-path/ui/legacy_light_theme.css",
-          ]
-        `);
-      });
+          ],
+        }
+      `);
     });
   });
 });

--- a/src/core/server/rendering/render_utils.ts
+++ b/src/core/server/rendering/render_utils.ts
@@ -9,6 +9,7 @@
 import UiSharedDepsNpm from '@kbn/ui-shared-deps-npm';
 import * as UiSharedDepsSrc from '@kbn/ui-shared-deps-src';
 import { PublicUiSettingsParams, UserProvidedValues } from '../ui_settings';
+import type { StylesheetPaths } from './types';
 
 export const getSettingValue = <T>(
   settingName: string,
@@ -24,33 +25,30 @@ export const getSettingValue = <T>(
 
 export const getStylesheetPaths = ({
   themeVersion,
-  darkMode,
   basePath,
   buildNum,
 }: {
   themeVersion: UiSharedDepsNpm.ThemeVersion;
-  darkMode: boolean;
   buildNum: number;
   basePath: string;
-}) => {
+}): StylesheetPaths => {
   const regularBundlePath = `${basePath}/${buildNum}/bundles`;
-  return [
-    ...(darkMode
-      ? [
-          `${regularBundlePath}/kbn-ui-shared-deps-npm/${UiSharedDepsNpm.darkCssDistFilename(
-            themeVersion
-          )}`,
-          `${regularBundlePath}/kbn-ui-shared-deps-src/${UiSharedDepsSrc.cssDistFilename}`,
-          `${basePath}/node_modules/@kbn/ui-framework/dist/kui_dark.css`,
-          `${basePath}/ui/legacy_dark_theme.css`,
-        ]
-      : [
-          `${regularBundlePath}/kbn-ui-shared-deps-npm/${UiSharedDepsNpm.lightCssDistFilename(
-            themeVersion
-          )}`,
-          `${regularBundlePath}/kbn-ui-shared-deps-src/${UiSharedDepsSrc.cssDistFilename}`,
-          `${basePath}/node_modules/@kbn/ui-framework/dist/kui_light.css`,
-          `${basePath}/ui/legacy_light_theme.css`,
-        ]),
-  ];
+  return {
+    light: [
+      `${regularBundlePath}/kbn-ui-shared-deps-npm/${UiSharedDepsNpm.lightCssDistFilename(
+        themeVersion
+      )}`,
+      `${regularBundlePath}/kbn-ui-shared-deps-src/${UiSharedDepsSrc.cssDistFilename}`,
+      `${basePath}/node_modules/@kbn/ui-framework/dist/kui_light.css`,
+      `${basePath}/ui/legacy_light_theme.css`,
+    ],
+    dark: [
+      `${regularBundlePath}/kbn-ui-shared-deps-npm/${UiSharedDepsNpm.darkCssDistFilename(
+        themeVersion
+      )}`,
+      `${regularBundlePath}/kbn-ui-shared-deps-src/${UiSharedDepsSrc.cssDistFilename}`,
+      `${basePath}/node_modules/@kbn/ui-framework/dist/kui_dark.css`,
+      `${basePath}/ui/legacy_dark_theme.css`,
+    ],
+  };
 };

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -94,11 +94,11 @@ export class RenderingService {
       user: isAnonymousPage ? {} : await uiSettings.getUserProvided(),
     };
 
+    const theme = getSettingValue('theme', settings, String);
     const darkMode = getSettingValue('theme:darkMode', settings, Boolean);
     const themeVersion: ThemeVersion = 'v8';
 
     const stylesheetPaths = getStylesheetPaths({
-      darkMode,
       themeVersion,
       basePath: serverBasePath,
       buildNum,
@@ -112,6 +112,7 @@ export class RenderingService {
       bootstrapScriptUrl: `${basePath}/${bootstrapScript}`,
       i18n: i18n.translate,
       locale: i18n.getLocale(),
+      theme,
       darkMode,
       themeVersion,
       stylesheetPaths,

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -113,7 +113,6 @@ export class RenderingService {
       i18n: i18n.translate,
       locale: i18n.getLocale(),
       theme,
-      darkMode,
       themeVersion,
       stylesheetPaths,
       injectedMetadata: {
@@ -129,6 +128,7 @@ export class RenderingService {
           translationsUrl: `${basePath}/translations/${i18n.getLocale()}.json`,
         },
         theme: {
+          theme,
           darkMode,
           version: themeVersion,
         },

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -95,7 +95,6 @@ export class RenderingService {
     };
 
     const theme = getSettingValue('theme', settings, String);
-    const darkMode = getSettingValue('theme:darkMode', settings, Boolean);
     const themeVersion: ThemeVersion = 'v8';
 
     const stylesheetPaths = getStylesheetPaths({
@@ -129,7 +128,6 @@ export class RenderingService {
         },
         theme: {
           theme,
-          darkMode,
           version: themeVersion,
         },
         csp: { warnLegacyBrowsers: http.csp.warnLegacyBrowsers },

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -31,7 +31,6 @@ export interface RenderingMetadata {
   i18n: typeof i18n.translate;
   locale: string;
   theme: string; // FIXME ThemeOption
-  darkMode: boolean;
   themeVersion: ThemeVersion;
   stylesheetPaths: StylesheetPaths;
   injectedMetadata: InjectedMetadata;
@@ -55,6 +54,7 @@ export interface InjectedMetadata {
   };
   theme: {
     darkMode: boolean;
+    theme: string; // FIXME ThemeOption
     version: ThemeVersion;
   };
   csp: Pick<ICspConfig, 'warnLegacyBrowsers'>;

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -18,15 +18,22 @@ import type { InternalStatusServiceSetup } from '../status';
 import { IExternalUrlPolicy } from '../external_url';
 
 /** @internal */
+export interface StylesheetPaths {
+  light: string[];
+  dark: string[];
+}
+
+/** @internal */
 export interface RenderingMetadata {
   strictCsp: ICspConfig['strict'];
   uiPublicUrl: string;
   bootstrapScriptUrl: string;
   i18n: typeof i18n.translate;
   locale: string;
+  theme: string; // FIXME ThemeOption
   darkMode: boolean;
   themeVersion: ThemeVersion;
-  stylesheetPaths: string[];
+  stylesheetPaths: StylesheetPaths;
   injectedMetadata: InjectedMetadata;
 }
 

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -53,7 +53,6 @@ export interface InjectedMetadata {
     translationsUrl: string;
   };
   theme: {
-    darkMode: boolean;
     theme: string; // FIXME ThemeOption
     version: ThemeVersion;
   };

--- a/src/core/server/rendering/views/styles.tsx
+++ b/src/core/server/rendering/views/styles.tsx
@@ -9,24 +9,88 @@
 /* eslint-disable react/no-danger */
 
 import React, { FC } from 'react';
+import type { StylesheetPaths } from '../types';
 
 interface Props {
-  darkMode: boolean;
-  stylesheetPaths: string[];
+  theme: string; // FIXME ThemeOptions
+  stylesheetPaths: StylesheetPaths;
 }
 
-export const Styles: FC<Props> = ({ darkMode, stylesheetPaths }) => {
+export const Styles: FC<Props> = ({ theme, stylesheetPaths }) => {
   return (
     <>
-      <InlineStyles darkMode={darkMode} />
-      {stylesheetPaths.map((path) => (
-        <link key={path} rel="stylesheet" type="text/css" href={path} />
-      ))}
+      <InlineStyles theme={theme} />
+      {theme === 'system'
+        ? Object.entries(stylesheetPaths).flatMap(([themeKey, paths]) =>
+            paths.map((path: string) => (
+              <link
+                key={path}
+                rel="stylesheet"
+                type="text/css"
+                href={path}
+                media={`(prefers-color-scheme: ${themeKey})`}
+              />
+            ))
+          )
+        : stylesheetPaths[theme as 'light' | 'dark'].map((path) => (
+            <link key={path} rel="stylesheet" type="text/css" href={path} />
+          ))}
+
+      {}
     </>
   );
 };
 
-const InlineStyles: FC<{ darkMode: boolean }> = ({ darkMode }) => {
+const InlineStyles: FC<{
+  theme: string; // FIXME ThemeOptions
+}> = ({ theme }) => {
+  let htmlBackgroundColor;
+  let kbnWelcomeTextColor;
+  let kbnProgressBackgroundColor;
+  let kbnProgressBeforeBackgroundColor;
+
+  switch (theme) {
+    case 'system':
+      htmlBackgroundColor = `
+        html { background-color: #F8FAFD }
+        @media (prefers-color-scheme: dark) {
+          html { background-color: #141519 }
+        }`;
+
+      kbnWelcomeTextColor = `
+        .kbnWelcomeText { color: #69707D }
+        @media (prefers-color-scheme: dark) {
+          .kbnWelcomeText { color: #98A2B3 }
+        }`;
+
+      kbnProgressBackgroundColor = `
+        .kbnProgress { background-color: #F5F7FA }
+        @media (prefers-color-scheme: dark) {
+          .kbnProgress { background-color: #25262E }
+        }`;
+
+      kbnProgressBeforeBackgroundColor = `
+        .kbnProgress:before { background-color: #006DE4 }
+        @media (prefers-color-scheme: dark) {
+          .kbnProgress:before { background-color: #1BA9F5 }
+        }`;
+      break;
+
+    case 'light':
+      htmlBackgroundColor = 'html { background-color: #F8FAFD }';
+      kbnWelcomeTextColor = '.kbnWelcomeText { color: #69707D }';
+      kbnProgressBackgroundColor = '.kbnProgress { background-color: #F5F7FA }';
+      kbnProgressBeforeBackgroundColor = '.kbnProgress:before { background-color: #006DE4 }';
+      break;
+
+    case 'dark':
+      htmlBackgroundColor = 'html { background-color: #141519 }';
+      kbnWelcomeTextColor = '.kbnWelcomeText { color: #98A2B3 }';
+      kbnProgressBackgroundColor = '.kbnProgress { background-color: #25262E }';
+      kbnProgressBeforeBackgroundColor = '.kbnProgress:before { background-color: #1BA9F5 }';
+      break;
+  }
+
   return (
     <style
       dangerouslySetInnerHTML={{
@@ -50,9 +114,7 @@ const InlineStyles: FC<{ darkMode: boolean }> = ({ darkMode }) => {
             display: block;
           }
 
-          html {
-            background-color: ${darkMode ? '#141519' : '#F8FAFD'}
-          }
+          ${htmlBackgroundColor}
 
           .kbnWelcomeView {
             line-height: 1.5;
@@ -97,9 +159,9 @@ const InlineStyles: FC<{ darkMode: boolean }> = ({ darkMode }) => {
             font-family: sans-serif;
             line-height: 40px !important;
             height: 40px !important;
-            color: #98a2b3;
-            color: ${darkMode ? '#98A2B3' : '#69707D'};
           }
+
+          ${kbnWelcomeTextColor}
 
           .kbnLoaderWrap {
             text-align: center;
@@ -130,9 +192,10 @@ const InlineStyles: FC<{ darkMode: boolean }> = ({ darkMode }) => {
             width: 32px;
             height: 4px;
             overflow: hidden;
-            background-color: ${darkMode ? '#25262E' : '#F5F7FA'};
             line-height: 1;
           }
+
+          ${kbnProgressBackgroundColor}
 
           .kbnProgress:before {
             position: absolute;
@@ -144,8 +207,9 @@ const InlineStyles: FC<{ darkMode: boolean }> = ({ darkMode }) => {
             left: 0;
             transform: scaleX(0) translateX(0%);
             animation: kbnProgress 1s cubic-bezier(.694, .0482, .335, 1) infinite;
-            background-color: ${darkMode ? '#1BA9F5' : '#006DE4'};
           }
+
+          ${kbnProgressBeforeBackgroundColor}
 
           @keyframes kbnProgress {
             0% {

--- a/src/core/server/rendering/views/template.tsx
+++ b/src/core/server/rendering/views/template.tsx
@@ -22,7 +22,7 @@ export const Template: FunctionComponent<Props> = ({
   metadata: {
     uiPublicUrl,
     locale,
-    darkMode,
+    theme,
     stylesheetPaths,
     injectedMetadata,
     i18n,
@@ -45,7 +45,7 @@ export const Template: FunctionComponent<Props> = ({
         <meta name="color-scheme" content="light dark" />
         {/* Inject EUI reset and global styles before all other component styles */}
         <meta name={EUI_STYLES_GLOBAL} />
-        <Styles darkMode={darkMode} stylesheetPaths={stylesheetPaths} />
+        <Styles theme={theme} stylesheetPaths={stylesheetPaths} />
 
         {/* Inject stylesheets into the <head> before scripts so that KP plugins with bundled styles will override them */}
         <meta name="add-styles-here" />

--- a/src/core/server/ui_settings/settings/theme.ts
+++ b/src/core/server/ui_settings/settings/theme.ts
@@ -42,6 +42,19 @@ export const getThemeSettings = (
   const { defaultDarkMode } = getThemeInfo(options);
 
   return {
+    theme: {
+      name: i18n.translate('core.ui_settings.params.themeTitle', {
+        defaultMessage: 'Theme',
+      }),
+      description: i18n.translate('core.ui_settings.params.darkModeText', {
+        defaultMessage: `Choose if Kibana's theme should follow your system settings, or fixed in light or dark. A page refresh is required for the setting to be applied.`,
+      }),
+      value: 'system',
+      requiresPageReload: true,
+      type: 'select',
+      options: ['system', 'light', 'dark'],
+      schema: schema.string(),
+    },
     'theme:darkMode': {
       name: i18n.translate('core.ui_settings.params.darkModeTitle', {
         defaultMessage: 'Dark mode',

--- a/src/plugins/kibana_react/public/code_editor/index.tsx
+++ b/src/plugins/kibana_react/public/code_editor/index.tsx
@@ -7,7 +7,13 @@
  */
 
 import React from 'react';
-import { EuiDelayRender, EuiErrorBoundary, EuiLoadingContent } from '@elastic/eui';
+import {
+  EuiDelayRender,
+  EuiErrorBoundary,
+  EuiLoadingContent,
+  useEuiTheme,
+  COLOR_MODES_STANDARD,
+} from '@elastic/eui';
 import useObservable from 'react-use/lib/useObservable';
 
 import type { Props } from './code_editor';
@@ -41,14 +47,12 @@ export type CodeEditorProps = Props;
  * @see CodeEditorField to render a code editor in the same style as other EUI form fields.
  */
 export const CodeEditor: React.FunctionComponent<Props> = (props) => {
-  const { services } = useKibana();
-  const theme = useObservable(services.theme!.theme$);
-  const darkMode = theme?.darkMode || false;
+  const { colorMode } = useEuiTheme();
 
   return (
     <EuiErrorBoundary>
       <React.Suspense fallback={<Fallback height={props.height} />}>
-        <LazyBaseEditor {...props} useDarkTheme={darkMode} />
+        <LazyBaseEditor {...props} useDarkTheme={colorMode === COLOR_MODES_STANDARD.dark} />
       </React.Suspense>
     </EuiErrorBoundary>
   );

--- a/src/plugins/kibana_react/public/code_editor/index.tsx
+++ b/src/plugins/kibana_react/public/code_editor/index.tsx
@@ -8,9 +8,10 @@
 
 import React from 'react';
 import { EuiDelayRender, EuiErrorBoundary, EuiLoadingContent } from '@elastic/eui';
+import useObservable from 'react-use/lib/useObservable';
 
-import { useUiSetting } from '../ui_settings';
 import type { Props } from './code_editor';
+import { useKibana } from '..';
 
 export * from './languages/constants';
 
@@ -40,7 +41,10 @@ export type CodeEditorProps = Props;
  * @see CodeEditorField to render a code editor in the same style as other EUI form fields.
  */
 export const CodeEditor: React.FunctionComponent<Props> = (props) => {
-  const darkMode = useUiSetting<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const theme = useObservable(services.theme!.theme$);
+  const darkMode = theme?.darkMode || false;
+
   return (
     <EuiErrorBoundary>
       <React.Suspense fallback={<Fallback height={props.height} />}>
@@ -54,7 +58,10 @@ export const CodeEditor: React.FunctionComponent<Props> = (props) => {
  * Renders a Monaco code editor in the same style as other EUI form fields.
  */
 export const CodeEditorField: React.FunctionComponent<Props> = (props) => {
-  const darkMode = useUiSetting<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const theme = useObservable(services.theme!.theme$);
+  const darkMode = theme?.darkMode || false;
+
   return (
     <EuiErrorBoundary>
       <React.Suspense fallback={<Fallback height={props.height} />}>

--- a/src/plugins/kibana_react/public/ui_settings/use_ui_setting.ts
+++ b/src/plugins/kibana_react/public/ui_settings/use_ui_setting.ts
@@ -16,7 +16,7 @@ import { useKibana } from '../context';
  * Usage:
  *
  * ```js
- * const darkMode = useUiSetting('theme:darkMode');
+ * const theme = useUiSetting('theme');
  * ```
  */
 export const useUiSetting = <T>(key: string, defaultValue?: T): T => {
@@ -41,7 +41,7 @@ type Setter<T> = (newValue: T) => Promise<boolean>;
  * Usage:
  *
  * ```js
- * const [darkMode, setDarkMode] = useUiSetting$('theme:darkMode');
+ * const [theme, setTheme] = useUiSetting$('theme');
  * ```
  */
 export const useUiSetting$ = <T>(key: string, defaultValue?: T): [T, Setter<T>] => {

--- a/x-pack/plugins/apm/public/components/routing/app_root.tsx
+++ b/x-pack/plugins/apm/public/components/routing/app_root.tsx
@@ -10,11 +10,12 @@ import { RouteRenderer, RouterProvider } from '@kbn/typed-react-router-config';
 import React from 'react';
 import { Route } from 'react-router-dom';
 import { DefaultTheme, ThemeProvider } from 'styled-components';
+import useObservable from 'react-use/lib/useObservable';
 import { APP_WRAPPER_CLASS } from '@kbn/core/public';
 import {
   KibanaContextProvider,
   RedirectAppLinks,
-  useUiSetting$,
+  useKibana,
 } from '@kbn/kibana-react-plugin/public';
 import {
   HeaderMenuPortal,
@@ -109,7 +110,9 @@ function MountApmHeaderActionMenu() {
 }
 
 function ApmThemeProvider({ children }: { children: React.ReactNode }) {
-  const [darkMode] = useUiSetting$<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const theme = useObservable(services.theme!.theme$);
+  const darkMode = theme?.darkMode || false;
 
   return (
     <ThemeProvider

--- a/x-pack/plugins/fleet/public/applications/fleet/app.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/app.tsx
@@ -14,7 +14,6 @@ import { Router, Redirect, Route, Switch, useRouteMatch } from 'react-router-dom
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import styled from 'styled-components';
-import useObservable from 'react-use/lib/useObservable';
 
 import type { TopNavMenuData } from '@kbn/navigation-plugin/public';
 
@@ -233,8 +232,6 @@ export const FleetAppContext: React.FC<{
     routerHistory,
     theme$,
   }) => {
-    const isDarkMode = useObservable<boolean>(startServices.uiSettings.get$('theme:darkMode'));
-
     return (
       <RedirectAppLinks application={startServices.application}>
         <startServices.i18n.Context>
@@ -243,7 +240,7 @@ export const FleetAppContext: React.FC<{
               <ConfigContext.Provider value={config}>
                 <KibanaVersionContext.Provider value={kibanaVersion}>
                   <KibanaThemeProvider theme$={theme$}>
-                    <EuiThemeProvider darkMode={isDarkMode}>
+                    <EuiThemeProvider theme$={theme$}>
                       <UIExtensionsContext.Provider value={extensions}>
                         <FleetStatusProvider>
                           <Router history={history}>

--- a/x-pack/plugins/fleet/public/applications/integrations/app.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/app.tsx
@@ -10,7 +10,6 @@ import type { AppMountParameters } from '@kbn/core/public';
 import { EuiErrorBoundary } from '@elastic/eui';
 import type { History } from 'history';
 import { Router, Redirect, Route, Switch } from 'react-router-dom';
-import useObservable from 'react-use/lib/useObservable';
 
 import { KibanaContextProvider, RedirectAppLinks } from '@kbn/kibana-react-plugin/public';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
@@ -59,7 +58,6 @@ export const IntegrationsAppContext: React.FC<{
     setHeaderActionMenu,
     theme$,
   }) => {
-    const isDarkMode = useObservable<boolean>(startServices.uiSettings.get$('theme:darkMode'));
     const CloudContext = startServices.cloud?.CloudContextProvider || EmptyContext;
 
     return (
@@ -70,7 +68,7 @@ export const IntegrationsAppContext: React.FC<{
               <ConfigContext.Provider value={config}>
                 <KibanaVersionContext.Provider value={kibanaVersion}>
                   <KibanaThemeProvider theme$={theme$}>
-                    <EuiThemeProvider darkMode={isDarkMode}>
+                    <EuiThemeProvider theme$={theme$}>
                       <UIExtensionsContext.Provider value={extensions}>
                         <FleetStatusProvider>
                           <startServices.customIntegrations.ContextProvider>

--- a/x-pack/plugins/infra/public/alerting/inventory/components/expression_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/inventory/components/expression_chart.tsx
@@ -10,11 +10,13 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { first, last } from 'lodash';
 import moment from 'moment';
 import React, { useCallback, useMemo } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { InventoryMetricConditions } from '../../../../common/alerting/metrics';
+
 import { Color } from '../../../../common/color_palette';
 import { MetricsExplorerAggregation, MetricsExplorerRow } from '../../../../common/http_api';
 import { InventoryItemType, SnapshotMetricType } from '../../../../common/inventory_models/types';
-import { useKibanaContextForPlugin } from '../../../hooks/use_kibana';
 import { useSnapshot } from '../../../pages/metrics/inventory_view/hooks/use_snaphot';
 import { useWaffleOptionsContext } from '../../../pages/metrics/inventory_view/hooks/use_waffle_options';
 import { createInventoryMetricFormatter } from '../../../pages/metrics/inventory_view/lib/create_inventory_metric_formatter';
@@ -22,6 +24,7 @@ import { calculateDomain } from '../../../pages/metrics/metrics_explorer/compone
 import { getMetricId } from '../../../pages/metrics/metrics_explorer/components/helpers/get_metric_id';
 import { MetricExplorerSeriesChart } from '../../../pages/metrics/metrics_explorer/components/series_chart';
 import { MetricsExplorerChartType } from '../../../pages/metrics/metrics_explorer/hooks/use_metrics_explorer_options';
+
 import {
   ChartContainer,
   getChartTheme,
@@ -31,6 +34,7 @@ import {
   tooltipProps,
 } from '../../common/criterion_preview_chart/criterion_preview_chart';
 import { ThresholdAnnotations } from '../../common/criterion_preview_chart/threshold_annotations';
+import { InfraClientCoreStart } from '../../../types';
 
 interface Props {
   expression: InventoryMetricConditions;
@@ -79,14 +83,15 @@ export const ExpressionChart: React.FC<Props> = ({
     timerange
   );
 
-  const { uiSettings } = useKibanaContextForPlugin().services;
+  const { services } = useKibana<InfraClientCoreStart>();
+  const theme = useObservable(services.theme.theme$);
+  const isDarkMode = theme?.darkMode || false;
 
   const metric = {
     field: expression.metric,
     aggregation: 'avg' as MetricsExplorerAggregation,
     color: Color.color0,
   };
-  const isDarkMode = uiSettings?.get('theme:darkMode') || false;
   const dateFormatter = useMemo(() => {
     const firstSeries = nodes[0]?.metrics[0]?.timeseries;
     const firstTimestamp = first(firstSeries?.rows)?.timestamp;

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criterion_preview_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criterion_preview_chart.tsx
@@ -20,7 +20,9 @@ import {
 } from '@elastic/charts';
 import { EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import useObservable from 'react-use/lib/useObservable';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { InfraClientCoreStart } from '../../../../types';
 import {
   ChartContainer,
   LoadingState,
@@ -125,8 +127,9 @@ const CriterionPreviewChart: React.FC<ChartProps> = ({
   chartAlertParams,
   showThreshold,
 }) => {
-  const { uiSettings } = useKibana().services;
-  const isDarkMode = uiSettings?.get('theme:darkMode') || false;
+  const { services } = useKibana<InfraClientCoreStart>();
+  const theme = useObservable(services.theme.theme$);
+  const isDarkMode = theme?.darkMode || false;
   const timezone = useKibanaTimeZoneSetting();
 
   const {

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
@@ -13,7 +13,7 @@ import { DataViewBase } from '@kbn/es-query';
 import { first, last } from 'lodash';
 import useObservable from 'react-use/lib/useObservable';
 
-import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { MetricsSourceConfiguration } from '../../../../common/metrics_sources';
 import { Color } from '../../../../common/color_palette';
 import { MetricsExplorerRow, MetricsExplorerAggregation } from '../../../../common/http_api';

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
@@ -11,7 +11,9 @@ import { EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { DataViewBase } from '@kbn/es-query';
 import { first, last } from 'lodash';
+import useObservable from 'react-use/lib/useObservable';
 
+import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
 import { MetricsSourceConfiguration } from '../../../../common/metrics_sources';
 import { Color } from '../../../../common/color_palette';
 import { MetricsExplorerRow, MetricsExplorerAggregation } from '../../../../common/http_api';
@@ -22,7 +24,6 @@ import { createFormatterForMetric } from '../../../pages/metrics/metrics_explore
 import { calculateDomain } from '../../../pages/metrics/metrics_explorer/components/helpers/calculate_domain';
 import { useMetricsExplorerChartData } from '../hooks/use_metrics_explorer_chart_data';
 import { getMetricId } from '../../../pages/metrics/metrics_explorer/components/helpers/get_metric_id';
-import { useKibanaContextForPlugin } from '../../../hooks/use_kibana';
 import {
   ChartContainer,
   LoadingState,
@@ -32,6 +33,7 @@ import {
   getChartTheme,
 } from '../../common/criterion_preview_chart/criterion_preview_chart';
 import { ThresholdAnnotations } from '../../common/criterion_preview_chart/threshold_annotations';
+import { InfraClientCoreStart } from '../../../types';
 
 interface Props {
   expression: MetricExpression;
@@ -56,14 +58,16 @@ export const ExpressionChart: React.FC<Props> = ({
     groupBy
   );
 
-  const { uiSettings } = useKibanaContextForPlugin().services;
-
   const metric = {
     field: expression.metric,
     aggregation: expression.aggType as MetricsExplorerAggregation,
     color: Color.color0,
   };
-  const isDarkMode = uiSettings?.get('theme:darkMode') || false;
+
+  const { services } = useKibana<InfraClientCoreStart>();
+  const theme = useObservable(services.theme.theme$);
+  const isDarkMode = theme?.darkMode || false;
+
   const dateFormatter = useMemo(() => {
     const firstSeries = first(data?.series);
     const firstTimestamp = first(firstSeries?.rows)?.timestamp;

--- a/x-pack/plugins/infra/public/apps/common_providers.tsx
+++ b/x-pack/plugins/infra/public/apps/common_providers.tsx
@@ -17,7 +17,7 @@ import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { NavigationWarningPromptProvider } from '@kbn/observability-plugin/public';
 import { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-actions-ui-plugin/public';
 import { useKibanaContextForPluginProvider } from '../hooks/use_kibana';
-import { InfraClientStartDeps, InfraClientStartExports } from '../types';
+import { InfraClientCoreStart, InfraClientStartDeps, InfraClientStartExports } from '../types';
 import { HeaderActionMenuProvider } from '../utils/header_action_menu_provider';
 import { TriggersActionsProvider } from '../utils/triggers_actions_context';
 
@@ -28,11 +28,11 @@ export const CommonInfraProviders: React.FC<{
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
   theme$: AppMountParameters['theme$'];
 }> = ({ children, triggersActionsUI, setHeaderActionMenu, appName, storage, theme$ }) => {
-  const { services } = useKibana();
+  const { services } = useKibana<InfraClientCoreStart>();
 
   return (
     <TriggersActionsProvider triggersActionsUI={triggersActionsUI}>
-      <EuiThemeProvider theme$={services.theme?.theme$}>
+      <EuiThemeProvider theme$={services.theme.theme$}>
         <DataUIProviders appName={appName} storage={storage}>
           <HeaderActionMenuProvider setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
             <NavigationWarningPromptProvider>{children}</NavigationWarningPromptProvider>

--- a/x-pack/plugins/infra/public/apps/common_providers.tsx
+++ b/x-pack/plugins/infra/public/apps/common_providers.tsx
@@ -11,7 +11,7 @@ import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import {
   KibanaContextProvider,
   KibanaThemeProvider,
-  useUiSetting$,
+  useKibana,
 } from '@kbn/kibana-react-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { NavigationWarningPromptProvider } from '@kbn/observability-plugin/public';
@@ -28,11 +28,11 @@ export const CommonInfraProviders: React.FC<{
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
   theme$: AppMountParameters['theme$'];
 }> = ({ children, triggersActionsUI, setHeaderActionMenu, appName, storage, theme$ }) => {
-  const [darkMode] = useUiSetting$<boolean>('theme:darkMode');
+  const { services } = useKibana();
 
   return (
     <TriggersActionsProvider triggersActionsUI={triggersActionsUI}>
-      <EuiThemeProvider darkMode={darkMode}>
+      <EuiThemeProvider theme$={services.theme?.theme$}>
         <DataUIProviders appName={appName} storage={storage}>
           <HeaderActionMenuProvider setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
             <NavigationWarningPromptProvider>{children}</NavigationWarningPromptProvider>

--- a/x-pack/plugins/infra/public/pages/logs/log_entry_categories/sections/top_categories/single_metric_sparkline.tsx
+++ b/x-pack/plugins/infra/public/pages/logs/log_entry_categories/sections/top_categories/single_metric_sparkline.tsx
@@ -12,9 +12,11 @@ import {
   EUI_SPARKLINE_THEME_PARTIAL,
   EUI_CHARTS_THEME_DARK,
 } from '@elastic/eui/dist/eui_charts_theme';
+import useObservable from 'react-use/lib/useObservable';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 
-import { useKibanaUiSetting } from '../../../../../utils/use_kibana_ui_setting';
 import { useKibanaTimeZoneSetting } from '../../../../../hooks/use_kibana_time_zone_setting';
+import { InfraClientCoreStart } from '../../../../../types';
 import { TimeRange } from '../../../../../../common/time';
 
 interface TimeSeriesPoint {
@@ -33,7 +35,9 @@ export const SingleMetricSparkline: React.FunctionComponent<{
   metric: TimeSeriesPoint[];
   timeRange: TimeRange;
 }> = ({ metric, timeRange }) => {
-  const [isDarkMode] = useKibanaUiSetting('theme:darkMode');
+  const { services } = useKibana<InfraClientCoreStart>();
+  const kibanaTheme = useObservable(services.theme.theme$);
+  const isDarkMode = kibanaTheme?.darkMode || false;
   const timeZone = useKibanaTimeZoneSetting();
 
   const theme = useMemo(

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/metrics/chart_section.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/metrics/chart_section.tsx
@@ -17,7 +17,8 @@ import {
 } from '@elastic/charts';
 import React from 'react';
 import moment from 'moment';
-import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { MetricsExplorerSeries } from '../../../../../../../../common/http_api';
 import { MetricExplorerSeriesChart } from '../../../../../metrics_explorer/components/series_chart';
 import {
@@ -26,6 +27,7 @@ import {
 } from '../../../../../metrics_explorer/hooks/use_metrics_explorer_options';
 import { ChartHeader } from './chart_header';
 import { getTimelineChartTheme } from '../../../../../metrics_explorer/components/helpers/get_chart_theme';
+import { InfraClientCoreStart } from '../../../../../../../types';
 
 const CHART_SIZE: ChartSizeArray = ['100%', 160];
 
@@ -57,7 +59,10 @@ export const ChartSection = ({
   domain,
   stack = false,
 }: Props) => {
-  const isDarkMode = useUiSetting<boolean>('theme:darkMode');
+  const { services } = useKibana<InfraClientCoreStart>();
+  const theme = useObservable(services.theme.theme$);
+  const isDarkMode = theme?.darkMode || false;
+
   const metrics = series.map((chartSeries) => chartSeries.metric);
   const tooltipProps = {
     headerFormatter: (tooltipValue: TooltipValue) =>

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/processes/process_row_charts.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/processes/process_row_charts.tsx
@@ -18,8 +18,9 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { Axis, Chart, Settings, Position, TooltipValue, niceTimeFormatter } from '@elastic/charts';
-import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
+import useObservable from 'react-use/lib/useObservable';
 import { createFormatter } from '../../../../../../../../common/formatters';
 import { getChartTheme } from '../../../../../metrics_explorer/components/helpers/get_chart_theme';
 import { calculateDomain } from '../../../../../metrics_explorer/components/helpers/calculate_domain';
@@ -29,6 +30,7 @@ import { MetricsExplorerAggregation } from '../../../../../../../../common/http_
 import { Color } from '../../../../../../../../common/color_palette';
 import { useProcessListRowChart } from '../../../../hooks/use_process_list_row_chart';
 import { Process } from './types';
+import { InfraClientCoreStart } from '../../../../../../../types';
 
 interface Props {
   command: string;
@@ -79,7 +81,9 @@ const ProcessChart = ({ timeseries, color, label }: ProcessChartProps) => {
     aggregation: 'avg' as MetricsExplorerAggregation,
     label,
   };
-  const isDarkMode = useUiSetting<boolean>('theme:darkMode');
+  const { services } = useKibana<InfraClientCoreStart>();
+  const theme = useObservable(services.theme.theme$);
+  const isDarkMode = theme?.darkMode || false;
 
   const dateFormatter = useMemo(() => {
     if (!timeseries) return () => '';

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/timeline/timeline.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/timeline/timeline.tsx
@@ -26,8 +26,9 @@ import {
 import { EuiFlexItem } from '@elastic/eui';
 import { EuiFlexGroup } from '@elastic/eui';
 import { EuiIcon } from '@elastic/eui';
-import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
+import useObservable from 'react-use/lib/useObservable';
 import { toMetricOpt } from '../../../../../../common/snapshot_metric_i18n';
 import { MetricsExplorerAggregation } from '../../../../../../common/http_api';
 import { colorTransformer, Color } from '../../../../../../common/color_palette';
@@ -44,6 +45,7 @@ import { calculateDomain } from '../../../metrics_explorer/components/helpers/ca
 import { InfraFormatter } from '../../../../../lib/lib';
 import { useMetricsHostsAnomaliesResults } from '../../hooks/use_metrics_hosts_anomalies';
 import { useMetricsK8sAnomaliesResults } from '../../hooks/use_metrics_k8s_anomalies';
+import { InfraClientCoreStart } from '../../../../../types';
 
 interface Props {
   interval: string;
@@ -123,7 +125,10 @@ export const Timeline: React.FC<Props> = ({ interval, yAxisFormatter, isVisible 
     return niceTimeFormatter([firstTimestamp, lastTimestamp]);
   }, [timeseries]);
 
-  const isDarkMode = useUiSetting<boolean>('theme:darkMode');
+  const { services } = useKibana<InfraClientCoreStart>();
+  const theme = useObservable(services.theme.theme$);
+  const isDarkMode = theme?.darkMode || false;
+
   const tooltipProps = {
     headerFormatter: (tooltipValue: TooltipValue) =>
       moment(tooltipValue.value).format('Y-MM-DD HH:mm:ss.SSS'),

--- a/x-pack/plugins/infra/public/pages/metrics/metric_detail/components/chart_section_vis.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metric_detail/components/chart_section_vis.tsx
@@ -18,7 +18,9 @@ import {
   BrushEndListener,
 } from '@elastic/charts';
 import { EuiPageContentBody } from '@elastic/eui';
-import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
+
 import { getChartTheme } from '../../metrics_explorer/components/helpers/get_chart_theme';
 import { SeriesChart } from './series_chart';
 import {
@@ -32,6 +34,7 @@ import {
 import { ErrorMessage } from './error_message';
 import { useKibanaUiSetting } from '../../../../utils/use_kibana_ui_setting';
 import { VisSectionProps } from '../types';
+import { InfraClientCoreStart } from '../../../../types';
 
 export const ChartSectionVis = ({
   id,
@@ -45,7 +48,10 @@ export const ChartSectionVis = ({
   seriesOverrides,
   type,
 }: VisSectionProps) => {
-  const isDarkMode = useUiSetting<boolean>('theme:darkMode');
+  const { services } = useKibana<InfraClientCoreStart>();
+  const theme = useObservable(services.theme.theme$);
+  const isDarkMode = theme?.darkMode || false;
+
   const [dateFormat] = useKibanaUiSetting('dateFormat');
   /* eslint-disable-next-line react-hooks/exhaustive-deps */
   const valueFormatter = useCallback(getFormatter(formatter, formatterTemplate), [

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/chart.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/chart.tsx
@@ -20,7 +20,9 @@ import {
 import { first, last } from 'lodash';
 import moment from 'moment';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
-import { useKibana, useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
+
 import { MetricsSourceConfigurationProperties } from '../../../../../common/metrics_sources';
 import { MetricsExplorerSeries } from '../../../../../common/http_api/metrics_explorer';
 import {
@@ -38,6 +40,7 @@ import { getChartTheme } from './helpers/get_chart_theme';
 import { useKibanaUiSetting } from '../../../../utils/use_kibana_ui_setting';
 import { calculateDomain } from './helpers/calculate_domain';
 import { ChartTitle } from './chart_title';
+import { InfraClientCoreStart } from '../../../../types';
 
 interface Props {
   title?: string | null;
@@ -65,7 +68,10 @@ export const MetricsExplorerChart = ({
   onTimeChange,
 }: Props) => {
   const uiCapabilities = useKibana().services.application?.capabilities;
-  const isDarkMode = useUiSetting<boolean>('theme:darkMode');
+  const { services } = useKibana<InfraClientCoreStart>();
+  const theme = useObservable(services.theme.theme$);
+  const isDarkMode = theme?.darkMode || false;
+
   const { metrics } = options;
   const [dateFormat] = useKibanaUiSetting('dateFormat');
   const handleTimeChange: BrushEndListener = ({ x }) => {

--- a/x-pack/plugins/maps/public/kibana_services.ts
+++ b/x-pack/plugins/maps/public/kibana_services.ts
@@ -36,7 +36,15 @@ export const getAutocompleteService = () => pluginsStart.unifiedSearch.autocompl
 export const getInspector = () => pluginsStart.inspector;
 export const getFileUpload = () => pluginsStart.fileUpload;
 export const getUiSettings = () => coreStart.uiSettings;
-export const getIsDarkMode = () => getUiSettings().get('theme:darkMode', false);
+export const getIsDarkMode = () => {
+  const theme = getUiSettings().get('theme', 'system');
+
+  if (theme === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark').matches;
+  }
+
+  return theme === 'dark';
+};
 export const getIndexPatternSelectComponent = () =>
   pluginsStart.unifiedSearch.ui.IndexPatternSelect;
 export const getSearchBar = () => pluginsStart.unifiedSearch.ui.SearchBar;

--- a/x-pack/plugins/observability/public/application/index.tsx
+++ b/x-pack/plugins/observability/public/application/index.tsx
@@ -65,7 +65,6 @@ export const renderApp = ({
 }) => {
   const { element, history, theme$ } = appMountParameters;
   const i18nCore = core.i18n;
-  const isDarkMode = core.uiSettings.get('theme:darkMode');
 
   core.chrome.setHelpExtension({
     appName: i18n.translate('xpack.observability.feedbackMenu.appName', {
@@ -90,7 +89,7 @@ export const renderApp = ({
           }}
         >
           <Router history={history}>
-            <EuiThemeProvider darkMode={isDarkMode}>
+            <EuiThemeProvider theme$={theme$}>
               <i18nCore.Context>
                 <RedirectAppLinks application={core.application} className={APP_WRAPPER_CLASS}>
                   <DatePickerContextProvider>

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/index.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/index.tsx
@@ -35,8 +35,6 @@ export function getExploratoryViewEmbeddable(
 
     const series = props.attributes && props.attributes[0];
 
-    const isDarkMode = core.uiSettings.get('theme:darkMode');
-
     const loadIndexPattern = useCallback(
       async ({ dataType }: { dataType: AppDataType }) => {
         const dataTypesIndexPatterns = props.dataTypesIndexPatterns;
@@ -69,7 +67,7 @@ export function getExploratoryViewEmbeddable(
     }
 
     return (
-      <EuiThemeProvider darkMode={isDarkMode}>
+      <EuiThemeProvider theme$={core.theme.theme$}>
         <ExploratoryViewEmbeddable {...props} indexPatterns={indexPatterns} lens={plugins.lens} />
       </EuiThemeProvider>
     );

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/rtl_helpers.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/rtl_helpers.tsx
@@ -151,7 +151,7 @@ export function MockKibanaProvider<ExtraCore extends Partial<CoreStart>>({
 
   return (
     <KibanaContextProvider services={{ ...core }} {...kibanaProps}>
-      <EuiThemeProvider darkMode={false}>
+      <EuiThemeProvider theme$={core!.theme!.theme$}>
         <I18nProvider>
           <DataViewContextProvider>{children}</DataViewContextProvider>
         </I18nProvider>

--- a/x-pack/plugins/security_solution/public/common/mock/endpoint/app_root_provider.tsx
+++ b/x-pack/plugins/security_solution/public/common/mock/endpoint/app_root_provider.tsx
@@ -31,11 +31,13 @@ export const AppRootProvider = memo<{
   ({
     store,
     history,
-    coreStart: { http, notifications, uiSettings, application },
+    coreStart: { http, notifications, application, theme },
     depsStart: { data },
     children,
   }) => {
-    const isDarkMode = useObservable<boolean>(uiSettings.get$('theme:darkMode'));
+    const kibanaTheme = useObservable(theme.theme$);
+    const isDarkMode = kibanaTheme?.darkMode || false;
+
     const services = useMemo(
       () => ({ http, notifications, application, data }),
       [application, data, http, notifications]

--- a/x-pack/plugins/security_solution/public/resolver/view/symbol_definitions.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/symbol_definitions.tsx
@@ -14,6 +14,7 @@ import useObservable from 'react-use/lib/useObservable';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useSymbolIDs } from './use_symbol_ids';
 import { usePaintServerIDs } from './use_paint_server_ids';
+import { of } from 'rxjs';
 
 const loadingProcessTitle = i18n.translate(
   'xpack.securitySolution.resolver.symbolDefinitions.loadingProcess',
@@ -436,7 +437,7 @@ const SymbolsAndShapes = memo(({ isDarkMode }: { isDarkMode: boolean }) => {
  */
 export const SymbolDefinitions = memo(() => {
   const { services } = useKibana();
-  const theme = useObservable(services.theme.theme$);
+  const theme = useObservable(services.theme?.theme$ || of({ darkMode: false }));
   const isDarkMode = theme?.darkMode || false;
 
   return (

--- a/x-pack/plugins/security_solution/public/resolver/view/symbol_definitions.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/symbol_definitions.tsx
@@ -10,7 +10,8 @@
 import React, { memo } from 'react';
 import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
-import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useSymbolIDs } from './use_symbol_ids';
 import { usePaintServerIDs } from './use_paint_server_ids';
 
@@ -434,7 +435,10 @@ const SymbolsAndShapes = memo(({ isDarkMode }: { isDarkMode: boolean }) => {
  *  3. `<use>` elements can be handled by compositor (faster)
  */
 export const SymbolDefinitions = memo(() => {
-  const isDarkMode = useUiSetting<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const theme = useObservable(services.theme.theme$);
+  const isDarkMode = theme?.darkMode || false;
+
   return (
     <HiddenSVG>
       <defs>

--- a/x-pack/plugins/security_solution/public/resolver/view/symbol_definitions.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/symbol_definitions.tsx
@@ -12,9 +12,9 @@ import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
 import useObservable from 'react-use/lib/useObservable';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { of } from 'rxjs';
 import { useSymbolIDs } from './use_symbol_ids';
 import { usePaintServerIDs } from './use_paint_server_ids';
-import { of } from 'rxjs';
 
 const loadingProcessTitle = i18n.translate(
   'xpack.securitySolution.resolver.symbolDefinitions.loadingProcess',

--- a/x-pack/plugins/synthetics/common/constants/capabilities.ts
+++ b/x-pack/plugins/synthetics/common/constants/capabilities.ts
@@ -8,4 +8,3 @@
 export const INTEGRATED_SOLUTIONS = ['apm', 'infrastructure', 'logs'];
 
 export const DEFAULT_TIMEPICKER_QUICK_RANGES = 'timepicker:quickRanges';
-export const DEFAULT_DARK_MODE = 'theme:darkMode';

--- a/x-pack/plugins/synthetics/public/legacy_uptime/app/render_app.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/app/render_app.tsx
@@ -10,11 +10,7 @@ import ReactDOM from 'react-dom';
 import { i18n as i18nFormatter } from '@kbn/i18n';
 import { AppMountParameters, CoreStart } from '@kbn/core/public';
 import { getIntegratedAppAvailability } from '../lib/adapters/framework/capabilities_adapter';
-import {
-  DEFAULT_DARK_MODE,
-  DEFAULT_TIMEPICKER_QUICK_RANGES,
-  INTEGRATED_SOLUTIONS,
-} from '../../../common/constants';
+import { DEFAULT_TIMEPICKER_QUICK_RANGES, INTEGRATED_SOLUTIONS } from '../../../common/constants';
 import { UptimeApp, UptimeAppProps } from './uptime_app';
 import { ClientPluginsSetup, ClientPluginsStart } from '../../plugin';
 
@@ -48,7 +44,6 @@ export function renderApp(
     i18n,
     startPlugins,
     basePath: basePath.get(),
-    darkMode: core.uiSettings.get(DEFAULT_DARK_MODE),
     commonlyUsedRanges: core.uiSettings.get(DEFAULT_TIMEPICKER_QUICK_RANGES),
     isApmAvailable: apm,
     isInfraAvailable: infrastructure,

--- a/x-pack/plugins/synthetics/public/legacy_uptime/app/uptime_app.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/app/uptime_app.tsx
@@ -50,7 +50,6 @@ export interface UptimeAppProps {
   basePath: string;
   canSave: boolean;
   core: CoreStart;
-  darkMode: boolean;
   i18n: I18nStart;
   isApmAvailable: boolean;
   isInfraAvailable: boolean;
@@ -70,7 +69,6 @@ const Application = (props: UptimeAppProps) => {
     basePath,
     canSave,
     core,
-    darkMode,
     i18n: i18nCore,
     plugins,
     renderGlobalHelpControls,
@@ -119,10 +117,10 @@ const Application = (props: UptimeAppProps) => {
               }}
             >
               <Router history={appMountParameters.history}>
-                <EuiThemeProvider darkMode={darkMode}>
+                <EuiThemeProvider theme$={props.appMountParameters.theme$}>
                   <UptimeRefreshContextProvider>
                     <UptimeSettingsContextProvider {...props}>
-                      <UptimeThemeContextProvider darkMode={darkMode}>
+                      <UptimeThemeContextProvider theme$={props.appMountParameters.theme$}>
                         <UptimeStartupPluginsContextProvider {...startPlugins}>
                           <UptimeDataViewContextProvider dataViews={startPlugins.dataViews}>
                             <div className={APP_WRAPPER_CLASS} data-test-subj="uptimeApp">

--- a/x-pack/plugins/synthetics/public/legacy_uptime/contexts/uptime_theme_context.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/contexts/uptime_theme_context.tsx
@@ -9,6 +9,10 @@ import { euiLightVars, euiDarkVars } from '@kbn/ui-theme';
 import React, { createContext, useMemo } from 'react';
 import { EUI_CHARTS_THEME_DARK, EUI_CHARTS_THEME_LIGHT } from '@elastic/eui/dist/eui_charts_theme';
 import { DARK_THEME, LIGHT_THEME, PartialTheme, Theme } from '@elastic/charts';
+import { CoreTheme } from '@kbn/core/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { Observable } from 'rxjs';
+import useObservable from 'react-use/lib/useObservable';
 import { UptimeAppColors } from '../app/uptime_app';
 
 export interface UptimeThemeContextValues {
@@ -43,11 +47,16 @@ const defaultContext: UptimeThemeContextValues = {
 export const UptimeThemeContext = createContext(defaultContext);
 
 interface ThemeContextProps {
-  darkMode: boolean;
+  theme$: Observable<CoreTheme>;
 }
 
-export const UptimeThemeContextProvider: React.FC<ThemeContextProps> = ({ darkMode, children }) => {
+export const UptimeThemeContextProvider: React.FC<ThemeContextProps> = ({ theme$, children }) => {
+  const { services } = useKibana();
+  const theme = useObservable(services.theme!.theme$);
+  const darkMode = theme?.darkMode || false;
+
   let colors: UptimeAppColors;
+
   if (darkMode) {
     colors = {
       danger: euiDarkVars.euiColorVis9,

--- a/x-pack/plugins/synthetics/public/legacy_uptime/hooks/use_chart_theme.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/hooks/use_chart_theme.ts
@@ -7,10 +7,13 @@
 
 import { EUI_CHARTS_THEME_DARK, EUI_CHARTS_THEME_LIGHT } from '@elastic/eui/dist/eui_charts_theme';
 import { useMemo } from 'react';
-import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 
 export const useChartTheme = () => {
-  const [darkMode] = useUiSetting$<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const kibanaTheme = useObservable(services!.theme!.theme$);
+  const darkMode = kibanaTheme?.darkMode || false;
 
   const theme = useMemo(() => {
     return darkMode ? EUI_CHARTS_THEME_DARK.theme : EUI_CHARTS_THEME_LIGHT.theme;

--- a/x-pack/plugins/synthetics/public/legacy_uptime/lib/helper/rtl_helpers.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/lib/helper/rtl_helpers.tsx
@@ -159,7 +159,7 @@ export function MockKibanaProvider<ExtraCore>({
           data={(coreOptions as any).data}
           observability={(coreOptions as any).observability}
         >
-          <EuiThemeProvider darkMode={false}>
+          <EuiThemeProvider theme$={(coreOptions as any).theme.theme$}>
             <I18nProvider>{children}</I18nProvider>
           </EuiThemeProvider>
         </UptimeStartupPluginsContextProvider>

--- a/x-pack/plugins/triggers_actions_ui/public/application/app.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/app.tsx
@@ -10,7 +10,6 @@ import { Switch, Route, Redirect, Router } from 'react-router-dom';
 import { ChromeBreadcrumb, CoreStart, CoreTheme, ScopedHistory } from '@kbn/core/public';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { I18nProvider } from '@kbn/i18n-react';
-import useObservable from 'react-use/lib/useObservable';
 import { Observable } from 'rxjs';
 import { KibanaFeature } from '@kbn/features-plugin/common';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
@@ -67,15 +66,14 @@ export const renderApp = (deps: TriggersAndActionsUiServices) => {
 };
 
 export const App = ({ deps }: { deps: TriggersAndActionsUiServices }) => {
-  const { savedObjects, uiSettings, theme$ } = deps;
+  const { savedObjects, theme$ } = deps;
   const sections: Section[] = ['rules', 'connectors', 'alerts', '__components_sandbox'];
-  const isDarkMode = useObservable<boolean>(uiSettings.get$('theme:darkMode'));
 
   const sectionsRegex = sections.join('|');
   setSavedObjectsClient(savedObjects.client);
   return (
     <I18nProvider>
-      <EuiThemeProvider darkMode={isDarkMode}>
+      <EuiThemeProvider theme$={theme$}>
         <KibanaThemeProvider theme$={theme$}>
           <KibanaContextProvider services={{ ...deps }}>
             <Router history={deps.history}>

--- a/x-pack/plugins/ux/public/application/ux_app.tsx
+++ b/x-pack/plugins/ux/public/application/ux_app.tsx
@@ -13,6 +13,7 @@ import { Redirect } from 'react-router-dom';
 import { DefaultTheme, ThemeProvider } from 'styled-components';
 import { RouterProvider, createRouter } from '@kbn/typed-react-router-config';
 import { i18n } from '@kbn/i18n';
+import useObservable from 'react-use/lib/useObservable';
 import { RouteComponentProps, RouteProps } from 'react-router-dom';
 import {
   AppMountParameters,
@@ -23,7 +24,7 @@ import {
 import {
   KibanaContextProvider,
   RedirectAppLinks,
-  useUiSetting$,
+  useKibana,
 } from '@kbn/kibana-react-plugin/public';
 
 import {
@@ -31,6 +32,7 @@ import {
   InspectorContextProvider,
   useBreadcrumbs,
 } from '@kbn/observability-plugin/public';
+
 import {
   DASHBOARD_LABEL,
   RumHome,
@@ -62,7 +64,9 @@ export const uxRoutes: RouteDefinition[] = [
 ];
 
 function UxApp() {
-  const [darkMode] = useUiSetting$<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const theme = useObservable(services.theme!.theme$);
+  const darkMode = theme?.darkMode || false;
 
   const { http } = useKibanaServices();
   const basePath = http.basePath.get();

--- a/x-pack/plugins/ux/public/components/app/rum_dashboard/charts/page_load_dist_chart.tsx
+++ b/x-pack/plugins/ux/public/components/app/rum_dashboard/charts/page_load_dist_chart.tsx
@@ -28,7 +28,8 @@ import {
   EUI_CHARTS_THEME_LIGHT,
 } from '@elastic/eui/dist/eui_charts_theme';
 import styled from 'styled-components';
-import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { PercentileAnnotations } from '../page_load_distribution/percentile_annotations';
 import { I18LABELS } from '../translations';
 import { ChartWrapper } from '../chart_wrapper';
@@ -87,7 +88,9 @@ export function PageLoadDistChart({
     headerFormatter,
   };
 
-  const [darkMode] = useUiSetting$<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const theme = useObservable(services.theme!.theme$);
+  const darkMode = theme?.darkMode || false;
 
   const euiChartTheme = darkMode
     ? EUI_CHARTS_THEME_DARK

--- a/x-pack/plugins/ux/public/components/app/rum_dashboard/charts/page_views_chart.tsx
+++ b/x-pack/plugins/ux/public/components/app/rum_dashboard/charts/page_views_chart.tsx
@@ -27,7 +27,8 @@ import numeral from '@elastic/numeral';
 import moment from 'moment';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { fromQuery, toQuery } from '@kbn/observability-plugin/public';
 import { useLegacyUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { ChartWrapper } from '../chart_wrapper';
@@ -76,7 +77,9 @@ export function PageViewsChart({ data, loading }: Props) {
 
   const breakdownAccessors = data?.topItems?.length ? data?.topItems : ['y'];
 
-  const [darkMode] = useUiSetting$<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const theme = useObservable(services.theme!.theme$);
+  const darkMode = theme?.darkMode || false;
 
   const customSeriesNaming: SeriesNameFn = ({ yAccessor }) => {
     if (yAccessor === 'y') {

--- a/x-pack/plugins/ux/public/components/app/rum_dashboard/charts/visitor_breakdown_chart.tsx
+++ b/x-pack/plugins/ux/public/components/app/rum_dashboard/charts/visitor_breakdown_chart.tsx
@@ -21,7 +21,8 @@ import {
   EUI_CHARTS_THEME_DARK,
   EUI_CHARTS_THEME_LIGHT,
 } from '@elastic/eui/dist/eui_charts_theme';
-import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { ChartWrapper } from '../chart_wrapper';
 import { I18LABELS } from '../translations';
 
@@ -50,7 +51,9 @@ const theme: PartialTheme = {
 };
 
 export function VisitorBreakdownChart({ loading, options }: Props) {
-  const [darkMode] = useUiSetting$<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const kibanaTheme = useObservable(services.theme!.theme$);
+  const darkMode = kibanaTheme?.darkMode || false;
 
   const euiChartTheme = darkMode
     ? EUI_CHARTS_THEME_DARK

--- a/x-pack/plugins/ux/public/components/app/rum_dashboard/page_load_distribution/breakdown_series.tsx
+++ b/x-pack/plugins/ux/public/components/app/rum_dashboard/page_load_distribution/breakdown_series.tsx
@@ -12,7 +12,8 @@ import {
   EUI_CHARTS_THEME_DARK,
   EUI_CHARTS_THEME_LIGHT,
 } from '@elastic/eui/dist/eui_charts_theme';
-import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import useObservable from 'react-use/lib/useObservable';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { PercentileRange } from '.';
 import { useBreakdowns } from './use_breakdowns';
 
@@ -29,7 +30,9 @@ export function BreakdownSeries({
   percentileRange,
   onLoadingChange,
 }: Props) {
-  const [darkMode] = useUiSetting$<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const theme = useObservable(services.theme!.theme$);
+  const darkMode = theme?.darkMode || false;
 
   const euiChartTheme = darkMode
     ? EUI_CHARTS_THEME_DARK


### PR DESCRIPTION
## Summary

Part of #63777. Automatically switches the kibana theme based on the users's OS setting.

https://user-images.githubusercontent.com/57448/149770394-9807d8f7-ced0-4eb4-be12-e6fdc4547d23.mov

### To Do

- [x] Add a new UI setting for the theme with three values: `light`, `dark` and `system`.
- [ ] Determine what should the default value should be for the new setting.
- [ ] Determine what to do with uses who have selected `theme:darkMode`.
- [x] Serve all stylesheets for `system` theme and let the browser determine which one to serve based on a media query.
- [x] Use the new setting in the `ThemeService`.
- [x] Implement automatic switching between themes when the user changes the OS setting.
- [ ] Compile both versions of `light` and `dark` SCSS themes and let the browser decide which one to serve based on a media query.
- [ ] Remove all usages of old `theme:darkMode` setting.
- [ ] Update telemetry mappings.
- [ ] Fix tests



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
