### PR TITLE
Fix docs for defaultRuleTaskTimeout by setting the default to 5m instead of 60s

### DIFF
--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -190,7 +190,7 @@ Specifies the default timeout for the all rule types tasks. The time is formatte
 +
 `<count>[ms,s,m,h,d,w,M,Y]` 
 +
-For example, `20m`, `24h`, `7d`, `1w`. Default: `60s`.
+For example, `20m`, `24h`, `7d`, `1w`. Default: `5m`.
 
 `xpack.alerting.cancelAlertsOnRuleTimeout`::
 Specifies whether to skip writing alerts and scheduling actions if rule execution is cancelled due to timeout. Default: `true`. This setting can be overridden by individual rule types.


### PR DESCRIPTION
This PR aligns the documentation of the default value for `xpack.alerting.defaultRuleTaskTimeout` with the actual default set within https://github.com/elastic/kibana/blob/905ac6cb99491569c4ace6d453cb2cda053e6b7e/x-pack/plugins/alerting/server/config.ts#L23.