### PR TITLE
[SecuritySolution][bugfix] handles 0ms on inspect

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/inspect/modal.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/inspect/modal.tsx
@@ -149,7 +149,9 @@ export const ModalInspectQuery = ({
       ),
       description: (
         <span data-test-subj="query-time-description">
-          {inspectResponses[0]?.took
+          {inspectResponses[0]?.took === 0
+            ? '0ms'
+            : inspectResponses[0]?.took
             ? `${numeral(inspectResponses[0].took).format('0,0')}ms`
             : i18n.SOMETHING_WENT_WRONG}
         </span>


### PR DESCRIPTION
## Summary

when response time is 0

before
<img width="618" alt="Screen Shot 2022-01-10 at 5 03 06 PM" src="https://user-images.githubusercontent.com/18617331/148846187-76e53ff8-f266-4190-9e64-6fe75f420c10.png">

after
<img width="619" alt="Screen Shot 2022-01-10 at 5 02 23 PM" src="https://user-images.githubusercontent.com/18617331/148846185-43e4cdc1-f086-4314-befd-29f3e3dffb85.png">

