### PR TITLE
[8.0] [Form lib] Fix validation type execution when none is specified (#123363)

### DIFF
--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.ts
@@ -203,7 +203,7 @@ export const useField = <T, FormType = FormData, I = T>(
         formData: any;
         value: I;
         onlyBlocking: boolean;
-        validationTypeToValidate?: string;
+        validationTypeToValidate: string;
       },
       clearFieldErrors: FieldHook['clearErrors']
     ): ValidationError[] | Promise<ValidationError[]> => {
@@ -224,10 +224,7 @@ export const useField = <T, FormType = FormData, I = T>(
         type: validationType,
         isBlocking,
       }: ValidationConfig<FormType, string, I>) => {
-        if (
-          typeof validationTypeToValidate !== 'undefined' &&
-          validationType !== validationTypeToValidate
-        ) {
+        if (validationType !== undefined && validationType !== validationTypeToValidate) {
           return true;
         }
 
@@ -384,7 +381,7 @@ export const useField = <T, FormType = FormData, I = T>(
       const {
         formData = __getFormData$().value,
         value: valueToValidate = value,
-        validationType,
+        validationType = VALIDATION_TYPES.FIELD,
         onlyBlocking = false,
       } = validationData;
 

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.test.tsx
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.test.tsx
@@ -16,6 +16,7 @@ import {
   FormSubmitHandler,
   OnUpdateHandler,
   FormHook,
+  FieldHook,
   ValidationFunc,
   FieldConfig,
   VALIDATION_TYPES,
@@ -37,6 +38,14 @@ const onFormHook = (_form: FormHook<any>) => {
 };
 
 describe('useForm() hook', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   beforeEach(() => {
     formHook = null;
   });
@@ -539,6 +548,8 @@ describe('useForm() hook', () => {
     });
 
     test('should invalidate a field with a blocking arrayItem validation when validating a form', async () => {
+      let fieldHook: FieldHook;
+
       const TestComp = () => {
         const { form } = useForm();
         formHook = form;
@@ -556,7 +567,12 @@ describe('useForm() hook', () => {
                   },
                 ],
               }}
-            />
+            >
+              {(field) => {
+                fieldHook = field;
+                return null;
+              }}
+            </UseField>
           </Form>
         );
       };
@@ -564,6 +580,12 @@ describe('useForm() hook', () => {
       registerTestBed(TestComp)();
 
       let isValid: boolean = false;
+
+      act(() => {
+        // We need to call the field validation to mark this field as invalid.
+        // This will then mark the form as invalid when calling formHook.validate() below
+        fieldHook.validate({ validationType: VALIDATION_TYPES.ARRAY_ITEM });
+      });
 
       await act(async () => {
         isValid = await formHook!.validate();


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Form lib] Fix validation type execution when none is specified (#123363)