### PR TITLE
[Lens] Duplicated datatable available as inspector data for Heatmap chart

### DIFF
--- a/src/plugins/chart_expressions/expression_heatmap/common/expression_functions/heatmap_function.ts
+++ b/src/plugins/chart_expressions/expression_heatmap/common/expression_functions/heatmap_function.ts
@@ -143,7 +143,8 @@ export const heatmapFunction = (): HeatmapExpressionFunctionDefinition => ({
     },
   },
   fn(data, args, handlers) {
-    if (handlers?.inspectorAdapters?.tables) {
+    // as in lens we've already calling logDatatable for heatmap we shouldn't do it here
+    if (handlers?.inspectorAdapters?.tables && handlers?.getExecutionContext?.()?.type !== 'lens') {
       const argsTable: Dimension[] = [];
       if (args.valueAccessor) {
         prepareHeatmapLogTable(

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -630,6 +630,12 @@ export const VisualizationWrapper = ({
         onData$={onData$}
         inspectorAdapters={lensInspector.adapters}
         renderMode="edit"
+        executionContext={{
+          type: 'lens',
+          name: '',
+          id: '',
+          description: '',
+        }}
         renderError={(errorMessage?: string | null, error?: ExpressionRenderError | null) => {
           const errorsFromRequest = getOriginalRequestErrorMessages(error);
           const visibleErrorMessages = errorsFromRequest.length


### PR DESCRIPTION
Closes:  #123176

## Summary

We shouldn't execute `logDatatable` in heatmap_function if we open heatmap in lens because here we alredy had the function which execute `logDatatable`.
