### PR TITLE
[Uptime] Add locator to aid other plugins in linking properly to Uptime

### DIFF
--- a/x-pack/plugins/observability/common/index.ts
+++ b/x-pack/plugins/observability/common/index.ts
@@ -24,3 +24,7 @@ export const observabilityFeatureId = 'observability';
 
 // Used by Cases to install routes
 export const casesPath = '/cases';
+
+// Name of a locator created by the uptime plugin. Intended for use
+// by other plugins as well, so defined here to prevent cross-references.
+export const uptimeOverviewLocator = 'uptime-overview-locator';

--- a/x-pack/plugins/observability/common/index.ts
+++ b/x-pack/plugins/observability/common/index.ts
@@ -27,4 +27,4 @@ export const casesPath = '/cases';
 
 // Name of a locator created by the uptime plugin. Intended for use
 // by other plugins as well, so defined here to prevent cross-references.
-export const uptimeOverviewLocator = 'uptime-overview-locator';
+export const uptimeOverviewLocatorID = 'uptime-overview-locator';

--- a/x-pack/plugins/observability/public/index.ts
+++ b/x-pack/plugins/observability/public/index.ts
@@ -24,6 +24,7 @@ export type {
   ObservabilityPublicPluginsStart,
 };
 export { enableInspectEsQueries } from '../common/ui_settings_keys';
