### PR TITLE
[Rule Registry] Remove constant_keyword field mappings from ECS component template

### DIFF
--- a/x-pack/plugins/rule_registry/common/assets/field_maps/ecs_field_map.ts
+++ b/x-pack/plugins/rule_registry/common/assets/field_maps/ecs_field_map.ts
@@ -415,21 +415,6 @@ export const ecsFieldMap = {
     array: false,
     required: false,
   },
-  'data_stream.dataset': {
-    type: 'constant_keyword',
-    array: false,
-    required: false,
-  },
-  'data_stream.namespace': {
-    type: 'constant_keyword',
-    array: false,
-    required: false,
-  },
-  'data_stream.type': {
-    type: 'constant_keyword',
-    array: false,
-    required: false,
-  },
   'destination.address': {
     type: 'keyword',
     array: false,

--- a/x-pack/plugins/rule_registry/scripts/generate_ecs_fieldmap/index.js
+++ b/x-pack/plugins/rule_registry/scripts/generate_ecs_fieldmap/index.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 const util = require('util');
 const yaml = require('js-yaml');
 const { exec: execCb } = require('child_process');
-const { mapValues } = require('lodash');
+const { reduce } = require('lodash');
 
 const exists = util.promisify(fs.exists);
 const readFile = util.promisify(fs.readFile);
@@ -32,19 +32,27 @@ async function generate() {
 
   const flatYaml = await yaml.safeLoad(await readFile(ecsYamlFilename));
 
-  const fields = mapValues(flatYaml, (description) => {
-    const field = {
-      type: description.type,
-      array: description.normalize.includes('array'),
-      required: !!description.required,
-    };
+  const fields = reduce(
+    flatYaml,
+    (fieldsObj, value, key) => {
+      const field = {
+        type: value.type,
+        array: value.normalize.includes('array'),
+        required: !!value.required,
+      };
 
-    if (description.scaling_factor) {
-      field.scaling_factor = description.scaling_factor;
-    }
+      if (value.scaling_factor) {
+        field.scaling_factor = value.scaling_factor;
+      }
 
-    return field;
-  });
+      if (field.type !== 'constant_keyword') {
+        fieldsObj[key] = field;
+      }
+
+      return fieldsObj;
+    },
+    {}
+  );
 
   await Promise.all([
     writeFile(


### PR DESCRIPTION
## Summary
These ECS fields are meant for specific indices (datastreams), but do
not make sense (especially as `constant_keyword`) on our alerts-as-data
indices, as they will cause errors when attempting to ingest different
values from different indices.

Addresses https://github.com/elastic/kibana/issues/123420.



### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
