### PR TITLE
[Fleet] Allow empty strings for required text fields in package policies

### DIFF
--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -253,7 +253,7 @@ describe('Fleet - validatePackagePolicy()', () => {
           enabled: true,
           vars: {
             'foo-input-var-name': { value: undefined, type: 'text' },
-            'foo-input2-var-name': { value: '', type: 'text' },
+            'foo-input2-var-name': { value: undefined, type: 'text' },
             'foo-input3-var-name': { value: [], type: 'text' },
           },
           streams: [
@@ -553,6 +553,57 @@ describe('Fleet - validatePackagePolicy()', () => {
         description: null,
         namespace: null,
         inputs: null,
+      });
+    });
+
+    it('returns no errors when required field is present but empty', () => {
+      expect(
+        validatePackagePolicy(
+          {
+            ...validPackagePolicy,
+            inputs: [
+              {
+                type: 'foo',
+                policy_template: 'pkgPolicy1',
+                enabled: true,
+                vars: {
+                  'foo-input-var-name': { value: '', type: 'text' },
+                  'foo-input2-var-name': { value: '', type: 'text' },
+                  'foo-input3-var-name': { value: ['test'], type: 'text' },
+                },
+                streams: [
+                  {
+                    data_stream: { dataset: 'foo', type: 'logs' },
+                    enabled: true,
+                    vars: { 'var-name': { value: 'test_yaml: value', type: 'yaml' } },
+                  },
+                ],
+              },
+            ],
+          },
+          mockPackage,
+          safeLoad
+        )
+      ).toEqual({
+        name: null,
+        description: null,
+        namespace: null,
+        inputs: {
+          foo: {
+            streams: {
+              foo: {
+                vars: {
+                  'var-name': null,
+                },
+              },
+            },
+            vars: {
+              'foo-input-var-name': null,
+              'foo-input2-var-name': null,
+              'foo-input3-var-name': null,
+            },
+          },
+        },
       });
     });
   });

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -217,7 +217,7 @@ export const validatePackagePolicyConfig = (
   }
 
   if (varDef.required) {
-    if (parsedValue === undefined || (typeof parsedValue === 'string' && !parsedValue)) {
+    if (parsedValue === undefined || (varDef.type === 'yaml' && !parsedValue)) {
       errors.push(
         i18n.translate('xpack.fleet.packagePolicyValidation.requiredErrorMessage', {
           defaultMessage: '{fieldName} is required',

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -217,7 +217,7 @@ export const validatePackagePolicyConfig = (
   }
 
   if (varDef.required) {
-    if (parsedValue === undefined || (varDef.type === 'yaml' && !parsedValue)) {
+    if (parsedValue === undefined || (varDef.type === 'yaml' && parsedValue === '')) {
       errors.push(
         i18n.translate('xpack.fleet.packagePolicyValidation.requiredErrorMessage', {
           defaultMessage: '{fieldName} is required',


### PR DESCRIPTION
## Summary

Closes #123596.

If a text variable is marked as required in the package manifest, we will now allow empty strings to be supplied as a valid value. I have opted to keep it as invalid to have an empty yaml variable. 

### Test

Unit tests updated, but choose any package with a required text value and provide an empty string when creating a package policy.
