### PR TITLE
[7.17] Remove deprecated "type" field

### DIFF
--- a/packages/kbn-es-archiver/src/lib/docs/generate_doc_records_stream.test.ts
+++ b/packages/kbn-es-archiver/src/lib/docs/generate_doc_records_stream.test.ts
@@ -27,7 +27,6 @@ interface SearchResponses {
         total: number;
         hits: Array<{
           _index: string;
-          _type: string;
           _id: string;
           _source: Record<string, unknown>;
         }>;
@@ -59,9 +58,9 @@ describe('esArchiver: createGenerateDocRecordsStream()', () => {
             hits: {
               total: 5,
               hits: [
-                { _index: 'foo', _type: '_doc', _id: '0', _source: {} },
-                { _index: 'foo', _type: '_doc', _id: '1', _source: {} },
-                { _index: 'foo', _type: '_doc', _id: '2', _source: {} },
+                { _index: 'foo', _id: '0', _source: {} },
+                { _index: 'foo', _id: '1', _source: {} },
+                { _index: 'foo', _id: '2', _source: {} },
               ],
             },
           },
@@ -71,8 +70,8 @@ describe('esArchiver: createGenerateDocRecordsStream()', () => {
             hits: {
               total: 5,
               hits: [
-                { _index: 'foo', _type: '_doc', _id: '3', _source: {} },
-                { _index: 'foo', _type: '_doc', _id: '4', _source: {} },
+                { _index: 'foo', _id: '3', _source: {} },
+                { _index: 'foo', _id: '4', _source: {} },
               ],
             },
           },
@@ -84,8 +83,8 @@ describe('esArchiver: createGenerateDocRecordsStream()', () => {
             hits: {
               total: 2,
               hits: [
-                { _index: 'bar', _type: '_doc', _id: '0', _source: {} },
-                { _index: 'bar', _type: '_doc', _id: '1', _source: {} },
+                { _index: 'bar', _id: '0', _source: {} },
+                { _index: 'bar', _id: '1', _source: {} },
               ],
             },
           },
@@ -108,7 +107,6 @@ describe('esArchiver: createGenerateDocRecordsStream()', () => {
       createMapStream((record: any) => {
         expect(record).toHaveProperty('type', 'doc');
         expect(record.value.source).toEqual({});
-        expect(record.value.type).toBe('_doc');
         expect(record.value.index).toMatch(/^(foo|bar)$/);
         expect(record.value.id).toMatch(/^\d+$/);
         return `${record.value.index}:${record.value.id}`;
@@ -224,7 +222,7 @@ describe('esArchiver: createGenerateDocRecordsStream()', () => {
 
   describe('keepIndexNames', () => {
     it('changes .kibana* index names if keepIndexNames is not enabled', async () => {
-      const hits = [{ _index: '.kibana_7.16.0_001', _type: '_doc', _id: '0', _source: {} }];
+      const hits = [{ _index: '.kibana_7.16.0_001', _id: '0', _source: {} }];
       const responses = {
         ['.kibana_7.16.0_001']: [{ body: { hits: { hits, total: hits.length } } }],
       };
@@ -248,7 +246,7 @@ describe('esArchiver: createGenerateDocRecordsStream()', () => {
     });
 
     it('does not change non-.kibana* index names if keepIndexNames is not enabled', async () => {
-      const hits = [{ _index: '.foo', _type: '_doc', _id: '0', _source: {} }];
+      const hits = [{ _index: '.foo', _id: '0', _source: {} }];
       const responses = {
         ['.foo']: [{ body: { hits: { hits, total: hits.length } } }],
       };
@@ -272,7 +270,7 @@ describe('esArchiver: createGenerateDocRecordsStream()', () => {
     });
 
     it('does not change .kibana* index names if keepIndexNames is enabled', async () => {
-      const hits = [{ _index: '.kibana_7.16.0_001', _type: '_doc', _id: '0', _source: {} }];
+      const hits = [{ _index: '.kibana_7.16.0_001', _id: '0', _source: {} }];
       const responses = {
         ['.kibana_7.16.0_001']: [{ body: { hits: { hits, total: hits.length } } }],
       };

--- a/packages/kbn-es-archiver/src/lib/docs/generate_doc_records_stream.ts
+++ b/packages/kbn-es-archiver/src/lib/docs/generate_doc_records_stream.ts
@@ -67,7 +67,6 @@ export function createGenerateDocRecordsStream({
                 // when it is loaded it can skip migration, if possible
                 index:
                   hit._index.startsWith('.kibana') && !keepIndexNames ? '.kibana_1' : hit._index,
-                type: hit._type,
                 id: hit._id,
                 source: hit._source,
               },

--- a/packages/kbn-es-archiver/src/lib/docs/index_doc_records_stream.ts
+++ b/packages/kbn-es-archiver/src/lib/docs/index_doc_records_stream.ts
@@ -32,7 +32,6 @@ export function createIndexDocRecordsStream(
           ops.set(body, {
             [operation]: {
               _index: doc.index,
-              _type: doc.type,
               _id: doc.id,
             },
           });

--- a/packages/kbn-es-archiver/src/lib/indices/kibana_index.ts
+++ b/packages/kbn-es-archiver/src/lib/indices/kibana_index.ts
@@ -114,7 +114,6 @@ export async function cleanKibanaIndices({
             bool: {
               must_not: {
                 ids: {
-                  type: '_doc',
                   values: ['space:default'],
                 },
               },

--- a/test/functional/fixtures/es_archiver/saved_objects_management/show_relationships/data.json
+++ b/test/functional/fixtures/es_archiver/saved_objects_management/show_relationships/data.json
@@ -2,7 +2,7 @@
   "type": "doc",
   "value": {
     "index": ".kibana",
-    "type": "doc",
+    "type": "_doc",
     "id": "dashboard:dash-with-missing-refs",
     "source": {
       "dashboard": {

--- a/test/functional/fixtures/es_archiver/saved_objects_management/show_relationships/mappings.json
+++ b/test/functional/fixtures/es_archiver/saved_objects_management/show_relationships/mappings.json
@@ -13,421 +13,419 @@
       }
     },
     "mappings": {
-      "doc": {
-        "dynamic": "strict",
-        "properties": {
-          "references": {
-            "properties": {
-              "id": {
-                "type": "keyword"
-              },
-              "name": {
-                "type": "keyword"
-              },
-              "type": {
-                "type": "keyword"
+      "dynamic": "strict",
+      "properties": {
+        "references": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            }
+          },
+          "type": "nested"
+        },
+        "apm-telemetry": {
+          "properties": {
+            "has_any_services": {
+              "type": "boolean"
+            },
+            "services_per_agent": {
+              "properties": {
+                "go": {
+                  "type": "long",
+                  "null_value": 0
+                },
+                "java": {
+                  "type": "long",
+                  "null_value": 0
+                },
+                "js-base": {
+                  "type": "long",
+                  "null_value": 0
+                },
+                "nodejs": {
+                  "type": "long",
+                  "null_value": 0
+                },
+                "python": {
+                  "type": "long",
+                  "null_value": 0
+                },
+                "ruby": {
+                  "type": "long",
+                  "null_value": 0
+                }
+              }
+            }
+          }
+        },
+        "canvas-workpad": {
+          "dynamic": "false",
+          "properties": {
+            "@created": {
+              "type": "date"
+            },
+            "@timestamp": {
+              "type": "date"
+            },
+            "id": {
+              "type": "text",
+              "index": false
+            },
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "config": {
+          "dynamic": "true",
+          "properties": {
+            "accessibility:disableAnimations": {
+              "type": "boolean"
+            },
+            "buildNum": {
+              "type": "keyword"
+            },
+            "dateFormat:tz": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
               }
             },
-            "type": "nested"
-          },
-          "apm-telemetry": {
-            "properties": {
-              "has_any_services": {
-                "type": "boolean"
-              },
-              "services_per_agent": {
-                "properties": {
-                  "go": {
-                    "type": "long",
-                    "null_value": 0
-                  },
-                  "java": {
-                    "type": "long",
-                    "null_value": 0
-                  },
-                  "js-base": {
-                    "type": "long",
-                    "null_value": 0
-                  },
-                  "nodejs": {
-                    "type": "long",
-                    "null_value": 0
-                  },
-                  "python": {
-                    "type": "long",
-                    "null_value": 0
-                  },
-                  "ruby": {
-                    "type": "long",
-                    "null_value": 0
-                  }
-                }
-              }
-            }
-          },
-          "canvas-workpad": {
-            "dynamic": "false",
-            "properties": {
-              "@created": {
-                "type": "date"
-              },
-              "@timestamp": {
-                "type": "date"
-              },
-              "id": {
-                "type": "text",
-                "index": false
-              },
-              "name": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword"
-                  }
-                }
-              }
-            }
-          },
-          "config": {
-            "dynamic": "true",
-            "properties": {
-              "accessibility:disableAnimations": {
-                "type": "boolean"
-              },
-              "buildNum": {
-                "type": "keyword"
-              },
-              "dateFormat:tz": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "defaultIndex": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "telemetry:optIn": {
-                "type": "boolean"
-              }
-            }
-          },
-          "dashboard": {
-            "properties": {
-              "description": {
-                "type": "text"
-              },
-              "hits": {
-                "type": "integer"
-              },
-              "kibanaSavedObjectMeta": {
-                "properties": {
-                  "searchSourceJSON": {
-                    "type": "text"
-                  }
-                }
-              },
-              "optionsJSON": {
-                "type": "text"
-              },
-              "panelsJSON": {
-                "type": "text"
-              },
-              "refreshInterval": {
-                "properties": {
-                  "display": {
-                    "type": "keyword"
-                  },
-                  "pause": {
-                    "type": "boolean"
-                  },
-                  "section": {
-                    "type": "integer"
-                  },
-                  "value": {
-                    "type": "integer"
-                  }
-                }
-              },
-              "timeFrom": {
-                "type": "keyword"
-              },
-              "timeRestore": {
-                "type": "boolean"
-              },
-              "timeTo": {
-                "type": "keyword"
-              },
-              "title": {
-                "type": "text"
-              },
-              "uiStateJSON": {
-                "type": "text"
-              },
-              "version": {
-                "type": "integer"
-              }
-            }
-          },
-          "map": {
-            "properties": {
-              "bounds": {
-                "type": "geo_shape",
-                "tree": "quadtree"
-              },
-              "description": {
-                "type": "text"
-              },
-              "layerListJSON": {
-                "type": "text"
-              },
-              "mapStateJSON": {
-                "type": "text"
-              },
-              "title": {
-                "type": "text"
-              },
-              "uiStateJSON": {
-                "type": "text"
-              },
-              "version": {
-                "type": "integer"
-              }
-            }
-          },
-          "graph-workspace": {
-            "properties": {
-              "description": {
-                "type": "text"
-              },
-              "kibanaSavedObjectMeta": {
-                "properties": {
-                  "searchSourceJSON": {
-                    "type": "text"
-                  }
-                }
-              },
-              "numLinks": {
-                "type": "integer"
-              },
-              "numVertices": {
-                "type": "integer"
-              },
-              "title": {
-                "type": "text"
-              },
-              "version": {
-                "type": "integer"
-              },
-              "wsState": {
-                "type": "text"
-              }
-            }
-          },
-          "index-pattern": {
-            "properties": {
-              "fieldFormatMap": {
-                "type": "text"
-              },
+            "defaultIndex": {
+              "type": "text",
               "fields": {
-                "type": "text"
-              },
-              "intervalName": {
-                "type": "keyword"
-              },
-              "notExpandable": {
-                "type": "boolean"
-              },
-              "sourceFilters": {
-                "type": "text"
-              },
-              "timeFieldName": {
-                "type": "keyword"
-              },
-              "title": {
-                "type": "text"
-              },
-              "type": {
-                "type": "keyword"
-              },
-              "typeMeta": {
-                "type": "keyword"
-              }
-            }
-          },
-          "kql-telemetry": {
-            "properties": {
-              "optInCount": {
-                "type": "long"
-              },
-              "optOutCount": {
-                "type": "long"
-              }
-            }
-          },
-          "migrationVersion": {
-            "dynamic": "true",
-            "properties": {
-              "index-pattern": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "space": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
                 }
               }
+            },
+            "telemetry:optIn": {
+              "type": "boolean"
             }
-          },
-          "namespace": {
-            "type": "keyword"
-          },
-          "search": {
-            "properties": {
-              "columns": {
-                "type": "keyword"
-              },
-              "description": {
-                "type": "text"
-              },
-              "hits": {
-                "type": "integer"
-              },
-              "kibanaSavedObjectMeta": {
-                "properties": {
-                  "searchSourceJSON": {
-                    "type": "text"
-                  }
-                }
-              },
-              "sort": {
-                "type": "keyword"
-              },
-              "title": {
-                "type": "text"
-              },
-              "version": {
-                "type": "integer"
-              }
-            }
-          },
-          "server": {
-            "properties": {
-              "uuid": {
-                "type": "keyword"
-              }
-            }
-          },
-          "space": {
-            "properties": {
-              "_reserved": {
-                "type": "boolean"
-              },
-              "color": {
-                "type": "keyword"
-              },
-              "description": {
-                "type": "text"
-              },
-              "disabledFeatures": {
-                "type": "keyword"
-              },
-              "initials": {
-                "type": "keyword"
-              },
-              "name": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 2048
-                  }
+          }
+        },
+        "dashboard": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
                 }
               }
-            }
-          },
-          "spaceId": {
-            "type": "keyword"
-          },
-          "telemetry": {
-            "properties": {
-              "enabled": {
-                "type": "boolean"
+            },
+            "optionsJSON": {
+              "type": "text"
+            },
+            "panelsJSON": {
+              "type": "text"
+            },
+            "refreshInterval": {
+              "properties": {
+                "display": {
+                  "type": "keyword"
+                },
+                "pause": {
+                  "type": "boolean"
+                },
+                "section": {
+                  "type": "integer"
+                },
+                "value": {
+                  "type": "integer"
+                }
               }
+            },
+            "timeFrom": {
+              "type": "keyword"
+            },
+            "timeRestore": {
+              "type": "boolean"
+            },
+            "timeTo": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
             }
-          },
-          "type": {
-            "type": "keyword"
-          },
-          "updated_at": {
-            "type": "date"
-          },
-          "url": {
-            "properties": {
-              "accessCount": {
-                "type": "long"
-              },
-              "accessDate": {
-                "type": "date"
-              },
-              "createDate": {
-                "type": "date"
-              },
-              "url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 2048
-                  }
+          }
+        },
+        "map": {
+          "properties": {
+            "bounds": {
+              "type": "geo_shape",
+              "tree": "quadtree"
+            },
+            "description": {
+              "type": "text"
+            },
+            "layerListJSON": {
+              "type": "text"
+            },
+            "mapStateJSON": {
+              "type": "text"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "graph-workspace": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "numLinks": {
+              "type": "integer"
+            },
+            "numVertices": {
+              "type": "integer"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "wsState": {
+              "type": "text"
+            }
+          }
+        },
+        "index-pattern": {
+          "properties": {
+            "fieldFormatMap": {
+              "type": "text"
+            },
+            "fields": {
+              "type": "text"
+            },
+            "intervalName": {
+              "type": "keyword"
+            },
+            "notExpandable": {
+              "type": "boolean"
+            },
+            "sourceFilters": {
+              "type": "text"
+            },
+            "timeFieldName": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "typeMeta": {
+              "type": "keyword"
+            }
+          }
+        },
+        "kql-telemetry": {
+          "properties": {
+            "optInCount": {
+              "type": "long"
+            },
+            "optOutCount": {
+              "type": "long"
+            }
+          }
+        },
+        "migrationVersion": {
+          "dynamic": "true",
+          "properties": {
+            "index-pattern": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "space": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
                 }
               }
             }
-          },
-          "visualization": {
-            "properties": {
-              "description": {
-                "type": "text"
-              },
-              "kibanaSavedObjectMeta": {
-                "properties": {
-                  "searchSourceJSON": {
-                    "type": "text"
-                  }
+          }
+        },
+        "namespace": {
+          "type": "keyword"
+        },
+        "search": {
+          "properties": {
+            "columns": {
+              "type": "keyword"
+            },
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
                 }
-              },
-              "savedSearchId": {
-                "type": "keyword"
-              },
-              "title": {
-                "type": "text"
-              },
-              "uiStateJSON": {
-                "type": "text"
-              },
-              "version": {
-                "type": "integer"
-              },
-              "visState": {
-                "type": "text"
               }
+            },
+            "sort": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "server": {
+          "properties": {
+            "uuid": {
+              "type": "keyword"
+            }
+          }
+        },
+        "space": {
+          "properties": {
+            "_reserved": {
+              "type": "boolean"
+            },
+            "color": {
+              "type": "keyword"
+            },
+            "description": {
+              "type": "text"
+            },
+            "disabledFeatures": {
+              "type": "keyword"
+            },
+            "initials": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 2048
+                }
+              }
+            }
+          }
+        },
+        "spaceId": {
+          "type": "keyword"
+        },
+        "telemetry": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "updated_at": {
+          "type": "date"
+        },
+        "url": {
+          "properties": {
+            "accessCount": {
+              "type": "long"
+            },
+            "accessDate": {
+              "type": "date"
+            },
+            "createDate": {
+              "type": "date"
+            },
+            "url": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 2048
+                }
+              }
+            }
+          }
+        },
+        "visualization": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "savedSearchId": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "visState": {
+              "type": "text"
             }
           }
         }


### PR DESCRIPTION
## Summary

After https://github.com/elastic/kibana/pull/122627 Kibana must be compatible with ES 8.x. Ops team added a CI check to verify the compatibility on CI. 
Obviously, some functional tests using deprecated API (removed in 8.x) started failing. This PR makes necessary changes to ensure tests compatibility with the 8.x ES version.

closes https://github.com/elastic/kibana/issues/122806
closes https://github.com/elastic/kibana/issues/122809
closes https://github.com/elastic/kibana/issues/122814
