### PR TITLE
[7.17] Accept connecting to ES 8.x

### DIFF
--- a/packages/kbn-test/src/es/test_es_cluster.ts
+++ b/packages/kbn-test/src/es/test_es_cluster.ts
@@ -64,6 +64,10 @@ export interface CreateTestEsClusterOptions {
   basePath?: string;
   clusterName?: string;
   /**
+   * The ES version to start
+   */
+  version?: string;
+  /**
    * Path to data archive snapshot to run Elasticsearch with.
    * To prepare the the snapshot:
    * - run Elasticsearch server
@@ -150,6 +154,7 @@ export function createTestEsCluster<
     log,
     basePath = Path.resolve(KIBANA_ROOT, '.es'),
     esFrom = esTestConfig.getBuildFrom(),
+    version = esTestConfig.getVersion(),
     dataArchive,
     nodes = [{ name: 'node-01' }],
     esArgs: customEsArgs = [],
@@ -173,7 +178,7 @@ export function createTestEsCluster<
   const esArgs = assignArgs(defaultEsArgs, customEsArgs);
 
   const config = {
-    version: esTestConfig.getVersion(),
+    version,
     installPath: Path.resolve(basePath, clusterName),
     sourcePath: Path.resolve(KIBANA_ROOT, '../elasticsearch'),
     password,

--- a/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
@@ -25,10 +25,7 @@ describe('esVersionCompatibleWithKibana', () => {
     }
   });
 
-  const start = async ({
-    esArgs = [],
-    version,
-  }: { esArgs?: string[]; version?: string } = {}) => {
+  const start = async ({ esArgs = [], version }: { esArgs?: string[]; version?: string } = {}) => {
     const { startES, startKibana } = createTestServers({
       adjustTimeout: jest.setTimeout,
       settings: {

--- a/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
@@ -42,6 +42,9 @@ describe('esVersionCompatibleWithKibana', () => {
 
   it('successfully starts Kibana 7.17.x against Elasticsearch 8.0.0', async () => {
     const { startKibana } = await start({ version: '8.0.0' });
-    await expect(startKibana()).resolves.toBeDefined();
+    const startWithCleanup = async () => {
+      kibanaServer = await startKibana();
+    };
+    await expect(startWithCleanup).resolves.toBeDefined();
   });
 });

--- a/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
@@ -25,7 +25,7 @@ describe('esVersionCompatibleWithKibana', () => {
     }
   });
 
-  const startES = async ({
+  const start = async ({
     esArgs = [],
     version,
   }: { esArgs?: string[]; version?: string } = {}) => {
@@ -44,7 +44,7 @@ describe('esVersionCompatibleWithKibana', () => {
   };
 
   it('successfully starts Kibana 7.17.x against Elasticsearch 8.0.0', async () => {
-    const { startKibana } = await startES({ version: '8.0.0' });
+    const { startKibana } = await start({ version: '8.0.0' });
     await expect(startKibana()).resolves.toBeDefined();
   });
 });

--- a/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
@@ -45,6 +45,6 @@ describe('esVersionCompatibleWithKibana', () => {
     const startWithCleanup = async () => {
       kibanaServer = await startKibana();
     };
-    await expect(startWithCleanup).resolves.toBeDefined();
+    await expect(startWithCleanup()).resolves.toBeDefined();
   });
 });

--- a/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  createTestServers,
+  TestElasticsearchUtils,
+  TestKibanaUtils,
+} from '../../../test_helpers/kbn_server';
+
+describe('esVersionCompatibleWithKibana', () => {
+  let esServer: TestElasticsearchUtils;
+  let kibanaServer: TestKibanaUtils;
+
+  afterEach(async () => {
+    if (kibanaServer) {
+      await kibanaServer.stop();
+    }
+    if (esServer) {
+      await esServer.stop();
+    }
+  });
+
+  const startES = async ({
+    esArgs = [],
+    version,
+  }: { esArgs?: string[]; version?: string } = {}) => {
+    const { startES, startKibana } = createTestServers({
+      adjustTimeout: jest.setTimeout,
+      settings: {
+        es: {
+          version,
+          esArgs,
+        },
+      },
+    });
+
+    esServer = await startES();
+    return { startKibana };
+  };
+
+  it('successfully starts Kibana 7.17.x against Elasticsearch 8.0.0', async () => {
+    const { startKibana } = await startES({ version: '8.0.0' });
+    await expect(startKibana()).resolves.toBeDefined();
+  });
+});

--- a/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
@@ -44,6 +44,7 @@ describe('esVersionCompatibleWithKibana', () => {
     const { startKibana } = await start({ version: '8.0.0' });
     const startWithCleanup = async () => {
       kibanaServer = await startKibana();
+      return kibanaServer;
     };
     await expect(startWithCleanup()).resolves.toBeDefined();
   });

--- a/src/core/server/elasticsearch/version_check/ensure_es_version.test.ts
+++ b/src/core/server/elasticsearch/version_check/ensure_es_version.test.ts
@@ -69,11 +69,11 @@ describe('mapNodesVersionCompatibility', () => {
   });
 
   it('returns isCompatible=false for an incompatible node without http publish address', async () => {
-    const nodesInfo = createNodesInfoWithoutHTTP('6.1.1');
+    const nodesInfo = createNodesInfoWithoutHTTP('7.1.1');
     const result = mapNodesVersionCompatibility(nodesInfo, KIBANA_VERSION, false);
     expect(result.isCompatible).toBe(false);
     expect(result.message).toMatchInlineSnapshot(
-      `"This version of Kibana (v5.1.0) is incompatible with the following Elasticsearch nodes in your cluster: v6.1.1 @ undefined (ip)"`
+      `"This version of Kibana (v5.1.0) is incompatible with the following Elasticsearch nodes in your cluster: v7.1.1 @ undefined (ip)"`
     );
   });
 

--- a/src/core/server/elasticsearch/version_check/es_kibana_version_compatability.test.ts
+++ b/src/core/server/elasticsearch/version_check/es_kibana_version_compatability.test.ts
@@ -8,38 +8,42 @@
 
 import { esVersionCompatibleWithKibana } from './es_kibana_version_compatability';
 
-describe('plugins/elasticsearch', () => {
-  describe('lib/is_es_compatible_with_kibana', () => {
-    describe('returns false', () => {
-      it('when ES major is greater than Kibana major', () => {
-        expect(esVersionCompatibleWithKibana('1.0.0', '0.0.0')).toBe(false);
-      });
-
-      it('when ES major is less than Kibana major', () => {
-        expect(esVersionCompatibleWithKibana('0.0.0', '1.0.0')).toBe(false);
-      });
-
-      it('when majors are equal, but ES minor is less than Kibana minor', () => {
-        expect(esVersionCompatibleWithKibana('1.0.0', '1.1.0')).toBe(false);
-      });
+describe('esVersionCompatibleWithKibana', () => {
+  describe('returns false', () => {
+    it('when ES major is greater than Kibana major + 1', () => {
+      expect(esVersionCompatibleWithKibana('2.0.0', '0.0.0')).toBe(false);
     });
 
-    describe('returns true', () => {
-      it('when version numbers are the same', () => {
-        expect(esVersionCompatibleWithKibana('1.1.1', '1.1.1')).toBe(true);
-      });
+    it('when ES major is less than Kibana major', () => {
+      expect(esVersionCompatibleWithKibana('0.0.0', '1.0.0')).toBe(false);
+    });
 
-      it('when majors are equal, and ES minor is greater than Kibana minor', () => {
-        expect(esVersionCompatibleWithKibana('1.1.0', '1.0.0')).toBe(true);
-      });
+    it('when majors are equal, but ES minor is less than Kibana minor', () => {
+      expect(esVersionCompatibleWithKibana('1.0.0', '1.1.0')).toBe(false);
+    });
+  });
 
-      it('when majors and minors are equal, and ES patch is greater than Kibana patch', () => {
-        expect(esVersionCompatibleWithKibana('1.1.1', '1.1.0')).toBe(true);
-      });
+  describe('returns true', () => {
+    it('when version numbers are the same', () => {
+      expect(esVersionCompatibleWithKibana('1.1.1', '1.1.1')).toBe(true);
+    });
 
-      it('when majors and minors are equal, but ES patch is less than Kibana patch', () => {
-        expect(esVersionCompatibleWithKibana('1.1.0', '1.1.1')).toBe(true);
-      });
+    it('when majors are equal, and ES minor is greater than Kibana minor', () => {
+      expect(esVersionCompatibleWithKibana('1.1.0', '1.0.0')).toBe(true);
+    });
+
+    it('when majors and minors are equal, and ES patch is greater than Kibana patch', () => {
+      expect(esVersionCompatibleWithKibana('1.1.1', '1.1.0')).toBe(true);
+    });
+
+    it('when majors and minors are equal, but ES patch is less than Kibana patch', () => {
+      expect(esVersionCompatibleWithKibana('1.1.0', '1.1.1')).toBe(true);
+    });
+
+    it('when ES major is Kibana major + 1', () => {
+      expect(esVersionCompatibleWithKibana('1.0.0', '0.0.0')).toBe(true);
+      expect(esVersionCompatibleWithKibana('1.0.0', '0.7.0')).toBe(true);
+      expect(esVersionCompatibleWithKibana('1.9.2', '0.7.12')).toBe(true);
     });
   });
 });

--- a/src/core/server/elasticsearch/version_check/es_kibana_version_compatability.ts
+++ b/src/core/server/elasticsearch/version_check/es_kibana_version_compatability.ts
@@ -26,6 +26,11 @@ export function esVersionCompatibleWithKibana(esVersion: string, kibanaVersion: 
     patch: semver.patch(kibanaVersion),
   };
 
+  // Accept the next major version of ES.
+  if (esVersionNumbers.major === kibanaVersionNumbers.major + 1) {
+    return true;
+  }
+
   // Reject mismatching major version numbers.
   if (esVersionNumbers.major !== kibanaVersionNumbers.major) {
     return false;

--- a/src/core/server/elasticsearch/version_check/es_kibana_version_compatability.ts
+++ b/src/core/server/elasticsearch/version_check/es_kibana_version_compatability.ts
@@ -26,7 +26,7 @@ export function esVersionCompatibleWithKibana(esVersion: string, kibanaVersion: 
     patch: semver.patch(kibanaVersion),
   };
 
-  // Accept the next major version of ES.
+  // On 7.17: Accept the next major version of ES.
   if (esVersionNumbers.major === kibanaVersionNumbers.major + 1) {
     return true;
   }


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/122459

Change the es version compatibility logic on the `7.17` branch to allow connecting to any 8 minor version of elasticsearch