### PR TITLE
[DOCS] Updates the CentOS base image to Ubuntu

### DIFF
--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 Docker images for {kib} are available from the Elastic Docker registry. The
-base image is https://hub.docker.com/_/kibana[kibana].
+base image is https://hub.docker.com/_/ubuntu[ubuntu:20.04].
 
 A list of all published Docker images and tags is available at
 https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in


### PR DESCRIPTION
## Summary

Removes the CentOS base image from [Install Kibana with Docker](https://kibana_123242.docs-preview.app.elstc.co/guide/en/kibana/master/docker.html), and replaces with Ubuntu. 

