### PR TITLE
[File data visualizer] Removing file upload retries

### DIFF
--- a/x-pack/plugins/file_upload/server/analyze_file.tsx
+++ b/x-pack/plugins/file_upload/server/analyze_file.tsx
@@ -19,10 +19,13 @@ export async function analyzeFile(
   overrides: InputOverrides
 ): Promise<AnalysisResult> {
   overrides.explain = overrides.explain === undefined ? 'true' : overrides.explain;
-  const { body } = await client.asInternalUser.textStructure.findStructure({
-    body: data,
-    ...overrides,
-  });
+  const { body } = await client.asInternalUser.textStructure.findStructure(
+    {
+      body: data,
+      ...overrides,
+    },
+    { maxRetries: 0 }
+  );
 
   const { hasOverrides, reducedOverrides } = formatOverrides(overrides);
 

--- a/x-pack/plugins/file_upload/server/import_data.ts
+++ b/x-pack/plugins/file_upload/server/import_data.ts
@@ -104,7 +104,7 @@ export function importDataProvider({ asCurrentUser }: IScopedClusterClient) {
     }
 
     // @ts-expect-error settings.index is not compatible
-    await asCurrentUser.indices.create({ index, body });
+    await asCurrentUser.indices.create({ index, body }, { maxRetries: 0 });
   }
 
   async function indexData(index: string, pipelineId: string, data: InputData) {
@@ -120,7 +120,7 @@ export function importDataProvider({ asCurrentUser }: IScopedClusterClient) {
         settings.pipeline = pipelineId;
       }
 
-      const { body: resp } = await asCurrentUser.bulk(settings);
+      const { body: resp } = await asCurrentUser.bulk(settings, { maxRetries: 0 });
       if (resp.errors) {
         throw resp;
       } else {


### PR DESCRIPTION
Removes api retries when calling the elasticsearch endpoints to analyse data and upload documents.
If elasticsearch takes too long to analyse the file or to process any uploaded documents, the es client used in kibana should not retry.
In the case of uploading documents, the ingest pipeline may take longer than expected especially if an inference processor is being used. Retrying the document will lead to duplicates.

Related to this previous PR https://github.com/elastic/kibana/pull/121353

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
