### PR TITLE
[Uptime] Allow specifying dev url  for service

### DIFF
--- a/x-pack/plugins/uptime/common/config.ts
+++ b/x-pack/plugins/uptime/common/config.ts
@@ -17,6 +17,7 @@ const serviceConfig = schema.object({
   hosts: schema.maybe(schema.arrayOf(schema.string())),
   syncInterval: schema.maybe(schema.string()),
   tls: schema.maybe(sslSchema),
+  devUrl: schema.maybe(schema.string()),
 });
 
 const uptimeConfig = schema.object({

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/service_api_client.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/service_api_client.ts
@@ -28,6 +28,7 @@ export interface ServiceData {
 
 export class ServiceAPIClient {
   private readonly username?: string;
+  private readonly devUrl?: string;
   private readonly authorization: string;
   private locations: ServiceLocations;
   private logger: Logger;
@@ -35,8 +36,9 @@ export class ServiceAPIClient {
 
   constructor(logger: Logger, config: ServiceConfig) {
     this.config = config;
-    const { username, password, manifestUrl } = config;
+    const { username, password, manifestUrl, devUrl } = config;
     this.username = username;
+    this.devUrl = devUrl;
 
     if (username && password) {
       this.authorization = 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
@@ -91,7 +93,7 @@ export class ServiceAPIClient {
 
       return axios({
         method,
-        url: url + '/monitors',
+        url: (this.devUrl ?? url) + '/monitors',
         data: { monitors: monitorsStreams, output },
         headers: this.authorization
           ? {


### PR DESCRIPTION
## Summary

Make it easy to use dev url for service by specifying as config option.

for example for running service locally and specifying config, it will make call to local service

`xpack.uptime.unsafe.service.devUrl: http://localhost:8080
`