### PR TITLE
[Security Solution] Newsfeed Url bugfix

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/news_feed/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/news_feed/helpers.test.ts
@@ -47,10 +47,10 @@ describe('helpers', () => {
       expect(removeSuffixFromVersion(version)).toEqual('8.0.0');
     });
 
-    test('it should NOT transform a version if it omits the dash in `SNAPSHOT`', () => {
+    test('it should transform a version if it omits the dash in `SNAPSHOT`', () => {
       const version = '8.0.0SNAPSHOT';
 
-      expect(removeSuffixFromVersion(version)).toEqual('8.0.0SNAPSHOT');
+      expect(removeSuffixFromVersion(version)).toEqual('8.0.0');
     });
 
     test('it should NOT transform an undefined version', () => {

--- a/x-pack/plugins/security_solution/public/common/components/news_feed/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/news_feed/helpers.test.ts
@@ -15,7 +15,7 @@ import {
   getLocale,
   getNewsFeedUrl,
   getNewsItemsFromApiResponse,
-  removeSnapshotFromVersion,
+  removeSuffixFromVersion,
   showNewsItem,
 } from './helpers';
 import { NewsItem, RawNewsApiResponse } from './types';
@@ -23,53 +23,46 @@ import { NewsItem, RawNewsApiResponse } from './types';
 jest.mock('../../lib/kibana');
 
 describe('helpers', () => {
-  describe('removeSnapshotFromVersion', () => {
+  describe('removeSuffixFromVersion', () => {
+    test('removes entire suffix after version number', () => {
+      const version = '8.0.0-SNAPSHOT-rc1';
+
+      expect(removeSuffixFromVersion(version)).toEqual('8.0.0');
+    });
     test('it should remove an all-caps `-SNAPSHOT`', () => {
       const version = '8.0.0-SNAPSHOT';
 
-      expect(removeSnapshotFromVersion(version)).toEqual('8.0.0');
+      expect(removeSuffixFromVersion(version)).toEqual('8.0.0');
     });
 
     test('it should remove a mixed-case `-SnApShoT`', () => {
       const version = '8.0.0-SnApShoT';
 
-      expect(removeSnapshotFromVersion(version)).toEqual('8.0.0');
-    });
-
-    test('it should remove all occurrences of `-SNAPSHOT`, regardless of where they appear in the version', () => {
-      const version = '-SNAPSHOT8.0.0-SNAPSHOT';
-
-      expect(removeSnapshotFromVersion(version)).toEqual('8.0.0');
+      expect(removeSuffixFromVersion(version)).toEqual('8.0.0');
     });
 
     test('it should NOT transform a version when it does not contain a `-SNAPSHOT`', () => {
       const version = '8.0.0';
 
-      expect(removeSnapshotFromVersion(version)).toEqual('8.0.0');
+      expect(removeSuffixFromVersion(version)).toEqual('8.0.0');
     });
 
     test('it should NOT transform a version if it omits the dash in `SNAPSHOT`', () => {
       const version = '8.0.0SNAPSHOT';
 
-      expect(removeSnapshotFromVersion(version)).toEqual('8.0.0SNAPSHOT');
-    });
-
-    test('it should NOT transform a version if has only a partial `-SNAPSHOT`', () => {
-      const version = '8.0.0-SNAP';
-
-      expect(removeSnapshotFromVersion(version)).toEqual('8.0.0-SNAP');
+      expect(removeSuffixFromVersion(version)).toEqual('8.0.0SNAPSHOT');
     });
 
     test('it should NOT transform an undefined version', () => {
       const version = undefined;
 
-      expect(removeSnapshotFromVersion(version)).toBeUndefined();
+      expect(removeSuffixFromVersion(version)).toBeUndefined();
     });
 
     test('it should NOT transform an empty version', () => {
       const version = '';
 
-      expect(removeSnapshotFromVersion(version)).toEqual('');
+      expect(removeSuffixFromVersion(version)).toEqual('');
     });
   });
 

--- a/x-pack/plugins/security_solution/public/common/components/news_feed/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/news_feed/helpers.ts
@@ -8,17 +8,17 @@
 import { get } from 'lodash/fp';
 import moment from 'moment';
 import uuid from 'uuid';
-
+import semverCoerce from 'semver/functions/coerce';
 import { NewsItem, RawNewsApiItem, RawNewsApiResponse } from './types';
 import { KibanaServices } from '../../lib/kibana';
 
 /**
- * Removes the `-SNAPSHOT` that is sometimes appended to the Kibana version,
- * (e.g. `8.0.0-SNAPSHOT`), which is typically only seen in non-production
+ * Removes the suffix that is sometimes appended to the Kibana version,
+ * (e.g. `8.0.0-SNAPSHOT-rc1`), which is typically only seen in non-production
  * environments
  */
 export const removeSuffixFromVersion = (kibanaVersion?: string) =>
-  kibanaVersion?.split('-')[0] ?? kibanaVersion;
+  semverCoerce(kibanaVersion)?.version ?? kibanaVersion;
 
 /**
  * Combines the URL specified in the `newsFeedUrlSetting`, e.g.

--- a/x-pack/plugins/security_solution/public/common/components/news_feed/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/news_feed/helpers.ts
@@ -17,8 +17,8 @@ import { KibanaServices } from '../../lib/kibana';
  * (e.g. `8.0.0-SNAPSHOT`), which is typically only seen in non-production
  * environments
  */
-export const removeSnapshotFromVersion = (kibanaVersion?: string) =>
-  kibanaVersion?.replace(/-SNAPSHOT/gi, '') ?? kibanaVersion;
+export const removeSuffixFromVersion = (kibanaVersion?: string) =>
+  kibanaVersion?.split('-')[0] ?? kibanaVersion;
 
 /**
  * Combines the URL specified in the `newsFeedUrlSetting`, e.g.
@@ -36,7 +36,7 @@ export const getNewsFeedUrl = ({
 }) =>
   [
     newsFeedUrlSetting?.trim().replace(/\/$/, ''),
-    `v${removeSnapshotFromVersion(getKibanaVersion())}.json`,
+    `v${removeSuffixFromVersion(getKibanaVersion())}.json`,
   ].join('/');
 
 /** Fall back to this language when extracting i18n news items from the feed */


### PR DESCRIPTION
## Summary

Bugfix for https://github.com/elastic/kibana/issues/122654.

The newsfeed url is always <version number>.json:
![image](https://user-images.githubusercontent.com/6935300/149997896-ec1a48c9-2dff-4641-ac66-a01672102875.png)

We were checking for only versions formatted like `8.0.0-SNAPSHOT` and removing instances of the string "-snapshot". However, it is possible the `getKibanaVersion()` returns with rc number, ex: `8.0.0-SNAPSHOT-rc1`. So our code would request the file as  `8.0.0-rc1` when we only ever want the number. I updated the replace function to split on `-` and take the first part of the version only: `version.split('-')[0]`


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios