### PR TITLE
[Security Solution][Lists] - Remove disabled exception list delete icon

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/columns.tsx
@@ -154,16 +154,19 @@ export const getAllExceptionListsColumns = (
         ),
       },
       {
-        render: ({ id, list_id: listId, namespace_type: namespaceType }: ExceptionListInfo) => (
-          <EuiButtonIcon
-            color="danger"
-            onClick={onDelete({ id, listId, namespaceType })}
-            aria-label="Delete exception list"
-            iconType="trash"
-            isDisabled={listId === 'endpoint_list'}
-            data-test-subj="exceptionsTableDeleteButton"
-          />
-        ),
+        render: ({ id, list_id: listId, namespace_type: namespaceType }: ExceptionListInfo) => {
+          return listId === 'endpoint_list' ? (
+            <></>
+          ) : (
+            <EuiButtonIcon
+              color="danger"
+              onClick={onDelete({ id, listId, namespaceType })}
+              aria-label="Delete exception list"
+              iconType="trash"
+              data-test-subj="exceptionsTableDeleteButton"
+            />
+          );
+        },
       },
     ],
   },

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.test.tsx
@@ -88,7 +88,7 @@ describe('ExceptionListsTable', () => {
     ]);
   });
 
-  it('renders delete option disabled if list is "endpoint_list"', async () => {
+  it('does not render delete option disabled if list is "endpoint_list"', async () => {
     const wrapper = mount(
       <TestProviders>
         <ExceptionListsTable />
@@ -97,15 +97,13 @@ describe('ExceptionListsTable', () => {
     expect(wrapper.find('[data-test-subj="exceptionsTableListId"]').at(0).text()).toEqual(
       'endpoint_list'
     );
-    expect(
-      wrapper.find('[data-test-subj="exceptionsTableDeleteButton"] button').at(0).prop('disabled')
-    ).toBeTruthy();
 
     expect(wrapper.find('[data-test-subj="exceptionsTableListId"]').at(1).text()).toEqual(
       'not_endpoint_list'
     );
+    expect(wrapper.find('[data-test-subj="exceptionsTableDeleteButton"] button')).toHaveLength(1);
     expect(
-      wrapper.find('[data-test-subj="exceptionsTableDeleteButton"] button').at(1).prop('disabled')
+      wrapper.find('[data-test-subj="exceptionsTableDeleteButton"] button').at(0).prop('disabled')
     ).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/121761 . Instead of showing disabled exception delete icon in exceptions table, if it's disabled, simply don't show it at all.

<img width="2292" alt="Screen Shot 2022-01-12 at 8 37 30 AM" src="https://user-images.githubusercontent.com/10927944/149188136-8de3ed04-851d-4595-8974-d87f55a7ef01.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)