### PR TITLE
[Maps][ML] Integration part 1: Create anomalies layer in maps

### DIFF
--- a/x-pack/plugins/maps/common/index.ts
+++ b/x-pack/plugins/maps/common/index.ts
@@ -33,4 +33,5 @@ export type {
   TooltipFeature,
   VectorLayerDescriptor,
   VectorStyleDescriptor,
+  VectorSourceRequestMeta,
 } from './descriptor_types';

--- a/x-pack/plugins/ml/common/constants/anomalies.ts
+++ b/x-pack/plugins/ml/common/constants/anomalies.ts
@@ -31,6 +31,25 @@ export const SEVERITY_COLORS = {
   BLANK: '#ffffff',
 };
 
+export const SEVERITY_COLOR_RAMP = [
+  {
+    stop: ANOMALY_THRESHOLD.LOW,
+    color: SEVERITY_COLORS.WARNING,
+  },
+  {
+    stop: ANOMALY_THRESHOLD.MINOR,
+    color: SEVERITY_COLORS.MINOR,
+  },
+  {
+    stop: ANOMALY_THRESHOLD.MAJOR,
+    color: SEVERITY_COLORS.MAJOR,
+  },
+  {
+    stop: ANOMALY_THRESHOLD.CRITICAL,
+    color: SEVERITY_COLORS.CRITICAL,
+  },
+];
+
 export const ANOMALY_RESULT_TYPE = {
   BUCKET: 'bucket',
   RECORD: 'record',

--- a/x-pack/plugins/ml/common/index.ts
+++ b/x-pack/plugins/ml/common/index.ts
@@ -7,7 +7,12 @@
 
 export { ES_CLIENT_TOTAL_HITS_RELATION } from './types/es_client';
 export type { ChartData } from './types/field_histograms';
-export { ANOMALY_SEVERITY, ANOMALY_THRESHOLD, SEVERITY_COLORS } from './constants/anomalies';
+export {
+  ANOMALY_SEVERITY,
+  ANOMALY_THRESHOLD,
+  SEVERITY_COLOR_RAMP,
+  SEVERITY_COLORS,
+} from './constants/anomalies';
 export { getSeverityColor, getSeverityType } from './util/anomaly_utils';
 export { isPopulatedObject } from './util/object_utils';
 export { composeValidators, patternValidator } from './util/validators';

--- a/x-pack/plugins/ml/common/util/job_utils.ts
+++ b/x-pack/plugins/ml/common/util/job_utils.ts
@@ -73,6 +73,19 @@ export function isMappableJob(job: CombinedJob, detectorIndex: number): boolean 
   return isMappable;
 }
 
+// Returns a boolean indicating whether the specified job is suitable for maps plugin.
+export function isJobWithGeoData(job: Job): boolean {
+  let isMappable = false;
+  const { detectors } = job.analysis_config;
+
+  detectors.forEach((detector) => {
+    if (detector.function === ML_JOB_AGGREGATION.LAT_LONG) {
+      isMappable = true;
+    }
+  });
+  return isMappable;
+}
+
 /**
  * Validates that composite definition only have sources that are only terms and date_histogram
  * if composite is defined.

--- a/x-pack/plugins/ml/common/util/job_utils.ts
+++ b/x-pack/plugins/ml/common/util/job_utils.ts
@@ -75,15 +75,8 @@ export function isMappableJob(job: CombinedJob, detectorIndex: number): boolean 
 
 // Returns a boolean indicating whether the specified job is suitable for maps plugin.
 export function isJobWithGeoData(job: Job): boolean {
-  let isMappable = false;
   const { detectors } = job.analysis_config;
-
-  detectors.forEach((detector) => {
-    if (detector.function === ML_JOB_AGGREGATION.LAT_LONG) {
-      isMappable = true;
-    }
-  });
-  return isMappable;
+  return detectors.some((detector) => detector.function === ML_JOB_AGGREGATION.LAT_LONG);
 }
 
 /**

--- a/x-pack/plugins/ml/public/application/app.tsx
+++ b/x-pack/plugins/ml/public/application/app.tsx
@@ -28,7 +28,7 @@ import { mlApiServicesProvider } from './services/ml_api_service';
 import { HttpService } from './services/http_service';
 import { ML_APP_LOCATOR, ML_PAGES } from '../../common/constants/locator';
 
-export type MlDependencies = Omit<MlSetupDependencies, 'share' | 'fieldFormats'> &
+export type MlDependencies = Omit<MlSetupDependencies, 'share' | 'fieldFormats' | 'maps'> &
   MlStartDependencies;
 
 interface AppProps {

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/map_config.ts
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/map_config.ts
@@ -6,29 +6,11 @@
  */
 
 import { FIELD_ORIGIN, LAYER_TYPE, STYLE_TYPE } from '../../../../../maps/common';
-import { ANOMALY_THRESHOLD, SEVERITY_COLORS } from '../../../../common';
+import { SEVERITY_COLOR_RAMP } from '../../../../common';
 import { AnomaliesTableData } from '../explorer_utils';
 
 const FEATURE = 'Feature';
 const POINT = 'Point';
-const SEVERITY_COLOR_RAMP = [
-  {
-    stop: ANOMALY_THRESHOLD.LOW,
-    color: SEVERITY_COLORS.WARNING,
-  },
-  {
-    stop: ANOMALY_THRESHOLD.MINOR,
-    color: SEVERITY_COLORS.MINOR,
-  },
-  {
-    stop: ANOMALY_THRESHOLD.MAJOR,
-    color: SEVERITY_COLORS.MAJOR,
-  },
-  {
-    stop: ANOMALY_THRESHOLD.CRITICAL,
-    color: SEVERITY_COLORS.CRITICAL,
-  },
-];
 
 function getAnomalyFeatures(
   anomalies: AnomaliesTableData['anomalies'],

--- a/x-pack/plugins/ml/public/application/services/ml_api_service/jobs.ts
+++ b/x-pack/plugins/ml/public/application/services/ml_api_service/jobs.ts
@@ -45,6 +45,13 @@ export const jobsApiProvider = (httpService: HttpService) => ({
     });
   },
 
