### PR TITLE
Remove reference to deprecated kibana.index setting

### DIFF
--- a/docs/developer/advanced/running-elasticsearch.asciidoc
+++ b/docs/developer/advanced/running-elasticsearch.asciidoc
@@ -71,13 +71,6 @@ elasticsearch.password: {{ password }}
 elasticsearch.ssl.verificationMode: none
 ----
 
-If many other users will be interacting with your remote cluster, you'll want to add the following to avoid causing conflicts:
-
-[source,bash]
-----
-kibana.index: '.{YourGitHubHandle}-kibana'
-----
-
 ==== Running remote clusters
 
 Setup remote clusters for cross cluster search (CCS) and cross cluster replication (CCR).


### PR DESCRIPTION
Updates legacy developer docs to remove reference to the deprecated as of 8.0 `kibana.index` setting.