### PR TITLE
[DOCS] Removes coming tag from 8.0.0-rc1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -19,8 +19,6 @@ Review important information about the {kib} 8.0.0 releases.
 [[release-notes-8.0.0-rc1]]
 == {kib} 8.0.0-rc1
 
-coming::[8.0.0-rc1]
-
 Review the {kib} 8.0.0-rc1 changes, then use the <<upgrade-assistant,Upgrade Assistant>> to complete the upgrade.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the coming tag from the 8.0.0-rc1 release notes.