### PR TITLE
[Cases] Disable the lens plugin in the new case form (including flyout)

### DIFF
--- a/x-pack/plugins/cases/public/components/create/description.tsx
+++ b/x-pack/plugins/cases/public/components/create/description.tsx
@@ -9,6 +9,7 @@ import React, { memo, useEffect, useRef } from 'react';
 import { MarkdownEditorForm } from '../markdown_editor';
 import { UseField, useFormContext, useFormData } from '../../common/shared_imports';
 import { useLensDraftComment } from '../markdown_editor/plugins/lens/use_lens_draft_comment';
+import { ID as LensPluginId } from '../markdown_editor/plugins/lens/constants';
 
 interface Props {
   isLoading: boolean;
@@ -22,6 +23,7 @@ const DescriptionComponent: React.FC<Props> = ({ isLoading }) => {
   const { setFieldValue } = useFormContext();
   const [{ title, tags }] = useFormData({ watch: ['title', 'tags'] });
   const editorRef = useRef<Record<string, unknown>>();
+  const disabledUiPlugins = [LensPluginId];
 
   useEffect(() => {
     if (draftComment?.commentId === fieldName && editorRef.current) {
@@ -55,6 +57,7 @@ const DescriptionComponent: React.FC<Props> = ({ isLoading }) => {
         isDisabled: isLoading,
         caseTitle: title,
         caseTags: tags,
+        disabledUiPlugins,
       }}
     />
   );

--- a/x-pack/plugins/cases/public/components/markdown_editor/editor.tsx
+++ b/x-pack/plugins/cases/public/components/markdown_editor/editor.tsx
@@ -15,12 +15,7 @@ import React, {
   ElementRef,
 } from 'react';
 import { PluggableList } from 'unified';
-import {
-  EuiMarkdownEditor,
-  EuiMarkdownEditorProps,
-  EuiMarkdownAstNode,
-  EuiMarkdownEditorUiPlugin,
-} from '@elastic/eui';
+import { EuiMarkdownEditor, EuiMarkdownEditorProps, EuiMarkdownAstNode } from '@elastic/eui';
 import { ContextShape } from '@elastic/eui/src/components/markdown_editor/markdown_context';
 import { usePlugins } from './use_plugins';
 import { useLensButtonToggle } from './plugins/lens/use_lens_button_toggle';
@@ -33,7 +28,6 @@ interface MarkdownEditorProps {
   onChange: (content: string) => void;
   parsingPlugins?: PluggableList;
   processingPlugins?: PluggableList;
-  uiPlugins?: EuiMarkdownEditorUiPlugin[] | undefined;
   disabledUiPlugins?: string[] | undefined;
   value: string;
 }

--- a/x-pack/plugins/cases/public/components/markdown_editor/editor.tsx
+++ b/x-pack/plugins/cases/public/components/markdown_editor/editor.tsx
@@ -34,6 +34,7 @@ interface MarkdownEditorProps {
   parsingPlugins?: PluggableList;
   processingPlugins?: PluggableList;
   uiPlugins?: EuiMarkdownEditorUiPlugin[] | undefined;
+  disabledUiPlugins?: string[] | undefined;
   value: string;
 }
 
@@ -46,14 +47,15 @@ export interface MarkdownEditorRef {
 }
 
 const MarkdownEditorComponent = forwardRef<MarkdownEditorRef, MarkdownEditorProps>(
-  ({ ariaLabel, dataTestSubj, editorId, height, onChange, value }, ref) => {
+  ({ ariaLabel, dataTestSubj, editorId, height, onChange, value, disabledUiPlugins }, ref) => {
     const astRef = useRef<EuiMarkdownAstNode | undefined>(undefined);
     const [markdownErrorMessages, setMarkdownErrorMessages] = useState([]);
     const onParse: EuiMarkdownEditorProps['onParse'] = useCallback((err, { messages, ast }) => {
       setMarkdownErrorMessages(err ? [err] : messages);
       astRef.current = ast;
     }, []);
-    const { parsingPlugins, processingPlugins, uiPlugins } = usePlugins();
+
+    const { parsingPlugins, processingPlugins, uiPlugins } = usePlugins(disabledUiPlugins);
     const editorRef = useRef<EuiMarkdownEditorRef>(null);
 
     useLensButtonToggle({

--- a/x-pack/plugins/cases/public/components/markdown_editor/eui_form.tsx
+++ b/x-pack/plugins/cases/public/components/markdown_editor/eui_form.tsx
@@ -21,6 +21,7 @@ type MarkdownEditorFormProps = EuiMarkdownEditorProps & {
   bottomRightContent?: React.ReactNode;
   caseTitle?: string;
   caseTags?: string[];
+  disabledUiPlugins?: string[];
 };
 
 const BottomContentWrapper = styled(EuiFlexGroup)`
@@ -31,7 +32,19 @@ const BottomContentWrapper = styled(EuiFlexGroup)`
 
 export const MarkdownEditorForm = React.memo(
   forwardRef<MarkdownEditorRef, MarkdownEditorFormProps>(
-    ({ id, field, dataTestSubj, idAria, bottomRightContent, caseTitle, caseTags }, ref) => {
+    (
+      {
+        id,
+        field,
+        dataTestSubj,
+        idAria,
+        bottomRightContent,
+        caseTitle,
+        caseTags,
+        disabledUiPlugins,
+      },
+      ref
+    ) => {
       const { isInvalid, errorMessage } = getFieldValidityAndErrorMessage(field);
 
       const commentEditorContextValue = useMemo(
@@ -62,6 +75,7 @@ export const MarkdownEditorForm = React.memo(
               editorId={id}
               onChange={field.setValue}
               value={field.value}
+              disabledUiPlugins={disabledUiPlugins}
               data-test-subj={`${dataTestSubj}-markdown-editor`}
             />
           </EuiFormRow>

--- a/x-pack/plugins/cases/public/components/markdown_editor/use_plugins.ts
+++ b/x-pack/plugins/cases/public/components/markdown_editor/use_plugins.ts
@@ -15,8 +15,9 @@ import { useTimelineContext } from '../timeline_context/use_timeline_context';
 import { TemporaryProcessingPluginsType } from './types';
 import { KibanaServices } from '../../common/lib/kibana';
 import * as lensMarkdownPlugin from './plugins/lens';
+import { ID as LensPluginId } from './plugins/lens/constants';
 
-export const usePlugins = () => {
+export const usePlugins = (disabledPlugins?: string[]) => {
   const kibanaConfig = KibanaServices.getConfig();
   const timelinePlugins = useTimelineContext()?.editor_plugins;
 
@@ -35,7 +36,7 @@ export const usePlugins = () => {
       processingPlugins[1][1].components.timeline = timelinePlugins.processingPluginRenderer;
     }
 
-    if (kibanaConfig?.markdownPlugins?.lens) {
+    if (kibanaConfig?.markdownPlugins?.lens && !disabledPlugins?.includes(LensPluginId)) {
       uiPlugins.push(lensMarkdownPlugin.plugin);
     }
 

--- a/x-pack/plugins/cases/public/components/markdown_editor/use_plugins.ts
+++ b/x-pack/plugins/cases/public/components/markdown_editor/use_plugins.ts
@@ -49,5 +49,5 @@ export const usePlugins = (disabledPlugins?: string[]) => {
       parsingPlugins,
       processingPlugins,
     };
-  }, [kibanaConfig?.markdownPlugins?.lens, timelinePlugins]);
+  }, [disabledPlugins, kibanaConfig?.markdownPlugins?.lens, timelinePlugins]);
 };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/122932

It removes the lens plugin from the description field in the new case.

The plugin remains active in the case page.

![image](https://user-images.githubusercontent.com/227916/149339830-18db5751-5231-4e98-b379-238a3eb4ea00.png)



### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
