### PR TITLE
[Cases][Lens] Disable triggers for lens embeddables

### DIFF
--- a/x-pack/plugins/cases/public/components/markdown_editor/plugins/lens/processor.tsx
+++ b/x-pack/plugins/cases/public/components/markdown_editor/plugins/lens/processor.tsx
@@ -49,6 +49,7 @@ const LensMarkDownRendererComponent: React.FC<LensMarkDownRendererProps> = ({
         timeRange={timeRange}
         attributes={attributes}
         renderMode="view"
+        disableTriggers
       />
       <LensChartTooltipFix />
     </Container>


### PR DESCRIPTION
## Summary

Disables the triggers on Lens chart embedddables for the 'filter for value' and 'filter out value' buttons.

Related issue: https://github.com/elastic/kibana/issues/122210

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
