### PR TITLE
[8.0] [Fleet] Show missing fleet server host callout for fleet server policy too (#122354)

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -127,7 +127,6 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
       <EuiFlyoutBody
         banner={
           fleetStatus.isReady &&
-          !isFleetServerPolicySelected &&
           !isLoadingInitialRequest &&
           fleetServerHosts.length === 0 &&
           mode === 'managed' ? (


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #122354

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
