### PR TITLE
[ci] Build and publish webpack bundle reports

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -168,7 +168,7 @@ steps:
     timeout_in_minutes: 60
 
   - command: .buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
-    label: 'Build webpack bundle analyzer reports'
+    label: 'Build Webpack Bundle Analyzer reports'
     agents:
       queue: n2-2
     key: webpack_bundle_analyzer

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -173,4 +173,3 @@ steps:
       queue: n2-2
     key: webpack_bundle_analyzer
     timeout_in_minutes: 60
-  

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -166,3 +166,10 @@ steps:
       queue: c2-4
     key: storybooks
     timeout_in_minutes: 60
+
+  - command: .buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
+    label: 'Build webpack bundle analyzer reports'
+    agents:
+      queue: n2-2
+    key: webpack_bundle_analyzer
+    timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -173,3 +173,4 @@ steps:
       queue: n2-2
     key: webpack_bundle_analyzer
     timeout_in_minutes: 60
+  

--- a/.buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
+++ b/.buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # node scripts/build_kibana_platform_plugins.js --dist --profile
 
-mkdir -p built_assets/webpack_bundle_reports
+mkdir -p built_assets/webpack_bundle_analyzer
 find . -path "*target/public/*" -name "stats.json" | while read line; do
   PLUGIN=$(echo $line | xargs dirname | xargs dirname | xargs dirname | xargs basename)
   ./node_modules/.bin/webpack-bundle-analyzer $line --report "built_assets/webpack_bundle_analyzer_reports/$PLUGIN.html" --mode static --no-open

--- a/.buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
+++ b/.buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# .buildkite/scripts/bootstrap.sh
+
+# node scripts/build_kibana_platform_plugins.js --dist --profile
+
+mkdir -p built_assets/webpack_bundle_reports
+find . -path "*target/public/*" -name "stats.json" | while read line; do
+  PLUGIN=$(echo $line | xargs dirname | xargs dirname | xargs dirname | xargs basename)
+  ./node_modules/.bin/webpack-bundle-analyzer $line --report "built_assets/webpack_bundle_analyzer_reports/$PLUGIN.html" --mode static --no-open
+done
+
+node .buildkite/scripts/steps/webpack_bundle_analyzer/upload.js

--- a/.buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
+++ b/.buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 mkdir -p built_assets/webpack_bundle_analyzer
 find . -path "*target/public/*" -name "stats.json" | while read line; do
   PLUGIN=$(echo $line | xargs dirname | xargs dirname | xargs dirname | xargs basename)
-  ./node_modules/.bin/webpack-bundle-analyzer $line --report "built_assets/webpack_bundle_analyzer_reports/$PLUGIN.html" --mode static --no-open
+  ./node_modules/.bin/webpack-bundle-analyzer $line --report "built_assets/webpack_bundle_analyzer/$PLUGIN.html" --mode static --no-open
 done
 
 node .buildkite/scripts/steps/webpack_bundle_analyzer/upload.js

--- a/.buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
+++ b/.buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-# .buildkite/scripts/bootstrap.sh
+.buildkite/scripts/bootstrap.sh
 
-# node scripts/build_kibana_platform_plugins.js --dist --profile
+node scripts/build_kibana_platform_plugins.js --dist --profile
 
 mkdir -p built_assets/webpack_bundle_analyzer
 find . -path "*target/public/*" -name "stats.json" | while read line; do

