### PR TITLE
[8.0] [Index Management] Indices list only load specific index properties from ES (#123629)

### DIFF
--- a/x-pack/plugins/index_management/server/lib/fetch_indices.ts
+++ b/x-pack/plugins/index_management/server/lib/fetch_indices.ts
@@ -18,7 +18,9 @@ async function fetchIndicesCall(
   // This call retrieves alias and settings (incl. hidden status) information about indices
   const { body: indices } = await client.asCurrentUser.indices.get({
     index: indexNamesString,
-    expand_wildcards: 'hidden,all',
+    expand_wildcards: ['hidden', 'all'],
+    // only get specified properties in the response
+    filter_path: ['*.aliases', '*.settings.index.hidden', '*.data_stream'],
   });
 
   if (!Object.keys(indices).length) {
@@ -28,7 +30,7 @@ async function fetchIndicesCall(
   const { body: catHits } = await client.asCurrentUser.cat.indices({
     format: 'json',
     h: 'health,status,index,uuid,pri,rep,docs.count,sth,store.size',
-    expand_wildcards: 'hidden,all',
+    expand_wildcards: ['hidden', 'all'],
     index: indexNamesString,
   });
 
@@ -53,7 +55,7 @@ async function fetchIndicesCall(
         isFrozen: hit.sth === 'true', // sth value coming back as a string from ES
         aliases: aliases.length ? aliases : 'none',
         // @ts-expect-error @elastic/elasticsearch https://github.com/elastic/elasticsearch-specification/issues/532
-        hidden: index.settings.index.hidden === 'true',
+        hidden: index.settings?.index.hidden === 'true',
         data_stream: index.data_stream!,
       });
     }


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #123629

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
