### PR TITLE
[Security Solution][8.0] Fix threshold timeline on 8.0 release branch

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_fetch_ecs_alerts_data.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_fetch_ecs_alerts_data.ts
@@ -8,14 +8,11 @@ import { useEffect, useState } from 'react';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { isEmpty } from 'lodash';
 
-import {
-  buildAlertsQuery,
-  formatAlertToEcsSignal,
-} from '../../../../cases/components/case_view/helpers';
 import { Ecs } from '../../../../../common/ecs';
 
 import { DETECTION_ENGINE_QUERY_SIGNALS_URL } from '../../../../../common/constants';
 import { KibanaServices } from '../../../../common/lib/kibana';
+import { buildAlertsQuery, formatAlertToEcsSignal } from '../../../../common/utils/alerts';
 
 export const useFetchEcsAlertsData = ({
   alertIds,


### PR DESCRIPTION
## Summary
Completes fix for https://github.com/elastic/kibana/issues/120596 on the 8.0 release branch.

Because https://github.com/elastic/kibana/pull/117582 was not backported, the alerts were not formatted correctly, which was causing the functionality to break on the release branch.

This PR fixes those imports.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