--- a/.buildkite/scripts/steps/webpack_bundle_analyzer/upload.js
+++ b/.buildkite/scripts/steps/webpack_bundle_analyzer/upload.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+const path = require('path');
+
+const GITHUB_CONTEXT = 'Build and Publish Webpack bundle analyzer reports';
+
+const WEBPACK_REPORTS =
+  process.env.BUILDKITE_PULL_REQUEST && process.env.BUILDKITE_PULL_REQUEST !== 'false'
+    ? `pr-${process.env.BUILDKITE_PULL_REQUEST}`
+    : process.env.BUILDKITE_BRANCH.replace('/', '__');
+const WEBPACK_REPORTS_BUCKET = 'ci-artifacts.kibana.dev/webpack_bundle_analyzer';
+const WEBPACK_REPORTS_BUCKET_URL = `https://${WEBPACK_REPORTS_BUCKET}/${WEBPACK_REPORTS}`;
+const WEBPACK_REPORTS_BASE_URL = `${WEBPACK_REPORTS_BUCKET_URL}/${process.env.BUILDKITE_COMMIT}`;
+
+const exec = (...args) => execSync(args.join(' '), { stdio: 'inherit' });
+
+const ghStatus = (state, description) =>
+  exec(
+    `gh api "repos/elastic/kibana/statuses/${process.env.BUILDKITE_COMMIT}"`,
+    `-f state=${state}`,
+    `-f target_url="${process.env.BUILDKITE_BUILD_URL}"`,
+    `-f context="${GITHUB_CONTEXT}"`,
+    `-f description="${description}"`,
+    `--silent`
+  );
+
+const upload = () => {
+  const originalDirectory = process.cwd();
+  process.chdir(path.join('.', 'built_assets', 'webpack_bundle_analyzer'));
+  try {
+    const reports = execSync(`ls -1d */`)
+      .toString()
+      .trim()
+      .split('\n')
+      .map((path) => path.replace('/', ''));
+
+    const listHtml = reports
+      .map((report) => `<li><a href="${WEBPACK_REPORTS_BASE_URL}/${report}">${report}</a></li>`)
+      .join('\n');
+
+    const html = `
+      <html>
+        <body>
+          <h1>Webpack bundle analyzer</h1>
+          <ul>
+            ${listHtml}
+          </ul>
+        </body>
+      </html>
+    `;
+
+    fs.writeFileSync('index.html', html);
+
+    console.log('--- Uploading webpack bundle reports');
+    exec(`
+      gsutil -q -m cp -r -z html '*' 'gs://${WEBPACK_REPORTS_BUCKET}/${WEBPACK_REPORTS}/${process.env.BUILDKITE_COMMIT}/'
+      gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp -z html 'index.html' 'gs://${WEBPACK_REPORTS_BUCKET}/${WEBPACK_REPORTS}/latest/'
+    `);
+
+    if (process.env.BUILDKITE_PULL_REQUEST && process.env.BUILDKITE_PULL_REQUEST !== 'false') {
+      exec(
+        `buildkite-agent meta-data set pr_comment:webpack_bundle_reports:head '* [Webpack Bundle Analyzer](${WEBPACK_REPORTS_BASE_URL})'`
+      );
+    }
+  } finally {
+    process.chdir(originalDirectory);
+  }
+};
+
+try {
+  ghStatus('pending', 'Building webpack bundle analyzer reports');
+  upload();
+  ghStatus('success', 'Webpack bundle analyzer reports built');
+} catch (error) {
+  ghStatus('error', 'Building webpack bundle analyzer reports failed');
+  throw error;
+}

