### PR TITLE
[Cases] Fix missing displayName for some react components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -939,18 +939,6 @@ module.exports = {
       },
     },
     {
-      // Cases plugin specific overrirites
-      // typescript and javascript for front and back end
-      files: ['x-pack/plugins/cases/public/**/*.{js,mjs,ts,tsx}'],
-      plugins: ['eslint-plugin-node', 'react'],
-      env: {
-        jest: true,
-      },
-      rules: {
-        'react/display-name': ['error', { ignoreTranspilerName: true }],
-      },
-    },
-    {
       // typescript only for front and back end, but excludes the test files.
       // We use this section to add rules in which we do not want to apply to test files.
       // This should be a very small set as most linter rules are useful for tests as well.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -939,6 +939,18 @@ module.exports = {
       },
     },
     {
+      // Cases plugin specific overrirites
+      // typescript and javascript for front and back end
+      files: ['x-pack/plugins/cases/public/**/*.{js,mjs,ts,tsx}'],
+      plugins: ['eslint-plugin-node', 'react'],
+      env: {
+        jest: true,
+      },
+      rules: {
+        'react/display-name': ['error', { ignoreTranspilerName: true }],
+      },
+    },
+    {
       // typescript only for front and back end, but excludes the test files.
       // We use this section to add rules in which we do not want to apply to test files.
       // This should be a very small set as most linter rules are useful for tests as well.

--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -43,6 +43,7 @@ const TestProvidersComponent: React.FC<Props> = ({
     </I18nProvider>
   );
 };
+TestProvidersComponent.displayName = 'TestProviders';
 
 export const TestProviders = React.memo(TestProvidersComponent);
 

--- a/x-pack/plugins/cases/public/components/all_cases/columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns.tsx
@@ -456,3 +456,4 @@ export const ExternalServiceColumn: React.FC<Props> = ({ theCase, connectors }) 
     </p>
   );
 };
+ExternalServiceColumn.displayName = 'ExternalServiceColumn';

--- a/x-pack/plugins/cases/public/components/all_cases/count.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/count.tsx
@@ -56,3 +56,4 @@ export const Count: FunctionComponent<CountProps> = ({ refresh }) => {
     </EuiFlexGroup>
   );
 };
+Count.displayName = 'Count';

--- a/x-pack/plugins/cases/public/components/all_cases/header.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/header.tsx
@@ -64,3 +64,4 @@ export const CasesTableHeader: FunctionComponent<Props> = ({
     </EuiFlexGroup>
   </HeaderPage>
 );
+CasesTableHeader.displayName = 'CasesTableHeader';

--- a/x-pack/plugins/cases/public/components/all_cases/index.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/index.tsx
@@ -33,6 +33,7 @@ export const AllCases: React.FC = () => {
     </>
   );
 };
+AllCases.displayName = 'AllCases';
 
 // eslint-disable-next-line import/no-default-export
 export { AllCases as default };

--- a/x-pack/plugins/cases/public/components/all_cases/nav_buttons.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/nav_buttons.tsx
@@ -64,3 +64,4 @@ export const NavButtons: FunctionComponent<Props> = ({ actionsErrors }) => {
     </ButtonFlexGroup>
   );
 };
+NavButtons.displayName = 'NavButtons';

--- a/x-pack/plugins/cases/public/components/all_cases/status_filter.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/status_filter.tsx
@@ -50,5 +50,6 @@ const StatusFilterComponent: React.FC<Props> = ({
     />
   );
 };
+StatusFilterComponent.displayName = 'StatusFilter';
 
 export const StatusFilter = memo(StatusFilterComponent);

--- a/x-pack/plugins/cases/public/components/all_cases/table.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table.tsx
@@ -164,3 +164,4 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
     </Div>
   );
 };
+CasesTable.displayName = 'CasesTable';

--- a/x-pack/plugins/cases/public/components/all_cases/utility_bar.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/utility_bar.tsx
@@ -161,3 +161,4 @@ export const CasesTableUtilityBar: FunctionComponent<Props> = ({
     </UtilityBar>
   );
 };
+CasesTableUtilityBar.displayName = 'CasesTableUtilityBar';

