### PR TITLE
[charts] Fix timezone regression in charts

### DIFF
--- a/x-pack/plugins/apm/public/components/app/RumDashboard/Charts/PageViewsChart.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/Charts/PageViewsChart.tsx
@@ -117,6 +117,7 @@ export function PageViewsChart({ data, loading }: Props) {
             labelFormat={(d) => numeral(d).format('0a')}
           />
           <BarSeries
+            timeZone="local"
             id={I18LABELS.pageViews}
             xScaleType={ScaleType.Time}
             yScaleType={ScaleType.Linear}

--- a/x-pack/plugins/apm/public/components/app/service_profiling/service_profiling_timeline.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_profiling/service_profiling_timeline.tsx
@@ -94,6 +94,7 @@ export function ServiceProfilingTimeline({
           {specs.map((spec) => (
             <BarSeries
               {...spec}
+              timeZone="local"
               key={spec.id}
               xScaleType={ScaleType.Time}
               yScaleType={ScaleType.Linear}

--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -106,6 +106,7 @@ export function SparkPlot({
               xAccessor={'x'}
               yAccessors={['y']}
               data={series}
+              timeZone="local"
               color={colorValue}
               curve={CurveType.CURVE_MONOTONE_X}
             />
@@ -117,6 +118,7 @@ export function SparkPlot({
                 xAccessor={'x'}
                 yAccessors={['y']}
                 data={comparisonSeries}
+                timeZone="local"
                 color={theme.eui.euiColorLightestShade}
                 curve={CurveType.CURVE_MONOTONE_X}
               />

--- a/x-pack/plugins/data_visualizer/public/application/common/components/document_count_content/document_count_chart/document_count_chart.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/document_count_content/document_count_chart/document_count_chart.tsx
@@ -138,6 +138,7 @@ export const DocumentCountChart: FC<Props> = ({
           xAccessor="time"
           yAccessors={['value']}
           data={adjustedChartPoints}
+          timeZone="local"
         />
       </Chart>
     </div>

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -442,6 +442,7 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({ jobId, end, 
                           yAccessors={[1]}
                           data={sourceData}
                           curve={CurveType.LINEAR}
+                          timeZone="local"
                         />
                         <LineSeries
                           key={'job-results'}
@@ -455,6 +456,7 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({ jobId, end, 
                           yAccessors={[1]}
                           data={bucketData}
                           curve={CurveType.LINEAR}
+                          timeZone="local"
                         />
                       </Chart>
                     </div>

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/anomaly_chart/model_bounds.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/anomaly_chart/model_bounds.tsx
@@ -44,6 +44,7 @@ export const ModelBounds: FC<Props> = ({ modelData }) => {
       curve={CurveType.CURVE_MONOTONE_X}
       areaSeriesStyle={areaSeriesStyle}
       color={MODEL_COLOR}
+      timeZone="local"
     />
   );
 };

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/event_rate_chart/event_rate_chart.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/event_rate_chart/event_rate_chart.tsx
@@ -90,6 +90,7 @@ export const EventRateChart: FC<Props> = ({
             yAccessors={['value']}
             data={eventRateChartData}
             color={barColor}
+            timeZone="local"
           />
         </Chart>
       </LoadingWrapper>

--- a/x-pack/plugins/observability/public/components/app/section/apm/index.tsx
+++ b/x-pack/plugins/observability/public/components/app/section/apm/index.tsx
@@ -142,6 +142,7 @@ export function APMSection({ bucketSize }: Props) {
               xAccessor={'x'}
               yAccessors={['y']}
               color={transactionsColor}
+              timeZone="local"
             />
             <Axis
               id="y-axis"

--- a/x-pack/plugins/observability/public/components/app/section/metrics/metric_with_sparkline.tsx
+++ b/x-pack/plugins/observability/public/components/app/section/metrics/metric_with_sparkline.tsx
@@ -53,6 +53,7 @@ export function MetricWithSparkline({ id, formatter, value, timeseries, color }:
             xAccessor={'timestamp'}
             yAccessors={[id]}
             color={colors[color] || '#006BB4'}
+            timeZone="local"
           />
         </Chart>
       </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/alerts_histogram.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/alerts_histogram.tsx
@@ -99,6 +99,7 @@ export const AlertsHistogram = React.memo<AlertsHistogramProps>(
                 yAccessors={yAccessors}
                 splitSeriesAccessors={splitSeriesAccessors}
                 data={data}
+                timeZone={'local'}
               />
             </Chart>
           </EuiFlexItem>

--- a/x-pack/plugins/uptime/public/components/common/charts/duration_line_series_list.tsx
+++ b/x-pack/plugins/uptime/public/components/common/charts/duration_line_series_list.tsx
@@ -23,6 +23,7 @@ export const DurationLineSeriesList = ({ monitorType, lines }: Props) => (
         curve={CurveType.CURVE_MONOTONE_X}
         // this id is used for the line chart representing the average duration length
         data={line.map(({ x, y }) => [x, y || null])}
+        timeZone="local"
         id={`loc-avg-${name}`}
         key={`loc-line-${name}`}
         name={name}


### PR DESCRIPTION
## Summary

We introduced a regression that causes time series charts without a `timezone` configured to be rendered with `UTC` by default instead of the `local` timezone.
We already have fixed the bug in charts [here](https://github.com/elastic/elastic-charts/pull/1544) and the dependency is updated already in versions [7.17](https://github.com/elastic/kibana/pull/123264),  [8.0.1](https://github.com/elastic/kibana/pull/123265), [8.1](https://github.com/elastic/kibana/pull/121593)  but we are missing `8.0` since we are really close to the next RC.

This PR brings back the default behavior marking all time-series with no `timezone` parameter using the `local` timezone.

I will forward these changes to `7.17`, `8.1`, `main` in a different PR to land this PR sooner as it has a higher priority