### PR TITLE
[Lens] Remove nested legend option from waffle

### DIFF
--- a/x-pack/plugins/lens/public/pie_visualization/partition_charts_meta.ts
+++ b/x-pack/plugins/lens/public/pie_visualization/partition_charts_meta.ts
@@ -47,6 +47,7 @@ interface PartitionChartMeta {
   legend: {
     flat?: boolean;
     showValues?: boolean;
+    hideNestedLegendSwitch?: boolean;
     getShowLegendDefault?: (bucketColumns: DatatableColumn[]) => boolean;
   };
   sortPredicate?: (
@@ -235,6 +236,7 @@ export const PartitionChartsMeta: Record<PieChartTypes, PartitionChartMeta> = {
     legend: {
       flat: true,
       showValues: true,
+      hideNestedLegendSwitch: true,
       getShowLegendDefault: () => true,
     },
     sortPredicate:

--- a/x-pack/plugins/lens/public/pie_visualization/toolbar.tsx
+++ b/x-pack/plugins/lens/public/pie_visualization/toolbar.tsx
@@ -245,7 +245,7 @@ export function PieToolbar(props: VisualizationToolbarProps<PieVisualizationStat
         position={layer.legendPosition}
         onPositionChange={onLegendPositionChange}
         renderNestedLegendSwitch={
-          !(PartitionChartsMeta[state.shape]?.legend.hideNestedLegendSwitch ?? false)
+          !(PartitionChartsMeta[state.shape]?.legend.hideNestedLegendSwitch)
         }
         nestedLegend={Boolean(layer.nestedLegend)}
         onNestedLegendChange={onNestedLegendChange}

--- a/x-pack/plugins/lens/public/pie_visualization/toolbar.tsx
+++ b/x-pack/plugins/lens/public/pie_visualization/toolbar.tsx
@@ -244,9 +244,7 @@ export function PieToolbar(props: VisualizationToolbarProps<PieVisualizationStat
         onValueInLegendChange={onValueInLegendChange}
         position={layer.legendPosition}
         onPositionChange={onLegendPositionChange}
-        renderNestedLegendSwitch={
-          !(PartitionChartsMeta[state.shape]?.legend.hideNestedLegendSwitch)
-        }
+        renderNestedLegendSwitch={!PartitionChartsMeta[state.shape]?.legend.hideNestedLegendSwitch}
         nestedLegend={Boolean(layer.nestedLegend)}
         onNestedLegendChange={onNestedLegendChange}
         shouldTruncate={layer.truncateLegend ?? defaultTruncationValue}

--- a/x-pack/plugins/lens/public/pie_visualization/toolbar.tsx
+++ b/x-pack/plugins/lens/public/pie_visualization/toolbar.tsx
@@ -244,8 +244,10 @@ export function PieToolbar(props: VisualizationToolbarProps<PieVisualizationStat
         onValueInLegendChange={onValueInLegendChange}
         position={layer.legendPosition}
         onPositionChange={onLegendPositionChange}
-        renderNestedLegendSwitch
-        nestedLegend={!!layer.nestedLegend}
+        renderNestedLegendSwitch={
+          !(PartitionChartsMeta[state.shape]?.legend.hideNestedLegendSwitch ?? false)
+        }
+        nestedLegend={Boolean(layer.nestedLegend)}
         onNestedLegendChange={onNestedLegendChange}
         shouldTruncate={layer.truncateLegend ?? defaultTruncationValue}
         onTruncateLegendChange={onTruncateLegendChange}


### PR DESCRIPTION
Closes: #123156

## Summary

Nested legend switch is available on waffle partition chart but it doesn't affect the legend as I cant have a waffle with a nested legend.

We should remove it specifically for waffles because it might cause confusion to the users or disable it with a tooltip.

### Screens

![image](https://user-images.githubusercontent.com/20072247/149924339-f9726813-7efb-41ae-8ad2-5c86bd2f5afd.png)

