### PR TITLE
[ML] Functional tests - stabilize data frame analytics creation

### DIFF
--- a/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation.ts
@@ -13,8 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
   const editedDescription = 'Edited description';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/122927
-  describe.skip('regression creation', function () {
+  describe('regression creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/egs_regression');
       await ml.testResources.createIndexPatternIfNeeded('ft_egs_regression', '@timestamp');

--- a/x-pack/test/functional/services/ml/data_frame_analytics.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics.ts
@@ -51,13 +51,15 @@ export function MachineLearningDataFrameAnalyticsProvider(
     },
 
     async startAnalyticsCreation() {
-      await retry.tryForTime(20 * 1000, async () => {
-        if (await testSubjects.exists('mlNoDataFrameAnalyticsFound', { timeout: 1000 })) {
+      await retry.tryForTime(30 * 1000, async () => {
+        if (await testSubjects.exists('mlAnalyticsCreateFirstButton', { timeout: 1000 })) {
           await testSubjects.click('mlAnalyticsCreateFirstButton');
-        } else {
+        } else if (await testSubjects.exists('mlAnalyticsButtonCreate', { timeout: 1000 })) {
           await testSubjects.click('mlAnalyticsButtonCreate');
+        } else {
+          throw new Error('No Analytics create button found');
         }
-        await testSubjects.existOrFail('analyticsCreateSourceIndexModal');
+        await testSubjects.existOrFail('analyticsCreateSourceIndexModal', { timeout: 5000 });
       });
     },
 


### PR DESCRIPTION
## Summary

This PR stabilizes the data frame analytics creation during functional tests.

### Details

- There are two different buttons to start the job creation, depending on exisitng jobs.
- We already had code to look for one or the other button, but it turned out that the `click` for the second button took 2 minutes to fail (default timeout in the service method), which was more than the retry allowed, so the tests didn't actually try the first button again.
- With this PR, it tries 1 second to find the first button, then 1 second to find the second button and if both fail, it triggers the retry.
- Also, some retry timeouts are slightly tweaked

Closes #122927
Closes #122485
Closes #122860