### PR TITLE
[plugin-helpers/tests] filter out ci-stats warnings

### DIFF
--- a/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
@@ -60,7 +60,12 @@ it('builds a generated plugin into a viable archive', async () => {
     }
   );
 
-  expect(buildProc.all).toMatchInlineSnapshot(`
+  expect(
+    buildProc.all
+      ?.split('\n')
+      .filter((l) => !l.includes('failed to reach ci-stats service'))
+      .join('\n')
+  ).toMatchInlineSnapshot(`
     " info deleting the build and target directories
      info running @kbn/optimizer
      │ info initialized, 0 bundles cached


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/89079

ci-stats is sometimes unreachable, and oddly enough it's pretty common for GCP to have trouble reaching it (even though we run it on Cloud Run) so these warning messages end up in the log output being checked. This change filters those log lines out when comparing to the snapshot.