### PR TITLE
[ML] Adding V3 modules for Security_Linux and Security_Windows

### DIFF
--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/logo.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/logo.json
@@ -1,0 +1,3 @@
+{
+  "icon": "logoSecurity"
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "security_linux_v3",
-  "title": "Security: Linux v3",
-  "description": "Security: Linux v3 (2022). This module is a replacement for the v2 Linux module. This module contains all shipping ML jobs for Linux host based threat hunting and detection..",
+  "title": "Security: Linux v3 (2022)",
+  "description": "This module contains all shipping ML jobs for Linux host based threat hunting and detection. This module is a replacement for the v2 Linux module named Security: Linux.",
   "type": "linux data",
   "logoFile": "logo.json",
   "defaultIndexPattern": "auditbeat-*,logs-*",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "security_linux_v3",
   "title": "Security: Linux v3",
-  "description": "Security: Linux v3. Version 3 of the Linux Security Machine Learning Module, released in 2022, this module is a replacement for the v2 Linux module. This module contains all shipping ML jobs for Linux host based threat hunting and detection. Any ECS (Elastic Common Schema) compatable Linux events can be used by this module.",
+  "description": "Contains all shipping ML jobs for Linux host-based threat hunting and detection. Any ECS-compatible Linux events can be used by the jobs.",
   "type": "linux data",
   "logoFile": "logo.json",
   "defaultIndexPattern": "auditbeat-*,logs-*",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "security_linux_v3",
   "title": "Security: Linux v3",
-  "description": "Contains all shipping ML jobs for Linux host-based threat hunting and detection. Any ECS-compatible Linux events can be used by the jobs.",
+  "description": "Security: Linux v3 (2022). This module is a replacement for the v2 Linux module. This module contains all shipping ML jobs for Linux host based threat hunting and detection..",
   "type": "linux data",
   "logoFile": "logo.json",
   "defaultIndexPattern": "auditbeat-*,logs-*",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/manifest.json
@@ -1,0 +1,176 @@
+{
+  "id": "security_linux_v3",
+  "title": "Security: Linux v3",
+  "description": "Security: Linux v3. Version 3 of the Linux Security Machine Learning Module, released in 2022, this module is a replacement for the v2 Linux module. This module contains all shipping ML jobs for Linux host based threat hunting and detection. Any ECS (Elastic Common Schema) compatable Linux events can be used by this module.",
+  "type": "linux data",
+  "logoFile": "logo.json",
+  "defaultIndexPattern": "auditbeat-*,logs-*",
+  "query": {
+    "bool": {
+      "should": [
+        {
+          "match": {
+            "host.os.type": {
+              "query": "linux",
+              "operator": "OR"
+            }
+          }
+        },
+        {
+          "match": {
+            "host.os.family": {
+              "query": "debian",
+              "operator": "OR"
+            }
+          }
+        },
+        {
+          "match": {
+            "host.os.family": {
+              "query": "redhat",
+              "operator": "OR"
+            }
+          }
+        },
+        {
+          "match": {
+            "host.os.family": {
+              "query": "suse",
+              "operator": "OR"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "jobs": [
+    {
+      "id": "v3_linux_anomalous_network_port_activity_ecs",
+      "file": "v3_linux_anomalous_network_port_activity_ecs.json"
+    },
+    {
+      "id": "v3_linux_network_configuration_discovery",
+      "file": "v3_linux_network_configuration_discovery.json"
+    },
+    {
+      "id": "v3_linux_network_connection_discovery",
+      "file": "v3_linux_network_connection_discovery.json"
+    },
+    {
+      "id": "v3_linux_rare_sudo_user",
+      "file": "v3_linux_rare_sudo_user.json"
+    },
+    {
+      "id": "v3_linux_rare_user_compiler",
+      "file": "v3_linux_rare_user_compiler.json"
+    },
+    {
+      "id": "v3_linux_system_information_discovery",
+      "file": "v3_linux_system_information_discovery.json"
+    },
+    {
+      "id": "v3_linux_system_process_discovery",
+      "file": "v3_linux_system_process_discovery.json"
+    },
+    {
+      "id": "v3_linux_system_user_discovery",
+      "file": "v3_linux_system_user_discovery.json"
+    },
+    {
+      "id": "v3_linux_anomalous_process_all_hosts_ecs",
+      "file": "v3_linux_anomalous_process_all_hosts_ecs.json"
+    },
+    {
+      "id": "v3_linux_anomalous_user_name_ecs",
+      "file": "v3_linux_anomalous_user_name_ecs.json"
+    },
+    {
+      "id": "v3_linux_rare_metadata_process",
+      "file": "v3_linux_rare_metadata_process.json"
+    },
+    {
+      "id": "v3_linux_rare_metadata_user",
+      "file": "v3_linux_rare_metadata_user.json"
+    },
+    {
+      "id": "v3_rare_process_by_host_linux_ecs",
+      "file": "v3_rare_process_by_host_linux_ecs.json"
+    },
+    {
+      "id": "v3_linux_anomalous_network_activity",
+      "file": "v3_linux_anomalous_network_activity.json"
+    }
+  ],
+  "datafeeds": [
+    {
+      "id": "datafeed-v3_linux_anomalous_network_port_activity_ecs",
+      "file": "datafeed_v3_linux_anomalous_network_port_activity_ecs.json",
+      "job_id": "v3_linux_anomalous_network_port_activity_ecs"
+    },
+    {
+      "id": "datafeed-v3_linux_network_configuration_discovery",
+      "file": "datafeed_v3_linux_network_configuration_discovery.json",
+      "job_id": "v3_linux_network_configuration_discovery"
+    },
+    {
+      "id": "datafeed-v3_linux_network_connection_discovery",
+      "file": "datafeed_v3_linux_network_connection_discovery.json",
+      "job_id": "v3_linux_network_connection_discovery"
+    },
+    {
+      "id": "datafeed-v3_linux_rare_sudo_user",
+      "file": "datafeed_v3_linux_rare_sudo_user.json",
+      "job_id": "v3_linux_rare_sudo_user"
+    },
+    {
+      "id": "datafeed-v3_linux_rare_user_compiler",
+      "file": "datafeed_v3_linux_rare_user_compiler.json",
+      "job_id": "v3_linux_rare_user_compiler"
+    },
+    {
+      "id": "datafeed-v3_linux_system_information_discovery",
+      "file": "datafeed_v3_linux_system_information_discovery.json",
+      "job_id": "v3_linux_system_information_discovery"
+    },
+    {
+      "id": "datafeed-v3_linux_system_process_discovery",
+      "file": "datafeed_v3_linux_system_process_discovery.json",
+      "job_id": "v3_linux_system_process_discovery"
+    },
+    {
+      "id": "datafeed-v3_linux_system_user_discovery",
+      "file": "datafeed_v3_linux_system_user_discovery.json",
+      "job_id": "v3_linux_system_user_discovery"
+    },
+    {
+      "id": "datafeed-v3_linux_anomalous_process_all_hosts_ecs",
+      "file": "datafeed_v3_linux_anomalous_process_all_hosts_ecs.json",
+      "job_id": "v3_linux_anomalous_process_all_hosts_ecs"
+    },
+    {
+      "id": "datafeed-v3_linux_anomalous_user_name_ecs",
+      "file": "datafeed_v3_linux_anomalous_user_name_ecs.json",
+      "job_id": "v3_linux_anomalous_user_name_ecs"
+    },
+    {
+      "id": "datafeed-v3_linux_rare_metadata_process",
+      "file": "datafeed_v3_linux_rare_metadata_process.json",
+      "job_id": "v3_linux_rare_metadata_process"
+    },
+    {
+      "id": "datafeed-v3_linux_rare_metadata_user",
+      "file": "datafeed_v3_linux_rare_metadata_user.json",
+      "job_id": "v3_linux_rare_metadata_user"
+    },
+    {
+      "id": "datafeed-v3_rare_process_by_host_linux_ecs",
+      "file": "datafeed_v3_rare_process_by_host_linux_ecs.json",
+      "job_id": "v3_rare_process_by_host_linux_ecs"
+    },
+    {
+      "id": "datafeed-v3_linux_anomalous_network_activity",
+      "file": "datafeed_v3_linux_anomalous_network_activity.json",
+      "job_id": "v3_linux_anomalous_network_activity"
+    }
+  ]
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_anomalous_network_activity.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_anomalous_network_activity.json
@@ -1,0 +1,77 @@
+{
+    "job_id": "v3_linux_anomalous_network_activity",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool":
+        {
+          "filter": [
+            {"term": {"event.category": "network"}},
+            {"term": {"event.type": "start"}}
+          ],
+          "must": [
+        {
+          "bool": {
+            "should": [
+               {
+                "match": {
+                  "host.os.type": {
+                    "query": "linux",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "debian",
+                    "operator": "OR"
+                  }
+                }
+              },
+               {
+                "match": {
+                  "host.os.family": {
+                    "query": "redhat",
+                    "operator": "OR"
+                  }
+                }
+              },
+                 {
+                "match": {
+                  "host.os.family": {
+                    "query": "suse",
+                    "operator": "OR"
+                  }
+                }
+              },
+               {
+                "match": {
+                  "host.os.family": {
+                    "query": "ubuntu",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {"term": {"destination.ip": "127.0.0.1"}},
+                  {"term": {"destination.ip": "127.0.0.53"}},
+                  {"term": {"destination.ip": "::"}},
+                  {"term": {"destination.ip": "::1"}},
+                  {"term": {"user.name":"jenkins"}}
+                ]
+              }
+            }
+          ]
+        }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_anomalous_network_port_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_anomalous_network_port_activity_ecs.json
@@ -1,0 +1,77 @@
+{
+    "job_id": "v3_linux_anomalous_network_port_activity_ecs",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": 
+        {
+          "filter": [
+            {"term": {"event.category": "network"}},
+            {"term": {"event.type": "start"}}
+          ],
+          "must": [
+        {
+          "bool": {
+            "should": [
+               {
+                "match": {
+                  "host.os.type": {
+                    "query": "linux",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "debian",
+                    "operator": "OR"
+                  }
+                }
+              },
+               {
+                "match": {
+                  "host.os.family": {
+                    "query": "redhat",
+                    "operator": "OR"
+                  }
+                }
+              },
+                 {
+                "match": {
+                  "host.os.family": {
+                    "query": "suse",
+                    "operator": "OR"
+                  }
+                }
+              },
+               {
+                "match": {
+                  "host.os.family": {
+                    "query": "ubuntu",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {"term": {"destination.ip": "127.0.0.1"}},
+                  {"term": {"destination.ip": "127.0.0.53"}},
+                  {"term": {"destination.ip": "::"}},
+                  {"term": {"destination.ip": "::1"}},
+                  {"term": {"user.name":"jenkins"}}
+                ]
+              }
+            }
+          ]
+        }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_anomalous_process_all_hosts_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,101 @@
+{
+    "job_id": "v3_linux_anomalous_process_all_hosts_ecs",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.category": "process"
+            }
+          },
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "linux",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "debian",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "redhat",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "suse",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "ubuntu",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "must_not": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "term": {
+                    "user.name": "jenkins-worker"
+                  }
+                },
+                {
+                  "term": {
+                    "user.name": "jenkins-user"
+                  }
+                },
+                {
+                  "term": {
+                    "user.name": "jenkins"
+                  }
+                },
+                {
+                  "wildcard": {
+                    "process.name": {
+                      "wildcard": "jenkins*"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_anomalous_user_name_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_anomalous_user_name_ecs.json
@@ -1,0 +1,71 @@
+{
+    "job_id": "v3_linux_anomalous_user_name_ecs",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.category": "process"
+            }
+          },
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "linux",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "debian",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "redhat",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "suse",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "ubuntu",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_network_configuration_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_network_configuration_discovery.json
@@ -1,0 +1,107 @@
+{
+  "job_id": "v3_linux_network_configuration_discovery",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "linux",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "debian",
+                    "operator": "OR"
+                  }
+                }
+              },
+               {
+                "match": {
+                  "host.os.family": {
+                    "query": "redhat",
+                    "operator": "OR"
+                  }
+                }
+              },
+                 {
+                "match": {
+                  "host.os.family": {
+                    "query": "suse",
+                    "operator": "OR"
+                  }
+                }
+              },
+               {
+                "match": {
+                  "host.os.family": {
+                    "query": "ubuntu",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "term": {
+                  "process.name": "arp"
+                }
+              },
+              {
+                "term": {
+                  "process.name": "echo"
+                }
+              },
+              {
+                "term": {
+                  "process.name": "ethtool"
+                }
+              },
+              {
+                "term": {
+                  "process.name": "ifconfig"
+                }
+              },
+              {
+                "term": {
+                  "process.name": "ip"
+                }
+              },
+              {
+                "term": {
+                  "process.name": "iptables"
+                }
+              },
+              {
+                "term": {
+                  "process.name": "ufw"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_network_connection_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_network_connection_discovery.json
@@ -1,0 +1,92 @@
+{
+    "job_id": "v3_linux_network_connection_discovery",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "linux",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "debian",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                 {
+                  "match": {
+                    "host.os.family": {
+                      "query": "redhat",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                   {
+                  "match": {
+                    "host.os.family": {
+                      "query": "suse",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                 {
+                  "match": {
+                    "host.os.family": {
+                      "query": "ubuntu",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "bool": {
+              "should": [
+                {
+                  "term": {
+                    "process.name": "netstat"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "ss"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "route"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "showmount"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_rare_metadata_process.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_rare_metadata_process.json
@@ -1,0 +1,66 @@
+{
+    "job_id": "v3_linux_rare_metadata_process",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "destination.ip": "169.254.169.254"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "linux",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "debian",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "redhat",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "suse",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "ubuntu",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_rare_metadata_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_rare_metadata_user.json
@@ -1,0 +1,66 @@
+{
+    "job_id": "v3_linux_rare_metadata_user",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "destination.ip": "169.254.169.254"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "linux",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "debian",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "redhat",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "suse",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "ubuntu",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_rare_sudo_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_rare_sudo_user.json
@@ -1,0 +1,71 @@
+{
+    "job_id": "v3_linux_rare_sudo_user",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.type": "start"
+            }
+          },
+          {
+            "term": {
+              "process.name": "sudo"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "linux",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "debian",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                 {
+                  "match": {
+                    "host.os.family": {
+                      "query": "redhat",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                   {
+                  "match": {
+                    "host.os.family": {
+                      "query": "suse",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                 {
+                  "match": {
+                    "host.os.family": {
+                      "query": "ubuntu",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_rare_user_compiler.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_rare_user_compiler.json
@@ -1,0 +1,92 @@
+{
+    "job_id": "v3_linux_rare_user_compiler",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "linux",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "debian",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                 {
+                  "match": {
+                    "host.os.family": {
+                      "query": "redhat",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                   {
+                  "match": {
+                    "host.os.family": {
+                      "query": "suse",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                 {
+                  "match": {
+                    "host.os.family": {
+                      "query": "ubuntu",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "bool": {
+              "should": [
+                {
+                  "term": {
+                    "process.name": "compile"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "gcc"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "make"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "yasm"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_system_information_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_system_information_discovery.json
@@ -1,0 +1,132 @@
+{
+    "job_id": "v3_linux_system_information_discovery",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "linux",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "debian",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                 {
+                  "match": {
+                    "host.os.family": {
+                      "query": "redhat",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                   {
+                  "match": {
+                    "host.os.family": {
+                      "query": "suse",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                 {
+                  "match": {
+                    "host.os.family": {
+                      "query": "ubuntu",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "bool": {
+              "should": [
+                {
+                  "term": {
+                    "process.name": "cat"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "grep"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "head"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "hostname"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "less"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "ls"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "lsmod"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "more"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "strings"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "tail"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "uptime"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "uname"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_system_process_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_system_process_discovery.json
@@ -1,0 +1,82 @@
+{
+  "job_id": "v3_linux_system_process_discovery",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "linux",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "debian",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "redhat",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "suse",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "ubuntu",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "term": {
+                  "process.name": "ps"
+                }
+              },
+              {
+                "term": {
+                  "process.name": "top"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_system_user_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_linux_system_user_discovery.json
@@ -1,0 +1,92 @@
+{
+    "job_id": "v3_inux_system_user_discovery",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "linux",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "debian",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                 {
+                  "match": {
+                    "host.os.family": {
+                      "query": "redhat",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                   {
+                  "match": {
+                    "host.os.family": {
+                      "query": "suse",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                 {
+                  "match": {
+                    "host.os.family": {
+                      "query": "ubuntu",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "bool": {
+              "should": [
+                {
+                  "term": {
+                    "process.name": "users"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "w"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "who"
+                  }
+                },
+                {
+                  "term": {
+                    "process.name": "whoami"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_rare_process_by_host_linux_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/datafeed_v3_rare_process_by_host_linux_ecs.json
@@ -1,0 +1,71 @@
+{
+    "job_id": "v3_rare_process_by_host_linux_ecs",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.category": "process"
+            }
+          },
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "linux",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "debian",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "redhat",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "suse",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "ubuntu",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_network_activity.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_network_activity.json
@@ -1,0 +1,53 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.",
+  "groups": [
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "network",
+    "security"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name",
+      "destination.ip"
+    ]
+  },
+  "analysis_limits": {
+    "model_memory_limit": "64mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "siem#/ml-hosts/$host.name$?_g=()&kqlQuery=(filterQuery:(expression:'process.name%20:%20%22$process.name$%22',kind:kuery),queryLocation:hosts.details,type:details)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "siem#/ml-hosts/$host.name$?_g=()&kqlQuery=(filterQuery:(expression:'user.name%20:%20%22$user.name$%22',kind:kuery),queryLocation:hosts.details,type:details)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "siem#/ml-hosts?_g=()&kqlQuery=(filterQuery:(expression:'process.name%20:%20%22$process.name$%22',kind:kuery),queryLocation:hosts.page,type:page)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "siem#/ml-hosts?_g=()&kqlQuery=(filterQuery:(expression:'user.name%20:%20%22$user.name$%22',kind:kuery),queryLocation:hosts.page,type:page)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_network_activity.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_network_activity.json
@@ -24,6 +24,7 @@
       "destination.ip"
     ]
   },
+  "allow_lazy_open": true,
   "analysis_limits": {
     "model_memory_limit": "64mb"
   },

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_network_port_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_network_port_activity_ecs.json
@@ -1,0 +1,55 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Linux - This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux v3 -  Looks for unusual destination port activity that could indicate command-and-control, persistence mechanism, or data exfiltration activity.",
+  "groups": [
+    "security",
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "network"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"destination.port\"",
+        "function": "rare",
+        "by_field_name": "destination.port"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name",
+      "destination.ip"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "32mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux-v3",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_network_port_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_network_port_activity_ecs.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "Security: Linux - This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux v3 -  Looks for unusual destination port activity that could indicate command-and-control, persistence mechanism, or data exfiltration activity.",
+  "description": "Security: Linux v3 -  Looks for unusual destination port activity that could indicate command-and-control, persistence mechanism, or data exfiltration activity.",
   "groups": [
     "security",
     "auditbeat",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_process_all_hosts_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,58 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for processes that are unusual to all Linux hosts. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.",
+  "groups": [
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "process",
+    "security"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_process_all_hosts_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_process_all_hosts_ecs.json
@@ -26,7 +26,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "512mb",
     "categorization_examples_limit": 4
 
   },

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_process_all_hosts_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_process_all_hosts_ecs.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for processes that are unusual to all Linux hosts. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.",
+  "description": "Security: Linux - Looks for processes that are unusual to all Linux hosts. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.",
   "groups": [
     "auditbeat",
     "endpoint",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_user_name_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_user_name_ecs.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.",
+  "description": "Security: Linux - Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.",
   "groups": [
     "auditbeat",
     "endpoint",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_user_name_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_user_name_ecs.json
@@ -26,7 +26,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "32mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_user_name_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_anomalous_user_name_ecs.json
@@ -1,0 +1,57 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.",
+  "groups": [
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "process",
+    "security"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_network_configuration_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_network_configuration_discovery.json
@@ -1,0 +1,55 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Linux - Looks for commands related to system network configuration discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network configuration discovery in order to increase their understanding of connected networks and hosts. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "endpoint",
+      "linux",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "64mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-security-linux-v3",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_network_configuration_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_network_configuration_discovery.json
@@ -1,6 +1,6 @@
 {
     "job_type": "anomaly_detector",
-    "description": "Security: Linux - Looks for commands related to system network configuration discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network configuration discovery in order to increase their understanding of connected networks and hosts. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.",
+    "description": "Security: Linux - Looks for commands related to system network configuration discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network configuration discovery to increase their understanding of connected networks and hosts. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.",
     "groups": [
       "security",
       "auditbeat",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_network_connection_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_network_connection_discovery.json
@@ -1,6 +1,6 @@
 {
     "job_type": "anomaly_detector",
-    "description": "Security: Linux - Looks for commands related to system network connection discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network connection discovery in order to increase their understanding of connected services and systems. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.",
+    "description": "Security: Linux - Looks for commands related to system network connection discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network connection discovery to increase their understanding of connected services and systems. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.",
     "groups": [
       "security",
       "auditbeat",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_network_connection_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_network_connection_discovery.json
@@ -1,0 +1,55 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Linux - Looks for commands related to system network connection discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network connection discovery in order to increase their understanding of connected services and systems. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "endpoint",
+      "linux",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "64mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-security-linux-v3",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_process.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_process.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "description": "Security: Linux - Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
   "groups": [
     "auditbeat",
     "endpoint",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_process.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_process.json
@@ -26,7 +26,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "32mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_process.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_process.json
@@ -1,0 +1,38 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "groups": [
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "process",
+    "security"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "user.name",
+      "process.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux"  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_user.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "description": "Security: Linux - Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
   "groups": [
     "auditbeat",
     "endpoint",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_user.json
@@ -25,7 +25,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "32mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_metadata_user.json
@@ -1,0 +1,38 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "groups": [
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "process",
+    "security"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux"
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_sudo_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_sudo_user.json
@@ -1,0 +1,55 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Linux - Looks for sudo activity from an unusual user context.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "endpoint",
+      "linux",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "32mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-security-linux-v3",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_user_compiler.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_rare_user_compiler.json
@@ -1,0 +1,47 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Linux - Looks for compiler activity by a user context which does not normally run compilers. This can be ad-hoc software changes or unauthorized software deployment. This can also be due to local privilege elevation via locally run exploits or malware activity.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "endpoint",
+      "linux",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.title",
+        "host.name",
+        "process.working_directory",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "256mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-security-linux-v3",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_information_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_information_discovery.json
@@ -1,0 +1,55 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Linux - Looks for commands related to system information discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system information discovery in order to gather detailed information about system configuration and software versions. This may be a precursor to selection of a persistence mechanism or a method of privilege elevation.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "endpoint",
+      "linux",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "16mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-security-linux-v3",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_information_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_information_discovery.json
@@ -1,6 +1,6 @@
 {
     "job_type": "anomaly_detector",
-    "description": "Security: Linux - Looks for commands related to system information discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system information discovery in order to gather detailed information about system configuration and software versions. This may be a precursor to selection of a persistence mechanism or a method of privilege elevation.",
+    "description": "Security: Linux - Looks for commands related to system information discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system information discovery to gather detailed information about system configuration and software versions. This may be a precursor to the selection of a persistence mechanism or a method of privilege elevation.",
     "groups": [
       "security",
       "auditbeat",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_process_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_process_discovery.json
@@ -1,6 +1,6 @@
 {
     "job_type": "anomaly_detector",
-    "description": "Security: Linux - Looks for commands related to system process discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system process discovery in order to increase their understanding of software applications running on a target host or network. This may be a precursor to selection of a persistence mechanism or a method of privilege elevation.",
+    "description": "Security: Linux - Looks for commands related to system process discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system process discovery to increase their understanding of software applications running on a target host or network. This may be a precursor to the selection of a persistence mechanism or a method of privilege elevation.",
     "groups": [
       "security",
       "auditbeat",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_process_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_process_discovery.json
@@ -1,0 +1,55 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Linux - Looks for commands related to system process discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system process discovery in order to increase their understanding of software applications running on a target host or network. This may be a precursor to selection of a persistence mechanism or a method of privilege elevation.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "endpoint",
+      "linux",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "16mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-security-linux-v3",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_user_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_user_discovery.json
@@ -1,0 +1,55 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Linux - Looks for commands related to system user or owner discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system owner or user discovery in order to identify currently active or primary users of a system. This may be a precursor to additional discovery, credential dumping or privilege elevation activity.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "endpoint",
+      "linux",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "16mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-security-linux-v3",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_user_discovery.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_linux_system_user_discovery.json
@@ -1,6 +1,6 @@
 {
     "job_type": "anomaly_detector",
-    "description": "Security: Linux - Looks for commands related to system user or owner discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system owner or user discovery in order to identify currently active or primary users of a system. This may be a precursor to additional discovery, credential dumping or privilege elevation activity.",
+    "description": "Security: Linux - Looks for commands related to system user or owner discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system owner or user discovery to identify currently active or primary users of a system. This may be a precursor to additional discovery, credential dumping, or privilege elevation activity.",
     "groups": [
       "security",
       "auditbeat",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_rare_process_by_host_linux_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_rare_process_by_host_linux_ecs.json
@@ -1,0 +1,58 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for processes that are unusual to a particular Linux host. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.",
+  "groups": [
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "process",
+    "security"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare process executions on Linux",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "partition_field_name": "host.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_rare_process_by_host_linux_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_rare_process_by_host_linux_ecs.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for processes that are unusual to a particular Linux host. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.",
+  "description": "Security: Linux - Looks for processes that are unusual to a particular Linux host. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.",
   "groups": [
     "auditbeat",
     "endpoint",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_rare_process_by_host_linux_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux_v3/ml/v3_rare_process_by_host_linux_ecs.json
@@ -27,7 +27,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "256mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/logo.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/logo.json
@@ -1,0 +1,3 @@
+{
+  "icon": "logoSecurity"
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "security_windows_v3",
-  "title": "Security: Windows v3",
-  "description": "Security: Windows v3 (2022). This module is a replacement for the v2 Windows module. This module contains all shipping ML jobs for Windows host based threat hunting and detection.",
+  "title": "Security: Windows v3 (2022)",
+  "description": "This module contains all shipping ML jobs for Windows host based threat hunting and detection. This module is a replacement for the v2 Windows module named Security: Windows.",
   "type": "windows data",
   "logoFile": "logo.json",
   "defaultIndexPattern": "winlogbeat-*,logs-*",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "security_windows_v3",
   "title": "Security: Windows v3",
-  "description": "Security: Linux v3. Version 3 of the Windows Security Machine Learning Module, released in 2022, this module is a replacement for the v2 Windows module. This module contains all shipping ML jobs for Windows host based threat hunting and detection. Any ECS (Elastic Common Schema) compatable Windows events can be used by this module.",
+  "description": "Contains all shipping ML jobs for Windows host-based threat hunting and detection. Any ECS-compatible Windows events can be used by the jobs.",
   "type": "windows data",
   "logoFile": "logo.json",
   "defaultIndexPattern": "winlogbeat-*,logs-*",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "security_windows_v3",
   "title": "Security: Windows v3",
-  "description": "Contains all shipping ML jobs for Windows host-based threat hunting and detection. Any ECS-compatible Windows events can be used by the jobs.",
+  "description": "Security: Windows v3 (2022). This module is a replacement for the v2 Windows module. This module contains all shipping ML jobs for Windows host based threat hunting and detection.",
   "type": "windows data",
   "logoFile": "logo.json",
   "defaultIndexPattern": "winlogbeat-*,logs-*",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/manifest.json
@@ -1,0 +1,148 @@
+{
+  "id": "security_windows_v3",
+  "title": "Security: Windows v3",
+  "description": "Security: Linux v3. Version 3 of the Windows Security Machine Learning Module, released in 2022, this module is a replacement for the v2 Windows module. This module contains all shipping ML jobs for Windows host based threat hunting and detection. Any ECS (Elastic Common Schema) compatable Windows events can be used by this module.",
+  "type": "windows data",
+  "logoFile": "logo.json",
+  "defaultIndexPattern": "winlogbeat-*,logs-*",
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "jobs": [
+    {
+      "id": "v3_windows_anomalous_service",
+      "file": "v3_windows_anomalous_service.json"
+    },
+    {
+      "id": "v3_windows_rare_user_runas_event",
+      "file": "v3_windows_rare_user_runas_event.json"
+    },
+    {
+      "id": "v3_windows_rare_user_type10_remote_login",
+      "file": "v3_windows_rare_user_type10_remote_login.json"
+    },
+    {
+      "id": "v3_rare_process_by_host_windows_ecs",
+      "file": "v3_rare_process_by_host_windows_ecs.json"
+    },
+    {
+      "id": "v3_windows_anomalous_network_activity_ecs",
+      "file": "v3_windows_anomalous_network_activity_ecs.json"
+    },
+    {
+      "id": "v3_windows_anomalous_path_activity_ecs",
+      "file": "v3_windows_anomalous_path_activity_ecs.json"
+    },
+    {
+      "id": "v3_windows_anomalous_process_all_hosts_ecs",
+      "file": "v3_windows_anomalous_process_all_hosts_ecs.json"
+    },
+    {
+      "id": "v3_windows_anomalous_process_creation",
+      "file": "v3_windows_anomalous_process_creation.json"
+    },
+    {
+      "id": "v3_windows_anomalous_user_name_ecs",
+      "file": "v3_windows_anomalous_user_name_ecs.json"
+    },
+    {
+      "id": "v3_windows_rare_metadata_process",
+      "file": "v3_windows_rare_metadata_process.json"
+    },
+    {
+      "id": "v3_windows_rare_metadata_user",
+      "file": "v3_windows_rare_metadata_user.json"
+    },
+    {
+      "id": "v3_windows_anomalous_script",
+      "file": "v3_windows_anomalous_script.json"
+    }
+  ],
+  "datafeeds": [
+    {
+      "id": "datafeed-v3_windows_anomalous_service",
+      "file": "datafeed_v3_windows_anomalous_service.json",
+      "job_id": "v3_windows_anomalous_service"
+    },
+    {
+      "id": "datafeed-v3_windows_rare_user_runas_event",
+      "file": "datafeed_v3_windows_rare_user_runas_event.json",
+      "job_id": "v3_windows_rare_user_runas_event"
+    },
+    {
+      "id": "datafeed-v3_windows_rare_user_type10_remote_login",
+      "file": "datafeed_v3_windows_rare_user_type10_remote_login.json",
+      "job_id": "v3_windows_rare_user_type10_remote_login"
+    },
+    {
+      "id": "datafeed-v3_rare_process_by_host_windows_ecs",
+      "file": "datafeed_v3_rare_process_by_host_windows_ecs.json",
+      "job_id": "v3_rare_process_by_host_windows_ecs"
+    },
+    {
+      "id": "datafeed-v3_windows_anomalous_network_activity_ecs",
+      "file": "datafeed_v3_windows_anomalous_network_activity_ecs.json",
+      "job_id": "v3_windows_anomalous_network_activity_ecs"
+    },
+    {
+      "id": "datafeed-v3_windows_anomalous_path_activity_ecs",
+      "file": "datafeed_v3_windows_anomalous_path_activity_ecs.json",
+      "job_id": "v3_windows_anomalous_path_activity_ecs"
+    },
+    {
+      "id": "datafeed-v3_windows_anomalous_process_all_hosts_ecs",
+      "file": "datafeed_v3_windows_anomalous_process_all_hosts_ecs.json",
+      "job_id": "v3_windows_anomalous_process_all_hosts_ecs"
+    },
+    {
+      "id": "datafeed-v3_windows_anomalous_process_creation",
+      "file": "datafeed_v3_windows_anomalous_process_creation.json",
+      "job_id": "v3_windows_anomalous_process_creation"
+    },
+    {
+      "id": "datafeed-v3_windows_anomalous_user_name_ecs",
+      "file": "datafeed_v3_windows_anomalous_user_name_ecs.json",
+      "job_id": "v3_windows_anomalous_user_name_ecs"
+    },
+    {
+      "id": "datafeed-v3_windows_rare_metadata_process",
+      "file": "datafeed_v3_windows_rare_metadata_process.json",
+      "job_id": "v3_windows_rare_metadata_process"
+    },
+    {
+      "id": "datafeed-v3_windows_rare_metadata_user",
+      "file": "datafeed_v3_windows_rare_metadata_user.json",
+      "job_id": "v3_windows_rare_metadata_user"
+    },
+    {
+      "id": "datafeed-v3_windows_anomalous_script",
+      "file": "datafeed_v3_windows_anomalous_script.json",
+      "job_id": "v3_windows_anomalous_script"
+    }
+  ]
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_rare_process_by_host_windows_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_rare_process_by_host_windows_ecs.json
@@ -1,0 +1,47 @@
+{
+    "job_id": "v3_rare_process_by_host_windows_ecs",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.category": "process"
+            }
+          },
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_network_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_network_activity_ecs.json
@@ -1,0 +1,71 @@
+{
+    "job_id": "v3_windows_anomalous_network_activity_ecs",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.category": "network"
+            }
+          },
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "must_not": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "term": {
+                    "destination.ip": "127.0.0.1"
+                  }
+                },
+                {
+                  "term": {
+                    "destination.ip": "127.0.0.53"
+                  }
+                },
+                {
+                  "term": {
+                    "destination.ip": "::1"
+                  }
+                }
+              ],
+              "minimum_should_match": 1
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_path_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_path_activity_ecs.json
@@ -1,0 +1,47 @@
+{
+    "job_id": "v3_windows_anomalous_path_activity_ecs",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.category": "process"
+            }
+          },
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_process_all_hosts_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,47 @@
+{
+    "job_id": "v3_windows_anomalous_process_all_hosts_ecs",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.category": "process"
+            }
+          },
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_process_creation.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_process_creation.json
@@ -1,0 +1,47 @@
+{
+    "job_id": "v3_windows_anomalous_process_creation",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.category": "process"
+            }
+          },
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_script.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_script.json
@@ -1,0 +1,42 @@
+{
+  "job_id": "v3_windows_anomalous_script",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.provider": "Microsoft-Windows-PowerShell"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_service.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_service.json
@@ -1,0 +1,42 @@
+{
+  "job_id": "v3_windows_anomalous_service",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.code": "7045"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_user_name_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_anomalous_user_name_ecs.json
@@ -1,0 +1,47 @@
+{
+    "job_id": "v3_windows_anomalous_user_name_ecs",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.category": "process"
+            }
+          },
+          {
+            "term": {
+              "event.type": "start"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_rare_metadata_process.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_rare_metadata_process.json
@@ -1,0 +1,23 @@
+{
+    "job_id": "v3_windows_rare_metadata_process",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "host.os.family": "windows"
+            }
+          },
+          {
+            "term": {
+              "destination.ip": "169.254.169.254"
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_rare_metadata_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_rare_metadata_user.json
@@ -1,0 +1,23 @@
+{
+    "job_id": "v3_windows_rare_metadata_user",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "host.os.family": "windows"
+            }
+          },
+          {
+            "term": {
+              "destination.ip": "169.254.169.254"
+            }
+          }
+        ]
+      }
+    }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_rare_user_runas_event.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_rare_user_runas_event.json
@@ -1,0 +1,42 @@
+{
+    "job_id": "v3_windows_rare_user_runas_event",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.code": "4648"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "host.os.family": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "host.os.type": {
+                      "query": "windows",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_rare_user_type10_remote_login.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_rare_user_type10_remote_login.json
@@ -1,0 +1,42 @@
+{
+    "job_id": "v3_windows_rare_user_type10_remote_login",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "term": {
+              "event.code": "4624"
+            }
+          }
+        ],
+        "must": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "match": {
+                    "winlog.event_data.LogonType": {
+                      "query": "10",
+                      "operator": "OR"
+                    }
+                  }
+                },
+                {
+                  "match": {
+                    "winlog.logon.type": {
+                      "query": "RemoteInteractive",
+                      "operator": "OR"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_rare_user_type10_remote_login.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/datafeed_v3_windows_rare_user_type10_remote_login.json
@@ -5,38 +5,38 @@
     ],
     "max_empty_searches": 10,
     "query": {
-      "bool": {
-        "filter": [
-          {
-            "term": {
-              "event.code": "4624"
-            }
+       "bool": {
+      "filter": [
+        {
+          "term": {
+            "winlog.event_data.LogonType": "10"
           }
-        ],
-        "must": [
-          {
-            "bool": {
-              "should": [
-                {
-                  "match": {
-                    "winlog.event_data.LogonType": {
-                      "query": "10",
-                      "operator": "OR"
-                    }
-                  }
-                },
-                {
-                  "match": {
-                    "winlog.logon.type": {
-                      "query": "RemoteInteractive",
-                      "operator": "OR"
-                    }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "event.type": {
+                    "query": "authentication_success",
+                    "operator": "OR"
                   }
                 }
-              ]
-            }
+              },
+              {
+                "match": {
+                  "event.action": {
+                    "query": "logged-in",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
+    }
     }
   }

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_rare_process_by_host_windows_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_rare_process_by_host_windows_ecs.json
@@ -1,0 +1,60 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Detects unusually rare processes on Windows hosts.",
+  "groups": [
+    "endpoint",
+    "event-log",
+    "process",
+    "security",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare process executions on Windows",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "partition_field_name": "host.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_rare_process_by_host_windows_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_rare_process_by_host_windows_ecs.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Detects unusually rare processes on Windows hosts.",
+  "description": "Security: Windows - Detects unusually rare processes on Windows hosts.",
   "groups": [
     "endpoint",
     "event-log",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_rare_process_by_host_windows_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_rare_process_by_host_windows_ecs.json
@@ -29,7 +29,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "256mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_network_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_network_activity_ecs.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.",
+  "description": "Security: Windows - Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.",
   "groups": [
     "endpoint",
     "network",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_network_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_network_activity_ecs.json
@@ -28,7 +28,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "64mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_network_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_network_activity_ecs.json
@@ -1,0 +1,59 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.",
+  "groups": [
+    "endpoint",
+    "network",
+    "security",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name",
+      "destination.ip"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_path_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_path_activity_ecs.json
@@ -1,0 +1,58 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for activity in unusual paths that may indicate execution of malware or persistence mechanisms. Windows payloads often execute from user profile paths.",
+  "groups": [
+    "endpoint",
+    "network",
+    "security",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.working_directory\"",
+        "function": "rare",
+        "by_field_name": "process.working_directory",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_path_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_path_activity_ecs.json
@@ -27,7 +27,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "256mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_path_activity_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_path_activity_ecs.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for activity in unusual paths that may indicate execution of malware or persistence mechanisms. Windows payloads often execute from user profile paths.",
+  "description": "Security: Windows - Looks for activity in unusual paths that may indicate execution of malware or persistence mechanisms. Windows payloads often execute from user profile paths.",
   "groups": [
     "endpoint",
     "network",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_all_hosts_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_all_hosts_ecs.json
@@ -28,7 +28,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "256mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_all_hosts_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,59 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for processes that are unusual to all Windows hosts. Such unusual processes may indicate execution of unauthorized services, malware, or persistence mechanisms.",
+  "groups": [
+    "endpoint",
+    "event-log",
+    "process",
+    "security",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.executable\"",
+        "function": "rare",
+        "by_field_name": "process.executable",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_all_hosts_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_all_hosts_ecs.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for processes that are unusual to all Windows hosts. Such unusual processes may indicate execution of unauthorized services, malware, or persistence mechanisms.",
+  "description": "Security: Windows - Looks for processes that are unusual to all Windows hosts. Such unusual processes may indicate execution of unauthorized services, malware, or persistence mechanisms.",
   "groups": [
     "endpoint",
     "event-log",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_creation.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_creation.json
@@ -1,0 +1,60 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for unusual process relationships which may indicate execution of malware or persistence mechanisms.",
+  "groups": [
+    "endpoint",
+    "event-log",
+    "process",
+    "security",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "Unusual process creation activity",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "partition_field_name": "process.parent.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_creation.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_creation.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for unusual process relationships which may indicate execution of malware or persistence mechanisms.",
+  "description": "Security: Windows - Looks for unusual process relationships which may indicate execution of malware or persistence mechanisms.",
   "groups": [
     "endpoint",
     "event-log",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_creation.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_process_creation.json
@@ -29,7 +29,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "256mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_script.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_script.json
@@ -1,0 +1,45 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Looks for unusual powershell scripts that may indicate execution of malware, or persistence mechanisms.",
+  "groups": [
+    "endpoint",
+    "event-log",
+    "process",
+    "windows",
+    "winlogbeat",
+    "powershell"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "high_info_content(\"powershell.file.script_block_text\")",
+        "function": "high_info_content",
+        "field_name": "powershell.file.script_block_text"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "user.name",
+      "file.Path"
+    ]
+  },
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "custom_urls": [
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "siem#/ml-hosts/$host.name$?_g=()&kqlQuery=(filterQuery:(expression:'user.name%20:%20%22$user.name$%22',kind:kuery),queryLocation:hosts.details,type:details)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "siem#/ml-hosts?_g=()&kqlQuery=(filterQuery:(expression:'user.name%20:%20%22$user.name$%22',kind:kuery),queryLocation:hosts.page,type:page)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_script.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_script.json
@@ -24,6 +24,7 @@
       "file.Path"
     ]
   },
+  "allow_lazy_open": true,
   "analysis_limits": {
     "model_memory_limit": "256mb"
   },

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_service.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_service.json
@@ -1,0 +1,43 @@
+{
+  "job_type": "anomaly_detector",
+  "groups": [
+    "endpoint",
+    "event-log",
+    "process",
+    "security",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "description": "Security: Windows - Looks for rare and unusual Windows services which may indicate execution of unauthorized services, malware, or persistence mechanisms.",
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"winlog.event_data.ServiceName\"",
+        "function": "rare",
+        "by_field_name": "winlog.event_data.ServiceName"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "winlog.event_data.ServiceName"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows-v3",
+    "custom_urls": [
+      {
+        "url_name": "Host Details",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_user_name_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_user_name_ecs.json
@@ -28,7 +28,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "256mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_user_name_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_user_name_ecs.json
@@ -1,0 +1,59 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.",
+  "groups": [
+    "endpoint",
+    "event-log",
+    "process",
+    "security",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_user_name_ecs.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_anomalous_user_name_ecs.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.",
+  "description": "Security: Windows - Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.",
   "groups": [
     "endpoint",
     "event-log",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_process.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_process.json
@@ -1,0 +1,40 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "groups": [
+    "security",
+    "endpoint",
+    "process",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "process.name",
+      "host.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows"
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_process.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_process.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "description": "Security: Windows - Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
   "groups": [
     "security",
     "endpoint",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_process.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_process.json
@@ -27,7 +27,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "32mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_user.json
@@ -26,7 +26,7 @@
   },
   "allow_lazy_open": true,
   "analysis_limits": {
-    "model_memory_limit": "11mb",
+    "model_memory_limit": "32mb",
     "categorization_examples_limit": 4
   },
   "data_description": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_user.json
@@ -1,6 +1,6 @@
 {
   "job_type": "anomaly_detector",
-  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "description": "Security: Windows - Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
   "groups": [
     "endpoint",
     "process",

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_metadata_user.json
@@ -1,0 +1,39 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "groups": [
+    "endpoint",
+    "process",
+    "security",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name",
+        "detector_index": 0
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "11mb",
+    "categorization_examples_limit": 4
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows"
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_user_runas_event.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_user_runas_event.json
@@ -1,0 +1,55 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Windows - Unusual user context switches can be due to privilege escalation.",
+  "groups": [
+    "endpoint",
+    "event-log",
+    "security",
+    "windows",
+    "winlogbeat",
+    "authentication"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "128mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows-v3",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_user_type10_remote_login.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows_v3/ml/v3_windows_rare_user_type10_remote_login.json
@@ -1,0 +1,55 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Windows - Unusual RDP (remote desktop protocol) user logins can indicate account takeover or credentialed access.",
+  "groups": [
+    "endpoint",
+    "event-log",
+    "security",
+    "windows",
+    "winlogbeat",
+    "authentication"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "128mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows-v3",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/ml_modules.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/ml_modules.tsx
@@ -21,6 +21,6 @@ export const mlModules: string[] = [
   'security_linux',
   'security_network',
   'security_windows',
-  'security_linux_v3', 
+  'security_linux_v3',
   'security_windows_v3',
 ];

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/ml_modules.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/ml_modules.tsx
@@ -22,5 +22,5 @@ export const mlModules: string[] = [
   'security_network',
   'security_windows',
   'security_linux_v3', 
-  'security_windows_v3'
+  'security_windows_v3',
 ];

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/ml_modules.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/ml_modules.tsx
@@ -21,4 +21,6 @@ export const mlModules: string[] = [
   'security_linux',
   'security_network',
   'security_windows',
+  'security_linux_v3', 
+  'security_windows_v3'
 ];

--- a/x-pack/test/api_integration/apis/ml/modules/get_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/get_module.ts
@@ -40,7 +40,7 @@ const moduleIds = [
   'siem_winlogbeat_auth',
   'uptime_heartbeat',
   'security_linux_v3',
-  'security_windows_v3'
+  'security_windows_v3',
 ];
 
 export default ({ getService }: FtrProviderContext) => {

--- a/x-pack/test/api_integration/apis/ml/modules/get_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/get_module.ts
@@ -30,8 +30,10 @@ const moduleIds = [
   'sample_data_weblogs',
   'security_auth',
   'security_linux',
+  'security_linux_v3',
   'security_network',
   'security_windows',
+  'security_windows_v3',
   'siem_auditbeat',
   'siem_auditbeat_auth',
   'siem_cloudtrail',
@@ -39,8 +41,6 @@ const moduleIds = [
   'siem_winlogbeat',
   'siem_winlogbeat_auth',
   'uptime_heartbeat',
-  'security_linux_v3',
-  'security_windows_v3',
 ];
 
 export default ({ getService }: FtrProviderContext) => {

--- a/x-pack/test/api_integration/apis/ml/modules/get_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/get_module.ts
@@ -39,6 +39,8 @@ const moduleIds = [
   'siem_winlogbeat',
   'siem_winlogbeat_auth',
   'uptime_heartbeat',
+  'security_linux_v3',
+  'security_windows_v3'
 ];
 
 export default ({ getService }: FtrProviderContext) => {

--- a/x-pack/test/api_integration/apis/ml/modules/recognize_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/recognize_module.ts
@@ -98,6 +98,7 @@ export default ({ getService }: FtrProviderContext) => {
           'security_auth',
           'security_network',
           'security_windows',
+          'security_windows_v3',
           'siem_winlogbeat',
           'siem_winlogbeat_auth',
         ],
@@ -129,7 +130,7 @@ export default ({ getService }: FtrProviderContext) => {
       user: USER.ML_POWERUSER,
       expected: {
         responseCode: 200,
-        moduleIds: ['auditbeat_process_hosts_ecs', 'security_linux', 'siem_auditbeat'],
+        moduleIds: ['auditbeat_process_hosts_ecs', 'security_linux', 'security_linux_v3', siem_auditbeat'],
       },
     },
     {
@@ -139,7 +140,7 @@ export default ({ getService }: FtrProviderContext) => {
       user: USER.ML_POWERUSER,
       expected: {
         responseCode: 200,
-        moduleIds: ['security_auth', 'security_linux', 'security_network', 'security_windows'],
+        moduleIds: ['security_auth', 'security_linux', 'security_linux_v3', 'security_network', 'security_windows', 'security_windows_v3'],
       },
     },
     {
@@ -149,7 +150,7 @@ export default ({ getService }: FtrProviderContext) => {
       user: USER.ML_POWERUSER,
       expected: {
         responseCode: 200,
-        moduleIds: ['metricbeat_system_ecs', 'security_linux'],
+        moduleIds: ['metricbeat_system_ecs', 'security_linux', 'security_linux_v3'],
       },
     },
     {
@@ -169,7 +170,7 @@ export default ({ getService }: FtrProviderContext) => {
       user: USER.ML_POWERUSER,
       expected: {
         responseCode: 200,
-        moduleIds: ['security_linux'], // the metrics ui modules don't define a query and can't be recognized
+        moduleIds: ['security_linux', 'security_linux_v3'], // the metrics ui modules don't define a query and can't be recognized
       },
     },
     {

--- a/x-pack/test/api_integration/apis/ml/modules/recognize_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/recognize_module.ts
@@ -130,7 +130,7 @@ export default ({ getService }: FtrProviderContext) => {
       user: USER.ML_POWERUSER,
       expected: {
         responseCode: 200,
-        moduleIds: ['auditbeat_process_hosts_ecs', 'security_linux', 'security_linux_v3', siem_auditbeat'],
+        moduleIds: ['auditbeat_process_hosts_ecs', 'security_linux', 'security_linux_v3', 'siem_auditbeat'],
       },
     },
     {

--- a/x-pack/test/api_integration/apis/ml/modules/recognize_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/recognize_module.ts
@@ -130,7 +130,12 @@ export default ({ getService }: FtrProviderContext) => {
       user: USER.ML_POWERUSER,
       expected: {
         responseCode: 200,
-        moduleIds: ['auditbeat_process_hosts_ecs', 'security_linux', 'security_linux_v3', 'siem_auditbeat'],
+        moduleIds: [
+          'auditbeat_process_hosts_ecs',
+          'security_linux',
+          'security_linux_v3',
+          'siem_auditbeat',
+        ],
       },
     },
     {
@@ -140,7 +145,14 @@ export default ({ getService }: FtrProviderContext) => {
       user: USER.ML_POWERUSER,
       expected: {
         responseCode: 200,
-        moduleIds: ['security_auth', 'security_linux', 'security_linux_v3', 'security_network', 'security_windows', 'security_windows_v3'],
+        moduleIds: [
+          'security_auth',
+          'security_linux',
+          'security_linux_v3',
+          'security_network',
+          'security_windows',
+          'security_windows_v3',
+        ],
       },
     },
     {


### PR DESCRIPTION
## Summary
- Follow up to https://github.com/elastic/kibana/pull/123000 since the previous PR overwrote the V2 module/files, was simpler to kick off a new PR
- Adds files for new + refactored v3 jobs for both `security_linux` and `security_windows` - for use within the Security app. 

### Files/Job Artifacts:
---
- 2 updated manifest `.json` files - for both linux and windows

- Updated/new ML Job configurations for 26 jobs - each with associated datafeed configuration files:
  - **security_linux: 14 jobs**
    - v3_linux_anomalous_network_activity
    - v3_linux_anomalous_network_port_activity_ecs
    - v3_linux_anomalous_process_all_hosts_ecs
    - v3_linux_anomalous_user_name_ecs
    - v3_linux_network_configuration_discovery
    - v3_linux_network_connection_discovery
    - v3_linux_rare_metadata_process
    - v3_linux_rare_metadata_user
    - v3_linux_rare_sudo_user
    - v3_linux_rare_user_compiler
    - v3_linux_system_information_discovery
    - v3_linux_system_process_discovery
    - v3_linux_system_user_discovery
    - v3_rare_process_by_host_linux_ecs
    
  - **security_windows: 12 jobs**
    - v3_rare_process_by_host_windows_ecs
    - v3_windows_anomalous_network_activity_ecs
    - v3_windows_anomalous_path_activity_ecs
    - v3_windows_anomalous_process_all_hosts_ecs
    - v3_windows_anomalous_process_creation
    - v3_windows_anomalous_script
    - v3_windows_anomalous_service
    - v3_windows_anomalous_user_name_ecs
    - v3_windows_rare_metadata_process
    - v3_windows_rare_metadata_user
    - v3_windows_rare_user_runas_event
    - v3_windows_rare_user_type10_remote_login

### Tests:
---
Individual job test tracking stats available here: https://docs.google.com/spreadsheets/d/1JOUIVsitaMdEdhM3WT2Eag4ELI-rI2Jec7bXildJsdQ/edit#gid=0

@randomuserid to also post more updates as needed to this issue + regarding tests, thanks