--- a/x-pack/plugins/cases/public/components/app/routes.tsx
+++ b/x-pack/plugins/cases/public/components/app/routes.tsx
@@ -98,5 +98,6 @@ const CasesRoutesComponent: React.FC<CasesRoutesProps> = ({
     </Switch>
   );
 };
+CasesRoutesComponent.displayName = 'CasesRoutes';
 
 export const CasesRoutes = React.memo(CasesRoutesComponent);

--- a/x-pack/plugins/cases/public/components/case_action_bar/actions.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/actions.tsx
@@ -64,5 +64,6 @@ const ActionsComponent: React.FC<CaseViewActions> = ({ caseData, currentExternal
     </>
   );
 };
+ActionsComponent.displayName = 'Actions';
 
 export const Actions = React.memo(ActionsComponent);

--- a/x-pack/plugins/cases/public/components/case_action_bar/index.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.tsx
@@ -164,5 +164,6 @@ const CaseActionBarComponent: React.FC<CaseActionBarProps> = ({
     </EuiFlexGroup>
   );
 };
+CaseActionBarComponent.displayName = 'CaseActionBar';
 
 export const CaseActionBar = React.memo(CaseActionBarComponent);

--- a/x-pack/plugins/cases/public/components/case_action_bar/status_context_menu.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/status_context_menu.tsx
@@ -69,5 +69,6 @@ const StatusContextMenuComponent: React.FC<Props> = ({
     </EuiPopover>
   );
 };
+StatusContextMenuComponent.displayName = 'StatusContextMenu';
 
 export const StatusContextMenu = memo(StatusContextMenuComponent);

--- a/x-pack/plugins/cases/public/components/cases_context/index.tsx
+++ b/x-pack/plugins/cases/public/components/cases_context/index.tsx
@@ -61,6 +61,7 @@ export const CasesProvider: React.FC<{ value: CasesContextProps }> = ({
     <CasesContext.Provider value={value}>{children}</CasesContext.Provider>
   ) : null;
 };
+CasesProvider.displayName = 'CasesProvider';
 
 function isCasesContextValue(value: CasesContextStateValue): value is CasesContextValue {
   return value.appId != null && value.appTitle != null && value.userCanCrud != null;

--- a/x-pack/plugins/cases/public/components/configure_cases/closure_options.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/closure_options.tsx
@@ -48,5 +48,6 @@ const ClosureOptionsComponent: React.FC<ClosureOptionsProps> = ({
     </EuiFormRow>
   </EuiDescribedFormGroup>
 );
+ClosureOptionsComponent.displayName = 'ClosureOptions';
 
 export const ClosureOptions = React.memo(ClosureOptionsComponent);

--- a/x-pack/plugins/cases/public/components/configure_cases/closure_options_radio.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/closure_options_radio.tsx
@@ -56,5 +56,6 @@ const ClosureOptionsRadioComponent: React.FC<ClosureOptionsRadioComponentProps> 
     />
   );
 };
+ClosureOptionsRadioComponent.displayName = 'ClosureOptionsRadio';
 
 export const ClosureOptionsRadio = React.memo(ClosureOptionsRadioComponent);

--- a/x-pack/plugins/cases/public/components/configure_cases/connectors.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/connectors.tsx
@@ -131,5 +131,6 @@ const ConnectorsComponent: React.FC<Props> = ({
     </>
   );
 };
+ConnectorsComponent.displayName = 'Connectors';
 
 export const Connectors = React.memo(ConnectorsComponent);

--- a/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.tsx
@@ -139,5 +139,6 @@ const ConnectorsDropdownComponent: React.FC<Props> = ({
     />
   );
 };
+ConnectorsDropdownComponent.displayName = 'ConnectorsDropdown';
 
 export const ConnectorsDropdown = React.memo(ConnectorsDropdownComponent);

--- a/x-pack/plugins/cases/public/components/configure_cases/field_mapping.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/field_mapping.tsx
@@ -62,5 +62,6 @@ const FieldMappingComponent: React.FC<FieldMappingProps> = ({
     </EuiFlexGroup>
   ) : null;
 };
+FieldMappingComponent.displayName = 'FieldMapping';
 
 export const FieldMapping = React.memo(FieldMappingComponent);

