### PR TITLE
[Security Solutions] Fixes the "batch based telemetry" to use the new rule types

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/receiver.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/receiver.ts
@@ -13,6 +13,15 @@ import {
 } from 'src/core/server';
 import { SearchRequest } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ENDPOINT_TRUSTED_APPS_LIST_ID } from '@kbn/securitysolution-list-constants';
+import {
+  EQL_RULE_TYPE_ID,
+  INDICATOR_RULE_TYPE_ID,
+  ML_RULE_TYPE_ID,
+  QUERY_RULE_TYPE_ID,
+  SAVED_QUERY_RULE_TYPE_ID,
+  SIGNALS_ID,
+  THRESHOLD_RULE_TYPE_ID,
+} from '@kbn/securitysolution-rules';
 import { AgentClient, AgentPolicyServiceInterface } from '../../../../fleet/server';
 import { ExceptionListClient } from '../../../../lists/server';
 import { EndpointAppContextService } from '../../endpoint/endpoint_app_context_services';
@@ -265,6 +274,10 @@ export class TelemetryReceiver {
     };
   }
 
+  /**
+   * Gets the elastic rules which are the rules that have immutable set to true and are of a particular rule type
+   * @returns The elastic rules
+   */
   public async fetchDetectionRules() {
     if (this.esClient === undefined || this.esClient === null) {
       throw Error('elasticsearch client is unavailable: cannot retrieve diagnostic alerts');
@@ -278,15 +291,38 @@ export class TelemetryReceiver {
       body: {
         query: {
           bool: {
-            filter: [
-              { term: { 'alert.alertTypeId': 'siem.signals' } },
-              { term: { 'alert.params.immutable': true } },
+            must: [
+              {
+                bool: {
+                  filter: {
+                    terms: {
+                      'alert.alertTypeId': [
+                        SIGNALS_ID,
+                        EQL_RULE_TYPE_ID,
+                        ML_RULE_TYPE_ID,
+                        QUERY_RULE_TYPE_ID,
+                        SAVED_QUERY_RULE_TYPE_ID,
+                        INDICATOR_RULE_TYPE_ID,
+                        THRESHOLD_RULE_TYPE_ID,
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                bool: {
+                  filter: {
+                    terms: {
+                      'alert.params.immutable': [true],
+                    },
+                  },
+                },
+              },
             ],
           },
         },
       },
     };
-
     return this.esClient.search<RuleSearchResult>(query);
   }
 


### PR DESCRIPTION
## Summary

Telemetry was not updated to use the newer rule types so it was not querying the elastic package rules.

The query before was:

```json
# Original query which will not get the new elastic pre-packaged rule types 
GET .kibana*/_search
{
  "query": {
    "bool": {
      "filter": [
        {
          "term": {
            "alert.alertTypeId": "siem.signals"
          }
        },
        {
          "term": {
            "alert.params.immutable": true
          }
        }
      ]
    }
  }
}
```

The query after this change uses the new rule types and I tested it by manually executing this query to ensure everything works as expected:

```json
# Modified query which filters against two arrays of terms. One for the set of rules
# and the second terms which filters against the rule being immutable
GET .kibana*/_search
{
  "query": {
    "bool": {
      "must": [
        {
          "bool": {
            "filter": {
              "terms": {
                "alert.alertTypeId": [
                  "siem.signals",
                  "siem.eqlRule",
                  "siem.mlRule",
                  "siem.queryRule",
                  "siem.savedQueryRule",
                  "siem.indicatorRule",
                  "siem.thresholdRule"
                ]
              }
            }
          }
        },
        {
          "bool": {
            "filter": {
              "terms": {
                "alert.params.immutable": [true]
              }
            }
          }
        }
      ]
    }
  }
}
```

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

There doesn't look to be integration tests started for these or how to test them at this moment.