### PR TITLE
[Security Solutions] Adds type fixes for case cache in case it's null/undefined

### DIFF
--- a/x-pack/plugins/security_solution/server/usage/detections/detection_rule_helpers.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/detection_rule_helpers.ts
@@ -434,12 +434,13 @@ export const getDetectionRuleMetrics = async (
 
     const casesCache = cases.saved_objects.reduce((cache, { attributes: casesObject }) => {
       const ruleId = casesObject.rule.id;
-
-      const cacheCount = cache.get(ruleId);
-      if (cacheCount === undefined) {
-        cache.set(ruleId, 1);
-      } else {
-        cache.set(ruleId, cacheCount + 1);
+      if (ruleId != null) {
+        const cacheCount = cache.get(ruleId);
+        if (cacheCount === undefined) {
+          cache.set(ruleId, 1);
+        } else {
+          cache.set(ruleId, cacheCount + 1);
+        }
       }
       return cache;
     }, new Map<string, number>());

--- a/x-pack/plugins/security_solution/server/usage/detections/types.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/types.ts
@@ -154,8 +154,8 @@ export interface CasesSavedObject {
   alertId: string;
   index: string;
   rule: {
-    id: string;
-    name: string;
+    id: string | null;
+    name: string | null;
   };
 }
 


### PR DESCRIPTION
## Summary

See this PR from here:
https://github.com/elastic/kibana/pull/123094

Where `"rule": { "id": null, "name": null },` can be null. This just adds guards around it to prevent possible errors. Note, I tested it first and there aren't errors with this even if we don't merge but that is not a guarantee that later NodeJS wouldn't cause errors if the implementation details of [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) change.

Note, I don't try to do any additional lookups if these are `null` as the release is coming very quickly and I do not want to overcomplicate telemetry and we don't have dashboards around the cases feature. Over time I would expect the telemetry to become more accurate again even if cases are `nulled` out.

**Manual testing**

Either create a true upgrade where all the id's changed by going to 7.16 and making a new space, then within that space outside of default creating cases and alerts and then do an upgrade to 8.0.0 ... or ... 

Downgrade a `case-comments` like so manually in dev tools:
```ts
# Get all case-comments to choose an id
GET .kibana/_search
{
  "query": {
    "term": {
      "type": "cases-comments"
    }
  }
}
```

```ts
# Downgrades a case comment of id "25554290-7a36-11ec-8d37-0d0e30a77b60"
POST .kibana/_update/cases-comments:25554290-7a36-11ec-8d37-0d0e30a77b60
{
  "script" : {
    "source": """
    ctx._source.migrationVersion['cases-comments'] = "7.16.3";
    """,
    "lang": "painless"
  }
}
```

Restart Kibana and you should query the same `case-comments` and see that the `"rule": { "id": null, "name": null },` are all null.

Either way once you have a null rule go to `Advanced Settings -> cluster data` and ensure that you still get metrics flowing and that one is no longer counted but if you create a new one everything still works as expected:
<img width="647" alt="Screen Shot 2022-01-24 at 11 48 39 AM" src="https://user-images.githubusercontent.com/1151048/150846789-d94ac212-6c45-44cc-a663-cd304bfda22e.png">

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

We still don't have this for the existing telemetry and are running out of time for 8.0.0 to add them. We might re-write this part of telemetry as well so I am not adding tests just yet.