### PR TITLE
[ML] Functional tests - reduce setup module test execution time

### DIFF
--- a/x-pack/test/api_integration/apis/ml/modules/setup_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/setup_module.ts
@@ -69,7 +69,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf2_',
         indexPatternName: 'ft_module_sample_logs',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1585576710000,
       },
       expected: {
         responseCode: 200,
@@ -106,7 +106,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf3_',
         indexPatternName: 'ft_module_apache',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1536933580000,
       },
       expected: {
         responseCode: 200,
@@ -161,7 +161,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf5_',
         indexPatternName: 'ft_module_apm_transaction',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1632925220000,
       },
       expected: {
         responseCode: 200,
@@ -188,7 +188,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf6_',
         indexPatternName: 'ft_module_logs',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1556570920000,
       },
       expected: {
         responseCode: 200,
@@ -215,7 +215,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf7_',
         indexPatternName: 'ft_module_logs',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1556570920000,
       },
       expected: {
         responseCode: 200,
@@ -241,7 +241,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf8_',
         indexPatternName: 'ft_module_nginx',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1542372260000,
       },
       expected: {
         responseCode: 200,
@@ -296,7 +296,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf9_',
         indexPatternName: 'ft_module_sample_ecommerce',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1585260210000,
       },
       expected: {
         responseCode: 200,
@@ -323,7 +323,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf11_',
         indexPatternName: 'ft_module_siem_auditbeat',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1566403650000,
       },
       expected: {
         responseCode: 200,
@@ -350,7 +350,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf12_',
         indexPatternName: 'ft_module_siem_packetbeat',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1588688580000,
       },
       expected: {
         responseCode: 200,
@@ -397,7 +397,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf13_',
         indexPatternName: 'ft_module_heartbeat',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1584117860000,
       },
       expected: {
         responseCode: 200,
@@ -424,7 +424,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf14_',
         indexPatternName: 'ft_module_auditbeat',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1597847410000,
       },
       expected: {
         responseCode: 200,
@@ -463,7 +463,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf15_',
         indexPatternName: 'ft_logs-endpoint.events.*',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1606858680000,
       },
       expected: {
         responseCode: 200,
@@ -515,7 +515,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf16_',
         indexPatternName: 'ft_logs-endpoint.events.*',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1606858580000,
       },
       expected: {
         responseCode: 200,
@@ -577,7 +577,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf17_',
         indexPatternName: 'ft_module_metricbeat',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1554501720000,
       },
       expected: {
         responseCode: 200,
@@ -614,7 +614,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf18_',
         indexPatternName: 'ft_module_metrics_ui',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1599762970000,
       },
       expected: {
         responseCode: 200,
@@ -651,7 +651,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf19_',
         indexPatternName: 'ft_module_metrics_ui',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1599763000000,
       },
       expected: {
         responseCode: 200,
@@ -688,7 +688,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf20_',
         indexPatternName: 'ft_module_siem_cloudtrail',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1594231870000,
       },
       expected: {
         responseCode: 200,
@@ -735,7 +735,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf21_',
         indexPatternName: 'ft_module_siem_winlogbeat',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1595382280000,
       },
       expected: {
         responseCode: 200,
@@ -812,7 +812,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf22_',
         indexPatternName: 'ft_module_siem_winlogbeat',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1566321950000,
       },
       expected: {
         responseCode: 200,
@@ -839,7 +839,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf23_',
         indexPatternName: 'ft_module_apache_data_stream',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1536933580000,
       },
       expected: {
         responseCode: 200,
@@ -886,7 +886,7 @@ export default ({ getService }: FtrProviderContext) => {
         prefix: 'pf24_',
         indexPatternName: 'ft_module_nginx_data_stream',
         startDatafeed: true,
-        end: Date.now(),
+        end: 1542372260000,
       },
       expected: {
         responseCode: 200,


### PR DESCRIPTION
## Summary

This PR stabilizes the setup module tests in cloud by reducing the execution time.

### Details

- When running the setup module tests on cloud, we sometimes hit the 4 minutes timeout for a job to finish, particularly for the `metrics_ui_hosts` and `metrics_ui_k8s` modules.
- An investigation showed that datafeeds with date histogram aggs don't stop on the last document but continue to run to the end date specified in the datafeed start request. With the small chunking config in some of these jobs and the test starting the datafeed with end date `now`, the jobs had to go through lots of empty time buckets, which cause a long job run time.
- While there are ideas how to optimize this kind of scenario on the backend side, we want to adjust the tests, so they're  stable on cloud.
- With this PR, the setup module tests don't start the datafeed until `now` anymore, but provide an end date close to the last record timestamp (rounded up the next 10 seconds for simpler numbers). This brings it closer to the way how module jobs are started from the UI, where we use the full source data time range by default.

### Test execution time changes

In the following list we can see how the test execution time changed on my local machine for each of the modules. It's overall mostly the same within 1 or 2 seconds, which I consider usual timing changes between test runs. But the `metrics_ui_hosts` and `metrics_ui_k8s` test execution time went down from > 1.5 minutes (which easily took more than 5 minutes on cloud) to less than 10 seconds.

module id | old time in ms | new time in ms
---|---|---
sample_data_weblogs | 5953 | 5615
apache_ecs | 22931 | 22390
apm_transaction | 4565 | 4317
logs_ui_analysis | 10642 | 9745
logs_ui_categories | 16731 | 15729
nginx_ecs | 8221 | 8215
sample_data_ecommerce | 9031 | 9183
siem_auditbeat_auth | 3999 | 4034
siem_packetbeat | 8365 | 8503
uptime_heartbeat | 4098 | 4015
auditbeat_process_hosts_ecs | 8276 | 7694
security_linux | 9965 | 10001
security_windows | 12398 | 12792
metricbeat_system_ecs | 5923 | 6896
metrics_ui_hosts | 90695 | 7627
metrics_ui_k8s | 101119 | 8163
siem_cloudtrail | 8659 | 8697
siem_winlogbeat | 19233 | 17461
siem_winlogbeat_auth | 4067 | 3679
apache_data_stream | 23737 | 22542
nginx_data_stream | 8666 | 8736
