### PR TITLE
[Maps] Add kibana-theme to MapEmbeddable

### DIFF
--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
@@ -15,6 +15,8 @@ import { Subscription } from 'rxjs';
 import { Unsubscribe } from 'redux';
 import { EuiEmptyPrompt } from '@elastic/eui';
 import { Filter } from '@kbn/es-query';
+import { Observable } from 'rxjs';
+import { KibanaThemeProvider } from '../../../../../src/plugins/kibana_react/public';
 import {
   Embeddable,
   IContainer,
@@ -88,6 +90,7 @@ import {
   MapEmbeddableInput,
   MapEmbeddableOutput,
 } from './types';
+import { CoreTheme } from '../../../../../src/core/public/theme/types';
 
 function getIsRestore(searchSessionId?: string) {
   if (!searchSessionId) {
@@ -123,8 +126,11 @@ export class MapEmbeddable
   private _onInitialRenderComplete?: () => void = undefined;
   private _hasInitialRenderCompleteFired = false;
   private _isSharable = true;
+  private _theme$?: Observable<CoreTheme>;
 
   constructor(config: MapEmbeddableConfig, initialInput: MapEmbeddableInput, parent?: IContainer) {
+    console.trace();
+    console.log('Create new embeddalbe', config, initialInput, parent);
     super(
       initialInput,
       {
@@ -135,6 +141,7 @@ export class MapEmbeddable
       parent
     );
 
+    this._theme$ = config.theme$;
     this._isActive = true;
     this._savedMap = new SavedMap({ mapEmbeddableInput: initialInput });
     this._initializeSaveMap();
@@ -398,9 +405,16 @@ export class MapEmbeddable
       );
 
     const I18nContext = getCoreI18n().Context;
+
+    const themedContent = this._theme$ ? (
+      <KibanaThemeProvider theme$={this._theme$}>content</KibanaThemeProvider>
+    ) : (
+      content
+    );
+
     render(
       <Provider store={this._savedMap.getStore()}>
-        <I18nContext>{content}</I18nContext>
+        <I18nContext>{themedContent}</I18nContext>
       </Provider>,
       this._domNode
     );

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
@@ -15,7 +15,6 @@ import { Subscription } from 'rxjs';
 import { Unsubscribe } from 'redux';
 import { EuiEmptyPrompt } from '@elastic/eui';
 import { Filter } from '@kbn/es-query';
-import { Observable } from 'rxjs';
 import { KibanaThemeProvider } from '../../../../../src/plugins/kibana_react/public';
 import {
   Embeddable,
@@ -74,6 +73,7 @@ import {
   getChartsPaletteServiceGetColor,
   getSpacesApi,
   getSearchService,
+  getTheme,
 } from '../kibana_services';
 import { LayerDescriptor, MapExtent } from '../../common/descriptor_types';
 import { MapContainer } from '../connected_components/map_container';
@@ -90,7 +90,6 @@ import {
   MapEmbeddableInput,
   MapEmbeddableOutput,
 } from './types';
-import { CoreTheme } from '../../../../../src/core/public/theme/types';
 
 function getIsRestore(searchSessionId?: string) {
   if (!searchSessionId) {
@@ -126,11 +125,8 @@ export class MapEmbeddable
   private _onInitialRenderComplete?: () => void = undefined;
   private _hasInitialRenderCompleteFired = false;
   private _isSharable = true;
-  private _theme$?: Observable<CoreTheme>;
 
   constructor(config: MapEmbeddableConfig, initialInput: MapEmbeddableInput, parent?: IContainer) {
-    console.trace();
-    console.log('Create new embeddalbe', config, initialInput, parent);
     super(
       initialInput,
       {
@@ -141,7 +137,6 @@ export class MapEmbeddable
       parent
     );
 
-    this._theme$ = config.theme$;
     this._isActive = true;
     this._savedMap = new SavedMap({ mapEmbeddableInput: initialInput });
     this._initializeSaveMap();
@@ -405,16 +400,11 @@ export class MapEmbeddable
       );
 
     const I18nContext = getCoreI18n().Context;
-
-    const themedContent = this._theme$ ? (
-      <KibanaThemeProvider theme$={this._theme$}>content</KibanaThemeProvider>
-    ) : (
-      content
-    );
-
     render(
       <Provider store={this._savedMap.getStore()}>
-        <I18nContext>{themedContent}</I18nContext>
+        <I18nContext>
+          <KibanaThemeProvider theme$={getTheme().theme$}>{content}</KibanaThemeProvider>;
+        </I18nContext>
       </Provider>,
       this._domNode
     );

--- a/x-pack/plugins/maps/public/embeddable/types.ts
+++ b/x-pack/plugins/maps/public/embeddable/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { Observable } from 'rxjs';
 import type { IndexPattern } from '../../../../../src/plugins/data/common';
 import {
   Embeddable,
@@ -16,9 +17,11 @@ import { Query, Filter, TimeRange } from '../../../../../src/plugins/data/common
 import { MapCenterAndZoom, MapExtent } from '../../common/descriptor_types';
 import { MapSavedObjectAttributes } from '../../common/map_saved_object_type';
 import { MapSettings } from '../reducers/map';
+import { CoreTheme } from '../../../../../src/core/public';
 
 export interface MapEmbeddableConfig {
   editable: boolean;
+  theme$?: Observable<CoreTheme>;
 }
 
 interface MapEmbeddableState {

--- a/x-pack/plugins/maps/public/embeddable/types.ts
+++ b/x-pack/plugins/maps/public/embeddable/types.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { Observable } from 'rxjs';
 import type { IndexPattern } from '../../../../../src/plugins/data/common';
 import {
   Embeddable,
@@ -17,11 +16,9 @@ import { Query, Filter, TimeRange } from '../../../../../src/plugins/data/common
 import { MapCenterAndZoom, MapExtent } from '../../common/descriptor_types';
 import { MapSavedObjectAttributes } from '../../common/map_saved_object_type';
 import { MapSettings } from '../reducers/map';
-import { CoreTheme } from '../../../../../src/core/public';
 
 export interface MapEmbeddableConfig {
   editable: boolean;
-  theme$?: Observable<CoreTheme>;
 }
 
 interface MapEmbeddableState {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/118875

Adds the kibana-theme to the `MapEmbeddable`.

Similar to LensEmbeddable, just grab the theme internally. The consumer does not need to supply the theme.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
