### PR TITLE
[chore][Home] Rename IndexPattern to DataView

### DIFF
--- a/src/plugins/home/public/application/components/home.test.tsx
+++ b/src/plugins/home/public/application/components/home.test.tsx
@@ -61,7 +61,7 @@ describe('home', () => {
       addBasePath(url) {
         return `base_path/${url}`;
       },
-      hasUserIndexPattern: jest.fn(async () => true),
+      hasUserDataView: jest.fn(async () => true),
     };
   });
 
@@ -187,8 +187,8 @@ describe('home', () => {
     test('should show the welcome screen if enabled, and there are no index patterns defined', async () => {
       defaultProps.localStorage.getItem = jest.fn(() => 'true');
 
-      const hasUserIndexPattern = jest.fn(async () => false);
-      const component = await renderHome({ hasUserIndexPattern });
+      const hasUserDataView = jest.fn(async () => false);
+      const component = await renderHome({ hasUserDataView });
 
       expect(defaultProps.localStorage.getItem).toHaveBeenCalledTimes(1);
 
@@ -198,8 +198,8 @@ describe('home', () => {
     test('stores skip welcome setting if skipped', async () => {
       defaultProps.localStorage.getItem = jest.fn(() => 'true');
 
-      const hasUserIndexPattern = jest.fn(async () => false);
-      const component = await renderHome({ hasUserIndexPattern });
+      const hasUserDataView = jest.fn(async () => false);
+      const component = await renderHome({ hasUserDataView });
 
       component.instance().skipWelcome();
       component.update();
@@ -212,8 +212,8 @@ describe('home', () => {
     test('should show the normal home page if loading fails', async () => {
       defaultProps.localStorage.getItem = jest.fn(() => 'true');
 
-      const hasUserIndexPattern = jest.fn(() => Promise.reject('Doh!'));
-      const component = await renderHome({ hasUserIndexPattern });
+      const hasUserDataView = jest.fn(() => Promise.reject('Doh!'));
+      const component = await renderHome({ hasUserDataView });
 
       expect(component.find(Welcome).exists()).toBe(false);
     });
@@ -237,8 +237,8 @@ describe('home', () => {
 
   describe('isNewKibanaInstance', () => {
     test('should set isNewKibanaInstance to true when there are no index patterns', async () => {
-      const hasUserIndexPattern = jest.fn(async () => false);
-      const component = await renderHome({ hasUserIndexPattern });
+      const hasUserDataView = jest.fn(async () => false);
+      const component = await renderHome({ hasUserDataView });
 
       expect(component.state().isNewKibanaInstance).toBe(true);
 
@@ -246,8 +246,8 @@ describe('home', () => {
     });
 
     test('should set isNewKibanaInstance to false when there are index patterns', async () => {
-      const hasUserIndexPattern = jest.fn(async () => true);
-      const component = await renderHome({ hasUserIndexPattern });
+      const hasUserDataView = jest.fn(async () => true);
+      const component = await renderHome({ hasUserDataView });
 
       expect(component.state().isNewKibanaInstance).toBe(false);
 
@@ -255,10 +255,10 @@ describe('home', () => {
     });
 
     test('should safely handle exceptions', async () => {
-      const hasUserIndexPattern = jest.fn(() => {
+      const hasUserDataView = jest.fn(() => {
         throw new Error('simulated find error');
       });
-      const component = await renderHome({ hasUserIndexPattern });
+      const component = await renderHome({ hasUserDataView });
 
       expect(component.state().isNewKibanaInstance).toBe(false);
 

--- a/src/plugins/home/public/application/components/home.tsx
+++ b/src/plugins/home/public/application/components/home.tsx
@@ -30,7 +30,7 @@ export interface HomeProps {
   localStorage: Storage;
   urlBasePath: string;
   telemetry: TelemetryPluginStart;
-  hasUserIndexPattern: () => Promise<boolean>;
+  hasUserDataView: () => Promise<boolean>;
 }
 
 interface State {
@@ -89,7 +89,7 @@ export class Home extends Component<HomeProps, State> {
         }
       }, 10000);
 
-      const hasUserIndexPattern = await this.props.hasUserIndexPattern();
+      const hasUserIndexPattern = await this.props.hasUserDataView();
 
       this.endLoading({ isNewKibanaInstance: !hasUserIndexPattern });
     } catch (err) {

--- a/src/plugins/home/public/application/components/home_app.js
+++ b/src/plugins/home/public/application/components/home_app.js
@@ -76,7 +76,7 @@ export function HomeApp({ directories, solutions }) {
               localStorage={localStorage}
               urlBasePath={getBasePath()}
               telemetry={telemetry}
-              hasUserIndexPattern={() => indexPatternService.hasUserDataView()}
+              hasUserDataView={() => indexPatternService.hasUserDataView()}
             />
           </Route>
           <Redirect to="/" />


### PR DESCRIPTION
## Summary

Based on [this comment](https://github.com/elastic/kibana/issues/112109#issuecomment-1015465729) we need to properly rename the prop in the `Home` app so it doesn't look like we apply different logics across the platform when validating if there's any User data.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
