### PR TITLE
[Fleet] Fix enrollment api key role descriptor application name

### DIFF
--- a/x-pack/plugins/fleet/server/services/api_keys/enrollment_api_key.ts
+++ b/x-pack/plugins/fleet/server/services/api_keys/enrollment_api_key.ts
@@ -213,7 +213,7 @@ export async function generateEnrollmentAPIKey(
             index: [],
             applications: [
               {
-                application: '.fleet',
+                application: 'fleet',
                 privileges: ['no-privileges'],
                 resources: ['*'],
               },


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/beats/issues/29811

In https://github.com/elastic/elasticsearch/pull/82049 Elasticsearch started to validate the role descriptor inside an API key our application name was invalid so it started to throw and block the creation of enrollment API key.

That PR fix that by providing a valid application name.