### PR TITLE
[App Search] Fix engines label showing 'All' when no access to engines defined

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.test.tsx
@@ -83,8 +83,7 @@ describe('UsersTable', () => {
       <UsersTable {...props} accessItemKey="engines" singleUserRoleMappings={[userWithAllItems]} />
     );
 
-    expect(wrapper.find('[data-test-subj="AllItems"]')).toHaveLength(1);
-    expect(wrapper.find('[data-test-subj="NoItems"]')).toHaveLength(0);
+    expect(wrapper.find('[data-test-subj="AccessItems"]').prop('children')).toEqual('All');
   });
 
   it('handles access items display for no items are available.', () => {
@@ -100,8 +99,7 @@ describe('UsersTable', () => {
       <UsersTable {...props} accessItemKey="engines" singleUserRoleMappings={[userWithAllItems]} />
     );
 
-    expect(wrapper.find('[data-test-subj="AllItems"]')).toHaveLength(0);
-    expect(wrapper.find('[data-test-subj="NoItems"]')).toHaveLength(1);
+    expect(wrapper.find('[data-test-subj="AccessItems"]').prop('children')).toEqual('-');
   });
 
   it('handles access items display more than 2 items', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.test.tsx
@@ -84,6 +84,24 @@ describe('UsersTable', () => {
     );
 
     expect(wrapper.find('[data-test-subj="AllItems"]')).toHaveLength(1);
+    expect(wrapper.find('[data-test-subj="NoItems"]')).toHaveLength(0);
+  });
+
+  it('handles access items display for no items are available.', () => {
+    const userWithAllItems = {
+      ...asSingleUserRoleMapping,
+      roleMapping: {
+        ...asRoleMapping,
+        accessAllEngines: false,
+        engines: [],
+      },
+    };
+    const wrapper = mount(
+      <UsersTable {...props} accessItemKey="engines" singleUserRoleMappings={[userWithAllItems]} />
+    );
+
+    expect(wrapper.find('[data-test-subj="AllItems"]')).toHaveLength(0);
+    expect(wrapper.find('[data-test-subj="NoItems"]')).toHaveLength(1);
   });
 
   it('handles access items display more than 2 items', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.tsx
@@ -116,24 +116,9 @@ export const UsersTable: React.FC<Props> = ({
     {
       field: 'accessItems',
       name: accessItemKey === 'groups' ? GROUPS_LABEL : ENGINES_LABEL,
-      render: (_, { accessItems, accessAll }: SharedUser) => {
-        const isAppSearch = accessItemKey === 'engines';
-        // Design calls for showing the first 2 items followed by a +x after those 2.
-        // ['foo', 'bar', 'baz'] would display as: "foo, bar + 1"
-        const numItems = accessItems.length;
-        if (numItems === 0) {
-          // There is a possibility to add users without setting an access. We should not show All in that case
-          if (isAppSearch && !accessAll) {
-            return <span data-test-subj="NoItems">-</span>;
-          }
-          return <span data-test-subj="AllItems">{ALL_LABEL}</span>;
-        }
-        const additionalItems = numItems > 2 ? ` + ${numItems - 2}` : '';
-        const names = accessItems.map((item) => item.name);
-        return (
-          <span data-test-subj="AccessItems">{names.slice(0, 2).join(', ') + additionalItems}</span>
-        );
-      },
+      render: (_, user: SharedUser) => (
+        <span data-test-subj="AccessItems">{getAccessItemsContent(user)}</span>
+      ),
     },
     {
       field: 'id',
@@ -148,6 +133,23 @@ export const UsersTable: React.FC<Props> = ({
       ),
     },
   ];
+
+  const getAccessItemsContent = ({ accessItems, accessAll }: SharedUser): string => {
+    const isAppSearch = accessItemKey === 'engines';
+    const numItems = accessItems.length;
+
+    if (numItems === 0) {
+      // There is a possibility to add users without setting an access. We should not show 'All' in that case.
+      return isAppSearch && !accessAll ? '-' : ALL_LABEL;
+    }
+
+    // Design calls for showing the first 2 items followed by a +x after those 2.
+    // ['foo', 'bar', 'baz'] would display as: "foo, bar + 1"
+    const additionalItems = numItems > 2 ? ` + ${numItems - 2}` : '';
+    const names = accessItems.map((item) => item.name);
+
+    return names.slice(0, 2).join(', ') + additionalItems;
+  };
 
   const pagination = {
     hidePerPageOptions: true,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.tsx
@@ -34,6 +34,7 @@ interface AccessItem {
 }
 
 interface SharedUser extends SingleUserRoleMapping<ASRoleMapping | WSRoleMapping> {
+  accessAll: ASRoleMapping['accessAllEngines'] | WSRoleMapping['allGroups'];
   accessItems: AccessItem[];
   username: string;
   email: string | null;
@@ -73,6 +74,9 @@ export const UsersTable: React.FC<Props> = ({
     roleType: user.roleMapping.roleType,
     id: user.roleMapping.id,
     accessItems: (user.roleMapping as SharedRoleMapping)[accessItemKey],
+    accessAll: (user.roleMapping as SharedRoleMapping)[
+      accessItemKey === 'engines' ? 'accessAllEngines' : 'allGroups'
+    ],
     invitation: user.invitation,
   })) as unknown as Users;
 
@@ -112,11 +116,18 @@ export const UsersTable: React.FC<Props> = ({
     {
       field: 'accessItems',
       name: accessItemKey === 'groups' ? GROUPS_LABEL : ENGINES_LABEL,
-      render: (_, { accessItems }: SharedUser) => {
+      render: (_, { accessItems, accessAll }: SharedUser) => {
+        const isAppSearch = accessItemKey === 'engines';
         // Design calls for showing the first 2 items followed by a +x after those 2.
         // ['foo', 'bar', 'baz'] would display as: "foo, bar + 1"
         const numItems = accessItems.length;
-        if (numItems === 0) return <span data-test-subj="AllItems">{ALL_LABEL}</span>;
+        if (numItems === 0) {
+          // There is a possibility to add users without setting an access. We should not show All in that case
+          if (isAppSearch && !accessAll) {
+            return <span data-test-subj="NoItems">-</span>;
+          }
+          return <span data-test-subj="AllItems">{ALL_LABEL}</span>;
+        }
         const additionalItems = numItems > 2 ? ` + ${numItems - 2}` : '';
         const names = accessItems.map((item) => item.name);
         return (


### PR DESCRIPTION
This fixes https://github.com/elastic/enterprise-search-team/issues/994

## Summary

Engines label for the single user roles on "Users and Roles" page were showing "All" when user
didn't have access to any engines. This fixes and show a -(dash) instead
of all on the engines column.

![Screenshot 2022-01-24 at 14 21 07](https://user-images.githubusercontent.com/1410658/150790242-f4c691b1-9fa4-4b2d-b225-137c1011f741.png)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

