### PR TITLE
[Security Solution][Endpoint] Fix endpointAppContextServices use of `calculateEndpointAuthz`

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -139,7 +139,9 @@ export class EndpointAppContextService {
 
   public async getEndpointAuthz(request: KibanaRequest): Promise<EndpointAuthz> {
     const fleetAuthz = await this.getFleetAuthzService().fromRequest(request);
-    return calculateEndpointAuthz(this.getLicenseService(), fleetAuthz);
+    const userRoles = this.startDependencies?.security.authc.getCurrentUser(request)?.roles ?? [];
+
+    return calculateEndpointAuthz(this.getLicenseService(), fleetAuthz, userRoles);
   }
 
   public getEndpointMetadataService(): EndpointMetadataService {


### PR DESCRIPTION
## Summary

- ensure that `calculateEndpointAuthz()` of EndpointAppContextServices is given user roles

Fix merge run condition with two prior PR I merged just seconds apart
