### PR TITLE
[Security Solution] Fixes broken cypress test after 8.0 ECS update to Rule Registry

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/timelines/fields_browser.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/timelines/fields_browser.spec.ts
@@ -109,7 +109,7 @@ describe('Fields Browser', () => {
 
       filterFieldsBrowser(filterInput);
 
-      cy.get(FIELDS_BROWSER_SELECTED_CATEGORY_COUNT).should('have.text', '4');
+      cy.get(FIELDS_BROWSER_SELECTED_CATEGORY_COUNT).should('have.text', '5');
     });
   });
 


### PR DESCRIPTION
## Summary

New ECS FieldMap was generated in https://github.com/elastic/kibana/pull/123012, however since it only contained changes to `Rule Registry` code the `Security Solution` Cypress tests were not run, and thus did not catch this field change.

See https://github.com/elastic/kibana/pull/122661#discussion_r784412959 for details. Confirmed w/ @madirey that expected value is indeed `5` now that `host.geo.continent_code` has been [added](https://github.com/elastic/kibana/pull/123012/files#diff-a1647ccb73ef26c8c8b6aefd87084504b146af72fcb088ccacad93fcaad15b69R1524-R1528).


Some failing PR's from `main`:
https://github.com/elastic/kibana/pull/123357
https://github.com/elastic/kibana/pull/121644
https://github.com/elastic/kibana/pull/123352

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
