### PR TITLE
Deprecation logs test

### DIFF
--- a/packages/kbn-es-archiver/src/cli.ts
+++ b/packages/kbn-es-archiver/src/cli.ts
@@ -107,6 +107,7 @@ export function runCli() {
       const client = new Client({
         node: esUrl,
         ssl: esCa ? { ca: esCa } : undefined,
+        headers: { 'X-Opaque-Id': 'kbn-es-archiver' },
       });
       addCleanupTask(() => client.close());
 

--- a/packages/kbn-es/src/cluster.js
+++ b/packages/kbn-es/src/cluster.js
@@ -249,10 +249,7 @@ exports.Cluster = class Cluster {
     this._log.info(chalk.bold('Starting'));
     this._log.indent(4);
 
-    const esArgs = [
-      'action.destructive_requires_name=true',
-      'ingest.geoip.downloader.enabled=false',
-    ].concat(options.esArgs || []);
+    const esArgs = ['action.destructive_requires_name=true'].concat(options.esArgs || []);
 
     // Add to esArgs if ssl is enabled
     if (this._ssl) {

--- a/packages/kbn-test/src/es/es_test_config.ts
+++ b/packages/kbn-test/src/es/es_test_config.ts
@@ -31,7 +31,7 @@ class EsTestConfig {
     return process.env.TEST_ES_TRANSPORT_PORT || '9300-9400';
   }
 
-  getUrlParts() {
+  getUrlParts(ssl?: boolean) {
     // Allow setting one complete TEST_ES_URL for Es like https://elastic:changeme@myCloudInstance:9200
     if (process.env.TEST_ES_URL) {
       const testEsUrl = Url.parse(process.env.TEST_ES_URL);
@@ -65,7 +65,7 @@ class EsTestConfig {
     return {
       // Allow setting any individual component(s) of the URL,
       // or use default values (username and password from ../kbn/users.js)
-      protocol: process.env.TEST_ES_PROTOCOL || 'http',
+      protocol: process.env.TEST_ES_PROTOCOL || ssl ? 'https' : 'http',
       hostname: process.env.TEST_ES_HOSTNAME || 'localhost',
       port,
       auth: `${username}:${password}`,

--- a/packages/kbn-test/src/es/test_es_cluster.ts
+++ b/packages/kbn-test/src/es/test_es_cluster.ts
@@ -266,7 +266,11 @@ export function createTestEsCluster<
 
     async stop() {
       await this.getClient()
-        .search<{ message: string; 'elasticsearch.http.request.x_opaque_id': string }>(
+        .search<{
+          'log.level': string;
+          message: string;
+          'elasticsearch.http.request.x_opaque_id': string;
+        }>(
           { index: '.logs-deprecation.elasticsearch-default', ignore_unavailable: true, size: 100 },
           { ignore: [404] }
         )
@@ -276,11 +280,11 @@ export function createTestEsCluster<
               (d) => d._source!['elasticsearch.http.request.x_opaque_id'] !== 'kbn-test-client'
             )
             .map((d) => {
-              return d._source!.message;
+              return `ES DEPRECATION ${d._source!['log.level']} ${d._source!.message}`;
             });
 
           if (deps.length > 0) {
-            log.error(`Found ${deps.length} deprecation warnings.`);
+            log.error(`Found ${deps.length} deprecation logs:`);
           }
           deps.forEach((m) => {
             log.error(m);

--- a/packages/kbn-test/src/es/test_es_cluster.ts
+++ b/packages/kbn-test/src/es/test_es_cluster.ts
@@ -277,9 +277,7 @@ export function createTestEsCluster<
         )
         .then((res) => {
           const deps = res.body.hits.hits
-            .filter(
-              (d) => d._source!['elasticsearch.http.request.x_opaque_id'] !== 'kbn-test-client'
-            )
+            .filter((d) => /^kbn-test.*/.test(d._source!['elasticsearch.http.request.x_opaque_id']))
             .map((d) => {
               return `ES DEPRECATION ${d._source!['log.level']} ${d._source!.message}`;
             });
@@ -315,7 +313,7 @@ export function createTestEsCluster<
     getClient(): KibanaClient {
       return new Client({
         node: this.getHostUrls(),
-        headers: { 'X-Opaque-Id': 'kbn-test-client' },
+        headers: { 'X-Opaque-Id': 'kbn-test' },
         ...(ssl && { ssl: { ca: Fs.readFileSync(CA_CERT_PATH), rejectUnauthorized: true } }),
       });
     }

--- a/packages/kbn-test/src/es/test_es_cluster.ts
+++ b/packages/kbn-test/src/es/test_es_cluster.ts
@@ -314,7 +314,7 @@ export function createTestEsCluster<
      */
     getClient(): KibanaClient {
       return new Client({
-        node: this.getHostUrls()[0],
+        node: this.getHostUrls(),
         headers: { 'X-Opaque-Id': 'kbn-test-client' },
         ...(ssl && { ssl: { ca: Fs.readFileSync(CA_CERT_PATH), rejectUnauthorized: true } }),
       });
@@ -341,7 +341,9 @@ export function createTestEsCluster<
      * in this list.
      */
     getHostUrls(): string[] {
-      return this.ports.map((p) => format({ ...esTestConfig.getUrlParts(ssl), port: p }));
+      return this.ports.map((p) =>
+        format({ ...esTestConfig.getUrlParts(ssl), port: p, protocol: ssl ? 'https' : 'http' })
+      );
     }
   })() as EsTestCluster<Options>;
 }

--- a/packages/kbn-test/src/es/test_es_cluster.ts
+++ b/packages/kbn-test/src/es/test_es_cluster.ts
@@ -271,6 +271,7 @@ export function createTestEsCluster<
           'log.level': string;
           message: string;
           'elasticsearch.http.request.x_opaque_id': string;
+          'elasticsearch.elastic_product_origin': string;
         }>(
           { index: '.logs-deprecation.elasticsearch-default', ignore_unavailable: true, size: 100 },
           { ignore: [404] } // The index doesn't exist if there's no deprecation logs
@@ -278,8 +279,11 @@ export function createTestEsCluster<
         .then((res) => {
           const deps = res.body.hits.hits
             .filter((d) => /^kbn-test.*/.test(d._source!['elasticsearch.http.request.x_opaque_id']))
+            .filter((d) => /^kibana*/.test(d._source!['elasticsearch.elastic_product_origin']))
             .map((d) => {
-              return `ES DEPRECATION ${d._source!['log.level']} ${d._source!.message}`;
+              return `ES DEPRECATION ${d._source!['log.level']} ${
+                d._source!.message
+              } ${JSON.stringify(d._source)}`;
             });
 
           if (deps.length > 0) {

--- a/test/common/services/elasticsearch.ts
+++ b/test/common/services/elasticsearch.ts
@@ -24,6 +24,7 @@ export function ElasticsearchProvider({ getService }: FtrProviderContext): Kiban
     return new Client({
       nodes: [formatUrl(config.get('servers.elasticsearch'))],
       requestTimeout: config.get('timeouts.esRequestTimeout'),
+      headers: { 'X-Opaque-Id': 'kbn-test-client' },
     });
   } else {
     return new Client({
@@ -32,6 +33,7 @@ export function ElasticsearchProvider({ getService }: FtrProviderContext): Kiban
       },
       nodes: [formatUrl(config.get('servers.elasticsearch'))],
       requestTimeout: config.get('timeouts.esRequestTimeout'),
+      headers: { 'X-Opaque-Id': 'kbn-test-client' },
     });
   }
 }

--- a/test/common/services/elasticsearch.ts
+++ b/test/common/services/elasticsearch.ts
@@ -24,7 +24,7 @@ export function ElasticsearchProvider({ getService }: FtrProviderContext): Kiban
     return new Client({
       nodes: [formatUrl(config.get('servers.elasticsearch'))],
       requestTimeout: config.get('timeouts.esRequestTimeout'),
-      headers: { 'X-Opaque-Id': 'kbn-test-client' },
+      headers: { 'X-Opaque-Id': 'kbn-test-es-service' },
     });
   } else {
     return new Client({
@@ -33,7 +33,7 @@ export function ElasticsearchProvider({ getService }: FtrProviderContext): Kiban
       },
       nodes: [formatUrl(config.get('servers.elasticsearch'))],
       requestTimeout: config.get('timeouts.esRequestTimeout'),
-      headers: { 'X-Opaque-Id': 'kbn-test-client' },
+      headers: { 'X-Opaque-Id': 'kbn-test-es-service' },
     });
   }
 }

--- a/test/common/services/saved_object_info/saved_object_info.ts
+++ b/test/common/services/saved_object_info/saved_object_info.ts
@@ -37,7 +37,10 @@ export const types =
     await pipe(
       TE.tryCatch(
         async () => {
-          const { body } = await new Client({ node }).search({
+          const { body } = await new Client({
+            node,
+            headers: { 'X-Opaque-Id': 'kbn-test-so-service' },
+          }).search({
             index,
             size: 0,
             body: query,


### PR DESCRIPTION
## Summary

Elasticsearch doesn't always pass the `x-elastic-product-origin` header into the `elasticsearch.elastic_product_origin` field in the deprecation log. This means that some deprecations won't get filtered out by UA even though they should be. This CI run is to detect remaining deprecation notices.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
