### PR TITLE
[Fleet] Fix upgrade notice displaying in error

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/utils/has_upgrade_available.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/utils/has_upgrade_available.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import semverGt from 'semver/functions/gt';
+
+import type { UpgradePackagePolicyDryRunResponse } from '../../../../types';
+
+/**
+ * Given a dry run response, determines if a greater version exists in the "proposed"
+ * version of the first package policy in the response.
+ */
+export function hasUpgradeAvailable(dryRunData: UpgradePackagePolicyDryRunResponse) {
+  return (
+    dryRunData &&
+    dryRunData[0].diff &&
+    semverGt(
+      dryRunData[0].diff[1].package?.version ?? '',
+      dryRunData[0].diff[0].package?.version ?? ''
+    )
+  );
+}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/utils/index.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/utils/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './has_upgrade_available';

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/upgrade_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/upgrade_package_policy_page/index.tsx
@@ -30,5 +30,5 @@ export const UpgradePackagePolicyPage = memo(() => {
     from = 'upgrade-from-integrations-policy-list';
   }
 
-  return <EditPackagePolicyForm packagePolicyId={packagePolicyId} from={from} isUpgrade />;
+  return <EditPackagePolicyForm packagePolicyId={packagePolicyId} from={from} forceUpgrade />;
 });

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
@@ -28,7 +28,7 @@ export const Policy = memo(() => {
     <EditPackagePolicyForm
       packagePolicyId={packagePolicyId}
       from="package-edit"
-      isUpgrade={extensionView?.useLatestPackageVersion}
+      forceUpgrade={extensionView?.useLatestPackageVersion}
     />
   );
 });


### PR DESCRIPTION
## Summary

Fixes #122582

Due to changes in the dry run API introduced in https://github.com/elastic/kibana/commit/518726ad54595464b9cd149065ee31b929073372, we can no longer rely on `hasErrors` in the dry run response to determine whether to show the upgrade notice. This PR updates our UI logic to instead compare versions in the resulting dry run diff to determine whether we are in an upgrade state. 

I've also cleared up the naming of our `isUpgrade` prop that's passed in for UI extensions to `forceUpgrade` to more clearly indicate its intended effect. We will now force the UI into the upgrade state if an upgrade is available based on the versions in the dry run diff. Otherwise, we'll display the edit form as normal.


## To test

1. Install an outdated version of synthetics or APM
2. Verify that editing the integration policy displays the "Upgrade available" prompt as expected
3. After completing an upgrade, verify that the "Upgrade available" prompt no longer appears