--- a/x-pack/plugins/cases/public/components/configure_cases/field_mapping_row_static.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/field_mapping_row_static.tsx
@@ -57,5 +57,6 @@ const FieldMappingRowComponent: React.FC<RowProps> = ({
     </EuiFlexGroup>
   );
 };
+FieldMappingRowComponent.displayName = 'FieldMappingRow';
 
 export const FieldMappingRowStatic = React.memo(FieldMappingRowComponent);

--- a/x-pack/plugins/cases/public/components/configure_cases/mapping.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/mapping.tsx
@@ -56,5 +56,6 @@ const MappingComponent: React.FC<MappingProps> = ({ actionTypeName, isLoading, m
     </EuiFlexGroup>
   );
 };
+MappingComponent.displayName = 'Mapping';
 
 export const Mapping = React.memo(MappingComponent);

--- a/x-pack/plugins/cases/public/components/confirm_delete_case/index.tsx
+++ b/x-pack/plugins/cases/public/components/confirm_delete_case/index.tsx
@@ -42,5 +42,6 @@ const ConfirmDeleteCaseModalComp: React.FC<ConfirmDeleteCaseModalProps> = ({
     </EuiConfirmModal>
   );
 };
+ConfirmDeleteCaseModalComp.displayName = 'ConfirmDeleteCaseModalComp';
 
 export const ConfirmDeleteCaseModal = React.memo(ConfirmDeleteCaseModalComp);

--- a/x-pack/plugins/cases/public/components/connector_selector/form.tsx
+++ b/x-pack/plugins/cases/public/components/connector_selector/form.tsx
@@ -76,3 +76,4 @@ export const ConnectorSelector = ({
     </EuiFormRowWrapper>
   ) : null;
 };
+ConnectorSelector.displayName = 'ConnectorSelector';

--- a/x-pack/plugins/cases/public/components/connectors/card.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/card.tsx
@@ -77,5 +77,6 @@ const ConnectorCardDisplay: React.FC<ConnectorCardProps> = ({
     </>
   );
 };
+ConnectorCardDisplay.displayName = 'ConnectorCardDisplay';
 
 export const ConnectorCard = memo(ConnectorCardDisplay);

--- a/x-pack/plugins/cases/public/components/connectors/case/alert_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/case/alert_fields.tsx
@@ -103,6 +103,7 @@ const CaseParamsFields: React.FunctionComponent<ActionParamsProps<CaseActionPara
     </Container>
   );
 };
+CaseParamsFields.displayName = 'CaseParamsFields';
 
 // eslint-disable-next-line import/no-default-export
 export { CaseParamsFields as default };

--- a/x-pack/plugins/cases/public/components/connectors/case/cases_dropdown.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/case/cases_dropdown.tsx
@@ -69,5 +69,6 @@ const CasesDropdownComponent: React.FC<CaseDropdownProps> = ({
     </EuiFormRow>
   );
 };
+CasesDropdownComponent.displayName = 'CasesDropdown';
 
 export const CasesDropdown = memo(CasesDropdownComponent);

--- a/x-pack/plugins/cases/public/components/connectors/case/existing_case.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/case/existing_case.tsx
@@ -77,5 +77,6 @@ const ExistingCaseComponent: React.FC<ExistingCaseProps> = ({ onCaseChanged, sel
     </>
   );
 };
+ExistingCaseComponent.displayName = 'ExistingCase';
 
 export const ExistingCase = memo(ExistingCaseComponent);

--- a/x-pack/plugins/cases/public/components/connectors/deprecated_callout.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/deprecated_callout.tsx
@@ -37,5 +37,6 @@ const DeprecatedCalloutComponent: React.FC<Props> = ({ type = 'warning' }) => (
     {DEPRECATED_CONNECTOR_WARNING_DESC}
   </EuiCallOut>
 );
+DeprecatedCalloutComponent.displayName = 'DeprecatedCallout';
 
 export const DeprecatedCallout = React.memo(DeprecatedCalloutComponent);

--- a/x-pack/plugins/cases/public/components/connectors/fields_form.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/fields_form.tsx
@@ -51,5 +51,6 @@ const ConnectorFieldsFormComponent: React.FC<Props> = ({ connector, isEdit, onCh
     </>
   );
 };
