### PR TITLE
[7.17] Move bazel remote cache token to a space that more employees have access to (#123402)

### DIFF
--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -58952,7 +58952,7 @@ async function setupRemoteCache(repoRootPath) {
   try {
     const {
       stdout
-    } = await Object(_child_process__WEBPACK_IMPORTED_MODULE_3__["spawn"])('vault', ['read', '-field=readonly-key', 'secret/kibana-issues/dev/bazel-remote-cache'], {
+    } = await Object(_child_process__WEBPACK_IMPORTED_MODULE_3__["spawn"])('vault', ['read', '-field=readonly-key', 'secret/ui-team/kibana-bazel-remote-cache'], {
       stdio: 'pipe'
     });
     apiKey = stdout.trim();

--- a/packages/kbn-pm/src/utils/bazel/setup_remote_cache.ts
+++ b/packages/kbn-pm/src/utils/bazel/setup_remote_cache.ts
@@ -60,7 +60,7 @@ export async function setupRemoteCache(repoRootPath: string) {
   try {
     const { stdout } = await spawn(
       'vault',
-      ['read', '-field=readonly-key', 'secret/kibana-issues/dev/bazel-remote-cache'],
+      ['read', '-field=readonly-key', 'secret/ui-team/kibana-bazel-remote-cache'],
       {
         stdio: 'pipe',
       }


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #123402

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
