### PR TITLE
[Fleet] Fix hide enrollment key tooltip

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
@@ -96,7 +96,6 @@ const ApiKeyField: React.FunctionComponent<{ apiKeyId: string }> = ({ apiKeyId }
                   })
             }
             color="text"
-            isDisabled={state === 'LOADING'}
             onClick={toggleKey}
             iconType={state === 'VISIBLE' ? 'eyeClosed' : 'eye'}
           />

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
@@ -268,6 +268,10 @@ export const EnrollmentTokenListPage: React.FunctionComponent<{}> = () => {
     },
   ];
 
+  const isLoading =
+    (enrollmentAPIKeysRequest.isLoading && enrollmentAPIKeysRequest.isInitialRequest) ||
+    (agentPoliciesRequest.isLoading && agentPoliciesRequest.isInitialRequest);
+
   return (
     <DefaultLayout section="enrollment_tokens">
       {isModalOpen && (
@@ -311,14 +315,10 @@ export const EnrollmentTokenListPage: React.FunctionComponent<{}> = () => {
       </EuiFlexGroup>
       <EuiSpacer size="m" />
       <EuiBasicTable<EnrollmentAPIKey>
-        loading={
-          (enrollmentAPIKeysRequest.isLoading && enrollmentAPIKeysRequest.isInitialRequest) ||
-          (agentPoliciesRequest.isLoading && agentPoliciesRequest.isInitialRequest)
-        }
+        loading={isLoading}
         hasActions={true}
         noItemsMessage={
-          (enrollmentAPIKeysRequest.isLoading && enrollmentAPIKeysRequest.isInitialRequest) ||
-          (agentPoliciesRequest.isLoading && agentPoliciesRequest.isInitialRequest) ? (
+          isLoading ? (
             <FormattedMessage
               id="xpack.fleet.enrollemntAPIKeyList.loadingTokensMessage"
               defaultMessage="Loading enrollment tokens..."

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
@@ -311,10 +311,14 @@ export const EnrollmentTokenListPage: React.FunctionComponent<{}> = () => {
       </EuiFlexGroup>
       <EuiSpacer size="m" />
       <EuiBasicTable<EnrollmentAPIKey>
-        loading={enrollmentAPIKeysRequest.isLoading && enrollmentAPIKeysRequest.isInitialRequest}
+        loading={
+          (enrollmentAPIKeysRequest.isLoading && enrollmentAPIKeysRequest.isInitialRequest) ||
+          (agentPoliciesRequest.isLoading && agentPoliciesRequest.isInitialRequest)
+        }
         hasActions={true}
         noItemsMessage={
-          enrollmentAPIKeysRequest.isLoading && enrollmentAPIKeysRequest.isInitialRequest ? (
+          (enrollmentAPIKeysRequest.isLoading && enrollmentAPIKeysRequest.isInitialRequest) ||
+          (agentPoliciesRequest.isLoading && agentPoliciesRequest.isInitialRequest) ? (
             <FormattedMessage
               id="xpack.fleet.enrollemntAPIKeyList.loadingTokensMessage"
               defaultMessage="Loading enrollment tokens..."


### PR DESCRIPTION
## Summary

Resolve #120874

In the enrollment list page  with multiple enrollment tokens when clicking on show enrollment token of multiple tokens we were keeping the "hide token" tooltip for all the previous tokens.

This was due to the fact that we were disabling the button and react is not triggering the blur event to hide the tooltip, that PR fix that by removing the button disablement.


Also fix the loading state to wait for the agent policies too otherwise the UI was blink and showing no enrollment tokens for an instant.

## Before

<img width="1310" alt="Screen Shot 2022-01-17 at 4 46 04 PM" src="https://user-images.githubusercontent.com/1336873/149840560-2640e1e8-c7ca-4cf2-81c9-a9185817d92b.png">

## After 

<img width="1293" alt="Screen Shot 2022-01-17 at 4 48 59 PM" src="https://user-images.githubusercontent.com/1336873/149840568-7870947f-8217-4bab-8959-9b39665978fc.png">
