### PR TITLE
[Security Solutions] Fixes "Saved Query Rule" to be grouped under "Security" instead of "Security-solution"

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/saved_query/create_saved_query_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/saved_query/create_saved_query_alert_type.ts
@@ -7,6 +7,7 @@
 
 import { validateNonExact } from '@kbn/securitysolution-io-ts-utils';
 import { SAVED_QUERY_RULE_TYPE_ID } from '@kbn/securitysolution-rules';
+import { SERVER_APP_ID } from '../../../../../common/constants';
 
 import {
   CompleteRule,
@@ -50,7 +51,7 @@ export const createSavedQueryAlertType = (
     },
     minimumLicenseRequired: 'basic',
     isExportable: false,
-    producer: 'security-solution',
+    producer: SERVER_APP_ID,
     async executor(execOptions) {
       const {
         runOpts: {


### PR DESCRIPTION
## Summary

See:
https://github.com/elastic/kibana/issues/123500

This is a one line fix to change the `producer` to be the `SERVER_APP_ID` like the others

Before:
<img width="1700" alt="Screen Shot 2022-01-20 at 11 51 17 AM" src="https://user-images.githubusercontent.com/1151048/150410877-7c2da681-9d66-4fb8-9f17-b6015f683cf2.png">

After:
<img width="421" alt="Screen Shot 2022-01-20 at 12 39 05 PM" src="https://user-images.githubusercontent.com/1151048/150410905-12772489-ebd6-4450-8715-de8d651cff40.png">

