### PR TITLE
[build] Stabilize download cloud dependencies

### DIFF
--- a/src/dev/build/tasks/download_cloud_dependencies.ts
+++ b/src/dev/build/tasks/download_cloud_dependencies.ts
@@ -15,7 +15,7 @@ export const DownloadCloudDependencies: Task = {
   description: 'Downloading cloud dependencies',
 
   async run(config, log, build) {
-    const downloadBeat = async (beat: string, id) => {
+    const downloadBeat = async (beat: string, id: string) => {
       const subdomain = config.isRelease ? 'artifacts' : 'snapshots';
       const version = config.getBuildVersion();
       const buildId = id.match(/[0-9]\.[0-9]\.[0-9]-[0-9a-z]{8}/);

--- a/src/dev/build/tasks/download_cloud_dependencies.ts
+++ b/src/dev/build/tasks/download_cloud_dependencies.ts
@@ -8,17 +8,20 @@
 
 import Path from 'path';
 import del from 'del';
+import Axios from 'axios';
 import { Task, downloadToDisk, downloadToString } from '../lib';
 
 export const DownloadCloudDependencies: Task = {
   description: 'Downloading cloud dependencies',
 
   async run(config, log, build) {
-    const downloadBeat = async (beat: string) => {
+    const downloadBeat = async (beat: string, id) => {
       const subdomain = config.isRelease ? 'artifacts' : 'snapshots';
       const version = config.getBuildVersion();
+      const buildId = id.match(/[0-9]\.[0-9]\.[0-9]-[0-9a-z]{8}/);
+      const buildIdUrl = buildId ? `${buildId[0]}/` : '';
       const architecture = process.arch === 'arm64' ? 'arm64' : 'x86_64';
-      const url = `https://${subdomain}-no-kpi.elastic.co/downloads/beats/${beat}/${beat}-${version}-linux-${architecture}.tar.gz`;
+      const url = `https://${subdomain}-no-kpi.elastic.co/${buildIdUrl}downloads/beats/${beat}/${beat}-${version}-linux-${architecture}.tar.gz`;
       const checksum = await downloadToString({ log, url: url + '.sha512', expectStatus: 200 });
       const destination = config.resolveFromRepo('.beats', Path.basename(url));
       return downloadToDisk({
@@ -31,8 +34,15 @@ export const DownloadCloudDependencies: Task = {
       });
     };
 
+    let buildId = '';
+    if (!config.isRelease) {
+      const manifest = await Axios.get(
+        `https://artifacts-api.elastic.co/v1/versions/${config.getBuildVersion()}/builds/latest`
+      );
+      buildId = manifest.data.build.build_id;
+    }
     await del([config.resolveFromRepo('.beats')]);
-    await downloadBeat('metricbeat');
-    await downloadBeat('filebeat');
+    await downloadBeat('metricbeat', buildId);
+    await downloadBeat('filebeat', buildId);
   },
 };


### PR DESCRIPTION
Currently metricbeat and filebeat are downloaded from a bucket pointing
to the latest snapshot.  We're seeing occasional timing errors where the
shasum doesn't match the artifact when a build is in progress.  Instead
of using the redirect, this grabs the most recent build id to point to a
consistent bucket.