+export { uptimeOverviewLocator } from '../common';
 
 export interface ConfigSchema {
   unsafe: {

--- a/x-pack/plugins/observability/public/index.ts
+++ b/x-pack/plugins/observability/public/index.ts
@@ -24,7 +24,7 @@ export type {
   ObservabilityPublicPluginsStart,
 };
 export { enableInspectEsQueries } from '../common/ui_settings_keys';
-export { uptimeOverviewLocator } from '../common';
+export { uptimeOverviewLocatorID } from '../common';
 
 export interface ConfigSchema {
   unsafe: {

--- a/x-pack/plugins/uptime/kibana.json
+++ b/x-pack/plugins/uptime/kibana.json
@@ -1,43 +1,27 @@
 {
-  "configPath": [
-    "xpack",
-    "uptime"
-  ],
+  "configPath": ["xpack", "uptime"],
   "id": "uptime",
   "kibanaVersion": "kibana",
-  "optionalPlugins": [
-    "cloud",
-    "data",
-    "fleet",
-    "home",
-    "ml"
-  ],
+  "optionalPlugins": ["cloud", "data", "fleet", "home", "ml"],
   "requiredPlugins": [
     "alerting",
     "embeddable",
     "encryptedSavedObjects",
-    "inspector",
     "features",
+    "inspector",
     "licensing",
     "observability",
     "ruleRegistry",
     "security",
+    "share",
+    "taskManager",
     "triggersActionsUi",
-    "usageCollection",
-    "taskManager"
+    "usageCollection"
   ],
   "server": true,
   "ui": true,
   "version": "8.0.0",
-  "requiredBundles": [
-    "observability",
-    "kibanaReact",
-    "kibanaUtils",
-    "home",
-    "data",
-    "ml",
-    "fleet"
-  ],
+  "requiredBundles": ["data", "fleet", "home", "kibanaReact", "kibanaUtils", "ml", "observability"],
   "owner": {
     "name": "Uptime",
     "githubTeam": "uptime"

--- a/x-pack/plugins/uptime/public/apps/locators/overview.test.ts
+++ b/x-pack/plugins/uptime/public/apps/locators/overview.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { OVERVIEW_ROUTE } from '../../../common/constants';
+import { uptimeOverviewNavigatorParams } from './overview';
+
+describe('uptimeOverviewNavigatorParams', () => {
+  it('supplies the correct app name', async () => {
+    const location = await uptimeOverviewNavigatorParams.getLocation({});
+    expect(location.app).toEqual('uptime');
+  });
+
+  it('creates the expected path when no params specified', async () => {
+    const location = await uptimeOverviewNavigatorParams.getLocation({});
+    expect(location.path).toEqual(OVERVIEW_ROUTE);
+  });
+
+  it('creates a path with expected search when ip is specified', async () => {
+    const location = await uptimeOverviewNavigatorParams.getLocation({ ip: '127.0.0.1' });
+    expect(location.path).toEqual(`${OVERVIEW_ROUTE}?search=monitor.ip: "127.0.0.1"`);
+  });
+
+  it('creates a path with expected search when hostname is specified', async () => {
+    const location = await uptimeOverviewNavigatorParams.getLocation({ hostname: 'elastic.co' });
+    expect(location.path).toEqual(`${OVERVIEW_ROUTE}?search=url.domain: "elastic.co"`);
+  });
+
+  it('creates a path with expected search when multiple keys are specified', async () => {
+    const location = await uptimeOverviewNavigatorParams.getLocation({
+      hostname: 'elastic.co',
+      ip: '127.0.0.1',
+    });
+    expect(location.path).toEqual(
+      `${OVERVIEW_ROUTE}?search=monitor.ip: "127.0.0.1" OR url.domain: "elastic.co"`
+    );
+  });
+});

--- a/x-pack/plugins/uptime/public/apps/locators/overview.ts
+++ b/x-pack/plugins/uptime/public/apps/locators/overview.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { uptimeOverviewLocator } from '../../../../observability/public';
+import { OVERVIEW_ROUTE } from '../../../common/constants';
+
+const formatSearchKey = (key: string, value: string) => `${key}: "${value}"`;
+
+async function navigate({ ip, hostname }: { ip?: string; hostname?: string }) {
+  const searchParams: string[] = [];
+
+  if (ip) searchParams.push(formatSearchKey('monitor.ip', ip));
+  if (hostname) searchParams.push(formatSearchKey('url.domain', hostname));
+
+  const searchString = searchParams.join(' OR ');
+
+  const path =
+    searchParams.length === 0 ? OVERVIEW_ROUTE : OVERVIEW_ROUTE + `?search=${searchString}`;
+
+  return {
+    app: 'uptime',
+    path,
+    state: {},
+  };
+}
+
+export const uptimeOverviewNavigatorParams = {
+  id: uptimeOverviewLocator,
+  getLocation: navigate,
+};

--- a/x-pack/plugins/uptime/public/apps/locators/overview.ts
+++ b/x-pack/plugins/uptime/public/apps/locators/overview.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { uptimeOverviewLocator } from '../../../../observability/public';
+import { uptimeOverviewLocatorID } from '../../../../observability/public';
 import { OVERVIEW_ROUTE } from '../../../common/constants';
 
 const formatSearchKey = (key: string, value: string) => `${key}: "${value}"`;
@@ -29,6 +29,6 @@ async function navigate({ ip, hostname }: { ip?: string; hostname?: string }) {
 }
 
 export const uptimeOverviewNavigatorParams = {
-  id: uptimeOverviewLocator,
+  id: uptimeOverviewLocatorID,
   getLocation: navigate,
 };

--- a/x-pack/plugins/uptime/public/apps/plugin.ts
+++ b/x-pack/plugins/uptime/public/apps/plugin.ts
@@ -48,7 +48,6 @@ import {
 import { LazySyntheticsCustomAssetsExtension } from '../components/fleet_package/lazy_synthetics_custom_assets_extension';
 import { Start as InspectorPluginStart } from '../../../../../src/plugins/inspector/public';
 import { UptimeUiConfig } from '../../common/config';
-import { uptimeOverviewNavigatorParams } from './locators/overview';
 
 export interface ClientPluginsSetup {
   home?: HomePublicPluginSetup;
@@ -102,8 +101,6 @@ export class UptimePlugin
 
       return UptimeDataHelper(coreStart);
     };
-
-    plugins.share.url.locators.create(uptimeOverviewNavigatorParams);
 
     plugins.observability.dashboard.register({
       appName: 'synthetics',

--- a/x-pack/plugins/uptime/public/apps/plugin.ts
+++ b/x-pack/plugins/uptime/public/apps/plugin.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import {
   CoreSetup,
   CoreStart,
@@ -14,6 +15,7 @@ import {
 import { from } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { i18n } from '@kbn/i18n';
+import { SharePluginSetup, SharePluginStart } from '../../../../../src/plugins/share/public';
 import { DEFAULT_APP_CATEGORIES } from '../../../../../src/core/public';
 
 import {
@@ -29,6 +31,7 @@ import {
   DataPublicPluginSetup,
   DataPublicPluginStart,
 } from '../../../../../src/plugins/data/public';
+
 import { alertTypeInitializers, legacyAlertTypeInitializers } from '../lib/alert_types';
 import { FleetStart } from '../../../fleet/public';
 import {
@@ -45,21 +48,24 @@ import {
 import { LazySyntheticsCustomAssetsExtension } from '../components/fleet_package/lazy_synthetics_custom_assets_extension';
 import { Start as InspectorPluginStart } from '../../../../../src/plugins/inspector/public';
 import { UptimeUiConfig } from '../../common/config';
+import { uptimeOverviewNavigatorParams } from './locators/overview';
 
 export interface ClientPluginsSetup {
-  data: DataPublicPluginSetup;
   home?: HomePublicPluginSetup;
+  data: DataPublicPluginSetup;
   observability: ObservabilityPublicSetup;
+  share: SharePluginSetup;
   triggersActionsUi: TriggersAndActionsUIPublicPluginSetup;
 }
 
 export interface ClientPluginsStart {
-  embeddable: EmbeddableStart;
-  data: DataPublicPluginStart;
-  triggersActionsUi: TriggersAndActionsUIPublicPluginStart;
   fleet?: FleetStart;
-  observability: ObservabilityPublicStart;
+  data: DataPublicPluginStart;
   inspector: InspectorPluginStart;
+  embeddable: EmbeddableStart;
+  observability: ObservabilityPublicStart;
+  share: SharePluginStart;
+  triggersActionsUi: TriggersAndActionsUIPublicPluginStart;
 }
 
 export interface UptimePluginServices extends Partial<CoreStart> {
@@ -96,6 +102,8 @@ export class UptimePlugin
 
       return UptimeDataHelper(coreStart);
     };
+
+    plugins.share.url.locators.create(uptimeOverviewNavigatorParams);
 
     plugins.observability.dashboard.register({
       appName: 'synthetics',

--- a/x-pack/plugins/uptime/public/apps/render_app.tsx
+++ b/x-pack/plugins/uptime/public/apps/render_app.tsx
@@ -18,6 +18,7 @@ import {
 import { UptimeApp, UptimeAppProps } from './uptime_app';
 import { ClientPluginsSetup, ClientPluginsStart } from './plugin';
 import { UptimeUiConfig } from '../../common/config';
+import { uptimeOverviewNavigatorParams } from './locators/overview';
 
 export function renderApp(
   core: CoreStart,
@@ -40,6 +41,8 @@ export function renderApp(
   );
 
   const canSave = (capabilities.uptime.save ?? false) as boolean;
+
+  plugins.share.url.locators.create(uptimeOverviewNavigatorParams);
 
   const props: UptimeAppProps = {
     plugins,


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/121258.

Adds a Kibana [Locator](https://github.com/elastic/kibana/blob/6693ef371f887eca639b09c4c9b15701b4ebabd4/src/plugins/share/common/url_service/locators/README.md#locators) to help apps that want to link directly to a pre-filtered version of the Uptime Overview UI.

This is a first step, we should add additional deep link functionality that allows for more powerful filtering, direct linking to the monitor page, etc.

This was driven by [a bug](https://github.com/elastic/kibana/issues/121258) where we found that some plugins are not linking with the correct queries for the Uptime URL API to pick up the searched values, leading to a bad linking experience.

## Testing this PR

The best way to test this patch is to try and reference the locator from another plugin. To do this, it might be required to add the `share` plugin to the `requiredPlugins` key of the `kibana.json` in your chosen test location.

For example, to run this from `infra`:
- go to https://github.com/elastic/kibana/blob/main/x-pack/plugins/infra/kibana.json#L5 and add `share`.
- go to https://github.com/elastic/kibana/blob/main/x-pack/plugins/infra/public/plugin.ts#L57 and add `console.log(plugins.share.url.locators.get('uptime-overview-locator'))`. 
- in Dev Tools you can now interact with the locator, and use it to navigate to the Uptime overview page
- you can navigate by running `await locator.navigate({ ip: 'some-ip' })` and you should arrive at the overview page with that IP in the search. You can also use `hostname`, which should run against `url.domain`.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
