### PR TITLE
[ResponseOps] Migrate EUI CodeEditor in the triggers actions ui to use the monaco based editor

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/code_editor.mock.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/code_editor.mock.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+
+export const mockEditorInstance = {
+  executeEdits: () => {},
+  getSelection: () => {},
+  getValue: () => {},
+  onDidBlurEditorWidget: () => ({
+    dispose: () => {},
+  }),
+};
+
+export const MockCodeEditor = (props: any) => {
+  const { editorDidMount } = props;
+  useEffect(() => {
+    editorDidMount(mockEditorInstance);
+  }, [editorDidMount]);
+
+  return (
+    <input
+      data-test-subj={props['data-test-subj'] || 'mockCodeEditor'}
+      data-value={props.value}
+      value={props.value}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        props.onChange(e.target.value);
+      }}
+    />
+  );
+};

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/es_index/es_index_params.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/es_index/es_index_params.test.tsx
@@ -10,8 +10,21 @@ import { mountWithIntl, nextTick } from '@kbn/test/jest';
 import { act } from '@testing-library/react';
 import ParamsFields from './es_index_params';
 import { AlertHistoryEsIndexConnectorId } from '../../../../types';
+import { MockCodeEditor } from '../../../code_editor.mock';
+
+const kibanaReactPath = '../../../../../../../../src/plugins/kibana_react/public';
 
 jest.mock('../../../../common/lib/kibana');
