### PR TITLE
[8.0] Handle access tokens that expire after authentication stage. (#122155)

### DIFF
--- a/x-pack/plugins/security/server/authentication/authentication_service.test.ts
+++ b/x-pack/plugins/security/server/authentication/authentication_service.test.ts
@@ -10,18 +10,22 @@ jest.mock('./unauthenticated_page');
 
 import { mockCanRedirectRequest } from './authentication_service.test.mocks';
 
-import Boom from '@hapi/boom';
+import { errors } from '@elastic/elasticsearch';
 
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import type {
   AuthenticationHandler,
   AuthToolkit,
+  ElasticsearchServiceSetup,
   HttpServiceSetup,
   HttpServiceStart,
   KibanaRequest,
   Logger,
   LoggerFactory,
   OnPreResponseToolkit,
+  UnauthorizedError,
+  UnauthorizedErrorHandler,
+  UnauthorizedErrorHandlerToolkit,
 } from 'src/core/server';
 import {
   coreMock,
@@ -31,9 +35,8 @@ import {
   loggingSystemMock,
 } from 'src/core/server/mocks';
 
-import type { SecurityLicense } from '../../common/licensing';
+import type { AuthenticatedUser, SecurityLicense } from '../../common';
 import { licenseMock } from '../../common/licensing/index.mock';
-import type { AuthenticatedUser } from '../../common/model';
 import { mockAuthenticatedUser } from '../../common/model/authenticated_user.mock';
 import type { AuditServiceSetup } from '../audit';
 import { auditServiceMock } from '../audit/index.mock';
@@ -41,6 +44,7 @@ import type { ConfigType } from '../config';
 import { ConfigSchema, createConfig } from '../config';
 import type { SecurityFeatureUsageServiceStart } from '../feature_usage';
 import { securityFeatureUsageServiceMock } from '../feature_usage/index.mock';
+import { securityMock } from '../mocks';
 import { ROUTE_TAG_AUTH_FLOW } from '../routes/tags';
 import type { Session } from '../session_management';
 import { sessionMock } from '../session_management/session.mock';
@@ -52,6 +56,7 @@ describe('AuthenticationService', () => {
   let logger: jest.Mocked<Logger>;
   let mockSetupAuthenticationParams: {
     http: jest.Mocked<HttpServiceSetup>;
+    elasticsearch: jest.Mocked<ElasticsearchServiceSetup>;
     config: ConfigType;
     license: jest.Mocked<SecurityLicense>;
     buildNumber: number;
@@ -68,13 +73,15 @@ describe('AuthenticationService', () => {
   beforeEach(() => {
     logger = loggingSystemMock.createLogger();
 
-    const httpMock = coreMock.createSetup().http;
+    const coreSetupMock = coreMock.createSetup();
+    const httpMock = coreSetupMock.http;
     (httpMock.basePath.prepend as jest.Mock).mockImplementation(
       (path) => `${httpMock.basePath.serverBasePath}${path}`
     );
     (httpMock.basePath.get as jest.Mock).mockImplementation(() => httpMock.basePath.serverBasePath);
     mockSetupAuthenticationParams = {
       http: httpMock,
+      elasticsearch: coreSetupMock.elasticsearch,
       config: createConfig(ConfigSchema.validate({}), loggingSystemMock.create().get(), {
         isTLSEnabled: false,
       }),
@@ -118,6 +125,17 @@ describe('AuthenticationService', () => {
       expect(mockSetupAuthenticationParams.http.registerAuth).toHaveBeenCalledWith(
         expect.any(Function)
       );
+    });
+
+    it('properly registers unauthorized error handler', () => {
+      service.setup(mockSetupAuthenticationParams);
+
+      expect(
+        mockSetupAuthenticationParams.elasticsearch.setUnauthorizedErrorHandler
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockSetupAuthenticationParams.elasticsearch.setUnauthorizedErrorHandler
+      ).toHaveBeenCalledWith(expect.any(Function));
     });
 
     it('properly registers onPreResponse handler', () => {
@@ -278,7 +296,9 @@ describe('AuthenticationService', () => {
 
       it('rejects with original `badRequest` error when `authenticate` fails to authenticate user', async () => {
         const mockResponse = httpServerMock.createLifecycleResponseFactory();
-        const esError = Boom.badRequest('some message');
+        const esError = new errors.ResponseError(
+          securityMock.createApiResponse({ statusCode: 400, body: 'some message' })
+        );
         authenticate.mockResolvedValue(AuthenticationResult.failed(esError));
 
         await authHandler(httpServerMock.createKibanaRequest(), mockResponse, mockAuthToolkit);
@@ -293,12 +313,19 @@ describe('AuthenticationService', () => {
 
       it('includes `WWW-Authenticate` header if `authenticate` fails to authenticate user and provides challenges', async () => {
         const mockResponse = httpServerMock.createLifecycleResponseFactory();
-        const originalError = Boom.unauthorized('some message');
-        (originalError.output.headers as { [key: string]: string })['WWW-Authenticate'] = [
-          'Basic realm="Access to prod", charset="UTF-8"',
-          'Basic',
-          'Negotiate',
-        ] as any;
+        const originalError = new errors.ResponseError(
+          securityMock.createApiResponse({
+            statusCode: 403,
+            body: 'some message',
+            headers: {
+              'WWW-Authenticate': [
+                'Basic realm="Access to prod", charset="UTF-8"',
+                'Basic',
+                'Negotiate',
+              ],
+            },
+          })
+        );
         authenticate.mockResolvedValue(
           AuthenticationResult.failed(originalError, {
             authResponseHeaders: { 'WWW-Authenticate': 'Negotiate' },
@@ -326,6 +353,221 @@ describe('AuthenticationService', () => {
 
         expect(mockAuthToolkit.authenticated).not.toHaveBeenCalled();
         expect(mockAuthToolkit.redirected).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('unauthorized error handler', () => {
+      let unauthorizedErrorHandler: UnauthorizedErrorHandler;
+      let reauthenticate: jest.SpyInstance<Promise<AuthenticationResult>, [KibanaRequest]>;
+      let mockUnauthorizedErrorToolkit: jest.Mocked<UnauthorizedErrorHandlerToolkit>;
+      beforeEach(() => {
+        mockUnauthorizedErrorToolkit = { notHandled: jest.fn(), retry: jest.fn() };
+
+        service.start(mockStartAuthenticationParams);
+
+        unauthorizedErrorHandler =
+          mockSetupAuthenticationParams.elasticsearch.setUnauthorizedErrorHandler.mock.calls[0][0];
+        reauthenticate =
+          jest.requireMock('./authenticator').Authenticator.mock.instances[0].reauthenticate;
+      });
+
+      it('does not handle error if license is not available.', async () => {
+        mockSetupAuthenticationParams.license.isLicenseAvailable.mockReturnValue(false);
+
+        const failureReason = new errors.ResponseError(
+          securityMock.createApiResponse({ statusCode: 401, body: {} })
+        ) as UnauthorizedError;
+
+        await unauthorizedErrorHandler(
+          { error: failureReason, request: httpServerMock.createKibanaRequest() },
+          mockUnauthorizedErrorToolkit
+        );
+
+        expect(mockUnauthorizedErrorToolkit.notHandled).toHaveBeenCalledTimes(1);
+        expect(mockUnauthorizedErrorToolkit.retry).not.toHaveBeenCalled();
+        expect(reauthenticate).not.toHaveBeenCalled();
+      });
+
+      it('does not handle error when security is disabled in elasticsearch.', async () => {
+        mockSetupAuthenticationParams.license.isEnabled.mockReturnValue(false);
+
+        const failureReason = new errors.ResponseError(
+          securityMock.createApiResponse({ statusCode: 401, body: {} })
+        ) as UnauthorizedError;
+
+        await unauthorizedErrorHandler(
+          { error: failureReason, request: httpServerMock.createKibanaRequest() },
+          mockUnauthorizedErrorToolkit
+        );
+
+        expect(mockUnauthorizedErrorToolkit.notHandled).toHaveBeenCalledTimes(1);
+        expect(mockUnauthorizedErrorToolkit.retry).not.toHaveBeenCalled();
+        expect(reauthenticate).not.toHaveBeenCalled();
+      });
+
+      it('does not handle non-401 errors.', async () => {
+        const failureReason = new errors.ResponseError(
+          securityMock.createApiResponse({ statusCode: 403, body: {} })
+        ) as UnauthorizedError;
+
+        await unauthorizedErrorHandler(
+          { error: failureReason, request: httpServerMock.createKibanaRequest() },
+          mockUnauthorizedErrorToolkit
+        );
+
+        expect(mockUnauthorizedErrorToolkit.notHandled).toHaveBeenCalledTimes(1);
+        expect(mockUnauthorizedErrorToolkit.retry).not.toHaveBeenCalled();
+        expect(reauthenticate).not.toHaveBeenCalled();
+      });
+
+      it('does not handle error unless provider successfully returns new headers.', async () => {
+        const failureReason = new errors.ResponseError(
+          securityMock.createApiResponse({ statusCode: 401, body: {} })
+        ) as UnauthorizedError;
+
+        const nonHandleableResults = [
+          AuthenticationResult.notHandled(),
+          AuthenticationResult.failed(
+            new errors.ResponseError(securityMock.createApiResponse({ statusCode: 404, body: {} }))
+          ),
+          AuthenticationResult.redirectTo('some-url'),
+          AuthenticationResult.succeeded(mockAuthenticatedUser(), {
+            authResponseHeaders: { header: 'value' },
+          }),
+        ];
+
+        const mockRequest = httpServerMock.createKibanaRequest();
+        for (const result of nonHandleableResults) {
+          reauthenticate.mockResolvedValue(result);
+
+          await unauthorizedErrorHandler(
+            { error: failureReason, request: mockRequest },
+            mockUnauthorizedErrorToolkit
+          );
+
+          expect(mockUnauthorizedErrorToolkit.notHandled).toHaveBeenCalledTimes(1);
+          expect(mockUnauthorizedErrorToolkit.retry).not.toHaveBeenCalled();
+
+          expect(reauthenticate).toHaveBeenCalledTimes(1);
+          expect(reauthenticate).toHaveBeenCalledWith(mockRequest);
+
+          mockUnauthorizedErrorToolkit.notHandled.mockClear();
+          reauthenticate.mockClear();
+        }
+      });
+
+      it('handles error if authentication succeeds and authentication headers are available.', async () => {
+        const failureReason = new errors.ResponseError(
+          securityMock.createApiResponse({ statusCode: 401, body: {} })
+        ) as UnauthorizedError;
+
+        reauthenticate.mockResolvedValue(
+          AuthenticationResult.succeeded(mockAuthenticatedUser(), {
+            authHeaders: { header: 'value' },
+          })
+        );
+
+        const mockRequest = httpServerMock.createKibanaRequest();
+        await unauthorizedErrorHandler(
+          { error: failureReason, request: mockRequest },
+          mockUnauthorizedErrorToolkit
+        );
+
+        expect(mockUnauthorizedErrorToolkit.retry).toHaveBeenCalledTimes(1);
+        expect(mockUnauthorizedErrorToolkit.retry).toHaveBeenCalledWith({
+          authHeaders: { header: 'value' },
+        });
+        expect(mockUnauthorizedErrorToolkit.notHandled).not.toHaveBeenCalled();
+
+        expect(reauthenticate).toHaveBeenCalledTimes(1);
+        expect(reauthenticate).toHaveBeenCalledWith(mockRequest);
+      });
+
+      it('filters out and recovers `Authorization` header when provider cannot handle error.', async () => {
+        const failureReason = new errors.ResponseError(
+          securityMock.createApiResponse({ statusCode: 401, body: {} })
+        ) as UnauthorizedError;
+
+        const mockRequest = httpServerMock.createKibanaRequest({
+          headers: { Authorization: 'Basic xxx', Random: 'random' },
+        });
+
+        let modifiedHeaders;
+        reauthenticate.mockImplementation((request) => {
+          modifiedHeaders = request.headers;
+          return Promise.resolve(AuthenticationResult.notHandled());
+        });
+
+        await unauthorizedErrorHandler(
+          { error: failureReason, request: mockRequest },
+          mockUnauthorizedErrorToolkit
+        );
+
+        expect(reauthenticate).toHaveBeenCalledTimes(1);
+        expect(reauthenticate).toHaveBeenCalledWith(mockRequest);
+        expect(modifiedHeaders).toEqual({ Random: 'random' });
+
+        expect(mockRequest.headers).toEqual({ Authorization: 'Basic xxx', Random: 'random' });
+      });
+
+      it('filters out and recovers `Authorization` header when provider can handle error.', async () => {
+        const failureReason = new errors.ResponseError(
+          securityMock.createApiResponse({ statusCode: 401, body: {} })
+        ) as UnauthorizedError;
+
+        const mockRequest = httpServerMock.createKibanaRequest({
+          headers: { Authorization: 'Basic xxx', Random: 'random' },
+        });
+
+        let modifiedHeaders;
+        reauthenticate.mockImplementation((request) => {
+          modifiedHeaders = request.headers;
+          return Promise.resolve(
+            AuthenticationResult.succeeded(mockAuthenticatedUser(), {
+              authHeaders: { header: 'value' },
+            })
+          );
+        });
+
+        await unauthorizedErrorHandler(
+          { error: failureReason, request: mockRequest },
+          mockUnauthorizedErrorToolkit
+        );
+
+        expect(reauthenticate).toHaveBeenCalledTimes(1);
+        expect(reauthenticate).toHaveBeenCalledWith(mockRequest);
+        expect(modifiedHeaders).toEqual({ Random: 'random' });
+
+        expect(mockRequest.headers).toEqual({ Authorization: 'Basic xxx', Random: 'random' });
+      });
+
+      it('filters out and recovers `Authorization` header when provider fails with unexpected error.', async () => {
+        const failureReason = new errors.ResponseError(
+          securityMock.createApiResponse({ statusCode: 401, body: {} })
+        ) as UnauthorizedError;
+
+        const mockRequest = httpServerMock.createKibanaRequest({
+          headers: { Authorization: 'Basic xxx', Random: 'random' },
+        });
+
+        let modifiedHeaders;
+        reauthenticate.mockImplementation((request) => {
+          modifiedHeaders = request.headers;
+          return Promise.reject(new Error('Uh oh.'));
+        });
+
+        await expect(
+          unauthorizedErrorHandler(
+            { error: failureReason, request: mockRequest },
+            mockUnauthorizedErrorToolkit
+          )
+        ).rejects.toThrow(new Error('Uh oh.'));
+
+        expect(reauthenticate).toHaveBeenCalledTimes(1);
+        expect(reauthenticate).toHaveBeenCalledWith(mockRequest);
+        expect(modifiedHeaders).toEqual({ Random: 'random' });
+
+        expect(mockRequest.headers).toEqual({ Authorization: 'Basic xxx', Random: 'random' });
       });
     });
 

--- a/x-pack/plugins/security/server/authentication/authenticator.ts
+++ b/x-pack/plugins/security/server/authentication/authenticator.ts
@@ -407,6 +407,34 @@ export class Authenticator {
   }
 
   /**
+   * Tries to reauthenticate request with the existing session.
+   * @param request Request instance.
+   */
+  async reauthenticate(request: KibanaRequest) {
+    assertRequest(request);
+
+    const existingSessionValue = await this.getSessionValue(request);
+    if (!existingSessionValue) {
+      this.logger.warn('Session is no longer available and cannot be re-authenticated.');
+      return AuthenticationResult.notHandled();
+    }
+
+    // We can ignore `undefined` value here since it's ruled out on the previous step, if provider isn't
+    // available then `getSessionValue` should have returned `null`.
+    const provider = this.providers.get(existingSessionValue.provider.name)!;
+    const authenticationResult = await provider.authenticate(request, existingSessionValue.state);
+    if (!authenticationResult.notHandled()) {
+      await this.updateSessionValue(request, {
+        provider: existingSessionValue.provider,
+        authenticationResult,
+        existingSessionValue,
+      });
+    }
+
+    return authenticationResult;
+  }
+
+  /**
    * Deauthenticates current request.
    * @param request Request instance.
    */

--- a/x-pack/plugins/security/server/plugin.ts
+++ b/x-pack/plugins/security/server/plugin.ts
@@ -242,6 +242,7 @@ export class SecurityPlugin
     this.sessionManagementService.setup({ config, http: core.http, taskManager });
     this.authenticationService.setup({
       http: core.http,
+      elasticsearch: core.elasticsearch,
       config,
       license,
       buildNumber: this.initializerContext.env.packageInfo.buildNum,

--- a/x-pack/test/security_api_integration/kerberos.config.ts
+++ b/x-pack/test/security_api_integration/kerberos.config.ts
@@ -15,6 +15,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const kerberosKeytabPath = resolve(__dirname, './fixtures/kerberos/krb5.keytab');
   const kerberosConfigPath = resolve(__dirname, './fixtures/kerberos/krb5.conf');
 
+  const testEndpointsPlugin = resolve(
+    __dirname,
+    '../security_functional/fixtures/common/test_endpoints'
+  );
+
   return {
     testFiles: [require.resolve('./tests/kerberos')],
     servers: xPackAPITestsConfig.get('servers'),
@@ -42,6 +47,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ...xPackAPITestsConfig.get('kbnTestServer'),
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
+        `--plugin-path=${testEndpointsPlugin}`,
         `--xpack.security.authc.providers=${JSON.stringify(['kerberos', 'basic'])}`,
       ],
     },

--- a/x-pack/test/security_api_integration/oidc.config.ts
+++ b/x-pack/test/security_api_integration/oidc.config.ts
@@ -15,6 +15,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const kibanaPort = xPackAPITestsConfig.get('servers.kibana.port');
   const jwksPath = resolve(__dirname, './fixtures/oidc/jwks.json');
 
+  const testEndpointsPlugin = resolve(
+    __dirname,
+    '../security_functional/fixtures/common/test_endpoints'
+  );
+
   return {
     testFiles: [require.resolve('./tests/oidc/authorization_code_flow')],
     servers: xPackAPITestsConfig.get('servers'),
@@ -50,6 +55,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
         `--plugin-path=${plugin}`,
+        `--plugin-path=${testEndpointsPlugin}`,
         `--xpack.security.authProviders=${JSON.stringify(['oidc', 'basic'])}`,
         '--xpack.security.authc.oidc.realm="oidc1"',
       ],

--- a/x-pack/test/security_api_integration/pki.config.ts
+++ b/x-pack/test/security_api_integration/pki.config.ts
@@ -13,6 +13,11 @@ import { services } from './services';
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xPackAPITestsConfig = await readConfigFile(require.resolve('../api_integration/config.ts'));
 
+  const testEndpointsPlugin = resolve(
+    __dirname,
+    '../security_functional/fixtures/common/test_endpoints'
+  );
+
   const servers = {
     ...xPackAPITestsConfig.get('servers'),
     elasticsearch: {
@@ -54,6 +59,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ...xPackAPITestsConfig.get('kbnTestServer'),
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
+        `--plugin-path=${testEndpointsPlugin}`,
         '--server.ssl.enabled=true',
         `--server.ssl.key=${KBN_KEY_PATH}`,
         `--server.ssl.certificate=${KBN_CERT_PATH}`,

--- a/x-pack/test/security_api_integration/saml.config.ts
+++ b/x-pack/test/security_api_integration/saml.config.ts
@@ -15,6 +15,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const kibanaPort = xPackAPITestsConfig.get('servers.kibana.port');
   const idpPath = resolve(__dirname, './fixtures/saml/idp_metadata.xml');
 
+  const testEndpointsPlugin = resolve(
+    __dirname,
+    '../security_functional/fixtures/common/test_endpoints'
+  );
+
   return {
     testFiles: [require.resolve('./tests/saml')],
     servers: xPackAPITestsConfig.get('servers'),
@@ -44,6 +49,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ...xPackAPITestsConfig.get('kbnTestServer'),
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
+        `--plugin-path=${testEndpointsPlugin}`,
         `--xpack.security.authc.providers=${JSON.stringify(['saml', 'basic'])}`,
         '--xpack.security.authc.saml.realm=saml1',
         '--xpack.security.authc.saml.maxRedirectURLSize=100b',

--- a/x-pack/test/security_api_integration/tests/kerberos/kerberos_login.ts
+++ b/x-pack/test/security_api_integration/tests/kerberos/kerberos_login.ts
@@ -374,6 +374,55 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(nonAjaxResponse.headers['www-authenticate']).to.be(undefined);
       });
+
+      describe('post-authentication stage', () => {
+        for (const client of ['start-contract', 'request-context', 'custom']) {
+          it(`expired access token should be automatically refreshed by the ${client} client`, async function () {
+            this.timeout(60000);
+
+            // Access token expiration is set to 15s for API integration tests.
+            // Let's tell test endpoint to wait 30s after authentication and try to make a request to Elasticsearch
+            // triggering token refresh logic.
+            const response = await supertest
+              .post('/authentication/slow/me')
+              .set('kbn-xsrf', 'xxx')
+              .set('Cookie', sessionCookie.cookieString())
+              .send({ duration: '30s', client })
+              .expect(200);
+
+            const newSessionCookies = response.headers['set-cookie'];
+            expect(newSessionCookies).to.have.length(1);
+
+            const refreshedCookie = parseCookie(newSessionCookies[0])!;
+            checkCookieIsSet(refreshedCookie);
+
+            // The second new cookie with fresh pair of access and refresh tokens should work.
+            await supertest
+              .get('/internal/security/me')
+              .set('kbn-xsrf', 'xxx')
+              .set('Cookie', refreshedCookie.cookieString())
+              .expect(200);
+
+            expect(response.headers['www-authenticate']).to.be(undefined);
+          });
+
+          it(`expired access token should be automatically refreshed by the ${client} client even for multiple concurrent requests`, async function () {
+            this.timeout(60000);
+
+            // Send 5 concurrent requests with a cookie that contains an expired access token.
+            await Promise.all(
+              Array.from({ length: 5 }).map((value, index) =>
+                supertest
+                  .post(`/authentication/slow/me?a=${index}`)
+                  .set('kbn-xsrf', 'xxx')
+                  .set('Cookie', sessionCookie.cookieString())
+                  .send({ duration: '30s', client })
+                  .expect(200)
+              )
+            );
+          });
+        }
+      });
     });
 
     describe('API access with missing access token document or expired refresh token.', () => {

--- a/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/oidc_auth.ts
+++ b/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/oidc_auth.ts
@@ -540,6 +540,53 @@ export default function ({ getService }: FtrProviderContext) {
           .set('Cookie', secondNewCookie.cookieString())
           .expect(200);
       });
+
+      describe('post-authentication stage', () => {
+        for (const client of ['start-contract', 'request-context', 'custom']) {
+          it(`expired access token should be automatically refreshed by the ${client} client`, async function () {
+            this.timeout(60000);
+
+            // Access token expiration is set to 15s for API integration tests.
+            // Let's tell test endpoint to wait 30s after authentication and try to make a request to Elasticsearch
+            // triggering token refresh logic.
+            const response = await supertest
+              .post('/authentication/slow/me')
+              .set('kbn-xsrf', 'xxx')
+              .set('Cookie', sessionCookie.cookieString())
+              .send({ duration: '30s', client })
+              .expect(200);
+
+            const newSessionCookies = response.headers['set-cookie'];
+            expect(newSessionCookies).to.have.length(1);
+
+            const newSessionCookie = parseCookie(newSessionCookies[0])!;
+            expectNewSessionCookie(newSessionCookie);
+
+            // The second new cookie with fresh pair of access and refresh tokens should work.
+            await supertest
+              .get('/internal/security/me')
+              .set('kbn-xsrf', 'xxx')
+              .set('Cookie', newSessionCookie.cookieString())
+              .expect(200);
+          });
+
+          it(`expired access token should be automatically refreshed by the ${client} client even for multiple concurrent requests`, async function () {
+            this.timeout(60000);
+
+            // Send 5 concurrent requests with a cookie that contains an expired access token.
+            await Promise.all(
+              Array.from({ length: 5 }).map((value, index) =>
+                supertest
+                  .post(`/authentication/slow/me?a=${index}`)
+                  .set('kbn-xsrf', 'xxx')
+                  .set('Cookie', sessionCookie.cookieString())
+                  .send({ duration: '30s', client })
+                  .expect(200)
+              )
+            );
+          });
+        }
+      });
     });
 
     describe('API access with missing access token document.', () => {

--- a/x-pack/test/security_api_integration/tests/pki/pki_auth.ts
+++ b/x-pack/test/security_api_integration/tests/pki/pki_auth.ts
@@ -399,6 +399,59 @@ export default function ({ getService }: FtrProviderContext) {
         const refreshedCookie = parseCookie(cookies[0])!;
         checkCookieIsSet(refreshedCookie);
       });
+
+      describe('post-authentication stage', () => {
+        for (const client of ['start-contract', 'request-context', 'custom']) {
+          it(`expired access token should be automatically refreshed by the ${client} client`, async function () {
+            this.timeout(60000);
+
+            // Access token expiration is set to 15s for API integration tests.
+            // Let's tell test endpoint to wait 30s after authentication and try to make a request to Elasticsearch
+            // triggering token refresh logic.
+            const response = await supertest
+              .post('/authentication/slow/me')
+              .ca(CA_CERT)
+              .pfx(FIRST_CLIENT_CERT)
+              .set('kbn-xsrf', 'xxx')
+              .set('Cookie', sessionCookie.cookieString())
+              .send({ duration: '30s', client })
+              .expect(200);
+
+            const newSessionCookies = response.headers['set-cookie'];
+            expect(newSessionCookies).to.have.length(1);
+
+            const refreshedCookie = parseCookie(newSessionCookies[0])!;
+            checkCookieIsSet(refreshedCookie);
+
+            // The second new cookie with fresh pair of access and refresh tokens should work.
+            await supertest
+              .get('/internal/security/me')
+              .ca(CA_CERT)
+              .pfx(FIRST_CLIENT_CERT)
+              .set('kbn-xsrf', 'xxx')
+              .set('Cookie', refreshedCookie.cookieString())
+              .expect(200);
+          });
+
+          it(`expired access token should be automatically refreshed by the ${client} client even for multiple concurrent requests`, async function () {
+            this.timeout(60000);
+
+            // Send 5 concurrent requests with a cookie that contains an expired access token.
+            await Promise.all(
+              Array.from({ length: 5 }).map((value, index) =>
+                supertest
+                  .post(`/authentication/slow/me?a=${index}`)
+                  .ca(CA_CERT)
+                  .pfx(FIRST_CLIENT_CERT)
+                  .set('kbn-xsrf', 'xxx')
+                  .set('Cookie', sessionCookie.cookieString())
+                  .send({ duration: '30s', client })
+                  .expect(200)
+              )
+            );
+          });
+        }
+      });
     });
   });
 }

--- a/x-pack/test/security_api_integration/tests/saml/saml_login.ts
+++ b/x-pack/test/security_api_integration/tests/saml/saml_login.ts
@@ -447,8 +447,6 @@ export default function ({ getService }: FtrProviderContext) {
       let sessionCookie: Cookie;
 
       beforeEach(async function () {
-        this.timeout(40000);
-
         const handshakeResponse = await supertest
           .get(
             '/abc/xyz/handshake?one=two three&auth_provider_hint=saml&auth_url_hash=%23%2Fworkpad'
@@ -465,10 +463,6 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(302);
 
         sessionCookie = parseCookie(samlAuthenticationResponse.headers['set-cookie'][0])!;
-
-        // Access token expiration is set to 15s for API integration tests.
-        // Let's wait for 20s to make sure token expires.
-        await delay(20000);
       });
 
       const expectNewSessionCookie = (cookie: Cookie) => {
@@ -479,7 +473,13 @@ export default function ({ getService }: FtrProviderContext) {
         expect(cookie.value).to.not.be(sessionCookie.value);
       };
 
-      it('expired access token should be automatically refreshed', async () => {
+      it('expired access token should be automatically refreshed', async function () {
+        this.timeout(60000);
+
+        // Access token expiration is set to 15s for API integration tests.
+        // Let's wait for 20s to make sure token expires.
+        await delay(20000);
+
         // This api call should succeed and automatically refresh token. Returned cookie will contain
         // the new access and refresh token pair.
         const firstResponse = await supertest
@@ -525,7 +525,13 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(200);
       });
 
-      it('should refresh access token even if multiple concurrent requests try to refresh it', async () => {
+      it('should refresh access token even if multiple concurrent requests try to refresh it', async function () {
+        this.timeout(60000);
+
+        // Access token expiration is set to 15s for API integration tests.
+        // Let's wait for 20s to make sure token expires.
+        await delay(20000);
+
         // Send 5 concurrent requests with a cookie that contains an expired access token.
         await Promise.all(
           Array.from({ length: 5 }).map((value, index) =>
@@ -536,6 +542,54 @@ export default function ({ getService }: FtrProviderContext) {
               .expect(200)
           )
         );
+      });
+
+      describe('post-authentication stage', () => {
+        for (const client of ['start-contract', 'request-context', 'custom']) {
+          it(`expired access token should be automatically refreshed by the ${client} client`, async function () {
+            this.timeout(60000);
+
+            // Access token expiration is set to 15s for API integration tests.
+            // Let's tell test endpoint to wait 30s after authentication and try to make a request to Elasticsearch
+            // triggering token refresh logic.
+            const response = await supertest
+              .post('/authentication/slow/me')
+              .set('kbn-xsrf', 'xxx')
+              .set('Cookie', sessionCookie.cookieString())
+              .send({ duration: '30s', client })
+              .expect(200);
+
+            const newSessionCookies = response.headers['set-cookie'];
+            expect(newSessionCookies).to.have.length(1);
+
+            const newSessionCookie = parseCookie(newSessionCookies[0])!;
+            expectNewSessionCookie(newSessionCookie);
+            await checkSessionCookie(newSessionCookie);
+
+            // The second new cookie with fresh pair of access and refresh tokens should work.
+            await supertest
+              .get('/internal/security/me')
+              .set('kbn-xsrf', 'xxx')
+              .set('Cookie', newSessionCookie.cookieString())
+              .expect(200);
+          });
+
+          it(`expired access token should be automatically refreshed by the ${client} client even for multiple concurrent requests`, async function () {
+            this.timeout(60000);
+
+            // Send 5 concurrent requests with a cookie that contains an expired access token.
+            await Promise.all(
+              Array.from({ length: 5 }).map((value, index) =>
+                supertest
+                  .post(`/authentication/slow/me?a=${index}`)
+                  .set('kbn-xsrf', 'xxx')
+                  .set('Cookie', sessionCookie.cookieString())
+                  .send({ duration: '30s', client })
+                  .expect(200)
+              )
+            );
+          });
+        }
       });
     });
 

--- a/x-pack/test/security_api_integration/token.config.ts
+++ b/x-pack/test/security_api_integration/token.config.ts
@@ -6,10 +6,16 @@
  */
 
 import { FtrConfigProviderContext } from '@kbn/test';
+import { resolve } from 'path';
 import { services } from './services';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xPackAPITestsConfig = await readConfigFile(require.resolve('../api_integration/config.ts'));
+
+  const testEndpointsPlugin = resolve(
+    __dirname,
+    '../security_functional/fixtures/common/test_endpoints'
+  );
 
   return {
     testFiles: [require.resolve('./tests/token')],
@@ -33,6 +39,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ...xPackAPITestsConfig.get('kbnTestServer'),
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
+        `--plugin-path=${testEndpointsPlugin}`,
         '--xpack.security.authc.providers=["token"]',
       ],
     },

--- a/x-pack/test/security_functional/fixtures/common/test_endpoints/server/index.ts
+++ b/x-pack/test/security_functional/fixtures/common/test_endpoints/server/index.ts
@@ -8,8 +8,8 @@
 import { PluginInitializer, Plugin } from '../../../../../../../src/core/server';
 import { initRoutes } from './init_routes';
 
-export const plugin: PluginInitializer<void, void> = (): Plugin => ({
-  setup: (core) => initRoutes(core),
+export const plugin: PluginInitializer<void, void> = (initializerContext): Plugin => ({
+  setup: (core) => initRoutes(initializerContext, core),
   start: () => {},
   stop: () => {},
 });

--- a/x-pack/test/security_functional/fixtures/common/test_endpoints/server/init_routes.ts
+++ b/x-pack/test/security_functional/fixtures/common/test_endpoints/server/init_routes.ts
@@ -6,9 +6,12 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { CoreSetup } from '../../../../../../../src/core/server';
+import { errors } from '@elastic/elasticsearch';
+import { CoreSetup, PluginInitializerContext } from '../../../../../../../src/core/server';
 
-export function initRoutes(core: CoreSetup) {
+export function initRoutes(initializerContext: PluginInitializerContext, core: CoreSetup) {
+  const logger = initializerContext.logger.get();
+
   const authenticationAppOptions = { simulateUnauthorized: false };
   core.http.resources.register(
     {
@@ -33,6 +36,64 @@ export function initRoutes(core: CoreSetup) {
     (context, request, response) => {
       authenticationAppOptions.simulateUnauthorized = request.body.simulateUnauthorized;
       return response.ok();
+    }
+  );
+
+  router.post(
+    {
+      path: '/authentication/slow/me',
+      validate: {
+        body: schema.object({
+          duration: schema.duration(),
+          client: schema.oneOf([
+            schema.literal('request-context'),
+            schema.literal('start-contract'),
+            schema.literal('custom'),
+          ]),
+        }),
+      },
+      options: { xsrfRequired: false },
+    },
+    async (context, request, response) => {
+      const slowLog = logger.get('slow/me');
+      slowLog.info(`Received request ${JSON.stringify(request.body)}.`);
+
+      let scopedClient;
+      if (request.body.client === 'start-contract') {
+        scopedClient = (await core.getStartServices())[0].elasticsearch.client.asScoped(request);
+      } else if (request.body.client === 'request-context') {
+        scopedClient = context.core.elasticsearch.client;
+      } else {
+        scopedClient = (await core.getStartServices())[0].elasticsearch
+          .createClient('custom')
+          .asScoped(request);
+      }
+
+      await scopedClient.asCurrentUser.security.authenticate();
+      slowLog.info(
+        `Performed initial authentication request, waiting (${request.body.duration.asSeconds()}s)...`
+      );
+
+      // 2. Wait specified amount of time.
+      await new Promise((resolve) => setTimeout(resolve, request.body.duration.asMilliseconds()));
+      slowLog.info(`Waiting is done, performing final authentication request.`);
+
+      // 3. Make authentication request once again and return result.
+      try {
+        const { body } = await scopedClient.asCurrentUser.security.authenticate();
+        slowLog.info(
+          `Successfully performed final authentication request: ${JSON.stringify(body)}`
+        );
+        return response.ok({ body });
+      } catch (err) {
+        slowLog.error(
+          `Failed to perform final authentication request: ${
+            err instanceof errors.ResponseError ? JSON.stringify(err.body) : err.message
+          }`
+        );
+
+        throw err;
+      }
     }
   );
 }


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #122155

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
