### PR TITLE
[Canvas] [7.17] Fixes ESDocs Index argument not being initially applied.

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/uis/datasources/esdocs.js
+++ b/x-pack/plugins/canvas/canvas_plugin_src/uis/datasources/esdocs.js
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {
   EuiFormRow,
@@ -27,13 +27,16 @@ import { DataSourceStrings, LUCENE_QUERY_URL } from '../../../i18n';
 const { ESDocs: strings } = DataSourceStrings;
 
 const EsdocsDatasource = ({ args, updateArgs, defaultIndex }) => {
-  const setArg = (name, value) => {
-    updateArgs &&
-      updateArgs({
-        ...args,
-        ...setSimpleArg(name, value),
-      });
-  };
+  const setArg = useCallback(
+    (name, value) => {
+      updateArgs &&
+        updateArgs({
+          ...args,
+          ...setSimpleArg(name, value),
+        });
+    },
+    [args, updateArgs]
+  );
 
   // TODO: This is a terrible way of doing defaults. We need to find a way to read the defaults for the function
   // and set them for the data source UI.
@@ -72,6 +75,12 @@ const EsdocsDatasource = ({ args, updateArgs, defaultIndex }) => {
   const [sortField, sortOrder] = getSortBy();
 
   const index = getIndex();
+
+  useEffect(() => {
+    if (getSimpleArg('index', args)[0] !== index) {
+      setArg('index', index);
+    }
+  }, [args, index, setArg]);
 
   const sortOptions = [
     { value: 'asc', text: strings.getAscendingOption() },


### PR DESCRIPTION
## Summary
Fixes: https://github.com/elastic/kibana/issues/122975.
Branch `main` contains such changes from the original PR: https://github.com/elastic/kibana/pull/114808. Current PR is just for fixing such an issue in the previous versions (for v7.17).
