### PR TITLE
[Security Solution][Explore] Fixes advanced settings default message at the overview page

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/news_feed/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/news_feed/translations.ts
@@ -22,6 +22,6 @@ export const NO_NEWS_MESSAGE_ADMIN = i18n.translate(
 export const ADVANCED_SETTINGS_LINK_TITLE = i18n.translate(
   'xpack.securitySolution.newsFeed.advancedSettingsLinkTitle',
   {
-    defaultMessage: 'SIEM advanced settings',
+    defaultMessage: 'Security Solution advanced settings',
   }
 );


### PR DESCRIPTION
## Summary

When reviewing the ticket https://github.com/elastic/kibana/issues/122654 I saw we are using SIEM instead of Security Solution in the default message when there are no Security News

![image](https://user-images.githubusercontent.com/17427073/150372782-e17a5fa2-dceb-4f05-91fe-d6e62263c81a.png)

In this PR we are fixing this and now we are displaying Security Solution instead.

<img width="758" alt="Screenshot 2022-01-20 at 17 13 26" src="https://user-images.githubusercontent.com/17427073/150378085-59fe988e-2bb4-4e3a-b9af-a51b5ce0d018.png">

