### PR TITLE
[8.0] tooltip added to OS column (#123377)

### DIFF
--- a/x-pack/plugins/security_solution/public/hosts/components/hosts_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/hosts_table/columns.tsx
@@ -90,7 +90,13 @@ export const getHostsColumns = (): HostsTableColumns => [
   },
   {
     field: 'node.host.os.name',
-    name: i18n.OS,
+    name: (
+      <EuiToolTip content={i18n.OS_LAST_SEEN_TOOLTIP}>
+        <>
+          {i18n.OS} <EuiIcon color="subdued" type="iInCircle" className="eui-alignTop" />
+        </>
+      </EuiToolTip>
+    ),
     truncateText: false,
     hideForMobile: false,
     sortable: false,

--- a/x-pack/plugins/security_solution/public/hosts/components/hosts_table/translations.ts
+++ b/x-pack/plugins/security_solution/public/hosts/components/hosts_table/translations.ts
@@ -32,6 +32,21 @@ export const FIRST_LAST_SEEN_TOOLTIP = i18n.translate(
   }
 );
 
+export const HOST_RISK_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.hostsTable.hostRiskToolTip',
+  {
+    defaultMessage:
+      'Host risk classifcation is determined by host risk score. Hosts classified as Critical or High are indicated as risky.',
+  }
+);
+
+export const OS_LAST_SEEN_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.hostsTable.osLastSeenToolTip',
+  {
+    defaultMessage: 'Most recently observed OS',
+  }
+);
+
 export const OS = i18n.translate('xpack.securitySolution.hostsTable.osTitle', {
   defaultMessage: 'Operating system',
 });

--- a/x-pack/plugins/security_solution/public/hosts/components/hosts_table/translations.ts
+++ b/x-pack/plugins/security_solution/public/hosts/components/hosts_table/translations.ts
@@ -32,14 +32,6 @@ export const FIRST_LAST_SEEN_TOOLTIP = i18n.translate(
   }
 );
 
-export const HOST_RISK_TOOLTIP = i18n.translate(
-  'xpack.securitySolution.hostsTable.hostRiskToolTip',
-  {
-    defaultMessage:
-      'Host risk classifcation is determined by host risk score. Hosts classified as Critical or High are indicated as risky.',
-  }
-);
-
 export const OS_LAST_SEEN_TOOLTIP = i18n.translate(
   'xpack.securitySolution.hostsTable.osLastSeenToolTip',
   {


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #123377

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
