### PR TITLE
[8.0] [Fleet] Fix reset one preconfiguration API (#122963)

### DIFF
--- a/x-pack/plugins/fleet/server/integration_tests/reset_preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/reset_preconfiguration.test.ts
@@ -53,6 +53,7 @@ describe('Fleet preconfiguration rest', () => {
         {
           xpack: {
             fleet: {
+              // Preconfigure two policies test-12345 and test-456789
               agentPolicies: [
                 {
                   name: 'Elastic Cloud agent policy 0001',
@@ -65,6 +66,36 @@ describe('Fleet preconfiguration rest', () => {
                   package_policies: [
                     {
                       name: 'fleet_server123456789',
+                      package: {
+                        name: 'fleet_server',
+                      },
+                      inputs: [
+                        {
+                          type: 'fleet-server',
+                          keep_enabled: true,
+                          vars: [
+                            {
+                              name: 'host',
+                              value: '127.0.0.1',
+                              frozen: true,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  name: 'Second preconfigured policy',
+                  description: 'second policy',
+                  is_default: false,
+                  is_managed: true,
+                  id: 'test-456789',
+                  namespace: 'default',
+                  monitoring_enabled: [],
+                  package_policies: [
+                    {
+                      name: 'fleet_server987654321',
                       package: {
                         name: 'fleet_server',
                       },
@@ -139,11 +170,12 @@ describe('Fleet preconfiguration rest', () => {
     await new Promise((res) => setTimeout(res, 10000));
   };
 
-  beforeEach(async () => {
+  // Share the same servers for all the test to make test a lot faster (but test are not isolated anymore)
+  beforeAll(async () => {
     await startServers();
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await stopServers();
   });
 
@@ -162,11 +194,14 @@ describe('Fleet preconfiguration rest', () => {
           type: 'ingest-agent-policies',
           perPage: 10000,
         });
-      expect(agentPolicies.saved_objects).toHaveLength(1);
+      expect(agentPolicies.saved_objects).toHaveLength(2);
       expect(agentPolicies.saved_objects.map((ap) => ap.attributes)).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: 'Elastic Cloud agent policy 0001',
+          }),
+          expect.objectContaining({
+            name: 'Second preconfigured policy',
           }),
         ])
       );
@@ -181,6 +216,13 @@ describe('Fleet preconfiguration rest', () => {
 
       await soClient.delete('ingest-agent-policies', POLICY_ID);
 
+      const oldAgentPolicies = await soClient.find<AgentPolicySOAttributes>({
+        type: 'ingest-agent-policies',
+        perPage: 10000,
+      });
+
+      const secondAgentPoliciesUpdatedAt = oldAgentPolicies.saved_objects[0].updated_at;
+
       const resetAPI = kbnTestServer.getSupertest(
         kbnServer.root,
         'post',
@@ -194,11 +236,17 @@ describe('Fleet preconfiguration rest', () => {
           type: 'ingest-agent-policies',
           perPage: 10000,
         });
-      expect(agentPolicies.saved_objects).toHaveLength(1);
-      expect(agentPolicies.saved_objects.map((ap) => ap.attributes)).toEqual(
+      expect(agentPolicies.saved_objects).toHaveLength(2);
+      expect(
+        agentPolicies.saved_objects.map((ap) => ({ ...ap.attributes, updated_at: ap.updated_at }))
+      ).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: 'Elastic Cloud agent policy 0001',
+          }),
+          expect.objectContaining({
+            name: 'Second preconfigured policy',
+            updated_at: secondAgentPoliciesUpdatedAt, // Check that policy was not updated
           }),
         ])
       );
@@ -222,12 +270,15 @@ describe('Fleet preconfiguration rest', () => {
         type: 'ingest-agent-policies',
         perPage: 10000,
       });
-      expect(agentPolicies.saved_objects).toHaveLength(1);
+      expect(agentPolicies.saved_objects).toHaveLength(2);
       expect(agentPolicies.saved_objects.map((ap) => ap.attributes)).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: 'Elastic Cloud agent policy 0001',
             package_policies: expect.arrayContaining([expect.stringMatching(/.*/)]),
+          }),
+          expect.objectContaining({
+            name: 'Second preconfigured policy',
           }),
         ])
       );

--- a/x-pack/plugins/fleet/server/routes/preconfiguration/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/preconfiguration/handler.ts
@@ -12,7 +12,7 @@ import type { PreconfiguredAgentPolicy } from '../../../common';
 import type { FleetRequestHandler } from '../../types';
 import type {
   PutPreconfigurationSchema,
-  PostResetOnePreconfiguredAgentPolicies,
+  PostResetOnePreconfiguredAgentPoliciesSchema,
 } from '../../types';
 import { defaultIngestErrorHandler } from '../../errors';
 import { ensurePreconfiguredPackagesAndPolicies, outputService } from '../../services';
@@ -44,8 +44,8 @@ export const updatePreconfigurationHandler: FleetRequestHandler<
   }
 };
 
-export const resetPreconfigurationHandler: FleetRequestHandler<
-  TypeOf<typeof PostResetOnePreconfiguredAgentPolicies.params>,
+export const resetOnePreconfigurationHandler: FleetRequestHandler<
+  TypeOf<typeof PostResetOnePreconfiguredAgentPoliciesSchema.params>,
   undefined,
   undefined
 > = async (context, request, response) => {
@@ -53,22 +53,25 @@ export const resetPreconfigurationHandler: FleetRequestHandler<
   const esClient = context.core.elasticsearch.client.asInternalUser;
 
   try {
-    await resetPreconfiguredAgentPolicies(soClient, esClient, request.params.agentPolicyid);
+    await resetPreconfiguredAgentPolicies(soClient, esClient, request.params.agentPolicyId);
     return response.ok({});
   } catch (error) {
     return defaultIngestErrorHandler({ error, response });
   }
 };
 
-export const resetOnePreconfigurationHandler: FleetRequestHandler<undefined, undefined, undefined> =
-  async (context, request, response) => {
-    const soClient = context.core.savedObjects.client;
-    const esClient = context.core.elasticsearch.client.asInternalUser;
+export const resetPreconfigurationHandler: FleetRequestHandler<
+  undefined,
+  undefined,
+  undefined
+> = async (context, request, response) => {
+  const soClient = context.core.savedObjects.client;
+  const esClient = context.core.elasticsearch.client.asInternalUser;
 
-    try {
-      await resetPreconfiguredAgentPolicies(soClient, esClient);
-      return response.ok({});
-    } catch (error) {
-      return defaultIngestErrorHandler({ error, response });
-    }
-  };
+  try {
+    await resetPreconfiguredAgentPolicies(soClient, esClient);
+    return response.ok({});
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
+  }
+};

--- a/x-pack/plugins/fleet/server/routes/preconfiguration/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/preconfiguration/handler.ts
@@ -60,18 +60,15 @@ export const resetOnePreconfigurationHandler: FleetRequestHandler<
   }
 };
 
-export const resetPreconfigurationHandler: FleetRequestHandler<
-  undefined,
-  undefined,
-  undefined
-> = async (context, request, response) => {
-  const soClient = context.core.savedObjects.client;
-  const esClient = context.core.elasticsearch.client.asInternalUser;
+export const resetPreconfigurationHandler: FleetRequestHandler<undefined, undefined, undefined> =
+  async (context, request, response) => {
+    const soClient = context.core.savedObjects.client;
+    const esClient = context.core.elasticsearch.client.asInternalUser;
 
-  try {
-    await resetPreconfiguredAgentPolicies(soClient, esClient);
-    return response.ok({});
-  } catch (error) {
-    return defaultIngestErrorHandler({ error, response });
-  }
-};
+    try {
+      await resetPreconfiguredAgentPolicies(soClient, esClient);
+      return response.ok({});
+    } catch (error) {
+      return defaultIngestErrorHandler({ error, response });
+    }
+  };

--- a/x-pack/plugins/fleet/server/routes/preconfiguration/index.ts
+++ b/x-pack/plugins/fleet/server/routes/preconfiguration/index.ts
@@ -8,7 +8,10 @@
 import type { IRouter, RequestHandler } from 'src/core/server';
 
 import { PLUGIN_ID, PRECONFIGURATION_API_ROUTES } from '../../constants';
-import { PutPreconfigurationSchema } from '../../types';
+import {
+  PutPreconfigurationSchema,
+  PostResetOnePreconfiguredAgentPoliciesSchema,
+} from '../../types';
 
 import {
   updatePreconfigurationHandler,
@@ -28,7 +31,7 @@ export const registerRoutes = (router: IRouter) => {
   router.post(
     {
       path: PRECONFIGURATION_API_ROUTES.RESET_ONE_PATTERN,
-      validate: false,
+      validate: PostResetOnePreconfiguredAgentPoliciesSchema,
       options: { tags: [`access:${PLUGIN_ID}-all`] },
     },
     resetOnePreconfigurationHandler as RequestHandler

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -679,7 +679,7 @@ class AgentPolicyService {
     await this.triggerAgentPolicyUpdatedEvent(soClient, esClient, 'deleted', id);
 
     if (options?.removeFleetServerDocuments) {
-      this.deleteFleetServerPoliciesForPolicyId(esClient, id);
+      await this.deleteFleetServerPoliciesForPolicyId(esClient, id);
     }
 
     return {

--- a/x-pack/plugins/fleet/server/types/rest_spec/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/preconfiguration.ts
@@ -16,8 +16,8 @@ export const PutPreconfigurationSchema = {
   }),
 };
 
-export const PostResetOnePreconfiguredAgentPolicies = {
+export const PostResetOnePreconfiguredAgentPoliciesSchema = {
   params: schema.object({
-    agentPolicyid: schema.string(),
+    agentPolicyId: schema.string(),
   }),
 };


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #122963

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
