### PR TITLE
[Maps][ML] Integration follow up: adds partition field info to map point tooltip if available

### DIFF
--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -29,13 +29,13 @@ import type { SourceEditorArgs } from '../../../maps/public';
 import type { DataRequest } from '../../../maps/public';
 import type { IVectorSource, SourceStatus } from '../../../maps/public';
 import { ML_ANOMALY } from './anomaly_source_factory';
-import { getResultsForJobId, MlAnomalyLayers } from './util';
+import { getResultsForJobId, ML_ANOMALY_LAYERS } from './util';
 import { UpdateAnomalySourceEditor } from './update_anomaly_source_editor';
 import type { MlApiServices } from '../application/services/ml_api_service';
 
 export interface AnomalySourceDescriptor extends AbstractSourceDescriptor {
   jobId: string;
-  typicalActual: MlAnomalyLayers;
+  typicalActual: ML_ANOMALY_LAYERS;
 }
 
 export class AnomalySource implements IVectorSource {
@@ -50,7 +50,7 @@ export class AnomalySource implements IVectorSource {
     return {
       type: ML_ANOMALY,
       jobId: descriptor.jobId,
-      typicalActual: descriptor.typicalActual || 'actual',
+      typicalActual: descriptor.typicalActual || ML_ANOMALY_LAYERS.ACTUAL,
     };
   }
 

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -232,7 +232,7 @@ export class AnomalySource implements IVectorSource {
   }
 
   async getSupportedShapeTypes(): Promise<VECTOR_SHAPE_TYPE[]> {
-    return this._descriptor.typicalActual === 'connected'
+    return this._descriptor.typicalActual === 'typical to actual'
       ? [VECTOR_SHAPE_TYPE.LINE]
       : [VECTOR_SHAPE_TYPE.POINT];
   }
@@ -251,6 +251,9 @@ export class AnomalySource implements IVectorSource {
         const label = ANOMALY_SOURCE_FIELDS[key]?.label;
         if (label) {
           tooltipProperties.push(new AnomalySourceTooltipProperty(label, properties[key]));
+        } else if (!ANOMALY_SOURCE_FIELDS[key]) {
+          // partition field keys will be different each time so won't be in ANOMALY_SOURCE_FIELDS
+          tooltipProperties.push(new AnomalySourceTooltipProperty(key, properties[key]));
         }
       }
     }

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -29,13 +29,13 @@ import type { SourceEditorArgs } from '../../../maps/public';
 import type { DataRequest } from '../../../maps/public';
 import type { IVectorSource, SourceStatus } from '../../../maps/public';
 import { ML_ANOMALY } from './anomaly_source_factory';
-import { getResultsForJobId, ML_ANOMALY_LAYERS } from './util';
+import { getResultsForJobId, ML_ANOMALY_LAYERS, MlAnomalyLayersType } from './util';
 import { UpdateAnomalySourceEditor } from './update_anomaly_source_editor';
 import type { MlApiServices } from '../application/services/ml_api_service';
 
 export interface AnomalySourceDescriptor extends AbstractSourceDescriptor {
   jobId: string;
-  typicalActual: ML_ANOMALY_LAYERS;
+  typicalActual: MlAnomalyLayersType;
 }
 
 export class AnomalySource implements IVectorSource {

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -232,7 +232,7 @@ export class AnomalySource implements IVectorSource {
   }
 
   async getSupportedShapeTypes(): Promise<VECTOR_SHAPE_TYPE[]> {
-    return this._descriptor.typicalActual === 'typical to actual'
+    return this._descriptor.typicalActual === ML_ANOMALY_LAYERS.TYPICAL_TO_ACTUAL
       ? [VECTOR_SHAPE_TYPE.LINE]
       : [VECTOR_SHAPE_TYPE.POINT];
   }

--- a/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
@@ -40,6 +40,7 @@ export const ANOMALY_SOURCE_FIELDS: Record<string, Record<string, string>> = {
     }),
     type: 'string',
   },
