### PR TITLE
[8.0] Azure, GCS, and AWS snapshot repos no longer require plugins (#123387)

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -491,7 +491,7 @@ export class DocLinksService {
           gcsRepo: `${ELASTICSEARCH_DOCS}repository-gcs.html`,
           hdfsRepo: `${PLUGIN_DOCS}repository-hdfs.html`,
           s3Repo: `${ELASTICSEARCH_DOCS}repository-s3.html`,
-          snapshotRestoreRepos: `${PLUGIN_DOCS}repository.html`,
+          snapshotRestoreRepos: `${ELASTICSEARCH_DOCS}snapshots-register-repository.html`,
           mapperSize: `${PLUGIN_DOCS}mapper-size-usage.html`,
         },
         snapshotRestore: {

--- a/x-pack/plugins/snapshot_restore/README.md
+++ b/x-pack/plugins/snapshot_restore/README.md
@@ -67,12 +67,11 @@ PUT _snapshot/my_src_only_repository
 
 ### Plugin-based repositories:
 
-There are four official repository plugins available: S3, GCS, HDFS, Azure. Available plugin repository settings can be found in the docs: https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository.html.
+There is one official repository plugin available: HDFS. You can find the repository settings in the docs: https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-hdfs-config.html.
 
 To run ES with plugins:
 
 1. Run `yarn es snapshot` from the Kibana directory like normal, then exit out of process.
 2. `cd .es/8.0.0`
-3. `bin/elasticsearch-plugin install https://snapshots.elastic.co/downloads/elasticsearch-plugins/repository-s3/repository-s3-8.0.0-SNAPSHOT.zip`
-4. Repeat step 3 for additional plugins, replacing occurrences of `repository-s3` with the plugin you want to install.
-5. Run `bin/elasticsearch` from the `.es/8.0.0` directory. Otherwise, starting ES with `yarn es snapshot` would overwrite the plugins you just installed.
+3. `bin/elasticsearch-plugin install https://snapshots.elastic.co/downloads/elasticsearch-plugins/repository-hdfs/repository-hdfs-8.0.0-SNAPSHOT.zip`
+4. Run `bin/elasticsearch` from the `.es/8.0.0` directory. Otherwise, starting ES with `yarn es snapshot` would overwrite the plugins you just installed.

--- a/x-pack/plugins/snapshot_restore/common/constants.ts
+++ b/x-pack/plugins/snapshot_restore/common/constants.ts
@@ -36,22 +36,17 @@ export enum REPOSITORY_TYPES {
 
 // Deliberately do not include `source` as a default repository since we treat it as a flag
 export const DEFAULT_REPOSITORY_TYPES: RepositoryType[] = [
+  REPOSITORY_TYPES.azure,
+  REPOSITORY_TYPES.gcs,
+  REPOSITORY_TYPES.s3,
   REPOSITORY_TYPES.fs,
   REPOSITORY_TYPES.url,
 ];
 
-export const PLUGIN_REPOSITORY_TYPES: RepositoryType[] = [
-  REPOSITORY_TYPES.s3,
-  REPOSITORY_TYPES.hdfs,
-  REPOSITORY_TYPES.azure,
-  REPOSITORY_TYPES.gcs,
-];
+export const PLUGIN_REPOSITORY_TYPES: RepositoryType[] = [REPOSITORY_TYPES.hdfs];
 
 export const REPOSITORY_PLUGINS_MAP: { [key: string]: RepositoryType } = {
-  'repository-s3': REPOSITORY_TYPES.s3,
   'repository-hdfs': REPOSITORY_TYPES.hdfs,
-  'repository-azure': REPOSITORY_TYPES.azure,
-  'repository-gcs': REPOSITORY_TYPES.gcs,
 };
 
 export const APP_REQUIRED_CLUSTER_PRIVILEGES = [

--- a/x-pack/plugins/snapshot_restore/public/application/components/repository_form/step_one.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/components/repository_form/step_one.tsx
@@ -74,11 +74,11 @@ export const RepositoryFormStepOne: React.FunctionComponent<Props> = ({
     }
   };
 
-  const pluginDocLink = (
+  const snapshotRepoDocLink = (
     <EuiLink href={docLinks.links.plugins.snapshotRestoreRepos} target="_blank">
       <FormattedMessage
         id="xpack.snapshotRestore.repositoryForm.fields.typePluginsDocLinkText"
-        defaultMessage="Learn more about plugins."
+        defaultMessage="Learn more about repository types."
       />
     </EuiLink>
   );
@@ -206,7 +206,7 @@ export const RepositoryFormStepOne: React.FunctionComponent<Props> = ({
             id="xpack.snapshotRestore.repositoryForm.noRepositoryTypesErrorMessage"
             defaultMessage="You can install plugins to enable different repository types. {docLink}"
             values={{
-              docLink: pluginDocLink,
+              docLink: snapshotRepoDocLink,
             }}
           />
         </EuiCallOut>
@@ -233,25 +233,13 @@ export const RepositoryFormStepOne: React.FunctionComponent<Props> = ({
         </EuiTitle>
         <EuiSpacer size="s" />
         <EuiText id="repositoryTypeDescription" size="s" color="subdued">
-          {repositoryTypes.includes(REPOSITORY_TYPES.fs) &&
-          repositoryTypes.includes(REPOSITORY_TYPES.url) ? (
-            <FormattedMessage
-              id="xpack.snapshotRestore.repositoryForm.fields.defaultTypeDescription"
-              defaultMessage="Elasticsearch supports file system and read-only URL repositories.
-                Additional types require plugins. {docLink}"
-              values={{
-                docLink: pluginDocLink,
-              }}
-            />
-          ) : (
-            <FormattedMessage
-              id="xpack.snapshotRestore.repositoryForm.fields.cloudTypeDescription"
-              defaultMessage="Elasticsearch provides core plugins for custom repositories. {docLink}"
-              values={{
-                docLink: pluginDocLink,
-              }}
-            />
-          )}
+          <FormattedMessage
+            id="xpack.snapshotRestore.repositoryForm.fields.defaultTypeDescription"
+            defaultMessage="Storage location for your snapshots. {docLink}"
+            values={{
+              docLink: snapshotRepoDocLink,
+            }}
+          />
         </EuiText>
         <EuiFormRow
           hasEmptyLabelSpace

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -25430,7 +25430,6 @@
     "xpack.snapshotRestore.repositoryForm.commonFields.maxSnapshotBytesTitle": "1 秒間の最高スナップショットバイト数",
     "xpack.snapshotRestore.repositoryForm.errorUnknownRepositoryTypesMessage": "レポジトリタイプ「{type}」はサポートされていません。",
     "xpack.snapshotRestore.repositoryForm.errorUnknownRepositoryTypesTitle": "不明なレポジトリタイプ",
-    "xpack.snapshotRestore.repositoryForm.fields.cloudTypeDescription": "Elasticsearch はカスタムレポジトリ用のコアプラグインを提供します。{docLink}",
     "xpack.snapshotRestore.repositoryForm.fields.defaultTypeDescription": "Elasticsearch はファイルシステムと読み取り専用の URL レポジトリをサポートします。他のタイプにはプラグインが必要です。{docLink}",
     "xpack.snapshotRestore.repositoryForm.fields.nameDescription": "レポジトリの固有の名前です。",
     "xpack.snapshotRestore.repositoryForm.fields.nameDescriptionTitle": "レポジトリ名",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -25860,7 +25860,6 @@
     "xpack.snapshotRestore.repositoryForm.commonFields.maxSnapshotBytesTitle": "每秒最大快照字节数",
     "xpack.snapshotRestore.repositoryForm.errorUnknownRepositoryTypesMessage": "存储库类型“{type}”不受支持。",
     "xpack.snapshotRestore.repositoryForm.errorUnknownRepositoryTypesTitle": "未知的存储库类型",
-    "xpack.snapshotRestore.repositoryForm.fields.cloudTypeDescription": "Elasticsearch 为定制存储库提供核心插件。{docLink}",
     "xpack.snapshotRestore.repositoryForm.fields.defaultTypeDescription": "Elasticsearch 支持文件系统和只读 URL 存储库。其他类型需要插件。{docLink}",
     "xpack.snapshotRestore.repositoryForm.fields.nameDescription": "存储库的唯一名称。",
     "xpack.snapshotRestore.repositoryForm.fields.nameDescriptionTitle": "存储库名称",


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #123387

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
