### PR TITLE
[ResponseOps] Add P50/95/99 for rule execution duration in the rules table

### DIFF
--- a/x-pack/plugins/alerting/common/alert.ts
+++ b/x-pack/plugins/alerting/common/alert.ts
@@ -137,13 +137,19 @@ export interface ActionVariable {
   useWithTripleBracesInTemplates?: boolean;
 }
 
+export interface RuleMonitoringHistory extends SavedObjectAttributes {
+  success: boolean;
+  timestamp: number;
+  duration?: number;
+}
+
 export interface RuleMonitoring extends SavedObjectAttributes {
   execution: {
-    history: Array<{
-      success: boolean;
-      timestamp: number;
-    }>;
+    history: RuleMonitoringHistory[];
     calculated_metrics: {
+      p50?: number;
+      p95?: number;
+      p99?: number;
       success_ratio: number;
     };
   };

--- a/x-pack/plugins/alerting/common/index.ts
+++ b/x-pack/plugins/alerting/common/index.ts
@@ -31,3 +31,4 @@ export const LEGACY_BASE_ALERT_API_PATH = '/api/alerts';
 export const BASE_ALERTING_API_PATH = '/api/alerting';
 export const INTERNAL_BASE_ALERTING_API_PATH = '/internal/alerting';
 export const ALERTS_FEATURE_ID = 'alerts';
+export const MONITORING_HISTORY_LIMIT = 200;

--- a/x-pack/plugins/alerting/server/lib/monitoring.test.ts
+++ b/x-pack/plugins/alerting/server/lib/monitoring.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getExecutionDurationPercentiles } from './monitoring';
+import { RuleMonitoring } from '../types';
+
+const mockHistory = [
+  {
+    success: true,
+    duration: 100,
+  },
+  {
+    success: true,
+    duration: 200,
+  },
+  {
+    success: false,
+    duration: 300,
+  },
+  {
+    success: false,
+    duration: 100,
+  },
+  {
+    success: false,
+  },
+  {
+    success: true,
+  },
+  {
+    success: true,
+    duration: 400,
+  },
+  {
+    success: true,
+    duration: 500,
+  },
+];
+
+const mockRuleMonitoring = {
+  execution: {
+    history: mockHistory,
+    calculated_metrics: {
+      success_ratio: 0,
+    },
+  },
+} as RuleMonitoring;
+
+describe('getExecutionDurationPercentiles', () => {
+  it('Calculates the percentile given partly undefined durations', () => {
+    const percentiles = getExecutionDurationPercentiles(mockRuleMonitoring);
+    expect(percentiles.p50).toEqual(250);
+    expect(percentiles.p95).toEqual(500);
+    expect(percentiles.p99).toEqual(500);
+  });
+
+  it('Returns empty object when given all undefined durations', () => {
+    // remove all duration fields
+    const nullDurationHistory = mockHistory.map((history) => ({
+      success: history.success,
+    }));
+
+    const newMockRuleMonitoring = {
+      ...mockRuleMonitoring,
+      execution: {
+        ...mockRuleMonitoring.execution,
+        history: nullDurationHistory,
+      },
+    } as RuleMonitoring;
+
+    const percentiles = getExecutionDurationPercentiles(newMockRuleMonitoring);
+    expect(Object.keys(percentiles).length).toEqual(0);
+  });
+});

--- a/x-pack/plugins/alerting/server/lib/monitoring.ts
+++ b/x-pack/plugins/alerting/server/lib/monitoring.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import stats from 'stats-lite';
+import { RuleMonitoring } from '../types';
+
+export const getExecutionSuccessRatio = (ruleMonitoring: RuleMonitoring) => {
+  const { history } = ruleMonitoring.execution;
+  return history.filter(({ success }) => success).length / history.length;
+};
+
+export const getExecutionDurationPercentiles = (ruleMonitoring: RuleMonitoring) => {
+  const durationSamples = ruleMonitoring.execution.history.reduce((duration, history) => {
+    if (typeof history.duration === 'number') {
+      return [...duration, history.duration];
+    }
+    return duration;
+  }, [] as number[]);
+
+  if (durationSamples.length) {
+    return {
+      p50: stats.percentile(durationSamples as number[], 0.5),
+      p95: stats.percentile(durationSamples as number[], 0.95),
+      p99: stats.percentile(durationSamples as number[], 0.99),
+    };
+  }
+
+  return {};
+};

