### PR TITLE
[7.14] [DOC] Clarify rolling upgrades of Kibana are not supported and report… (#117644)

### DIFF
--- a/docs/user/production-considerations/production.asciidoc
+++ b/docs/user/production-considerations/production.asciidoc
@@ -16,6 +16,11 @@ separate from  your {es} data or master nodes. To distribute {kib}
 traffic across the nodes in your {es} cluster,
 you can configure {kib} to use a list of {es} hosts.
 
+[WARNING]
+====
+{kib} does not support rolling upgrades, and deploying mixed versions of {kib} can result in data loss or upgrade failures. Please shut down all instances of {kib} before performing an upgrade, and ensure all running {kib} instances have matching versions.
+====
+
 [float]
 [[load-balancing-kibana]]
 === Load balancing across multiple {kib} instances
@@ -59,12 +64,17 @@ bin/kibana -c config/instance2.yml
 === Accessing multiple load-balanced {kib} clusters
 
 To access multiple load-balanced {kib} clusters from the same browser,
-set `xpack.security.cookieName` in the configuration.
+explicitly set `xpack.security.cookieName` to the same value in the {kib} configuration
+of each {kib} instance.
+
+Each {kib} cluster must have a different value of `xpack.security.cookieName`.
+
 This avoids conflicts between cookies from the different {kib} instances.
 
-In each cluster, {kib} instances should have the same `cookieName`
-value. This will achieve seamless high availability and keep the session
+This will achieve seamless high availability and keep the session
 active in case of failure from the currently used instance.
+
+
 
 [float]
 [[high-availability]]


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.14` of:
 - #117644

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
