### PR TITLE
[Maps] Add ordering to layer wizard registration API

### DIFF
--- a/x-pack/plugins/maps/common/index.ts
+++ b/x-pack/plugins/maps/common/index.ts
@@ -18,6 +18,11 @@ export {
   SOURCE_TYPES,
   STYLE_TYPE,
   SYMBOLIZE_AS_TYPES,
+  FieldFormatter,
+  LAYER_WIZARD_CATEGORY,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  VECTOR_SHAPE_TYPE,
 } from './constants';
 
 export type {

--- a/x-pack/plugins/maps/common/index.ts
+++ b/x-pack/plugins/maps/common/index.ts
@@ -18,12 +18,13 @@ export {
   SOURCE_TYPES,
   STYLE_TYPE,
   SYMBOLIZE_AS_TYPES,
-  FieldFormatter,
   LAYER_WIZARD_CATEGORY,
   MAX_ZOOM,
   MIN_ZOOM,
   VECTOR_SHAPE_TYPE,
 } from './constants';
+
+export type { FieldFormatter } from './constants';
 
 export type {
   EMSFileSourceDescriptor,

--- a/x-pack/plugins/maps/public/classes/layers/index.ts
+++ b/x-pack/plugins/maps/public/classes/layers/index.ts
@@ -6,4 +6,4 @@
  */
 
 export type { LayerWizard, LayerWizardWithMeta, RenderWizardArguments } from './wizards';
-export { getLayerWizards, registerLayerWizard } from './wizards';
+export { getLayerWizards, registerLayerWizardExternal } from './wizards';

--- a/x-pack/plugins/maps/public/classes/layers/wizards/choropleth_layer_wizard/choropleth_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/choropleth_layer_wizard/choropleth_layer_wizard.tsx
@@ -13,6 +13,7 @@ import { LayerTemplate } from './layer_template';
 import { ChoroplethLayerIcon } from '../icons/cloropleth_layer_icon';
 
 export const choroplethLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.ELASTICSEARCH],
   description: i18n.translate('xpack.maps.choropleth.desc', {
     defaultMessage: 'Shaded areas to compare statistics across boundaries',

--- a/x-pack/plugins/maps/public/classes/layers/wizards/file_upload_wizard/config.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/file_upload_wizard/config.tsx
@@ -12,6 +12,7 @@ import { ClientFileCreateSourceEditor, UPLOAD_STEPS } from './wizard';
 import { getFileUpload } from '../../../../kibana_services';
 
 export const uploadLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [],
   description: i18n.translate('xpack.maps.fileUploadWizard.description', {
     defaultMessage: 'Index GeoJSON data in Elasticsearch',

--- a/x-pack/plugins/maps/public/classes/layers/wizards/index.ts
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/index.ts
@@ -10,4 +10,4 @@ export type {
   LayerWizardWithMeta,
   RenderWizardArguments,
 } from './layer_wizard_registry';
-export { getLayerWizards, registerLayerWizard } from './layer_wizard_registry';
+export { getLayerWizards, registerLayerWizardExternal } from './layer_wizard_registry';

--- a/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.test.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.test.tsx
@@ -6,12 +6,28 @@
  */
 
 import React from 'react';
-import { getLayerWizards, registerLayerWizard } from './layer_wizard_registry';
+import {
+  getLayerWizards,
+  registerLayerWizardInternal,
+  registerLayerWizardExternal,
+} from './layer_wizard_registry';
 import { LAYER_WIZARD_CATEGORY } from '../../../../common/constants';
 
 describe('LayerWizardRegistryTest', () => {
   it('should enforce ordering', async () => {
-    registerLayerWizard({
+    registerLayerWizardExternal({
+      categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
+      description: '',
+      icon: '',
+      title: 'foo',
+      renderWizard(): React.ReactElement<any> {
+        return <></>;
+      },
+      order: 100,
+    });
+
+    registerLayerWizardInternal({
+      order: 1,
       categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
       description: '',
       icon: '',
@@ -21,18 +37,8 @@ describe('LayerWizardRegistryTest', () => {
       },
     });
 
-    registerLayerWizard({
-      categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
-      description: '',
-      icon: '',
-      title: 'foo',
-      renderWizard(): React.ReactElement<any> {
-        return <></>;
-      },
+    registerLayerWizardInternal({
       order: 1,
-    });
-
-    registerLayerWizard({
       categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
       description: '',
       icon: '',
@@ -47,5 +53,20 @@ describe('LayerWizardRegistryTest', () => {
     expect(wizards[0].title).toBe('foobar');
     expect(wizards[1].title).toBe('bar');
     expect(wizards[2].title).toBe('foo');
+  });
+
+  it('external users must add order higher than 99 ', async () => {
+    expect(() => {
+      registerLayerWizardExternal({
+        order: 99,
+        categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
+        description: '',
+        icon: '',
+        title: 'bar',
+        renderWizard(): React.ReactElement<any> {
+          return <></>;
+        },
+      });
+    }).toThrow(`layerWizard.order should be greater than or equal to '100'`);
   });
 });

--- a/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.test.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { getLayerWizards, registerLayerWizard } from './layer_wizard_registry';
+import { LAYER_WIZARD_CATEGORY } from '../../../../common/constants';
+
+describe('LayerWizardRegistryTest', () => {
+  it('should enforce ordering', async () => {
+    registerLayerWizard({
+      categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
+      description: '',
+      icon: '',
+      title: 'foobar',
+      renderWizard(): React.ReactElement<any> {
+        return <></>;
+      },
+    });
+
+    registerLayerWizard({
+      categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
+      description: '',
+      icon: '',
+      title: 'foo',
+      renderWizard(): React.ReactElement<any> {
+        return <></>;
+      },
+      order: 1,
+    });
+
+    registerLayerWizard({
+      categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
+      description: '',
+      icon: '',
+      title: 'bar',
+      renderWizard(): React.ReactElement<any> {
+        return <></>;
+      },
+    });
+
+    const wizards = await getLayerWizards();
+
+    expect(wizards[0].title).toBe('foobar');
+    expect(wizards[1].title).toBe('bar');
+    expect(wizards[2].title).toBe('foo');
+  });
+});

--- a/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.ts
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.ts
@@ -39,11 +39,13 @@ export type LayerWizard = {
   renderWizard(renderWizardArguments: RenderWizardArguments): ReactElement<any>;
   title: string;
   showFeatureEditTools?: boolean;
+  order?: number;
 };
 
 export type LayerWizardWithMeta = LayerWizard & {
   isVisible: boolean;
   isDisabled: boolean;
+  order: number;
 };
 
 const registry: LayerWizard[] = [];
@@ -67,9 +69,14 @@ export async function getLayerWizards(): Promise<LayerWizardWithMeta[]> {
       ...layerWizard,
       isVisible: await layerWizard.checkVisibility!(),
       isDisabled: await layerWizard.getIsDisabled!(),
+      order: typeof layerWizard.order === 'number' ? layerWizard.order : 0,
     };
   });
-  return (await Promise.all(promises)).filter(({ isVisible }) => {
-    return isVisible;
-  });
+  return (await Promise.all(promises))
+    .filter(({ isVisible }) => {
+      return isVisible;
+    })
+    .sort((wizard1: LayerWizardWithMeta, wizard2: LayerWizardWithMeta) => {
+      return wizard1.order - wizard2.order;
+    });
 }

--- a/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.ts
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.ts
@@ -14,6 +14,11 @@ import { LAYER_WIZARD_CATEGORY } from '../../../../common/constants';
 export type LayerWizard = {
   title: string;
   categories: LAYER_WIZARD_CATEGORY[];
+  /*
+   * Sets display order.
+   * Lower numbers are displayed before higher numbers.
+   * 0-99 reserved for Maps-plugin wizards.
+   */
   order: number;
   description: string;
   icon: string | FunctionComponent<any>;

--- a/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.ts
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.ts
@@ -64,7 +64,7 @@ export function registerLayerWizardInternal(layerWizard: LayerWizard) {
 
 export function registerLayerWizardExternal(layerWizard: LayerWizard) {
   if (layerWizard.order < 100) {
-    throw new Error(`layerWizard.order should be greater than or equal to '100`);
+    throw new Error(`layerWizard.order should be greater than or equal to '100'`);
   }
   registerLayerWizardInternal(layerWizard);
 }

--- a/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.ts
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/layer_wizard_registry.ts
@@ -11,6 +11,21 @@ import { ReactElement, FunctionComponent } from 'react';
 import type { LayerDescriptor } from '../../../../common/descriptor_types';
 import { LAYER_WIZARD_CATEGORY } from '../../../../common/constants';
 
+export type LayerWizard = {
+  title: string;
+  categories: LAYER_WIZARD_CATEGORY[];
+  order: number;
+  description: string;
+  icon: string | FunctionComponent<any>;
+  renderWizard(renderWizardArguments: RenderWizardArguments): ReactElement<any>;
+  prerequisiteSteps?: Array<{ id: string; label: string }>;
+  disabledReason?: string;
+  getIsDisabled?: () => Promise<boolean> | boolean;
+  isBeta?: boolean;
+  checkVisibility?: () => Promise<boolean>;
+  showFeatureEditTools?: boolean;
+};
+
 export type RenderWizardArguments = {
   previewLayers: (layerDescriptors: LayerDescriptor[]) => void;
   mapColors: string[];
@@ -27,30 +42,14 @@ export type RenderWizardArguments = {
   advanceToNextStep: () => void;
 };
 
-export type LayerWizard = {
-  categories: LAYER_WIZARD_CATEGORY[];
-  checkVisibility?: () => Promise<boolean>;
-  description: string;
-  disabledReason?: string;
-  getIsDisabled?: () => Promise<boolean> | boolean;
-  isBeta?: boolean;
-  icon: string | FunctionComponent<any>;
-  prerequisiteSteps?: Array<{ id: string; label: string }>;
-  renderWizard(renderWizardArguments: RenderWizardArguments): ReactElement<any>;
-  title: string;
-  showFeatureEditTools?: boolean;
-  order?: number;
-};
-
 export type LayerWizardWithMeta = LayerWizard & {
   isVisible: boolean;
   isDisabled: boolean;
-  order: number;
 };
 
 const registry: LayerWizard[] = [];
 
-export function registerLayerWizard(layerWizard: LayerWizard) {
+export function registerLayerWizardInternal(layerWizard: LayerWizard) {
   registry.push({
     checkVisibility: async () => {
       return true;
@@ -63,13 +62,19 @@ export function registerLayerWizard(layerWizard: LayerWizard) {
   });
 }
 
+export function registerLayerWizardExternal(layerWizard: LayerWizard) {
+  if (layerWizard.order < 100) {
+    throw new Error(`layerWizard.order should be greater than or equal to '100`);
+  }
+  registerLayerWizardInternal(layerWizard);
+}
+
 export async function getLayerWizards(): Promise<LayerWizardWithMeta[]> {
   const promises = registry.map(async (layerWizard: LayerWizard) => {
     return {
       ...layerWizard,
       isVisible: await layerWizard.checkVisibility!(),
       isDisabled: await layerWizard.getIsDisabled!(),
-      order: typeof layerWizard.order === 'number' ? layerWizard.order : 0,
     };
   });
   return (await Promise.all(promises))

--- a/x-pack/plugins/maps/public/classes/layers/wizards/load_layer_wizards.ts
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/load_layer_wizards.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { registerLayerWizard } from './layer_wizard_registry';
+import { registerLayerWizardInternal } from './layer_wizard_registry';
 import { uploadLayerWizardConfig } from './file_upload_wizard';
 import {
   esDocumentsLayerWizardConfig,
@@ -16,17 +16,12 @@ import {
   heatmapLayerWizardConfig,
 } from '../../sources/es_geo_grid_source';
 import { geoLineLayerWizardConfig } from '../../sources/es_geo_line_source';
-// @ts-ignore
-import { point2PointLayerWizardConfig } from '../../sources/es_pew_pew_source';
-// @ts-ignore
+import { point2PointLayerWizardConfig } from '../../sources/es_pew_pew_source/point_2_point_layer_wizard';
 import { emsBoundariesLayerWizardConfig } from '../../sources/ems_file_source';
-// @ts-ignore
 import { emsBaseMapLayerWizardConfig } from '../../sources/ems_tms_source';
-// @ts-ignore
-import { kibanaBasemapLayerWizardConfig } from '../../sources/kibana_tilemap_source';
+import { kibanaBasemapLayerWizardConfig } from '../../sources/kibana_tilemap_source/kibana_base_map_layer_wizard';
 import { tmsLayerWizardConfig } from '../../sources/xyz_tms_source';
-// @ts-ignore
-import { wmsLayerWizardConfig } from '../../sources/wms_source';
+import { wmsLayerWizardConfig } from '../../sources/wms_source/wms_layer_wizard';
 import { mvtVectorSourceWizardConfig } from '../../sources/mvt_single_layer_vector_source';
 import { ObservabilityLayerWizardConfig } from './solution_layers/observability';
 import { SecurityLayerWizardConfig } from './solution_layers/security';
@@ -39,31 +34,23 @@ export function registerLayerWizards() {
     return;
   }
 
-  // Registration order determines display order
-  registerLayerWizard(uploadLayerWizardConfig);
-  registerLayerWizard(esDocumentsLayerWizardConfig);
-  // @ts-ignore
-  registerLayerWizard(choroplethLayerWizardConfig);
-  registerLayerWizard(clustersLayerWizardConfig);
-  // @ts-ignore
-  registerLayerWizard(heatmapLayerWizardConfig);
-  registerLayerWizard(esTopHitsLayerWizardConfig);
-  registerLayerWizard(geoLineLayerWizardConfig);
-  // @ts-ignore
-  registerLayerWizard(point2PointLayerWizardConfig);
-  // @ts-ignore
-  registerLayerWizard(emsBoundariesLayerWizardConfig);
-  registerLayerWizard(newVectorLayerWizardConfig);
-  // @ts-ignore
-  registerLayerWizard(emsBaseMapLayerWizardConfig);
-  // @ts-ignore
-  registerLayerWizard(kibanaBasemapLayerWizardConfig);
-  registerLayerWizard(tmsLayerWizardConfig);
-  // @ts-ignore
-  registerLayerWizard(wmsLayerWizardConfig);
+  registerLayerWizardInternal(uploadLayerWizardConfig);
+  registerLayerWizardInternal(esDocumentsLayerWizardConfig);
+  registerLayerWizardInternal(choroplethLayerWizardConfig);
+  registerLayerWizardInternal(clustersLayerWizardConfig);
+  registerLayerWizardInternal(heatmapLayerWizardConfig);
+  registerLayerWizardInternal(esTopHitsLayerWizardConfig);
+  registerLayerWizardInternal(geoLineLayerWizardConfig);
+  registerLayerWizardInternal(point2PointLayerWizardConfig);
+  registerLayerWizardInternal(emsBoundariesLayerWizardConfig);
+  registerLayerWizardInternal(newVectorLayerWizardConfig);
+  registerLayerWizardInternal(emsBaseMapLayerWizardConfig);
+  registerLayerWizardInternal(kibanaBasemapLayerWizardConfig);
+  registerLayerWizardInternal(tmsLayerWizardConfig);
+  registerLayerWizardInternal(wmsLayerWizardConfig);
 
-  registerLayerWizard(mvtVectorSourceWizardConfig);
-  registerLayerWizard(ObservabilityLayerWizardConfig);
-  registerLayerWizard(SecurityLayerWizardConfig);
+  registerLayerWizardInternal(mvtVectorSourceWizardConfig);
+  registerLayerWizardInternal(ObservabilityLayerWizardConfig);
+  registerLayerWizardInternal(SecurityLayerWizardConfig);
   registered = true;
 }

--- a/x-pack/plugins/maps/public/classes/layers/wizards/new_vector_layer_wizard/config.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/new_vector_layer_wizard/config.tsx
@@ -16,6 +16,7 @@ import { LAYER_WIZARD_CATEGORY } from '../../../../../common/constants';
 const ADD_VECTOR_DRAWING_LAYER = 'ADD_VECTOR_DRAWING_LAYER';
 
 export const newVectorLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.ELASTICSEARCH],
   description: i18n.translate('xpack.maps.newVectorLayerWizard.description', {
     defaultMessage: 'Draw shapes on the map and index in Elasticsearch',

--- a/x-pack/plugins/maps/public/classes/layers/wizards/solution_layers/observability/observability_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/solution_layers/observability/observability_layer_wizard.tsx
@@ -14,6 +14,7 @@ import { APM_INDEX_PATTERN_ID } from './create_layer_descriptor';
 import { getIndexPatternService } from '../../../../../kibana_services';
 
 export const ObservabilityLayerWizardConfig: LayerWizard = {
+  order: 20,
   categories: [LAYER_WIZARD_CATEGORY.ELASTICSEARCH, LAYER_WIZARD_CATEGORY.SOLUTIONS],
   getIsDisabled: async () => {
     try {

--- a/x-pack/plugins/maps/public/classes/layers/wizards/solution_layers/security/security_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/solution_layers/security/security_layer_wizard.tsx
@@ -13,6 +13,7 @@ import { getSecurityIndexPatterns } from './security_index_pattern_utils';
 import { SecurityLayerTemplate } from './security_layer_template';
 
 export const SecurityLayerWizardConfig: LayerWizard = {
+  order: 20,
   categories: [LAYER_WIZARD_CATEGORY.ELASTICSEARCH, LAYER_WIZARD_CATEGORY.SOLUTIONS],
   getIsDisabled: async () => {
     const indexPatterns = await getSecurityIndexPatterns();

--- a/x-pack/plugins/maps/public/classes/sources/ems_file_source/ems_boundaries_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/ems_file_source/ems_boundaries_layer_wizard.tsx
@@ -29,6 +29,7 @@ function getDescription() {
 }
 
 export const emsBoundariesLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
   checkVisibility: async () => {
     const emsSettings = getEMSSettings();

--- a/x-pack/plugins/maps/public/classes/sources/ems_tms_source/ems_base_map_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/ems_tms_source/ems_base_map_layer_wizard.tsx
@@ -27,6 +27,7 @@ function getDescription() {
 }
 
 export const emsBaseMapLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
   checkVisibility: async () => {
     const emsSettings = getEMSSettings();

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/clusters_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/clusters_layer_wizard.tsx
@@ -33,6 +33,7 @@ import { NUMERICAL_COLOR_PALETTES } from '../../styles/color_palettes';
 import { ClustersLayerIcon } from '../../layers/wizards/icons/clusters_layer_icon';
 
 export const clustersLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.ELASTICSEARCH],
   description: i18n.translate('xpack.maps.source.esGridClustersDescription', {
     defaultMessage: 'Geospatial data grouped in grids with metrics for each gridded cell',

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/heatmap_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/heatmap_layer_wizard.tsx
@@ -17,6 +17,7 @@ import { GRID_RESOLUTION, LAYER_WIZARD_CATEGORY, RENDER_AS } from '../../../../c
 import { HeatmapLayerIcon } from '../../layers/wizards/icons/heatmap_layer_icon';
 
 export const heatmapLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.ELASTICSEARCH],
   description: i18n.translate('xpack.maps.source.esGridHeatmapDescription', {
     defaultMessage: 'Geospatial data grouped in grids to show density',

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/layer_wizard.tsx
@@ -17,6 +17,7 @@ import { getIsGoldPlus } from '../../../licensed_features';
 import { TracksLayerIcon } from '../../layers/wizards/icons/tracks_layer_icon';
 
 export const geoLineLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.ELASTICSEARCH],
   description: i18n.translate('xpack.maps.source.esGeoLineDescription', {
     defaultMessage: 'Create lines from points',

--- a/x-pack/plugins/maps/public/classes/sources/es_pew_pew_source/point_2_point_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_pew_pew_source/point_2_point_layer_wizard.tsx
@@ -27,6 +27,7 @@ import { ColorDynamicOptions, SizeDynamicOptions } from '../../../../common/desc
 import { Point2PointLayerIcon } from '../../layers/wizards/icons/point_2_point_layer_icon';
 
 export const point2PointLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.ELASTICSEARCH],
   description: i18n.translate('xpack.maps.source.pewPewDescription', {
     defaultMessage: 'Aggregated data paths between the source and destination',

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/es_documents_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/es_documents_layer_wizard.tsx
@@ -35,6 +35,7 @@ export function createDefaultLayerDescriptor(
 }
 
 export const esDocumentsLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.ELASTICSEARCH],
   description: i18n.translate('xpack.maps.source.esSearchDescription', {
     defaultMessage: 'Points, lines, and polygons from Elasticsearch',

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/top_hits/wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/top_hits/wizard.tsx
@@ -16,6 +16,7 @@ import { ESSearchSourceDescriptor } from '../../../../../common/descriptor_types
 import { ESSearchSource } from '../es_search_source';
 
 export const esTopHitsLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.ELASTICSEARCH],
   description: i18n.translate('xpack.maps.source.topHitsDescription', {
     defaultMessage:

--- a/x-pack/plugins/maps/public/classes/sources/kibana_tilemap_source/kibana_base_map_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/kibana_tilemap_source/kibana_base_map_layer_wizard.tsx
@@ -17,6 +17,7 @@ import { getKibanaTileMap } from '../../../util';
 import { LAYER_WIZARD_CATEGORY } from '../../../../common/constants';
 
 export const kibanaBasemapLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
   checkVisibility: async () => {
     const tilemap = getKibanaTileMap();

--- a/x-pack/plugins/maps/public/classes/sources/mvt_single_layer_vector_source/layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/mvt_single_layer_vector_source/layer_wizard.tsx
@@ -16,6 +16,7 @@ import { TiledSingleLayerVectorSourceSettings } from '../../../../common/descrip
 import { VectorTileLayerIcon } from '../../layers/wizards/icons/vector_tile_layer_icon';
 
 export const mvtVectorSourceWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
   description: i18n.translate('xpack.maps.source.mvtVectorSourceWizard', {
     defaultMessage: 'Data service implementing the Mapbox vector tile specification',

--- a/x-pack/plugins/maps/public/classes/sources/wms_source/wms_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/wms_source/wms_layer_wizard.tsx
@@ -17,6 +17,7 @@ import { LAYER_WIZARD_CATEGORY } from '../../../../common/constants';
 import { WebMapServiceLayerIcon } from '../../layers/wizards/icons/web_map_service_layer_icon';
 
 export const wmsLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
   description: i18n.translate('xpack.maps.source.wmsDescription', {
     defaultMessage: 'Maps from OGC Standard WMS',

--- a/x-pack/plugins/maps/public/classes/sources/xyz_tms_source/layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/xyz_tms_source/layer_wizard.tsx
@@ -15,6 +15,7 @@ import { LAYER_WIZARD_CATEGORY } from '../../../../common/constants';
 import { WorldMapLayerIcon } from '../../layers/wizards/icons/world_map_layer_icon';
 
 export const tmsLayerWizardConfig: LayerWizard = {
+  order: 10,
   categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
   description: i18n.translate('xpack.maps.source.ems_xyzDescription', {
     defaultMessage: 'Raster image tile map service using {z}/{x}/{y} url pattern.',

--- a/x-pack/plugins/maps/public/plugin.ts
+++ b/x-pack/plugins/maps/public/plugin.ts
@@ -46,7 +46,7 @@ import {
   MapsStartApi,
   suggestEMSTermJoinConfig,
 } from './api';
-import { registerLayerWizard } from './classes/layers';
+import { registerLayerWizardExternal } from './classes/layers';
 import { registerSource } from './classes/sources/source_registry';
 import type { SharePluginSetup, SharePluginStart } from '../../../../src/plugins/share/public';
 import type { MapsEmsPluginPublicStart } from '../../../../src/plugins/maps_ems/public';
@@ -182,7 +182,7 @@ export class MapsPlugin
     plugins.visualizations.createBaseVisualization(tileMapVisType);
 
     return {
-      registerLayerWizard,
+      registerLayerWizard: registerLayerWizardExternal,
       registerSource,
     };
   }


### PR DESCRIPTION
The layer-wizard registration API is exposed to other plugins. 

There is no guarantee of the order in which the wizards are displayed in the UX, because there is no guarantee in the order in which plugins will call this API. e.g. they might even call it _before_ the Maps-app registers its own layer-wizards.

The practical result is that layer-wizards from other plugins would end up "on top", where the Maps-app would still want to surface its own wizards first (e.g. upload GeoJson-wizard should come on top).

This was revealed in https://github.com/elastic/kibana/pull/122862. 

~By default, the ordering is set to `0`.~

Clients using the `registerLayerWizard` API would have to set the `order` param. This will allow us to enforce an ordering of layer-wizards.

e.g. in https://github.com/elastic/kibana/pull/122862, we'd set the `order: 100` so the wizard does not surface on top.
