### PR TITLE
[Fleet] Validate policy id when creating an enrollment token

### DIFF
--- a/x-pack/plugins/fleet/public/components/new_enrollment_key_modal.tsx
+++ b/x-pack/plugins/fleet/public/components/new_enrollment_key_modal.tsx
@@ -5,12 +5,22 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiConfirmModal, EuiForm, EuiFormRow, EuiFieldText, EuiSelect } from '@elastic/eui';
 
 import type { AgentPolicy, EnrollmentAPIKey } from '../types';
 import { useInput, useStartServices, sendCreateEnrollmentAPIKey } from '../hooks';
+
+function validatePolicyId(value: string) {
+  if (value === '') {
+    return [
+      i18n.translate('xpack.fleet.newEnrollmentKeyForm.policyIdRequireErrorMessage', {
+        defaultMessage: 'Policy is required',
+      }),
+    ];
+  }
+}
 
 function useCreateApiKeyForm(
   policyIdDefaultValue: string | undefined,
@@ -19,10 +29,13 @@ function useCreateApiKeyForm(
 ) {
   const [isLoading, setIsLoading] = useState(false);
   const apiKeyNameInput = useInput('');
-  const policyIdInput = useInput(policyIdDefaultValue);
+  const policyIdInput = useInput(policyIdDefaultValue, validatePolicyId);
 
   const onSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+    if (!policyIdInput.validate() || !apiKeyNameInput.validate()) {
+      return;
+    }
     setIsLoading(true);
     try {
       const res = await sendCreateEnrollmentAPIKey({
@@ -65,7 +78,11 @@ export const NewEnrollmentTokenModal: React.FunctionComponent<Props> = ({
   const { notifications } = useStartServices();
   const policyIdDefaultValue = agentPolicies.find((agentPolicy) => agentPolicy.is_default)?.id;
   const form = useCreateApiKeyForm(
-    policyIdDefaultValue,
+    policyIdDefaultValue
+      ? policyIdDefaultValue
+      : agentPolicies.length > 0
+      ? agentPolicies[0].id
+      : undefined,
     (key: EnrollmentAPIKey) => {
       onClose(key);
       notifications.toasts.addSuccess(
@@ -80,6 +97,15 @@ export const NewEnrollmentTokenModal: React.FunctionComponent<Props> = ({
       });
     }
   );
+
+  const selectPolicyOptions = useMemo(() => {
+    return agentPolicies
+      .filter((agentPolicy) => !agentPolicy.is_managed)
+      .map((agentPolicy) => ({
+        value: agentPolicy.id,
+        text: agentPolicy.name,
+      }));
+  }, [agentPolicies]);
 
   const body = (
     <EuiForm>
@@ -106,18 +132,9 @@ export const NewEnrollmentTokenModal: React.FunctionComponent<Props> = ({
           label={i18n.translate('xpack.fleet.newEnrollmentKey.policyLabel', {
             defaultMessage: 'Policy',
           })}
+          {...form.policyIdInput.formRowProps}
         >
-          <EuiSelect
-            required={true}
-            defaultValue={policyIdDefaultValue}
-            {...form.policyIdInput.props}
-            options={agentPolicies
-              .filter((agentPolicy) => !agentPolicy.is_managed)
-              .map((agentPolicy) => ({
-                value: agentPolicy.id,
-                text: agentPolicy.name,
-              }))}
-          />
+          <EuiSelect required={true} {...form.policyIdInput.props} options={selectPolicyOptions} />
         </EuiFormRow>
       </form>
     </EuiForm>

--- a/x-pack/plugins/fleet/server/errors/index.ts
+++ b/x-pack/plugins/fleet/server/errors/index.ts
@@ -32,6 +32,7 @@ export class PackageNotFoundError extends IngestManagerError {}
 export class PackageKeyInvalidError extends IngestManagerError {}
 export class PackageOutdatedError extends IngestManagerError {}
 export class AgentPolicyError extends IngestManagerError {}
+export class AgentPolicyNotFoundError extends IngestManagerError {}
 export class AgentNotFoundError extends IngestManagerError {}
 export class AgentPolicyNameExistsError extends AgentPolicyError {}
 export class PackageUnsupportedMediaTypeError extends IngestManagerError {}

--- a/x-pack/test/fleet_api_integration/apis/enrollment_api_keys/crud.ts
+++ b/x-pack/test/fleet_api_integration/apis/enrollment_api_keys/crud.ts
@@ -92,14 +92,16 @@ export default function (providerContext: FtrProviderContext) {
           .expect(400);
       });
 
-      it('should return a 400 if the fleet admin user is modifed outside of Fleet', async () => {
-        await supertest
+      it('should return a 400 if the policy_id is not a valid policy', async () => {
+        const { body: apiResponse } = await supertest
           .post(`/api/fleet/enrollment_api_keys`)
           .set('kbn-xsrf', 'xxx')
           .send({
-            raoul: 'raoul',
+            policy_id: 'idonotexists',
           })
           .expect(400);
+
+        expect(apiResponse.message).to.be('Agent policy "idonotexists" not found');
       });
 
       it('should allow to create an enrollment api key with only an agent policy', async () => {


### PR DESCRIPTION
## Summary

While testing #121628 I found that we were not validating the policy_id is valid when creating an enrollment token that PR fix that.

The POST /api/fleet/enrollment_api_keys endpoint now return a `400` if the policy id is not valid.

