### PR TITLE
[Fleet] fixed bug with policy upgrade and updated vars

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -187,7 +187,24 @@ export const EditPackagePolicyForm = memo<{
             ...restOfPackagePolicy,
             inputs: baseInputs.map((input: any) => {
               // Remove `compiled_input` from all input info, we assign this after saving
-              const { streams, compiled_input: compiledInput, ...restOfInput } = input;
+              const { streams, compiled_input: compiledInput, vars, ...restOfInput } = input;
+              let basePolicyInputVars: any =
+                isUpgrade &&
+                basePolicy.inputs.find(
+                  (i) => i.type === input.type && i.policy_template === input.policy_template
+                )?.vars;
+              let newVars = vars;
+              if (basePolicyInputVars && vars) {
+                // merging vars from dry run with updated ones
+                basePolicyInputVars = Object.keys(vars).reduce(
+                  (acc, curr) => ({ ...acc, [curr]: basePolicyInputVars[curr] }),
+                  {}
+                );
+                newVars = {
+                  ...vars,
+                  ...basePolicyInputVars,
+                };
+              }
               return {
                 ...restOfInput,
                 streams: streams.map((stream: any) => {
@@ -195,6 +212,7 @@ export const EditPackagePolicyForm = memo<{
                   const { compiled_stream, ...restOfStream } = stream;
                   return restOfStream;
                 }),
+                vars: newVars,
               };
             }),
             package: basePackage,


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/122436

Merging policy input vars from Edit integration with upgrade dry run result to make sure changes are persisted.

Steps to verify:

1. Go to /app/fleet/policies -> Default Fleet Server policy -> Add Elastic APM integration -> Edit integration

2. Disable the RUM settings and save/deploy the integration.

3. Edit the Elastic APM integration again and verify that RUM is disabled

