### PR TITLE
Adding author in some packages so "owner" attribute is filled in for ci stats

### DIFF
--- a/packages/kbn-interpreter/package.json
+++ b/packages/kbn-interpreter/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@kbn/interpreter",
+  "author": "App Services",
   "main": "./target_node/index.js",
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",

--- a/packages/kbn-storybook/package.json
+++ b/packages/kbn-storybook/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@kbn/storybook",
+  "author": "Operations",
   "version": "1.0.0",
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",

--- a/packages/kbn-test/package.json
+++ b/packages/kbn-test/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@kbn/test",
+  "author": "Operations",
   "version": "1.0.0",
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",


### PR DESCRIPTION
kbn/interpreter -> App Services
kbn/test -> Ops
kbn/storybook -> Ops

Noticed they were missing when `Any` stats went up for total count but the team-level stats didn't show the increase because "missing owner" plugins are filtered out.