### PR TITLE
[build] Fix docker ubuntu context

### DIFF
--- a/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
+++ b/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
@@ -119,6 +119,7 @@ export const CreateDockerContexts: Task = {
 
   async run(config, log, build) {
     await runDockerGenerator(config, log, build, {
+      ubuntu: true,
       context: true,
       image: false,
       dockerBuildDate,


### PR DESCRIPTION
The docker ubuntu context is missing the base registry due to a missing
argument.  This declares the context build as ubuntu for the default
image.

Testing
- Verify `FROM ubuntu:20.04` instead of `FROM` is in Dockerfile
- Verify apt-get install is present in Dockerfile