### PR TITLE
[7.17] log ES client response size (#123173)

### DIFF
--- a/src/core/server/elasticsearch/client/get_ecs_response_log.test.ts
+++ b/src/core/server/elasticsearch/client/get_ecs_response_log.test.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { type DiagnosticResult, type ConnectionRequestParams } from '@elastic/elasticsearch';
+import { getEcsResponseLog } from './get_ecs_response_log';
+
+interface ResponseFixtureOptions {
+  requestParams?: Partial<ConnectionRequestParams>;
+
+  response?: {
+    body?: any;
+    headers?: Record<string, string | string[]>;
+    statusCode?: number;
+  };
+}
+
+function createResponseEvent({
+  requestParams = {},
+  response = {},
+}: ResponseFixtureOptions = {}): DiagnosticResult {
+  return {
+    body: response.body ?? {},
+    statusCode: response.statusCode ?? 200,
+    headers: response.headers ?? {},
+    meta: {
+      request: {
+        params: {
+          headers: requestParams.headers ?? { 'content-length': '123' },
+          method: requestParams.method ?? 'get',
+          path: requestParams.path ?? '/path',
+          querystring: requestParams.querystring ?? '?wait_for_completion=true',
+        },
+        options: {
+          id: '42',
+        },
+      } as DiagnosticResult['meta']['request'],
+    } as DiagnosticResult['meta'],
+    warnings: null,
+  };
+}
+
+describe('getEcsResponseLog', () => {
+  describe('filters sensitive headers', () => {
+    test('redacts Authorization and Cookie headers by default', () => {
+      const event = createResponseEvent({
+        requestParams: { headers: { authorization: 'a', cookie: 'b', 'user-agent': 'hi' } },
+        response: { headers: { 'content-length': '123', 'set-cookie': 'c' } },
+      });
+      const log = getEcsResponseLog(event);
+      // @ts-expect-error ECS custom field
+      expect(log.http.request.headers).toMatchInlineSnapshot(`
+        Object {
+          "authorization": "[REDACTED]",
+          "cookie": "[REDACTED]",
+          "user-agent": "hi",
+        }
+      `);
+      // @ts-expect-error ECS custom field
+      expect(log.http.response.headers).toMatchInlineSnapshot(`
+        Object {
+          "content-length": "123",
+          "set-cookie": "[REDACTED]",
+        }
+      `);
+    });
+
+    test('does not mutate original headers', () => {
+      const reqHeaders = { a: 'foo', b: ['hello', 'world'] };
+      const resHeaders = { c: 'bar' };
+      const event = createResponseEvent({
+        requestParams: { headers: reqHeaders },
+        response: { headers: resHeaders },
+      });
+
+      const log = getEcsResponseLog(event);
+      expect(reqHeaders).toMatchInlineSnapshot(`
+        Object {
+          "a": "foo",
+          "b": Array [
+            "hello",
+            "world",
+          ],
+        }
+      `);
+      expect(resHeaders).toMatchInlineSnapshot(`
+        Object {
+          "c": "bar",
+        }
+      `);
+
+      // @ts-expect-error ECS custom field
+      log.http.request.headers.a = 'testA';
+      // @ts-expect-error ECS custom field
+      log.http.request.headers.b[1] = 'testB';
+      // @ts-expect-error ECS custom field
+      log.http.request.headers.c = 'testC';
+      expect(reqHeaders).toMatchInlineSnapshot(`
+        Object {
+          "a": "foo",
+          "b": Array [
+            "hello",
+            "testB",
+          ],
+        }
+      `);
+      expect(resHeaders).toMatchInlineSnapshot(`
+        Object {
+          "c": "bar",
+        }
+      `);
+    });
+
+    test('does not mutate original headers when redacting sensitive data', () => {
+      const reqHeaders = { authorization: 'a', cookie: 'b', 'user-agent': 'hi' };
+      const resHeaders = { 'content-length': '123', 'set-cookie': 'c' };
+      const event = createResponseEvent({
+        requestParams: { headers: reqHeaders },
+        response: { headers: resHeaders },
+      });
+      getEcsResponseLog(event);
+
+      expect(reqHeaders).toMatchInlineSnapshot(`
+          Object {
+            "authorization": "a",
+            "cookie": "b",
+            "user-agent": "hi",
+          }
+        `);
+      expect(resHeaders).toMatchInlineSnapshot(`
+          Object {
+            "content-length": "123",
+            "set-cookie": "c",
+          }
+        `);
+    });
+  });
+
+  describe('ecs', () => {
+    test('provides an ECS-compatible response', () => {
+      const event = createResponseEvent();
+      const result = getEcsResponseLog(event, 123);
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "http": Object {
+            "request": Object {
+              "headers": Object {
+                "content-length": "123",
+              },
+              "id": undefined,
+              "method": "GET",
+            },
+            "response": Object {
+              "body": Object {
+                "bytes": 123,
+              },
+              "headers": Object {},
+              "status_code": 200,
+            },
+          },
+          "url": Object {
+            "path": "/path",
+            "query": "?wait_for_completion=true",
+          },
+        }
+      `);
+    });
+  });
+});

--- a/src/core/server/elasticsearch/client/get_ecs_response_log.test.ts
+++ b/src/core/server/elasticsearch/client/get_ecs_response_log.test.ts
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { type DiagnosticResult, type ConnectionRequestParams } from '@elastic/elasticsearch';
+import type { DiagnosticResult, ConnectionRequestParams } from '@elastic/elasticsearch';
 import { getEcsResponseLog } from './get_ecs_response_log';
 
 interface ResponseFixtureOptions {

--- a/src/core/server/elasticsearch/client/get_ecs_response_log.ts
+++ b/src/core/server/elasticsearch/client/get_ecs_response_log.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { type IncomingHttpHeaders } from 'http';
+import { type DiagnosticResult } from '@elastic/elasticsearch';
+import { type LogMeta } from '@kbn/logging';
+
+const FORBIDDEN_HEADERS = ['authorization', 'cookie', 'set-cookie'];
+const REDACTED_HEADER_TEXT = '[REDACTED]';
+
+// We are excluding sensitive headers by default, until we have a log filtering mechanism.
+function redactSensitiveHeaders(key: string, value: string | string[]): string | string[] {
+  return FORBIDDEN_HEADERS.includes(key) ? REDACTED_HEADER_TEXT : value;
+}
+
+// Shallow clone the headers so they are not mutated if filtered by a RewriteAppender.
+function cloneAndFilterHeaders(headers?: IncomingHttpHeaders) {
+  const result = {} as IncomingHttpHeaders;
+  if (headers) {
+    for (const key of Object.keys(headers)) {
+      const value = headers[key];
+      if (value) {
+        result[key] = redactSensitiveHeaders(key, value);
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Retruns ECS-compliant `LogMeta` for logging.
+ *
+ * @internal
+ */
+export function getEcsResponseLog(event: DiagnosticResult, bytes?: number): LogMeta {
+  const meta: LogMeta = {
+    http: {
+      request: {
+        id: event.meta.request.options.opaqueId,
+        method: event.meta.request.params.method.toUpperCase(),
+        // @ts-expect-error ECS custom field: https://github.com/elastic/ecs/issues/232.
+        headers: cloneAndFilterHeaders(event.meta.request.params.headers),
+      },
+      response: {
+        body: {
+          bytes,
+        },
+        status_code: event.statusCode,
+        // @ts-expect-error ECS custom field: https://github.com/elastic/ecs/issues/232.
+        headers: cloneAndFilterHeaders(event.headers),
+      },
+    },
+    url: {
+      path: event.meta.request.params.path,
+      query: event.meta.request.params.querystring,
+    },
+  };
+
+  return meta;
+}

--- a/src/core/server/elasticsearch/client/get_ecs_response_log.ts
+++ b/src/core/server/elasticsearch/client/get_ecs_response_log.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 import type { IncomingHttpHeaders } from 'http';
-import type { DiagnosticResult } from '@elastic/elasticsearch';
+import type { RequestEvent } from '@elastic/elasticsearch';
 import type { LogMeta } from '@kbn/logging';
 
 const FORBIDDEN_HEADERS = ['authorization', 'cookie', 'set-cookie'];
@@ -36,27 +36,24 @@ function cloneAndFilterHeaders(headers?: IncomingHttpHeaders) {
  *
  * @internal
  */
-export function getEcsResponseLog(event: DiagnosticResult, bytes?: number): LogMeta {
+export function getEcsResponseLog(event: RequestEvent, bytes?: number): LogMeta {
   const meta: LogMeta = {
     http: {
       request: {
         id: event.meta.request.options.opaqueId,
         method: event.meta.request.params.method.toUpperCase(),
-        // @ts-expect-error ECS custom field: https://github.com/elastic/ecs/issues/232.
-        headers: cloneAndFilterHeaders(event.meta.request.params.headers),
       },
       response: {
         body: {
           bytes,
         },
-        status_code: event.statusCode,
+        status_code: event.statusCode || undefined,
         // @ts-expect-error ECS custom field: https://github.com/elastic/ecs/issues/232.
         headers: cloneAndFilterHeaders(event.headers),
       },
     },
     url: {
       path: event.meta.request.params.path,
-      query: event.meta.request.params.querystring,
     },
   };
 

--- a/src/core/server/elasticsearch/client/get_ecs_response_log.ts
+++ b/src/core/server/elasticsearch/client/get_ecs_response_log.ts
@@ -5,9 +5,9 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { type IncomingHttpHeaders } from 'http';
-import { type DiagnosticResult } from '@elastic/elasticsearch';
-import { type LogMeta } from '@kbn/logging';
+import type { IncomingHttpHeaders } from 'http';
+import type { DiagnosticResult } from '@elastic/elasticsearch';
+import type { LogMeta } from '@kbn/logging';
 
 const FORBIDDEN_HEADERS = ['authorization', 'cookie', 'set-cookie'];
 const REDACTED_HEADER_TEXT = '[REDACTED]';

--- a/src/core/server/elasticsearch/client/log_query_and_deprecation.test.ts
+++ b/src/core/server/elasticsearch/client/log_query_and_deprecation.test.ts
@@ -344,7 +344,6 @@ describe('instrumentQueryAndDeprecationLogger', () => {
         Object {
           "http": Object {
             "request": Object {
-              "headers": Object {},
               "id": "opaque-id",
               "method": "GET",
             },
@@ -358,7 +357,6 @@ describe('instrumentQueryAndDeprecationLogger', () => {
           },
           "url": Object {
             "path": "/_path",
-            "query": undefined,
           },
         }
       `);
@@ -383,7 +381,6 @@ describe('instrumentQueryAndDeprecationLogger', () => {
         Object {
           "http": Object {
             "request": Object {
-              "headers": Object {},
               "id": "opaque-id",
               "method": "GET",
             },
@@ -397,7 +394,6 @@ describe('instrumentQueryAndDeprecationLogger', () => {
           },
           "url": Object {
             "path": "/_path",
-            "query": undefined,
           },
         }
       `);

--- a/src/core/server/elasticsearch/client/log_query_and_deprecation.test.ts
+++ b/src/core/server/elasticsearch/client/log_query_and_deprecation.test.ts
@@ -10,7 +10,6 @@ import { Buffer } from 'buffer';
 import { Readable } from 'stream';
 
 import { Client, errors } from '@elastic/elasticsearch';
-
 import { parseClientOptionsMock, ClientMock } from './configure_client.test.mocks';
 import { loggingSystemMock } from '../../logging/logging_system.mock';
 import { instrumentEsQueryAndDeprecationLogger } from './log_query_and_deprecation';
@@ -26,7 +25,7 @@ const createApiResponse = <T>({
   statusCode = 200,
   headers = {},
   warnings = null,
-  params,
+  params = { method: 'GET', path: '/path', querystring: '?wait_for_completion=true' },
   requestOptions = {},
 }: {
   body: T;
@@ -76,10 +75,14 @@ describe('instrumentQueryAndDeprecationLogger', () => {
     jest.clearAllMocks();
   });
 
-  function createResponseWithBody(body?: RequestBody) {
+  function createResponseWithBody(
+    body?: RequestBody,
+    params?: { headers?: Record<string, string> }
+  ) {
     return createApiResponse({
       body: {},
       statusCode: 200,
+      headers: params?.headers ?? {},
       params: {
         method: 'GET',
         path: '/foo',
@@ -106,15 +109,10 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       });
 
       client.emit('response', null, response);
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "200
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "200
         GET /foo?hello=dolly
-        {\\"seq_no_primary_term\\":true,\\"query\\":{\\"term\\":{\\"user\\":\\"kimchy\\"}}}",
-            undefined,
-          ],
-        ]
+        {\\"seq_no_primary_term\\":true,\\"query\\":{\\"term\\":{\\"user\\":\\"kimchy\\"}}}"
       `);
     });
 
@@ -131,15 +129,10 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       );
 
       client.emit('response', null, response);
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "200
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "200
         GET /foo?hello=dolly
-        {\\"seq_no_primary_term\\":true,\\"query\\":{\\"term\\":{\\"user\\":\\"kimchy\\"}}}",
-            undefined,
-          ],
-        ]
+        {\\"seq_no_primary_term\\":true,\\"query\\":{\\"term\\":{\\"user\\":\\"kimchy\\"}}}"
       `);
     });
 
@@ -158,15 +151,10 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       );
 
       client.emit('response', null, response);
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "200
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "200
         GET /foo?hello=dolly
-        [buffer]",
-            undefined,
-          ],
-        ]
+        [buffer]"
       `);
     });
 
