### PR TITLE
[Synthetics Service] Make service keys optional

### DIFF
--- a/x-pack/plugins/uptime/common/config.ts
+++ b/x-pack/plugins/uptime/common/config.ts
@@ -10,10 +10,10 @@ import { schema, TypeOf } from '@kbn/config-schema';
 import { sslSchema } from '@kbn/server-http-tools';
 
 const serviceConfig = schema.object({
-  enabled: schema.boolean(),
+  enabled: schema.maybe(schema.boolean()),
   username: schema.maybe(schema.string()),
   password: schema.maybe(schema.string()),
-  manifestUrl: schema.string(),
+  manifestUrl: schema.maybe(schema.string()),
   hosts: schema.maybe(schema.arrayOf(schema.string())),
   syncInterval: schema.maybe(schema.string()),
   tls: schema.maybe(sslSchema),

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.ts
@@ -12,8 +12,13 @@ import {
   ServiceLocationsApiResponse,
 } from '../../../common/runtime_types';
 
-export async function getServiceLocations({ manifestUrl }: { manifestUrl: string }) {
+export async function getServiceLocations({ manifestUrl }: { manifestUrl?: string }) {
   const locations: ServiceLocations = [];
+
+  if (!manifestUrl) {
+    return { locations };
+  }
+
   try {
     const { data } = await axios.get<{ locations: Record<string, ManifestLocation> }>(manifestUrl);
 

--- a/x-pack/plugins/uptime/server/rest_api/synthetics_service/get_service_locations.ts
+++ b/x-pack/plugins/uptime/server/rest_api/synthetics_service/get_service_locations.ts
@@ -14,5 +14,5 @@ export const getServiceLocationsRoute: UMRestApiRouteFactory = () => ({
   path: API_URLS.SERVICE_LOCATIONS,
   validate: {},
   handler: async ({ server }): Promise<any> =>
-    getServiceLocations({ manifestUrl: server.config.service!.manifestUrl }),
+    getServiceLocations({ manifestUrl: server.config.service!.manifestUrl! }),
 });


### PR DESCRIPTION
## Summary

With PR in cloud merged https://github.com/elastic/cloud-assets/pull/947

We need to make rest of the keys in the config schema optional.

```
xpack.uptime.service.tls.certificate: 
xpack.uptime.service.tls.key: 
```

Just setting above two keys should be possible in kibana
