### PR TITLE
[DOCS] Changes an attribute to resolve correctly

### DIFF
--- a/docs/user/dashboard/make-dashboards-interactive.asciidoc
+++ b/docs/user/dashboard/make-dashboards-interactive.asciidoc
@@ -48,7 +48,7 @@ To create *Controls* panels:
 
 . Select the control panel type from the dropdown, then click *Add*.
 
-. Enter the *Control Label*, then select the *{data-sources-caps}* and *Field*.
+. Enter the *Control Label*, then select the *{data-source-caps}* and *Field*.
 
 . If you are adding a *Range slider*, enter the *Step Size* and *Decimal Places*.
 

--- a/docs/user/dashboard/make-dashboards-interactive.asciidoc
+++ b/docs/user/dashboard/make-dashboards-interactive.asciidoc
@@ -48,7 +48,7 @@ To create *Controls* panels:
 
 . Select the control panel type from the dropdown, then click *Add*.
 
-. Enter the *Control Label*, then select the *{Data-Source}* and *Field*.
+. Enter the *Control Label*, then select the *{data-sources-caps}* and *Field*.
 
 . If you are adding a *Range slider*, enter the *Step Size* and *Decimal Places*.
 


### PR DESCRIPTION
## Summary

This PR changes a `Data-Source` attribute to `data-source-caps`. The first one resolves as `data view` while it should be `Data View`. The new attribute fixes this issue.

### Note

**Do not merge** this PR before https://github.com/elastic/docs/pull/2342