@@ -185,15 +173,10 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       );
 
       client.emit('response', null, response);
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "200
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "200
         GET /foo?hello=dolly
-        [stream]",
-            undefined,
-          ],
-        ]
+        [stream]"
       `);
     });
 
@@ -203,14 +186,9 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       const response = createResponseWithBody();
 
       client.emit('response', null, response);
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "200
-        GET /foo?hello=dolly",
-            undefined,
-          ],
-        ]
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "200
+        GET /foo?hello=dolly"
       `);
     });
 
@@ -229,14 +207,9 @@ describe('instrumentQueryAndDeprecationLogger', () => {
 
       client.emit('response', null, response);
 
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "200
-        GET /foo?city=M%C3%BCnich",
-            undefined,
-          ],
-        ]
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "200
+        GET /foo?city=M%C3%BCnich"
       `);
     });
 
@@ -264,15 +237,10 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       });
       client.emit('response', new errors.ResponseError(response), response);
 
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "500
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "500
         GET /foo?hello=dolly
-        {\\"seq_no_primary_term\\":true,\\"query\\":{\\"term\\":{\\"user\\":\\"kimchy\\"}}} [internal server error]: internal server error",
-            undefined,
-          ],
-        ]
+        {\\"seq_no_primary_term\\":true,\\"query\\":{\\"term\\":{\\"user\\":\\"kimchy\\"}}} [internal server error]: internal server error"
       `);
     });
 