+
+jest.mock(kibanaReactPath, () => {
+  const original = jest.requireActual(kibanaReactPath);
+  return {
+    ...original,
+    CodeEditor: (props: any) => {
+      return <MockCodeEditor {...props} />;
+    },
+  };
+});
 
 const actionConnector = {
   actionTypeId: '.index',

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/webhook/webhook_params.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/webhook/webhook_params.test.tsx
@@ -8,6 +8,19 @@
 import React from 'react';
 import { mountWithIntl } from '@kbn/test/jest';
 import WebhookParamsFields from './webhook_params';
+import { MockCodeEditor } from '../../../code_editor.mock';
+
+const kibanaReactPath = '../../../../../../../../src/plugins/kibana_react/public';
+
+jest.mock(kibanaReactPath, () => {
+  const original = jest.requireActual(kibanaReactPath);
+  return {
+    ...original,
+    CodeEditor: (props: any) => {
+      return <MockCodeEditor {...props} />;
+    },
+  };
+});
 
 describe('WebhookParamsFields renders', () => {
   test('all params fields is rendered', () => {

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/json_editor_with_message_variables.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/json_editor_with_message_variables.test.tsx
@@ -4,10 +4,46 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import React from 'react';
+import React, { useEffect } from 'react';
 import { mountWithIntl } from '@kbn/test/jest';
 import { JsonEditorWithMessageVariables } from './json_editor_with_message_variables';
+
+const mockEditorInstance = {
+  executeEdits: () => {},
+  getSelection: () => {},
+  getValue: () => {},
+  onDidBlurEditorWidget: () => ({
+    dispose: () => {},
+  }),
+};
+
+const MockCodeEditor = (props: any) => {
+  const { editorDidMount } = props;
+  useEffect(() => {
+    editorDidMount(mockEditorInstance);
+  }, [editorDidMount]);
+
+  return (
+    <input
+      data-test-subj={props['data-test-subj'] || 'mockCodeEditor'}
+      data-value={props.value}
+      value={props.value}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        props.onChange(e.target.value);
+      }}
+    />
+  );
+};
+
+jest.mock('../../../../../../src/plugins/kibana_react/public', () => {
+  const original = jest.requireActual('../../../../../../src/plugins/kibana_react/public');
+  return {
+    ...original,
+    CodeEditor: (props: any) => {
+      return <MockCodeEditor {...props} />;
+    },
+  };
+});
 
 describe('JsonEditorWithMessageVariables', () => {
   const onDocumentsChange = jest.fn();

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/json_editor_with_message_variables.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/json_editor_with_message_variables.test.tsx
@@ -4,39 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useEffect } from 'react';
+import React from 'react';
 import { mountWithIntl } from '@kbn/test/jest';
 import { JsonEditorWithMessageVariables } from './json_editor_with_message_variables';
+import { MockCodeEditor } from '../code_editor.mock';
 
-const mockEditorInstance = {
-  executeEdits: () => {},
-  getSelection: () => {},
-  getValue: () => {},
-  onDidBlurEditorWidget: () => ({
-    dispose: () => {},
-  }),
-};
+const kibanaReactPath = '../../../../../../src/plugins/kibana_react/public';
 
-const MockCodeEditor = (props: any) => {
-  const { editorDidMount } = props;
-  useEffect(() => {
-    editorDidMount(mockEditorInstance);
-  }, [editorDidMount]);
-
-  return (
-    <input
-      data-test-subj={props['data-test-subj'] || 'mockCodeEditor'}
-      data-value={props.value}
-      value={props.value}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-        props.onChange(e.target.value);
-      }}
-    />
-  );
-};
-
-jest.mock('../../../../../../src/plugins/kibana_react/public', () => {
-  const original = jest.requireActual('../../../../../../src/plugins/kibana_react/public');
+jest.mock(kibanaReactPath, () => {
+  const original = jest.requireActual(kibanaReactPath);
   return {
     ...original,
     CodeEditor: (props: any) => {

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/json_editor_with_message_variables.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/json_editor_with_message_variables.tsx
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { EuiFormRow } from '@elastic/eui';
 
-import { XJsonMode } from '@kbn/ace';
-import 'brace/theme/github';
+import { monaco, XJsonLang } from '@kbn/monaco';
 
 import './add_message_variables.scss';
-import { XJson, EuiCodeEditor } from '../../../../../../src/plugins/es_ui_shared/public';
+import { XJson } from '../../../../../../src/plugins/es_ui_shared/public';
+import { CodeEditor } from '../../../../../../src/plugins/kibana_react/public';
 
 import { AddMessageVariables } from './add_message_variables';
 import { ActionVariable } from '../../../../alerting/common';
@@ -31,7 +31,8 @@ interface Props {
 }
 
 const { useXJsonMode } = XJson;
-const xJsonMode = new XJsonMode();
+// Source used to insert text imperatively into the code editor
+const EDITOR_SOURCE = 'json-editor-with-message-variables';
 
 export const JsonEditorWithMessageVariables: React.FunctionComponent<Props> = ({
   messageVariables,
@@ -44,17 +45,28 @@ export const JsonEditorWithMessageVariables: React.FunctionComponent<Props> = ({
   helpText,
   onBlur,
 }) => {
-  const [cursorPosition, setCursorPosition] = useState<any>(null);
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
+  const editorDisposables = useRef<monaco.IDisposable[]>([]);
 
   const { convertToJson, setXJson, xJson } = useXJsonMode(inputTargetValue ?? null);
 
   const onSelectMessageVariable = (variable: ActionVariable) => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    const cursorPosition = editor.getSelection();
     const templatedVar = templateActionVariable(variable);
+
     let newValue = '';
     if (cursorPosition) {
-      const cursor = cursorPosition.getCursor();
-      cursorPosition.session.insert(cursor, templatedVar);
-      newValue = cursorPosition.session.getValue();
+      editor.executeEdits(EDITOR_SOURCE, [
+        {
+          range: cursorPosition,
+          text: templatedVar,
+        },
+      ]);
+      newValue = editor.getValue();
     } else {
       newValue = templatedVar;
     }
@@ -63,9 +75,34 @@ export const JsonEditorWithMessageVariables: React.FunctionComponent<Props> = ({
     onDocumentsChange(convertToJson(newValue));
   };
 
-  const onClickWithMessageVariable = (_value: any) => {
-    setCursorPosition(_value);
+  const registerEditorListeners = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    editorDisposables.current.push(
+      editor.onDidBlurEditorWidget(() => {
+        onBlur?.();
+      })
+    );
+  }, [onBlur]);
+
+  const unregisterEditorListeners = () => {
+    editorDisposables.current.forEach((d) => {
+      d.dispose();
+    });
+    editorDisposables.current = [];
   };
+
+  const onEditorMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
+    editorRef.current = editor;
+    registerEditorListeners();
+  };
+
+  useEffect(() => {
+    registerEditorListeners();
+    return () => unregisterEditorListeners();
+  }, [registerEditorListeners]);
 
   return (
     <EuiFormRow
@@ -82,21 +119,32 @@ export const JsonEditorWithMessageVariables: React.FunctionComponent<Props> = ({
       }
       helpText={helpText}
     >
-      <EuiCodeEditor
-        mode={xJsonMode}
+      <CodeEditor
+        languageId={XJsonLang.ID}
+        options={{
+          renderValidationDecorations: xJson ? 'on' : 'off', // Disable error underline when empty
+          lineNumbers: 'on',
+          fontSize: 14,
+          minimap: {
+            enabled: false,
+          },
+          scrollBeyondLastLine: false,
+          folding: true,
+          wordWrap: 'on',
+          wrappingIndent: 'indent',
+          automaticLayout: true,
+        }}
+        value={xJson}
         width="100%"
         height="200px"
-        theme="github"
         data-test-subj={`${paramsProperty}JsonEditor`}
         aria-label={areaLabel}
-        value={xJson}
-        onChange={(xjson: string, e: any) => {
+        editorDidMount={onEditorMount}
+        onChange={(xjson: string) => {
           setXJson(xjson);
           // Keep the documents in sync with the editor content
           onDocumentsChange(convertToJson(xjson));
         }}
-        onCursorChange={(_value: any) => onClickWithMessageVariable(_value)}
-        onBlur={onBlur}
       />
     </EuiFormRow>
   );

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/json_editor_with_message_variables.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/json_editor_with_message_variables.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useRef } from 'react';
-import { EuiFormRow } from '@elastic/eui';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { EuiFormRow, EuiCallOut, EuiSpacer } from '@elastic/eui';
 
+import { i18n } from '@kbn/i18n';
 import { monaco, XJsonLang } from '@kbn/monaco';
 
 import './add_message_variables.scss';
@@ -17,6 +18,20 @@ import { CodeEditor } from '../../../../../../src/plugins/kibana_react/public';
 import { AddMessageVariables } from './add_message_variables';
 import { ActionVariable } from '../../../../alerting/common';
 import { templateActionVariable } from '../lib';
+
+const NO_EDITOR_ERROR_TITLE = i18n.translate(
+  'xpack.triggersActionsUI.components.jsonEditorWithMessageVariable.noEditorErrorTitle',
+  {
+    defaultMessage: 'Unable to add message variable',
+  }
+);
+
+const NO_EDITOR_ERROR_MESSAGE = i18n.translate(
+  'xpack.triggersActionsUI.components.jsonEditorWithMessageVariable.noEditorErrorMessage',
+  {
+    defaultMessage: 'Editor was not found, please refresh page and try again',
+  }
+);
 
 interface Props {
   messageVariables?: ActionVariable[];
@@ -31,7 +46,10 @@ interface Props {
 }
 
 const { useXJsonMode } = XJson;
-// Source used to insert text imperatively into the code editor
+
+// Source ID used to insert text imperatively into the code editor,
+// this value is only used to uniquely identify any single edit attempt.
+// Multiple editors can use the same ID without any issues.
 const EDITOR_SOURCE = 'json-editor-with-message-variables';
 
 export const JsonEditorWithMessageVariables: React.FunctionComponent<Props> = ({
@@ -47,12 +65,14 @@ export const JsonEditorWithMessageVariables: React.FunctionComponent<Props> = ({
 }) => {
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
   const editorDisposables = useRef<monaco.IDisposable[]>([]);
+  const [showErrorMessage, setShowErrorMessage] = useState(false);
 
   const { convertToJson, setXJson, xJson } = useXJsonMode(inputTargetValue ?? null);
 
   const onSelectMessageVariable = (variable: ActionVariable) => {
     const editor = editorRef.current;
     if (!editor) {
+      setShowErrorMessage(true);
       return;
     }
     const cursorPosition = editor.getSelection();
@@ -70,6 +90,7 @@ export const JsonEditorWithMessageVariables: React.FunctionComponent<Props> = ({
     } else {
       newValue = templatedVar;
     }
+    setShowErrorMessage(false);
     setXJson(newValue);
     // Keep the documents in sync with the editor content
     onDocumentsChange(convertToJson(newValue));
@@ -99,6 +120,21 @@ export const JsonEditorWithMessageVariables: React.FunctionComponent<Props> = ({
     registerEditorListeners();
   };
 
+  const renderErrorMessage = () => {
+    if (!showErrorMessage) {
+      return null;
+    }
+    return (
+      <>
+        <EuiSpacer size="s" />
+        <EuiCallOut size="s" color="danger" iconType="alert" title={NO_EDITOR_ERROR_TITLE}>
+          <p>{NO_EDITOR_ERROR_MESSAGE}</p>
+        </EuiCallOut>
+        <EuiSpacer size="s" />
+      </>
+    );
+  };
+
   useEffect(() => {
     registerEditorListeners();
     return () => unregisterEditorListeners();
@@ -119,33 +155,36 @@ export const JsonEditorWithMessageVariables: React.FunctionComponent<Props> = ({
       }
       helpText={helpText}
     >
-      <CodeEditor
-        languageId={XJsonLang.ID}
-        options={{
-          renderValidationDecorations: xJson ? 'on' : 'off', // Disable error underline when empty
-          lineNumbers: 'on',
-          fontSize: 14,
-          minimap: {
-            enabled: false,
-          },
-          scrollBeyondLastLine: false,
-          folding: true,
-          wordWrap: 'on',
-          wrappingIndent: 'indent',
-          automaticLayout: true,
-        }}
-        value={xJson}
-        width="100%"
-        height="200px"
-        data-test-subj={`${paramsProperty}JsonEditor`}
-        aria-label={areaLabel}
-        editorDidMount={onEditorMount}
-        onChange={(xjson: string) => {
-          setXJson(xjson);
-          // Keep the documents in sync with the editor content
-          onDocumentsChange(convertToJson(xjson));
-        }}
-      />
+      <>
+        {renderErrorMessage()}
+        <CodeEditor
+          languageId={XJsonLang.ID}
+          options={{
+            renderValidationDecorations: xJson ? 'on' : 'off', // Disable error underline when empty
+            lineNumbers: 'on',
+            fontSize: 14,
+            minimap: {
+              enabled: false,
+            },
+            scrollBeyondLastLine: false,
+            folding: true,
+            wordWrap: 'on',
+            wrappingIndent: 'indent',
+            automaticLayout: true,
+          }}
+          value={xJson}
+          width="100%"
+          height="200px"
+          data-test-subj={`${paramsProperty}JsonEditor`}
+          aria-label={areaLabel}
+          editorDidMount={onEditorMount}
+          onChange={(xjson: string) => {
+            setXJson(xjson);
+            // Keep the documents in sync with the editor content
+            onDocumentsChange(convertToJson(xjson));
+          }}
+        />
+      </>
     </EuiFormRow>
   );
 };


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/107203

The JSON code editor in the triggers actions UI now uses the monaco based editor.

![Screenshot from 2022-01-11 16-51-25](https://user-images.githubusercontent.com/74562234/149044468-67ed9258-c63b-4f07-b24a-6c3e904c4f61.png)

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
