### PR TITLE
[7.17] [Fleet] Fix reset one preconfiguration API (#122963)

### DIFF
--- a/x-pack/plugins/fleet/server/routes/preconfiguration/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/preconfiguration/handler.ts
@@ -58,18 +58,15 @@ export const resetOnePreconfigurationHandler: FleetRequestHandler<
   }
 };
 
-export const resetPreconfigurationHandler: FleetRequestHandler<
-  undefined,
-  undefined,
-  undefined
-> = async (context, request, response) => {
-  const soClient = context.core.savedObjects.client;
-  const esClient = context.core.elasticsearch.client.asInternalUser;
+export const resetPreconfigurationHandler: FleetRequestHandler<undefined, undefined, undefined> =
+  async (context, request, response) => {
+    const soClient = context.core.savedObjects.client;
+    const esClient = context.core.elasticsearch.client.asInternalUser;
 
-  try {
-    await resetPreconfiguredAgentPolicies(soClient, esClient);
-    return response.ok({});
-  } catch (error) {
-    return defaultIngestErrorHandler({ error, response });
-  }
-};
+    try {
+      await resetPreconfiguredAgentPolicies(soClient, esClient);
+      return response.ok({});
+    } catch (error) {
+      return defaultIngestErrorHandler({ error, response });
+    }
+  };

--- a/x-pack/plugins/fleet/server/routes/preconfiguration/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/preconfiguration/handler.ts
@@ -12,7 +12,7 @@ import type { PreconfiguredAgentPolicy } from '../../../common';
 import type { FleetRequestHandler } from '../../types';
 import type {
   PutPreconfigurationSchema,
-  PostResetOnePreconfiguredAgentPolicies,
+  PostResetOnePreconfiguredAgentPoliciesSchema,
 } from '../../types';
 import { defaultIngestErrorHandler } from '../../errors';
 import { ensurePreconfiguredPackagesAndPolicies, outputService } from '../../services';
@@ -42,8 +42,8 @@ export const updatePreconfigurationHandler: FleetRequestHandler<
   }
 };
 
-export const resetPreconfigurationHandler: FleetRequestHandler<
-  TypeOf<typeof PostResetOnePreconfiguredAgentPolicies.params>,
+export const resetOnePreconfigurationHandler: FleetRequestHandler<
+  TypeOf<typeof PostResetOnePreconfiguredAgentPoliciesSchema.params>,
   undefined,
   undefined
 > = async (context, request, response) => {
@@ -51,22 +51,25 @@ export const resetPreconfigurationHandler: FleetRequestHandler<
   const esClient = context.core.elasticsearch.client.asInternalUser;
 
   try {
-    await resetPreconfiguredAgentPolicies(soClient, esClient, request.params.agentPolicyid);
+    await resetPreconfiguredAgentPolicies(soClient, esClient, request.params.agentPolicyId);
     return response.ok({});
   } catch (error) {
     return defaultIngestErrorHandler({ error, response });
   }
 };
 
-export const resetOnePreconfigurationHandler: FleetRequestHandler<undefined, undefined, undefined> =
-  async (context, request, response) => {
-    const soClient = context.core.savedObjects.client;
-    const esClient = context.core.elasticsearch.client.asInternalUser;
+export const resetPreconfigurationHandler: FleetRequestHandler<
+  undefined,
+  undefined,
+  undefined
+> = async (context, request, response) => {
+  const soClient = context.core.savedObjects.client;
+  const esClient = context.core.elasticsearch.client.asInternalUser;
 
-    try {
-      await resetPreconfiguredAgentPolicies(soClient, esClient);
-      return response.ok({});
-    } catch (error) {
-      return defaultIngestErrorHandler({ error, response });
-    }
-  };
+  try {
+    await resetPreconfiguredAgentPolicies(soClient, esClient);
+    return response.ok({});
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
+  }
+};

--- a/x-pack/plugins/fleet/server/routes/preconfiguration/index.ts
+++ b/x-pack/plugins/fleet/server/routes/preconfiguration/index.ts
@@ -8,7 +8,10 @@
 import type { IRouter, RequestHandler } from 'src/core/server';
 
 import { PLUGIN_ID, PRECONFIGURATION_API_ROUTES } from '../../constants';
-import { PutPreconfigurationSchema } from '../../types';
+import {
+  PutPreconfigurationSchema,
+  PostResetOnePreconfiguredAgentPoliciesSchema,
+} from '../../types';
 
 import {
   updatePreconfigurationHandler,
@@ -28,7 +31,7 @@ export const registerRoutes = (router: IRouter) => {
   router.post(
     {
       path: PRECONFIGURATION_API_ROUTES.RESET_ONE_PATTERN,
-      validate: false,
+      validate: PostResetOnePreconfiguredAgentPoliciesSchema,
       options: { tags: [`access:${PLUGIN_ID}-all`] },
     },
     resetOnePreconfigurationHandler as RequestHandler

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -679,7 +679,7 @@ class AgentPolicyService {
     await this.triggerAgentPolicyUpdatedEvent(soClient, esClient, 'deleted', id);
 
     if (options?.removeFleetServerDocuments) {
-      this.deleteFleetServerPoliciesForPolicyId(esClient, id);
+      await this.deleteFleetServerPoliciesForPolicyId(esClient, id);
     }
 
     return {

--- a/x-pack/plugins/fleet/server/types/rest_spec/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/preconfiguration.ts
@@ -16,8 +16,8 @@ export const PutPreconfigurationSchema = {
   }),
 };
 
-export const PostResetOnePreconfiguredAgentPolicies = {
+export const PostResetOnePreconfiguredAgentPoliciesSchema = {
   params: schema.object({
-    agentPolicyid: schema.string(),
+    agentPolicyId: schema.string(),
   }),
 };


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #122963

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