@@ -282,14 +250,9 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       const response = createApiResponse({ body: {} });
       client.emit('response', new errors.TimeoutError('message', response), response);
 
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "[TimeoutError]: message",
-            undefined,
-          ],
-        ]
-      `);
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(
+        `"[TimeoutError]: message"`
+      );
     });
 
     it('logs debug when the client emits an ResponseError returned by elasticsearch', () => {
@@ -312,14 +275,9 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       });
       client.emit('response', new errors.ResponseError(response), response);
 
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "400
-        GET /_path?hello=dolly [illegal_argument_exception]: request [/_path] contains unrecognized parameter: [name]",
-            undefined,
-          ],
-        ]
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "400
+        GET /_path?hello=dolly [illegal_argument_exception]: request [/_path] contains unrecognized parameter: [name]"
       `);
     });
 
@@ -339,14 +297,9 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       });
       client.emit('response', new errors.ResponseError(response), response);
 
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "400
-        GET /_path [undefined]: {\\"error\\":{}}",
-            undefined,
-          ],
-        ]
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "400
+        GET /_path [undefined]: {\\"error\\":{}}"
       `);
 
       logger.debug.mockClear();
@@ -362,14 +315,9 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       });
       client.emit('response', new errors.ResponseError(response), response);
 
-      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "400
-        GET /_path [undefined]: Response Error",
-            undefined,
-          ],
-        ]
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "400
+        GET /_path [undefined]: Response Error"
       `);
     });
 
