### PR TITLE
[7.16] [ftr] document flaky test runner (#122721)

### DIFF
--- a/docs/developer/contributing/development-functional-tests.asciidoc
+++ b/docs/developer/contributing/development-functional-tests.asciidoc
@@ -515,3 +515,12 @@ macOS users on a machine with a discrete graphics card may see significant speed
 * Open "Advanced GPU Settings..."
 * Uncheck the "Prefer integrated to discrete GPU" option
 * Restart iTerm
+
+[discrete]
+== Flaky Test Runner
+
+If your functional tests are flaky then the Operations team might skip them and ask that you make them less flaky before enabling them once again. This process usually involves looking at the failures which are logged on the relevant Github issue and finding incorrect assumptions or conditions which need to be awaited at some point in the test. To determine if your changes make the test fail less often you can run your tests in the Flaky Test Runner. This tool runs up to 500 executions of a specific ciGroup. To start a build of the Flaky Test Runner create a PR with your changes and then visit https://ci-stats.kibana.dev/trigger_flaky_test_runner, select your PR, choose the CI Group that your tests are in, and trigger the build.
+
+This will take you to Buildkite where your build will run and tell you if it failed in any execution.
+
+A flaky test may only fail once in 1000 runs, so keep this in mind and make sure you use enough executions to really prove that a test isn't flaky anymore.


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.16` of:
 - #122721

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
