### PR TITLE
[App Search] Show meta engines even when there is no indexed engine

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
@@ -119,6 +119,18 @@ describe('EnginesOverview', () => {
       expect(actions.loadMetaEngines).toHaveBeenCalled();
     });
 
+    it('renders meta engines even if there is no indexed engine', () => {
+      setMockValues({
+        ...valuesWithEngines,
+        hasPlatinumLicense: true,
+        engines: [],
+      });
+      const wrapper = shallow(<EnginesOverview />);
+
+      expect(wrapper.find(MetaEnginesTable)).toHaveLength(1);
+      expect(actions.loadMetaEngines).toHaveBeenCalled();
+    });
+
     describe('meta engine creation', () => {
       it('renders a create meta engine action when the user can create meta engines', () => {
         setMockValues({

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
@@ -66,7 +66,7 @@ export const EnginesOverview: React.FC = () => {
       pageChrome={[ENGINES_TITLE]}
       pageHeader={{ pageTitle: ENGINES_OVERVIEW_TITLE }}
       isLoading={dataLoading}
-      isEmptyState={!engines.length}
+      isEmptyState={!engines.length && !metaEngines.length}
       emptyState={<EmptyState />}
     >
       <DataPanel


### PR DESCRIPTION
This fixes https://github.com/elastic/enterprise-search-team/issues/1151

## Summary

![Screenshot 2022-01-24 at 18 45 18](https://user-images.githubusercontent.com/1410658/150836178-cb23041f-35f1-4aba-ae6a-0a3c357e3131.png)

Fixing an issue that caused user to see Create a new engine dialog when there are only meta engines available. It is an edge case that user can have access only to meta engines that have no indexed engine associated, still should see the meta engine that they have access to.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

- [x] Checked with different license types to make sure it doesn't break when user has basic license