@@ -396,8 +344,21 @@ describe('instrumentQueryAndDeprecationLogger', () => {
         Object {
           "http": Object {
             "request": Object {
+              "headers": Object {},
               "id": "opaque-id",
+              "method": "GET",
             },
+            "response": Object {
+              "body": Object {
+                "bytes": undefined,
+              },
+              "headers": Object {},
+              "status_code": 400,
+            },
+          },
+          "url": Object {
+            "path": "/_path",
+            "query": undefined,
           },
         }
       `);
@@ -422,10 +383,46 @@ describe('instrumentQueryAndDeprecationLogger', () => {
         Object {
           "http": Object {
             "request": Object {
+              "headers": Object {},
               "id": "opaque-id",
+              "method": "GET",
+            },
+            "response": Object {
+              "body": Object {
+                "bytes": undefined,
+              },
+              "headers": Object {},
+              "status_code": 400,
             },
           },
+          "url": Object {
+            "path": "/_path",
+            "query": undefined,
+          },
         }
+      `);
+    });
+
+    it('logs response size', () => {
+      instrumentEsQueryAndDeprecationLogger({ logger, client, type: 'test type' });
+
+      const response = createResponseWithBody(
+        {
+          seq_no_primary_term: true,
+          query: {
+            term: { user: 'kimchy' },
+          },
+        },
+        {
+          headers: { 'content-length': '12345678' },
+        }
+      );
+
+      client.emit('response', null, response);
+      expect(loggingSystemMock.collect(logger).debug[0][0]).toMatchInlineSnapshot(`
+        "200 - 11.8MB
+        GET /foo?hello=dolly
+        {\\"seq_no_primary_term\\":true,\\"query\\":{\\"term\\":{\\"user\\":\\"kimchy\\"}}}"
       `);
     });
   });


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #123173

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
