### PR TITLE
[Uptime] Use authorised saved object client only for write operations

### DIFF
--- a/x-pack/plugins/uptime/server/lib/adapters/framework/adapter_types.ts
+++ b/x-pack/plugins/uptime/server/lib/adapters/framework/adapter_types.ts
@@ -47,6 +47,7 @@ export interface UptimeServerSetup {
   fleet: FleetStartContract;
   security: SecurityPluginStart;
   savedObjectsClient?: SavedObjectsClientContract;
+  authSavedObjectsClient?: SavedObjectsClientContract;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
   syntheticsService: SyntheticsService;
 }

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/service_api_client.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/service_api_client.ts
@@ -116,6 +116,9 @@ export class ServiceAPIClient {
           rxjsFrom(callServiceEndpoint(locMonitors, url)).pipe(
             tap((result) => {
               this.logger.debug(result.data);
+              this.logger.debug(
+                `Successfully called service with method ${method} with ${allMonitors.length} monitors `
+              );
             }),
             catchError((err) => {
               pushErrors.push({ locationId: id, error: err });

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
@@ -149,6 +149,7 @@ export class SyntheticsService {
       try {
         this.apiKey = await getAPIKeyForSyntheticsService({ server: this.server, request });
       } catch (err) {
+        this.logger.error(err);
         throw err;
       }
     }
@@ -159,6 +160,8 @@ export class SyntheticsService {
       throw error;
     }
 
+    this.logger.debug('Found api key and esHosts for service.');
+
     return {
       hosts: this.esHosts,
       api_key: `${this.apiKey.id}:${this.apiKey.apiKey}`,
@@ -168,12 +171,15 @@ export class SyntheticsService {
   async pushConfigs(request?: KibanaRequest, configs?: SyntheticsMonitorWithId[]) {
     const monitors = this.formatConfigs(configs || (await this.getMonitorConfigs()));
     if (monitors.length === 0) {
+      this.logger.debug('No mounter found which can be pushed to service.');
       return;
     }
     const data = {
       monitors,
       output: await this.getOutput(request),
     };
+
+    this.logger.debug(`${monitors.length} monitors will be pushed to synthetics service.`);
 
     try {
       return await this.apiClient.post(data);

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
@@ -171,7 +171,7 @@ export class SyntheticsService {
   async pushConfigs(request?: KibanaRequest, configs?: SyntheticsMonitorWithId[]) {
     const monitors = this.formatConfigs(configs || (await this.getMonitorConfigs()));
     if (monitors.length === 0) {
-      this.logger.debug('No mounter found which can be pushed to service.');
+      this.logger.debug('No moniter found which can be pushed to service.');
       return;
     }
     const data = {

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
@@ -171,7 +171,7 @@ export class SyntheticsService {
   async pushConfigs(request?: KibanaRequest, configs?: SyntheticsMonitorWithId[]) {
     const monitors = this.formatConfigs(configs || (await this.getMonitorConfigs()));
     if (monitors.length === 0) {
-      this.logger.debug('No moniter found which can be pushed to service.');
+      this.logger.debug('No monitor found which can be pushed to service.');
       return;
     }
     const data = {

--- a/x-pack/plugins/uptime/server/rest_api/uptime_route_wrapper.ts
+++ b/x-pack/plugins/uptime/server/rest_api/uptime_route_wrapper.ts
@@ -31,7 +31,7 @@ export const uptimeRouteWrapper: UMKibanaRouteWrapper = (uptimeRoute, server) =>
     }
 
     // specifically needed for the synthetics service api key generation
-    server.savedObjectsClient = savedObjectsClient;
+    server.authSavedObjectsClient = savedObjectsClient;
 
     const isInspectorEnabled = await context.core.uiSettings.client.get<boolean>(
       enableInspectEsQueries


### PR DESCRIPTION
## Summary

While pushing configs to synthetics service ,we use saved objects client, right now for read operation like reading configs from saved objects, we are using authorised saved object client, which get's expired in an async task, like pushing configs from task manager. 

So i have modified the code to use authorised saved object client, only in case of creating/deleting/editing configs and api keys.

For reading, it will use normal saved objects client.


UptimServerSetup has two saved objects clients now 

```
  savedObjectsClient?: SavedObjectsClientContract;
  authSavedObjectsClient?: SavedObjectsClientContract;
```

`savedObjectsClient` get's set when uptime plugin is starting in `plugin.ts` and it lives forever in the lifecycle of kibana.

`authSavedObjectsClient` get set when user is creating/editing/deleting saved objects from ui, it get's set in `uptime_router_wrapper` it's life depends auth token expiry 

`xpack.security.authc.token.timeout`

default value for which in elasticsearch is 20m and can be increased to maximum 1h.


Also improved some debug logs.


### Testing

- [ ] Make sure user can add/edit/delete monitors
- [ ] Make sure api keys are working as expected on fresh instance of elasticsearch
- [ ] Make sure configs are being pushed to service sync while CRUD
- [ ] Make sure configs are being pushed to service via task manager task