### PR TITLE
[Security Solution] Adjust policy test to make it more reliable

### DIFF
--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
@@ -409,9 +409,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                 version: policyInfo.packageInfo.version,
               },
             },
-            artifact_manifest: {
-              manifest_version: agentFullPolicy.inputs[0].artifact_manifest.manifest_version,
-            },
+            artifact_manifest: agentFullPolicy.inputs[0].artifact_manifest,
             policy: {
               linux: {
                 events: {
@@ -495,9 +493,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                 version: policyInfo.packageInfo.version,
               },
             },
-            artifact_manifest: {
-              manifest_version: agentFullPolicy.inputs[0].artifact_manifest.manifest_version,
-            },
+            artifact_manifest: agentFullPolicy.inputs[0].artifact_manifest,
           }),
         ]);
       });

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
@@ -458,9 +458,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                 version: policyInfo.packageInfo.version,
               },
             },
-            artifact_manifest: {
-              manifest_version: agentFullPolicy.inputs[0].artifact_manifest.manifest_version,
-            },
+            artifact_manifest: agentFullPolicy.inputs[0].artifact_manifest,
             policy: {
               linux: {
                 advanced: {


### PR DESCRIPTION
## Summary
Makes the policy test more reliable by removing the policy manifest check from the equation.  We're not testing for the manifests to match in this test, so it can be eliminated from the assertion.

This manifest check is also what periodically fails about once a week: https://github.com/elastic/kibana/issues/92567#issuecomment-1013732732

~~Flakey test runner instance: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/110~~
Above test bubbled up a failure which should be addressed with latest commit: https://github.com/elastic/kibana/pull/123608/commits/f18a99ea2996cc8e75da425500935ff34d877d74

New test runner instance with latest commit: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/111

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