+ConnectorFieldsFormComponent.displayName = 'ConnectorFieldsForm';
 
 export const ConnectorFieldsForm = memo(ConnectorFieldsFormComponent);

--- a/x-pack/plugins/cases/public/components/connectors/jira/case_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/case_fields.tsx
@@ -209,6 +209,7 @@ const JiraFieldsComponent: React.FunctionComponent<ConnectorFieldsProps<JiraFiel
     />
   );
 };
+JiraFieldsComponent.displayName = 'JiraFields';
 
 // eslint-disable-next-line import/no-default-export
 export { JiraFieldsComponent as default };

--- a/x-pack/plugins/cases/public/components/connectors/jira/search_issues.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/search_issues.tsx
@@ -92,5 +92,6 @@ const SearchIssuesComponent: React.FC<Props> = ({ selectedValue, actionConnector
     />
   );
 };
+SearchIssuesComponent.displayName = 'SearchIssues';
 
 export const SearchIssues = memo(SearchIssuesComponent);

--- a/x-pack/plugins/cases/public/components/connectors/swimlane/case_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/swimlane/case_fields.tsx
@@ -43,6 +43,7 @@ const SwimlaneComponent: React.FunctionComponent<ConnectorFieldsProps<SwimlaneFi
     </>
   );
 };
+SwimlaneComponent.displayName = 'Swimlane';
 
 // eslint-disable-next-line import/no-default-export
 export { SwimlaneComponent as default };

--- a/x-pack/plugins/cases/public/components/create/connector.tsx
+++ b/x-pack/plugins/cases/public/components/create/connector.tsx
@@ -64,6 +64,7 @@ const ConnectorFields = ({
     />
   );
 };
