### PR TITLE
[Uptime] Fix centered headers on desktop [#121919]

### DIFF
--- a/x-pack/plugins/uptime/public/apps/__snapshots__/uptime_page_template.test.tsx.snap
+++ b/x-pack/plugins/uptime/public/apps/__snapshots__/uptime_page_template.test.tsx.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UptimePageTemplateComponent styling applies the header centering on mobile 1`] = `
+.c0 .euiPageHeaderContent > .euiFlexGroup {
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c0 .euiPageHeaderContent > .euiFlexGroup > .euiFlexItem {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+<div
+  class="euiPage euiPage--grow euiPageTemplate c0"
+  style="min-height: 460px;"
+>
+  <div
+    class="euiPageBody euiPageBody--borderRadiusNone"
+  >
+    <div
+      class="euiPanel euiPanel--borderRadiusNone euiPanel--plain euiPanel--noShadow euiPanel--noBorder euiPageContent euiPageContent--borderRadiusNone"
+      role="main"
+    >
+      <div
+        class="euiPageContentBody euiPage--paddingLarge euiPage--restrictWidth-default"
+      >
+        <div
+          style="visibility: initial;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`UptimePageTemplateComponent styling does not apply header centering on bigger resolutions 1`] = `
+.c0 .euiPageHeaderContent > .euiFlexGroup {
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+<div
+  class="euiPage euiPage--grow euiPageTemplate c0"
+  style="min-height: 460px;"
+>
+  <div
+    class="euiPageBody euiPageBody--borderRadiusNone"
+  >
+    <div
+      class="euiPanel euiPanel--borderRadiusNone euiPanel--plain euiPanel--noShadow euiPanel--noBorder euiPageContent euiPageContent--borderRadiusNone"
+      role="main"
+    >
+      <div
+        class="euiPageContentBody euiPage--paddingLarge euiPage--restrictWidth-default"
+      >
+        <div
+          style="visibility: initial;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/x-pack/plugins/uptime/public/apps/uptime_page_template.test.tsx
+++ b/x-pack/plugins/uptime/public/apps/uptime_page_template.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// app.test.js
+import React from 'react';
+import 'jest-styled-components';
+import { render } from '../lib/helper/rtl_helpers';
+import { UptimePageTemplateComponent } from './uptime_page_template';
+import { OVERVIEW_ROUTE } from '../../common/constants';
+import { useBreakpoints } from '../hooks/use_breakpoints';
+
+jest.mock('../hooks/use_breakpoints', () => {
+  const down = jest.fn().mockReturnValue(false);
+  return {
+    useBreakpoints: () => ({ down }),
+  };
+});
+
+describe('UptimePageTemplateComponent', () => {
+  describe('styling', () => {
+    // In this test we use snapshots because we're asserting on generated
+    // styles. Writing assertions manually here could make this test really
+    // convoluted, and it require us to manually update styling strings
+    // according to `styled-components` generator, which is counter-productive.
+    // In general, however, we avoid snaphshot tests.
+
+    it('does not apply header centering on bigger resolutions', () => {
+      const { container } = render(<UptimePageTemplateComponent path={OVERVIEW_ROUTE} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('applies the header centering on mobile', () => {
+      (useBreakpoints().down as jest.Mock).mockReturnValue(true);
+      const { container } = render(<UptimePageTemplateComponent path={OVERVIEW_ROUTE} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+});

--- a/x-pack/plugins/uptime/public/apps/uptime_page_template.tsx
+++ b/x-pack/plugins/uptime/public/apps/uptime_page_template.tsx
@@ -16,11 +16,18 @@ import { EmptyStateLoading } from '../components/overview/empty_state/empty_stat
 import { EmptyStateError } from '../components/overview/empty_state/empty_state_error';
 import { useHasData } from '../components/overview/empty_state/use_has_data';
 import { useInspectorContext } from '../../../observability/public';
+import { useBreakpoints } from '../hooks/use_breakpoints';
 
 interface Props {
   path: string;
   pageHeader?: EuiPageHeaderProps;
 }
+
+const mobileCenteredHeader = `
+  .euiPageHeaderContent > .euiFlexGroup > .euiFlexItem {
+    align-items: center;
+  }
+`;
 
 export const UptimePageTemplateComponent: React.FC<Props & EuiPageTemplateProps> = ({
   path,
@@ -31,18 +38,17 @@ export const UptimePageTemplateComponent: React.FC<Props & EuiPageTemplateProps>
   const {
     services: { observability },
   } = useKibana<ClientPluginsStart>();
+  const { down } = useBreakpoints();
+  const isMobile = down('s');
 
   const PageTemplateComponent = observability.navigation.PageTemplate;
-
   const StyledPageTemplateComponent = useMemo(() => {
-    return styled(PageTemplateComponent)`
+    return styled(PageTemplateComponent)<{ isMobile: boolean }>`
       .euiPageHeaderContent > .euiFlexGroup {
         flex-wrap: wrap;
       }
 
-      .euiPageHeaderContent > .euiFlexGroup > .euiFlexItem {
-        align-items: center;
-      }
+      ${(props) => (props.isMobile ? mobileCenteredHeader : '')}
     `;
   }, [PageTemplateComponent]);
 
@@ -66,6 +72,7 @@ export const UptimePageTemplateComponent: React.FC<Props & EuiPageTemplateProps>
   return (
     <>
       <StyledPageTemplateComponent
+        isMobile={isMobile}
         pageHeader={pageHeader}
         data-test-subj={noDataConfig ? 'data-missing' : undefined}
         noDataConfig={isMainRoute && !loading ? noDataConfig : undefined}


### PR DESCRIPTION
## Summary

Fixes the reopening of  #121919.

In the previous PR which added mobile layouts for the check-group details (https://github.com/elastic/kibana/pull/122171), I added stylings which centered headers so that they'd look good on mobile.

However, those styles seem to have also been applied _outside_ the check-group details page, and on desktop, which causes other screens like the monitor list to look weird, as shown below.

![Screenshot 2022-01-11 at 10 57 05](https://user-images.githubusercontent.com/6868147/148931068-120954a3-bd4f-4fef-b6f5-a7914c51d972.png)

This PR fixes the centering on desktop resolutions, so that headers will _not_ be centered. Headers will only be centered on mobile as shown below.

![Screenshot 2022-01-11 at 11 01 32](https://user-images.githubusercontent.com/6868147/148931081-dd99b214-08fb-4bed-9cfe-165ff847cee8.png)
![Screenshot 2022-01-11 at 11 00 46](https://user-images.githubusercontent.com/6868147/148931082-66d930e6-798f-494d-8ba3-abe48c8a57b2.png)

> ⚠️ Please note that I think there's a separate issue we could create for the `useBreakpoints` hook as it's currently only calculated when the page is first loaded, not as the user resizes it. Therefore, you'll need to refresh the page in different resolutions to see the changes being applied. Please let me know if you think this is indeed a separate issue or whether it should be within this PR's scope.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release note

Fixes a bug in which headers would be incorrectly centered on desktop.