### PR TITLE
[Security Solution][bugfix] adds tooltip to long host name 

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/overview_risky_host_links/navigate_to_host.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_risky_host_links/navigate_to_host.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiButtonEmpty, EuiText } from '@elastic/eui';
+import { EuiButtonEmpty, EuiText, EuiToolTip } from '@elastic/eui';
 import { APP_UI_ID, SecurityPageName } from '../../../../common/constants';
 import { useKibana } from '../../../common/lib/kibana';
 
@@ -34,8 +34,10 @@ export const NavigateToHost: React.FC<{ name: string }> = ({ name }): JSX.Elemen
     [filterManager, name, navigateToApp]
   );
   return (
-    <EuiButtonEmpty color="text" onClick={goToHostPage} size="xs">
-      <EuiText size="s">{name}</EuiText>
-    </EuiButtonEmpty>
+    <EuiToolTip content={name} position="top">
+      <EuiButtonEmpty color="text" onClick={goToHostPage} size="xs">
+        <EuiText size="s">{name}</EuiText>
+      </EuiButtonEmpty>
+    </EuiToolTip>
   );
 };


### PR DESCRIPTION
## Summary

adds tooltip so that long host names can be read
<img width="568" alt="Screen Shot 2022-01-10 at 4 22 19 PM" src="https://user-images.githubusercontent.com/18617331/148841601-15329591-45a2-4e59-98a4-dbcf71b625a5.png">
