### PR TITLE
[Enterprise Search] Fix a couple of bugs with the error state when not connected

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.test.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { setMockValues } from '../../__mocks__/kea_logic';
+import '../../__mocks__/shallow_useeffect.mock';
+import { setMockValues, mockKibanaValues } from '../../__mocks__/kea_logic';
 
 import React from 'react';
 
@@ -49,5 +50,21 @@ describe('ErrorState', () => {
 
     expect(wrapper.find('[data-test-subj="CloudError"]').exists()).toBe(false);
     expect(wrapper.find('[data-test-subj="SelfManagedError"]').exists()).toBe(true);
+  });
+
+  describe('chrome visiblity', () => {
+    it('sets chrome visibility to true when not on personal dashboard route', () => {
+      mockKibanaValues.history.location.pathname = '/overview';
+      mountWithIntl(<ErrorStatePrompt />);
+
+      expect(mockKibanaValues.setChromeIsVisible).toHaveBeenCalledWith(true);
+    });
+
+    it('sets chrome visibility to false when on personal dashboard route', () => {
+      mockKibanaValues.history.location.pathname = '/p/sources';
+      mountWithIntl(<ErrorStatePrompt />);
+
+      expect(mockKibanaValues.setChromeIsVisible).toHaveBeenCalledWith(false);
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { useValues } from 'kea';
 
@@ -21,10 +21,27 @@ import { EuiButtonTo, EuiLinkTo } from '../react_router_helpers';
 
 import './error_state_prompt.scss';
 
+/**
+ * Personal dashboard urls begin with /p/
+ * EX: http://localhost:5601/app/enterprise_search/workplace_search/p/sources
+ */
+const WORKPLACE_SEARCH_PERSONAL_DASHBOARD_PATH = '/p/';
+
 export const ErrorStatePrompt: React.FC = () => {
   const { errorConnectingMessage } = useValues(HttpLogic);
-  const { config, cloud } = useValues(KibanaLogic);
+  const { config, cloud, setChromeIsVisible, history } = useValues(KibanaLogic);
   const isCloudEnabled = cloud.isCloudEnabled;
+  const isWorkplaceSearchPersonalDashboardRoute = history.location.pathname.includes(
+    WORKPLACE_SEARCH_PERSONAL_DASHBOARD_PATH
+  );
+
+  useEffect(() => {
+    // We hide the Kibana chrome for Workplace Search for Personal Dashboard routes. It is reenabled when the user enters the
+    // Workplace Search organization admin section of the product. If the Enterprise Search API is not working, we never show
+    // the chrome and this can have adverse effects when the user leaves thispage and returns to Kibana. To get around this,
+    // we always show the chrome when the error state is shown, unless the user is visiting the Personal Dashboard.
+    setChromeIsVisible(!isWorkplaceSearchPersonalDashboardRoute);
+  }, []);
 
   return (
     <EuiEmptyPrompt

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -48,13 +48,24 @@ describe('WorkplaceSearch', () => {
     expect(wrapper.find(WorkplaceSearchConfigured)).toHaveLength(1);
   });
 
-  it('renders ErrorState', () => {
+  it('renders ErrorState when not on SetupGuide', () => {
+    mockUseRouteMatch.mockReturnValue(false);
     setMockValues({ errorConnectingMessage: '502 Bad Gateway' });
 
     const wrapper = shallow(<WorkplaceSearch />);
 
     const errorState = wrapper.find(ErrorState);
     expect(errorState).toHaveLength(1);
+  });
+
+  it('does not render ErrorState when on SetupGuide', () => {
+    mockUseRouteMatch.mockReturnValue(true);
+    setMockValues({ errorConnectingMessage: '502 Bad Gateway' });
+
+    const wrapper = shallow(<WorkplaceSearch />);
+
+    const errorState = wrapper.find(ErrorState);
+    expect(errorState).toHaveLength(0);
   });
 });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -53,6 +53,7 @@ export const WorkplaceSearch: React.FC<InitialAppData> = (props) => {
   const { errorConnectingMessage } = useValues(HttpLogic);
   const { enterpriseSearchVersion, kibanaVersion } = props;
   const incompatibleVersions = isVersionMismatch(enterpriseSearchVersion, kibanaVersion);
+  const isSetupGuidePath = !!useRouteMatch(SETUP_GUIDE_PATH);
 
   if (!config.host) {
     return <WorkplaceSearchUnconfigured />;
@@ -63,7 +64,7 @@ export const WorkplaceSearch: React.FC<InitialAppData> = (props) => {
         kibanaVersion={kibanaVersion}
       />
     );
-  } else if (errorConnectingMessage) {
+  } else if (errorConnectingMessage && !isSetupGuidePath) {
     return <ErrorState />;
   }
 
@@ -79,7 +80,6 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
    * Personal dashboard urls begin with /p/
    * EX: http://localhost:5601/app/enterprise_search/workplace_search/p/sources
    */
-
   const isOrganization = !useRouteMatch(PERSONAL_PATH);
 
   setContext(isOrganization);


### PR DESCRIPTION
## Summary

We recently merged a [PR](https://github.com/elastic/kibana/pull/122044) that gives consistent error handling when the Enterprise Search API is not running. In doing so, there were 2 bugs that were missed when I did QA. 

### 1. The Chrome is hidden on Workplace Search
We [hide the Kibana chrome](https://github.com/elastic/kibana/blob/main/x-pack/plugins/enterprise_search/public/plugin.ts#L122-L124) for Workplace Search for Personal Dashboard routes. It is [re-enabled](https://github.com/elastic/kibana/blob/main/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx#L78-L89) when the user enters the Workplace Search organization admin section of the product. If the Enterprise Search API is not working, we never show the chrome and this can have adverse effects when the user leaves this page and returns to Kibana. To get around this, we always show the chrome when the error state is shown unless the user is visiting the Personal Dashboard.

**Before**

https://user-images.githubusercontent.com/1869731/149389254-2f68a4c7-65c8-4c62-8db4-a7884a35855e.mp4

**After**

https://user-images.githubusercontent.com/1869731/149389356-771c8918-9aa3-499b-8550-5db147ffe888.mp4

### 2. The Setup guide link for Workplace Search does not work
The issue is that all routes for Workplace Search defaulted to the error state when there is an error connecting to the API. This adds a condition to skip the Setup guide route and render it instead of the error.

**Before**

https://user-images.githubusercontent.com/1869731/149389583-d1f3b822-8306-478a-a7a2-7a53aff15b3a.mp4

**After**

https://user-images.githubusercontent.com/1869731/149389602-2f4041f3-5d95-4fdb-a435-872b8b72512d.mp4

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
