### PR TITLE
[Fleet] Remove output id from agent policy APIs

### DIFF
--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -22,8 +22,6 @@ export const AgentPolicyBaseSchema = {
       schema.oneOf([schema.literal(dataTypes.Logs), schema.literal(dataTypes.Metrics)])
     )
   ),
-  data_output_id: schema.maybe(schema.string()),
-  data_monitoring_output_id: schema.maybe(schema.string()),
 };
 
 export const NewAgentPolicySchema = schema.object({


### PR DESCRIPTION
## Summary

Remove output id fields from agent policy APIs (`data_output_id` and `monitoring_output_id`) as we do not support yet multiple output and should not allow user to configure this using API.

