### PR TITLE
[Index Management] Optimize ES response for indices list

### DIFF
--- a/x-pack/plugins/index_management/server/lib/fetch_indices.ts
+++ b/x-pack/plugins/index_management/server/lib/fetch_indices.ts
@@ -19,6 +19,8 @@ async function fetchIndicesCall(
   const { body: indices } = await client.asCurrentUser.indices.get({
     index: indexNamesString,
     expand_wildcards: ['hidden', 'all'],
+    // only get specified properties in the response
+    filter_path: ['*.aliases', '*.settings.index.hidden', '*.data_stream'],
   });
 
   if (!Object.keys(indices).length) {
@@ -53,7 +55,7 @@ async function fetchIndicesCall(
         isFrozen: hit.sth === 'true', // sth value coming back as a string from ES
         aliases: aliases.length ? aliases : 'none',
         // @ts-expect-error @elastic/elasticsearch https://github.com/elastic/elasticsearch-specification/issues/532
-        hidden: index.settings.index.hidden === 'true',
+        hidden: index.settings?.index.hidden === 'true',
         data_stream: index.data_stream!,
       });
     }


### PR DESCRIPTION
Fixes #106041
## Summary
When loading all indices from ES for Index Management page, the request `GET *?expand_wildcards=hidden,all` includes all indices of the cluster with their settings and mappings. The response to this request can surpass [the limit of 536MB](https://github.com/nodejs/node/issues/33960) and that would crash Kibana server. 

This PR updates the request used in Index Management to `GET *?expand_wildcards=hidden,all&filter_path=*.aliases,*.settings.index.hidden,*.data_stream` that would only return specific index properties from the ES. 

This change reduces the risk of Index Management requests to reach the limit of 536MB. 

### How to test
Check if Index Management is loading and there are no regressions in the indices table. 