+  // this value is only used to place the point on the map
   actual: {},
   actualDisplay: {
     label: i18n.translate('xpack.ml.maps.anomalyLayerActualLabel', {
@@ -47,6 +48,7 @@ export const ANOMALY_SOURCE_FIELDS: Record<string, Record<string, string>> = {
     }),
     type: 'string',
   },
+  // this value is only used to place the point on the map
   typical: {},
   typicalDisplay: {
     label: i18n.translate('xpack.ml.maps.anomalyLayerTypicalLabel', {

--- a/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
@@ -52,6 +52,42 @@ export const ANOMALY_SOURCE_FIELDS: Record<string, Record<string, string>> = {
     }),
     type: 'string',
   },
+  partition_field_name: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerPartitionFieldNameLabel', {
+      defaultMessage: 'Partition field name',
+    }),
+    type: 'string',
+  },
+  partition_field_value: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerPartitionFieldValueLabel', {
+      defaultMessage: 'Partition field value',
+    }),
+    type: 'string',
+  },
+  by_field_name: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerByFieldNameLabel', {
+      defaultMessage: 'By field name',
+    }),
+    type: 'string',
+  },
+  by_field_value: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerByFieldValueLabel', {
+      defaultMessage: 'By field value',
+    }),
+    type: 'string',
+  },
+  over_field_name: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerOverFieldNameLabel', {
+      defaultMessage: 'Over field name',
+    }),
+    type: 'string',
+  },
+  over_field_value: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerOverFieldValueLabel', {
+      defaultMessage: 'Over field value',
+    }),
+    type: 'string',
+  },
 };
 
 export class AnomalySourceTooltipProperty implements ITooltipProperty {

--- a/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
@@ -40,12 +40,14 @@ export const ANOMALY_SOURCE_FIELDS: Record<string, Record<string, string>> = {
     }),
     type: 'string',
   },
+  actual: {},
   actualDisplay: {
     label: i18n.translate('xpack.ml.maps.anomalyLayerActualLabel', {
       defaultMessage: 'Actual',
     }),
     type: 'string',
   },
