### PR TITLE
[8.0] [Uptime] Overview link to Exploratory View should not filter by monitor (#122907)

### DIFF
--- a/x-pack/plugins/uptime/public/components/common/header/action_menu_content.tsx
+++ b/x-pack/plugins/uptime/public/components/common/header/action_menu_content.tsx
@@ -9,14 +9,14 @@ import React from 'react';
 import { EuiHeaderLinks, EuiToolTip, EuiHeaderLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useRouteMatch } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { createExploratoryViewUrl } from '../../../../../observability/public';
 import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
 import { useUptimeSettingsContext } from '../../../contexts/uptime_settings_context';
 import { useGetUrlParams } from '../../../hooks';
 import { ToggleAlertFlyoutButton } from '../../overview/alerts/alerts_containers';
-import { SETTINGS_ROUTE } from '../../../../common/constants';
+import { MONITOR_ROUTE, SETTINGS_ROUTE } from '../../../../common/constants';
 import { stringifyUrlParams } from '../../../lib/helper/stringify_url_params';
 import { InspectorHeaderLink } from './inspector_header_link';
 import { monitorStatusSelector } from '../../../state/selectors';
@@ -43,6 +43,7 @@ export function ActionMenuContent(): React.ReactElement {
 
   const selectedMonitor = useSelector(monitorStatusSelector);
 
+  const detailRouteMatch = useRouteMatch(MONITOR_ROUTE);
   const monitorId = selectedMonitor?.monitor?.id;
 
   const syntheticExploratoryViewLink = createExploratoryViewUrl(
@@ -56,7 +57,10 @@ export function ActionMenuContent(): React.ReactElement {
           time: { from: dateRangeStart, to: dateRangeEnd },
           breakdown: monitorId ? 'observer.geo.name' : 'monitor.type',
           reportDefinitions: {
-            'monitor.name': selectedMonitor?.monitor?.name ? [selectedMonitor?.monitor?.name] : [],
+            'monitor.name':
+              selectedMonitor?.monitor?.name && detailRouteMatch?.isExact === true
+                ? [selectedMonitor?.monitor?.name]
+                : [],
             'url.full': ['ALL_VALUES'],
           },
           name: monitorId ? `${monitorId}-response-duration` : 'All monitors response duration',


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #122907

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
