### PR TITLE
Endpoint metrics telemetry: Bump timeout by 5m.

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
@@ -40,8 +40,8 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
     type: 'security:endpoint-meta-telemetry',
     title: 'Security Solution Telemetry Endpoint Metrics and Info task',
     interval: '24h',
-    timeout: '5m',
-    version: '1.0.0',
+    timeout: '10m',
+    version: '1.0.1',
     getLastExecutionTime: getPreviousDailyTaskTimestamp,
     runTask: async (
       taskId: string,


### PR DESCRIPTION
## Summary

Data engineering believes this task could be timing out on some larger endpoint fleets (1000+ endpoints). We are bumping the timeout while we load test and come up with a longer-term solution. 

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
