### PR TITLE
[bfetch] Improve error handling

### DIFF
--- a/src/plugins/bfetch/public/streaming/fetch_streaming.test.ts
+++ b/src/plugins/bfetch/public/streaming/fetch_streaming.test.ts
@@ -22,6 +22,7 @@ const tick = () => new Promise((resolve) => setTimeout(resolve, 1));
 const setup = () => {
   const { xhr, XMLHttpRequest } = mockXMLHttpRequest();
   window.XMLHttpRequest = XMLHttpRequest;
+  (xhr as any).status = 200;
   return { xhr };
 };
 

--- a/src/plugins/bfetch/public/streaming/from_streaming_xhr.test.ts
+++ b/src/plugins/bfetch/public/streaming/from_streaming_xhr.test.ts
@@ -15,7 +15,7 @@ const createXhr = (): XMLHttpRequest =>
     onreadystatechange: () => {},
     readyState: 0,
     responseText: '',
-    status: 0,
+    status: 200,
   } as unknown as XMLHttpRequest);
 
 test('returns observable', () => {
@@ -149,6 +149,36 @@ test('errors observable if request returns with error', () => {
   xhr.onreadystatechange!({} as any);
 
   expect(complete).toHaveBeenCalledTimes(0);
+  expect(error).toHaveBeenCalledTimes(1);
+  expect(error.mock.calls[0][0]).toBeInstanceOf(Error);
+  expect(error.mock.calls[0][0].message).toMatchInlineSnapshot(
+    `"Batch request failed with status 400"`
+  );
+});
+
+test('does not emit when gets error response', () => {
+  const xhr = createXhr();
+  const observable = fromStreamingXhr(xhr);
+
+  const next = jest.fn();
+  const complete = jest.fn();
+  const error = jest.fn();
+  observable.subscribe({
+    next,
+    complete,
+    error,
+  });
+
+  (xhr as any).responseText = 'error';
+  (xhr as any).status = 400;
+  xhr.onprogress!({} as any);
+
+  expect(next).toHaveBeenCalledTimes(0);
+
+  (xhr as any).readyState = 4;
+  xhr.onreadystatechange!({} as any);
+
+  expect(next).toHaveBeenCalledTimes(0);
   expect(error).toHaveBeenCalledTimes(1);
   expect(error.mock.calls[0][0]).toBeInstanceOf(Error);
   expect(error.mock.calls[0][0].message).toMatchInlineSnapshot(

--- a/src/plugins/bfetch/public/streaming/from_streaming_xhr.ts
+++ b/src/plugins/bfetch/public/streaming/from_streaming_xhr.ts
@@ -23,8 +23,12 @@ export const fromStreamingXhr = (
   let index = 0;
   let aborted = false;
 
+  // 0 indicates a network failure. 400+ messages are considered server errors
+  const isErrorStatus = () => xhr.status === 0 || xhr.status >= 400;
+
   const processBatch = () => {
     if (aborted) return;
+    if (isErrorStatus()) return;
 
     const { responseText } = xhr;
     if (index >= responseText.length) return;
@@ -56,8 +60,7 @@ export const fromStreamingXhr = (
     if (xhr.readyState === 4) {
       if (signal) signal.removeEventListener('abort', onBatchAbort);
 
-      // 0 indicates a network failure. 400+ messages are considered server errors
-      if (xhr.status === 0 || xhr.status >= 400) {
+      if (isErrorStatus()) {
         subject.error(new Error(`Batch request failed with status ${xhr.status}`));
       } else {
         subject.complete();


### PR DESCRIPTION
## Summary

Fixes error where `bfetch` didn't handle the response as an error when proxy streamed an error response. For example `502 Bad Gateway` from azure. 

This led to confusing errors like this https://github.com/elastic/kibana/issues/122664 where application code tried to parse an error response (usually plain html text) as base64 string or as json string

**Note:** this pr doesn't fix the https://github.com/elastic/kibana/issues/122664, it just fixed error handling that hides underlying network error

### How to test

I added mock response from proxy [here](https://github.com/elastic/kibana/blob/ab5741ff78bfbf7a9df6a664c741278f21582ea7/src/plugins/bfetch/server/plugin.ts#L118)

```
return response.custom({
            statusCode: 502,
            bypassErrorFormat: true,
            headers: {
              'Content-Type': 'text/html',
            },
            body: `<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>Microsoft-Azure-Application-Gateway/v2</center>
</body>
</html>
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->`,
          });
```


#### Before the fix
![Screen Shot 2022-01-20 at 13 33 54](https://user-images.githubusercontent.com/7784120/150339581-92649896-8841-4ec4-ab1d-e9b34e32aaa9.png)

#### After the fix
![Screen Shot 2022-01-20 at 13 34 50](https://user-images.githubusercontent.com/7784120/150339694-e5c57875-72e7-40f8-af4d-ace2357eee36.png)



### Release Notes

Improve `bfetch` error handling

