### PR TITLE
Fix issue with parsing out endpoint package policy.

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/helpers.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/helpers.test.ts
@@ -14,6 +14,7 @@ import {
   LIST_TRUSTED_APPLICATION,
 } from './constants';
 import {
+  extractEndpointPolicyConfig,
   getPreviousDiagTaskTimestamp,
   getPreviousDailyTaskTimestamp,
   batchTelemetryRecords,
@@ -21,6 +22,7 @@ import {
   templateExceptionList,
 } from './helpers';
 import type { ESClusterInfo, ESLicense, ExceptionListItem } from './types';
+import { PolicyData } from '../../../common/endpoint/types';
 
 describe('test diagnostic telemetry scheduled task timing helper', () => {
   test('test -5 mins is returned when there is no previous task run', async () => {
@@ -264,5 +266,41 @@ describe('list telemetry schema', () => {
     expect(templatedItems[1]?.endpoint_event_filter).not.toBeUndefined();
     expect(templatedItems[0]?.endpoint_exception).toBeUndefined();
     expect(templatedItems[0]?.trusted_application).toBeUndefined();
+  });
+});
+
+describe('test endpoint policy data config extraction', () => {
+  const stubPolicyData = {
+    id: '872de8c5-85cf-4e1b-a504-9fd39b38570c',
+    version: 'WzU4MjkwLDFd',
+    name: 'Test Policy Data',
+    namespace: 'default',
+    description: '',
+    package: {
+      name: 'endpoint',
+      title: 'Endpoint Security',
+      version: '1.4.1',
+    },
+    enabled: true,
+    policy_id: '499b5aa7-d214-5b5d-838b-3cd76469844e',
+    output_id: '',
+    inputs: [
+      {
+        type: 'endpoint',
+        enabled: true,
+        streams: [],
+        config: null,
+      },
+    ],
+    revision: 1,
+    created_at: '2022-01-18T14:52:17.385Z',
+    created_by: 'elastic',
+    updated_at: '2022-01-18T14:52:17.385Z',
+    updated_by: 'elastic',
+  } as unknown as PolicyData;
+
+  test('can succeed when policy config is null or empty', async () => {
+    const endpointPolicyConfig = extractEndpointPolicyConfig(stubPolicyData);
+    expect(endpointPolicyConfig).toBeNull();
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/telemetry/helpers.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/helpers.ts
@@ -9,6 +9,7 @@ import moment from 'moment';
 import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { PackagePolicy } from '../../../../fleet/common/types/models/package_policy';
 import { copyAllowlistedFields, exceptionListEventFields } from './filters';
+import { PolicyData } from '../../../common/endpoint/types';
 import type {
   ExceptionListItem,
   ESClusterInfo,
@@ -216,6 +217,14 @@ export const templateExceptionList = (
  * @param label_list the list of labels to create standardized UsageCounter from
  * @returns a string label for usage in the UsageCounter
  */
-export function createUsageCounterLabel(labelList: string[]): string {
-  return labelList.join('-');
-}
+export const createUsageCounterLabel = (labelList: string[]): string => labelList.join('-');
+
+/**
+ * Resiliantly handles an edge case where the endpoint config details are not present
+ *
+ * @returns the endpoint policy configuration
+ */
+export const extractEndpointPolicyConfig = (policyData: PolicyData | null) => {
+  const epPolicyConfig = policyData?.inputs[0]?.config?.policy;
+  return epPolicyConfig ? epPolicyConfig : null;
+};

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
@@ -40,7 +40,7 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
   return {
     type: 'security:endpoint-meta-telemetry',
     title: 'Security Solution Telemetry Endpoint Metrics and Info task',
-    interval: '3m',
+    interval: '24h',
     timeout: '5m',
     version: '1.0.0',
     getLastExecutionTime: getPreviousDailyTaskTimestamp,

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
@@ -260,7 +260,7 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
         );
         return telemetryPayloads.length;
       } catch (err) {
-        logger.warn('could not complete endpoint alert telemetry task', err);
+        logger.warn('could not complete endpoint alert telemetry task');
         return 0;
       }
     },

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
@@ -18,6 +18,7 @@ import { TelemetryReceiver } from '../receiver';
 import { TaskExecutionPeriod } from '../task';
 import {
   batchTelemetryRecords,
+  extractEndpointPolicyConfig,
   getPreviousDailyTaskTimestamp,
   isPackagePolicyList,
 } from '../helpers';
@@ -39,7 +40,7 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
   return {
     type: 'security:endpoint-meta-telemetry',
     title: 'Security Solution Telemetry Endpoint Metrics and Info task',
-    interval: '24h',
+    interval: '3m',
     timeout: '5m',
     version: '1.0.0',
     getLastExecutionTime: getPreviousDailyTaskTimestamp,
@@ -145,11 +146,11 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
             packagePolicies
               .map((pPolicy) => pPolicy as PolicyData)
               .forEach((pPolicy) => {
-                if (pPolicy.inputs[0].config !== undefined) {
+                if (pPolicy.inputs[0]?.config !== undefined && pPolicy.inputs[0]?.config !== null) {
                   pPolicy.inputs.forEach((input) => {
                     if (
                       input.type === FLEET_ENDPOINT_PACKAGE &&
-                      input.config !== undefined &&
+                      input?.config !== undefined &&
                       policyInfo !== undefined
                     ) {
                       endpointPolicyCache.set(policyInfo, pPolicy);
@@ -212,6 +213,7 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
           }
 
           const { cpu, memory, uptime } = endpoint.endpoint_metrics.Endpoint.metrics;
+          const endpointPolicyDetail = extractEndpointPolicyConfig(policyConfig);
 
           return {
             '@timestamp': taskExecutionPeriod.current,
@@ -229,7 +231,7 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
             endpoint_meta: {
               os: endpoint.endpoint_metrics.host.os,
             },
-            policy_config: policyConfig !== null ? policyConfig?.inputs[0].config.policy : {},
+            policy_config: endpointPolicyDetail !== null ? endpointPolicyDetail : {},
             policy_response:
               failedPolicy !== null && failedPolicy !== undefined
                 ? {
@@ -258,7 +260,7 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
         );
         return telemetryPayloads.length;
       } catch (err) {
-        logger.warn('could not complete endpoint alert telemetry task');
+        logger.warn('could not complete endpoint alert telemetry task', err);
         return 0;
       }
     },


### PR DESCRIPTION
## Summary

We found an edge case on customer deployments where the telemetry was going dark due to a type error. While the root cause of why this is happening hasn't been established, the optional chaining and defaulting circumvents the reproducible type error.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
