### PR TITLE
[Fleet] Fix reset one preconfiguration API

### DIFF
--- a/x-pack/plugins/fleet/server/integration_tests/reset_preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/reset_preconfiguration.test.ts
@@ -53,6 +53,7 @@ describe('Fleet preconfiguration rest', () => {
         {
           xpack: {
             fleet: {
+              // Preconfigure two policies test-12345 and test-456789
               agentPolicies: [
                 {
                   name: 'Elastic Cloud agent policy 0001',
@@ -65,6 +66,36 @@ describe('Fleet preconfiguration rest', () => {
                   package_policies: [
                     {
                       name: 'fleet_server123456789',
+                      package: {
+                        name: 'fleet_server',
+                      },
+                      inputs: [
+                        {
+                          type: 'fleet-server',
+                          keep_enabled: true,
+                          vars: [
+                            {
+                              name: 'host',
+                              value: '127.0.0.1',
+                              frozen: true,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  name: 'Second preconfigured policy',
+                  description: 'second policy',
+                  is_default: false,
+                  is_managed: true,
+                  id: 'test-456789',
+                  namespace: 'default',
+                  monitoring_enabled: [],
+                  package_policies: [
+                    {
+                      name: 'fleet_server987654321',
                       package: {
                         name: 'fleet_server',
                       },
@@ -139,11 +170,12 @@ describe('Fleet preconfiguration rest', () => {
     await new Promise((res) => setTimeout(res, 10000));
   };
 
-  beforeEach(async () => {
+  // Share the same servers for all the test to make test a lot faster (but test are not isolated anymore)
+  beforeAll(async () => {
     await startServers();
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await stopServers();
   });
 
@@ -162,11 +194,14 @@ describe('Fleet preconfiguration rest', () => {
           type: 'ingest-agent-policies',
           perPage: 10000,
         });
-      expect(agentPolicies.saved_objects).toHaveLength(1);
+      expect(agentPolicies.saved_objects).toHaveLength(2);
       expect(agentPolicies.saved_objects.map((ap) => ap.attributes)).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: 'Elastic Cloud agent policy 0001',
+          }),
+          expect.objectContaining({
+            name: 'Second preconfigured policy',
           }),
         ])
       );
@@ -181,6 +216,13 @@ describe('Fleet preconfiguration rest', () => {
 
       await soClient.delete('ingest-agent-policies', POLICY_ID);
 
+      const oldAgentPolicies = await soClient.find<AgentPolicySOAttributes>({
+        type: 'ingest-agent-policies',
+        perPage: 10000,
+      });
+
+      const secondAgentPoliciesUpdatedAt = oldAgentPolicies.saved_objects[0].updated_at;
+
       const resetAPI = kbnTestServer.getSupertest(
         kbnServer.root,
         'post',
@@ -194,11 +236,17 @@ describe('Fleet preconfiguration rest', () => {
           type: 'ingest-agent-policies',
           perPage: 10000,
         });
-      expect(agentPolicies.saved_objects).toHaveLength(1);
-      expect(agentPolicies.saved_objects.map((ap) => ap.attributes)).toEqual(
+      expect(agentPolicies.saved_objects).toHaveLength(2);
+      expect(
+        agentPolicies.saved_objects.map((ap) => ({ ...ap.attributes, updated_at: ap.updated_at }))
+      ).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: 'Elastic Cloud agent policy 0001',
+          }),
+          expect.objectContaining({
+            name: 'Second preconfigured policy',
+            updated_at: secondAgentPoliciesUpdatedAt, // Check that policy was not updated
           }),
         ])
       );
@@ -222,12 +270,15 @@ describe('Fleet preconfiguration rest', () => {
         type: 'ingest-agent-policies',
         perPage: 10000,
       });
-      expect(agentPolicies.saved_objects).toHaveLength(1);
+      expect(agentPolicies.saved_objects).toHaveLength(2);
       expect(agentPolicies.saved_objects.map((ap) => ap.attributes)).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: 'Elastic Cloud agent policy 0001',
             package_policies: expect.arrayContaining([expect.stringMatching(/.*/)]),
+          }),
+          expect.objectContaining({
+            name: 'Second preconfigured policy',
           }),
         ])
       );

--- a/x-pack/plugins/fleet/server/routes/preconfiguration/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/preconfiguration/handler.ts
@@ -12,7 +12,7 @@ import type { PreconfiguredAgentPolicy } from '../../../common';
 import type { FleetRequestHandler } from '../../types';
 import type {
   PutPreconfigurationSchema,
-  PostResetOnePreconfiguredAgentPolicies,
+  PostResetOnePreconfiguredAgentPoliciesSchema,
 } from '../../types';
 import { defaultIngestErrorHandler } from '../../errors';
 import { ensurePreconfiguredPackagesAndPolicies, outputService } from '../../services';
@@ -44,8 +44,8 @@ export const updatePreconfigurationHandler: FleetRequestHandler<
   }
 };
 
-export const resetPreconfigurationHandler: FleetRequestHandler<
-  TypeOf<typeof PostResetOnePreconfiguredAgentPolicies.params>,
+export const resetOnePreconfigurationHandler: FleetRequestHandler<
+  TypeOf<typeof PostResetOnePreconfiguredAgentPoliciesSchema.params>,
   undefined,
   undefined
 > = async (context, request, response) => {
@@ -53,14 +53,14 @@ export const resetPreconfigurationHandler: FleetRequestHandler<
   const esClient = context.core.elasticsearch.client.asInternalUser;
 
   try {
-    await resetPreconfiguredAgentPolicies(soClient, esClient, request.params.agentPolicyid);
+    await resetPreconfiguredAgentPolicies(soClient, esClient, request.params.agentPolicyId);
     return response.ok({});
   } catch (error) {
     return defaultIngestErrorHandler({ error, response });
   }
 };
 
-export const resetOnePreconfigurationHandler: FleetRequestHandler<
+export const resetPreconfigurationHandler: FleetRequestHandler<
   undefined,
   undefined,
   undefined

--- a/x-pack/plugins/fleet/server/routes/preconfiguration/index.ts
+++ b/x-pack/plugins/fleet/server/routes/preconfiguration/index.ts
@@ -6,7 +6,10 @@
  */
 
 import { PRECONFIGURATION_API_ROUTES } from '../../constants';
-import { PutPreconfigurationSchema } from '../../types';
+import {
+  PutPreconfigurationSchema,
+  PostResetOnePreconfiguredAgentPoliciesSchema,
+} from '../../types';
 import type { FleetAuthzRouter } from '../security';
 
 import {
@@ -29,7 +32,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
   router.post(
     {
       path: PRECONFIGURATION_API_ROUTES.RESET_ONE_PATTERN,
-      validate: false,
+      validate: PostResetOnePreconfiguredAgentPoliciesSchema,
       fleetAuthz: {
         fleet: { all: true },
       },

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -679,7 +679,7 @@ class AgentPolicyService {
     await this.triggerAgentPolicyUpdatedEvent(soClient, esClient, 'deleted', id);
 
     if (options?.removeFleetServerDocuments) {
-      this.deleteFleetServerPoliciesForPolicyId(esClient, id);
+      await this.deleteFleetServerPoliciesForPolicyId(esClient, id);
     }
 
     return {

--- a/x-pack/plugins/fleet/server/types/rest_spec/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/preconfiguration.ts
@@ -16,8 +16,8 @@ export const PutPreconfigurationSchema = {
   }),
 };
 
-export const PostResetOnePreconfiguredAgentPolicies = {
+export const PostResetOnePreconfiguredAgentPoliciesSchema = {
   params: schema.object({
-    agentPolicyid: schema.string(),
+    agentPolicyId: schema.string(),
   }),
 };


### PR DESCRIPTION
## Summary

Follow up on https://github.com/elastic/kibana/pull/122467 

When doing some test on the reset preconfiguration APIs I discovered that I miss a few things and the reset one preconfigured API was not working as expected (resetting all the preconfigured policies instead of one) 

That PR address that and add missing tests that would have catch that.