### PR TITLE
[App Search] Prevent negative boost values in Relevance Tuning UI

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item_content/boost_item_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item_content/boost_item_content.tsx
@@ -55,7 +55,7 @@ export const BoostItemContent: React.FC<Props> = ({ boost, index, name }) => {
         fullWidth
       >
         <EuiRange
-          min={-10}
+          min={0}
           max={10}
           step={0.1}
           value={boost.factor}


### PR DESCRIPTION
## Summary

Recently a [change](https://github.com/elastic/app-search-team/issues/1833) was made to the Enterprise Search API to prevent negative boost values. This PR adjusts the UI code to prevent the values from being set with the slider.

| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/1869731/150366905-ebdc9c58-04fb-427c-a03b-91a53c687068.gif)  | ![after](https://user-images.githubusercontent.com/1869731/150366952-a70b0cb6-e551-4acc-bd3e-534c535e459d.gif) |
