### PR TITLE
[Lists] Support for Server extension points for `get` (one), `find`, `export`, get summary and `delete`

### DIFF
--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
@@ -65,7 +65,8 @@ describe('exception_list_client', () => {
       expect(extensionPointStorageContext.exceptionPreCreate.callback).toHaveBeenCalled();
     });
 
-    // Test client methods that use the `pipeRun()` method of the ExtensionPointStorageClient`
+    // Test client methods that use the `pipeRun()` method of the ExtensionPointStorageClient` and
+    // receive an exception item for create or update
     describe.each([
       [
         'createExceptionListItem',
@@ -109,6 +110,17 @@ describe('exception_list_client', () => {
             expect(getExtensionPointCallback()).toHaveBeenCalled();
           });
 
+          it('should error if extension point callback throws an error', async () => {
+            const error = new Error('foo');
+            const extensionCallback = getExtensionPointCallback();
+
+            extensionCallback.mockImplementation(async () => {
+              throw error;
+            });
+
+            await expect(callExceptionListClientMethod()).rejects.toBe(error);
+          });
+
           it('should validate extension point callback returned data and throw if not valid', async () => {
             const extensionPointCallback = getExtensionPointCallback();
             extensionPointCallback.mockImplementation(async (args) => {
@@ -138,6 +150,58 @@ describe('exception_list_client', () => {
               })
             );
           });
+        });
+
+        describe('and server extension points are DISABLED', () => {
+          beforeEach(() => {
+            exceptionListClient = new ExceptionListClient({
+              enableServerExtensionPoints: false,
+              savedObjectsClient: getExceptionListSavedObjectClientMock(),
+              serverExtensionsClient:
+                extensionPointStorageContext.extensionPointStorage.getClient(),
+              user: 'elastic',
+            });
+          });
+
+          it('should NOT call server extension points', async () => {
+            await callExceptionListClientMethod();
+
+            expect(getExtensionPointCallback()).not.toHaveBeenCalled();
+          });
+        });
+      }
+    );
+
+    // Test Client methods that use `pipeRun()` for executing extension points, but don't mutate it (access only)
+    describe.each([
+      [
+        'getExceptionListItem',
+        (): ReturnType<ExceptionListClient['getExceptionListItem']> => {
+          return exceptionListClient.getExceptionListItem({
+            id: '1',
+            itemId: '1',
+            namespaceType: 'agnostic',
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreGetOne']['callback'] => {
+          return extensionPointStorageContext.exceptionPreGetOne.callback;
+        },
+      ],
+    ])(
+      'and calling `ExceptionListClient#%s()`',
+      (methodName, callExceptionListClientMethod, getExtensionPointCallback) => {
+        beforeEach(() => {
+          exceptionListClient = new ExceptionListClient({
+            savedObjectsClient: getExceptionListSavedObjectClientMock(),
+            serverExtensionsClient: extensionPointStorageContext.extensionPointStorage.getClient(),
+            user: 'elastic',
+          });
+        });
+
+        it('should execute extension point callbacks', async () => {
+          await callExceptionListClientMethod();
+
+          expect(getExtensionPointCallback()).toHaveBeenCalled();
         });
 
         describe('and server extension points are DISABLED', () => {

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
@@ -221,6 +221,19 @@ describe('exception_list_client', () => {
           return extensionPointStorageContext.exceptionPreMultiListFind.callback;
         },
       ],
+      [
+        'exportExceptionListAndItems',
+        (): ReturnType<ExceptionListClient['exportExceptionListAndItems']> => {
+          return exceptionListClient.exportExceptionListAndItems({
+            id: '1',
+            listId: '1',
+            namespaceType: 'agnostic',
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreExport']['callback'] => {
+          return extensionPointStorageContext.exceptionPreExport.callback;
+        },
+      ],
     ])(
       'and calling `ExceptionListClient#%s()`',
       (methodName, callExceptionListClientMethod, getExtensionPointCallback) => {

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
@@ -187,6 +187,23 @@ describe('exception_list_client', () => {
           return extensionPointStorageContext.exceptionPreGetOne.callback;
         },
       ],
+      [
+        'findExceptionListItem',
+        (): ReturnType<ExceptionListClient['findEndpointListItem']> => {
+          return exceptionListClient.findExceptionListItem({
+            filter: undefined,
+            listId: 'one',
+            namespaceType: 'agnostic',
+            page: 1,
+            perPage: 1,
+            sortField: 'name',
+            sortOrder: 'asc',
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreSingleListFind']['callback'] => {
+          return extensionPointStorageContext.exceptionPreSingleListFind.callback;
+        },
+      ],
     ])(
       'and calling `ExceptionListClient#%s()`',
       (methodName, callExceptionListClientMethod, getExtensionPointCallback) => {
@@ -202,6 +219,17 @@ describe('exception_list_client', () => {
           await callExceptionListClientMethod();
 
           expect(getExtensionPointCallback()).toHaveBeenCalled();
+        });
+
+        it('should error if extension point callback throws an error', async () => {
+          const error = new Error('foo');
+          const extensionCallback = getExtensionPointCallback();
+
+          extensionCallback.mockImplementation(async () => {
+            throw error;
+          });
+
+          await expect(callExceptionListClientMethod()).rejects.toBe(error);
         });
 
         describe('and server extension points are DISABLED', () => {

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
@@ -247,6 +247,31 @@ describe('exception_list_client', () => {
           return extensionPointStorageContext.exceptionPreSummary.callback;
         },
       ],
+      [
+        'deleteExceptionListItem',
+        (): ReturnType<ExceptionListClient['deleteExceptionListItem']> => {
+          return exceptionListClient.deleteExceptionListItem({
+            id: '1',
+            itemId: '1',
+            namespaceType: 'agnostic',
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreDelete']['callback'] => {
+          return extensionPointStorageContext.exceptionPreDelete.callback;
+        },
+      ],
+      [
+        'deleteExceptionListItemById',
+        (): ReturnType<ExceptionListClient['deleteExceptionListItemById']> => {
+          return exceptionListClient.deleteExceptionListItemById({
+            id: '1',
+            namespaceType: 'agnostic',
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreDelete']['callback'] => {
+          return extensionPointStorageContext.exceptionPreDelete.callback;
+        },
+      ],
     ])(
       'and calling `ExceptionListClient#%s()`',
       (methodName, callExceptionListClientMethod, getExtensionPointCallback) => {

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
@@ -234,6 +234,19 @@ describe('exception_list_client', () => {
           return extensionPointStorageContext.exceptionPreExport.callback;
         },
       ],
+      [
+        'getExceptionListSummary',
+        (): ReturnType<ExceptionListClient['getExceptionListSummary']> => {
+          return exceptionListClient.getExceptionListSummary({
+            id: '1',
+            listId: '1',
+            namespaceType: 'agnostic',
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreSummary']['callback'] => {
+          return extensionPointStorageContext.exceptionPreSummary.callback;
+        },
+      ],
     ])(
       'and calling `ExceptionListClient#%s()`',
       (methodName, callExceptionListClientMethod, getExtensionPointCallback) => {

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
@@ -204,6 +204,23 @@ describe('exception_list_client', () => {
           return extensionPointStorageContext.exceptionPreSingleListFind.callback;
         },
       ],
+      [
+        'findExceptionListsItem',
+        (): ReturnType<ExceptionListClient['findExceptionListsItem']> => {
+          return exceptionListClient.findExceptionListsItem({
+            filter: [],
+            listId: ['one'],
+            namespaceType: ['agnostic'],
+            page: 1,
+            perPage: 1,
+            sortField: 'name',
+            sortOrder: 'asc',
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreMultiListFind']['callback'] => {
+          return extensionPointStorageContext.exceptionPreMultiListFind.callback;
+        },
+      ],
     ])(
       'and calling `ExceptionListClient#%s()`',
       (methodName, callExceptionListClientMethod, getExtensionPointCallback) => {

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
@@ -723,6 +723,18 @@ export class ExceptionListClient {
   }: ExportExceptionListAndItemsOptions): Promise<ExportExceptionListAndItemsReturn | null> => {
     const { savedObjectsClient } = this;
 
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreExport',
+        {
+          id,
+          listId,
+          namespaceType,
+        },
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
     return exportExceptionListAndItems({
       id,
       listId,

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
@@ -535,6 +535,15 @@ export class ExceptionListClient {
     namespaceType,
   }: DeleteExceptionListItemOptions): Promise<ExceptionListItemSchema | null> => {
     const { savedObjectsClient } = this;
+
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreDeleteItem',
+        { id, itemId, namespaceType },
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
     return deleteExceptionListItem({
       id,
       itemId,
@@ -554,6 +563,15 @@ export class ExceptionListClient {
     namespaceType,
   }: DeleteExceptionListItemByIdOptions): Promise<void> => {
     const { savedObjectsClient } = this;
+
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreDeleteItem',
+        { id, itemId: undefined, namespaceType },
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
     return deleteExceptionListItemById({
       id,
       namespaceType,

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
@@ -151,6 +151,15 @@ export class ExceptionListClient {
     namespaceType,
   }: GetExceptionListItemOptions): Promise<ExceptionListItemSchema | null> => {
     const { savedObjectsClient } = this;
+
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreGetOneItem',
+        { id, itemId, namespaceType },
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
     return getExceptionListItem({ id, itemId, namespaceType, savedObjectsClient });
   };
 

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
@@ -574,6 +574,23 @@ export class ExceptionListClient {
     namespaceType,
   }: FindExceptionListItemOptions): Promise<FoundExceptionListItemSchema | null> => {
     const { savedObjectsClient } = this;
+
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreSingleListFind',
+        {
+          filter,
+          listId,
+          namespaceType,
+          page,
+          perPage,
+          sortField,
+          sortOrder,
+        },
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
     return findExceptionListItem({
       filter,
       listId,

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
@@ -613,6 +613,23 @@ export class ExceptionListClient {
     namespaceType,
   }: FindExceptionListsItemOptions): Promise<FoundExceptionListItemSchema | null> => {
     const { savedObjectsClient } = this;
+
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreMultiListFind',
+        {
+          filter,
+          listId,
+          namespaceType,
+          page,
+          perPage,
+          sortField,
+          sortOrder,
+        },
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
     return findExceptionListsItem({
       filter,
       listId,

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
@@ -135,6 +135,19 @@ export class ExceptionListClient {
     namespaceType,
   }: GetExceptionListSummaryOptions): Promise<ExceptionListSummarySchema | null> => {
     const { savedObjectsClient } = this;
+
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreSummary',
+        {
+          id,
+          listId,
+          namespaceType,
+        },
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
     return getExceptionListSummary({ id, listId, namespaceType, savedObjectsClient });
   };
 

--- a/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
@@ -13,6 +13,7 @@ import { ExtensionPointStorage } from './extension_point_storage';
 import {
   ExceptionsListPreCreateItemServerExtension,
   ExceptionsListPreGetOneItemServerExtension,
+  ExceptionsListPreMultiListFindServerExtension,
   ExceptionsListPreSingleListFindServerExtension,
   ExceptionsListPreUpdateItemServerExtension,
   ExtensionPointStorageInterface,
@@ -31,6 +32,8 @@ export interface ExtensionPointStorageContextMock {
   exceptionPreGetOne: jest.Mocked<ExceptionsListPreGetOneItemServerExtension>;
   /** an exception list pre-find extension when searching a single list */
   exceptionPreSingleListFind: jest.Mocked<ExceptionsListPreSingleListFindServerExtension>;
+  /** an exception list pre-find extension when searching a multiple lists */
+  exceptionPreMultiListFind: jest.Mocked<ExceptionsListPreMultiListFindServerExtension>;
   callbackContext: jest.Mocked<ServerExtensionCallbackContext>;
 }
 
@@ -60,24 +63,26 @@ export const createExtensionPointStorageMock = (
   };
 
   const exceptionPreGetOne: ExtensionPointStorageContextMock['exceptionPreGetOne'] = {
-    callback: jest.fn(async ({ data }) => {
-      return data;
-    }),
+    callback: jest.fn(async ({ data }) => data),
     type: 'exceptionsListPreGetOneItem',
   };
 
   const exceptionPreSingleListFind: ExtensionPointStorageContextMock['exceptionPreSingleListFind'] =
     {
-      callback: jest.fn(async ({ data }) => {
-        return data;
-      }),
+      callback: jest.fn(async ({ data }) => data),
       type: 'exceptionsListPreSingleListFind',
     };
+
+  const exceptionPreMultiListFind: ExtensionPointStorageContextMock['exceptionPreMultiListFind'] = {
+    callback: jest.fn(async ({ data }) => data),
+    type: 'exceptionsListPreMultiListFind',
+  };
 
   extensionPointStorage.add(exceptionPreCreate);
   extensionPointStorage.add(exceptionPreUpdate);
   extensionPointStorage.add(exceptionPreGetOne);
   extensionPointStorage.add(exceptionPreSingleListFind);
+  extensionPointStorage.add(exceptionPreMultiListFind);
 
   return {
     callbackContext: {
@@ -85,6 +90,7 @@ export const createExtensionPointStorageMock = (
     },
     exceptionPreCreate,
     exceptionPreGetOne,
+    exceptionPreMultiListFind,
     exceptionPreSingleListFind,
     exceptionPreUpdate,
     extensionPointStorage,

--- a/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
@@ -12,6 +12,7 @@ import { httpServerMock } from '../../../../../../src/core/server/mocks';
 import { ExtensionPointStorage } from './extension_point_storage';
 import {
   ExceptionsListPreCreateItemServerExtension,
+  ExceptionsListPreGetOneItemServerExtension,
   ExceptionsListPreUpdateItemServerExtension,
   ExtensionPointStorageInterface,
   ServerExtensionCallbackContext,
@@ -25,6 +26,8 @@ export interface ExtensionPointStorageContextMock {
   exceptionPreCreate: jest.Mocked<ExceptionsListPreCreateItemServerExtension>;
   /** An Exception List Item pre-update extension point added to the storage. Appends `-2` to the data's `name` attribute */
   exceptionPreUpdate: jest.Mocked<ExceptionsListPreUpdateItemServerExtension>;
+  /** An Exception List Item pre-get extension point added to the storage */
+  exceptionPreGetOne: jest.Mocked<ExceptionsListPreGetOneItemServerExtension>;
   callbackContext: jest.Mocked<ServerExtensionCallbackContext>;
 }
 
@@ -53,14 +56,23 @@ export const createExtensionPointStorageMock = (
     type: 'exceptionsListPreUpdateItem',
   };
 
+  const exceptionPreGetOne: ExtensionPointStorageContextMock['exceptionPreGetOne'] = {
+    callback: jest.fn(async ({ data }) => {
+      return data;
+    }),
+    type: 'exceptionsListPreGetOneItem',
+  };
+
   extensionPointStorage.add(exceptionPreCreate);
   extensionPointStorage.add(exceptionPreUpdate);
+  extensionPointStorage.add(exceptionPreGetOne);
 
   return {
     callbackContext: {
       request: httpServerMock.createKibanaRequest(),
     },
     exceptionPreCreate,
+    exceptionPreGetOne,
     exceptionPreUpdate,
     extensionPointStorage,
     logger,

--- a/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
@@ -16,6 +16,7 @@ import {
   ExceptionsListPreGetOneItemServerExtension,
   ExceptionsListPreMultiListFindServerExtension,
   ExceptionsListPreSingleListFindServerExtension,
+  ExceptionsListPreSummaryServerExtension,
   ExceptionsListPreUpdateItemServerExtension,
   ExtensionPointStorageInterface,
   ServerExtensionCallbackContext,
@@ -37,6 +38,8 @@ export interface ExtensionPointStorageContextMock {
   exceptionPreMultiListFind: jest.Mocked<ExceptionsListPreMultiListFindServerExtension>;
   /** an exception list pre-export extension */
   exceptionPreExport: jest.Mocked<ExceptionsListPreExportServerExtension>;
+  /** an exception list pre-summary extension */
+  exceptionPreSummary: jest.Mocked<ExceptionsListPreSummaryServerExtension>;
   callbackContext: jest.Mocked<ServerExtensionCallbackContext>;
 }
 
@@ -86,12 +89,18 @@ export const createExtensionPointStorageMock = (
     type: 'exceptionsListPreExport',
   };
 
+  const exceptionPreSummary: ExtensionPointStorageContextMock['exceptionPreSummary'] = {
+    callback: jest.fn(async ({ data }) => data),
+    type: 'exceptionsListPreSummary',
+  };
+
   extensionPointStorage.add(exceptionPreCreate);
   extensionPointStorage.add(exceptionPreUpdate);
   extensionPointStorage.add(exceptionPreGetOne);
   extensionPointStorage.add(exceptionPreSingleListFind);
   extensionPointStorage.add(exceptionPreMultiListFind);
   extensionPointStorage.add(exceptionPreExport);
+  extensionPointStorage.add(exceptionPreSummary);
 
   return {
     callbackContext: {
@@ -102,6 +111,7 @@ export const createExtensionPointStorageMock = (
     exceptionPreGetOne,
     exceptionPreMultiListFind,
     exceptionPreSingleListFind,
+    exceptionPreSummary,
     exceptionPreUpdate,
     extensionPointStorage,
     logger,

--- a/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
@@ -12,6 +12,7 @@ import { httpServerMock } from '../../../../../../src/core/server/mocks';
 import { ExtensionPointStorage } from './extension_point_storage';
 import {
   ExceptionsListPreCreateItemServerExtension,
+  ExceptionsListPreExportServerExtension,
   ExceptionsListPreGetOneItemServerExtension,
   ExceptionsListPreMultiListFindServerExtension,
   ExceptionsListPreSingleListFindServerExtension,
@@ -34,6 +35,8 @@ export interface ExtensionPointStorageContextMock {
   exceptionPreSingleListFind: jest.Mocked<ExceptionsListPreSingleListFindServerExtension>;
   /** an exception list pre-find extension when searching a multiple lists */
   exceptionPreMultiListFind: jest.Mocked<ExceptionsListPreMultiListFindServerExtension>;
+  /** an exception list pre-export extension */
+  exceptionPreExport: jest.Mocked<ExceptionsListPreExportServerExtension>;
   callbackContext: jest.Mocked<ServerExtensionCallbackContext>;
 }
 
@@ -78,17 +81,24 @@ export const createExtensionPointStorageMock = (
     type: 'exceptionsListPreMultiListFind',
   };
 
+  const exceptionPreExport: ExtensionPointStorageContextMock['exceptionPreExport'] = {
+    callback: jest.fn(async ({ data }) => data),
+    type: 'exceptionsListPreExport',
+  };
+
   extensionPointStorage.add(exceptionPreCreate);
   extensionPointStorage.add(exceptionPreUpdate);
   extensionPointStorage.add(exceptionPreGetOne);
   extensionPointStorage.add(exceptionPreSingleListFind);
   extensionPointStorage.add(exceptionPreMultiListFind);
+  extensionPointStorage.add(exceptionPreExport);
 
   return {
     callbackContext: {
       request: httpServerMock.createKibanaRequest(),
     },
     exceptionPreCreate,
+    exceptionPreExport,
     exceptionPreGetOne,
     exceptionPreMultiListFind,
     exceptionPreSingleListFind,

--- a/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
@@ -12,6 +12,7 @@ import { httpServerMock } from '../../../../../../src/core/server/mocks';
 import { ExtensionPointStorage } from './extension_point_storage';
 import {
   ExceptionsListPreCreateItemServerExtension,
+  ExceptionsListPreDeleteItemServerExtension,
   ExceptionsListPreExportServerExtension,
   ExceptionsListPreGetOneItemServerExtension,
   ExceptionsListPreMultiListFindServerExtension,
@@ -40,6 +41,8 @@ export interface ExtensionPointStorageContextMock {
   exceptionPreExport: jest.Mocked<ExceptionsListPreExportServerExtension>;
   /** an exception list pre-summary extension */
   exceptionPreSummary: jest.Mocked<ExceptionsListPreSummaryServerExtension>;
+  /** an exception list pre-delete extension */
+  exceptionPreDelete: jest.Mocked<ExceptionsListPreDeleteItemServerExtension>;
   callbackContext: jest.Mocked<ServerExtensionCallbackContext>;
 }
 
@@ -94,6 +97,11 @@ export const createExtensionPointStorageMock = (
     type: 'exceptionsListPreSummary',
   };
 
+  const exceptionPreDelete: ExtensionPointStorageContextMock['exceptionPreDelete'] = {
+    callback: jest.fn(async ({ data }) => data),
+    type: 'exceptionsListPreDeleteItem',
+  };
+
   extensionPointStorage.add(exceptionPreCreate);
   extensionPointStorage.add(exceptionPreUpdate);
   extensionPointStorage.add(exceptionPreGetOne);
@@ -101,12 +109,14 @@ export const createExtensionPointStorageMock = (
   extensionPointStorage.add(exceptionPreMultiListFind);
   extensionPointStorage.add(exceptionPreExport);
   extensionPointStorage.add(exceptionPreSummary);
+  extensionPointStorage.add(exceptionPreDelete);
 
   return {
     callbackContext: {
       request: httpServerMock.createKibanaRequest(),
     },
     exceptionPreCreate,
+    exceptionPreDelete,
     exceptionPreExport,
     exceptionPreGetOne,
     exceptionPreMultiListFind,

--- a/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
@@ -13,6 +13,7 @@ import { ExtensionPointStorage } from './extension_point_storage';
 import {
   ExceptionsListPreCreateItemServerExtension,
   ExceptionsListPreGetOneItemServerExtension,
+  ExceptionsListPreSingleListFindServerExtension,
   ExceptionsListPreUpdateItemServerExtension,
   ExtensionPointStorageInterface,
   ServerExtensionCallbackContext,
@@ -28,6 +29,8 @@ export interface ExtensionPointStorageContextMock {
   exceptionPreUpdate: jest.Mocked<ExceptionsListPreUpdateItemServerExtension>;
   /** An Exception List Item pre-get extension point added to the storage */
   exceptionPreGetOne: jest.Mocked<ExceptionsListPreGetOneItemServerExtension>;
+  /** an exception list pre-find extension when searching a single list */
+  exceptionPreSingleListFind: jest.Mocked<ExceptionsListPreSingleListFindServerExtension>;
   callbackContext: jest.Mocked<ServerExtensionCallbackContext>;
 }
 
@@ -63,9 +66,18 @@ export const createExtensionPointStorageMock = (
     type: 'exceptionsListPreGetOneItem',
   };
 
+  const exceptionPreSingleListFind: ExtensionPointStorageContextMock['exceptionPreSingleListFind'] =
+    {
+      callback: jest.fn(async ({ data }) => {
+        return data;
+      }),
+      type: 'exceptionsListPreSingleListFind',
+    };
+
   extensionPointStorage.add(exceptionPreCreate);
   extensionPointStorage.add(exceptionPreUpdate);
   extensionPointStorage.add(exceptionPreGetOne);
+  extensionPointStorage.add(exceptionPreSingleListFind);
 
   return {
     callbackContext: {
@@ -73,6 +85,7 @@ export const createExtensionPointStorageMock = (
     },
     exceptionPreCreate,
     exceptionPreGetOne,
+    exceptionPreSingleListFind,
     exceptionPreUpdate,
     extensionPointStorage,
     logger,

--- a/x-pack/plugins/lists/server/services/extension_points/extension_point_storage_client.test.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/extension_point_storage_client.test.ts
@@ -53,10 +53,15 @@ describe('When using the ExtensionPointStorageClient', () => {
       { data }: A
     ): Promise<A['data']> => {
       callbackRunLog += id;
-      return {
-        ...data,
-        name: `${data.name}-${id}`,
-      };
+
+      if ('name' in data) {
+        return {
+          ...data,
+          name: `${data.name}-${id}`,
+        };
+      }
+
+      return data;
     };
     preCreateExtensionPointMock1 = {
       callback: jest.fn(

--- a/x-pack/plugins/lists/server/services/extension_points/types.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/types.ts
@@ -10,6 +10,7 @@ import { KibanaRequest } from 'kibana/server';
 
 import {
   CreateExceptionListItemOptions,
+  DeleteExceptionListItemOptions,
   ExportExceptionListAndItemsOptions,
   FindExceptionListItemOptions,
   FindExceptionListsItemOptions,
@@ -116,6 +117,16 @@ export type ExceptionsListPreSummaryServerExtension = ServerExtensionPointDefini
   GetExceptionListSummaryOptions
 >;
 
+/**
+ * Extension point is triggered prior to performing a list item deletion. Note, this extension point
+ * is triggered by both `deleteExceptionListItem()` and `deleteExceptionListItemById()` methods of the
+ * `ExceptionListClient` class
+ */
+export type ExceptionsListPreDeleteItemServerExtension = ServerExtensionPointDefinition<
+  'exceptionsListPreDeleteItem',
+  DeleteExceptionListItemOptions
+>;
+
 export type ExtensionPoint =
   | ExceptionsListPreCreateItemServerExtension
   | ExceptionsListPreUpdateItemServerExtension
@@ -123,7 +134,8 @@ export type ExtensionPoint =
   | ExceptionsListPreSingleListFindServerExtension
   | ExceptionsListPreMultiListFindServerExtension
   | ExceptionsListPreExportServerExtension
-  | ExceptionsListPreSummaryServerExtension;
+  | ExceptionsListPreSummaryServerExtension
+  | ExceptionsListPreDeleteItemServerExtension;
 
 /**
  * A Map of extension point type and associated Set of callbacks

--- a/x-pack/plugins/lists/server/services/extension_points/types.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/types.ts
@@ -11,6 +11,7 @@ import { KibanaRequest } from 'kibana/server';
 import {
   CreateExceptionListItemOptions,
   FindExceptionListItemOptions,
+  FindExceptionListsItemOptions,
   GetExceptionListItemOptions,
   UpdateExceptionListItemOptions,
 } from '../exception_lists/exception_list_client_types';
@@ -89,11 +90,20 @@ export type ExceptionsListPreSingleListFindServerExtension = ServerExtensionPoin
   FindExceptionListItemOptions
 >;
 
+/**
+ * Extension point is triggered prior to performing a `find` operation against a multiple lists
+ */
+export type ExceptionsListPreMultiListFindServerExtension = ServerExtensionPointDefinition<
+  'exceptionsListPreMultiListFind',
+  FindExceptionListsItemOptions
+>;
+
 export type ExtensionPoint =
   | ExceptionsListPreCreateItemServerExtension
   | ExceptionsListPreUpdateItemServerExtension
   | ExceptionsListPreGetOneItemServerExtension
-  | ExceptionsListPreSingleListFindServerExtension;
+  | ExceptionsListPreSingleListFindServerExtension
+  | ExceptionsListPreMultiListFindServerExtension;
 
 /**
  * A Map of extension point type and associated Set of callbacks

--- a/x-pack/plugins/lists/server/services/extension_points/types.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/types.ts
@@ -10,6 +10,7 @@ import { KibanaRequest } from 'kibana/server';
 
 import {
   CreateExceptionListItemOptions,
+  GetExceptionListItemOptions,
   UpdateExceptionListItemOptions,
 } from '../exception_lists/exception_list_client_types';
 
@@ -70,10 +71,18 @@ export type ExceptionsListPreUpdateItemServerExtension = ServerExtensionPointDef
   'exceptionsListPreUpdateItem',
   UpdateExceptionListItemOptions
 >;
+/**
+ * Extension point is triggered prior to performing a `patch` operation on the exception item
+ */
+export type ExceptionsListPreGetOneItemServerExtension = ServerExtensionPointDefinition<
+  'exceptionsListPreGetOneItem',
+  GetExceptionListItemOptions
+>;
 
 export type ExtensionPoint =
   | ExceptionsListPreCreateItemServerExtension
-  | ExceptionsListPreUpdateItemServerExtension;
+  | ExceptionsListPreUpdateItemServerExtension
+  | ExceptionsListPreGetOneItemServerExtension;
 
 /**
  * A Map of extension point type and associated Set of callbacks

--- a/x-pack/plugins/lists/server/services/extension_points/types.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/types.ts
@@ -10,6 +10,7 @@ import { KibanaRequest } from 'kibana/server';
 
 import {
   CreateExceptionListItemOptions,
+  FindExceptionListItemOptions,
   GetExceptionListItemOptions,
   UpdateExceptionListItemOptions,
 } from '../exception_lists/exception_list_client_types';
@@ -71,6 +72,7 @@ export type ExceptionsListPreUpdateItemServerExtension = ServerExtensionPointDef
   'exceptionsListPreUpdateItem',
   UpdateExceptionListItemOptions
 >;
+
 /**
  * Extension point is triggered prior to performing a `patch` operation on the exception item
  */
@@ -79,10 +81,19 @@ export type ExceptionsListPreGetOneItemServerExtension = ServerExtensionPointDef
   GetExceptionListItemOptions
 >;
 
+/**
+ * Extension point is triggered prior to performing a `find` operation against a SINGLE list
+ */
+export type ExceptionsListPreSingleListFindServerExtension = ServerExtensionPointDefinition<
+  'exceptionsListPreSingleListFind',
+  FindExceptionListItemOptions
+>;
+
 export type ExtensionPoint =
   | ExceptionsListPreCreateItemServerExtension
   | ExceptionsListPreUpdateItemServerExtension
-  | ExceptionsListPreGetOneItemServerExtension;
+  | ExceptionsListPreGetOneItemServerExtension
+  | ExceptionsListPreSingleListFindServerExtension;
 
 /**
  * A Map of extension point type and associated Set of callbacks

--- a/x-pack/plugins/lists/server/services/extension_points/types.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/types.ts
@@ -14,6 +14,7 @@ import {
   FindExceptionListItemOptions,
   FindExceptionListsItemOptions,
   GetExceptionListItemOptions,
+  GetExceptionListSummaryOptions,
   UpdateExceptionListItemOptions,
 } from '../exception_lists/exception_list_client_types';
 
@@ -107,13 +108,22 @@ export type ExceptionsListPreExportServerExtension = ServerExtensionPointDefinit
   ExportExceptionListAndItemsOptions
 >;
 
+/**
+ * Extension point is triggered prior to performing a list summary operation
+ */
+export type ExceptionsListPreSummaryServerExtension = ServerExtensionPointDefinition<
+  'exceptionsListPreSummary',
+  GetExceptionListSummaryOptions
+>;
+
 export type ExtensionPoint =
   | ExceptionsListPreCreateItemServerExtension
   | ExceptionsListPreUpdateItemServerExtension
   | ExceptionsListPreGetOneItemServerExtension
   | ExceptionsListPreSingleListFindServerExtension
   | ExceptionsListPreMultiListFindServerExtension
-  | ExceptionsListPreExportServerExtension;
+  | ExceptionsListPreExportServerExtension
+  | ExceptionsListPreSummaryServerExtension;
 
 /**
  * A Map of extension point type and associated Set of callbacks

--- a/x-pack/plugins/lists/server/services/extension_points/types.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/types.ts
@@ -10,6 +10,7 @@ import { KibanaRequest } from 'kibana/server';
 
 import {
   CreateExceptionListItemOptions,
+  ExportExceptionListAndItemsOptions,
   FindExceptionListItemOptions,
   FindExceptionListsItemOptions,
   GetExceptionListItemOptions,
@@ -98,12 +99,21 @@ export type ExceptionsListPreMultiListFindServerExtension = ServerExtensionPoint
   FindExceptionListsItemOptions
 >;
 
+/**
+ * Extension point is triggered prior to performing an `export` operation against exceptions list and items
+ */
+export type ExceptionsListPreExportServerExtension = ServerExtensionPointDefinition<
+  'exceptionsListPreExport',
+  ExportExceptionListAndItemsOptions
+>;
+
 export type ExtensionPoint =
   | ExceptionsListPreCreateItemServerExtension
   | ExceptionsListPreUpdateItemServerExtension
   | ExceptionsListPreGetOneItemServerExtension
   | ExceptionsListPreSingleListFindServerExtension
-  | ExceptionsListPreMultiListFindServerExtension;
+  | ExceptionsListPreMultiListFindServerExtension
+  | ExceptionsListPreExportServerExtension;
 
 /**
  * A Map of extension point type and associated Set of callbacks


### PR DESCRIPTION
## Summary

Adds the following additional lists plugin server extension points for Exception Lists:

- `get` one item
- `find` agains a single list or multiple lists
- `export` of list and items,
- get exceptions list summary
- `delete` and `delete by id` of items


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
