### PR TITLE
Use unencrypted P12 keystore for Elasticsearch snapshot

### DIFF
--- a/packages/kbn-es/src/cluster.js
+++ b/packages/kbn-es/src/cluster.js
@@ -18,7 +18,7 @@ const { createCliError } = require('./errors');
 const { promisify } = require('util');
 const treeKillAsync = promisify(require('tree-kill'));
 const { parseSettings, SettingsFilter } = require('./settings');
-const { CA_CERT_PATH, ES_P12_PATH, ES_P12_PASSWORD, extract } = require('@kbn/dev-utils');
+const { CA_CERT_PATH, ES_NOPASSWORD_P12_PATH, extract } = require('@kbn/dev-utils');
 const readFile = util.promisify(fs.readFile);
 
 // listen to data on stream until map returns anything but undefined
@@ -260,9 +260,10 @@ exports.Cluster = class Cluster {
 
       // Include default keystore settings only if keystore isn't configured.
       if (!esArgs.some((arg) => arg.startsWith('xpack.security.http.ssl.keystore'))) {
-        esArgs.push(`xpack.security.http.ssl.keystore.path=${ES_P12_PATH}`);
+        esArgs.push(`xpack.security.http.ssl.keystore.path=${ES_NOPASSWORD_P12_PATH}`);
         esArgs.push(`xpack.security.http.ssl.keystore.type=PKCS12`);
-        esArgs.push(`xpack.security.http.ssl.keystore.password=${ES_P12_PASSWORD}`);
+        // We are explicitly using ES_NOPASSWORD_P12_PATH instead of ES_P12_PATH + ES_P12_PASSWORD. The reasoning for this is that setting
+        // the keystore password using environment variables causes Elasticsearch to emit deprecation warnings.
       }
     }
 

--- a/packages/kbn-es/src/integration_tests/cluster.test.js
+++ b/packages/kbn-es/src/integration_tests/cluster.test.js
@@ -9,8 +9,7 @@
 const {
   ToolingLog,
   ToolingLogCollectingWriter,
-  ES_P12_PATH,
-  ES_P12_PASSWORD,
+  ES_NOPASSWORD_P12_PATH,
   createAnyInstanceSerializer,
   createStripAnsiSerializer,
 } = require('@kbn/dev-utils');
@@ -292,9 +291,8 @@ describe('#start(installPath)', () => {
 
     const config = extractConfigFiles.mock.calls[0][0];
     expect(config).toContain('xpack.security.http.ssl.enabled=true');
-    expect(config).toContain(`xpack.security.http.ssl.keystore.path=${ES_P12_PATH}`);
+    expect(config).toContain(`xpack.security.http.ssl.keystore.path=${ES_NOPASSWORD_P12_PATH}`);
     expect(config).toContain(`xpack.security.http.ssl.keystore.type=PKCS12`);
-    expect(config).toContain(`xpack.security.http.ssl.keystore.password=${ES_P12_PASSWORD}`);
   });
 
   it(`doesn't setup SSL when disabled`, async () => {
@@ -371,9 +369,8 @@ describe('#run()', () => {
 
     const config = extractConfigFiles.mock.calls[0][0];
     expect(config).toContain('xpack.security.http.ssl.enabled=true');
-    expect(config).toContain(`xpack.security.http.ssl.keystore.path=${ES_P12_PATH}`);
+    expect(config).toContain(`xpack.security.http.ssl.keystore.path=${ES_NOPASSWORD_P12_PATH}`);
     expect(config).toContain(`xpack.security.http.ssl.keystore.type=PKCS12`);
-    expect(config).toContain(`xpack.security.http.ssl.keystore.password=${ES_P12_PASSWORD}`);
   });
 
   it(`doesn't setup SSL when disabled`, async () => {


### PR DESCRIPTION
## Overview

Elasticsearch can be configured with SSL/TLS encryption using a PKCS12 (P12) keystore. If the keystore is encrypted, ES also needs a password to decrypt the keystore.

Several years ago, the ES configuration for plaintext keystore passwords was deprecated via elastic/elasticsearch#1852.
However, with some recent changes, Elasticsearch started emitting deprecation warnings to Kibana over HTTP response headers. Kibana logs these deprecation warnings.

When running Elasticsearch from snapshot, if you enable TLS encryption, the script currently uses an encrypted P12 keystore.
The deprecation warnings are merely annoying in local development, but they are extremely spammy in integration test logs.

Our `es snapshot` script doesn't provide a way to set a secure keystore password inside the ES configuration keystore. The simplest way to avoid the deprecation warning for now is to use an unencrypted keystore.

I labeled this PR with `release_note:skip` because this P12 file is only used during development and testing, not in production.

## Testing

Start Elasticsearch with TLS:
```sh
yarn es snapshot --ssl
```

Configure Kibana to connect to ES using TLS:
```yml
elasticsearch.hosts: ["https://localhost:9200"]
elasticsearch.ssl.certificateAuthorities: packages/kbn-dev-utils/certs/ca.crt
```

Start Kibana:
```sh
yarn start
```

Before this PR, you would see a warning like this when starting Kibana:
```
[2022-01-24T14:58:50.609-05:00][INFO ][elasticsearch.deprecation] Elasticsearch deprecation: 299 Elasticsearch-8.1.0-SNAPSHOT-353117244e661653aa49dcdb67d149245c7be464 "[xpack.security.http.ssl.keystore.password] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
Origin:kibana
Stack trace:
    at KibanaTransport.request (/Users/joe/GitHub/kibana-1/src/core/server/elasticsearch/client/create_transport.ts:62:17)
    at Cluster.getSettings (/Users/joe/GitHub/kibana-1/node_modules/@elastic/elasticsearch/src/api/api/cluster.ts:198:12)
    at isInlineScriptingEnabled (/Users/joe/GitHub/kibana-1/src/core/server/elasticsearch/is_scripting_enabled.ts:18:30)
    at ElasticsearchService.start (/Users/joe/GitHub/kibana-1/src/core/server/elasticsearch/elasticsearch_service.ts:129:32)
    at Server.start (/Users/joe/GitHub/kibana-1/src/core/server/server.ts:297:32)
    at Root.start (/Users/joe/GitHub/kibana-1/src/core/server/root/index.ts:62:14)
    at bootstrap (/Users/joe/GitHub/kibana-1/src/core/server/bootstrap.ts:102:5)
    at Command.<anonymous> (/Users/joe/GitHub/kibana-1/src/cli/serve/serve.js:244:5)
Query:
200 - 25.9KB
GET /_cluster/settings?include_defaults=true&flat_settings=true
```

After this change, the warning is no longer logged.