+ConnectorFields.displayName = 'ConnectorFields';
 
 const ConnectorComponent: React.FC<Props> = ({
   connectors,

--- a/x-pack/plugins/cases/public/components/create/owner_selector.tsx
+++ b/x-pack/plugins/cases/public/components/create/owner_selector.tsx
@@ -101,6 +101,7 @@ const OwnerSelector = ({
     </EuiFormRow>
   );
 };
+OwnerSelector.displayName = 'OwnerSelector';
 
 const CaseOwnerSelector: React.FC<Props> = ({ availableOwners, isLoading }) => {
   return (

--- a/x-pack/plugins/cases/public/components/create/submit_button.tsx
+++ b/x-pack/plugins/cases/public/components/create/submit_button.tsx
@@ -27,5 +27,6 @@ const SubmitCaseButtonComponent: React.FC = () => {
     </EuiButton>
   );
 };
+SubmitCaseButtonComponent.displayName = 'SubmitCaseButton';
 
 export const SubmitCaseButton = memo(SubmitCaseButtonComponent);

--- a/x-pack/plugins/cases/public/components/formatted_date/index.tsx
+++ b/x-pack/plugins/cases/public/components/formatted_date/index.tsx
@@ -142,6 +142,7 @@ export const FormattedRelativePreferenceDate = ({ value }: { value?: string | nu
     </LocalizedDateTooltip>
   );
 };
+FormattedRelativePreferenceDate.displayName = 'FormattedRelativePreferenceDate';
 
 /**
  * Renders a preceding label according to under/over one hour

--- a/x-pack/plugins/cases/public/components/header_page/__snapshots__/editable_title.test.tsx.snap
+++ b/x-pack/plugins/cases/public/components/header_page/__snapshots__/editable_title.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`EditableTitle it renders 1`] = `
   <EuiFlexItem
     grow={false}
   >
-    <Memo(TitleComponent)
+    <Memo(Title)
       title="Test title"
     />
   </EuiFlexItem>

--- a/x-pack/plugins/cases/public/components/header_page/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/cases/public/components/header_page/__snapshots__/index.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`HeaderPage it renders 1`] = `
     alignItems="center"
   >
     <FlexItem>
-      <Memo(TitleComponent)
+      <Memo(Title)
         badgeOptions={
           Object {
             "beta": true,

--- a/x-pack/plugins/cases/public/components/header_page/__snapshots__/title.test.tsx.snap
+++ b/x-pack/plugins/cases/public/components/header_page/__snapshots__/title.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Title it renders 1`] = `
   <h1
     data-test-subj="header-page-title"
   >
-    <Memo(TruncatedTextComponent)
+    <Memo(TruncatedText)
       text="Test title"
     />
      

--- a/x-pack/plugins/cases/public/components/header_page/editable_title.tsx
+++ b/x-pack/plugins/cases/public/components/header_page/editable_title.tsx
@@ -134,5 +134,6 @@ const EditableTitleComponent: React.FC<EditableTitleProps> = ({
     </EuiFlexGroup>
   );
 };
+EditableTitleComponent.displayName = 'EditableTitle';
 
 export const EditableTitle = React.memo(EditableTitleComponent);

--- a/x-pack/plugins/cases/public/components/header_page/index.tsx
+++ b/x-pack/plugins/cases/public/components/header_page/index.tsx
@@ -127,5 +127,6 @@ const HeaderPageComponent: React.FC<HeaderPageProps> = ({
     </Header>
   );
 };
+HeaderPageComponent.displayName = 'HeaderPage';
 
 export const HeaderPage = React.memo(HeaderPageComponent);

--- a/x-pack/plugins/cases/public/components/header_page/title.tsx
+++ b/x-pack/plugins/cases/public/components/header_page/title.tsx
@@ -52,5 +52,6 @@ const TitleComponent: React.FC<Props> = ({ title, badgeOptions }) => (
     </h1>
   </EuiTitle>
 );
+TitleComponent.displayName = 'Title';
 
 export const Title = React.memo(TitleComponent);

--- a/x-pack/plugins/cases/public/components/markdown_editor/markdown_link.tsx
+++ b/x-pack/plugins/cases/public/components/markdown_editor/markdown_link.tsx
@@ -31,5 +31,6 @@ const MarkdownLinkComponent: React.FC<MarkdownLinkProps> = ({
     </EuiLink>
   </EuiToolTip>
 );
+MarkdownLinkComponent.displayName = 'MarkdownLink';
 
 export const MarkdownLink = memo(MarkdownLinkComponent);

--- a/x-pack/plugins/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
+++ b/x-pack/plugins/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
@@ -375,6 +375,7 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
     </ModalContainer>
   );
 };
+LensEditorComponent.displayName = 'LensEditor';
 
 export const LensEditor = React.memo(LensEditorComponent);
 

--- a/x-pack/plugins/cases/public/components/markdown_editor/plugins/lens/processor.tsx
+++ b/x-pack/plugins/cases/public/components/markdown_editor/plugins/lens/processor.tsx
@@ -55,5 +55,6 @@ const LensMarkDownRendererComponent: React.FC<LensMarkDownRendererProps> = ({
     </Container>
   );
 };
+LensMarkDownRendererComponent.displayName = 'LensMarkDownRenderer';
 
 export const LensMarkDownRenderer = React.memo(LensMarkDownRendererComponent);

--- a/x-pack/plugins/cases/public/components/markdown_editor/renderer.tsx
+++ b/x-pack/plugins/cases/public/components/markdown_editor/renderer.tsx
@@ -46,5 +46,6 @@ const MarkdownRendererComponent: React.FC<Props> = ({ children, disableLinks }) 
     </EuiMarkdownFormat>
   );
 };
+MarkdownRendererComponent.displayName = 'MarkdownRenderer';
 
 export const MarkdownRenderer = memo(MarkdownRendererComponent);

--- a/x-pack/plugins/cases/public/components/recent_cases/recent_cases.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/recent_cases.tsx
@@ -91,3 +91,4 @@ export const RecentCasesComp = ({ filterOptions, maxCasesToShow }: RecentCasesPr
     </>
   );
 };
+RecentCasesComp.displayName = 'RecentCasesComp';

--- a/x-pack/plugins/cases/public/components/status/button.tsx
+++ b/x-pack/plugins/cases/public/components/status/button.tsx
@@ -42,4 +42,5 @@ const StatusActionButtonComponent: React.FC<Props> = ({ status, onStatusChanged,
     </EuiButton>
   );
 };
+StatusActionButtonComponent.displayName = 'StatusActionButton';
 export const StatusActionButton = memo(StatusActionButtonComponent);

--- a/x-pack/plugins/cases/public/components/status/status.tsx
+++ b/x-pack/plugins/cases/public/components/status/status.tsx
@@ -46,5 +46,6 @@ const StatusComponent: React.FC<Props> = ({
     </EuiBadge>
   );
 };
+StatusComponent.displayName = 'Status';
 
 export const Status = memo(StatusComponent);

--- a/x-pack/plugins/cases/public/components/tag_list/tags.tsx
+++ b/x-pack/plugins/cases/public/components/tag_list/tags.tsx
@@ -30,5 +30,6 @@ const TagsComponent: React.FC<TagsProps> = ({ tags, color = 'default', gutterSiz
     )}
   </>
 );
+TagsComponent.displayName = 'Tags';
 
 export const Tags = memo(TagsComponent);

--- a/x-pack/plugins/cases/public/components/truncated_text/index.tsx
+++ b/x-pack/plugins/cases/public/components/truncated_text/index.tsx
@@ -26,5 +26,6 @@ interface Props {
 const TruncatedTextComponent: React.FC<Props> = ({ text }) => {
   return <Text title={text}>{text}</Text>;
 };
+TruncatedTextComponent.displayName = 'TruncatedText';
 
 export const TruncatedText = React.memo(TruncatedTextComponent);

--- a/x-pack/plugins/cases/public/components/use_create_case_modal/create_case_modal.tsx
+++ b/x-pack/plugins/cases/public/components/use_create_case_modal/create_case_modal.tsx
@@ -40,6 +40,7 @@ const CreateModalComponent: React.FC<CreateCaseModalProps> = ({
       </EuiModalBody>
     </EuiModal>
   ) : null;
+CreateModalComponent.displayName = 'CreateModal';
 
 export const CreateCaseModal = memo(CreateModalComponent);
 

--- a/x-pack/plugins/cases/public/components/use_push_to_service/callout/callout.tsx
+++ b/x-pack/plugins/cases/public/components/use_push_to_service/callout/callout.tsx
@@ -68,5 +68,6 @@ const CallOutComponent = ({
     </EuiCallOut>
   ) : null;
 };
+CallOutComponent.displayName = 'CallOut';
 
 export const CallOut = memo(CallOutComponent);

--- a/x-pack/plugins/cases/public/components/use_push_to_service/callout/index.tsx
+++ b/x-pack/plugins/cases/public/components/use_push_to_service/callout/index.tsx
@@ -89,5 +89,6 @@ const CaseCallOutComponent = ({
     </>
   );
 };
+CaseCallOutComponent.displayName = 'CaseCallOut';
 
 export const CaseCallOut = memo(CaseCallOutComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/avatar.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/avatar.tsx
@@ -20,5 +20,6 @@ const UserActionAvatarComponent = ({ username, fullName, size = 'm' }: UserActio
   const avatarName = fullName && fullName.length > 0 ? fullName : username ?? i18n.UNKNOWN;
   return <EuiAvatar name={avatarName} data-test-subj={`user-action-avatar`} size={size} />;
 };
+UserActionAvatarComponent.displayName = 'UserActionAvatar';
 
 export const UserActionAvatar = memo(UserActionAvatarComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/avatar_username.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/avatar_username.tsx
@@ -34,5 +34,6 @@ const UserActionUsernameWithAvatarComponent = ({
     </EuiFlexItem>
   </EuiFlexGroup>
 );
+UserActionUsernameWithAvatarComponent.displayName = 'UserActionUsernameWithAvatar';
 
 export const UserActionUsernameWithAvatar = memo(UserActionUsernameWithAvatarComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/comment/alert_event.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/alert_event.tsx
@@ -63,5 +63,6 @@ const AlertCommentEventComponent: React.FC<Props> = ({
     </>
   );
 };
+AlertCommentEventComponent.displayName = 'AlertCommentEvent';
 
 export const AlertCommentEvent = memo(AlertCommentEventComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/comment/host_isolation_event.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/host_isolation_event.tsx
@@ -52,5 +52,6 @@ const HostIsolationCommentEventComponent: React.FC<Props> = ({
     </>
   );
 };
+HostIsolationCommentEventComponent.displayName = 'HostIsolationCommentEvent';
 
 export const HostIsolationCommentEvent = memo(HostIsolationCommentEventComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/comment/show_alert.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/show_alert.tsx
@@ -38,5 +38,6 @@ const UserActionShowAlertComponent = ({
     </EuiToolTip>
   );
 };
+UserActionShowAlertComponent.displayName = 'UserActionShowAlert';
 
 export const UserActionShowAlert = memo(UserActionShowAlertComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/comment/user.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/user.tsx
@@ -43,7 +43,7 @@ export const createUserAttachmentUserActionBuilder = ({
   handleSaveComment,
   handleManageQuote,
 }: BuilderArgs): ReturnType<UserActionBuilder> => ({
-  build: Builder() => [
+  build: () => [
     {
       username: (
         <UserActionUsername

--- a/x-pack/plugins/cases/public/components/user_actions/comment/user.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/user.tsx
@@ -43,7 +43,7 @@ export const createUserAttachmentUserActionBuilder = ({
   handleSaveComment,
   handleManageQuote,
 }: BuilderArgs): ReturnType<UserActionBuilder> => ({
-  build: () => [
+  build: Builder() => [
     {
       username: (
         <UserActionUsername

--- a/x-pack/plugins/cases/public/components/user_actions/content_toolbar.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/content_toolbar.tsx
@@ -50,5 +50,6 @@ const UserActionContentToolbarComponent = ({
     </EuiFlexItem>
   </EuiFlexGroup>
 );
+UserActionContentToolbarComponent.displayName = 'UserActionContentToolbar';
 
 export const UserActionContentToolbar = memo(UserActionContentToolbarComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/copy_link.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/copy_link.tsx
@@ -36,5 +36,6 @@ const UserActionCopyLinkComponent = ({ id: commentId }: UserActionCopyLinkProps)
     </EuiToolTip>
   );
 };
+UserActionCopyLinkComponent.displayName = 'UserActionCopyLink';
 
 export const UserActionCopyLink = memo(UserActionCopyLinkComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/move_to_reference.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/move_to_reference.tsx
@@ -34,5 +34,6 @@ const UserActionMoveToReferenceComponent = ({
     </EuiToolTip>
   );
 };
+UserActionMoveToReferenceComponent.displayName = 'UserActionMoveToReference';
 
 export const UserActionMoveToReference = memo(UserActionMoveToReferenceComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions.tsx
@@ -69,5 +69,6 @@ const UserActionPropertyActionsComponent = ({
     </>
   );
 };
+UserActionPropertyActionsComponent.displayName = 'UserActionPropertyActions';
 
 export const UserActionPropertyActions = memo(UserActionPropertyActionsComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/timestamp.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/timestamp.tsx
@@ -41,5 +41,6 @@ const UserActionTimestampComponent = ({ createdAt, updatedAt }: UserActionAvatar
     )}
   </>
 );
+UserActionTimestampComponent.displayName = 'UserActionTimestamp';
 
 export const UserActionTimestamp = memo(UserActionTimestampComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/username.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/username.tsx
@@ -28,5 +28,6 @@ const UserActionUsernameComponent = ({ username, fullName }: UserActionUsernameP
     </EuiToolTip>
   );
 };
+UserActionUsernameComponent.displayName = 'UserActionUsername';
 
 export const UserActionUsername = memo(UserActionUsernameComponent);


### PR DESCRIPTION
## Summary

First part of https://github.com/elastic/kibana/issues/123375

This PR will fix most[1] of the existing components missing a displayName using the `ignoreTranspilerName` of the `react/display-name` linting rule.

[1] most because there are inlined components where a longer refactor is required to set a displayName. e.g.:

![image](https://user-images.githubusercontent.com/227916/150356048-8687d2b1-5e4c-4603-af82-28e7ac2da748.png)

in this case the react component is an anonymous function and enabling `ignoreTranspilerName` will make this file fail but it is harder to auto-fix. 

All these files were "auto-fixed" using a custom fixing script. https://gist.github.com/academo/f2bc72d733e6fe1d5960b3b9b37247ae (no fingers were exhausted typing all these changes by hand)