### PR TITLE
[ML] Functional tests - stop re-using saved objects

### DIFF
--- a/x-pack/test/api_integration/apis/ml/index.ts
+++ b/x-pack/test/api_integration/apis/ml/index.ts
@@ -23,25 +23,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await ml.securityCommon.cleanMlUsers();
       await ml.securityCommon.cleanMlRoles();
 
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_apache');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_auditbeat');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_apm_transaction');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_heartbeat');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_logs');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_nginx');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_ecommerce');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_logs');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_siem_auditbeat');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_siem_packetbeat');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_siem_winlogbeat');
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_logs-endpoint.events.*');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_metricbeat');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_siem_cloudtrail');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_metrics_ui');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_apache_data_stream');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_nginx_data_stream');
-
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/categorization');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/categorization_small');

--- a/x-pack/test/api_integration/apis/ml/jobs/close_jobs.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/close_jobs.ts
@@ -50,6 +50,10 @@ export default ({ getService }: FtrProviderContext) => {
       await ml.testResources.setKibanaTimeZoneToUTC();
     });
 
+    after(async () => {
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+    });
+
     beforeEach(async () => {
       for (const job of testSetupJobConfigs) {
         const datafeedId = `datafeed-${job.job_id}`;

--- a/x-pack/test/api_integration/apis/ml/jobs/jobs_exist.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/jobs_exist.ts
@@ -89,6 +89,7 @@ export default ({ getService }: FtrProviderContext) => {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     it('sets up jobs', async () => {

--- a/x-pack/test/api_integration/apis/ml/modules/setup_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/setup_module.ts
@@ -1015,6 +1015,7 @@ export default ({ getService }: FtrProviderContext) => {
             await ml.api.deleteAnomalyDetectionJobES(job.jobId);
           }
           await ml.api.cleanMlIndices();
+          await ml.testResources.deleteIndexPatternByTitle(testData.indexPattern.name);
         });
 
         it(testData.testTitleSuffix, async () => {
@@ -1157,6 +1158,9 @@ export default ({ getService }: FtrProviderContext) => {
 
         after(async () => {
           await ml.api.cleanMlIndices();
+          if (testData.hasOwnProperty('indexPattern')) {
+            await ml.testResources.deleteIndexPatternByTitle(testData.indexPattern!.name);
+          }
         });
 
         it(testData.testTitleSuffix, async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/advanced_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/advanced_job.ts
@@ -232,6 +232,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/aggregated_scripted_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/aggregated_scripted_job.ts
@@ -376,6 +376,8 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
     });
     for (const testData of supportedTestSuites) {
       describe(testData.suiteTitle, function () {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/annotations.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/annotations.ts
@@ -47,6 +47,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     describe('creating', function () {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
@@ -76,6 +76,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.testResources.deleteMLTestDashboard();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/categorization_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/categorization_job.ts
@@ -87,6 +87,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_categorization');
     });
 
     it('job creation loads the categorization wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/custom_urls.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/custom_urls.ts
@@ -77,6 +77,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await ml.testResources.deleteMLTestDashboard();
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     it('opens the custom URLs tab in the edit job flyout', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/date_nanos_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/date_nanos_job.ts
@@ -128,6 +128,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_event_rate_gen_trend_nanos');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/forecasts.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/forecasts.ts
@@ -54,6 +54,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       after(async () => {
         await ml.api.cleanMlIndices();
+        await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
       });
 
       it('opens a job from job list link', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/multi_metric_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/multi_metric_job.ts
@@ -84,6 +84,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     it('job creation loads the multi metric wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/population_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/population_job.ts
@@ -98,6 +98,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
     });
 
     it('job creation loads the population wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/saved_search_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/saved_search_job.ts
@@ -282,6 +282,8 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteSavedSearches();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/single_metric_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/single_metric_job.ts
@@ -84,6 +84,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     it('job creation loads the single metric wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/single_metric_job_without_datafeed_start.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/single_metric_job_without_datafeed_start.ts
@@ -68,6 +68,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     it('job creation loads the single metric wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection/single_metric_viewer.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/single_metric_viewer.ts
@@ -55,6 +55,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       after(async () => {
         await ml.api.cleanMlIndices();
+        await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
       });
 
       it('opens a job from job list link', async () => {
@@ -142,6 +143,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       after(async () => {
         await ml.api.cleanMlIndices();
+        await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
       });
 
       it('opens a job from job list link', async () => {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/classification_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/classification_creation.ts
@@ -24,6 +24,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_bank_marketing');
     });
 
     const jobId = `bm_1_${Date.now()}`;

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/cloning.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/cloning.ts
@@ -159,6 +159,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.api.deleteIndices(testData.job.dest!.index as string);
           await ml.testResources.deleteIndexPatternByTitle(testData.job.dest!.index as string);
           await ml.testResources.deleteIndexPatternByTitle(cloneDestIndex);
+          await ml.testResources.deleteIndexPatternByTitle(testData.indexPattern.name);
         });
 
         it('opens the existing job in the data frame analytics job wizard', async () => {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/feature_importance.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/feature_importance.ts
@@ -183,6 +183,9 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      for (const testData of testDataList) {
+        await ml.testResources.deleteIndexPatternByTitle(testData.indexPattern.name);
+      }
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation.ts
@@ -24,6 +24,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
     });
 
     const jobId = `ihp_1_${Date.now()}`;

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation.ts
@@ -24,6 +24,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_egs_regression');
     });
 
     const jobId = `egs_1_${Date.now()}`;

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
@@ -168,6 +168,12 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await ml.securityUI.loginAsMlPowerUser();
     });
 
+    after(async () => {
+      await ml.testResources.deleteSavedSearches();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_logs');
+    });
+
     describe('with farequote', function () {
       // Run tests on full farequote index.
       it(`${farequoteDataViewTestData.suiteTitle} loads the data visualizer selector page`, async () => {

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_actions_panel.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_actions_panel.ts
@@ -40,6 +40,11 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.securityUI.loginAsMlPowerUser();
     });
 
+    after(async () => {
+      await ml.testResources.deleteSavedSearches();
+      await ml.testResources.deleteIndexPatternByTitle(indexPatternName);
+    });
+
     describe('create advanced job action', function () {
       it('loads the source data in the data visualizer', async () => {
         await ml.testExecution.logTestStep('loads the data visualizer selector page');

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_grid_in_dashboard.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_grid_in_dashboard.ts
@@ -122,6 +122,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async function () {
       await ml.testResources.clearAdvancedSettingProperty(SHOW_FIELD_STATISTICS);
+      await ml.testResources.deleteSavedSearches();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     runTests(farequoteLuceneFiltersSearchTestData);

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_grid_in_discover.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_grid_in_discover.ts
@@ -107,6 +107,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async function () {
       await ml.testResources.clearAdvancedSettingProperty(SHOW_FIELD_STATISTICS);
+      await ml.testResources.deleteSavedSearches();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_logs');
     });
 
     describe('when enabled', function () {

--- a/x-pack/test/functional/apps/ml/embeddables/anomaly_charts_dashboard_embeddables.ts
+++ b/x-pack/test/functional/apps/ml/embeddables/anomaly_charts_dashboard_embeddables.ts
@@ -45,6 +45,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     for (const testData of testDataList) {
@@ -55,6 +56,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             testData.datafeedConfig
           );
           await PageObjects.common.navigateToApp('dashboard');
+        });
+
+        after(async () => {
+          await ml.testResources.deleteDashboardByTitle(testData.dashboardTitle);
         });
 
         it('can open job selection flyout', async () => {

--- a/x-pack/test/functional/apps/ml/embeddables/anomaly_embeddables_migration.ts
+++ b/x-pack/test/functional/apps/ml/embeddables/anomaly_embeddables_migration.ts
@@ -85,6 +85,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/index.ts
+++ b/x-pack/test/functional/apps/ml/index.ts
@@ -12,89 +12,46 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const ml = getService('ml');
 
   describe('machine learning', function () {
+    before(async () => {
+      await ml.securityCommon.createMlRoles();
+      await ml.securityCommon.createMlUsers();
+    });
+
+    after(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await ml.securityUI.logout();
+
+      await ml.securityCommon.cleanMlUsers();
+      await ml.securityCommon.cleanMlRoles();
+
+      await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
+      await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
+      await esArchiver.unload('x-pack/test/functional/es_archives/ml/categorization');
+      await esArchiver.unload('x-pack/test/functional/es_archives/ml/event_rate_nanos');
+      await esArchiver.unload('x-pack/test/functional/es_archives/ml/bm_classification');
+      await esArchiver.unload('x-pack/test/functional/es_archives/ml/ihp_outlier');
+      await esArchiver.unload('x-pack/test/functional/es_archives/ml/egs_regression');
+      await esArchiver.unload('x-pack/test/functional/es_archives/ml/module_sample_ecommerce');
+
+      await ml.testResources.resetKibanaTimeZone();
+    });
+
     describe('', function () {
-      before(async () => {
-        await ml.securityCommon.createMlRoles();
-        await ml.securityCommon.createMlUsers();
-      });
+      this.tags('ciGroup15');
+      loadTestFile(require.resolve('./permissions'));
+      loadTestFile(require.resolve('./pages'));
+      loadTestFile(require.resolve('./data_visualizer'));
+      loadTestFile(require.resolve('./data_frame_analytics'));
+      loadTestFile(require.resolve('./model_management'));
+    });
 
-      after(async () => {
-        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
-        await ml.securityUI.logout();
-
-        await ml.securityCommon.cleanMlUsers();
-        await ml.securityCommon.cleanMlRoles();
-        await ml.testResources.deleteSavedSearches();
-        await ml.testResources.deleteDashboards();
-        await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-        await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
-        await ml.testResources.deleteIndexPatternByTitle('ft_categorization');
-        await ml.testResources.deleteIndexPatternByTitle('ft_event_rate_gen_trend_nanos');
-        await ml.testResources.deleteIndexPatternByTitle('ft_bank_marketing');
-        await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
-        await ml.testResources.deleteIndexPatternByTitle('ft_egs_regression');
-        await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_ecommerce');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/categorization');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/event_rate_nanos');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/bm_classification');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/ihp_outlier');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/egs_regression');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/module_sample_ecommerce');
-        await ml.testResources.resetKibanaTimeZone();
-      });
-
-      describe('', function () {
-        this.tags('ciGroup15');
-        loadTestFile(require.resolve('./permissions'));
-        loadTestFile(require.resolve('./pages'));
-        loadTestFile(require.resolve('./data_visualizer'));
-        loadTestFile(require.resolve('./data_frame_analytics'));
-        loadTestFile(require.resolve('./model_management'));
-      });
-
-      describe('', function () {
-        this.tags('ciGroup26');
-        loadTestFile(require.resolve('./anomaly_detection'));
-      });
+    describe('', function () {
+      this.tags('ciGroup26');
+      loadTestFile(require.resolve('./anomaly_detection'));
     });
 
     describe('', function () {
       this.tags('ciGroup8');
-
-      before(async () => {
-        await ml.securityCommon.createMlRoles();
-        await ml.securityCommon.createMlUsers();
-      });
-
-      after(async () => {
-        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
-        await ml.securityUI.logout();
-
-        await ml.securityCommon.cleanMlUsers();
-        await ml.securityCommon.cleanMlRoles();
-        await ml.testResources.deleteSavedSearches();
-        await ml.testResources.deleteDashboards();
-        await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-        await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
-        await ml.testResources.deleteIndexPatternByTitle('ft_categorization');
-        await ml.testResources.deleteIndexPatternByTitle('ft_event_rate_gen_trend_nanos');
-        await ml.testResources.deleteIndexPatternByTitle('ft_bank_marketing');
-        await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
-        await ml.testResources.deleteIndexPatternByTitle('ft_egs_regression');
-        await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_ecommerce');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/categorization');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/event_rate_nanos');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/bm_classification');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/ihp_outlier');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/egs_regression');
-        await esArchiver.unload('x-pack/test/functional/es_archives/ml/module_sample_ecommerce');
-        await ml.testResources.resetKibanaTimeZone();
-      });
-
       loadTestFile(require.resolve('./feature_controls'));
       loadTestFile(require.resolve('./settings'));
       loadTestFile(require.resolve('./embeddables'));

--- a/x-pack/test/functional/apps/ml/permissions/full_ml_access.ts
+++ b/x-pack/test/functional/apps/ml/permissions/full_ml_access.ts
@@ -144,10 +144,13 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        await ml.api.cleanMlIndices();
         await ml.api.deleteIndices(`user-${dfaJobId}`);
         await ml.api.deleteCalendar(calendarId);
         await ml.api.deleteFilter(filterId);
+        await ml.api.cleanMlIndices();
+        await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+        await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
+        await ml.testResources.deleteIndexPatternByTitle(ecIndexPattern);
       });
 
       for (const testUser of testUsers) {

--- a/x-pack/test/functional/apps/ml/permissions/read_ml_access.ts
+++ b/x-pack/test/functional/apps/ml/permissions/read_ml_access.ts
@@ -145,10 +145,13 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        await ml.api.cleanMlIndices();
         await ml.api.deleteIndices(`user-${dfaJobId}`);
         await ml.api.deleteCalendar(calendarId);
         await ml.api.deleteFilter(filterId);
+        await ml.api.cleanMlIndices();
+        await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+        await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
+        await ml.testResources.deleteIndexPatternByTitle(ecIndexPattern);
       });
 
       for (const testUser of testUsers) {

--- a/x-pack/test/functional/apps/ml/settings/calendar_creation.ts
+++ b/x-pack/test/functional/apps/ml/settings/calendar_creation.ts
@@ -30,6 +30,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     afterEach(async () => {

--- a/x-pack/test/functional/apps/ml/settings/calendar_edit.ts
+++ b/x-pack/test/functional/apps/ml/settings/calendar_edit.ts
@@ -43,6 +43,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     afterEach(async () => {

--- a/x-pack/test/functional/apps/ml/stack_management_jobs/export_jobs.ts
+++ b/x-pack/test/functional/apps/ml/stack_management_jobs/export_jobs.ts
@@ -293,6 +293,10 @@ export default function ({ getService }: FtrProviderContext) {
         'anomaly_detection_jobs',
         'data_frame_analytics_jobs',
       ]);
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteIndexPatternByTitle('ft_bank_marketing');
+      await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
+      await ml.testResources.deleteIndexPatternByTitle('ft_egs_regression');
     });
 
     it('opens export flyout and exports anomaly detector jobs', async () => {

--- a/x-pack/test/functional/apps/ml/stack_management_jobs/import_jobs.ts
+++ b/x-pack/test/functional/apps/ml/stack_management_jobs/import_jobs.ts
@@ -49,6 +49,8 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteIndexPatternByTitle('ft_bank_marketing');
     });
 
     for (const testData of testDataListPositive) {

--- a/x-pack/test/functional/apps/ml/stack_management_jobs/manage_spaces.ts
+++ b/x-pack/test/functional/apps/ml/stack_management_jobs/manage_spaces.ts
@@ -132,6 +132,8 @@ export default function ({ getService }: FtrProviderContext) {
       }
       await ml.testResources.cleanMLSavedObjects();
       await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/stack_management_jobs/synchronize.ts
+++ b/x-pack/test/functional/apps/ml/stack_management_jobs/synchronize.ts
@@ -39,6 +39,7 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.api.deleteDataFrameAnalyticsJobES(dfaJobId);
       }
       await ml.testResources.cleanMLSavedObjects();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     it('should have nothing to sync initially', async () => {

--- a/x-pack/test/functional/apps/transform/cloning.ts
+++ b/x-pack/test/functional/apps/transform/cloning.ts
@@ -120,6 +120,7 @@ export default function ({ getService }: FtrProviderContext) {
       await transform.api.deleteIndices(transformConfigWithRuntimeMapping.dest.index);
       await transform.api.deleteIndices(transformConfigWithLatest.dest.index);
       await transform.api.cleanTransformIndices();
+      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
     });
 
     const testDataList: TestData[] = [

--- a/x-pack/test/functional/apps/transform/creation_index_pattern.ts
+++ b/x-pack/test/functional/apps/transform/creation_index_pattern.ts
@@ -32,6 +32,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await transform.api.cleanTransformIndices();
+      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
     });
 
     const testDataList: Array<PivotTransformTestData | LatestTransformTestData> = [

--- a/x-pack/test/functional/apps/transform/creation_runtime_mappings.ts
+++ b/x-pack/test/functional/apps/transform/creation_runtime_mappings.ts
@@ -45,6 +45,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await transform.api.cleanTransformIndices();
+      await transform.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     const histogramCharts: HistogramCharts = [

--- a/x-pack/test/functional/apps/transform/creation_saved_search.ts
+++ b/x-pack/test/functional/apps/transform/creation_saved_search.ts
@@ -32,6 +32,8 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await transform.api.cleanTransformIndices();
+      await transform.testResources.deleteSavedSearches();
+      await transform.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     const testDataList: Array<PivotTransformTestData | LatestTransformTestData> = [

--- a/x-pack/test/functional/apps/transform/deleting.ts
+++ b/x-pack/test/functional/apps/transform/deleting.ts
@@ -81,6 +81,7 @@ export default function ({ getService }: FtrProviderContext) {
         await transform.api.deleteIndices(testData.originalConfig.dest.index);
       }
       await transform.api.cleanTransformIndices();
+      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/transform/editing.ts
+++ b/x-pack/test/functional/apps/transform/editing.ts
@@ -57,6 +57,7 @@ export default function ({ getService }: FtrProviderContext) {
       await transform.testResources.deleteIndexPatternByTitle(transformConfigWithLatest.dest.index);
       await transform.api.deleteIndices(transformConfigWithLatest.dest.index);
       await transform.api.cleanTransformIndices();
+      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
     });
 
     const testDataList = [

--- a/x-pack/test/functional/apps/transform/index.ts
+++ b/x-pack/test/functional/apps/transform/index.ts
@@ -30,11 +30,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await transform.securityCommon.cleanTransformUsers();
       await transform.securityCommon.cleanTransformRoles();
 
-      await transform.testResources.deleteSavedSearches();
-
-      await transform.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
-
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
 

--- a/x-pack/test/functional/apps/transform/permissions/full_transform_access.ts
+++ b/x-pack/test/functional/apps/transform/permissions/full_transform_access.ts
@@ -68,6 +68,7 @@ export default function ({ getService }: FtrProviderContext) {
         );
         await transform.api.deleteIndices(transformConfigWithPivot.dest.index);
         await transform.api.cleanTransformIndices();
+        await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
       });
 
       it('should display elements in the Transform list page correctly', async () => {

--- a/x-pack/test/functional/apps/transform/permissions/read_transform_access.ts
+++ b/x-pack/test/functional/apps/transform/permissions/read_transform_access.ts
@@ -68,6 +68,7 @@ export default function ({ getService }: FtrProviderContext) {
         );
         await transform.api.deleteIndices(transformConfigWithPivot.dest.index);
         await transform.api.cleanTransformIndices();
+        await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
       });
 
       it('should display elements in the Transform list page correctly', async () => {

--- a/x-pack/test/functional/apps/transform/starting.ts
+++ b/x-pack/test/functional/apps/transform/starting.ts
@@ -56,6 +56,7 @@ export default function ({ getService }: FtrProviderContext) {
       }
 
       await transform.api.cleanTransformIndices();
+      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
     });
 
     for (const testData of testDataList) {


### PR DESCRIPTION
## Summary

This PR stabilizes tests that use saved searches be removing the re-use of saved objects from all ML + TFM tests.

### Details

- Data view ids are linked in saved searches. Some of the tests remove and re-create data views, which can (depending on test execution order) break existing saved searches, so follow-up tests that use such a saved search fail. This particularly happened on cloud execution.
- In order to make tests independent from each other, each test that creates a data view or saved search, now also removes it, so the next test has to create a new one.
- Also, this PR reduced duplicated `before` and `after` code in `x-pack/test/functional/apps/ml/index.ts`

Closes #120395
