### PR TITLE
[7.17] Log partial rule failures at the warning level (#123009)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -164,7 +164,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
           }
         } catch (exc) {
           const errorMessage = buildRuleMessage(`Check privileges failed to execute ${exc}`);
-          logger.error(errorMessage);
+          logger.warn(errorMessage);
           await ruleStatusClient.logStatusChange({
             ...basicLogArguments,
             message: errorMessage,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
@@ -779,7 +779,7 @@ describe('utils', () => {
           },
         },
       };
-      mockLogger.error.mockClear();
+      mockLogger.warn.mockClear();
       const res = await hasTimestampFields({
         timestampField,
         ruleName: 'myfakerulename',
@@ -793,11 +793,12 @@ describe('utils', () => {
         logger: mockLogger,
         buildRuleMessage,
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         'The following indices are missing the timestamp override field "event.ingested": ["myfakeindex-1","myfakeindex-2"] name: "fake name" id: "fake id" rule id: "fake rule id" signals index: "fakeindex"'
       );
       expect(res).toBeTruthy();
     });
+
     test('returns true when missing timestamp field', async () => {
       const timestampField = '@timestamp';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -822,7 +823,7 @@ describe('utils', () => {
           },
         },
       };
-      mockLogger.error.mockClear();
+      mockLogger.warn.mockClear();
       const res = await hasTimestampFields({
         timestampField,
         ruleName: 'myfakerulename',
@@ -836,7 +837,7 @@ describe('utils', () => {
         logger: mockLogger,
         buildRuleMessage,
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         'The following indices are missing the timestamp field "@timestamp": ["myfakeindex-1","myfakeindex-2"] name: "fake name" id: "fake id" rule id: "fake rule id" signals index: "fakeindex"'
       );
       expect(res).toBeTruthy();
@@ -851,7 +852,7 @@ describe('utils', () => {
           fields: {},
         },
       };
-      mockLogger.error.mockClear();
+      mockLogger.warn.mockClear();
       const res = await hasTimestampFields({
         timestampField,
         ruleName: 'Endpoint Security',
@@ -865,7 +866,7 @@ describe('utils', () => {
         logger: mockLogger,
         buildRuleMessage,
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         'This rule is attempting to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, however no index matching: ["logs-endpoint.alerts-*"] was found. This warning will continue to appear until a matching index is created or this rule is de-activated. If you have recently enrolled agents enabled with Endpoint Security through Fleet, this warning should stop once an alert is sent from an agent. name: "fake name" id: "fake id" rule id: "fake rule id" signals index: "fakeindex"'
       );
       expect(res).toBeTruthy();
@@ -880,7 +881,7 @@ describe('utils', () => {
           fields: {},
         },
       };
-      mockLogger.error.mockClear();
+      mockLogger.warn.mockClear();
       const res = await hasTimestampFields({
         timestampField,
         ruleName: 'NOT Endpoint Security',
@@ -894,7 +895,7 @@ describe('utils', () => {
         logger: mockLogger,
         buildRuleMessage,
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         'This rule is attempting to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, however no index matching: ["logs-endpoint.alerts-*"] was found. This warning will continue to appear until a matching index is created or this rule is de-activated. name: "fake name" id: "fake id" rule id: "fake rule id" signals index: "fakeindex"'
       );
       expect(res).toBeTruthy();

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -126,7 +126,7 @@ export const hasReadIndexPrivileges = async (args: {
     const errorString = `This rule may not have the required read privileges to the following indices/index patterns: ${JSON.stringify(
       indexesWithNoReadPrivileges
     )}`;
-    logger.error(buildRuleMessage(errorString));
+    logger.warn(buildRuleMessage(errorString));
     await ruleStatusClient.logStatusChange({
       message: errorString,
       ruleId,
@@ -176,7 +176,7 @@ export const hasTimestampFields = async (args: {
         ? 'If you have recently enrolled agents enabled with Endpoint Security through Fleet, this warning should stop once an alert is sent from an agent.'
         : ''
     }`;
-    logger.error(buildRuleMessage(errorString.trimEnd()));
+    logger.warn(buildRuleMessage(errorString.trimEnd()));
     await ruleStatusClient.logStatusChange({
       message: errorString.trimEnd(),
       ruleId,
@@ -203,7 +203,7 @@ export const hasTimestampFields = async (args: {
         ? timestampFieldCapsResponse.body.indices
         : timestampFieldCapsResponse.body.fields[timestampField]?.unmapped?.indices
     )}`;
-    logger.error(buildRuleMessage(errorString));
+    logger.warn(buildRuleMessage(errorString));
     await ruleStatusClient.logStatusChange({
       message: errorString,
       ruleId,


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #123009

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
