### PR TITLE
[Security Solution] Add back severity and riskScore assertions for EQL alerts

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/event_correlation_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/event_correlation_rule.spec.ts
@@ -165,6 +165,8 @@ describe('Detection rules, EQL', () => {
       .invoke('text')
       .then((text) => {
         expect(text).contains(this.rule.name);
+        expect(text).contains(this.rule.severity.toLowerCase());
+        expect(text).contains(this.rule.riskScore);
       });
   });
 });


### PR DESCRIPTION
## Summary
Adds missing assertions (see https://github.com/elastic/kibana/issues/116460).

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
