### PR TITLE
[7.17] [DOCS] Updates the CentOS base image to Ubuntu (#123242)

### DIFF
--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -4,8 +4,8 @@
 <titleabbrev>Install with Docker </titleabbrev>
 ++++
 
-Docker images for Kibana are available from the Elastic Docker registry. The
-base image is https://hub.docker.com/_/centos/[centos:7].
+Docker images for {kib} are available from the Elastic Docker registry. The
+base image is https://hub.docker.com/_/ubuntu[ubuntu:20.04].
 
 A list of all published Docker images and tags is available at
 https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #123242

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
