### PR TITLE
[Security Solution][Detections] Log partial rule failures at the warning level

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -184,7 +184,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             }
           } catch (exc) {
             const errorMessage = buildRuleMessage(`Check privileges failed to execute ${exc}`);
-            logger.error(errorMessage);
+            logger.warn(errorMessage);
             await ruleStatusClient.logStatusChange({
               ...basicLogArguments,
               message: errorMessage,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
@@ -661,7 +661,7 @@ describe('utils', () => {
           },
         },
       };
-      mockLogger.error.mockClear();
+      mockLogger.warn.mockClear();
       const res = await hasTimestampFields({
         timestampField,
         ruleName: 'myfakerulename',
@@ -677,11 +677,12 @@ describe('utils', () => {
         logger: mockLogger,
         buildRuleMessage,
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         'The following indices are missing the timestamp override field "event.ingested": ["myfakeindex-1","myfakeindex-2"] name: "fake name" id: "fake id" rule id: "fake rule id" signals index: "fakeindex"'
       );
       expect(res).toBeTruthy();
     });
+
     test('returns true when missing timestamp field', async () => {
       const timestampField = '@timestamp';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -706,7 +707,7 @@ describe('utils', () => {
           },
         },
       };
-      mockLogger.error.mockClear();
+      mockLogger.warn.mockClear();
       const res = await hasTimestampFields({
         timestampField,
         ruleName: 'myfakerulename',
@@ -722,7 +723,7 @@ describe('utils', () => {
         logger: mockLogger,
         buildRuleMessage,
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         'The following indices are missing the timestamp field "@timestamp": ["myfakeindex-1","myfakeindex-2"] name: "fake name" id: "fake id" rule id: "fake rule id" signals index: "fakeindex"'
       );
       expect(res).toBeTruthy();
@@ -737,7 +738,7 @@ describe('utils', () => {
           fields: {},
         },
       };
-      mockLogger.error.mockClear();
+      mockLogger.warn.mockClear();
       const res = await hasTimestampFields({
         timestampField,
         ruleName: 'Endpoint Security',
@@ -753,7 +754,7 @@ describe('utils', () => {
         logger: mockLogger,
         buildRuleMessage,
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         'This rule is attempting to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, however no index matching: ["logs-endpoint.alerts-*"] was found. This warning will continue to appear until a matching index is created or this rule is de-activated. If you have recently enrolled agents enabled with Endpoint Security through Fleet, this warning should stop once an alert is sent from an agent. name: "fake name" id: "fake id" rule id: "fake rule id" signals index: "fakeindex"'
       );
       expect(res).toBeTruthy();
@@ -768,7 +769,7 @@ describe('utils', () => {
           fields: {},
         },
       };
-      mockLogger.error.mockClear();
+      mockLogger.warn.mockClear();
       const res = await hasTimestampFields({
         timestampField,
         ruleName: 'NOT Endpoint Security',
@@ -784,7 +785,7 @@ describe('utils', () => {
         logger: mockLogger,
         buildRuleMessage,
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         'This rule is attempting to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, however no index matching: ["logs-endpoint.alerts-*"] was found. This warning will continue to appear until a matching index is created or this rule is de-activated. name: "fake name" id: "fake id" rule id: "fake rule id" signals index: "fakeindex"'
       );
       expect(res).toBeTruthy();

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -118,7 +118,7 @@ export const hasReadIndexPrivileges = async (args: {
     const errorString = `This rule may not have the required read privileges to the following indices/index patterns: ${JSON.stringify(
       indexesWithNoReadPrivileges
     )}`;
-    logger.error(buildRuleMessage(errorString));
+    logger.warn(buildRuleMessage(errorString));
     await ruleStatusClient.logStatusChange({
       message: errorString,
       ruleId,
@@ -168,7 +168,7 @@ export const hasTimestampFields = async (args: {
         ? 'If you have recently enrolled agents enabled with Endpoint Security through Fleet, this warning should stop once an alert is sent from an agent.'
         : ''
     }`;
-    logger.error(buildRuleMessage(errorString.trimEnd()));
+    logger.warn(buildRuleMessage(errorString.trimEnd()));
     await ruleStatusClient.logStatusChange({
       message: errorString.trimEnd(),
       ruleId,
@@ -195,7 +195,7 @@ export const hasTimestampFields = async (args: {
         ? timestampFieldCapsResponse.body.indices
         : timestampFieldCapsResponse.body.fields[timestampField]?.unmapped?.indices
     )}`;
-    logger.error(buildRuleMessage(errorString));
+    logger.warn(buildRuleMessage(errorString));
     await ruleStatusClient.logStatusChange({
       message: errorString,
       ruleId,


### PR DESCRIPTION
## Summary

We previously logged these at the error level, which can cause a lot of noise in certain situations. Moving these to the warn level should be more accurate and less noisy.


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
