### PR TITLE
[7.17] [Osquery] Remove agent policy reference from pack on integration deletion (#122082)

### DIFF
--- a/x-pack/plugins/fleet/common/types/rest_spec/package_policy.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/package_policy.ts
@@ -63,6 +63,7 @@ export type DeletePackagePoliciesResponse = Array<{
   name?: string;
   success: boolean;
   package?: PackagePolicyPackage;
+  policy_id?: string;
 }>;
 
 export interface UpgradePackagePolicyBaseResponse {

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -488,6 +488,7 @@ class PackagePolicyService {
             title: packagePolicy.package?.title || '',
             version: packagePolicy.package?.version || '',
           },
+          policy_id: packagePolicy.policy_id,
         });
       } catch (error) {
         result.push({

--- a/x-pack/plugins/osquery/server/lib/fleet_integration.ts
+++ b/x-pack/plugins/osquery/server/lib/fleet_integration.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SavedObjectReference, SavedObjectsClient } from 'kibana/server';
+import { filter, map } from 'lodash';
+import { packSavedObjectType } from '../../common/types';
+import { PostPackagePolicyDeleteCallback } from '../../../fleet/server';
+import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '../../../fleet/common';
+import { OSQUERY_INTEGRATION_NAME } from '../../common';
+
+export const getPackagePolicyDeleteCallback =
+  (packsClient: SavedObjectsClient): PostPackagePolicyDeleteCallback =>
+  async (deletedPackagePolicy) => {
+    const deletedOsqueryManagerPolicies = filter(deletedPackagePolicy, [
+      'package.name',
+      OSQUERY_INTEGRATION_NAME,
+    ]);
+    await Promise.all(
+      map(deletedOsqueryManagerPolicies, async (deletedOsqueryManagerPolicy) => {
+        if (deletedOsqueryManagerPolicy.policy_id) {
+          const foundPacks = await packsClient.find({
+            type: packSavedObjectType,
+            hasReference: {
+              type: AGENT_POLICY_SAVED_OBJECT_TYPE,
+              id: deletedOsqueryManagerPolicy.policy_id,
+            },
+            perPage: 1000,
+          });
+
+          await Promise.all(
+            map(
+              foundPacks.saved_objects,
+              (pack: { id: string; references: SavedObjectReference[] }) =>
+                packsClient.update(
+                  packSavedObjectType,
+                  pack.id,
+                  {},
+                  {
+                    references: filter(
+                      pack.references,
+                      (reference) => reference.id !== deletedOsqueryManagerPolicy.policy_id
+                    ),
+                  }
+                )
+            )
+          );
+        }
+      })
+    );
+  };

--- a/x-pack/plugins/osquery/server/plugin.ts
+++ b/x-pack/plugins/osquery/server/plugin.ts
@@ -18,8 +18,10 @@ import {
   CoreStart,
   Plugin,
   Logger,
+  SavedObjectsClient,
   DEFAULT_APP_CATEGORIES,
 } from '../../../../src/core/server';
+
 import { createConfig } from './create_config';
 import { OsqueryPluginSetup, OsqueryPluginStart, SetupPlugins, StartPlugins } from './types';
 import { defineRoutes } from './routes';
@@ -30,6 +32,7 @@ import { OsqueryAppContext, OsqueryAppContextService } from './lib/osquery_app_c
 import { ConfigType } from './config';
 import { packSavedObjectType, savedQuerySavedObjectType } from '../common/types';
 import { PLUGIN_ID } from '../common';
+import { getPackagePolicyDeleteCallback } from './lib/fleet_integration';
 
 const registerFeatures = (features: SetupPlugins['features']) => {
   features.registerKibanaFeature({
@@ -261,6 +264,11 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
       registerIngestCallback,
     });
 
+    if (registerIngestCallback) {
+      const client = new SavedObjectsClient(core.savedObjects.createInternalRepository());
+
+      registerIngestCallback('postPackagePolicyDelete', getPackagePolicyDeleteCallback(client));
+    }
     return {};
   }
 


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #122082

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
