### PR TITLE
[Cases] Enhancement: Add createAppMockRenderer method for easier unit testing

### DIFF
--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -10,11 +10,17 @@ import { euiDarkVars } from '@kbn/ui-theme';
 import { I18nProvider } from '@kbn/i18n-react';
 import { ThemeProvider } from 'styled-components';
 
+import { render as reactRender, RenderOptions, RenderResult } from '@testing-library/react';
+import { KibanaContextProvider } from 'src/plugins/kibana_react/public';
 import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { CasesFeatures } from '../../../common/ui/types';
 import { CasesProvider } from '../../components/cases_context';
-import { createKibanaContextProviderMock } from '../lib/kibana/kibana_react.mock';
+import {
+  createKibanaContextProviderMock,
+  createStartServicesMock,
+} from '../lib/kibana/kibana_react.mock';
 import { FieldHook } from '../shared_imports';
+import { StartServices } from '../../types';
 
 interface Props {
   children: React.ReactNode;
@@ -22,6 +28,7 @@ interface Props {
   features?: CasesFeatures;
   owner?: string[];
 }
+type UiRender = (ui: React.ReactElement, options?: RenderOptions) => RenderResult;
 
 window.scrollTo = jest.fn();
 const MockKibanaContextProvider = createKibanaContextProviderMock();
@@ -46,6 +53,42 @@ const TestProvidersComponent: React.FC<Props> = ({
 TestProvidersComponent.displayName = 'TestProviders';
 
 export const TestProviders = React.memo(TestProvidersComponent);
+
+export interface AppMockRenderer extends StartServices {
+  render: UiRender;
+}
+
+export const createAppMockRenderer = ({
+  features,
+  owner = [SECURITY_SOLUTION_OWNER],
+  userCanCrud = true,
+}: {
+  features?: CasesFeatures;
+  owner?: string[];
+  userCanCrud?: boolean;
+} = {}): AppMockRenderer => {
+  const services = createStartServicesMock();
+
+  const AppWrapper: React.FC<{ children: React.ReactElement }> = ({ children }) => (
+    <I18nProvider>
+      <KibanaContextProvider services={services}>
+        <ThemeProvider theme={() => ({ eui: euiDarkVars, darkMode: true })}>
+          <CasesProvider value={{ features, owner, userCanCrud }}>{children}</CasesProvider>
+        </ThemeProvider>
+      </KibanaContextProvider>
+    </I18nProvider>
+  );
+  const render: UiRender = (ui, options) => {
+    return reactRender(ui, {
+      wrapper: AppWrapper as React.ComponentType,
+      ...options,
+    });
+  };
+  return {
+    ...services,
+    render,
+  };
+};
 
 export const useFormFieldMock = <T,>(options?: Partial<FieldHook<T>>): FieldHook<T> => ({
   path: 'path',

--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -54,8 +54,9 @@ TestProvidersComponent.displayName = 'TestProviders';
 
 export const TestProviders = React.memo(TestProvidersComponent);
 
-export interface AppMockRenderer extends StartServices {
+export interface AppMockRenderer {
   render: UiRender;
+  coreStart: StartServices;
 }
 
 export const createAppMockRenderer = ({
@@ -85,7 +86,7 @@ export const createAppMockRenderer = ({
     });
   };
   return {
-    ...services,
+    coreStart: services,
     render,
   };
 };


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/kibana/issues/123374

## Background

Currently mocking kibana core start services can become tedious if you want to test its internal services. This PR tries to unify and simplify this process by introducing a `createAppMockRenderer` that will return a mockApp ready to render components.

Each call to `createAppMockRenderer` will return a fresh context with new services.

## Example

Given a component like this:

```typescript
import React, { useEffect } from 'react';
import { useToasts } from '../../common/lib/kibana';

export function TestMe() {
  const toasts = useToasts();
  useEffect(() => {
    toasts.addDanger("I'm in danger");
  }, [toasts]);
  return <h1 data-test-subj="the-element">{'this is a test component'}</h1>;
}
```

one could write test for it like this:

```typescript
describe('this is  test', () => {
  let mockedApp: AppMockRenderer;
  beforeEach(() => {
    mockedApp = createAppMockRenderer();
  });
  it('should test rendering', () => {
    const result = mockedApp.render(<TestMe />);
    expect(mockedApp.coreStart.notifications.toasts.addDanger).toHaveBeenCalledWith("I'm in danger");
    expect(result.getByTestId('the-element')).toHaveTextContent('test component');
  });
});
```