### PR TITLE
Updating host risk score index pattern

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/constants.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/constants.ts
@@ -122,7 +122,7 @@ export const DATA_DATASETS_INDEX_PATTERNS = [
   { pattern: '*meow*', patternName: 'meow' },
 
   // experimental ml
-  { pattern: '*host_risk_score_latest', patternName: 'host_risk_score' },
+  { pattern: 'ml_host_risk_score_latest_*', patternName: 'host_risk_score' },
 ] as const;
 
 // Get the unique list of index patterns (some are duplicated for documentation purposes)

--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
@@ -72,7 +72,8 @@ describe('get_data_telemetry', () => {
           { name: 'metricbeat-1234', docCount: 100, sizeInBytes: 10, isECS: false },
           { name: '.app-search-1234', docCount: 0 },
           { name: 'logs-endpoint.1234', docCount: 0 }, // Matching pattern with a dot in the name
-          { name: 'ml_host_risk_score_latest', docCount: 0 },
+          { name: 'ml_host_risk_score_latest_default', docCount: 0 },
+          { name: 'ml_host_risk_score_latest', docCount: 0 }, // This should not match,
           { name: 'ml_host_risk_score', docCount: 0 }, // This should not match
           // New Indexing strategy: everything can be inferred from the constant_keyword values
           {


### PR DESCRIPTION
## Summary

In [this](https://github.com/elastic/kibana/pull/108547) PR, we had added an index pattern (`*host_risk_score_latest`) to track the adoption of an experimental prototype of [Host Risk Score](https://github.com/elastic/dreml/tree/main/releases/HostRiskScore). The index pattern has changed since then. This PR updates the pattern to what it currently is.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
