### PR TITLE
[ML] Hide the `time_in_millis` from the model pipelines stats

### DIFF
--- a/x-pack/plugins/ml/public/application/trained_models/models_management/pipelines/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/pipelines/expanded_row.tsx
@@ -76,35 +76,42 @@ export const ProcessorsStats: FC<ProcessorsStatsProps> = ({ stats }) => {
       truncateText: true,
       'data-test-subj': 'mlProcessorStatsCount',
     },
-    {
-      field: 'stats.time_in_millis',
-      name: (
-        <EuiFlexGroup gutterSize="xs">
-          <EuiFlexItem grow={false}>
-            <FormattedMessage
-              id="xpack.ml.trainedModels.modelsList.pipelines.processorStats.timePerDocHeader"
-              defaultMessage="Time per doc"
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <HelpIcon
-              content={
-                <FormattedMessage
-                  id="xpack.ml.trainedModels.modelsList.pipelines.processorStats.timePerDocDescription"
-                  defaultMessage="Total time spent preprocessing ingest documents during the lifetime of this node"
-                />
-              }
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      ),
-      width: '100px',
-      truncateText: false,
-      'data-test-subj': 'mlProcessorStatsTimePerDoc',
-      render: (v: number) => {
-        return durationFormatter(v);
-      },
-    },
+    /**
+     * TODO Display when https://github.com/elastic/elasticsearch/issues/81037 is resolved
+     */
+    ...(true
+      ? []
+      : [
+          {
+            field: 'stats.time_in_millis',
+            name: (
+              <EuiFlexGroup gutterSize="xs">
+                <EuiFlexItem grow={false}>
+                  <FormattedMessage
+                    id="xpack.ml.trainedModels.modelsList.pipelines.processorStats.timePerDocHeader"
+                    defaultMessage="Time per doc"
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <HelpIcon
+                    content={
+                      <FormattedMessage
+                        id="xpack.ml.trainedModels.modelsList.pipelines.processorStats.timePerDocDescription"
+                        defaultMessage="Total time spent preprocessing ingest documents during the lifetime of this node"
+                      />
+                    }
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            ),
+            width: '100px',
+            truncateText: false,
+            'data-test-subj': 'mlProcessorStatsTimePerDoc',
+            render: (v: number) => {
+              return durationFormatter(v);
+            },
+          },
+        ]),
     {
       field: 'stats.current',
       name: (


### PR DESCRIPTION
## Summary

Hides the "Time per doc" column from the model pipelines stats until https://github.com/elastic/elasticsearch/issues/81037 is fixed. 

![image](https://user-images.githubusercontent.com/5236598/149336036-5e64c09c-51ad-4eab-96ff-567c27bb8767.png)

