### PR TITLE
[Security Solution] Clear any focus from the underlying part of the page when opening timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { rgba } from 'polished';
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import styled from 'styled-components';
 import uuid from 'uuid';
 import { IS_DRAGGING_CLASS_NAME } from '@kbn/securitysolution-t-grid';
@@ -93,6 +93,15 @@ export const DataProviders = React.memo<Props>(({ timelineId }) => {
     (state) => (getTimeline(state, timelineId) ?? timelineDefaults).dataProviders
   );
   const droppableId = useMemo(() => getDroppableId(timelineId), [timelineId]);
+  useEffect(() => {
+    const element = document.activeElement as HTMLInputElement;
+    if (element !== null) {
+      element.blur();
+    }
+    return () => {
+      element.blur();
+    };
+  }, []);
 
   return (
     <DropTargetDataProvidersContainer


### PR DESCRIPTION
## Summary

Currently, when a user selects an action button or any focusable element that has a tooltip and opens the timeline, that focus is maintained and a tooltip pointing to a no longer visible element is visible, this fixes that issue by clearing the focus of any element when the timeline is opened, and removed from any elements in the timeline on close.

Before:
![image](https://user-images.githubusercontent.com/56408403/151025822-89ca17ea-3413-4de6-bb6d-b754047b0020.png)

After:

![clear_focus_open_timeline](https://user-images.githubusercontent.com/56408403/151026106-696878ef-62a0-4876-ab6a-457cefa5936a.gif)



