### PR TITLE
[Security Solution][Endpoint] Search responses without a specific namespace to show pending actions

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/constants.ts
@@ -11,6 +11,8 @@ export const ENDPOINT_ACTIONS_DS = '.logs-endpoint.actions';
 export const ENDPOINT_ACTIONS_INDEX = `${ENDPOINT_ACTIONS_DS}-default`;
 export const ENDPOINT_ACTION_RESPONSES_DS = '.logs-endpoint.action.responses';
 export const ENDPOINT_ACTION_RESPONSES_INDEX = `${ENDPOINT_ACTION_RESPONSES_DS}-default`;
+// search in all namespaces and not only in default
+export const ENDPOINT_ACTION_RESPONSES_INDEX_PATTERN = `${ENDPOINT_ACTION_RESPONSES_DS}-*`;
 
 export const eventsIndexPattern = 'logs-endpoint.events.*';
 export const alertsIndexPattern = 'logs-endpoint.alerts-*';

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions.ts
@@ -9,7 +9,7 @@ import { ElasticsearchClient, Logger } from 'kibana/server';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { TransportResult } from '@elastic/elasticsearch';
 import { AGENT_ACTIONS_INDEX, AGENT_ACTIONS_RESULTS_INDEX } from '../../../../fleet/common';
-import { ENDPOINT_ACTION_RESPONSES_INDEX } from '../../../common/endpoint/constants';
+import { ENDPOINT_ACTION_RESPONSES_INDEX_PATTERN } from '../../../common/endpoint/constants';
 import { SecuritySolutionRequestHandlerContext } from '../../types';
 import {
   ActivityLog,
@@ -293,7 +293,7 @@ const hasEndpointResponseDoc = async ({
   const response = await esClient
     .search<LogsEndpointActionResponse>(
       {
-        index: ENDPOINT_ACTION_RESPONSES_INDEX,
+        index: ENDPOINT_ACTION_RESPONSES_INDEX_PATTERN,
         size: 10000,
         body: {
           query: {

--- a/x-pack/plugins/security_solution/server/endpoint/utils/audit_log_helpers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/utils/audit_log_helpers.ts
@@ -12,7 +12,7 @@ import { TransportResult } from '@elastic/elasticsearch';
 import { AGENT_ACTIONS_INDEX, AGENT_ACTIONS_RESULTS_INDEX } from '../../../../fleet/common';
 import {
   ENDPOINT_ACTIONS_INDEX,
-  ENDPOINT_ACTION_RESPONSES_INDEX,
+  ENDPOINT_ACTION_RESPONSES_INDEX_PATTERN,
   failedFleetActionErrorCode,
 } from '../../../common/endpoint/constants';
 import { SecuritySolutionRequestHandlerContext } from '../../types';
@@ -32,7 +32,8 @@ import {
 import { doesLogsEndpointActionsIndexExist } from '../utils';
 
 const actionsIndices = [AGENT_ACTIONS_INDEX, ENDPOINT_ACTIONS_INDEX];
-const responseIndices = [AGENT_ACTIONS_RESULTS_INDEX, ENDPOINT_ACTION_RESPONSES_INDEX];
+// search all responses indices irrelevant of namespace
+const responseIndices = [AGENT_ACTIONS_RESULTS_INDEX, ENDPOINT_ACTION_RESPONSES_INDEX_PATTERN];
 export const logsEndpointActionsRegex = new RegExp(`(^\.ds-\.logs-endpoint\.actions-default-).+`);
 export const logsEndpointResponsesRegex = new RegExp(
   `(^\.ds-\.logs-endpoint\.action\.responses-default-).+`
@@ -231,7 +232,7 @@ export const getActionResponsesResult = async ({
   const hasLogsEndpointActionResponsesIndex = await doesLogsEndpointActionsIndexExist({
     context,
     logger,
-    indexName: ENDPOINT_ACTION_RESPONSES_INDEX,
+    indexName: ENDPOINT_ACTION_RESPONSES_INDEX_PATTERN,
   });
 
   const responsesSearchQuery: SearchRequest = {

--- a/x-pack/plugins/security_solution/server/endpoint/utils/audit_log_helpers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/utils/audit_log_helpers.ts
@@ -35,8 +35,9 @@ const actionsIndices = [AGENT_ACTIONS_INDEX, ENDPOINT_ACTIONS_INDEX];
 // search all responses indices irrelevant of namespace
 const responseIndices = [AGENT_ACTIONS_RESULTS_INDEX, ENDPOINT_ACTION_RESPONSES_INDEX_PATTERN];
 export const logsEndpointActionsRegex = new RegExp(`(^\.ds-\.logs-endpoint\.actions-default-).+`);
+// matches index names like .ds-.logs-endpoint.action.responses-name_space---suffix-2022.01.25-000001
 export const logsEndpointResponsesRegex = new RegExp(
-  `(^\.ds-\.logs-endpoint\.action\.responses-default-).+`
+  `(^\.ds-\.logs-endpoint\.action\.responses-\\w+-).+`
 );
 const queryOptions = {
   headers: {


### PR DESCRIPTION
## Summary

Searches response docs in the endpoint response index pattern to determine pending action response counts.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
