### PR TITLE
[Security Solution][Exceptions] Fix export toast text

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/export_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/export_rule.spec.ts
@@ -11,7 +11,7 @@ import {
   waitForAlertsIndexToBeCreated,
   waitForAlertsPanelToBeLoaded,
 } from '../../tasks/alerts';
-import { exportFirstRule } from '../../tasks/alerts_detection_rules';
+import { exportFirstRule, getRulesImportExportToast } from '../../tasks/alerts_detection_rules';
 import { createCustomRule } from '../../tasks/api_calls/rules';
 import { cleanKibana } from '../../tasks/common';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
@@ -36,6 +36,9 @@ describe('Export rules', () => {
     exportFirstRule();
     cy.wait('@export').then(({ response }) => {
       cy.wrap(response?.body).should('eql', expectedExportedRule(this.ruleResponse));
+      getRulesImportExportToast([
+        'Successfully exported 1 of 1 rule. Prebuilt rules were excluded from the resulting file.',
+      ]);
     });
   });
 });

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/import_rules.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/import_rules.spec.ts
@@ -11,7 +11,7 @@ import {
   waitForAlertsPanelToBeLoaded,
 } from '../../tasks/alerts';
 import {
-  getRulesImportToast,
+  getRulesImportExportToast,
   importRules,
   importRulesWithOverwriteAll,
 } from '../../tasks/alerts_detection_rules';
@@ -35,7 +35,10 @@ describe('Import rules', () => {
 
     cy.wait('@import').then(({ response }) => {
       cy.wrap(response?.statusCode).should('eql', 200);
-      getRulesImportToast(['Successfully imported 1 rule', 'Successfully imported 2 exceptions.']);
+      getRulesImportExportToast([
+        'Successfully imported 1 rule',
+        'Successfully imported 2 exceptions.',
+      ]);
     });
   });
 
@@ -51,7 +54,7 @@ describe('Import rules', () => {
 
     cy.wait('@import').then(({ response }) => {
       cy.wrap(response?.statusCode).should('eql', 200);
-      getRulesImportToast(['Failed to import 1 rule', 'Failed to import 2 exceptions']);
+      getRulesImportExportToast(['Failed to import 1 rule', 'Failed to import 2 exceptions']);
     });
   });
 
@@ -67,7 +70,10 @@ describe('Import rules', () => {
 
     cy.wait('@import').then(({ response }) => {
       cy.wrap(response?.statusCode).should('eql', 200);
-      getRulesImportToast(['Successfully imported 1 rule', 'Successfully imported 2 exceptions.']);
+      getRulesImportExportToast([
+        'Successfully imported 1 rule',
+        'Successfully imported 2 exceptions.',
+      ]);
     });
   });
 });

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
@@ -275,7 +275,7 @@ export const importRules = (rulesFile: string) => {
   cy.get(INPUT_FILE).should('not.exist');
 };
 
-export const getRulesImportToast = (headers: string[]) => {
+export const getRulesImportExportToast = (headers: string[]) => {
   cy.get(TOASTER)
     .should('exist')
     .then(($els) => {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { Query } from '@elastic/eui';
+import { ExportRulesDetails } from '../../../../../../common/detection_engine/schemas/response/export_rules_details_schema';
 import {
   BulkRuleResponse,
   RuleResponseBuckets,
@@ -71,16 +72,29 @@ export const getSearchFilters = ({
 
 /**
  * This function helps to parse NDJSON with exported rules
+ * and retrieve the metadata of exported rules.
+ *
+ * @param blob a Blob received from an _export endpoint
+ * @returns Export details
+ */
+export const getExportedRulesDetails = async (blob: Blob): Promise<ExportRulesDetails> => {
+  const blobContent = await blob.text();
+  // The Blob content is an NDJSON file, the last line of which contains export details.
+  const exportDetailsJson = blobContent.split('\n').filter(Boolean).slice(-1)[0];
+  const exportDetails = JSON.parse(exportDetailsJson);
+
+  return exportDetails;
+};
+
+/**
+ * This function helps to parse NDJSON with exported rules
  * and retrieve the number of successfully exported rules.
  *
  * @param blob a Blob received from an _export endpoint
  * @returns Number of exported rules
  */
 export const getExportedRulesCount = async (blob: Blob): Promise<number> => {
-  const blobContent = await blob.text();
-  // The Blob content is an NDJSON file, the last line of which contains export details.
-  const exportDetailsJson = blobContent.split('\n').filter(Boolean).slice(-1)[0];
-  const exportDetails = JSON.parse(exportDetailsJson);
+  const details = await getExportedRulesDetails(blob);
 
-  return exportDetails.exported_count;
+  return details.exported_rules_count;
 };


### PR DESCRIPTION
## Summary

Fix bug on rule export where toaster reports export total as being rule objects + exceptions objects, but should just be rule objects total. Adds cypress test.

### Before
<img width="472" alt="Screen Shot 2022-01-11 at 8 50 26 AM" src="https://user-images.githubusercontent.com/10927944/150031667-eb481ddb-0daf-4aba-8760-8c2783377911.png">

### After
<img width="558" alt="Screen Shot 2022-01-18 at 10 21 04 AM" src="https://user-images.githubusercontent.com/10927944/150031682-532612a8-7ce3-4741-b92b-d3936dace3cb.png">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
