### PR TITLE
[7.17] [ftr] support filtering tests by es version

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -1,3 +1,6 @@
+env:
+  ES_SNAPSHOT_MANIFEST: https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.0.0/archives/20220114-151614_1e722727/manifest.json
+
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build

--- a/test/functional/apps/management/_scripted_fields.js
+++ b/test/functional/apps/management/_scripted_fields.js
@@ -42,6 +42,7 @@ export default function ({ getService, getPageObjects }) {
 
   describe('scripted fields', function () {
     this.tags(['skipFirefox']);
+    this.onlyEsVersion('<=7');
 
     before(async function () {
       await browser.setWindowSize(1200, 800);

--- a/x-pack/test/accessibility/apps/upgrade_assistant.ts
+++ b/x-pack/test/accessibility/apps/upgrade_assistant.ts
@@ -52,7 +52,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const es = getService('es');
   const log = getService('log');
 
-  describe('Upgrade Assistant', () => {
+  describe('Upgrade Assistant', function () {
+    this.onlyEsVersion('<=7');
+
     before(async () => {
       await PageObjects.upgradeAssistant.navigateToPage();
 

--- a/x-pack/test/api_integration/apis/management/index_lifecycle_management/policies.js
+++ b/x-pack/test/api_integration/apis/management/index_lifecycle_management/policies.js
@@ -32,7 +32,9 @@ export default function ({ getService }) {
 
   const { addPolicyToIndex } = registerIndexHelpers({ supertest });
 
-  describe('policies', () => {
+  describe('policies', function () {
+    this.onlyEsVersion('<=7');
+
     after(() => Promise.all([cleanUpEsResources(), cleanUpPolicies()]));
 
     describe('list', () => {

--- a/x-pack/test/api_integration/apis/management/index_management/indices.js
+++ b/x-pack/test/api_integration/apis/management/index_management/indices.js
@@ -34,7 +34,9 @@ export default function ({ getService }) {
     clearCache,
   } = registerHelpers({ supertest });
 
-  describe('indices', () => {
+  describe('indices', function () {
+    this.onlyEsVersion('<=7');
+
     after(() => Promise.all([cleanUpEsResources()]));
 
     describe('clear cache', () => {

--- a/x-pack/test/api_integration/apis/management/index_management/mapping.js
+++ b/x-pack/test/api_integration/apis/management/index_management/mapping.js
@@ -17,7 +17,9 @@ export default function ({ getService }) {
 
   const { getIndexMapping } = registerHelpers({ supertest });
 
-  describe('mapping', () => {
+  describe('mapping', function () {
+    this.onlyEsVersion('<=7');
+
     after(() => Promise.all([cleanUpEsResources()]));
 
     it('should fetch the index mapping', async () => {

--- a/x-pack/test/api_integration/apis/management/index_management/settings.js
+++ b/x-pack/test/api_integration/apis/management/index_management/settings.js
@@ -17,7 +17,9 @@ export default function ({ getService }) {
 
   const { getIndexSettings, updateIndexSettings } = registerHelpers({ supertest });
 
-  describe('settings', () => {
+  describe('settings', function () {
+    this.onlyEsVersion('<=7');
+
     after(() => Promise.all([cleanUpEsResources()]));
 
     it('should fetch an index settings', async () => {

--- a/x-pack/test/api_integration/apis/management/index_management/templates.js
+++ b/x-pack/test/api_integration/apis/management/index_management/templates.js
@@ -25,7 +25,9 @@ export default function ({ getService }) {
     cleanUpTemplates,
   } = registerHelpers({ supertest });
 
-  describe('index templates', () => {
+  describe('index templates', function () {
+    this.onlyEsVersion('<=7');
+
     after(() => Promise.all([cleanUpEsResources(), cleanUpTemplates()]));
 
     describe('get all', () => {

--- a/x-pack/test/api_integration/apis/management/rollup/rollup.js
+++ b/x-pack/test/api_integration/apis/management/rollup/rollup.js
@@ -24,7 +24,9 @@ export default function ({ getService }) {
     cleanUp,
   } = registerHelpers(getService);
 
-  describe('jobs', () => {
+  describe('jobs', function () {
+    this.onlyEsVersion('<=7');
+
     after(() => cleanUp());
 
     describe('indices', () => {

--- a/x-pack/test/api_integration/apis/search/search.ts
+++ b/x-pack/test/api_integration/apis/search/search.ts
@@ -13,7 +13,9 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  describe('search', () => {
+  describe('search', function () {
+    this.onlyEsVersion('<=7');
+
     // https://github.com/elastic/kibana/issues/113082
     describe.skip('post', () => {
       it('should return 200 with final response if wait_for_completion_timeout is long enough', async () => {

--- a/x-pack/test/api_integration/apis/security_solution/timeline_details.ts
+++ b/x-pack/test/api_integration/apis/security_solution/timeline_details.ts
@@ -682,6 +682,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const supertest = getService('supertest');
   const bsearch = getService('bsearch');
+  const esVersion = getService('esVersion');
 
   describe('Timeline Details', () => {
     before(
@@ -703,7 +704,12 @@ export default function ({ getService }: FtrProviderContext) {
         },
         strategy: 'timelineSearchStrategy',
       });
-      expect(sortBy(detailsData, 'field')).to.eql(sortBy(EXPECTED_DATA, 'field'));
+
+      const expectedData = esVersion.matchRange('>=8')
+        ? sortBy(EXPECTED_DATA, 'field').filter((f) => f.field !== '_type')
+        : sortBy(EXPECTED_DATA, 'field');
+
+      expect(sortBy(detailsData, 'field')).to.eql(expectedData);
     });
 
     it('Make sure that we get kpi data', async () => {

--- a/x-pack/test/api_integration/apis/upgrade_assistant/index.ts
+++ b/x-pack/test/api_integration/apis/upgrade_assistant/index.ts
@@ -8,7 +8,9 @@
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('Upgrade Assistant', () => {
+  describe('Upgrade Assistant', function () {
+    this.onlyEsVersion('<=7');
+
     loadTestFile(require.resolve('./upgrade_assistant'));
     loadTestFile(require.resolve('./cloud_backup_status'));
     loadTestFile(require.resolve('./privileges'));

--- a/x-pack/test/functional/apps/api_keys/home_page.ts
+++ b/x-pack/test/functional/apps/api_keys/home_page.ts
@@ -17,6 +17,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const browser = getService('browser');
 
   describe('Home page', function () {
+    this.onlyEsVersion('<=7');
+
     before(async () => {
       await security.testUser.setRoles(['kibana_admin']);
       await pageObjects.common.navigateToApp('apiKeys');

--- a/x-pack/test/functional/apps/discover/reporting.ts
+++ b/x-pack/test/functional/apps/discover/reporting.ts
@@ -36,7 +36,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     return res;
   };
 
-  describe('Discover CSV Export', () => {
+  describe('Discover CSV Export', function () {
+    this.onlyEsVersion('<=7');
+
     before('initialize tests', async () => {
       log.debug('ReportingPage:initTests');
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/ecommerce');

--- a/x-pack/test/functional/apps/index_management/feature_controls/index_management_security.ts
+++ b/x-pack/test/functional/apps/index_management/feature_controls/index_management_security.ts
@@ -15,7 +15,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const appsMenu = getService('appsMenu');
   const managementMenu = getService('managementMenu');
 
-  describe('security', () => {
+  describe('security', function () {
+    this.onlyEsVersion('<=7');
+
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
       await PageObjects.common.navigateToApp('home');

--- a/x-pack/test/functional/apps/index_management/home_page.ts
+++ b/x-pack/test/functional/apps/index_management/home_page.ts
@@ -17,6 +17,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const security = getService('security');
 
   describe('Home page', function () {
+    this.onlyEsVersion('<=7');
+
     before(async () => {
       await security.testUser.setRoles(['index_management_user']);
       await pageObjects.common.navigateToApp('indexManagement');

--- a/x-pack/test/functional/apps/ingest_pipelines/ingest_pipelines.ts
+++ b/x-pack/test/functional/apps/ingest_pipelines/ingest_pipelines.ts
@@ -22,6 +22,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
   describe('Ingest Pipelines', function () {
     this.tags('smoke');
+    this.onlyEsVersion('<=7');
+
     before(async () => {
       await security.testUser.setRoles(['ingest_pipelines_user']);
       await pageObjects.common.navigateToApp('ingestPipelines');

--- a/x-pack/test/functional/apps/security/users.ts
+++ b/x-pack/test/functional/apps/security/users.ts
@@ -24,6 +24,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   }
 
   describe('users', function () {
+    this.onlyEsVersion('<=7');
+
     const optionalUser: UserFormValues = {
       username: 'OptionalUser',
       password: 'OptionalUserPwd',

--- a/x-pack/test/functional/apps/upgrade_assistant/index.ts
+++ b/x-pack/test/functional/apps/upgrade_assistant/index.ts
@@ -10,6 +10,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function upgradeCheckup({ loadTestFile }: FtrProviderContext) {
   describe('Upgrade Assistant', function upgradeAssistantTestSuite() {
     this.tags('ciGroup4');
+    this.onlyEsVersion('<=7');
 
     loadTestFile(require.resolve('./feature_controls'));
     loadTestFile(require.resolve('./deprecation_pages'));

--- a/x-pack/test/functional/apps/upgrade_assistant/overview_page.ts
+++ b/x-pack/test/functional/apps/upgrade_assistant/overview_page.ts
@@ -18,6 +18,7 @@ export default function upgradeAssistantOverviewPageFunctionalTests({
 
   describe('Overview Page', function () {
     this.tags('skipFirefox');
+    this.onlyEsVersion('<=7');
 
     before(async () => {
       await security.testUser.setRoles(['superuser']);

--- a/x-pack/test/reporting_api_integration/reporting_and_security/download_csv_dashboard.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/download_csv_dashboard.ts
@@ -36,7 +36,9 @@ export default function ({ getService }: FtrProviderContext) {
   const fromTime = '2019-06-20T00:00:00.000Z';
   const toTime = '2019-06-25T00:00:00.000Z';
 
-  describe('CSV Generation from SearchSource', () => {
+  describe('CSV Generation from SearchSource', function () {
+    this.onlyEsVersion('<=7');
+
     before(async () => {
       await kibanaServer.uiSettings.update({
         'csv:quoteValues': false,

--- a/x-pack/test/reporting_api_integration/reporting_and_security/generate_csv_discover.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/generate_csv_discover.ts
@@ -14,7 +14,9 @@ import { FtrProviderContext } from '../ftr_provider_context';
 export default function ({ getService }: FtrProviderContext) {
   const reportingAPI = getService('reportingAPI');
 
-  describe('Generate CSV from SearchSource', () => {
+  describe('Generate CSV from SearchSource', function () {
+    this.onlyEsVersion('<=7');
+
     it(`exported CSV file matches snapshot`, async () => {
       await reportingAPI.initEcommerce();
 

--- a/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
@@ -20,7 +20,9 @@ export default function ({ getService }: FtrProviderContext) {
   const reportingAPI = getService('reportingAPI');
   const security = getService('security');
 
-  describe('ILM policy migration APIs', () => {
+  describe('ILM policy migration APIs', function () {
+    this.onlyEsVersion('<=7');
+
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/logs');
       await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');

--- a/x-pack/test/reporting_api_integration/reporting_and_security/search_frozen_indices.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/search_frozen_indices.ts
@@ -47,7 +47,9 @@ export default function ({ getService }: FtrProviderContext) {
       .send(job);
   }
 
-  describe('Frozen indices search', () => {
+  describe('Frozen indices search', function () {
+    this.onlyEsVersion('<=7');
+
     const reset = async () => {
       await kibanaServer.uiSettings.replace({ 'search:includeFrozen': false });
       try {

--- a/x-pack/test/security_api_integration/kerberos.config.ts
+++ b/x-pack/test/security_api_integration/kerberos.config.ts
@@ -29,6 +29,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         ...xPackAPITestsConfig.get('esTestCluster.serverArgs'),
         'xpack.security.authc.token.enabled=true',
         'xpack.security.authc.token.timeout=15s',
+        'xpack.security.authc.realms.kerberos.kerb1.order=0',
         `xpack.security.authc.realms.kerberos.kerb1.keytab.path=${kerberosKeytabPath}`,
       ],
 

--- a/x-pack/test/security_solution_endpoint_api_int/apis/package.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/package.ts
@@ -66,7 +66,9 @@ export default function ({ getService }: FtrProviderContext) {
     });
   };
 
-  describe('Endpoint package', () => {
+  describe('Endpoint package', function () {
+    this.onlyEsVersion('<=7');
+
     describe('network processors', () => {
       let networkIndexData: InsertedEvents;
 

--- a/x-pack/test/upgrade_assistant_integration/upgrade_assistant/index.js
+++ b/x-pack/test/upgrade_assistant_integration/upgrade_assistant/index.js
@@ -8,6 +8,7 @@
 export default function ({ loadTestFile }) {
   describe('upgrade assistant', function () {
     this.tags('ciGroup7');
+    this.onlyEsVersion('<=7');
 
     loadTestFile(require.resolve('./reindexing'));
   });


### PR DESCRIPTION
Test backport of #123289 to 7.17 and run against an 8.0 snapshot