### PR TITLE
Remove support for console.ssl setting.

### DIFF
--- a/src/plugins/console/server/config.ts
+++ b/src/plugins/console/server/config.ts
@@ -21,7 +21,6 @@ const kibanaVersion = new SemVer(MAJOR_VERSION);
 // -------------------------------
 const schemaLatest = schema.object(
   {
-    ssl: schema.object({ verify: schema.boolean({ defaultValue: false }) }, {}),
     ui: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
     }),


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/123728

To test, add `console.ssl.verify: true` to `kibana.yml`. The server will fail to start with this error:

```
 FATAL  Error: [config validation of [console].ssl]: definition for this key is missing
 server crashed  with status code 1
```

## Release note
The `console.ssl` setting has been removed.