### PR TITLE
Restores default chart `timezone` to `'local'`

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@elastic/apm-rum": "^5.9.1",
     "@elastic/apm-rum-react": "^1.3.1",
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
-    "@elastic/charts": "40.2.0",
+    "@elastic/charts": "40.3.0",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^7.16.0-canary.7",
     "@elastic/ems-client": "7.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,10 +1520,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@40.2.0":
-  version "40.2.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-40.2.0.tgz#2e329ce4f495731f478cbaf2f8f3b89b5167a65b"
-  integrity sha512-N0t7YK58Kce/s9LEgaocrD75NYuFMwrcI1QNIPcwZ9IAOHY8/9yRHD5Ipoz0caGibAgOE8OunGkpyPY/NHKB5Q==
+"@elastic/charts@40.3.0":
+  version "40.3.0"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-40.3.0.tgz#f7e8fb0e7770251484807b33dae01e36ff336b89"
+  integrity sha512-ZY5PQiwmsMaJo2u9h7XbrGcuV8A3yO7pdgbSne8nICIaOfEz3qpH6JjGXxOXerb0els/Y9nTyYh/i1mQd8S/dA==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"


### PR DESCRIPTION
## Summary

Restores default chart `timezone` to `'local'` see https://github.com/elastic/elastic-charts/pull/1544

fix #122684

Related to https://github.com/elastic/kibana/issues/122683