### PR TITLE
[7.17] [Fleet] Show missing fleet server host callout for fleet server policy too (#122354)

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -137,7 +137,6 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
       <EuiFlyoutBody
         banner={
           fleetStatus.isReady &&
-          !isFleetServerPolicySelected &&
           !isLoadingInitialRequest &&
           fleetServerHosts.length === 0 &&
           mode === 'managed' ? (


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #122354

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
