### PR TITLE
[Uptime] Overview link to Exploratory View should not filter by monitor

### DIFF
--- a/x-pack/plugins/uptime/public/components/common/header/action_menu_content.tsx
+++ b/x-pack/plugins/uptime/public/components/common/header/action_menu_content.tsx
@@ -16,7 +16,7 @@ import { useKibana } from '../../../../../../../src/plugins/kibana_react/public'
 import { useUptimeSettingsContext } from '../../../contexts/uptime_settings_context';
 import { useGetUrlParams } from '../../../hooks';
 import { ToggleAlertFlyoutButton } from '../../overview/alerts/alerts_containers';
-import { MONITOR_MANAGEMENT, OVERVIEW_ROUTE, SETTINGS_ROUTE } from '../../../../common/constants';
+import { MONITOR_MANAGEMENT, MONITOR_ROUTE, SETTINGS_ROUTE } from '../../../../common/constants';
 import { stringifyUrlParams } from '../../../lib/helper/stringify_url_params';
 import { InspectorHeaderLink } from './inspector_header_link';
 import { monitorStatusSelector } from '../../../state/selectors';
@@ -44,7 +44,7 @@ export function ActionMenuContent({ config }: { config: UptimeConfig }): React.R
 
   const selectedMonitor = useSelector(monitorStatusSelector);
 
-  const overviewRouteMatch = useRouteMatch(OVERVIEW_ROUTE);
+  const detailRouteMatch = useRouteMatch(MONITOR_ROUTE);
   const monitorId = selectedMonitor?.monitor?.id;
 
   const syntheticExploratoryViewLink = createExploratoryViewUrl(
@@ -66,7 +66,7 @@ export function ActionMenuContent({ config }: { config: UptimeConfig }): React.R
                *
                * This condition is intended to allow monitor filtering on all other pages.
                */
-              selectedMonitor?.monitor?.name && overviewRouteMatch?.isExact !== true
+              selectedMonitor?.monitor?.name && detailRouteMatch?.isExact === true
                 ? [selectedMonitor?.monitor?.name]
                 : [],
             'url.full': ['ALL_VALUES'],

--- a/x-pack/plugins/uptime/public/components/common/header/action_menu_content.tsx
+++ b/x-pack/plugins/uptime/public/components/common/header/action_menu_content.tsx
@@ -59,13 +59,6 @@ export function ActionMenuContent({ config }: { config: UptimeConfig }): React.R
           breakdown: monitorId ? 'observer.geo.name' : 'monitor.type',
           reportDefinitions: {
             'monitor.name':
-              /*
-               * The second condition exists because we don't want to link users to an
-               * exploratory view that is filtered by a specific monitor when they're on
-               * the Uptime Overview page.
-               *
-               * This condition is intended to allow monitor filtering on all other pages.
-               */
               selectedMonitor?.monitor?.name && detailRouteMatch?.isExact === true
                 ? [selectedMonitor?.monitor?.name]
                 : [],

--- a/x-pack/plugins/uptime/public/components/common/header/action_menu_content.tsx
+++ b/x-pack/plugins/uptime/public/components/common/header/action_menu_content.tsx
@@ -9,14 +9,14 @@ import React from 'react';
 import { EuiHeaderLinks, EuiToolTip, EuiHeaderLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useRouteMatch } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { createExploratoryViewUrl } from '../../../../../observability/public';
 import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
 import { useUptimeSettingsContext } from '../../../contexts/uptime_settings_context';
 import { useGetUrlParams } from '../../../hooks';
 import { ToggleAlertFlyoutButton } from '../../overview/alerts/alerts_containers';
-import { MONITOR_MANAGEMENT, SETTINGS_ROUTE } from '../../../../common/constants';
+import { MONITOR_MANAGEMENT, OVERVIEW_ROUTE, SETTINGS_ROUTE } from '../../../../common/constants';
 import { stringifyUrlParams } from '../../../lib/helper/stringify_url_params';
 import { InspectorHeaderLink } from './inspector_header_link';
 import { monitorStatusSelector } from '../../../state/selectors';
@@ -44,6 +44,7 @@ export function ActionMenuContent({ config }: { config: UptimeConfig }): React.R
 
   const selectedMonitor = useSelector(monitorStatusSelector);
 
+  const overviewRouteMatch = useRouteMatch(OVERVIEW_ROUTE);
   const monitorId = selectedMonitor?.monitor?.id;
 
   const syntheticExploratoryViewLink = createExploratoryViewUrl(
@@ -57,7 +58,17 @@ export function ActionMenuContent({ config }: { config: UptimeConfig }): React.R
           time: { from: dateRangeStart, to: dateRangeEnd },
           breakdown: monitorId ? 'observer.geo.name' : 'monitor.type',
           reportDefinitions: {
-            'monitor.name': selectedMonitor?.monitor?.name ? [selectedMonitor?.monitor?.name] : [],
+            'monitor.name':
+              /*
+               * The second condition exists because we don't want to link users to an
+               * exploratory view that is filtered by a specific monitor when they're on
+               * the Uptime Overview page.
+               *
+               * This condition is intended to allow monitor filtering on all other pages.
+               */
+              selectedMonitor?.monitor?.name && overviewRouteMatch?.isExact !== true
+                ? [selectedMonitor?.monitor?.name]
+                : [],
             'url.full': ['ALL_VALUES'],
           },
           name: monitorId ? `${monitorId}-response-duration` : 'All monitors response duration',


### PR DESCRIPTION
## Summary

Resolves #121348.

The Overview page should no longer filter the Exploratory View by monitor name when the link is clicked.

## Testing this PR

~Follow the steps in the linked issue. When running this branch you should see that the exploratory view link that the page generates does not contain a monitor-specific filter on the overview page. This monitor filtering should work on other pages.~

1. Index some data with Heartbeat.
2. Go to the Overview page in Uptime.
3. Drill into a monitor.
4. Return to the Overview page without reloading the app.
5. Click the Explore Data link.
6. Ensure that the Exploratory View is not filtered down to a single monitor.

Repeat these same steps with the certs view. Start on the overview page, drill in, then go to certs and link to exp. view.

Ensure that when clicking from the detail page of a monitor, the exp. view _is still filtered_ by monitor.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
