### PR TITLE
[7.17] [Discover] Fix saved search hidden chart can't be opened when returning to Discover (#122745)

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/chart/discover_chart.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/chart/discover_chart.tsx
@@ -18,7 +18,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { HitsCounter } from '../hits_counter';
 import { SavedSearch } from '../../../../../saved_searches';
-import { AppState, GetStateReturn } from '../../services/discover_state';
+import { GetStateReturn } from '../../services/discover_state';
 import { DiscoverHistogram } from './histogram';
 import { DataCharts$, DataTotalHits$ } from '../../services/use_saved_search';
 import { DiscoverServices } from '../../../../../build_services';
@@ -33,18 +33,20 @@ export function DiscoverChart({
   savedSearchDataChart$,
   savedSearchDataTotalHits$,
   services,
-  state,
   stateContainer,
   isTimeBased,
+  hideChart,
+  interval,
 }: {
   resetSavedSearch: () => void;
   savedSearch: SavedSearch;
   savedSearchDataChart$: DataCharts$;
   savedSearchDataTotalHits$: DataTotalHits$;
   services: DiscoverServices;
-  state: AppState;
   stateContainer: GetStateReturn;
   isTimeBased: boolean;
+  hideChart?: boolean;
+  interval?: string;
 }) {
   const [showChartOptionsPopover, setShowChartOptionsPopover] = useState(false);
 
@@ -67,14 +69,14 @@ export function DiscoverChart({
     if (chartRef.current.moveFocus && chartRef.current.element) {
       chartRef.current.element.focus();
     }
-  }, [state.hideChart]);
+  }, [hideChart]);
 
   const toggleHideChart = useCallback(() => {
-    const newHideChart = !state.hideChart;
-    stateContainer.setAppState({ hideChart: newHideChart });
+    const newHideChart = !hideChart;
     chartRef.current.moveFocus = !newHideChart;
     storage.set(CHART_HIDDEN_KEY, newHideChart);
-  }, [state.hideChart, stateContainer, storage]);
+    stateContainer.setAppState({ hideChart: newHideChart });
+  }, [hideChart, stateContainer, storage]);
 
   const timefilterUpdateHandler = useCallback(
     (ranges: { from: number; to: number }) => {
@@ -87,11 +89,11 @@ export function DiscoverChart({
     [data]
   );
   const panels = useChartPanels(
-    state,
-    savedSearchDataChart$,
     toggleHideChart,
-    (interval) => stateContainer.setAppState({ interval }),
-    () => setShowChartOptionsPopover(false)
+    (newInterval) => stateContainer.setAppState({ interval: newInterval }),
+    () => setShowChartOptionsPopover(false),
+    hideChart,
+    interval
   );
 
   return (
@@ -135,7 +137,7 @@ export function DiscoverChart({
           )}
         </EuiFlexGroup>
       </EuiFlexItem>
-      {isTimeBased && !state.hideChart && (
+      {isTimeBased && !hideChart && (
         <EuiFlexItem grow={false}>
           <section
             ref={(element) => (chartRef.current.element = element)}

--- a/src/plugins/discover/public/application/apps/main/components/chart/use_chart_panels.test.ts
+++ b/src/plugins/discover/public/application/apps/main/components/chart/use_chart_panels.test.ts
@@ -9,25 +9,12 @@
 import { renderHook } from '@testing-library/react-hooks';
 
 import { useChartPanels } from './use_chart_panels';
-import { AppState } from '../../services/discover_state';
-import { BehaviorSubject } from 'rxjs';
-import { DataCharts$ } from '../../services/use_saved_search';
-import { FetchStatus } from '../../../../types';
 import { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 
 describe('test useChartPanels', () => {
   test('useChartsPanel when hideChart is true', async () => {
-    const charts$ = new BehaviorSubject({
-      fetchStatus: FetchStatus.COMPLETE,
-    }) as DataCharts$;
     const { result } = renderHook(() => {
-      return useChartPanels(
-        { hideChart: true, interval: 'auto' } as AppState,
-        charts$,
-        jest.fn(),
-        jest.fn(),
-        jest.fn()
-      );
+      return useChartPanels(jest.fn(), jest.fn(), jest.fn(), true, 'auto');
     });
     const panels: EuiContextMenuPanelDescriptor[] = result.current;
     const panel0: EuiContextMenuPanelDescriptor = result.current[0];
@@ -35,17 +22,8 @@ describe('test useChartPanels', () => {
     expect(panel0!.items![0].icon).toBe('eye');
   });
   test('useChartsPanel when hideChart is false', async () => {
-    const charts$ = new BehaviorSubject({
-      fetchStatus: FetchStatus.COMPLETE,
-    }) as DataCharts$;
     const { result } = renderHook(() => {
-      return useChartPanels(
-        { hideChart: false, interval: 'auto' } as AppState,
-        charts$,
-        jest.fn(),
-        jest.fn(),
-        jest.fn()
-      );
+      return useChartPanels(jest.fn(), jest.fn(), jest.fn(), false, 'auto');
     });
     const panels: EuiContextMenuPanelDescriptor[] = result.current;
     const panel0: EuiContextMenuPanelDescriptor = result.current[0];

--- a/src/plugins/discover/public/application/apps/main/components/chart/use_chart_panels.ts
+++ b/src/plugins/discover/public/application/apps/main/components/chart/use_chart_panels.ts
@@ -11,17 +11,14 @@ import type {
   EuiContextMenuPanelDescriptor,
 } from '@elastic/eui';
 import { search } from '../../../../../../../data/public';
-import { AppState } from '../../services/discover_state';
-import { DataCharts$ } from '../../services/use_saved_search';
 
 export function useChartPanels(
-  state: AppState,
-  savedSearchDataChart$: DataCharts$,
   toggleHideChart: () => void,
   onChangeInterval: (value: string) => void,
-  closePopover: () => void
+  closePopover: () => void,
+  hideChart?: boolean,
+  interval?: string
 ) {
-  const { interval, hideChart } = state;
   const selectedOptionIdx = search.aggs.intervalOptions.findIndex((opt) => opt.val === interval);
   const intervalDisplay =
     selectedOptionIdx > -1

--- a/src/plugins/discover/public/application/apps/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/layout/discover_layout.tsx
@@ -276,7 +276,6 @@ export function DiscoverLayout({
                 >
                   <EuiFlexItem grow={false}>
                     <DiscoverChartMemoized
-                      state={state}
                       resetSavedSearch={resetSavedSearch}
                       savedSearch={savedSearch}
                       savedSearchDataChart$={charts$}
@@ -284,6 +283,8 @@ export function DiscoverLayout({
                       services={services}
                       stateContainer={stateContainer}
                       isTimeBased={isTimeBased}
+                      hideChart={state.hideChart}
+                      interval={state.interval}
                     />
                   </EuiFlexItem>
                   <EuiHorizontalRule margin="none" />

--- a/src/plugins/discover/public/application/apps/main/services/use_discover_state.test.ts
+++ b/src/plugins/discover/public/application/apps/main/services/use_discover_state.test.ts
@@ -41,7 +41,6 @@ describe('test useDiscoverState', () => {
     });
     expect(result.current.state.index).toBe(indexPatternMock.id);
     expect(result.current.stateContainer).toBeInstanceOf(Object);
-    expect(result.current.setState).toBeInstanceOf(Function);
     expect(result.current.searchSource).toBeInstanceOf(SearchSource);
   });
 

--- a/src/plugins/discover/public/application/apps/main/services/use_discover_state.test.ts
+++ b/src/plugins/discover/public/application/apps/main/services/use_discover_state.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
 import { createSearchSessionMock } from '../../../../__mocks__/search_session';
 import { discoverServiceMock } from '../../../../__mocks__/services';
 import { savedSearchMock } from '../../../../__mocks__/saved_search';
@@ -42,46 +42,5 @@ describe('test useDiscoverState', () => {
     expect(result.current.state.index).toBe(indexPatternMock.id);
     expect(result.current.stateContainer).toBeInstanceOf(Object);
     expect(result.current.searchSource).toBeInstanceOf(SearchSource);
-  });
-
-  test('setState', async () => {
-    const { history } = createSearchSessionMock();
-
-    const { result } = renderHook(() => {
-      return useDiscoverState({
-        services: discoverServiceMock,
-        history,
-        savedSearch: savedSearchMock,
-      });
-    });
-    await act(async () => {
-      result.current.setState({ columns: ['123'] });
-    });
-    expect(result.current.state.columns).toEqual(['123']);
-  });
-
-  test('resetSavedSearch', async () => {
-    const { history } = createSearchSessionMock();
-
-    const { result, waitForValueToChange } = renderHook(() => {
-      return useDiscoverState({
-        services: discoverServiceMock,
-        history,
-        savedSearch: savedSearchMock,
-      });
-    });
-
-    const initialColumns = result.current.state.columns;
-    await act(async () => {
-      result.current.setState({ columns: ['123'] });
-    });
-    expect(result.current.state.columns).toEqual(['123']);
-
-    result.current.resetSavedSearch('the-saved-search-id');
-    await waitForValueToChange(() => {
-      return result.current.state;
-    });
-
-    expect(result.current.state.columns).toEqual(initialColumns);
   });
 });

--- a/src/plugins/discover/public/application/apps/main/services/use_discover_state.ts
+++ b/src/plugins/discover/public/application/apps/main/services/use_discover_state.ts
@@ -95,8 +95,13 @@ export function useDiscoverState({
     useNewFieldsApi,
   });
 
+  /**
+   * Sync URL state with local app state on saved search load
+   * or dataView / savedSearch switch
+   */
   useEffect(() => {
     const stopSync = stateContainer.initializeAndSync(indexPattern, filterManager, data);
+    setState(stateContainer.appStateContainer.getState());
 
     return () => stopSync();
   }, [stateContainer, filterManager, data, indexPattern]);
@@ -201,21 +206,6 @@ export function useDiscoverState({
     },
     [refetch$, searchSessionManager]
   );
-
-  useEffect(() => {
-    if (!savedSearch || !savedSearch.id) {
-      return;
-    }
-    // handling pushing to state of a persisted saved object
-    const newAppState = getStateDefaults({
-      config,
-      data,
-      savedSearch,
-      storage,
-    });
-    stateContainer.replaceUrlAppState(newAppState);
-    setState(newAppState);
-  }, [config, data, savedSearch, reset, stateContainer, storage]);
 
   /**
    * Trigger data fetching on indexPattern or savedSearch changes

--- a/src/plugins/discover/public/application/apps/main/services/use_discover_state.ts
+++ b/src/plugins/discover/public/application/apps/main/services/use_discover_state.ts
@@ -225,7 +225,6 @@ export function useDiscoverState({
     onChangeIndexPattern,
     onUpdateQuery,
     searchSource,
-    setState,
     state,
     stateContainer,
   };

--- a/src/plugins/discover/public/application/apps/main/utils/get_state_defaults.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/get_state_defaults.ts
@@ -60,8 +60,6 @@ export function getStateDefaults({
     interval: 'auto',
     filters: cloneDeep(searchSource.getOwnField('filter')),
     hideChart: typeof chartHidden === 'boolean' ? chartHidden : undefined,
-    viewMode: undefined,
-    hideAggregatedPreview: undefined,
     savedQuery: undefined,
   } as AppState;
   if (savedSearch.grid) {

--- a/src/plugins/discover/public/application/apps/main/utils/get_state_defaults.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/get_state_defaults.ts
@@ -48,7 +48,7 @@ export function getStateDefaults({
   const query = searchSource.getField('query') || data.query.queryString.getDefaultQuery();
   const sort = getSortArray(savedSearch.sort ?? [], indexPattern!);
   const columns = getDefaultColumns(savedSearch, config);
-  const chartHidden = Boolean(storage.get(CHART_HIDDEN_KEY));
+  const chartHidden = storage.get(CHART_HIDDEN_KEY);
 
   const defaultState = {
     query,
@@ -59,7 +59,9 @@ export function getStateDefaults({
     index: indexPattern?.id,
     interval: 'auto',
     filters: cloneDeep(searchSource.getOwnField('filter')),
-    hideChart: chartHidden ? chartHidden : undefined,
+    hideChart: typeof chartHidden === 'boolean' ? chartHidden : undefined,
+    viewMode: undefined,
+    hideAggregatedPreview: undefined,
     savedQuery: undefined,
   } as AppState;
   if (savedSearch.grid) {

--- a/test/functional/apps/discover/_discover_histogram.ts
+++ b/test/functional/apps/discover/_discover_histogram.ts
@@ -102,20 +102,28 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const to = 'Mar 21, 2019 @ 00:00:00.000';
       const savedSearch = 'persisted hidden histogram';
       await prepareTest({ from, to });
+
+      // close chart for saved search
       await testSubjects.click('discoverChartOptionsToggle');
       await testSubjects.click('discoverChartToggle');
       let canvasExists = await elasticChart.canvasExists();
       expect(canvasExists).to.be(false);
+
+      // save search
       await PageObjects.discover.saveSearch(savedSearch);
       await PageObjects.header.waitUntilLoadingHasFinished();
 
+      // open new search
       await PageObjects.discover.clickNewSearchButton();
       await PageObjects.header.waitUntilLoadingHasFinished();
 
-      await PageObjects.discover.loadSavedSearch('persisted hidden histogram');
+      // load saved search
+      await PageObjects.discover.loadSavedSearch(savedSearch);
       await PageObjects.header.waitUntilLoadingHasFinished();
       canvasExists = await elasticChart.canvasExists();
       expect(canvasExists).to.be(false);
+
+      // open chart for saved search
       await testSubjects.click('discoverChartOptionsToggle');
       await testSubjects.click('discoverChartToggle');
       await retry.waitFor(`Discover histogram to be displayed`, async () => {
@@ -123,14 +131,52 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         return canvasExists;
       });
 
-      await PageObjects.discover.saveSearch('persisted hidden histogram');
+      // save search
+      await PageObjects.discover.saveSearch(savedSearch);
       await PageObjects.header.waitUntilLoadingHasFinished();
 
+      // open new search
       await PageObjects.discover.clickNewSearchButton();
-      await PageObjects.discover.loadSavedSearch('persisted hidden histogram');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+
+      // load saved search
+      await PageObjects.discover.loadSavedSearch(savedSearch);
       await PageObjects.header.waitUntilLoadingHasFinished();
       canvasExists = await elasticChart.canvasExists();
       expect(canvasExists).to.be(true);
+    });
+    it('should show permitted hidden histogram state when returning back to discover', async () => {
+      // close chart
+      await testSubjects.click('discoverChartOptionsToggle');
+      await testSubjects.click('discoverChartToggle');
+      let canvasExists = await elasticChart.canvasExists();
+      expect(canvasExists).to.be(false);
+
+      // save search
+      await PageObjects.discover.saveSearch('persisted hidden histogram');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+
+      // open chart
+      await testSubjects.click('discoverChartOptionsToggle');
+      await testSubjects.click('discoverChartToggle');
+      canvasExists = await elasticChart.canvasExists();
+      expect(canvasExists).to.be(true);
+
+      // go to dashboard
+      await PageObjects.common.navigateToApp('dashboard');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+
+      // go to discover
+      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      canvasExists = await elasticChart.canvasExists();
+      expect(canvasExists).to.be(true);
+
+      // close chart
+      await testSubjects.click('discoverChartOptionsToggle');
+      await testSubjects.click('discoverChartToggle');
+      canvasExists = await elasticChart.canvasExists();
+      expect(canvasExists).to.be(false);
     });
   });
 }


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #122745

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
