### PR TITLE
[Backport] Deletes "Pinned tab" test from the upgrade path #122786

### DIFF
--- a/x-pack/plugins/security_solution/cypress/upgrade_integration/import_timeline.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/upgrade_integration/import_timeline.spec.ts
@@ -17,7 +17,6 @@ import {
   NOTE_DESCRIPTION,
   NOTE_PREVIEW,
   NOTES_TAB_BUTTON,
-  PINNED_EVENT_TABLE_CELL,
   PINNED_TAB_BUTTON,
   PROCESS_KPI,
   QUERY_EVENT_TABLE_CELL,
@@ -39,13 +38,7 @@ import {
 } from '../screens/timelines';
 
 import { loginAndWaitForPageWithoutDateRange } from '../tasks/login';
-import {
-  closeTimeline,
-  deleteTimeline,
-  goToCorrelationTab,
-  goToNotesTab,
-  goToPinnedTab,
-} from '../tasks/timeline';
+import { closeTimeline, deleteTimeline, goToCorrelationTab, goToNotesTab } from '../tasks/timeline';
 import { expandNotes, importTimeline, openTimeline } from '../tasks/timelines';
 
 import { TIMELINES_URL } from '../urls/navigation';
@@ -191,18 +184,5 @@ describe('Import timeline after upgrade', () => {
       cy.get(NOTE_DESCRIPTION).invoke('text').should('match', descriptionRegex);
       cy.get(NOTE_PREVIEW).last().invoke('text').should('match', noteRegex);
     });
-  });
-
-  it('Displays the correct timeline details inside the pinned tab', () => {
-    goToPinnedTab();
-
-    cy.get(PINNED_EVENT_TABLE_CELL).eq(0).should('contain', detectionAlert.timestamp);
-    cy.get(PINNED_EVENT_TABLE_CELL).eq(1).should('contain', detectionAlert.message);
-    cy.get(PINNED_EVENT_TABLE_CELL).eq(2).should('contain', detectionAlert.eventCategory);
-    cy.get(PINNED_EVENT_TABLE_CELL).eq(3).should('contain', detectionAlert.eventAction);
-    cy.get(PINNED_EVENT_TABLE_CELL).eq(4).should('contain', detectionAlert.hostName);
-    cy.get(PINNED_EVENT_TABLE_CELL).eq(5).should('contain', detectionAlert.sourceIp);
-    cy.get(PINNED_EVENT_TABLE_CELL).eq(6).should('contain', detectionAlert.destinationIp);
-    cy.get(PINNED_EVENT_TABLE_CELL).eq(7).should('contain', detectionAlert.userName);
   });
 });


### PR DESCRIPTION
## Summary

Backports to 7.17 https://github.com/elastic/kibana/pull/122786
