### PR TITLE
Validate server UUID retrieved from data/uuid using the same match from config validation

### DIFF
--- a/src/core/server/environment/resolve_uuid.test.ts
+++ b/src/core/server/environment/resolve_uuid.test.ts
@@ -91,7 +91,7 @@ describe('resolveInstanceUuid', () => {
         expect(logger.debug).toHaveBeenCalledTimes(1);
         expect(logger.debug.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
-            "Updating Kibana instance UUID to: ${DEFAULT_CONFIG_UUID} (was: ${DEFAULT_FILE_UUID})",
+            "Updating Kibana instance UUID to: cccccccc-bbbb-0ccc-0ddd-eeeeeeeeeeee (was: ffffffff-bbbb-0ccc-0ddd-eeeeeeeeeeee)",
           ]
         `);
       });
@@ -106,7 +106,7 @@ describe('resolveInstanceUuid', () => {
         expect(logger.debug).toHaveBeenCalledTimes(1);
         expect(logger.debug.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
-            "Kibana instance UUID: ${DEFAULT_CONFIG_UUID}",
+            "Kibana instance UUID: cccccccc-bbbb-0ccc-0ddd-eeeeeeeeeeee",
           ]
         `);
       });
@@ -126,7 +126,7 @@ describe('resolveInstanceUuid', () => {
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug.mock.calls[0]).toMatchInlineSnapshot(`
         Array [
-          "Setting new Kibana instance UUID: ${DEFAULT_CONFIG_UUID}",
+          "Setting new Kibana instance UUID: cccccccc-bbbb-0ccc-0ddd-eeeeeeeeeeee",
         ]
       `);
     });
@@ -144,7 +144,7 @@ describe('resolveInstanceUuid', () => {
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug.mock.calls[0]).toMatchInlineSnapshot(`
         Array [
-          "Resuming persistent Kibana instance UUID: ${DEFAULT_FILE_UUID}",
+          "Resuming persistent Kibana instance UUID: ffffffff-bbbb-0ccc-0ddd-eeeeeeeeeeee",
         ]
       `);
     });
@@ -213,7 +213,7 @@ describe('resolveInstanceUuid', () => {
               "UUID from 7.6.0 bug detected, ignoring file UUID",
             ],
             Array [
-              "Setting new Kibana instance UUID: ${DEFAULT_CONFIG_UUID}",
+              "Setting new Kibana instance UUID: cccccccc-bbbb-0ccc-0ddd-eeeeeeeeeeee",
             ],
           ]
         `);

--- a/src/core/server/environment/resolve_uuid.test.ts
+++ b/src/core/server/environment/resolve_uuid.test.ts
@@ -22,8 +22,8 @@ jest.mock('./fs', () => ({
   writeFile: jest.fn(() => Promise.resolve('')),
 }));
 
-const DEFAULT_FILE_UUID = 'FILE_UUID';
-const DEFAULT_CONFIG_UUID = 'CONFIG_UUID';
+const DEFAULT_FILE_UUID = 'ffffffff-bbbb-0ccc-0ddd-eeeeeeeeeeee';
+const DEFAULT_CONFIG_UUID = 'cccccccc-bbbb-0ccc-0ddd-eeeeeeeeeeee';
 const fileNotFoundError = { code: 'ENOENT' };
 const permissionError = { code: 'EACCES' };
 const isDirectoryError = { code: 'EISDIR' };
@@ -91,7 +91,7 @@ describe('resolveInstanceUuid', () => {
         expect(logger.debug).toHaveBeenCalledTimes(1);
         expect(logger.debug.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
-            "Updating Kibana instance UUID to: CONFIG_UUID (was: FILE_UUID)",
+            "Updating Kibana instance UUID to: ${DEFAULT_CONFIG_UUID} (was: ${DEFAULT_FILE_UUID})",
           ]
         `);
       });
@@ -106,7 +106,7 @@ describe('resolveInstanceUuid', () => {
         expect(logger.debug).toHaveBeenCalledTimes(1);
         expect(logger.debug.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
-            "Kibana instance UUID: CONFIG_UUID",
+            "Kibana instance UUID: ${DEFAULT_CONFIG_UUID}",
           ]
         `);
       });
@@ -126,24 +126,44 @@ describe('resolveInstanceUuid', () => {
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug.mock.calls[0]).toMatchInlineSnapshot(`
         Array [
-          "Setting new Kibana instance UUID: CONFIG_UUID",
+          "Setting new Kibana instance UUID: ${DEFAULT_CONFIG_UUID}",
         ]
       `);
     });
   });
 
   describe('when file is present and config property is not set', () => {
-    it('does not write to file and returns the file uuid', async () => {
+    beforeEach(() => {
       serverConfig = createServerConfig(undefined);
+    });
+
+    it('does not write to file and returns the file uuid', async () => {
       const uuid = await resolveInstanceUuid({ pathConfig, serverConfig, logger });
       expect(uuid).toEqual(DEFAULT_FILE_UUID);
       expect(writeFile).not.toHaveBeenCalled();
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug.mock.calls[0]).toMatchInlineSnapshot(`
         Array [
-          "Resuming persistent Kibana instance UUID: FILE_UUID",
+          "Resuming persistent Kibana instance UUID: ${DEFAULT_FILE_UUID}",
         ]
       `);
+    });
+
+    describe('when file contains an invalid uuid', () => {
+      it('throws an explicit error for uuid formatting', async () => {
+        mockReadFile({ uuid: 'invalid uuid in data file' });
+        await expect(
+          resolveInstanceUuid({ pathConfig, serverConfig, logger })
+        ).rejects.toThrowErrorMatchingInlineSnapshot(`"data-folder/uuid contains an invalid UUID"`);
+      });
+    });
+
+    describe('when file contains a trailing new line', () => {
+      it('returns the trimmed file uuid', async () => {
+        mockReadFile({ uuid: DEFAULT_FILE_UUID + '\n' });
+        const uuid = await resolveInstanceUuid({ pathConfig, serverConfig, logger });
+        expect(uuid).toEqual(DEFAULT_FILE_UUID);
+      });
     });
   });
 
@@ -193,7 +213,7 @@ describe('resolveInstanceUuid', () => {
               "UUID from 7.6.0 bug detected, ignoring file UUID",
             ],
             Array [
-              "Setting new Kibana instance UUID: CONFIG_UUID",
+              "Setting new Kibana instance UUID: ${DEFAULT_CONFIG_UUID}",
             ],
           ]
         `);

--- a/src/core/server/http/http_config.ts
+++ b/src/core/server/http/http_config.ts
@@ -21,7 +21,8 @@ import {
 } from './security_response_headers_config';
 
 const validBasePathRegex = /^\/.*[^\/]$/;
-const uuidRegexp = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+export const uuidRegexp =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const hostURISchema = schema.uri({ scheme: ['http', 'https'] });
 const match = (regex: RegExp, errorMsg: string) => (str: string) =>
   regex.test(str) ? undefined : errorMsg;


### PR DESCRIPTION
## Summary

Validates the UUID picked up from `data/uuid` to avoid invalid UUIDs or possibly trailing whitespace from leaking into the server stats.

Fixes https://github.com/elastic/kibana/issues/123678

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
