### PR TITLE
[Uptime] Make duration line series use `local` for time zone value

### DIFF
--- a/x-pack/plugins/uptime/public/components/common/charts/duration_line_series_list.tsx
+++ b/x-pack/plugins/uptime/public/components/common/charts/duration_line_series_list.tsx
@@ -31,6 +31,7 @@ export const DurationLineSeriesList = ({ monitorType, lines }: Props) => (
         yAccessors={[1]}
         yScaleType={ScaleType.Linear}
         fit={Fit.Linear}
+        timeZone="local"
         tickFormat={(d) =>
           monitorType === 'browser'
             ? `${microToSec(d)} ${SEC_LABEL}`


### PR DESCRIPTION
## Summary

Resolves #123466.

As part of a recent version upgrade for Elastic Charts, we missed that the time zone value for the duration series on the Uptime detail page no longer displays values in accordance with the rest of the plugin.

This patch will fix the disparity.

## Testing this PR

The results of this patch are easily observable. See the linked issue for detailed repro steps.

### Before

![image](https://user-images.githubusercontent.com/18429259/150365115-935a8fb0-8e80-4b91-8442-a0a8da9d9706.png)

### After

![image](https://user-images.githubusercontent.com/18429259/150367492-bc498b68-c680-49c9-a271-25f95bad1355.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
