### PR TITLE
Removes "courier:batchSearches" setting during migration

### DIFF
--- a/src/core/server/ui_settings/saved_objects/migrations.test.ts
+++ b/src/core/server/ui_settings/saved_objects/migrations.test.ts
@@ -210,6 +210,31 @@ describe('ui_settings 8.0.0 migrations', () => {
       migrationVersion: {},
     });
   });
+
+  test('removes "courier:batchSearches" setting', () => {
+    const doc = {
+      type: 'config',
+      id: '8.0.0',
+      attributes: {
+        buildNum: 9007199254740991,
+        'courier:batchSearches': true,
+      },
+      references: [],
+      updated_at: '2020-06-09T20:18:20.349Z',
+      migrationVersion: {},
+    };
+
+    expect(migration(doc)).toEqual({
+      type: 'config',
+      id: '8.0.0',
+      attributes: {
+        buildNum: 9007199254740991,
+      },
+      references: [],
+      updated_at: '2020-06-09T20:18:20.349Z',
+      migrationVersion: {},
+    });
+  });
 });
 
 describe('ui_settings 8.1.0 migrations', () => {

--- a/src/core/server/ui_settings/saved_objects/migrations.ts
+++ b/src/core/server/ui_settings/saved_objects/migrations.ts
@@ -89,6 +89,8 @@ export const migrations = {
             'telemetry:optIn',
             'xPackMonitoring:allowReport',
             'theme:version',
+            // owner: Team:AppServices
+            'courier:batchSearches',
           ].includes(key)
             ? {
                 ...acc,


### PR DESCRIPTION
## Summary

close https://github.com/elastic/kibana/issues/122662



