### PR TITLE
[ResponseOps][Cases] Update plugins and docs to point to new github teams

### DIFF
--- a/api_docs/cases.mdx
+++ b/api_docs/cases.mdx
@@ -12,13 +12,13 @@ import casesObj from './cases.json';
 
 The Case management system in Kibana
 
-Contact [Security Solution Threat Hunting](https://github.com/orgs/elastic/teams/security-threat-hunting) for questions regarding this plugin.
+Contact [ResponseOps](https://github.com/orgs/elastic/teams/response-ops) for questions regarding this plugin.
 
 **Code health stats**
 
-| Public API count  | Any count | Items lacking comments | Missing exports |
-|-------------------|-----------|------------------------|-----------------|
-| 83 | 0 | 57 | 23 |
+| Public API count | Any count | Items lacking comments | Missing exports |
+| ---------------- | --------- | ---------------------- | --------------- |
+| 83               | 0         | 57                     | 23              |
 
 ## Client
 

--- a/api_docs/plugin_directory.mdx
+++ b/api_docs/plugin_directory.mdx
@@ -31,7 +31,7 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
 | <DocLink id="kibBannersPluginApi" text="banners"/> | [Kibana Core](https://github.com/orgs/elastic/teams/kibana-core) | - | 9 | 0 | 9 | 0 |
 | <DocLink id="kibBfetchPluginApi" text="bfetch"/> | [App Services](https://github.com/orgs/elastic/teams/kibana-app-services) | Considering using bfetch capabilities when fetching large amounts of data. This services supports batching HTTP requests and streaming responses back. | 76 | 1 | 67 | 2 |
 | <DocLink id="kibCanvasPluginApi" text="canvas"/> | [Kibana Presentation](https://github.com/orgs/elastic/teams/kibana-presentation) | Adds Canvas application to Kibana | 9 | 0 | 8 | 3 |
-| <DocLink id="kibCasesPluginApi" text="cases"/> | [Security Solution Threat Hunting](https://github.com/orgs/elastic/teams/security-threat-hunting) | The Case management system in Kibana | 83 | 0 | 57 | 23 |
+| <DocLink id="kibCasesPluginApi" text="cases"/> | [ResponseOps](https://github.com/orgs/elastic/teams/response-ops) | The Case management system in Kibana | 83 | 0 | 57 | 23 |
 | <DocLink id="kibChartsPluginApi" text="charts"/> | [Vis Editors](https://github.com/orgs/elastic/teams/kibana-vis-editors) | - | 314 | 2 | 281 | 4 |
 | <DocLink id="kibCloudPluginApi" text="cloud"/> | [Kibana Core](https://github.com/orgs/elastic/teams/kibana-core) | - | 22 | 0 | 22 | 0 |
 | <DocLink id="kibConsolePluginApi" text="console"/> | [Stack Management](https://github.com/orgs/elastic/teams/kibana-stack-management) | - | 13 | 0 | 13 | 1 |

--- a/x-pack/plugins/cases/kibana.json
+++ b/x-pack/plugins/cases/kibana.json
@@ -14,8 +14,8 @@
      "spaces"
   ],
   "owner":{
-     "githubTeam":"security-threat-hunting",
-     "name":"Security Solution Threat Hunting"
+     "githubTeam":"response-ops",
+     "name":"ResponseOps"
   },
   "requiredPlugins":[
      "actions",

--- a/x-pack/test/cases_api_integration/common/fixtures/plugins/cases_client_user/kibana.json
+++ b/x-pack/test/cases_api_integration/common/fixtures/plugins/cases_client_user/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "casesClientUserFixture",
   "owner": {
-    "githubTeam": "security-threat-hunting",
-    "name": "Security Solution Threat Hunting"
+    "githubTeam": "response-ops",
+    "name": "ResponseOps"
   },
   "version": "1.0.0",
   "kibanaVersion": "kibana",

--- a/x-pack/test/cases_api_integration/common/fixtures/plugins/observability/kibana.json
+++ b/x-pack/test/cases_api_integration/common/fixtures/plugins/observability/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "observabilityFixtures",
   "owner": {
-    "githubTeam": "security-threat-hunting",
-    "name": "Security Solution Threat Hunting"
+    "githubTeam": "response-ops",
+    "name": "ResponseOps"
   },
   "version": "1.0.0",
   "kibanaVersion": "kibana",

--- a/x-pack/test/cases_api_integration/common/fixtures/plugins/security_solution/kibana.json
+++ b/x-pack/test/cases_api_integration/common/fixtures/plugins/security_solution/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "securitySolutionFixtures",
   "owner": {
-    "githubTeam": "security-threat-hunting",
-    "name": "Security Solution Threat Hunting"
+    "githubTeam": "response-ops",
+    "name": "ResponseOps"
   },
   "version": "1.0.0",
   "kibanaVersion": "kibana",


### PR DESCRIPTION
## Summary

Address: https://github.com/elastic/kibana/issues/123036


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
