### PR TITLE
have to select elasticsearch cluster for stack _monitoring_metricbeat test

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/monitoring/_monitoring_metricbeat.js
+++ b/x-pack/test/stack_functional_integration/apps/monitoring/_monitoring_metricbeat.js
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import { Browser } from '../../../../../test/functional/services/common';
-
 export default ({ getService, getPageObjects }) => {
   describe('monitoring app - stack functional integration - suite', () => {
     const browser = getService('browser');
@@ -33,7 +31,6 @@ export default ({ getService, getPageObjects }) => {
     });
 
     it('should have Monitoring already enabled', async () => {
-      // await this.browser.refresh();
       await find.clickByLinkText('elasticsearch');
       await testSubjects.click('esOverview');
     });

--- a/x-pack/test/stack_functional_integration/apps/monitoring/_monitoring_metricbeat.js
+++ b/x-pack/test/stack_functional_integration/apps/monitoring/_monitoring_metricbeat.js
@@ -13,7 +13,7 @@ export default ({ getService, getPageObjects }) => {
     const testSubjects = getService('testSubjects');
     const isSaml = !!process.env.VM.includes('saml') || !!process.env.VM.includes('oidc');
     const clusterOverview = getService('monitoringClusterOverview');
-    const find = getService('find')
+    const find = getService('find');
 
     before(async () => {
       await browser.setWindowSize(1200, 800);

--- a/x-pack/test/stack_functional_integration/apps/monitoring/_monitoring_metricbeat.js
+++ b/x-pack/test/stack_functional_integration/apps/monitoring/_monitoring_metricbeat.js
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { Browser } from '../../../../../test/functional/services/common';
+
 export default ({ getService, getPageObjects }) => {
   describe('monitoring app - stack functional integration - suite', () => {
     const browser = getService('browser');
@@ -13,6 +15,7 @@ export default ({ getService, getPageObjects }) => {
     const testSubjects = getService('testSubjects');
     const isSaml = !!process.env.VM.includes('saml') || !!process.env.VM.includes('oidc');
     const clusterOverview = getService('monitoringClusterOverview');
+    const find = getService('find')
 
     before(async () => {
       await browser.setWindowSize(1200, 800);
@@ -30,6 +33,8 @@ export default ({ getService, getPageObjects }) => {
     });
 
     it('should have Monitoring already enabled', async () => {
+      // await this.browser.refresh();
+      await find.clickByLinkText('elasticsearch');
       await testSubjects.click('esOverview');
     });
 


### PR DESCRIPTION
## Summary

The test in this PR doesn't run as part of CI.  It runs as part of stack_functional_integration tests.

A recent change made it so that the stack monitoring page now shows an additional cluster in the list (see screenshot).  This PR adds a step to click the elasticsearch link to get to the main monitoring data it expects.

![monitoring app - stack functional integration - suite should have Monitoring already enabled](https://user-images.githubusercontent.com/13542669/148827367-639cefed-8072-4f50-b7f7-024be41e2ae7.png)