+  jobsWithGeo() {
+    return httpService.http<string[]>({
+      path: `${ML_BASE_PATH}/jobs/jobs_with_geo`,
+      method: 'GET',
+    });
+  },
+
   jobsWithTimerange(dateFormatTz: string) {
     const body = JSON.stringify({ dateFormatTz });
     return httpService.http<{

--- a/x-pack/plugins/ml/public/application/services/ml_api_service/jobs.ts
+++ b/x-pack/plugins/ml/public/application/services/ml_api_service/jobs.ts
@@ -45,7 +45,7 @@ export const jobsApiProvider = (httpService: HttpService) => ({
     });
   },
 
-  jobsWithGeo() {
+  jobIdsWithGeo() {
     return httpService.http<string[]>({
       path: `${ML_BASE_PATH}/jobs/jobs_with_geo`,
       method: 'GET',

--- a/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Component } from 'react';
+
+import { EuiComboBox, EuiFormRow, EuiComboBoxOptionOption } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { isEqual } from 'lodash';
+
+interface Props {
+  onJobChange: (jobId: string) => void;
+  mlJobsService: any; // todo: update types
+}
+
+interface State {
+  jobId?: string;
+  jobIdList?: Array<EuiComboBoxOptionOption<string>>;
+}
+
+export class AnomalyJobSelector extends Component<Props, State> {
+  private _isMounted: boolean = false;
+
+  state: State = {};
+
+  private async _loadJobs() {
+    const jobIdList = await this.props.mlJobsService.jobsWithGeo();
+    // TODO update types - remove any
+    const options = jobIdList.map((jobId: any) => {
+      return { label: jobId, value: jobId };
+    });
+    if (this._isMounted && !isEqual(options, this.state.jobIdList)) {
+      this.setState({
+        jobIdList: options,
+      });
+    }
+  }
+
+  componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>, snapshot?: any): void {
+    this._loadJobs();
+  }
+
+  componentDidMount(): void {
+    this._isMounted = true;
+    this._loadJobs();
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  onJobIdSelect = (selectedOptions: Array<EuiComboBoxOptionOption<string>>) => {
+    const jobId: string = selectedOptions[0].value!;
+    if (this._isMounted) {
+      this.setState({ jobId });
+      this.props.onJobChange(jobId);
+    }
+  };
+
+  render() {
+    if (!this.state.jobIdList) {
+      return null;
+    }
+
+    return (
+      <EuiFormRow
+        label={i18n.translate('xpack.ml.maps.jobIdLabel', {
+          defaultMessage: 'JobId',
+        })}
+        display="columnCompressed"
+      >
+        <EuiComboBox
+          singleSelection={true}
+          onChange={this.onJobIdSelect}
+          options={this.state.jobIdList}
+          selectedOptions={
+            this.state.jobId ? [{ value: this.state.jobId, label: this.state.jobId }] : []
+          }
+        />
+      </EuiFormRow>
+    );
+  }
+}

--- a/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
@@ -10,10 +10,11 @@ import React, { Component } from 'react';
 import { EuiComboBox, EuiFormRow, EuiComboBoxOptionOption } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isEqual } from 'lodash';
+import type { MlApiServices } from '../application/services/ml_api_service';
 
 interface Props {
   onJobChange: (jobId: string) => void;
-  mlJobsService: any; // todo: update types
+  mlJobsService: MlApiServices['jobs'];
 }
 
 interface State {
@@ -28,8 +29,7 @@ export class AnomalyJobSelector extends Component<Props, State> {
 
   private async _loadJobs() {
     const jobIdList = await this.props.mlJobsService.jobsWithGeo();
-    // TODO update types - remove any
-    const options = jobIdList.map((jobId: any) => {
+    const options = jobIdList.map((jobId) => {
       return { label: jobId, value: jobId };
     });
     if (this._isMounted && !isEqual(options, this.state.jobIdList)) {

--- a/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
@@ -28,7 +28,7 @@ export class AnomalyJobSelector extends Component<Props, State> {
   state: State = {};
 
   private async _loadJobs() {
-    const jobIdList = await this.props.mlJobsService.jobsWithGeo();
+    const jobIdList = await this.props.mlJobsService.jobIdsWithGeo();
     const options = jobIdList.map((jobId) => {
       return { label: jobId, value: jobId };
     });
@@ -39,7 +39,7 @@ export class AnomalyJobSelector extends Component<Props, State> {
     }
   }
 
-  componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>, snapshot?: any): void {
+  componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>): void {
     this._loadJobs();
   }
 
@@ -68,7 +68,7 @@ export class AnomalyJobSelector extends Component<Props, State> {
     return (
       <EuiFormRow
         label={i18n.translate('xpack.ml.maps.jobIdLabel', {
-          defaultMessage: 'JobId',
+          defaultMessage: 'Job ID',
         })}
         display="columnCompressed"
       >

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { LAYER_WIZARD_CATEGORY } from '../../../maps/common';
+import type { LayerWizard } from '../../../maps/public';
+
+export const anomalyLayerWizard: Partial<LayerWizard> = {
+  categories: [LAYER_WIZARD_CATEGORY.SOLUTIONS],
+  description: i18n.translate('xpack.ml.maps.anomalyLayerDescription', {
+    defaultMessage: 'Create anomalies layers',
+  }),
+  disabledReason: i18n.translate('xpack.ml.maps.anomalyLayerUnavailableMessage', {
+    defaultMessage:
+      'Whatever reason the user cannot see ML card (likely because no enterprise license or no ML privileges)',
+  }),
+  icon: 'outlierDetectionJob',
+  getIsDisabled: () => {
+    // return false by default
+    return false;
+  },
+  title: i18n.translate('xpack.ml.maps.anomalyLayerTitle', {
+    defaultMessage: 'ML Anomalies',
+  }),
+};

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard.tsx
@@ -26,4 +26,5 @@ export const anomalyLayerWizard: Partial<LayerWizard> = {
   title: i18n.translate('xpack.ml.maps.anomalyLayerTitle', {
     defaultMessage: 'ML Anomalies',
   }),
+  order: 100,
 };

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard.tsx
@@ -12,11 +12,11 @@ import type { LayerWizard } from '../../../maps/public';
 export const anomalyLayerWizard: Partial<LayerWizard> = {
   categories: [LAYER_WIZARD_CATEGORY.SOLUTIONS, LAYER_WIZARD_CATEGORY.ELASTICSEARCH],
   description: i18n.translate('xpack.ml.maps.anomalyLayerDescription', {
-    defaultMessage: 'Create anomalies layers',
+    defaultMessage: 'Display anomalies from a machine learning job',
   }),
   disabledReason: i18n.translate('xpack.ml.maps.anomalyLayerUnavailableMessage', {
     defaultMessage:
-      'Whatever reason the user cannot see ML card (likely because no enterprise license or no ML privileges)',
+      'Anomalies layers are a subscription feature. Ensure you have the right subscription and access to Machine Learning.',
   }),
   icon: 'outlierDetectionJob',
   getIsDisabled: () => {

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard.tsx
@@ -10,7 +10,7 @@ import { LAYER_WIZARD_CATEGORY } from '../../../maps/common';
 import type { LayerWizard } from '../../../maps/public';
 
 export const anomalyLayerWizard: Partial<LayerWizard> = {
-  categories: [LAYER_WIZARD_CATEGORY.SOLUTIONS],
+  categories: [LAYER_WIZARD_CATEGORY.SOLUTIONS, LAYER_WIZARD_CATEGORY.ELASTICSEARCH],
   description: i18n.translate('xpack.ml.maps.anomalyLayerDescription', {
     defaultMessage: 'Create anomalies layers',
   }),

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import uuid from 'uuid';
+import type { StartServicesAccessor } from 'kibana/public';
+import type { LayerWizard, RenderWizardArguments } from '../../../maps/public';
+import { COLOR_MAP_TYPE, FIELD_ORIGIN, LAYER_TYPE, STYLE_TYPE } from '../../../maps/common';
+import { CreateAnomalySourceEditor } from './create_anomaly_source_editor';
+import {
+  VectorLayerDescriptor,
+  VectorStylePropertiesDescriptor,
+} from '../../../maps/common/descriptor_types';
+import { AnomalySource, AnomalySourceDescriptor } from './anomaly_source';
+
+import { HttpService } from '../application/services/http_service';
+import type { MlPluginStart, MlStartDependencies } from '../plugin';
+import type { MlDependencies } from '../application/app';
+
+export const ML_ANOMALY = 'ML_ANOMALIES';
+
+export class AnomalyLayerWizardFactory {
+  public readonly type = ML_ANOMALY;
+
+  constructor(
+    private getStartServices: StartServicesAccessor<MlStartDependencies, MlPluginStart>,
+    private canGetJobs: any
+  ) {
+    this.canGetJobs = canGetJobs;
+  }
+
+  private async getServices(): Promise<any> {
+    const [coreStart, pluginsStart] = await this.getStartServices();
+    const { jobsApiProvider } = await import('../application/services/ml_api_service/jobs');
+
+    const httpService = new HttpService(coreStart.http);
+    const mlJobsService = jobsApiProvider(httpService);
+
+    return [coreStart, pluginsStart as MlDependencies, { mlJobsService }];
+  }
+
+  public async create(): Promise<LayerWizard> {
+    const services = await this.getServices();
+    const mlJobsService = services[2].mlJobsService;
+    const { anomalyLayerWizard } = await import('./anomaly_layer_wizard');
+
+    anomalyLayerWizard.getIsDisabled = () => !this.canGetJobs;
+
+    anomalyLayerWizard.renderWizard = ({ previewLayers }: RenderWizardArguments) => {
+      const onSourceConfigChange = (sourceConfig: Partial<AnomalySourceDescriptor> | null) => {
+        if (!sourceConfig) {
+          previewLayers([]);
+          return;
+        }
+
+        const anomalyLayerDescriptor: VectorLayerDescriptor = {
+          id: uuid(),
+          type: LAYER_TYPE.GEOJSON_VECTOR,
+          sourceDescriptor: AnomalySource.createDescriptor({
+            jobId: sourceConfig.jobId,
+            typicalActual: sourceConfig.typicalActual,
+          }),
+          style: {
+            type: 'VECTOR',
+            properties: {
+              fillColor: {
+                type: STYLE_TYPE.DYNAMIC,
+                options: {
+                  color: 'Blue to Red',
+                  colorCategory: 'palette_0',
+                  fieldMetaOptions: { isEnabled: true, sigma: 3 },
+                  type: COLOR_MAP_TYPE.ORDINAL,
+                  field: {
+                    name: 'record_score',
+                    origin: FIELD_ORIGIN.SOURCE,
+                  },
+                  useCustomColorRamp: false,
+                },
+              },
+            } as unknown as VectorStylePropertiesDescriptor,
+            isTimeAware: false,
+          },
+        };
+
+        previewLayers([anomalyLayerDescriptor]);
+      };
+
+      return (
+        <CreateAnomalySourceEditor
+          onSourceConfigChange={onSourceConfigChange}
+          mlJobsService={mlJobsService}
+        />
+      );
+    };
+
+    return anomalyLayerWizard as LayerWizard;
+  }
+}

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import uuid from 'uuid';
+import { htmlIdGenerator } from '@elastic/eui';
 import type { StartServicesAccessor } from 'kibana/public';
 import type { LayerWizard, RenderWizardArguments } from '../../../maps/public';
 import { FIELD_ORIGIN, LAYER_TYPE, STYLE_TYPE } from '../../../maps/common';
@@ -23,6 +23,17 @@ import type { MlPluginStart, MlStartDependencies } from '../plugin';
 import type { MlApiServices } from '../application/services/ml_api_service';
 
 export const ML_ANOMALY = 'ML_ANOMALIES';
+const CUSTOM_COLOR_RAMP = {
+  type: STYLE_TYPE.DYNAMIC,
+  options: {
+    customColorRamp: SEVERITY_COLOR_RAMP,
+    field: {
+      name: 'record_score',
+      origin: FIELD_ORIGIN.SOURCE,
+    },
+    useCustomColorRamp: true,
+  },
+};
 
 export class AnomalyLayerWizardFactory {
   public readonly type = ML_ANOMALY;
@@ -58,7 +69,7 @@ export class AnomalyLayerWizardFactory {
         }
 
         const anomalyLayerDescriptor: VectorLayerDescriptor = {
-          id: uuid(),
+          id: htmlIdGenerator()(),
           type: LAYER_TYPE.GEOJSON_VECTOR,
           sourceDescriptor: AnomalySource.createDescriptor({
             jobId: sourceConfig.jobId,
@@ -67,17 +78,8 @@ export class AnomalyLayerWizardFactory {
           style: {
             type: 'VECTOR',
             properties: {
-              fillColor: {
-                type: STYLE_TYPE.DYNAMIC,
-                options: {
-                  customColorRamp: SEVERITY_COLOR_RAMP,
-                  field: {
-                    name: 'record_score',
-                    origin: FIELD_ORIGIN.SOURCE,
-                  },
-                  useCustomColorRamp: true,
-                },
-              },
+              fillColor: CUSTOM_COLOR_RAMP,
+              lineColor: CUSTOM_COLOR_RAMP,
             } as unknown as VectorStylePropertiesDescriptor,
             isTimeAware: false,
           },

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
@@ -9,7 +9,8 @@ import React from 'react';
 import uuid from 'uuid';
 import type { StartServicesAccessor } from 'kibana/public';
 import type { LayerWizard, RenderWizardArguments } from '../../../maps/public';
-import { COLOR_MAP_TYPE, FIELD_ORIGIN, LAYER_TYPE, STYLE_TYPE } from '../../../maps/common';
+import { FIELD_ORIGIN, LAYER_TYPE, STYLE_TYPE } from '../../../maps/common';
+import { SEVERITY_COLOR_RAMP } from '../../common';
 import { CreateAnomalySourceEditor } from './create_anomaly_source_editor';
 import {
   VectorLayerDescriptor,
@@ -70,15 +71,12 @@ export class AnomalyLayerWizardFactory {
               fillColor: {
                 type: STYLE_TYPE.DYNAMIC,
                 options: {
-                  color: 'Blue to Red',
-                  colorCategory: 'palette_0',
-                  fieldMetaOptions: { isEnabled: true, sigma: 3 },
-                  type: COLOR_MAP_TYPE.ORDINAL,
+                  customColorRamp: SEVERITY_COLOR_RAMP,
                   field: {
                     name: 'record_score',
                     origin: FIELD_ORIGIN.SOURCE,
                   },
-                  useCustomColorRamp: false,
+                  useCustomColorRamp: true,
                 },
               },
             } as unknown as VectorStylePropertiesDescriptor,

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
@@ -20,7 +20,7 @@ import { AnomalySource, AnomalySourceDescriptor } from './anomaly_source';
 
 import { HttpService } from '../application/services/http_service';
 import type { MlPluginStart, MlStartDependencies } from '../plugin';
-import type { MlDependencies } from '../application/app';
+import type { MlApiServices } from '../application/services/ml_api_service';
 
 export const ML_ANOMALY = 'ML_ANOMALIES';
 
@@ -34,19 +34,18 @@ export class AnomalyLayerWizardFactory {
     this.canGetJobs = canGetJobs;
   }
 
-  private async getServices(): Promise<any> {
-    const [coreStart, pluginsStart] = await this.getStartServices();
+  private async getServices(): Promise<{ mlJobsService: MlApiServices['jobs'] }> {
+    const [coreStart] = await this.getStartServices();
     const { jobsApiProvider } = await import('../application/services/ml_api_service/jobs');
 
     const httpService = new HttpService(coreStart.http);
     const mlJobsService = jobsApiProvider(httpService);
 
-    return [coreStart, pluginsStart as MlDependencies, { mlJobsService }];
+    return { mlJobsService };
   }
 
   public async create(): Promise<LayerWizard> {
-    const services = await this.getServices();
-    const mlJobsService = services[2].mlJobsService;
+    const { mlJobsService } = await this.getServices();
     const { anomalyLayerWizard } = await import('./anomaly_layer_wizard');
 
     anomalyLayerWizard.getIsDisabled = () => !this.canGetJobs;

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
@@ -29,7 +29,7 @@ export class AnomalyLayerWizardFactory {
 
   constructor(
     private getStartServices: StartServicesAccessor<MlStartDependencies, MlPluginStart>,
-    private canGetJobs: any
+    private canGetJobs: boolean
   ) {
     this.canGetJobs = canGetJobs;
   }

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -1,0 +1,346 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import React, { ReactElement } from 'react';
+import { FieldFormatter, MAX_ZOOM, MIN_ZOOM, VECTOR_SHAPE_TYPE } from '../../../maps/common';
+import { AbstractSourceDescriptor, MapExtent } from '../../../maps/common/descriptor_types';
+import { ITooltipProperty } from '../../../maps/public';
+import { RecordScoreField, RecordScoreTooltipProperty } from './record_score_field';
+import type { Adapters } from '../../../../../src/plugins/inspector/common/adapters';
+import type { GeoJsonWithMeta } from '../../../maps/public';
+import type { IField } from '../../../maps/public';
+import type { Attribution, ImmutableSourceProperty, PreIndexedShape } from '../../../maps/public';
+import type { SourceEditorArgs } from '../../../maps/public';
+import type { DataRequest } from '../../../maps/public';
+import type { IVectorSource, SourceStatus } from '../../../maps/public';
+import { ML_ANOMALY } from './anomaly_source_factory';
+import { getResultsForJobId } from './util';
+import { UpdateAnomalySourceEditor } from './update_anomaly_source_editor';
+
+export interface AnomalySourceDescriptor extends AbstractSourceDescriptor {
+  jobId: string;
+  typicalActual: 'typical' | 'actual';
+}
+
+export class AnomalySource implements IVectorSource {
+  static services: any; // TODO fix these types
+  static canGetJobs: any;
+
+  static createDescriptor(descriptor: Partial<AnomalySourceDescriptor>) {
+    // TODO: Fill in all the defaults
+    return {
+      type: ML_ANOMALY,
+      jobId: typeof descriptor.jobId === 'string' ? descriptor.jobId : 'foobar',
+      typicalActual: descriptor.typicalActual || 'typical',
+    };
+  }
+
+  private readonly _descriptor: AnomalySourceDescriptor;
+
+  constructor(sourceDescriptor: Partial<AnomalySourceDescriptor>, adapters?: Adapters) {
+    this._descriptor = AnomalySource.createDescriptor(sourceDescriptor);
+  }
+  // TODO: implement Time filter functionality and query awareness
+  async getGeoJsonWithMeta(
+    layerName: string,
+    searchFilters: any & {
+      applyGlobalQuery: boolean;
+      applyGlobalTime: boolean;
+      fieldNames: string[];
+      geogridPrecision?: number;
+      sourceQuery?: object;
+      sourceMeta: object;
+    },
+    registerCancelCallback: (callback: () => void) => void,
+    isRequestStillActive: () => boolean
+  ): Promise<GeoJsonWithMeta> {
+    const results = await getResultsForJobId(
+      AnomalySource.services[2].mlResultsService,
+      this._descriptor.jobId,
+      this._descriptor.typicalActual
+    );
+
+    return {
+      data: results,
+      meta: {
+        // Set this to true if data is incomplete (e.g. capping number of results to first 10k)
+        areResultsTrimmed: false,
+      },
+    };
+  }
+
+  canFormatFeatureProperties(): boolean {
+    return false;
+  }
+
+  cloneDescriptor(): AnomalySourceDescriptor {
+    return {
+      type: this._descriptor.type,
+      jobId: this._descriptor.jobId,
+      typicalActual: this._descriptor.typicalActual,
+    };
+  }
+
+  createField({ fieldName }: { fieldName: string }): IField {
+    if (fieldName !== 'record_score') {
+      throw new Error('PEBKAC');
+    }
+    return new RecordScoreField({ source: this });
+  }
+
+  async createFieldFormatter(field: IField): Promise<FieldFormatter | null> {
+    return null;
+  }
+
+  destroy(): void {}
+
+  getApplyGlobalQuery(): boolean {
+    return false;
+  }
+
+  getApplyForceRefresh(): boolean {
+    return false;
+  }
+
+  getApplyGlobalTime(): boolean {
+    return false;
+  }
+
+  async getAttributions(): Promise<Attribution[]> {
+    return [];
+  }
+
+  async getBoundsForFilters(
+    boundsFilters: object,
+    registerCancelCallback: (callback: () => void) => void
+  ): Promise<MapExtent | null> {
+    return null;
+  }
+
+  async getDisplayName(): Promise<string> {
+    return i18n.translate('xpack.ml.maps.anomalySource.displayLabel', {
+      defaultMessage: '{typicalActual} for {jobId}',
+      values: {
+        typicalActual: this._descriptor.typicalActual,
+        jobId: this._descriptor.jobId,
+      },
+    });
+  }
+
+  getFieldByName(fieldName: string): IField | null {
+    if (fieldName === 'record_score') {
+      return new RecordScoreField({ source: this });
+    }
+    return null;
+  }
+
+  getSourceStatus() {
+    return { tooltipContent: null, areResultsTrimmed: false };
+  }
+
+  getType(): string {
+    return this._descriptor.type;
+  }
+
+  isMvt() {
+    return true;
+  }
+
+  showJoinEditor(): boolean {
+    // Ignore, only show if joins are enabled for current configuration
+    return false;
+  }
+
+  getFieldNames(): string[] {
+    return ['record_score'];
+  }
+
+  async getFields(): Promise<IField[]> {
+    return [new RecordScoreField({ source: this })];
+  }
+
+  getGeoGridPrecision(zoom: number): number {
+    return 0;
+  }
+
+  isBoundsAware(): boolean {
+    return false;
+  }
+
+  async getImmutableProperties(): Promise<ImmutableSourceProperty[]> {
+    return [
+      {
+        label: i18n.translate('xpack.ml.maps.anomalySourcePropLabel', {
+          defaultMessage: 'Job Id',
+        }),
+        value: this._descriptor.jobId,
+      },
+    ];
+  }
+
+  async isTimeAware(): Promise<boolean> {
+    return true;
+  }
+
+  renderSourceSettingsEditor({ onChange }: SourceEditorArgs): ReactElement<any> | null {
+    return (
+      <UpdateAnomalySourceEditor
+        onChange={onChange}
+        typicalActual={this._descriptor.typicalActual}
+      />
+    );
+  }
+
+  async supportsFitToBounds(): Promise<boolean> {
+    // Return true if you can compute bounds of data
+    return true;
+  }
+  // Promise<Array<{ name: string; license: string }>>
+  async getLicensedFeatures(): Promise<any[]> {
+    return [{ name: 'layer from ML anomaly job', license: 'enterprise' }];
+  }
+
+  getMaxZoom(): number {
+    return MAX_ZOOM;
+  }
+
+  getMinZoom(): number {
+    return MIN_ZOOM;
+  }
+
+  getSourceTooltipContent(sourceDataRequest?: DataRequest): SourceStatus {
+    return {
+      tooltipContent: i18n.translate('xpack.ml.maps.sourceTooltip', {
+        defaultMessage: `Shows anomalies`,
+      }),
+      areResultsTrimmed: false, // set to true if data is incomplete
+    };
+  }
+
+  async getSupportedShapeTypes(): Promise<VECTOR_SHAPE_TYPE[]> {
+    return [VECTOR_SHAPE_TYPE.POINT];
+  }
+
+  getSyncMeta(): object | null {
+    return {
+      jobId: this._descriptor.jobId,
+      typicalActual: this._descriptor.typicalActual,
+    };
+  }
+
+  async getTooltipProperties(properties: { [p: string]: any } | null): Promise<ITooltipProperty[]> {
+    const tooltipProperties: ITooltipProperty[] = [];
+    for (const key in properties) {
+      if (key === 'record_score') {
+        tooltipProperties.push(new RecordScoreTooltipProperty('Record score', properties[key]));
+      }
+    }
+    return tooltipProperties;
+  }
+
+  isFieldAware(): boolean {
+    return true;
+  }
+
+  // This is for type-ahead support in the UX for by-value styling
+  async getValueSuggestions(field: IField, query: string): Promise<string[]> {
+    return [];
+  }
+
+  // -----------------
+  // API ML probably can ignore
+  getAttributionProvider() {
+    return null;
+  }
+
+  getIndexPatternIds(): string[] {
+    // IGNORE: This is only relevant if your source is backed by an index-pattern
+    return [];
+  }
+
+  getInspectorAdapters(): Adapters | undefined {
+    // IGNORE: This is only relevant if your source is backed by an index-pattern
+    return undefined;
+  }
+
+  getJoinsDisabledReason(): string | null {
+    // IGNORE: This is only relevant if your source can be joined to other data
+    return null;
+  }
+
+  async getLeftJoinFields(): Promise<IField[]> {
+    // IGNORE: This is only relevant if your source can be joined to other data
+    return [];
+  }
+
+  async getPreIndexedShape(
+    properties: { [p: string]: any } | null
+  ): Promise<PreIndexedShape | null> {
+    // IGNORE: This is only relevant if your source is backed by an index-pattern
+    return null;
+  }
+
+  getQueryableIndexPatternIds(): string[] {
+    // IGNORE: This is only relevant if your source is backed by an index-pattern
+    return [];
+  }
+
+  isESSource(): boolean {
+    // IGNORE: This is only relevant if your source is backed by an index-pattern
+    return false;
+  }
+
+  isFilterByMapBounds(): boolean {
+    // Only implement if you can query this data with a bounding-box
+    return false;
+  }
+
+  isGeoGridPrecisionAware(): boolean {
+    // Ignore: only implement if your data is scale-dependent (probably not)
+    return false;
+  }
+
+  isQueryAware(): boolean {
+    // IGNORE: This is only relevant if your source is backed by an index-pattern
+    return false;
+  }
+
+  isRefreshTimerAware(): boolean {
+    // Allow force-refresh when user clicks "refresh" button in the global time-picker
+    return true;
+  }
+
+  async getTimesliceMaskFieldName() {
+    return null;
+  }
+
+  async supportsFeatureEditing() {
+    return false;
+  }
+
+  hasTooltipProperties() {
+    return true;
+  }
+
+  async addFeature() {
+    // TODO
+  }
+
+  async deleteFeature() {
+    // TODO
+  }
+
+  getUpdateDueToTimeslice() {
+    // TODO
+    return true;
+  }
+
+  async getDefaultFields(): Promise<Record<string, Record<string, string>>> {
+    return {};
+  }
+}

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -50,7 +50,7 @@ export class AnomalySource implements IVectorSource {
     return {
       type: ML_ANOMALY,
       jobId: descriptor.jobId,
-      typicalActual: descriptor.typicalActual || 'typical',
+      typicalActual: descriptor.typicalActual || 'actual',
     };
   }
 
@@ -148,7 +148,7 @@ export class AnomalySource implements IVectorSource {
   }
 
   getSourceStatus() {
-    return { tooltipContent: null, areResultsTrimmed: false };
+    return { tooltipContent: null, areResultsTrimmed: true };
   }
 
   getType(): string {
@@ -226,7 +226,8 @@ export class AnomalySource implements IVectorSource {
       tooltipContent: i18n.translate('xpack.ml.maps.sourceTooltip', {
         defaultMessage: 'Shows anomalies',
       }),
-      areResultsTrimmed: false, // set to true if data is incomplete
+      // set to true if data is incomplete (we limit to first 1000 results)
+      areResultsTrimmed: true,
     };
   }
 

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -19,7 +19,7 @@ import type { SourceEditorArgs } from '../../../maps/public';
 import type { DataRequest } from '../../../maps/public';
 import type { IVectorSource, SourceStatus } from '../../../maps/public';
 import { ML_ANOMALY } from './anomaly_source_factory';
-import { getResultsForJobId } from './util';
+import { getResultsForJobId, MlAnomalyLayers } from './util';
 import { UpdateAnomalySourceEditor } from './update_anomaly_source_editor';
 
 export type SearchFilters = any & {
@@ -33,7 +33,7 @@ export type SearchFilters = any & {
 
 export interface AnomalySourceDescriptor extends AbstractSourceDescriptor {
   jobId: string;
-  typicalActual: 'typical' | 'actual';
+  typicalActual: MlAnomalyLayers;
 }
 
 export class AnomalySource implements IVectorSource {
@@ -203,6 +203,7 @@ export class AnomalySource implements IVectorSource {
     // Return true if you can compute bounds of data
     return true;
   }
+
   // Promise<Array<{ name: string; license: string }>>
   async getLicensedFeatures(): Promise<any[]> {
     return [{ name: 'layer from ML anomaly job', license: 'enterprise' }];
@@ -226,7 +227,9 @@ export class AnomalySource implements IVectorSource {
   }
 
   async getSupportedShapeTypes(): Promise<VECTOR_SHAPE_TYPE[]> {
-    return [VECTOR_SHAPE_TYPE.POINT];
+    return this._descriptor.typicalActual === 'connected'
+      ? [VECTOR_SHAPE_TYPE.LINE]
+      : [VECTOR_SHAPE_TYPE.POINT];
   }
 
   getSyncMeta(): object | null {

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -7,7 +7,13 @@
 
 import { i18n } from '@kbn/i18n';
 import React, { ReactElement } from 'react';
-import { FieldFormatter, MAX_ZOOM, MIN_ZOOM, VECTOR_SHAPE_TYPE } from '../../../maps/common';
+import {
+  FieldFormatter,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  VECTOR_SHAPE_TYPE,
+  VectorSourceRequestMeta,
+} from '../../../maps/common';
 import { AbstractSourceDescriptor, MapExtent } from '../../../maps/common/descriptor_types';
 import { ITooltipProperty } from '../../../maps/public';
 import {
@@ -27,15 +33,6 @@ import { getResultsForJobId, MlAnomalyLayers } from './util';
 import { UpdateAnomalySourceEditor } from './update_anomaly_source_editor';
 import type { MlApiServices } from '../application/services/ml_api_service';
 
-export type SearchFilters = any & {
-  applyGlobalQuery: boolean;
-  applyGlobalTime: boolean;
-  fieldNames: string[];
-  geogridPrecision?: number;
-  sourceQuery?: object;
-  sourceMeta: object;
-};
-
 export interface AnomalySourceDescriptor extends AbstractSourceDescriptor {
   jobId: string;
   typicalActual: MlAnomalyLayers;
@@ -46,7 +43,7 @@ export class AnomalySource implements IVectorSource {
   static canGetJobs: boolean;
 
   static createDescriptor(descriptor: Partial<AnomalySourceDescriptor>) {
-    if (!(typeof descriptor.jobId === 'string')) {
+    if (typeof descriptor.jobId !== 'string') {
       throw new Error('Job id is required for anomaly layer creation');
     }
 
@@ -65,7 +62,7 @@ export class AnomalySource implements IVectorSource {
   // TODO: implement query awareness
   async getGeoJsonWithMeta(
     layerName: string,
-    searchFilters: SearchFilters,
+    searchFilters: VectorSourceRequestMeta,
     registerCancelCallback: (callback: () => void) => void,
     isRequestStillActive: () => boolean
   ): Promise<GeoJsonWithMeta> {
@@ -213,7 +210,6 @@ export class AnomalySource implements IVectorSource {
   }
 
   async getLicensedFeatures(): Promise<[]> {
-    // return [{ name: 'layer from ML anomaly job', license: 'enterprise' }];
     return [];
   }
 

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -22,6 +22,15 @@ import { ML_ANOMALY } from './anomaly_source_factory';
 import { getResultsForJobId } from './util';
 import { UpdateAnomalySourceEditor } from './update_anomaly_source_editor';
 
+export type SearchFilters = any & {
+  applyGlobalQuery: boolean;
+  applyGlobalTime: boolean;
+  fieldNames: string[];
+  geogridPrecision?: number;
+  sourceQuery?: object;
+  sourceMeta: object;
+};
+
 export interface AnomalySourceDescriptor extends AbstractSourceDescriptor {
   jobId: string;
   typicalActual: 'typical' | 'actual';
@@ -45,24 +54,18 @@ export class AnomalySource implements IVectorSource {
   constructor(sourceDescriptor: Partial<AnomalySourceDescriptor>, adapters?: Adapters) {
     this._descriptor = AnomalySource.createDescriptor(sourceDescriptor);
   }
-  // TODO: implement Time filter functionality and query awareness
+  // TODO: implement query awareness
   async getGeoJsonWithMeta(
     layerName: string,
-    searchFilters: any & {
-      applyGlobalQuery: boolean;
-      applyGlobalTime: boolean;
-      fieldNames: string[];
-      geogridPrecision?: number;
-      sourceQuery?: object;
-      sourceMeta: object;
-    },
+    searchFilters: SearchFilters,
     registerCancelCallback: (callback: () => void) => void,
     isRequestStillActive: () => boolean
   ): Promise<GeoJsonWithMeta> {
     const results = await getResultsForJobId(
       AnomalySource.services[2].mlResultsService,
       this._descriptor.jobId,
-      this._descriptor.typicalActual
+      this._descriptor.typicalActual,
+      searchFilters
     );
 
     return {
@@ -108,7 +111,7 @@ export class AnomalySource implements IVectorSource {
   }
 
   getApplyGlobalTime(): boolean {
-    return false;
+    return true;
   }
 
   async getAttributions(): Promise<Attribution[]> {

--- a/x-pack/plugins/ml/public/maps/anomaly_source_factory.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_factory.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { StartServicesAccessor } from 'kibana/public';
+import { HttpService } from '../application/services/http_service';
+import type { MlPluginStart, MlStartDependencies } from '../plugin';
+import type { MlDependencies } from '../application/app';
+
+export const ML_ANOMALY = 'ML_ANOMALIES';
+
+export class AnomalySourceFactory {
+  public readonly type = ML_ANOMALY;
+
+  constructor(
+    private getStartServices: StartServicesAccessor<MlStartDependencies, MlPluginStart>,
+    private canGetJobs: any
+  ) {
+    this.canGetJobs = canGetJobs;
+  }
+
+  private async getServices(): Promise<any> {
+    const [coreStart, pluginsStart] = await this.getStartServices();
+    const { mlApiServicesProvider } = await import('../application/services/ml_api_service');
+    // const { resultsApiProvider } = await import('../application/services/ml_api_service/results');
+
+    const httpService = new HttpService(coreStart.http);
+    // const mlApiService = mlApiServicesProvider(httpService);
+    const mlResultsService = mlApiServicesProvider(httpService).results;
+    // const mlResultsService = resultsApiProvider(httpService);
+
+    return [coreStart, pluginsStart as MlDependencies, { mlResultsService }];
+  }
+
+  public async create(): Promise<any> {
+    const services = await this.getServices();
+    const { AnomalySource } = await import('./anomaly_source');
+    AnomalySource.services = services;
+    AnomalySource.canGetJobs = this.canGetJobs;
+    return AnomalySource;
+  }
+}

--- a/x-pack/plugins/ml/public/maps/anomaly_source_factory.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_factory.ts
@@ -17,7 +17,7 @@ export class AnomalySourceFactory {
 
   constructor(
     private getStartServices: StartServicesAccessor<MlStartDependencies, MlPluginStart>,
-    private canGetJobs: any
+    private canGetJobs: boolean
   ) {
     this.canGetJobs = canGetJobs;
   }

--- a/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
@@ -7,6 +7,7 @@
 
 // eslint-disable-next-line max-classes-per-file
 import { escape } from 'lodash';
+import { i18n } from '@kbn/i18n';
 import { IField, IVectorSource } from '../../../maps/public';
 import { FIELD_ORIGIN } from '../../../maps/common';
 import { TileMetaFeature } from '../../../maps/common/descriptor_types';
@@ -15,12 +16,42 @@ import { ITooltipProperty } from '../../../maps/public';
 import { Filter } from '../../../../../src/plugins/data/public';
 
 export const ANOMALY_SOURCE_FIELDS: Record<string, Record<string, string>> = {
-  record_score: { label: 'Record score', type: 'number' },
-  timestamp: { label: 'Timestamp', type: 'string' },
-  fieldName: { label: 'Field label', type: 'string' },
-  functionDescription: { label: 'Function description', type: 'string' },
-  actual: { label: 'Actual', type: 'string' },
-  typical: { label: 'Typical', type: 'string' },
+  record_score: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerRecordScoreLabel', {
+      defaultMessage: 'Record score',
+    }),
+    type: 'number',
+  },
+  timestamp: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerTimeStampLabel', {
+      defaultMessage: 'Time',
+    }),
+    type: 'string',
+  },
+  fieldName: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerFieldNameLabel', {
+      defaultMessage: 'Field name',
+    }),
+    type: 'string',
+  },
+  functionDescription: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerFunctionDescriptionLabel', {
+      defaultMessage: 'Function',
+    }),
+    type: 'string',
+  },
+  actualDisplay: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerActualLabel', {
+      defaultMessage: 'Actual',
+    }),
+    type: 'string',
+  },
+  typicalDisplay: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerTypicalLabel', {
+      defaultMessage: 'Typical',
+    }),
+    type: 'string',
+  },
 };
 
 export class AnomalySourceTooltipProperty implements ITooltipProperty {

--- a/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
@@ -6,7 +6,7 @@
  */
 
 // eslint-disable-next-line max-classes-per-file
-import _ from 'lodash';
+import { escape } from 'lodash';
 import { IField, IVectorSource } from '../../../maps/public';
 import { FIELD_ORIGIN } from '../../../maps/common';
 import { TileMetaFeature } from '../../../maps/common/descriptor_types';
@@ -24,13 +24,7 @@ export const ANOMALY_SOURCE_FIELDS: Record<string, Record<string, string>> = {
 };
 
 export class AnomalySourceTooltipProperty implements ITooltipProperty {
-  private readonly _label: string;
-  private readonly _value: string;
-
-  constructor(label: string, value: string) {
-    this._label = label;
-    this._value = value;
-  }
+  constructor(private readonly _label: string, private readonly _value: string) {}
 
   async getESFilters(): Promise<Filter[]> {
     return [];
@@ -70,7 +64,7 @@ export class AnomalySourceField implements IField {
   async createTooltipProperty(value: string | string[] | undefined): Promise<ITooltipProperty> {
     return new AnomalySourceTooltipProperty(
       await this.getLabel(),
-      _.escape(Array.isArray(value) ? value.join() : value ? value : '')
+      escape(Array.isArray(value) ? value.join() : value ? value : '')
     );
   }
 

--- a/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
@@ -14,7 +14,16 @@ import { AnomalySource } from './anomaly_source';
 import { ITooltipProperty } from '../../../maps/public';
 import { Filter } from '../../../../../src/plugins/data/public';
 
-export class RecordScoreTooltipProperty implements ITooltipProperty {
+export const ANOMALY_SOURCE_FIELDS: Record<string, Record<string, string>> = {
+  record_score: { label: 'Record score', type: 'number' },
+  timestamp: { label: 'Timestamp', type: 'string' },
+  fieldName: { label: 'Field label', type: 'string' },
+  functionDescription: { label: 'Function description', type: 'string' },
+  actual: { label: 'Actual', type: 'string' },
+  typical: { label: 'Typical', type: 'string' },
+};
+
+export class AnomalySourceTooltipProperty implements ITooltipProperty {
   private readonly _label: string;
   private readonly _value: string;
 
@@ -48,30 +57,33 @@ export class RecordScoreTooltipProperty implements ITooltipProperty {
   }
 }
 
-export class RecordScoreField implements IField {
+// this needs to be generic so it works for all fields in anomaly record result
+export class AnomalySourceField implements IField {
   private readonly _source: AnomalySource;
+  private readonly _field: string;
 
-  constructor({ source }: { source: AnomalySource }) {
+  constructor({ source, field }: { source: AnomalySource; field: string }) {
     this._source = source;
+    this._field = field;
   }
 
   async createTooltipProperty(value: string | string[] | undefined): Promise<ITooltipProperty> {
-    return new RecordScoreTooltipProperty(
+    return new AnomalySourceTooltipProperty(
       await this.getLabel(),
       _.escape(Array.isArray(value) ? value.join() : value ? value : '')
     );
   }
 
   async getDataType(): Promise<string> {
-    return 'number';
+    return ANOMALY_SOURCE_FIELDS[this._field].type;
   }
 
   async getLabel(): Promise<string> {
-    return 'Record score';
+    return ANOMALY_SOURCE_FIELDS[this._field].label;
   }
 
   getName(): string {
-    return 'record_score';
+    return this._field;
   }
 
   getMbFieldName(): string {

--- a/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Component } from 'react';
+
+import { EuiPanel } from '@elastic/eui';
+import { AnomalySourceDescriptor } from './anomaly_source';
+import { AnomalyJobSelector } from './anomaly_job_selector';
+import { LayerSelector } from './layer_selector';
+
+interface Props {
+  onSourceConfigChange: (sourceConfig: Partial<AnomalySourceDescriptor> | null) => void;
+  mlJobsService: any; // todo: update types
+}
+
+interface State {
+  jobId?: string;
+  typicalActual?: 'typical' | 'actual';
+}
+
+export class CreateAnomalySourceEditor extends Component<Props, State> {
+  private _isMounted: boolean = false;
+  state: State = {};
+
+  private configChange() {
+    if (this.state.jobId) {
+      this.props.onSourceConfigChange({
+        jobId: this.state.jobId,
+        typicalActual: this.state.typicalActual,
+      });
+    }
+  }
+
+  componentDidMount(): void {
+    this._isMounted = true;
+  }
+
+  private onTypicalActualChange = (typicalActual: 'typical' | 'actual') => {
+    if (!this._isMounted) {
+      return;
+    }
+    this.setState(
+      {
+        typicalActual,
+      },
+      () => {
+        this.configChange();
+      }
+    );
+  };
+
+  private previewLayer = (jobId: string) => {
+    if (!this._isMounted) {
+      return;
+    }
+    this.setState(
+      {
+        jobId,
+      },
+      () => {
+        this.configChange();
+      }
+    );
+  };
+
+  render() {
+    const selector = this.state.jobId ? (
+      <LayerSelector
+        onChange={this.onTypicalActualChange}
+        typicalActual={this.state.typicalActual || 'typical'}
+      />
+    ) : null;
+    return (
+      <EuiPanel>
+        <AnomalyJobSelector
+          onJobChange={this.previewLayer}
+          mlJobsService={this.props.mlJobsService}
+        />
+        {selector}
+      </EuiPanel>
+    );
+  }
+}

--- a/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
@@ -73,7 +73,7 @@ export class CreateAnomalySourceEditor extends Component<Props, State> {
     const selector = this.state.jobId ? (
       <LayerSelector
         onChange={this.onTypicalActualChange}
-        typicalActual={this.state.typicalActual || 'typical'}
+        typicalActual={this.state.typicalActual || 'actual'}
       />
     ) : null;
     return (

--- a/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
@@ -12,10 +12,11 @@ import { AnomalySourceDescriptor } from './anomaly_source';
 import { AnomalyJobSelector } from './anomaly_job_selector';
 import { LayerSelector } from './layer_selector';
 import { MlAnomalyLayers } from './util';
+import type { MlApiServices } from '../application/services/ml_api_service';
 
 interface Props {
   onSourceConfigChange: (sourceConfig: Partial<AnomalySourceDescriptor> | null) => void;
-  mlJobsService: any; // todo: update types
+  mlJobsService: MlApiServices['jobs'];
 }
 
 interface State {

--- a/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
@@ -11,6 +11,7 @@ import { EuiPanel } from '@elastic/eui';
 import { AnomalySourceDescriptor } from './anomaly_source';
 import { AnomalyJobSelector } from './anomaly_job_selector';
 import { LayerSelector } from './layer_selector';
+import { MlAnomalyLayers } from './util';
 
 interface Props {
   onSourceConfigChange: (sourceConfig: Partial<AnomalySourceDescriptor> | null) => void;
@@ -19,7 +20,7 @@ interface Props {
 
 interface State {
   jobId?: string;
-  typicalActual?: 'typical' | 'actual';
+  typicalActual?: MlAnomalyLayers;
 }
 
 export class CreateAnomalySourceEditor extends Component<Props, State> {
@@ -39,7 +40,7 @@ export class CreateAnomalySourceEditor extends Component<Props, State> {
     this._isMounted = true;
   }
 
-  private onTypicalActualChange = (typicalActual: 'typical' | 'actual') => {
+  private onTypicalActualChange = (typicalActual: MlAnomalyLayers) => {
     if (!this._isMounted) {
       return;
     }

--- a/x-pack/plugins/ml/public/maps/layer_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/layer_selector.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Component } from 'react';
+
+import { EuiComboBox, EuiFormRow, EuiComboBoxOptionOption } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+interface Props {
+  onChange: (typicalActual: 'typical' | 'actual') => void;
+  typicalActual: 'typical' | 'actual';
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface State {}
+
+export class LayerSelector extends Component<Props, State> {
+  private _isMounted: boolean = false;
+
+  state: State = {};
+
+  componentDidMount(): void {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  onSelect = (selectedOptions: Array<EuiComboBoxOptionOption<string>>) => {
+    const typicalActual: 'typical' | 'actual' = selectedOptions[0].value! as 'typical' | 'actual';
+    if (this._isMounted) {
+      this.setState({ typicalActual });
+      this.props.onChange(typicalActual);
+    }
+  };
+
+  render() {
+    const options = [{ value: this.props.typicalActual, label: this.props.typicalActual }];
+    return (
+      <EuiFormRow
+        label={i18n.translate('xpack.ml.maps.typicalActualLabel', {
+          defaultMessage: 'Type',
+        })}
+        display="columnCompressed"
+      >
+        <EuiComboBox
+          singleSelection={true}
+          onChange={this.onSelect}
+          options={[
+            { value: 'typical', label: 'typical' },
+            { value: 'actual', label: 'actual' },
+          ]}
+          selectedOptions={options}
+        />
+      </EuiFormRow>
+    );
+  }
+}

--- a/x-pack/plugins/ml/public/maps/layer_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/layer_selector.tsx
@@ -56,8 +56,8 @@ export class LayerSelector extends Component<Props, State> {
           singleSelection={true}
           onChange={this.onSelect}
           options={[
-            { value: 'typical', label: 'typical' },
             { value: 'actual', label: 'actual' },
+            { value: 'typical', label: 'typical' },
             { value: 'connected', label: 'connected' },
           ]}
           selectedOptions={options}

--- a/x-pack/plugins/ml/public/maps/layer_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/layer_selector.tsx
@@ -9,10 +9,11 @@ import React, { Component } from 'react';
 
 import { EuiComboBox, EuiFormRow, EuiComboBoxOptionOption } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { MlAnomalyLayers } from './util';
 
 interface Props {
-  onChange: (typicalActual: 'typical' | 'actual') => void;
-  typicalActual: 'typical' | 'actual';
+  onChange: (typicalActual: MlAnomalyLayers) => void;
+  typicalActual: MlAnomalyLayers;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -32,7 +33,10 @@ export class LayerSelector extends Component<Props, State> {
   }
 
   onSelect = (selectedOptions: Array<EuiComboBoxOptionOption<string>>) => {
-    const typicalActual: 'typical' | 'actual' = selectedOptions[0].value! as 'typical' | 'actual';
+    const typicalActual: MlAnomalyLayers = selectedOptions[0].value! as
+      | 'typical'
+      | 'actual'
+      | 'connected';
     if (this._isMounted) {
       this.setState({ typicalActual });
       this.props.onChange(typicalActual);
@@ -54,6 +58,7 @@ export class LayerSelector extends Component<Props, State> {
           options={[
             { value: 'typical', label: 'typical' },
             { value: 'actual', label: 'actual' },
+            { value: 'connected', label: 'connected' },
           ]}
           selectedOptions={options}
         />

--- a/x-pack/plugins/ml/public/maps/record_score_field.ts
+++ b/x-pack/plugins/ml/public/maps/record_score_field.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// eslint-disable-next-line max-classes-per-file
+import _ from 'lodash';
+import { IField, IVectorSource } from '../../../maps/public';
+import { FIELD_ORIGIN } from '../../../maps/common';
+import { TileMetaFeature } from '../../../maps/common/descriptor_types';
+import { AnomalySource } from './anomaly_source';
+import { ITooltipProperty } from '../../../maps/public';
+import { Filter } from '../../../../../src/plugins/data/public';
+
+export class RecordScoreTooltipProperty implements ITooltipProperty {
+  private readonly _label: string;
+  private readonly _value: string;
+
+  constructor(label: string, value: string) {
+    this._label = label;
+    this._value = value;
+  }
+
+  async getESFilters(): Promise<Filter[]> {
+    return [];
+  }
+
+  getHtmlDisplayValue(): string {
+    return this._value.toString();
+  }
+
+  getPropertyKey(): string {
+    return this._label;
+  }
+
+  getPropertyName(): string {
+    return this._label;
+  }
+
+  getRawValue(): string | string[] | undefined {
+    return this._value.toString();
+  }
+
+  isFilterable(): boolean {
+    return false;
+  }
+}
+
+export class RecordScoreField implements IField {
+  private readonly _source: AnomalySource;
+
+  constructor({ source }: { source: AnomalySource }) {
+    this._source = source;
+  }
+
+  async createTooltipProperty(value: string | string[] | undefined): Promise<ITooltipProperty> {
+    return new RecordScoreTooltipProperty(
+      await this.getLabel(),
+      _.escape(Array.isArray(value) ? value.join() : value ? value : '')
+    );
+  }
+
+  async getDataType(): Promise<string> {
+    return 'number';
+  }
+
+  async getLabel(): Promise<string> {
+    return 'Record score';
+  }
+
+  getName(): string {
+    return 'record_score';
+  }
+
+  getMbFieldName(): string {
+    return this.getName();
+  }
+
+  getOrigin(): FIELD_ORIGIN {
+    return FIELD_ORIGIN.SOURCE;
+  }
+
+  getRootName(): string {
+    return this.getName();
+  }
+
+  getSource(): IVectorSource {
+    return this._source;
+  }
+
+  isCount() {
+    return false;
+  }
+
+  isEqual(field: IField): boolean {
+    return this.getName() === field.getName();
+  }
+
+  isValid(): boolean {
+    return true;
+  }
+
+  pluckRangeFromTileMetaFeature(metaFeature: TileMetaFeature) {
+    return null;
+  }
+
+  // NA
+  canReadFromGeoJson(): boolean {
+    return false;
+  }
+
+  // NA
+  canValueBeFormatted(): boolean {
+    return false;
+  }
+
+  // NA
+  supportsAutoDomain(): boolean {
+    return false;
+  }
+
+  // NA
+  supportsFieldMeta(): boolean {
+    return false;
+  }
+
+  supportsFieldMetaFromLocalData(): boolean {
+    return false;
+  }
+
+  supportsFieldMetaFromEs(): boolean {
+    return false;
+  }
+
+  // NA
+  async getPercentilesFieldMetaRequest(percentiles: number[]): Promise<unknown | null> {
+    return null;
+  }
+
+  // NA
+  async getExtendedStatsFieldMetaRequest(): Promise<unknown | null> {
+    return undefined;
+  }
+  // NA
+  async getCategoricalFieldMetaRequest(size: number): Promise<unknown> {
+    return undefined;
+  }
+}

--- a/x-pack/plugins/ml/public/maps/record_score_field.ts
+++ b/x-pack/plugins/ml/public/maps/record_score_field.ts
@@ -90,10 +90,6 @@ export class RecordScoreField implements IField {
     return this._source;
   }
 
-  isCount() {
-    return false;
-  }
-
   isEqual(field: IField): boolean {
     return this.getName() === field.getName();
   }
@@ -102,49 +98,35 @@ export class RecordScoreField implements IField {
     return true;
   }
 
-  pluckRangeFromTileMetaFeature(metaFeature: TileMetaFeature) {
-    return null;
-  }
-
-  // NA
-  canReadFromGeoJson(): boolean {
-    return false;
-  }
-
-  // NA
-  canValueBeFormatted(): boolean {
-    return false;
-  }
-
-  // NA
-  supportsAutoDomain(): boolean {
-    return false;
-  }
-
-  // NA
-  supportsFieldMeta(): boolean {
-    return false;
-  }
-
   supportsFieldMetaFromLocalData(): boolean {
-    return false;
+    return true;
   }
 
   supportsFieldMetaFromEs(): boolean {
     return false;
   }
 
-  // NA
-  async getPercentilesFieldMetaRequest(percentiles: number[]): Promise<unknown | null> {
+  canValueBeFormatted(): boolean {
+    return false;
+  }
+
+  async getExtendedStatsFieldMetaRequest(): Promise<unknown> {
     return null;
   }
 
-  // NA
-  async getExtendedStatsFieldMetaRequest(): Promise<unknown | null> {
-    return undefined;
+  async getPercentilesFieldMetaRequest(percentiles: number[]): Promise<unknown> {
+    return null;
   }
-  // NA
+
   async getCategoricalFieldMetaRequest(size: number): Promise<unknown> {
-    return undefined;
+    return null;
+  }
+
+  pluckRangeFromTileMetaFeature(metaFeature: TileMetaFeature): { min: number; max: number } | null {
+    return null;
+  }
+
+  isCount(): boolean {
+    return false;
   }
 }

--- a/x-pack/plugins/ml/public/maps/register_map_extension.ts
+++ b/x-pack/plugins/ml/public/maps/register_map_extension.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MapsSetupApi } from '../../../maps/public';
+import type { MlCoreSetup } from '../plugin';
+import { AnomalySourceFactory } from './anomaly_source_factory';
+import { AnomalyLayerWizardFactory } from './anomaly_layer_wizard_factory';
+
+export async function registerMapExtension(
+  mapsSetupApi: MapsSetupApi,
+  core: MlCoreSetup,
+  canGetJobs: any // update this type
+) {
+  const anomalySourceFactory = new AnomalySourceFactory(core.getStartServices, canGetJobs);
+  const anomalyLayerWizardFactory = new AnomalyLayerWizardFactory(
+    core.getStartServices,
+    canGetJobs
+  );
+  const anomalylayerWizard = await anomalyLayerWizardFactory.create();
+
+  mapsSetupApi.registerSource({
+    type: anomalySourceFactory.type,
+    ConstructorFunction: await anomalySourceFactory.create(),
+  });
+
+  mapsSetupApi.registerLayerWizard(anomalylayerWizard);
+}

--- a/x-pack/plugins/ml/public/maps/register_map_extension.ts
+++ b/x-pack/plugins/ml/public/maps/register_map_extension.ts
@@ -13,7 +13,7 @@ import { AnomalyLayerWizardFactory } from './anomaly_layer_wizard_factory';
 export async function registerMapExtension(
   mapsSetupApi: MapsSetupApi,
   core: MlCoreSetup,
-  canGetJobs: any // update this type
+  canGetJobs: boolean
 ) {
   const anomalySourceFactory = new AnomalySourceFactory(core.getStartServices, canGetJobs);
   const anomalyLayerWizardFactory = new AnomalyLayerWizardFactory(

--- a/x-pack/plugins/ml/public/maps/update_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/update_anomaly_source_editor.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Fragment, Component } from 'react';
+
+import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { LayerSelector } from './layer_selector';
+
+interface Props {
+  onChange: (...args: Array<{ propName: string; value: unknown }>) => void;
+  typicalActual: 'typical' | 'actual';
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface State {}
+
+export class UpdateAnomalySourceEditor extends Component<Props, State> {
+  state: State = {};
+
+  render() {
+    return (
+      <Fragment>
+        <EuiPanel>
+          <EuiTitle size="xs">
+            <h6>
+              <FormattedMessage id="xpack.ml.maps.settingsEditorLabel" defaultMessage="Anomalies" />
+            </h6>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <LayerSelector
+            onChange={(typicalActual: 'typical' | 'actual') => {
+              this.props.onChange({
+                propName: 'typicalActual',
+                value: typicalActual,
+              });
+            }}
+            typicalActual={this.props.typicalActual}
+          />
+        </EuiPanel>
+        <EuiSpacer size="s" />
+      </Fragment>
+    );
+  }
+}

--- a/x-pack/plugins/ml/public/maps/update_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/update_anomaly_source_editor.tsx
@@ -10,10 +10,11 @@ import React, { Fragment, Component } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { LayerSelector } from './layer_selector';
+import { MlAnomalyLayers } from './util';
 
 interface Props {
   onChange: (...args: Array<{ propName: string; value: unknown }>) => void;
-  typicalActual: 'typical' | 'actual';
+  typicalActual: MlAnomalyLayers;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -33,7 +34,7 @@ export class UpdateAnomalySourceEditor extends Component<Props, State> {
           </EuiTitle>
           <EuiSpacer size="s" />
           <LayerSelector
-            onChange={(typicalActual: 'typical' | 'actual') => {
+            onChange={(typicalActual: MlAnomalyLayers) => {
               this.props.onChange({
                 propName: 'typicalActual',
                 value: typicalActual,

--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FeatureCollection, Feature } from 'geojson';
+import { ESSearchResponse } from '../../../../../src/core/types/elasticsearch';
+import { MLAnomalyDoc } from '../../common/types/anomalies';
+
+export async function getResultsForJobId(
+  mlResultsService: any,
+  jobId: string,
+  locationType: 'typical' | 'actual'
+): Promise<FeatureCollection> {
+  // Query to look for the highest scoring anomaly.
+  const body: any = {
+    query: {
+      bool: {
+        must: [{ term: { job_id: jobId } }, { term: { result_type: 'record' } }],
+      },
+    },
+    size: 1000,
+    _source: {
+      excludes: [],
+    },
+  };
+
+  let resp: ESSearchResponse<MLAnomalyDoc> | null = null;
+  let hits: Array<{ typical: number[]; actual: number[]; record_score: number }> = [];
+
+  try {
+    resp = await mlResultsService.anomalySearch(
+      {
+        body,
+      },
+      [jobId]
+    );
+  } catch (error) {
+    // search may fail if the job doesn't already exist
+    // ignore this error as the outer function call will raise a toast
+  }
+  if (resp !== null && resp.hits.total.value > 0) {
+    hits = resp.hits.hits.map(({ _source }) => {
+      const geoResults = _source.geo_results;
+      const actualCoordStr = geoResults && geoResults.actual_point;
+      const typicalCoordStr = geoResults && geoResults.typical_point;
+      let typical;
+      let actual;
+      // Must reverse coordinates here. Map expects [lon, lat] - anomalies are stored as [lat, lon] for lat_lon jobs
+      if (actualCoordStr !== undefined) {
+        actual = actualCoordStr
+          .split(',')
+          .map((point: string) => Number(point))
+          .reverse();
+      }
+      if (typicalCoordStr !== undefined) {
+        typical = typicalCoordStr
+          .split(',')
+          .map((point: string) => Number(point))
+          .reverse();
+      }
+      return {
+        typical,
+        actual,
+        record_score: Math.floor(_source.record_score),
+      };
+    });
+  }
+
+  const features: Feature[] = hits!.map((result) => {
+    return {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: locationType === 'typical' ? result.typical : result.actual,
+      },
+      properties: {
+        record_score: result.record_score,
+      },
+    };
+  });
+
+  return {
+    type: 'FeatureCollection',
+    features,
+  };
+}

--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { FeatureCollection, Feature } from 'geojson';
+import { FeatureCollection, Feature, Geometry } from 'geojson';
 import { ESSearchResponse } from '../../../../../src/core/types/elasticsearch';
 import { formatHumanReadableDateTimeSeconds } from '../../common/util/date_utils';
 import type { MlApiServices } from '../application/services/ml_api_service';
 import { MLAnomalyDoc } from '../../common/types/anomalies';
-import type { SearchFilters } from './anomaly_source';
+import { VectorSourceRequestMeta } from '../../../maps/common';
 
 export type MlAnomalyLayers = 'typical' | 'actual' | 'connected';
 
@@ -18,7 +18,7 @@ export async function getResultsForJobId(
   mlResultsService: MlApiServices['results'],
   jobId: string,
   locationType: MlAnomalyLayers,
-  searchFilters: SearchFilters
+  searchFilters: VectorSourceRequestMeta
 ): Promise<FeatureCollection> {
   const { timeFilters } = searchFilters;
   // Query to look for the highest scoring anomaly.
@@ -98,9 +98,8 @@ export async function getResultsForJobId(
     });
   }
 
-  // @ts-ignore
-  const features: Feature[] = hits!.map((result) => {
-    let geometry;
+  const features: Feature[] = hits.map((result) => {
+    let geometry: Geometry;
     if (locationType === 'typical' || locationType === 'actual') {
       geometry = {
         type: 'Point',

--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -7,7 +7,7 @@
 
 import { FeatureCollection, Feature } from 'geojson';
 import { ESSearchResponse } from '../../../../../src/core/types/elasticsearch';
-import { MlApiServices } from '../application/services/ml_api_service';
+import type { MlApiServices } from '../application/services/ml_api_service';
 import { MLAnomalyDoc } from '../../common/types/anomalies';
 import type { SearchFilters } from './anomaly_source';
 

--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -7,6 +7,7 @@
 
 import { FeatureCollection, Feature } from 'geojson';
 import { ESSearchResponse } from '../../../../../src/core/types/elasticsearch';
+import { formatHumanReadableDateTimeSeconds } from '../../common/util/date_utils';
 import type { MlApiServices } from '../application/services/ml_api_service';
 import { MLAnomalyDoc } from '../../common/types/anomalies';
 import type { SearchFilters } from './anomaly_source';
@@ -46,7 +47,14 @@ export async function getResultsForJobId(
   }
 
   let resp: ESSearchResponse<MLAnomalyDoc> | null = null;
-  let hits: Array<{ typical: number[]; actual: number[]; record_score: number }> = [];
+  let hits: Array<{
+    actual: number[];
+    fieldName?: string;
+    functionDescription: string;
+    typical: number[];
+    record_score: number;
+    timestamp: string;
+  }> = [];
 
   try {
     resp = await mlResultsService.anomalySearch(
@@ -80,6 +88,9 @@ export async function getResultsForJobId(
           .reverse();
       }
       return {
+        fieldName: _source.field_name,
+        functionDescription: _source.function_description,
+        timestamp: formatHumanReadableDateTimeSeconds(_source.timestamp),
         typical,
         actual,
         record_score: Math.floor(_source.record_score),
@@ -105,6 +116,11 @@ export async function getResultsForJobId(
       type: 'Feature',
       geometry,
       properties: {
+        actual: result.actual,
+        typical: result.typical,
+        fieldName: result.fieldName,
+        functionDescription: result.functionDescription,
+        timestamp: result.timestamp,
         record_score: result.record_score,
       },
     };

--- a/x-pack/plugins/ml/public/plugin.ts
+++ b/x-pack/plugins/ml/public/plugin.ts
@@ -117,7 +117,6 @@ export class MlPlugin implements Plugin<MlPluginSetup, MlPluginStart> {
             licenseManagement: pluginsSetup.licenseManagement,
             home: pluginsSetup.home,
             embeddable: { ...pluginsSetup.embeddable, ...pluginsStart.embeddable },
-            // @ts-ignore
             maps: pluginsStart.maps,
             uiActions: pluginsStart.uiActions,
             kibanaVersion,

--- a/x-pack/plugins/ml/public/plugin.ts
+++ b/x-pack/plugins/ml/public/plugin.ts
@@ -36,7 +36,7 @@ import { isFullLicense, isMlEnabled } from '../common/license';
 import { setDependencyCache } from './application/util/dependency_cache';
 import { registerFeature } from './register_feature';
 import { MlLocatorDefinition, MlLocator } from './locator';
-import type { MapsStartApi } from '../../maps/public';
+import type { MapsStartApi, MapsSetupApi } from '../../maps/public';
 import {
   TriggersAndActionsUIPublicPluginSetup,
   TriggersAndActionsUIPublicPluginStart,
@@ -66,6 +66,7 @@ export interface MlStartDependencies {
 
 export interface MlSetupDependencies {
   security?: SecurityPluginSetup;
+  maps?: MapsSetupApi;
   licensing: LicensingPluginSetup;
   management?: ManagementSetup;
   licenseManagement?: LicenseManagementUIPluginSetup;
@@ -116,6 +117,7 @@ export class MlPlugin implements Plugin<MlPluginSetup, MlPluginStart> {
             licenseManagement: pluginsSetup.licenseManagement,
             home: pluginsSetup.home,
             embeddable: { ...pluginsSetup.embeddable, ...pluginsStart.embeddable },
+            // @ts-ignore
             maps: pluginsStart.maps,
             uiActions: pluginsStart.uiActions,
             kibanaVersion,
@@ -159,11 +161,23 @@ export class MlPlugin implements Plugin<MlPluginSetup, MlPluginStart> {
 
       // register various ML plugin features which require a full license
       // note including registerFeature in register_helper would cause the page bundle size to increase significantly
-      const { registerEmbeddables, registerMlUiActions, registerSearchLinks, registerMlAlerts } =
-        await import('./register_helper');
+      const {
+        registerEmbeddables,
+        registerMlUiActions,
+        registerSearchLinks,
+        registerMlAlerts,
+        registerMapExtension,
+      } = await import('./register_helper');
 
       const mlEnabled = isMlEnabled(license);
       const fullLicense = isFullLicense(license);
+
+      if (pluginsSetup.maps) {
+        // Pass capabilites.ml.canGetJobs as minimum permission to show anomalies card in maps layers
+        const canGetJobs = capabilities.ml?.canGetJobs || false;
+        await registerMapExtension(pluginsSetup.maps, core, canGetJobs);
+      }
+
       if (mlEnabled) {
         registerSearchLinks(this.appUpdater$, fullLicense);
 

--- a/x-pack/plugins/ml/public/plugin.ts
+++ b/x-pack/plugins/ml/public/plugin.ts
@@ -174,7 +174,7 @@ export class MlPlugin implements Plugin<MlPluginSetup, MlPluginStart> {
 
       if (pluginsSetup.maps) {
         // Pass capabilites.ml.canGetJobs as minimum permission to show anomalies card in maps layers
-        const canGetJobs = capabilities.ml?.canGetJobs || false;
+        const canGetJobs = capabilities.ml?.canGetJobs === true || false;
         await registerMapExtension(pluginsSetup.maps, core, canGetJobs);
       }
 

--- a/x-pack/plugins/ml/public/register_helper/index.ts
+++ b/x-pack/plugins/ml/public/register_helper/index.ts
@@ -10,3 +10,4 @@ export { registerManagementSection } from '../application/management';
 export { registerMlUiActions } from '../ui_actions';
 export { registerSearchLinks } from './register_search_links';
 export { registerMlAlerts } from '../alerting';
+export { registerMapExtension } from '../maps/register_map_extension';

--- a/x-pack/plugins/ml/server/models/job_service/jobs.ts
+++ b/x-pack/plugins/ml/server/models/job_service/jobs.ts
@@ -273,20 +273,9 @@ export function jobsProvider(
     return jobs;
   }
 
-  async function getJobsWithGeo(): Promise<string[]> {
+  async function getJobIdsWithGeo(): Promise<string[]> {
     const { body } = await mlClient.getJobs<MlJobsResponse>();
-
-    const geoJobs: string[] = [];
-
-    if (body.count && body.count > 0) {
-      body.jobs.forEach((job) => {
-        if (isJobWithGeoData(job)) {
-          geoJobs.push(job.job_id);
-        }
-      });
-    }
-
-    return geoJobs;
+    return body.jobs.filter(isJobWithGeoData).map((job) => job.job_id);
   }
 
   async function jobsWithTimerange() {
@@ -686,6 +675,6 @@ export function jobsProvider(
     getAllJobAndGroupIds,
     getLookBackProgress,
     bulkCreate,
-    getJobsWithGeo,
+    getJobIdsWithGeo,
   };
 }

--- a/x-pack/plugins/ml/server/models/job_service/jobs.ts
+++ b/x-pack/plugins/ml/server/models/job_service/jobs.ts
@@ -11,6 +11,7 @@ import { IScopedClusterClient } from 'kibana/server';
 import {
   getSingleMetricViewerJobErrorMessage,
   parseTimeIntervalForJob,
+  isJobWithGeoData,
 } from '../../../common/util/job_utils';
 import { JOB_STATE, DATAFEED_STATE } from '../../../common/constants/states';
 import {
@@ -270,6 +271,22 @@ export function jobsProvider(
     });
 
     return jobs;
+  }
+
+  async function getJobsWithGeo(): Promise<string[]> {
+    const { body } = await mlClient.getJobs<MlJobsResponse>();
+
+    const geoJobs: string[] = [];
+
+    if (body.count && body.count > 0) {
+      body.jobs.forEach((job) => {
+        if (isJobWithGeoData(job)) {
+          geoJobs.push(job.job_id);
+        }
+      });
+    }
+
+    return geoJobs;
   }
 
   async function jobsWithTimerange() {
@@ -669,5 +686,6 @@ export function jobsProvider(
     getAllJobAndGroupIds,
     getLookBackProgress,
     bulkCreate,
+    getJobsWithGeo,
   };
 }

--- a/x-pack/plugins/ml/server/routes/job_service.ts
+++ b/x-pack/plugins/ml/server/routes/job_service.ts
@@ -288,6 +288,44 @@ export function jobServiceRoutes({ router, routeGuard }: RouteInitialization) {
   /**
    * @apiGroup JobService
    *
+   * @api {post} /api/ml/jobs/jobs_with_geo Jobs summary
+   * @apiName JobsSummary
+   * @apiDescription Returns a list of anomaly detection jobs with analysis config with fields supported by maps.
+   *
+   * @apiSchema (body) optionalJobIdsSchema
+   *
+   * @apiSuccess {Array} jobIds list of job ids.
+   */
+  router.get(
+    {
+      path: '/api/ml/jobs/jobs_with_geo',
+      validate: false,
+      options: {
+        tags: ['access:ml:canGetJobs'],
+      },
+    },
+    routeGuard.fullLicenseAPIGuard(async ({ client, mlClient, response, context }) => {
+      try {
+        const { getJobsWithGeo } = jobServiceProvider(
+          client,
+          mlClient,
+          context.alerting?.getRulesClient()
+        );
+
+        const resp = await getJobsWithGeo();
+
+        return response.ok({
+          body: resp,
+        });
+      } catch (e) {
+        return response.customError(wrapError(e));
+      }
+    })
+  );
+
+  /**
+   * @apiGroup JobService
+   *
    * @api {post} /api/ml/jobs/jobs_with_time_range Jobs with time range
    * @apiName JobsWithTimeRange
    * @apiDescription Creates a list of jobs with data about the job's time range

--- a/x-pack/plugins/ml/server/routes/job_service.ts
+++ b/x-pack/plugins/ml/server/routes/job_service.ts
@@ -306,13 +306,13 @@ export function jobServiceRoutes({ router, routeGuard }: RouteInitialization) {
     },
     routeGuard.fullLicenseAPIGuard(async ({ client, mlClient, response, context }) => {
       try {
-        const { getJobsWithGeo } = jobServiceProvider(
+        const { getJobIdsWithGeo } = jobServiceProvider(
           client,
           mlClient,
           context.alerting?.getRulesClient()
         );
 
-        const resp = await getJobsWithGeo();
+        const resp = await getJobIdsWithGeo();
 
         return response.ok({
           body: resp,

--- a/x-pack/plugins/ml/server/routes/job_service.ts
+++ b/x-pack/plugins/ml/server/routes/job_service.ts
@@ -292,8 +292,6 @@ export function jobServiceRoutes({ router, routeGuard }: RouteInitialization) {
    * @apiName JobsSummary
    * @apiDescription Returns a list of anomaly detection jobs with analysis config with fields supported by maps.
    *
-   * @apiSchema (body) optionalJobIdsSchema
-   *
    * @apiSuccess {Array} jobIds list of job ids.
    */
   router.get(


### PR DESCRIPTION
## Summary

Related draft PR: https://github.com/elastic/kibana/pull/113857

Extends and updates #90497
Incorporates latest maps changes (#112465, #112333) into initial draft PR (#111228)

- [x] Anomalies layer card should be displayed in maps when creating layers
- [x]  Layer options for anomalies for the chosen job should include
    - [x] typical
    - [x] actual
    - [x] difference between typical/actual
- [x] The card should be disabled when the user does not have access to ML
- [x] Tooltip for point on the map should include useful information
- [ ] When there are no ML jobs available for selection in the wizard, we should not show the combo-box, and instead show some exaplanation/hyperlink. E.g. a link to ML job creation or job management page (for follow up)
- [x] Anomalies layer should incorporate time filter
- [ ] Anomalies layer should work with query filter (for follow up)
- [ ] `getResultsForJobId` needs a unit test and can be converted to service (for follow up)
- [ ] Add some explanatory text to job selector

Nice to have:
- [ ] Anytime a job is "mappable", should provide a hyperlink in the ML-app, something like "Explore in maps".
- [ ] hyperlink for anomaly explorer page (https://github.com/elastic/kibana/pull/122862#discussion_r787161873)
- [ ] Would it be useful to add a switch to turn on/off "time-awareness".
- [ ] get the partitioning field names and values in the tooltip too

## Screenshots

Anomalies layer card in maps:

![image](https://user-images.githubusercontent.com/6446462/150033063-517dff96-7eb2-46c1-ac84-6953453d8b85.png)

Job selection for jobs that contain supported geo data:

![image](https://user-images.githubusercontent.com/6446462/150033124-90f75c94-c4c4-4232-b740-553cf99759ba.png)

Layers available:

![image](https://user-images.githubusercontent.com/6446462/150033257-d6d79587-da2b-4b1c-b9f4-47b9176a1d59.png)

Tooltip:

![image](https://user-images.githubusercontent.com/6446462/150033305-c3608db9-669e-4ec0-be5c-9563332ddf17.png)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
