### PR TITLE
[7.17] fixes advanced seetings default message (#123480)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/news_feed/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/news_feed/translations.ts
@@ -22,6 +22,6 @@ export const NO_NEWS_MESSAGE_ADMIN = i18n.translate(
 export const ADVANCED_SETTINGS_LINK_TITLE = i18n.translate(
   'xpack.securitySolution.newsFeed.advancedSettingsLinkTitle',
   {
-    defaultMessage: 'SIEM advanced settings',
+    defaultMessage: 'Security Solution advanced settings',
   }
 );


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #123480

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
