### PR TITLE
Forbid using `elasticsearch.username: elastic` in production

### DIFF
--- a/src/core/server/core_usage_data/core_usage_data_service.test.ts
+++ b/src/core/server/core_usage_data/core_usage_data_service.test.ts
@@ -435,10 +435,6 @@ describe('CoreUsageDataService', () => {
           );
         }
 
-        it('returns expected usage data for elastic.username "elastic"', async () => {
-          return doTest({ username: 'elastic', expectedPrincipal: 'elastic_user' });
-        });
-
         it('returns expected usage data for elastic.username "kibana"', async () => {
           return doTest({ username: 'kibana', expectedPrincipal: 'kibana_user' });
         });

--- a/src/core/server/core_usage_data/core_usage_data_service.ts
+++ b/src/core/server/core_usage_data/core_usage_data_service.ts
@@ -530,7 +530,6 @@ function getEsPrincipalUsage({ username, serviceAccountToken }: ElasticsearchCon
   let value: CoreConfigUsageData['elasticsearch']['principal'] = 'unknown';
   if (isConfigured.string(username)) {
     switch (username) {
-      case 'elastic': // deprecated
       case 'kibana': // deprecated
       case 'kibana_system':
         value = `${username}_user` as const;

--- a/src/core/server/elasticsearch/elasticsearch_config.test.ts
+++ b/src/core/server/elasticsearch/elasticsearch_config.test.ts
@@ -318,15 +318,6 @@ describe('throws when config is invalid', () => {
 });
 
 describe('deprecations', () => {
-  it('logs a warning if elasticsearch.username is set to "elastic"', () => {
-    const { messages } = applyElasticsearchDeprecations({ username: 'elastic' });
-    expect(messages).toMatchInlineSnapshot(`
-      Array [
-        "Kibana is configured to authenticate to Elasticsearch with the \\"elastic\\" user. Use a service account token instead.",
-      ]
-    `);
-  });
-
   it('logs a warning if elasticsearch.username is set to "kibana"', () => {
     const { messages } = applyElasticsearchDeprecations({ username: 'kibana' });
     expect(messages).toMatchInlineSnapshot(`
@@ -370,19 +361,17 @@ describe('deprecations', () => {
   });
 });
 
-test('#username throws if equal to "elastic", only while running from source', () => {
+test('#username throws if equal to "elastic"', () => {
   const obj = {
     username: 'elastic',
   };
-  expect(() => config.schema.validate(obj, { dist: false })).toThrowErrorMatchingInlineSnapshot(
-    `"[username]: value of \\"elastic\\" is forbidden. This is a superuser account that can obfuscate privilege-related issues. You should use the \\"kibana_system\\" user instead."`
-  );
-  expect(() => config.schema.validate(obj, { dist: true })).not.toThrow();
+
+  expect(() => config.schema.validate(obj)).toThrow('[username]: value of "elastic" is forbidden');
 });
 
 test('serviceAccountToken throws if username is also set', () => {
   const obj = {
-    username: 'elastic',
+    username: 'kibana',
     serviceAccountToken: 'abc123',
   };
 

--- a/src/core/server/elasticsearch/elasticsearch_config.ts
+++ b/src/core/server/elasticsearch/elasticsearch_config.ts
@@ -37,21 +37,17 @@ export const configSchema = schema.object({
     defaultValue: 'http://localhost:9200',
   }),
   username: schema.maybe(
-    schema.conditional(
-      schema.contextRef('dist'),
-      false,
-      schema.string({
-        validate: (rawConfig) => {
-          if (rawConfig === 'elastic') {
-            return (
-              'value of "elastic" is forbidden. This is a superuser account that can obfuscate ' +
-              'privilege-related issues. You should use the "kibana_system" user instead.'
-            );
-          }
-        },
-      }),
-      schema.string()
-    )
+    schema.string({
+      validate: (rawConfig) => {
+        if (rawConfig === 'elastic') {
+          return (
+            'value of "elastic" is forbidden. This is a superuser account that cannot write to system indices that Kibana needs to ' +
+            'function. Use a service account token instead. Learn more: ' +
+            'https://www.elastic.co/guide/en/elasticsearch/reference/8.0/service-accounts.html' // we don't have a way to pass a branch into the config schema; hardcoding this one link to the 8.0 docs is OK
+          );
+        }
+      },
+    })
   ),
   password: schema.maybe(schema.string()),
   serviceAccountToken: schema.maybe(
@@ -178,7 +174,7 @@ const deprecations: ConfigDeprecationProvider = () => [
       return;
     }
 
-    if (es.username === 'elastic' || es.username === 'kibana') {
+    if (es.username === 'kibana') {
       const username = es.username;
       addDeprecation({
         configPath: `${fromPath}.username`,


### PR DESCRIPTION
Resolves #51101.

This was already forbidden when running Kibana from source, now it is also forbidden when running Kibana from the distribution (i.e., in production).

If you configure Kibana with `elasticsearch.username: elastic`, it will crash with the following error:

> [2022-01-11T17:18:15.527-05:00][FATAL][root] Error: [config validation of [elasticsearch].username]: value of "elastic" is forbidden. This is a superuser account that cannot write to system indices that Kibana needs to function. Use a service account token instead. Learn more: https://www.elastic.co/guide/en/elasticsearch/reference/8.0/service-accounts.html
>     at ensureValidConfiguration (/Users/joe/GitHub/kibana-2/src/core/server/config/ensure_valid_configuration.ts:24:11)
>     at Server.preboot (/Users/joe/GitHub/kibana-2/src/core/server/server.ts:140:5)
>     at Root.preboot (/Users/joe/GitHub/kibana-2/src/core/server/root/index.ts:42:14)
>     at bootstrap (/Users/joe/GitHub/kibana-2/src/core/server/bootstrap.ts:84:25)
>     at Command.<anonymous> (/Users/joe/GitHub/kibana-2/src/cli/serve/serve.js:244:5)

7.17 companion PR: #122717

-----

8.0 release note: Kibana can no longer use the `elastic` superuser to authenticate to Elasticsearch (configuring `elasticsearch.username: elastic` is forbidden).