+  typical: {},
   typicalDisplay: {
     label: i18n.translate('xpack.ml.maps.anomalyLayerTypicalLabel', {
       defaultMessage: 'Typical',

--- a/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
@@ -15,6 +15,16 @@ import { AnomalySource } from './anomaly_source';
 import { ITooltipProperty } from '../../../maps/public';
 import { Filter } from '../../../../../src/plugins/data/public';
 
+export const ACTUAL_LABEL = i18n.translate('xpack.ml.maps.anomalyLayerActualLabel', {
+  defaultMessage: 'Actual',
+});
+export const TYPICAL_LABEL = i18n.translate('xpack.ml.maps.anomalyLayerTypicalLabel', {
+  defaultMessage: 'Typical',
+});
+export const TYPICAL_TO_ACTUAL = i18n.translate('xpack.ml.maps.anomalyLayerTypicalToActualLabel', {
+  defaultMessage: 'Typical to actual',
+});
+
 export const ANOMALY_SOURCE_FIELDS: Record<string, Record<string, string>> = {
   record_score: {
     label: i18n.translate('xpack.ml.maps.anomalyLayerRecordScoreLabel', {
@@ -43,17 +53,13 @@ export const ANOMALY_SOURCE_FIELDS: Record<string, Record<string, string>> = {
   // this value is only used to place the point on the map
   actual: {},
   actualDisplay: {
-    label: i18n.translate('xpack.ml.maps.anomalyLayerActualLabel', {
-      defaultMessage: 'Actual',
-    }),
+    label: ACTUAL_LABEL,
     type: 'string',
   },
   // this value is only used to place the point on the map
   typical: {},
   typicalDisplay: {
-    label: i18n.translate('xpack.ml.maps.anomalyLayerTypicalLabel', {
-      defaultMessage: 'Typical',
-    }),
+    label: TYPICAL_LABEL,
     type: 'string',
   },
   partition_field_name: {

--- a/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
@@ -11,7 +11,7 @@ import { EuiPanel } from '@elastic/eui';
 import { AnomalySourceDescriptor } from './anomaly_source';
 import { AnomalyJobSelector } from './anomaly_job_selector';
 import { LayerSelector } from './layer_selector';
-import { ML_ANOMALY_LAYERS } from './util';
+import { ML_ANOMALY_LAYERS, MlAnomalyLayersType } from './util';
 import type { MlApiServices } from '../application/services/ml_api_service';
 
 interface Props {
@@ -21,7 +21,7 @@ interface Props {
 
 interface State {
   jobId?: string;
-  typicalActual?: ML_ANOMALY_LAYERS;
+  typicalActual?: MlAnomalyLayersType;
 }
 
 export class CreateAnomalySourceEditor extends Component<Props, State> {
@@ -41,7 +41,7 @@ export class CreateAnomalySourceEditor extends Component<Props, State> {
     this._isMounted = true;
   }
 
-  private onTypicalActualChange = (typicalActual: ML_ANOMALY_LAYERS) => {
+  private onTypicalActualChange = (typicalActual: MlAnomalyLayersType) => {
     if (!this._isMounted) {
       return;
     }

--- a/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
@@ -11,7 +11,7 @@ import { EuiPanel } from '@elastic/eui';
 import { AnomalySourceDescriptor } from './anomaly_source';
 import { AnomalyJobSelector } from './anomaly_job_selector';
 import { LayerSelector } from './layer_selector';
-import { MlAnomalyLayers } from './util';
+import { ML_ANOMALY_LAYERS } from './util';
 import type { MlApiServices } from '../application/services/ml_api_service';
 
 interface Props {
@@ -21,7 +21,7 @@ interface Props {
 
 interface State {
   jobId?: string;
-  typicalActual?: MlAnomalyLayers;
+  typicalActual?: ML_ANOMALY_LAYERS;
 }
 
 export class CreateAnomalySourceEditor extends Component<Props, State> {
@@ -32,7 +32,7 @@ export class CreateAnomalySourceEditor extends Component<Props, State> {
     if (this.state.jobId) {
       this.props.onSourceConfigChange({
         jobId: this.state.jobId,
-        typicalActual: this.state.typicalActual,
+        typicalActual: this.state.typicalActual || ML_ANOMALY_LAYERS.ACTUAL,
       });
     }
   }
@@ -41,7 +41,7 @@ export class CreateAnomalySourceEditor extends Component<Props, State> {
     this._isMounted = true;
   }
 
-  private onTypicalActualChange = (typicalActual: MlAnomalyLayers) => {
+  private onTypicalActualChange = (typicalActual: ML_ANOMALY_LAYERS) => {
     if (!this._isMounted) {
       return;
     }
@@ -73,7 +73,7 @@ export class CreateAnomalySourceEditor extends Component<Props, State> {
     const selector = this.state.jobId ? (
       <LayerSelector
         onChange={this.onTypicalActualChange}
-        typicalActual={this.state.typicalActual || 'actual'}
+        typicalActual={this.state.typicalActual || ML_ANOMALY_LAYERS.ACTUAL}
       />
     ) : null;
     return (

--- a/x-pack/plugins/ml/public/maps/layer_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/layer_selector.tsx
@@ -36,7 +36,7 @@ export class LayerSelector extends Component<Props, State> {
     const typicalActual: MlAnomalyLayers = selectedOptions[0].value! as
       | 'typical'
       | 'actual'
-      | 'connected';
+      | 'typical to actual';
     if (this._isMounted) {
       this.setState({ typicalActual });
       this.props.onChange(typicalActual);
@@ -58,7 +58,7 @@ export class LayerSelector extends Component<Props, State> {
           options={[
             { value: 'actual', label: 'actual' },
             { value: 'typical', label: 'typical' },
-            { value: 'connected', label: 'connected' },
+            { value: 'typical to actual', label: 'typical to actual' },
           ]}
           selectedOptions={options}
         />

--- a/x-pack/plugins/ml/public/maps/layer_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/layer_selector.tsx
@@ -9,11 +9,11 @@ import React, { Component } from 'react';
 
 import { EuiComboBox, EuiFormRow, EuiComboBoxOptionOption } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { MlAnomalyLayers } from './util';
+import { ML_ANOMALY_LAYERS } from './util';
 
 interface Props {
-  onChange: (typicalActual: MlAnomalyLayers) => void;
-  typicalActual: MlAnomalyLayers;
+  onChange: (typicalActual: ML_ANOMALY_LAYERS) => void;
+  typicalActual: ML_ANOMALY_LAYERS;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -33,10 +33,7 @@ export class LayerSelector extends Component<Props, State> {
   }
 
   onSelect = (selectedOptions: Array<EuiComboBoxOptionOption<string>>) => {
-    const typicalActual: MlAnomalyLayers = selectedOptions[0].value! as
-      | 'typical'
-      | 'actual'
-      | 'typical to actual';
+    const typicalActual: ML_ANOMALY_LAYERS = selectedOptions[0].value! as ML_ANOMALY_LAYERS;
     if (this._isMounted) {
       this.setState({ typicalActual });
       this.props.onChange(typicalActual);
@@ -56,9 +53,24 @@ export class LayerSelector extends Component<Props, State> {
           singleSelection={true}
           onChange={this.onSelect}
           options={[
-            { value: 'actual', label: 'actual' },
-            { value: 'typical', label: 'typical' },
-            { value: 'typical to actual', label: 'typical to actual' },
+            {
+              value: ML_ANOMALY_LAYERS.ACTUAL,
+              label: i18n.translate('xpack.ml.maps.actualLabel', {
+                defaultMessage: ML_ANOMALY_LAYERS.ACTUAL,
+              }),
+            },
+            {
+              value: ML_ANOMALY_LAYERS.TYPICAL,
+              label: i18n.translate('xpack.ml.maps.typicalLabel', {
+                defaultMessage: ML_ANOMALY_LAYERS.TYPICAL,
+              }),
+            },
+            {
+              value: ML_ANOMALY_LAYERS.TYPICAL_TO_ACTUAL,
+              label: i18n.translate('xpack.ml.maps.typicalToActualLabel', {
+                defaultMessage: ML_ANOMALY_LAYERS.TYPICAL_TO_ACTUAL,
+              }),
+            },
           ]}
           selectedOptions={options}
         />

--- a/x-pack/plugins/ml/public/maps/layer_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/layer_selector.tsx
@@ -9,11 +9,12 @@ import React, { Component } from 'react';
 
 import { EuiComboBox, EuiFormRow, EuiComboBoxOptionOption } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { ML_ANOMALY_LAYERS } from './util';
+import { ML_ANOMALY_LAYERS, MlAnomalyLayersType } from './util';
+import { ACTUAL_LABEL, TYPICAL_LABEL, TYPICAL_TO_ACTUAL } from './anomaly_source_field';
 
 interface Props {
-  onChange: (typicalActual: ML_ANOMALY_LAYERS) => void;
-  typicalActual: ML_ANOMALY_LAYERS;
+  onChange: (typicalActual: MlAnomalyLayersType) => void;
+  typicalActual: MlAnomalyLayersType;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -33,7 +34,7 @@ export class LayerSelector extends Component<Props, State> {
   }
 
   onSelect = (selectedOptions: Array<EuiComboBoxOptionOption<string>>) => {
-    const typicalActual: ML_ANOMALY_LAYERS = selectedOptions[0].value! as ML_ANOMALY_LAYERS;
+    const typicalActual: MlAnomalyLayersType = selectedOptions[0].value! as MlAnomalyLayersType;
     if (this._isMounted) {
       this.setState({ typicalActual });
       this.props.onChange(typicalActual);
@@ -55,21 +56,15 @@ export class LayerSelector extends Component<Props, State> {
           options={[
             {
               value: ML_ANOMALY_LAYERS.ACTUAL,
-              label: i18n.translate('xpack.ml.maps.actualLabel', {
-                defaultMessage: ML_ANOMALY_LAYERS.ACTUAL,
-              }),
+              label: ACTUAL_LABEL,
             },
             {
               value: ML_ANOMALY_LAYERS.TYPICAL,
-              label: i18n.translate('xpack.ml.maps.typicalLabel', {
-                defaultMessage: ML_ANOMALY_LAYERS.TYPICAL,
-              }),
+              label: TYPICAL_LABEL,
             },
             {
               value: ML_ANOMALY_LAYERS.TYPICAL_TO_ACTUAL,
-              label: i18n.translate('xpack.ml.maps.typicalToActualLabel', {
-                defaultMessage: ML_ANOMALY_LAYERS.TYPICAL_TO_ACTUAL,
-              }),
+              label: TYPICAL_TO_ACTUAL,
             },
           ]}
           selectedOptions={options}

--- a/x-pack/plugins/ml/public/maps/update_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/update_anomaly_source_editor.tsx
@@ -10,11 +10,11 @@ import React, { Fragment, Component } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { LayerSelector } from './layer_selector';
-import { MlAnomalyLayers } from './util';
+import { ML_ANOMALY_LAYERS } from './util';
 
 interface Props {
   onChange: (...args: Array<{ propName: string; value: unknown }>) => void;
-  typicalActual: MlAnomalyLayers;
+  typicalActual: ML_ANOMALY_LAYERS;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -34,7 +34,7 @@ export class UpdateAnomalySourceEditor extends Component<Props, State> {
           </EuiTitle>
           <EuiSpacer size="s" />
           <LayerSelector
-            onChange={(typicalActual: MlAnomalyLayers) => {
+            onChange={(typicalActual: ML_ANOMALY_LAYERS) => {
               this.props.onChange({
                 propName: 'typicalActual',
                 value: typicalActual,

--- a/x-pack/plugins/ml/public/maps/update_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/update_anomaly_source_editor.tsx
@@ -10,11 +10,11 @@ import React, { Fragment, Component } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { LayerSelector } from './layer_selector';
-import { ML_ANOMALY_LAYERS } from './util';
+import { MlAnomalyLayersType } from './util';
 
 interface Props {
   onChange: (...args: Array<{ propName: string; value: unknown }>) => void;
-  typicalActual: ML_ANOMALY_LAYERS;
+  typicalActual: MlAnomalyLayersType;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -34,7 +34,7 @@ export class UpdateAnomalySourceEditor extends Component<Props, State> {
           </EuiTitle>
           <EuiSpacer size="s" />
           <LayerSelector
-            onChange={(typicalActual: ML_ANOMALY_LAYERS) => {
+            onChange={(typicalActual: MlAnomalyLayersType) => {
               this.props.onChange({
                 propName: 'typicalActual',
                 value: typicalActual,

--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -13,7 +13,6 @@ import type { MlApiServices } from '../application/services/ml_api_service';
 import { MLAnomalyDoc } from '../../common/types/anomalies';
 import { VectorSourceRequestMeta } from '../../../maps/common';
 
-export type MlAnomalyLayers = 'typical' | 'actual' | 'typical to actual';
 export enum ML_ANOMALY_LAYERS {
   TYPICAL = 'typical',
   ACTUAL = 'actual',
@@ -33,7 +32,7 @@ function getCoordinates(actualCoordinateStr: string, round: boolean = false): nu
 export async function getResultsForJobId(
   mlResultsService: MlApiServices['results'],
   jobId: string,
-  locationType: MlAnomalyLayers,
+  locationType: ML_ANOMALY_LAYERS,
   searchFilters: VectorSourceRequestMeta
 ): Promise<FeatureCollection> {
   const { timeFilters } = searchFilters;
@@ -102,10 +101,10 @@ export async function getResultsForJobId(
       }
 
       let geometry: Geometry;
-      if (locationType === 'typical' || locationType === 'actual') {
+      if (locationType === ML_ANOMALY_LAYERS.TYPICAL || locationType === ML_ANOMALY_LAYERS.ACTUAL) {
         geometry = {
           type: 'Point',
-          coordinates: locationType === 'typical' ? typical : actual,
+          coordinates: locationType === ML_ANOMALY_LAYERS.TYPICAL ? typical : actual,
         };
       } else {
         geometry = {

--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -13,11 +13,13 @@ import type { MlApiServices } from '../application/services/ml_api_service';
 import { MLAnomalyDoc } from '../../common/types/anomalies';
 import { VectorSourceRequestMeta } from '../../../maps/common';
 
-export enum ML_ANOMALY_LAYERS {
-  TYPICAL = 'typical',
-  ACTUAL = 'actual',
-  TYPICAL_TO_ACTUAL = 'typical to actual',
-}
+export const ML_ANOMALY_LAYERS = {
+  TYPICAL: 'typical',
+  ACTUAL: 'actual',
+  TYPICAL_TO_ACTUAL: 'typical to actual',
+} as const;
+
+export type MlAnomalyLayersType = typeof ML_ANOMALY_LAYERS[keyof typeof ML_ANOMALY_LAYERS];
 
 // Must reverse coordinates here. Map expects [lon, lat] - anomalies are stored as [lat, lon] for lat_lon jobs
 function getCoordinates(actualCoordinateStr: string, round: boolean = false): number[] {
@@ -32,7 +34,7 @@ function getCoordinates(actualCoordinateStr: string, round: boolean = false): nu
 export async function getResultsForJobId(
   mlResultsService: MlApiServices['results'],
   jobId: string,
-  locationType: ML_ANOMALY_LAYERS,
+  locationType: MlAnomalyLayersType,
   searchFilters: VectorSourceRequestMeta
 ): Promise<FeatureCollection> {
   const { timeFilters } = searchFilters;

--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -14,6 +14,11 @@ import { MLAnomalyDoc } from '../../common/types/anomalies';
 import { VectorSourceRequestMeta } from '../../../maps/common';
 
 export type MlAnomalyLayers = 'typical' | 'actual' | 'typical to actual';
+export enum ML_ANOMALY_LAYERS {
+  TYPICAL = 'typical',
+  ACTUAL = 'actual',
+  TYPICAL_TO_ACTUAL = 'typical to actual',
+}
 
 // Must reverse coordinates here. Map expects [lon, lat] - anomalies are stored as [lat, lon] for lat_lon jobs
 function getCoordinates(actualCoordinateStr: string, round: boolean = false): number[] {

--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -13,18 +13,7 @@ import type { MlApiServices } from '../application/services/ml_api_service';
 import { MLAnomalyDoc } from '../../common/types/anomalies';
 import { VectorSourceRequestMeta } from '../../../maps/common';
 
-export type MlAnomalyLayers = 'typical' | 'actual' | 'connected';
-interface Hit {
-  [x: string]: any;
-  actual: number[];
-  actualDisplay: number[];
-  fieldName?: string;
-  functionDescription: string;
-  typical: number[];
-  typicalDisplay: number[];
-  record_score: number;
-  timestamp: string;
-}
+export type MlAnomalyLayers = 'typical' | 'actual' | 'typical to actual';
 
 // Must reverse coordinates here. Map expects [lon, lat] - anomalies are stored as [lat, lon] for lat_lon jobs
 function getCoordinates(actualCoordinateStr: string, round: boolean = false): number[] {
@@ -75,7 +64,6 @@ export async function getResultsForJobId(
   }
 
   let resp: ESSearchResponse<MLAnomalyDoc> | null = null;
-  let hits: Hit[] = [];
 
   try {
     resp = await mlResultsService.anomalySearch(
@@ -88,8 +76,9 @@ export async function getResultsForJobId(
     // search may fail if the job doesn't already exist
     // ignore this error as the outer function call will raise a toast
   }
-  if (resp !== null && resp.hits.total.value > 0) {
-    hits = resp.hits.hits.map(({ _source }) => {
+
+  const features: Feature[] =
+    resp?.hits.hits.map(({ _source }) => {
       const geoResults = _source.geo_results;
       const actualCoordStr = geoResults && geoResults.actual_point;
       const typicalCoordStr = geoResults && geoResults.typical_point;
@@ -106,65 +95,41 @@ export async function getResultsForJobId(
         typical = getCoordinates(typicalCoordStr);
         typicalDisplay = getCoordinates(typicalCoordStr, true);
       }
-      return {
-        fieldName: _source.field_name,
-        functionDescription: _source.function_description,
-        timestamp: formatHumanReadableDateTimeSeconds(_source.timestamp),
-        typical,
-        typicalDisplay,
-        actual,
-        actualDisplay,
-        record_score: Math.floor(_source.record_score),
-        ...(_source.partition_field_name
-          ? { partition_field_name: _source.partition_field_name }
-          : {}),
-        ...(_source.partition_field_value
-          ? { partition_field_value: _source.partition_field_value }
-          : {}),
-        ...(_source.by_field_name ? { by_field_name: _source.by_field_name } : {}),
-        ...(_source.by_field_value ? { by_field_value: _source.by_field_value } : {}),
-        ...(_source.over_field_value ? { over_field_value: _source.over_field_value } : {}),
-      };
-    });
-  }
 
-  const features: Feature[] = hits.map((result) => {
-    let geometry: Geometry;
-    if (locationType === 'typical' || locationType === 'actual') {
-      geometry = {
-        type: 'Point',
-        coordinates: locationType === 'typical' ? result.typical : result.actual,
+      let geometry: Geometry;
+      if (locationType === 'typical' || locationType === 'actual') {
+        geometry = {
+          type: 'Point',
+          coordinates: locationType === 'typical' ? typical : actual,
+        };
+      } else {
+        geometry = {
+          type: 'LineString',
+          coordinates: [typical, actual],
+        };
+      }
+      return {
+        type: 'Feature',
+        geometry,
+        properties: {
+          actual,
+          actualDisplay,
+          typical,
+          typicalDisplay,
+          fieldName: _source.field_name,
+          functionDescription: _source.function_description,
+          timestamp: formatHumanReadableDateTimeSeconds(_source.timestamp),
+          record_score: Math.floor(_source.record_score),
+          ...(_source.partition_field_name
+            ? { [_source.partition_field_name]: _source.partition_field_value }
+            : {}),
+          ...(_source.by_field_name ? { [_source.by_field_name]: _source.by_field_value } : {}),
+          ...(_source.over_field_name
+            ? { [_source.over_field_name]: _source.over_field_value }
+            : {}),
+        },
       };
-    } else {
-      geometry = {
-        type: 'LineString',
-        coordinates: [result.typical, result.actual],
-      };
-    }
-    return {
-      type: 'Feature',
-      geometry,
-      properties: {
-        actual: result.actual,
-        actualDisplay: result.actualDisplay,
-        typical: result.typical,
-        typicalDisplay: result.typicalDisplay,
-        fieldName: result.fieldName,
-        functionDescription: result.functionDescription,
-        timestamp: result.timestamp,
-        record_score: result.record_score,
-        ...(result.partition_field_name
-          ? { partition_field_name: result.partition_field_name }
-          : {}),
-        ...(result.partition_field_value
-          ? { partition_field_value: result.partition_field_value }
-          : {}),
-        ...(result.by_field_name ? { by_field_name: result.by_field_name } : {}),
-        ...(result.by_field_value ? { by_field_value: result.by_field_value } : {}),
-        ...(result.over_field_value ? { over_field_value: result.over_field_value } : {}),
-      },
-    };
-  });
+    }) || [];
 
   return {
     type: 'FeatureCollection',


### PR DESCRIPTION
## Summary

Related meta issue: https://github.com/elastic/kibana/issues/123492

- adds partition field to tooltip
- updates layer name to 'typical to actual'
- simplifies results fetch

![image](https://user-images.githubusercontent.com/6446462/150820355-7cd678a0-b274-452b-9594-7d382a732121.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))

