### PR TITLE
[Security Solution] [Endpoint] Adds error message when there are duplicated entries in Trusted Apps form

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.test.tsx
@@ -432,6 +432,18 @@ describe('When using the Trusted App Form', () => {
       expect(renderResult.getByText('[2] Field entry must have a value'));
     });
 
+    it('should validate duplicated conditions', () => {
+      const andButton = getConditionBuilderAndButton();
+      reactTestingLibrary.act(() => {
+        fireEvent.click(andButton, { button: 1 });
+      });
+
+      setTextFieldValue(getConditionValue(getCondition()), '');
+      rerenderWithLatestTrustedApp();
+
+      expect(renderResult.getByText('Hash cannot be added more than once'));
+    });
+
     it('should validate multiple errors in form', () => {
       const andButton = getConditionBuilderAndButton();
 

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.tsx
@@ -20,6 +20,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { EuiFormProps } from '@elastic/eui/src/components/form/form';
 import {
+  ConditionEntry,
   ConditionEntryField,
   EffectScope,
   MacosLinuxConditionEntry,
@@ -31,6 +32,7 @@ import {
   isValidHash,
   isPathValid,
   hasSimpleExecutableName,
+  getDuplicateFields,
 } from '../../../../../../common/endpoint/service/trusted_apps/validations';
 
 import {
@@ -40,7 +42,7 @@ import {
   isWindowsTrustedAppCondition,
 } from '../../state/type_guards';
 import { defaultConditionEntry } from '../../store/builders';
-import { OS_TITLES } from '../translations';
+import { CONDITION_FIELD_TITLE, OS_TITLES } from '../translations';
 import { LogicalConditionBuilder, LogicalConditionBuilderProps } from './logical_condition';
 import { useTestIdGenerator } from '../../../../components/hooks/use_test_id_generator';
 import { useLicense } from '../../../../../common/hooks/use_license';
@@ -135,6 +137,21 @@ const validateFormValues = (values: MaybeImmutable<NewTrustedApp>): ValidationRe
       })
     );
   } else {
+    const duplicated = getDuplicateFields(values.entries as ConditionEntry[]);
+    if (duplicated.length) {
+      isValid = false;
+      duplicated.forEach((field) => {
+        addResultToValidation(
+          validation,
+          'entries',
+          'errors',
+          i18n.translate('xpack.securitySolution.trustedapps.create.conditionFieldDuplicatedMsg', {
+            defaultMessage: '{field} cannot be added more than once',
+            values: { field: CONDITION_FIELD_TITLE[field] },
+          })
+        );
+      });
+    }
     values.entries.forEach((entry, index) => {
       const isValidPathEntry = isPathValid({
         os: values.os,


### PR DESCRIPTION
## Summary

![TA FE duplicated validation](https://user-images.githubusercontent.com/15727784/151158821-64897dff-5eb1-4363-b4e1-216d908cfa9a.gif)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
