### PR TITLE
[7.17] Change `elasticsearch.username: elastic` deprecation level to critical

### DIFF
--- a/src/core/server/elasticsearch/elasticsearch_config.test.ts
+++ b/src/core/server/elasticsearch/elasticsearch_config.test.ts
@@ -289,22 +289,24 @@ describe('throws when config is invalid', () => {
 });
 
 describe('deprecations', () => {
-  it('logs a warning if elasticsearch.username is set to "elastic"', () => {
-    const { messages } = applyElasticsearchDeprecations({ username: 'elastic' });
+  it('logs a critical deprecation if elasticsearch.username is set to "elastic"', () => {
+    const { messages, levels } = applyElasticsearchDeprecations({ username: 'elastic' });
     expect(messages).toMatchInlineSnapshot(`
       Array [
         "Kibana is configured to authenticate to Elasticsearch with the \\"elastic\\" user. Use a service account token instead.",
       ]
     `);
+    expect(levels).toEqual(['critical']);
   });
 
   it('logs a warning if elasticsearch.username is set to "kibana"', () => {
-    const { messages } = applyElasticsearchDeprecations({ username: 'kibana' });
+    const { messages, levels } = applyElasticsearchDeprecations({ username: 'kibana' });
     expect(messages).toMatchInlineSnapshot(`
       Array [
         "Kibana is configured to authenticate to Elasticsearch with the \\"kibana\\" user. Use a service account token instead.",
       ]
     `);
+    expect(levels).toEqual(['warning']);
   });
 
   it('does not log a warning if elasticsearch.username is set to something besides "elastic" or "kibana"', () => {

--- a/src/core/server/elasticsearch/elasticsearch_config.ts
+++ b/src/core/server/elasticsearch/elasticsearch_config.ts
@@ -147,6 +147,7 @@ const deprecations: ConfigDeprecationProvider = () => [
 
     if (es.username === 'elastic' || es.username === 'kibana') {
       const username = es.username;
+      const level = es.username === 'elastic' ? 'critical' : 'warning';
       addDeprecation({
         configPath: `${fromPath}.username`,
         title: i18n.translate('core.deprecations.elasticsearchUsername.title', {
@@ -158,7 +159,7 @@ const deprecations: ConfigDeprecationProvider = () => [
             'Kibana is configured to authenticate to Elasticsearch with the "{username}" user. Use a service account token instead.',
           values: { username },
         }),
-        level: 'warning',
+        level,
         documentationUrl: `https://www.elastic.co/guide/en/elasticsearch/reference/${branch}/service-accounts.html`,
         correctiveActions: {
           manualSteps: [


### PR DESCRIPTION
Resolves #122704.

This changes the warning in the upgrade assistant:

![image](https://user-images.githubusercontent.com/5295965/149025265-9f8c4f51-4939-493f-a367-7307eb8cd3a8.png)

### Testing

Kibana normally forbids you from using this config when running from source.
First, temporarily remove that validation:

```diff
diff --git a/src/core/server/elasticsearch/elasticsearch_config.ts b/src/core/server/elasticsearch/elasticsearch_config.ts
index 96b3bdcad1d..5f47092f95e 100644
--- a/src/core/server/elasticsearch/elasticsearch_config.ts
+++ b/src/core/server/elasticsearch/elasticsearch_config.ts
@@ -41,6 +41,7 @@ export const configSchema = schema.object({
       false,
       schema.string({
         validate: (rawConfig) => {
+          return; // don't throw an error here when running from source
           if (rawConfig === 'elastic') {
             return (
               'value of "elastic" is forbidden. This is a superuser account that can obfuscate ' +
```

Then, add this config to your kibana.yml:

```yml
elasticsearch.username: elastic
elasticsearch.password: changeme
```

Start Elasticsearch and Kibana, log into Kibana, and navigate to the upgrade assistant. You should see the critical deprecation there.

The upgrade assistant is at this route: http://localhost:5601/app/management/stack/upgrade_assistant/kibana_deprecations

8.1 companion PR: #122722 (will be backported to 8.0)