### PR TITLE
Security compatibility fixes when running Kibana 7.last against ES 8.x

### DIFF
--- a/x-pack/plugins/security/server/routes/api_keys/invalidate.test.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/invalidate.test.ts
@@ -129,7 +129,7 @@ describe('Invalidate API keys', () => {
         isAdmin: true,
       },
       asserts: {
-        apiArguments: [{ body: { id: 'si8If24B1bKsmSLTAhJV' } }],
+        apiArguments: [{ body: { ids: 'si8If24B1bKsmSLTAhJV' } }],
         statusCode: 200,
         result: {
           itemsInvalidated: [],
@@ -153,7 +153,7 @@ describe('Invalidate API keys', () => {
         isAdmin: true,
       },
       asserts: {
-        apiArguments: [{ body: { id: 'si8If24B1bKsmSLTAhJV' } }],
+        apiArguments: [{ body: { ids: 'si8If24B1bKsmSLTAhJV' } }],
         statusCode: 200,
         result: {
           itemsInvalidated: [{ id: 'si8If24B1bKsmSLTAhJV', name: 'my-api-key' }],
@@ -169,7 +169,7 @@ describe('Invalidate API keys', () => {
         isAdmin: false,
       },
       asserts: {
-        apiArguments: [{ body: { id: 'si8If24B1bKsmSLTAhJV', owner: true } }],
+        apiArguments: [{ body: { ids: 'si8If24B1bKsmSLTAhJV', owner: true } }],
         statusCode: 200,
         result: {
           itemsInvalidated: [{ id: 'si8If24B1bKsmSLTAhJV', name: 'my-api-key' }],
@@ -194,8 +194,8 @@ describe('Invalidate API keys', () => {
       },
       asserts: {
         apiArguments: [
-          { body: { id: 'si8If24B1bKsmSLTAhJV' } },
-          { body: { id: 'ab8If24B1bKsmSLTAhNC' } },
+          { body: { ids: 'si8If24B1bKsmSLTAhJV' } },
+          { body: { ids: 'ab8If24B1bKsmSLTAhNC' } },
         ],
         statusCode: 200,
         result: {

--- a/x-pack/plugins/security/server/routes/api_keys/invalidate.test.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/invalidate.test.ts
@@ -129,7 +129,7 @@ describe('Invalidate API keys', () => {
         isAdmin: true,
       },
       asserts: {
-        apiArguments: [{ body: { ids: 'si8If24B1bKsmSLTAhJV' } }],
+        apiArguments: [{ body: { ids: ['si8If24B1bKsmSLTAhJV'] } }],
         statusCode: 200,
         result: {
           itemsInvalidated: [],
@@ -153,7 +153,7 @@ describe('Invalidate API keys', () => {
         isAdmin: true,
       },
       asserts: {
-        apiArguments: [{ body: { ids: 'si8If24B1bKsmSLTAhJV' } }],
+        apiArguments: [{ body: { ids: ['si8If24B1bKsmSLTAhJV'] } }],
         statusCode: 200,
         result: {
           itemsInvalidated: [{ id: 'si8If24B1bKsmSLTAhJV', name: 'my-api-key' }],
@@ -169,7 +169,7 @@ describe('Invalidate API keys', () => {
         isAdmin: false,
       },
       asserts: {
-        apiArguments: [{ body: { ids: 'si8If24B1bKsmSLTAhJV', owner: true } }],
+        apiArguments: [{ body: { ids: ['si8If24B1bKsmSLTAhJV'], owner: true } }],
         statusCode: 200,
         result: {
           itemsInvalidated: [{ id: 'si8If24B1bKsmSLTAhJV', name: 'my-api-key' }],
@@ -194,8 +194,8 @@ describe('Invalidate API keys', () => {
       },
       asserts: {
         apiArguments: [
-          { body: { ids: 'si8If24B1bKsmSLTAhJV' } },
-          { body: { ids: 'ab8If24B1bKsmSLTAhNC' } },
+          { body: { ids: ['si8If24B1bKsmSLTAhJV'] } },
+          { body: { ids: ['ab8If24B1bKsmSLTAhNC'] } },
         ],
         statusCode: 200,
         result: {

--- a/x-pack/plugins/security/server/routes/api_keys/invalidate.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/invalidate.ts
@@ -35,7 +35,7 @@ export function defineInvalidateApiKeysRoutes({ router }: RouteDefinitionParams)
           await Promise.all(
             request.body.apiKeys.map(async (key) => {
               try {
-                const body: { id: string; owner?: boolean } = { ids: key.id };
+                const body: { ids: string[]; owner?: boolean } = { ids: [key.id] };
                 if (!request.body.isAdmin) {
                   body.owner = true;
                 }

--- a/x-pack/plugins/security/server/routes/api_keys/invalidate.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/invalidate.ts
@@ -35,7 +35,7 @@ export function defineInvalidateApiKeysRoutes({ router }: RouteDefinitionParams)
           await Promise.all(
             request.body.apiKeys.map(async (key) => {
               try {
-                const body: { id: string; owner?: boolean } = { id: key.id };
+                const body: { id: string; owner?: boolean } = { ids: key.id };
                 if (!request.body.isAdmin) {
                   body.owner = true;
                 }

--- a/x-pack/test/functional/apps/api_keys/home_page.ts
+++ b/x-pack/test/functional/apps/api_keys/home_page.ts
@@ -17,8 +17,6 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const browser = getService('browser');
 
   describe('Home page', function () {
-    this.onlyEsVersion('<=7');
-
     before(async () => {
       await security.testUser.setRoles(['kibana_admin']);
       await pageObjects.common.navigateToApp('apiKeys');

--- a/x-pack/test/functional/apps/security/users.ts
+++ b/x-pack/test/functional/apps/security/users.ts
@@ -24,8 +24,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   }
 
   describe('users', function () {
-    this.onlyEsVersion('<=7');
-
     const optionalUser: UserFormValues = {
       username: 'OptionalUser',
       password: 'OptionalUserPwd',
@@ -120,9 +118,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       expect(roles.kibana_user.reserved).to.be(true);
       expect(roles.kibana_user.deprecated).to.be(true);
-
-      expect(roles.kibana_dashboard_only_user.reserved).to.be(true);
-      expect(roles.kibana_dashboard_only_user.deprecated).to.be(true);
 
       expect(roles.kibana_system.reserved).to.be(true);
       expect(roles.kibana_system.deprecated).to.be(false);


### PR DESCRIPTION
## Summary

Updates the following to maintain compatibility with 8.x:

- Updates user tests to no longer assert on the removed `kibana_dashboard_only_user` role. While this is still a valid assertion when running against 7.x, I opted to remove it altogether, as it is of minimal value.
- Updates the API Key invalidate route to use the `ids` property instead of the removed `id` property. `ids` exists in both `7.17` and `8.x`, so it is safe to use this in both circumstances.

Resolves https://github.com/elastic/kibana/issues/123129