--- a/.buildkite/scripts/steps/webpack_bundle_analyzer/upload.js
+++ b/.buildkite/scripts/steps/webpack_bundle_analyzer/upload.js
@@ -36,7 +36,7 @@ const upload = () => {
   const originalDirectory = process.cwd();
   process.chdir(path.join('.', 'built_assets', 'webpack_bundle_analyzer'));
   try {
-    const reports = execSync(`ls -1d */`)
+    const reports = execSync(`ls -1d ./*`)
       .toString()
       .trim()
       .split('\n')

--- a/.buildkite/scripts/steps/webpack_bundle_analyzer/upload.js
+++ b/.buildkite/scripts/steps/webpack_bundle_analyzer/upload.js
@@ -36,12 +36,7 @@ const upload = () => {
   const originalDirectory = process.cwd();
   process.chdir(path.join('.', 'built_assets', 'webpack_bundle_analyzer'));
   try {
-    const reports = execSync(`ls -1d ./*`)
-      .toString()
-      .trim()
-      .split('\n')
-      .map((path) => path.replace('/', ''));
-
+    const reports = execSync(`ls -1`).toString().trim().split('\n');
     const listHtml = reports
       .map((report) => `<li><a href="${WEBPACK_REPORTS_BASE_URL}/${report}">${report}</a></li>`)
       .join('\n');
@@ -49,7 +44,7 @@ const upload = () => {
     const html = `
       <html>
         <body>
-          <h1>Webpack bundle analyzer</h1>
+          <h1>Webpack Bundle Analyzer</h1>
           <ul>
             ${listHtml}
           </ul>
@@ -58,8 +53,7 @@ const upload = () => {
     `;
 
     fs.writeFileSync('index.html', html);
-
-    console.log('--- Uploading webpack bundle reports');
+    console.log('--- Uploading Webpack Bundle Analyzer reports');
     exec(`
       gsutil -q -m cp -r -z html '*' 'gs://${WEBPACK_REPORTS_BUCKET}/${WEBPACK_REPORTS}/${process.env.BUILDKITE_COMMIT}/'
       gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp -z html 'index.html' 'gs://${WEBPACK_REPORTS_BUCKET}/${WEBPACK_REPORTS}/latest/'
@@ -76,10 +70,10 @@ const upload = () => {
 };
 
 try {
-  ghStatus('pending', 'Building webpack bundle analyzer reports');
+  ghStatus('pending', 'Building Webpack Bundle Analyzer reports');
   upload();
   ghStatus('success', 'Webpack bundle analyzer reports built');
 } catch (error) {
-  ghStatus('error', 'Building webpack bundle analyzer reports failed');
+  ghStatus('error', 'Building Webpack Bundle Analyzer reports failed');
   throw error;
 }

--- a/package.json
+++ b/package.json
@@ -881,6 +881,7 @@
     "wait-on": "^5.2.1",
     "watchpack": "^1.6.0",
     "webpack": "^4.41.5",
+    "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3823,6 +3823,11 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@polka/url@^1.0.0-next.20":
+  version "1.0.0-next.21"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
+  integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
+
 "@popperjs/core@^2.4.0", "@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
@@ -7269,7 +7274,7 @@ acorn-walk@^7.0.0, acorn-walk@^7.1.1, acorn-walk@^7.2.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.1.1:
+acorn-walk@^8.0.0, acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
@@ -7288,6 +7293,11 @@ acorn@^7.0.0, acorn@^7.1.1, acorn@^7.4.0, acorn@^7.4.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.0.4:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 acorn@^8.4.1:
   version "8.5.0"
@@ -10240,7 +10250,7 @@ commander@^6.1.0, commander@^6.2.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
-commander@^7.0.0:
+commander@^7.0.0, commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
@@ -12467,6 +12477,11 @@ duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
+
+duplexer@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
+  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
 duplexify@^3.2.0, duplexify@^3.4.2, duplexify@^3.5.3:
   version "3.7.1"
@@ -15340,6 +15355,13 @@ gzip-size@5.1.1:
   dependencies:
     duplexer "^0.1.1"
     pify "^4.0.1"
+
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
 
 handle-thing@^2.0.0:
   version "2.0.0"
@@ -20083,6 +20105,11 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
+mrmime@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.0.tgz#14d387f0585a5233d291baba339b063752a2398b"
+  integrity sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==
+
 ms-chromium-edge-driver@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/ms-chromium-edge-driver/-/ms-chromium-edge-driver-0.4.3.tgz#808723efaf24da086ebc2a2feb0975162164d2ff"
@@ -21052,6 +21079,11 @@ opener@^1.4.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
   integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
+
+opener@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 opentracing@^0.14.3:
   version "0.14.4"
@@ -25600,6 +25632,15 @@ sinon@^7.4.2:
     nise "^1.5.2"
     supports-color "^5.5.0"
 
+sirv@^1.0.7:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
+  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.20"
+    mrmime "^1.0.0"
+    totalist "^1.0.0"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -27534,6 +27575,11 @@ topojson-client@^3.1.0:
   dependencies:
     commander "2"
 
+totalist@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
+  integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
+
 touch@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/touch/-/touch-2.0.2.tgz#ca0b2a3ae3211246a61b16ba9e6cbf1596287164"
@@ -29359,6 +29405,21 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
+webpack-bundle-analyzer@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz#1b0eea2947e73528754a6f9af3e91b2b6e0f79d5"
+  integrity sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==
+  dependencies:
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    chalk "^4.1.0"
+    commander "^7.2.0"
+    gzip-size "^6.0.0"
+    lodash "^4.17.20"
+    opener "^1.5.2"
+    sirv "^1.0.7"
+    ws "^7.3.1"
+
 webpack-cli@^3.3.12:
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.12.tgz#94e9ada081453cd0aa609c99e500012fd3ad2d4a"
@@ -29842,6 +29903,11 @@ ws@^6.1.2, ws@^6.2.1:
   integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
   dependencies:
     async-limiter "~1.0.0"
+
+ws@^7.3.1:
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.6.tgz#e59fc509fb15ddfb65487ee9765c5a51dec5fe7b"
+  integrity sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==
 
 x-is-function@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This adds a new CI step to build and generate [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) reports.  These reports include a breakdown of plugin sizes per file.

The upload code is based on the implementation @brianseeders wrote for storybooks in https://github.com/elastic/kibana/pull/87701

Reports can be viewed by clicking the `Webpack Bundle Analyzer` link in the comment posted by kibana-ci.