### PR TITLE
[8.0] [DOCS] Removes coming tag from 8.0.0-rc1 release notes (#122725)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -19,8 +19,6 @@ Review important information about the {kib} 8.0.0 releases.
 [[release-notes-8.0.0-rc1]]
 == {kib} 8.0.0-rc1
 
-coming::[8.0.0-rc1]
-
 Review the {kib} 8.0.0-rc1 changes, then use the <<upgrade-assistant,Upgrade Assistant>> to complete the upgrade.
 
 [float]


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #122725

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