--- a/x-pack/plugins/alerting/server/lib/monitoring.ts
+++ b/x-pack/plugins/alerting/server/lib/monitoring.ts
@@ -14,12 +14,12 @@ export const getExecutionSuccessRatio = (ruleMonitoring: RuleMonitoring) => {
 };
 
 export const getExecutionDurationPercentiles = (ruleMonitoring: RuleMonitoring) => {
-  const durationSamples = ruleMonitoring.execution.history.reduce((duration, history) => {
+  const durationSamples = ruleMonitoring.execution.history.reduce<number[]>((duration, history) => {
     if (typeof history.duration === 'number') {
       return [...duration, history.duration];
     }
     return duration;
-  }, [] as number[]);
+  }, []);
 
   if (durationSamples.length) {
     return {

--- a/x-pack/plugins/alerting/server/saved_objects/mappings.json
+++ b/x-pack/plugins/alerting/server/saved_objects/mappings.json
@@ -99,6 +99,9 @@
             "properties": {
               "history": {
                 "properties": {
+                  "duration": {
+                    "type": "long"
+                  },
                   "success": {
                     "type": "boolean"
                   },
@@ -109,6 +112,15 @@
               },
               "calculated_metrics": {
                 "properties": {
+                  "p50": {
+                    "type": "long"
+                  },
+                  "p95": {
+                    "type": "long"
+                  },
+                  "p99": {
+                    "type": "long"
+                  },
                   "success_ratio": {
                     "type": "float"
                   }

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -36,9 +36,11 @@ import {
   AlertExecutionStatusErrorReasons,
   RuleTypeRegistry,
   RuleMonitoring,
+  RuleMonitoringHistory,
   RawRuleExecutionStatus,
 } from '../types';
 import { promiseResult, map, Resultable, asOk, asErr, resolveErr } from '../lib/result_type';
+import { getExecutionSuccessRatio, getExecutionDurationPercentiles } from '../lib/monitoring';
 import { taskInstanceToAlertTaskInstance } from './alert_task_instance';
 import { EVENT_LOG_ACTIONS } from '../plugin';
 import { IEvent, IEventLogger, SAVED_OBJECT_REL_PRIMARY } from '../../../event_log/server';
@@ -53,6 +55,7 @@ import {
   AlertInstanceContext,
   WithoutReservedActionGroups,
   parseDuration,
+  MONITORING_HISTORY_LIMIT,
 } from '../../common';
 import { NormalizedRuleType, UntypedNormalizedRuleType } from '../rule_type_registry';
 import { getEsErrorMessage } from '../lib/errors';
@@ -64,7 +67,6 @@ import { createAbortableEsClientFactory } from '../lib/create_abortable_es_clien
 
 const FALLBACK_RETRY_INTERVAL = '5m';
 const CONNECTIVITY_RETRY_INTERVAL = '5m';
-const MONITORING_HISTORY_LIMIT = 200;
 
 // 1,000,000 nanoseconds in 1 millisecond
 const Millis2Nanos = 1000 * 1000;
@@ -705,15 +707,17 @@ export class TaskRunner<
     event.kibana.alerting = event.kibana.alerting || {};
     event.kibana.alerting.status = executionStatus.status;
 
-    // Copy duration into execution status if available
-    if (null != event.event?.duration) {
-      executionStatus.lastDuration = Math.round(event.event?.duration / Millis2Nanos);
-    }
-
-    const monitoringHistory = {
+    const monitoringHistory: RuleMonitoringHistory = {
       success: true,
       timestamp: +new Date(),
     };
+
+    // Copy duration into execution status if available
+    if (null != event.event?.duration) {
+      executionStatus.lastDuration = Math.round(event.event?.duration / Millis2Nanos);
+      monitoringHistory.duration = executionStatus.lastDuration;
+    }
+
     // if executionStatus indicates an error, fill in fields in
     // event from it
     if (executionStatus.error) {
@@ -729,9 +733,11 @@ export class TaskRunner<
     }
 
     ruleMonitoring.execution.history.push(monitoringHistory);
-    ruleMonitoring.execution.calculated_metrics.success_ratio =
-      ruleMonitoring.execution.history.filter(({ success }) => success).length /
-      ruleMonitoring.execution.history.length;
+    ruleMonitoring.execution.calculated_metrics = {
+      success_ratio: getExecutionSuccessRatio(ruleMonitoring),
+      ...getExecutionDurationPercentiles(ruleMonitoring),
+    };
+
     eventLogger.logEvent(event);
 
     if (!this.cancelled) {

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/monitoring_utils.test.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/monitoring_utils.test.ts
@@ -4,11 +4,17 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { getFormattedSuccessRatio } from './monitoring_utils';
+import { getFormattedSuccessRatio, getFormattedRuleExecutionPercentile } from './monitoring_utils';
 
 describe('monitoring_utils', () => {
   it('should return a decimal as a percent', () => {
     expect(getFormattedSuccessRatio(0.66)).toEqual('66%');
     expect(getFormattedSuccessRatio(0.75345345345345)).toEqual('75%');
+  });
+
+  it('should return percentiles as an integer', () => {
+    expect(getFormattedRuleExecutionPercentile(0)).toEqual('0ms');
+    expect(getFormattedRuleExecutionPercentile(100.5555)).toEqual('101ms');
+    expect(getFormattedRuleExecutionPercentile(99.1111)).toEqual('99ms');
   });
 });

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/monitoring_utils.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/monitoring_utils.ts
@@ -10,3 +10,8 @@ export function getFormattedSuccessRatio(successRatio: number) {
   const formatted = numeral(successRatio! * 100).format('0,0');
   return `${formatted}%`;
 }
+
+export function getFormattedRuleExecutionPercentile(percentile: number) {
+  const formatted = numeral(percentile).format('0,0');
+  return `${formatted}ms`;
+}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.test.tsx
@@ -11,7 +11,7 @@ import { ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { actionTypeRegistryMock } from '../../../action_type_registry.mock';
 import { ruleTypeRegistryMock } from '../../../rule_type_registry.mock';
-import { AlertsList } from './alerts_list';
+import { AlertsList, percentileFields } from './alerts_list';
 import { RuleTypeModel, ValidationResult, Percentiles } from '../../../../types';
 import {
   AlertExecutionStatusErrorReasons,
@@ -521,6 +521,36 @@ describe('alerts_list component with items', () => {
       }
     });
 
+    // Click column to sort by P50
+    wrapper
+      .find(`[data-test-subj="alertsTable-${Percentiles.P50}ColumnName"]`)
+      .first()
+      .simulate('click');
+
+    expect(loadAlerts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: {
+          field: percentileFields[Percentiles.P50],
+          direction: 'asc',
+        },
+      })
+    );
+
+    // Click column again to reverse sort by P50
+    wrapper
+      .find(`[data-test-subj="alertsTable-${Percentiles.P50}ColumnName"]`)
+      .first()
+      .simulate('click');
+
+    expect(loadAlerts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: {
+          field: percentileFields[Percentiles.P50],
+          direction: 'desc',
+        },
+      })
+    );
+
     // Hover over percentile selection button
     wrapper
       .find('[data-test-subj="percentileSelectablePopover-iconButton"]')
@@ -563,6 +593,36 @@ describe('alerts_list component with items', () => {
         expect(percentiles.at(index).text()).toEqual('N/A');
       }
     });
+
+    // Click column to sort by P95
+    wrapper
+      .find(`[data-test-subj="alertsTable-${Percentiles.P95}ColumnName"]`)
+      .first()
+      .simulate('click');
+
+    expect(loadAlerts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: {
+          field: percentileFields[Percentiles.P95],
+          direction: 'asc',
+        },
+      })
+    );
+
+    // Click column again to reverse sort by P95
+    wrapper
+      .find(`[data-test-subj="alertsTable-${Percentiles.P95}ColumnName"]`)
+      .first()
+      .simulate('click');
+
+    expect(loadAlerts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: {
+          field: percentileFields[Percentiles.P95],
+          direction: 'desc',
+        },
+      })
+    );
 
     // Clearing all mocks will also reset fake timers.
     jest.clearAllMocks();

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.test.tsx
@@ -6,14 +6,13 @@
  */
 
 import * as React from 'react';
-
 import { mountWithIntl, nextTick } from '@kbn/test/jest';
 import { ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { actionTypeRegistryMock } from '../../../action_type_registry.mock';
 import { ruleTypeRegistryMock } from '../../../rule_type_registry.mock';
 import { AlertsList } from './alerts_list';
-import { RuleTypeModel, ValidationResult } from '../../../../types';
+import { RuleTypeModel, ValidationResult, Percentiles } from '../../../../types';
 import {
   AlertExecutionStatusErrorReasons,
   ALERTS_FEATURE_ID,
@@ -178,9 +177,25 @@ describe('alerts_list component with items', () => {
       },
       monitoring: {
         execution: {
-          history: [{ success: true }, { success: true }, { success: false }],
+          history: [
+            {
+              success: true,
+              duration: 100,
+            },
+            {
+              success: true,
+              duration: 200,
+            },
+            {
+              success: false,
+              duration: 300,
+            },
+          ],
           calculated_metrics: {
             success_ratio: 0.66,
+            p50: 200,
+            p95: 300,
+            p99: 300,
           },
         },
       },
@@ -209,9 +224,21 @@ describe('alerts_list component with items', () => {
       },
       monitoring: {
         execution: {
-          history: [{ success: true }, { success: true }],
+          history: [
+            {
+              success: true,
+              duration: 100,
+            },
+            {
+              success: true,
+              duration: 500,
+            },
+          ],
           calculated_metrics: {
             success_ratio: 1,
+            p50: 0,
+            p95: 100,
+            p99: 500,
           },
         },
       },
@@ -240,7 +267,7 @@ describe('alerts_list component with items', () => {
       },
       monitoring: {
         execution: {
-          history: [{ success: false }],
+          history: [{ success: false, duration: 100 }],
           calculated_metrics: {
             success_ratio: 0,
           },
@@ -464,6 +491,7 @@ describe('alerts_list component with items', () => {
     const ratios = wrapper.find(
       'EuiTableRowCell[data-test-subj="alertsTableCell-successRatio"] span[data-test-subj="successRatio"]'
     );
+
     mockedAlertsData.forEach((rule, index) => {
       if (rule.monitoring) {
         expect(ratios.at(index).text()).toEqual(
@@ -471,6 +499,68 @@ describe('alerts_list component with items', () => {
         );
       } else {
         expect(ratios.at(index).text()).toEqual(`N/A`);
+      }
+    });
+
+    // P50 column is rendered initially
+    expect(
+      wrapper.find(`[data-test-subj="alertsTable-${Percentiles.P50}ColumnName"]`).exists()
+    ).toBeTruthy();
+
+    let percentiles = wrapper.find(
+      `EuiTableRowCell[data-test-subj="alertsTableCell-ruleExecutionPercentile"] span[data-test-subj="${Percentiles.P50}Percentile"]`
+    );
+
+    mockedAlertsData.forEach((rule, index) => {
+      if (typeof rule.monitoring?.execution.calculated_metrics.p50 === 'number') {
+        expect(percentiles.at(index).text()).toEqual(
+          `${rule.monitoring.execution.calculated_metrics.p50}ms`
+        );
+      } else {
+        expect(percentiles.at(index).text()).toEqual('N/A');
+      }
+    });
+
+    // Hover over percentile selection button
+    wrapper
+      .find('[data-test-subj="percentileSelectablePopover-iconButton"]')
+      .first()
+      .simulate('click');
+
+    jest.runAllTimers();
+    wrapper.update();
+
+    // Percentile Selection
+    expect(
+      wrapper.find('[data-test-subj="percentileSelectablePopover-selectable"]').exists()
+    ).toBeTruthy();
+
+    const percentileOptions = wrapper.find(
+      '[data-test-subj="percentileSelectablePopover-selectable"] li'
+    );
+    expect(percentileOptions.length).toEqual(3);
+
+    // Select P95
+    percentileOptions.at(1).simulate('click');
+
+    jest.runAllTimers();
+    wrapper.update();
+
+    expect(
+      wrapper.find(`[data-test-subj="alertsTable-${Percentiles.P95}ColumnName"]`).exists()
+    ).toBeTruthy();
+
+    percentiles = wrapper.find(
+      `EuiTableRowCell[data-test-subj="alertsTableCell-ruleExecutionPercentile"] span[data-test-subj="${Percentiles.P95}Percentile"]`
+    );
+
+    mockedAlertsData.forEach((rule, index) => {
+      if (typeof rule.monitoring?.execution.calculated_metrics.p95 === 'number') {
+        expect(percentiles.at(index).text()).toEqual(
+          `${rule.monitoring.execution.calculated_metrics.p95}ms`
+        );
+      } else {
+        expect(percentiles.at(index).text()).toEqual('N/A');
       }
     });
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { capitalize, sortBy } from 'lodash';
 import moment from 'moment';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import {
   EuiBasicTable,
   EuiBadge,
@@ -33,8 +33,10 @@ import {
   EuiHorizontalRule,
   EuiPopover,
   EuiPopoverTitle,
+  EuiSelectableOption,
   EuiIcon,
 } from '@elastic/eui';
+import { EuiSelectableOptionCheckedType } from '@elastic/eui/src/components/selectable/selectable_option';
 import { useHistory } from 'react-router-dom';
 
 import { isEmpty } from 'lodash';
@@ -45,6 +47,7 @@ import {
   RuleType,
   RuleTypeIndex,
   Pagination,
+  Percentiles,
 } from '../../../../types';
 import { AlertAdd, AlertEdit } from '../../alert_form';
 import { BulkOperationPopover } from '../../common/components/bulk_operation_popover';
@@ -72,6 +75,7 @@ import {
   ALERTS_FEATURE_ID,
   AlertExecutionStatusErrorReasons,
   formatDuration,
+  MONITORING_HISTORY_LIMIT,
 } from '../../../../../../alerting/common';
 import { alertsStatusesTranslationsMapping, ALERT_STATUS_LICENSE_ERROR } from '../translations';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -81,11 +85,15 @@ import { CenterJustifiedSpinner } from '../../../components/center_justified_spi
 import { ManageLicenseModal } from './manage_license_modal';
 import { checkAlertTypeEnabled } from '../../../lib/check_alert_type_enabled';
 import { RuleEnabledSwitch } from './rule_enabled_switch';
+import { PercentileSelectablePopover } from './percentile_selectable_popover';
 import {
   formatMillisForDisplay,
   shouldShowDurationWarning,
 } from '../../../lib/execution_duration_utils';
-import { getFormattedSuccessRatio } from '../../../lib/monitoring_utils';
+import {
+  getFormattedSuccessRatio,
+  getFormattedRuleExecutionPercentile,
+} from '../../../lib/monitoring_utils';
 
 const ENTER_KEY = 13;
 
@@ -99,6 +107,24 @@ interface AlertState {
   data: Rule[];
   totalItemCount: number;
 }
+
+const percentileOrdinals = {
+  [Percentiles.P50]: '50th',
+  [Percentiles.P95]: '95th',
+  [Percentiles.P99]: '99th',
+};
+
+const percentileFields = {
+  [Percentiles.P50]: 'monitoring.execution.calculated_metrics.p50',
+  [Percentiles.P95]: 'monitoring.execution.calculated_metrics.p95',
+  [Percentiles.P99]: 'monitoring.execution.calculated_metrics.p99',
+};
+
+const initialPercentileOptions = Object.values(Percentiles).map((percentile) => ({
+  checked: percentile === Percentiles.P50 ? 'on' : (undefined as EuiSelectableOptionCheckedType),
+  label: percentile,
+  key: percentile,
+}));
 
 export const AlertsList: React.FunctionComponent = () => {
   const history = useHistory();
@@ -128,6 +154,16 @@ export const AlertsList: React.FunctionComponent = () => {
   const [editFlyoutVisible, setEditFlyoutVisibility] = useState<boolean>(false);
   const [currentRuleToEdit, setCurrentRuleToEdit] = useState<AlertTableItem | null>(null);
   const [tagPopoverOpenIndex, setTagPopoverOpenIndex] = useState<number>(-1);
+
+  const [percentileOptions, setPercentileOptions] =
+    useState<EuiSelectableOption[]>(initialPercentileOptions);
+
+  const selectedPercentile = useMemo(() => {
+    const selectedOption = percentileOptions.find((option) => option.checked === 'on');
+    if (selectedOption) {
+      return Percentiles[selectedOption.key as Percentiles];
+    }
+  }, [percentileOptions]);
 
   const [sort, setSort] = useState<EuiTableSortingType<AlertTableItem>['sort']>({
     field: 'name',
@@ -166,12 +202,17 @@ export const AlertsList: React.FunctionComponent = () => {
   const isRuleTypeEditableInContext = (ruleTypeId: string) =>
     ruleTypeRegistry.has(ruleTypeId) ? !ruleTypeRegistry.get(ruleTypeId).requiresAppContext : false;
 
+  const onPercentileOptionsChange = useCallback((options: EuiSelectableOption[]) => {
+    setPercentileOptions(options);
+  }, []);
+
   useEffect(() => {
     loadAlertsData();
   }, [
     alertTypesState,
     page,
     searchText,
+    percentileOptions,
     JSON.stringify(typesFilter),
     JSON.stringify(actionTypesFilter),
     JSON.stringify(alertStatusesFilter),
@@ -352,344 +393,398 @@ export const AlertsList: React.FunctionComponent = () => {
     );
   };
 
-  const alertsTableColumns = [
-    {
-      field: 'enabled',
-      name: i18n.translate(
-        'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.enabledTitle',
-        { defaultMessage: 'Enabled' }
-      ),
-      width: '50px',
-      render(_enabled: boolean | undefined, item: AlertTableItem) {
-        return (
-          <RuleEnabledSwitch
-            disableAlert={async () => await disableAlert({ http, id: item.id })}
-            enableAlert={async () => await enableAlert({ http, id: item.id })}
-            item={item}
-            onAlertChanged={() => loadAlertsData()}
-          />
-        );
-      },
-      sortable: true,
-      'data-test-subj': 'alertsTableCell-enabled',
-    },
-    {
-      field: 'name',
-      name: i18n.translate(
-        'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.nameTitle',
-        { defaultMessage: 'Name' }
-      ),
-      sortable: true,
-      truncateText: true,
-      width: '30%',
-      'data-test-subj': 'alertsTableCell-name',
-      render: (name: string, alert: AlertTableItem) => {
-        const ruleType = alertTypesState.data.get(alert.alertTypeId);
-        const checkEnabledResult = checkAlertTypeEnabled(ruleType);
-        const link = (
-          <>
-            <EuiFlexGroup direction="column" gutterSize="xs">
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup gutterSize="xs">
-                  <EuiFlexItem grow={false}>
-                    <EuiLink
-                      title={name}
-                      onClick={() => {
-                        history.push(routeToRuleDetails.replace(`:ruleId`, alert.id));
-                      }}
-                    >
-                      {name}
-                    </EuiLink>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    {!checkEnabledResult.isEnabled && (
-                      <EuiIconTip
-                        anchorClassName="ruleDisabledQuestionIcon"
-                        data-test-subj="ruleDisabledByLicenseTooltip"
-                        type="questionInCircle"
-                        content={checkEnabledResult.message}
-                        position="right"
-                      />
-                    )}
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiText color="subdued" size="xs">
-                  {alert.alertType}
-                </EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </>
-        );
-        return (
-          <>
-            {link}
-            {alert.enabled && alert.muteAll && (
-              <EuiBadge data-test-subj="mutedActionsBadge" color="hollow">
-                <FormattedMessage
-                  id="xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.mutedBadge"
-                  defaultMessage="Muted"
-                />
-              </EuiBadge>
-            )}
-          </>
-        );
-      },
-    },
-    {
-      field: 'tags',
-      name: '',
-      sortable: false,
-      width: '50px',
-      'data-test-subj': 'alertsTableCell-tagsPopover',
-      render: (tags: string[], item: AlertTableItem) => {
-        return tags.length > 0 ? (
-          <EuiPopover
-            button={
-              <EuiBadge
-                data-test-subj="ruleTagsBadge"
-                color="hollow"
-                iconType="tag"
-                iconSide="left"
-                tabIndex={-1}
-                onClick={() => setTagPopoverOpenIndex(item.index)}
-                onClickAriaLabel="Tags"
-                iconOnClick={() => setTagPopoverOpenIndex(item.index)}
-                iconOnClickAriaLabel="Tags"
-              >
-                {tags.length}
-              </EuiBadge>
-            }
-            anchorPosition="upCenter"
-            isOpen={tagPopoverOpenIndex === item.index}
-            closePopover={() => setTagPopoverOpenIndex(-1)}
-          >
-            <EuiPopoverTitle data-test-subj="ruleTagsPopoverTitle">Tags</EuiPopoverTitle>
-            <div style={{ width: '300px' }} />
-            {tags.map((tag: string, index: number) => (
-              <EuiBadge
-                data-test-subj="ruleTagsPopoverTag"
-                key={index}
-                color="hollow"
-                iconType="tag"
-                iconSide="left"
-              >
-                {tag}
-              </EuiBadge>
-            ))}
-          </EuiPopover>
-        ) : null;
-      },
-    },
-    {
-      field: 'executionStatus.lastExecutionDate',
-      name: (
-        <EuiToolTip
-          data-test-subj="alertsTableCell-lastExecutionDateTooltip"
+  const renderPercentileColumnName = () => {
+    return (
+      <span data-test-subj={`alertsTable-${selectedPercentile}ColumnName`}>
+        {selectedPercentile}&nbsp;
+        <EuiIconTip
+          type="questionInCircle"
+          iconProps={{
+            size: 's',
+            color: 'subdued',
+            className: 'eui-alignTop',
+          }}
           content={i18n.translate(
-            'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.lastExecutionDateTitle',
+            'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.ruleExecutionPercentileTooltip',
             {
-              defaultMessage: 'Start time of the last execution.',
+              defaultMessage: `{percentileOrdinal} percentile of this rule's past {sampleLimit} execution durations`,
+              values: {
+                percentileOrdinal: percentileOrdinals[selectedPercentile!],
+                sampleLimit: MONITORING_HISTORY_LIMIT,
+              },
             }
           )}
-        >
-          <span>
-            Last run{' '}
-            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
-          </span>
-        </EuiToolTip>
-      ),
+        />
+        <PercentileSelectablePopover
+          options={percentileOptions}
+          onOptionsChange={onPercentileOptionsChange}
+        />
+      </span>
+    );
+  };
+
+  const renderPercentileCellValue = (value: number) => {
+    return (
+      <span data-test-subj={`${selectedPercentile}Percentile`}>
+        {typeof value === 'number' ? getFormattedRuleExecutionPercentile(value) : 'N/A'}
+      </span>
+    );
+  };
+
+  const getPercentileColumn = () => {
+    return {
+      mobileOptions: { header: false },
+      field: percentileFields[selectedPercentile!],
+      width: '16%',
+      name: renderPercentileColumnName(),
+      'data-test-subj': 'alertsTableCell-ruleExecutionPercentile',
       sortable: true,
-      width: '15%',
-      'data-test-subj': 'alertsTableCell-lastExecutionDate',
-      render: (date: Date) => {
-        if (date) {
+      truncateText: false,
+      render: renderPercentileCellValue,
+    };
+  };
+
+  const getAlertsTableColumns = () => {
+    return [
+      {
+        field: 'enabled',
+        name: i18n.translate(
+          'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.enabledTitle',
+          { defaultMessage: 'Enabled' }
+        ),
+        width: '50px',
+        render(_enabled: boolean | undefined, item: AlertTableItem) {
           return (
+            <RuleEnabledSwitch
+              disableAlert={async () => await disableAlert({ http, id: item.id })}
+              enableAlert={async () => await enableAlert({ http, id: item.id })}
+              item={item}
+              onAlertChanged={() => loadAlertsData()}
+            />
+          );
+        },
+        sortable: true,
+        'data-test-subj': 'alertsTableCell-enabled',
+      },
+      {
+        field: 'name',
+        name: i18n.translate(
+          'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.nameTitle',
+          { defaultMessage: 'Name' }
+        ),
+        sortable: true,
+        truncateText: true,
+        width: '30%',
+        'data-test-subj': 'alertsTableCell-name',
+        render: (name: string, alert: AlertTableItem) => {
+          const ruleType = alertTypesState.data.get(alert.alertTypeId);
+          const checkEnabledResult = checkAlertTypeEnabled(ruleType);
+          const link = (
             <>
-              <EuiFlexGroup direction="column" gutterSize="none">
+              <EuiFlexGroup direction="column" gutterSize="xs">
                 <EuiFlexItem grow={false}>
-                  {moment(date).format('MMM D, YYYY HH:mm:ssa')}
+                  <EuiFlexGroup gutterSize="xs">
+                    <EuiFlexItem grow={false}>
+                      <EuiLink
+                        title={name}
+                        onClick={() => {
+                          history.push(routeToRuleDetails.replace(`:ruleId`, alert.id));
+                        }}
+                      >
+                        {name}
+                      </EuiLink>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      {!checkEnabledResult.isEnabled && (
+                        <EuiIconTip
+                          anchorClassName="ruleDisabledQuestionIcon"
+                          data-test-subj="ruleDisabledByLicenseTooltip"
+                          type="questionInCircle"
+                          content={checkEnabledResult.message}
+                          position="right"
+                        />
+                      )}
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiText color="subdued" size="xs">
-                    {moment(date).fromNow()}
+                    {alert.alertType}
                   </EuiText>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </>
           );
-        }
+          return (
+            <>
+              {link}
+              {alert.enabled && alert.muteAll && (
+                <EuiBadge data-test-subj="mutedActionsBadge" color="hollow">
+                  <FormattedMessage
+                    id="xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.mutedBadge"
+                    defaultMessage="Muted"
+                  />
+                </EuiBadge>
+              )}
+            </>
+          );
+        },
       },
-    },
-    {
-      field: 'schedule.interval',
-      width: '6%',
-      name: i18n.translate(
-        'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.scheduleTitle',
-        { defaultMessage: 'Interval' }
-      ),
-      sortable: false,
-      truncateText: false,
-      'data-test-subj': 'alertsTableCell-interval',
-      render: (interval: string) => formatDuration(interval),
-    },
-    {
-      field: 'executionStatus.lastDuration',
-      width: '12%',
-      name: (
-        <EuiToolTip
-          data-test-subj="alertsTableCell-durationTooltip"
-          content={i18n.translate(
-            'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.durationTitle',
-            {
-              defaultMessage: 'The length of time it took for the rule to run.',
-            }
-          )}
-        >
-          <span>
-            Duration{' '}
-            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
-          </span>
-        </EuiToolTip>
-      ),
-      sortable: true,
-      truncateText: false,
-      'data-test-subj': 'alertsTableCell-duration',
-      render: (value: number, item: AlertTableItem) => {
-        const showDurationWarning = shouldShowDurationWarning(
-          alertTypesState.data.get(item.alertTypeId),
-          value
-        );
-
-        return (
-          <>
-            {`${formatMillisForDisplay(value)}`}
-            {showDurationWarning && (
-              <EuiIconTip
-                data-test-subj="ruleDurationWarning"
-                anchorClassName="ruleDurationWarningIcon"
-                type="alert"
-                color="warning"
-                content={i18n.translate(
-                  'xpack.triggersActionsUI.sections.alertsList.ruleTypeExcessDurationMessage',
-                  {
-                    defaultMessage: `Duration exceeds the rule's expected run time.`,
-                  }
-                )}
-                position="right"
-              />
+      {
+        field: 'tags',
+        name: '',
+        sortable: false,
+        width: '50px',
+        'data-test-subj': 'alertsTableCell-tagsPopover',
+        render: (tags: string[], item: AlertTableItem) => {
+          return tags.length > 0 ? (
+            <EuiPopover
+              button={
+                <EuiBadge
+                  data-test-subj="ruleTagsBadge"
+                  color="hollow"
+                  iconType="tag"
+                  iconSide="left"
+                  tabIndex={-1}
+                  onClick={() => setTagPopoverOpenIndex(item.index)}
+                  onClickAriaLabel="Tags"
+                  iconOnClick={() => setTagPopoverOpenIndex(item.index)}
+                  iconOnClickAriaLabel="Tags"
+                >
+                  {tags.length}
+                </EuiBadge>
+              }
+              anchorPosition="upCenter"
+              isOpen={tagPopoverOpenIndex === item.index}
+              closePopover={() => setTagPopoverOpenIndex(-1)}
+            >
+              <EuiPopoverTitle data-test-subj="ruleTagsPopoverTitle">Tags</EuiPopoverTitle>
+              <div style={{ width: '300px' }} />
+              {tags.map((tag: string, index: number) => (
+                <EuiBadge
+                  data-test-subj="ruleTagsPopoverTag"
+                  key={index}
+                  color="hollow"
+                  iconType="tag"
+                  iconSide="left"
+                >
+                  {tag}
+                </EuiBadge>
+              ))}
+            </EuiPopover>
+          ) : null;
+        },
+      },
+      {
+        field: 'executionStatus.lastExecutionDate',
+        name: (
+          <EuiToolTip
+            data-test-subj="alertsTableCell-lastExecutionDateTooltip"
+            content={i18n.translate(
+              'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.lastExecutionDateTitle',
+              {
+                defaultMessage: 'Start time of the last execution.',
+              }
             )}
-          </>
-        );
-      },
-    },
-    {
-      field: 'monitoring.execution.calculated_metrics.success_ratio',
-      width: '12%',
-      name: (
-        <EuiToolTip
-          data-test-subj="alertsTableCell-successRatioTooltip"
-          content={i18n.translate(
-            'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.successRatioTitle',
-            {
-              defaultMessage: 'How often this rule executes successfully',
-            }
-          )}
-        >
-          <span>
-            Success ratio{' '}
-            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
-          </span>
-        </EuiToolTip>
-      ),
-      sortable: true,
-      truncateText: false,
-      'data-test-subj': 'alertsTableCell-successRatio',
-      render: (value: number) => {
-        return (
-          <span data-test-subj="successRatio">
-            {value !== undefined ? getFormattedSuccessRatio(value) : 'N/A'}
-          </span>
-        );
-      },
-    },
-    {
-      field: 'executionStatus.status',
-      name: i18n.translate(
-        'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.statusTitle',
-        { defaultMessage: 'Status' }
-      ),
-      sortable: true,
-      truncateText: false,
-      width: '120px',
-      'data-test-subj': 'alertsTableCell-status',
-      render: (_executionStatus: AlertExecutionStatus, item: AlertTableItem) => {
-        return renderAlertExecutionStatus(item.executionStatus, item);
-      },
-    },
-    {
-      name: '',
-      width: '10%',
-      render(item: AlertTableItem) {
-        return (
-          <EuiFlexGroup justifyContent="spaceBetween" gutterSize="s">
-            <EuiFlexItem grow={false} className="alertSidebarItem">
-              <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
-                {item.isEditable && isRuleTypeEditableInContext(item.alertTypeId) ? (
-                  <EuiFlexItem grow={false} data-test-subj="alertSidebarEditAction">
-                    <EuiButtonIcon
-                      color={'primary'}
-                      title={i18n.translate(
-                        'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.editButtonTooltip',
-                        { defaultMessage: 'Edit' }
-                      )}
-                      className="alertSidebarItem__action"
-                      data-test-subj="editActionHoverButton"
-                      onClick={() => onRuleEdit(item)}
-                      iconType={'pencil'}
-                      aria-label={i18n.translate(
-                        'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.editAriaLabel',
-                        { defaultMessage: 'Edit' }
-                      )}
-                    />
+          >
+            <span>
+              Last run{' '}
+              <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+            </span>
+          </EuiToolTip>
+        ),
+        sortable: true,
+        width: '15%',
+        'data-test-subj': 'alertsTableCell-lastExecutionDate',
+        render: (date: Date) => {
+          if (date) {
+            return (
+              <>
+                <EuiFlexGroup direction="column" gutterSize="none">
+                  <EuiFlexItem grow={false}>
+                    {moment(date).format('MMM D, YYYY HH:mm:ssa')}
                   </EuiFlexItem>
-                ) : null}
-                {item.isEditable ? (
-                  <EuiFlexItem grow={false} data-test-subj="alertSidebarDeleteAction">
-                    <EuiButtonIcon
-                      color={'danger'}
-                      title={i18n.translate(
-                        'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.deleteButtonTooltip',
-                        { defaultMessage: 'Delete' }
-                      )}
-                      className="alertSidebarItem__action"
-                      data-test-subj="deleteActionHoverButton"
-                      onClick={() => setAlertsToDelete([item.id])}
-                      iconType={'trash'}
-                      aria-label={i18n.translate(
-                        'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.deleteAriaLabel',
-                        { defaultMessage: 'Delete' }
-                      )}
-                    />
+                  <EuiFlexItem grow={false}>
+                    <EuiText color="subdued" size="xs">
+                      {moment(date).fromNow()}
+                    </EuiText>
                   </EuiFlexItem>
-                ) : null}
-              </EuiFlexGroup>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <CollapsedItemActions
-                key={item.id}
-                item={item}
-                onAlertChanged={() => loadAlertsData()}
-                setAlertsToDelete={setAlertsToDelete}
-                onEditAlert={() => onRuleEdit(item)}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        );
+                </EuiFlexGroup>
+              </>
+            );
+          }
+        },
       },
-    },
-  ];
+      {
+        field: 'schedule.interval',
+        width: '6%',
+        name: i18n.translate(
+          'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.scheduleTitle',
+          { defaultMessage: 'Interval' }
+        ),
+        sortable: false,
+        truncateText: false,
+        'data-test-subj': 'alertsTableCell-interval',
+        render: (interval: string) => formatDuration(interval),
+      },
+      {
+        field: 'executionStatus.lastDuration',
+        width: '12%',
+        name: (
+          <EuiToolTip
+            data-test-subj="alertsTableCell-durationTooltip"
+            content={i18n.translate(
+              'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.durationTitle',
+              {
+                defaultMessage: 'The length of time it took for the rule to run.',
+              }
+            )}
+          >
+            <span>
+              Duration{' '}
+              <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+            </span>
+          </EuiToolTip>
+        ),
+        sortable: true,
+        truncateText: false,
+        'data-test-subj': 'alertsTableCell-duration',
+        render: (value: number, item: AlertTableItem) => {
+          const showDurationWarning = shouldShowDurationWarning(
+            alertTypesState.data.get(item.alertTypeId),
+            value
+          );
+
+          return (
+            <>
+              {`${formatMillisForDisplay(value)}`}
+              {showDurationWarning && (
+                <EuiIconTip
+                  data-test-subj="ruleDurationWarning"
+                  anchorClassName="ruleDurationWarningIcon"
+                  type="alert"
+                  color="warning"
+                  content={i18n.translate(
+                    'xpack.triggersActionsUI.sections.alertsList.ruleTypeExcessDurationMessage',
+                    {
+                      defaultMessage: `Duration exceeds the rule's expected run time.`,
+                    }
+                  )}
+                  position="right"
+                />
+              )}
+            </>
+          );
+        },
+      },
+      {
+        field: 'monitoring.execution.calculated_metrics.success_ratio',
+        width: '12%',
+        name: (
+          <EuiToolTip
+            data-test-subj="alertsTableCell-successRatioTooltip"
+            content={i18n.translate(
+              'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.successRatioTitle',
+              {
+                defaultMessage: 'How often this rule executes successfully',
+              }
+            )}
+          >
+            <span>
+              Success ratio{' '}
+              <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+            </span>
+          </EuiToolTip>
+        ),
+        sortable: true,
+        truncateText: false,
+        'data-test-subj': 'alertsTableCell-successRatio',
+        render: (value: number) => {
+          return (
+            <span data-test-subj="successRatio">
+              {value !== undefined ? getFormattedSuccessRatio(value) : 'N/A'}
+            </span>
+          );
+        },
+      },
+      getPercentileColumn(),
+      {
+        field: 'executionStatus.status',
+        name: i18n.translate(
+          'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.statusTitle',
+          { defaultMessage: 'Status' }
+        ),
+        sortable: true,
+        truncateText: false,
+        width: '120px',
+        'data-test-subj': 'alertsTableCell-status',
+        render: (_executionStatus: AlertExecutionStatus, item: AlertTableItem) => {
+          return renderAlertExecutionStatus(item.executionStatus, item);
+        },
+      },
+      {
+        name: '',
+        width: '10%',
+        render(item: AlertTableItem) {
+          return (
+            <EuiFlexGroup justifyContent="spaceBetween" gutterSize="s">
+              <EuiFlexItem grow={false} className="alertSidebarItem">
+                <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+                  {item.isEditable && isRuleTypeEditableInContext(item.alertTypeId) ? (
+                    <EuiFlexItem grow={false} data-test-subj="alertSidebarEditAction">
+                      <EuiButtonIcon
+                        color={'primary'}
+                        title={i18n.translate(
+                          'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.editButtonTooltip',
+                          { defaultMessage: 'Edit' }
+                        )}
+                        className="alertSidebarItem__action"
+                        data-test-subj="editActionHoverButton"
+                        onClick={() => onRuleEdit(item)}
+                        iconType={'pencil'}
+                        aria-label={i18n.translate(
+                          'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.editAriaLabel',
+                          { defaultMessage: 'Edit' }
+                        )}
+                      />
+                    </EuiFlexItem>
+                  ) : null}
+                  {item.isEditable ? (
+                    <EuiFlexItem grow={false} data-test-subj="alertSidebarDeleteAction">
+                      <EuiButtonIcon
+                        color={'danger'}
+                        title={i18n.translate(
+                          'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.deleteButtonTooltip',
+                          { defaultMessage: 'Delete' }
+                        )}
+                        className="alertSidebarItem__action"
+                        data-test-subj="deleteActionHoverButton"
+                        onClick={() => setAlertsToDelete([item.id])}
+                        iconType={'trash'}
+                        aria-label={i18n.translate(
+                          'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.deleteAriaLabel',
+                          { defaultMessage: 'Delete' }
+                        )}
+                      />
+                    </EuiFlexItem>
+                  ) : null}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <CollapsedItemActions
+                  key={item.id}
+                  item={item}
+                  onAlertChanged={() => loadAlertsData()}
+                  setAlertsToDelete={setAlertsToDelete}
+                  onEditAlert={() => onRuleEdit(item)}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          );
+        },
+      },
+    ];
+  };
 
   const authorizedAlertTypes = [...alertTypesState.data.values()];
   const authorizedToCreateAnyAlerts = authorizedAlertTypes.some(
@@ -950,7 +1045,7 @@ export const AlertsList: React.FunctionComponent = () => {
             : convertAlertsToTableItems(alertsState.data, alertTypesState.data, canExecuteActions)
         }
         itemId="id"
-        columns={alertsTableColumns}
+        columns={getAlertsTableColumns()}
         sorting={{ sort }}
         rowProps={(item: AlertTableItem) => ({
           'data-test-subj': 'alert-row',

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.tsx
@@ -114,7 +114,7 @@ const percentileOrdinals = {
   [Percentiles.P99]: '99th',
 };
 
-const percentileFields = {
+export const percentileFields = {
   [Percentiles.P50]: 'monitoring.execution.calculated_metrics.p50',
   [Percentiles.P95]: 'monitoring.execution.calculated_metrics.p95',
   [Percentiles.P99]: 'monitoring.execution.calculated_metrics.p99',
@@ -396,14 +396,7 @@ export const AlertsList: React.FunctionComponent = () => {
   const renderPercentileColumnName = () => {
     return (
       <span data-test-subj={`alertsTable-${selectedPercentile}ColumnName`}>
-        {selectedPercentile}&nbsp;
-        <EuiIconTip
-          type="questionInCircle"
-          iconProps={{
-            size: 's',
-            color: 'subdued',
-            className: 'eui-alignTop',
-          }}
+        <EuiToolTip
           content={i18n.translate(
             'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.ruleExecutionPercentileTooltip',
             {
@@ -414,7 +407,12 @@ export const AlertsList: React.FunctionComponent = () => {
               },
             }
           )}
-        />
+        >
+          <span>
+            {selectedPercentile}&nbsp;
+            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+          </span>
+        </EuiToolTip>
         <PercentileSelectablePopover
           options={percentileOptions}
           onOptionsChange={onPercentileOptionsChange}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { capitalize, sortBy } from 'lodash';
 import moment from 'moment';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import {
   EuiBasicTable,
   EuiBadge,
@@ -201,10 +201,6 @@ export const AlertsList: React.FunctionComponent = () => {
 
   const isRuleTypeEditableInContext = (ruleTypeId: string) =>
     ruleTypeRegistry.has(ruleTypeId) ? !ruleTypeRegistry.get(ruleTypeId).requiresAppContext : false;
-
-  const onPercentileOptionsChange = useCallback((options: EuiSelectableOption[]) => {
-    setPercentileOptions(options);
-  }, []);
 
   useEffect(() => {
     loadAlertsData();
@@ -415,7 +411,7 @@ export const AlertsList: React.FunctionComponent = () => {
         </EuiToolTip>
         <PercentileSelectablePopover
           options={percentileOptions}
-          onOptionsChange={onPercentileOptionsChange}
+          onOptionsChange={setPercentileOptions}
         />
       </span>
     );

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/percentile_selectable_popover.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/percentile_selectable_popover.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useState, useCallback } from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiPopover, EuiButtonIcon, EuiSelectable, EuiSelectableOption } from '@elastic/eui';
+
+const iconButtonTitle = i18n.translate(
+  'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.ruleExecutionPercentileSelectButton',
+  { defaultMessage: 'select percentile' }
+);
+
+interface Props {
+  options: EuiSelectableOption[];
+  onOptionsChange: (options: EuiSelectableOption[]) => void;
+}
+
+const divStyle = { width: 200 };
+
+export const PercentileSelectablePopover = memo((props: Props) => {
+  const { options, onOptionsChange } = props;
+
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const onButtonClick = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    // stop propagation to prevent clicking on the column header
+    // which triggers a sorting call
+    e.stopPropagation();
+    setIsOpen((currentIsOpen) => !currentIsOpen);
+  }, []);
+
+  const onPopoverClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const onOptionsChangeAndClosePopover = useCallback(
+    (newOptions: EuiSelectableOption[]) => {
+      onPopoverClose();
+      onOptionsChange(newOptions);
+    },
+    [onOptionsChange, onPopoverClose]
+  );
+
+  const onDivClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    // Div to capture click events and stop propagation to
+    // prevent clicking on the column header which triggers a sorting call.
+    // The div needs to be here because EuiSelectable does not pass the event
+    // into the onChange handler
+    e.stopPropagation();
+  }, []);
+
+  return (
+    <EuiPopover
+      button={
+        <EuiButtonIcon
+          iconType="gear"
+          size="s"
+          data-test-subj={`percentileSelectablePopover-iconButton`}
+          title={iconButtonTitle}
+          aria-label={iconButtonTitle}
+          onClick={onButtonClick}
+        />
+      }
+      panelPaddingSize="s"
+      isOpen={isOpen}
+      closePopover={onPopoverClose}
+      anchorPosition="downRight"
+    >
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
+      <div style={divStyle} onClick={onDivClick}>
+        <EuiSelectable
+          data-test-subj="percentileSelectablePopover-selectable"
+          singleSelection="always"
+          options={options}
+          onChange={onOptionsChangeAndClosePopover}
+        >
+          {(list) => list}
+        </EuiSelectable>
+      </div>
+    </EuiPopover>
+  );
+});

--- a/x-pack/plugins/triggers_actions_ui/public/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/types.ts
@@ -327,3 +327,9 @@ export interface AlertAddProps<MetaData = Record<string, any>> {
   metadata?: MetaData;
   ruleTypeIndex?: RuleTypeIndex;
 }
+
+export enum Percentiles {
+  P50 = 'P50',
+  P95 = 'P95',
+  P99 = 'P99',
+}

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alerts_list.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alerts_list.ts
@@ -361,6 +361,26 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       );
     });
 
+    it('should render percentile column and cells correctly', async () => {
+      await createAlert({ supertest, objectRemover });
+      await refreshAlertsList();
+
+      await testSubjects.existOrFail('alertsTable-P50ColumnName');
+      await testSubjects.existOrFail('P50Percentile');
+
+      await retry.try(async () => {
+        await testSubjects.click('percentileSelectablePopover-iconButton');
+        await testSubjects.existOrFail('percentileSelectablePopover-selectable');
+        const searchClearButton = await find.byCssSelector(
+          '[data-test-subj="percentileSelectablePopover-selectable"] li:nth-child(2)'
+        );
+        await searchClearButton.click();
+        await testSubjects.missingOrFail('percentileSelectablePopover-selectable');
+        await testSubjects.existOrFail('alertsTable-P95ColumnName');
+        await testSubjects.existOrFail('P95Percentile');
+      });
+    });
+
     it('should delete all selection', async () => {
       const namePrefix = generateUniqueKey();
       const createdAlert = await createAlertManualCleanup({


### PR DESCRIPTION
## Summary

Adds the P50/95/99 Percentiles for rule execution duration to the rule management table. Implements the feature describe in https://github.com/elastic/kibana/issues/122399.

Piggybacks off the changes that Chris did for the rules execution success ratio (https://github.com/elastic/kibana/pull/122716).

This PR does not include the datagrid, that will be a separate change.

![Screenshot from 2022-01-25 10-56-49](https://user-images.githubusercontent.com/74562234/151043561-7ac94480-5920-4118-a9e0-66eae74a7483.png)

![Screenshot from 2022-01-25 10-57-04](https://user-images.githubusercontent.com/74562234/151043580-6a40e273-d45a-473c-8d47-c9111a5192be.png)

### Checklist
- [x]  Create schema on the rule saved object to add the duration, P50/95/99 

- [x]  Saved the duration of the execution at each run and let's cap it at 60

- [x]  calculate the P50/95/99 from the duration attributes at each run

- [x] add the columns P50/95/99 in the rule management table