### PR TITLE
Move bazel remote cache token to a space that more employees have access to

### DIFF
--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -59012,7 +59012,7 @@ async function setupRemoteCache(repoRootPath) {
   try {
     const {
       stdout
-    } = await Object(_child_process__WEBPACK_IMPORTED_MODULE_3__["spawn"])('vault', ['read', '-field=readonly-key', 'secret/kibana-issues/dev/bazel-remote-cache'], {
+    } = await Object(_child_process__WEBPACK_IMPORTED_MODULE_3__["spawn"])('vault', ['read', '-field=readonly-key', 'secret/ui-team/kibana-bazel-remote-cache'], {
       stdio: 'pipe'
     });
     apiKey = stdout.trim();

--- a/packages/kbn-pm/src/utils/bazel/setup_remote_cache.ts
+++ b/packages/kbn-pm/src/utils/bazel/setup_remote_cache.ts
@@ -60,7 +60,7 @@ export async function setupRemoteCache(repoRootPath: string) {
   try {
     const { stdout } = await spawn(
       'vault',
-      ['read', '-field=readonly-key', 'secret/kibana-issues/dev/bazel-remote-cache'],
+      ['read', '-field=readonly-key', 'secret/ui-team/kibana-bazel-remote-cache'],
       {
         stdio: 'pipe',
       }


### PR DESCRIPTION
Only the Operations team has access to the original space in vault.