### PR TITLE
[scripted fields] reenable functional tests for kibana 7.17 => ES 8.0 CI pipelines

### DIFF
--- a/test/functional/apps/management/_scripted_fields.js
+++ b/test/functional/apps/management/_scripted_fields.js
@@ -383,7 +383,7 @@ export default function ({ getService, getPageObjects }) {
           'date',
           { format: 'date', datePattern: 'YYYY-MM-DD HH:00' },
           '1',
-          "doc['utc_time'].value.getMillis() + (1000) * 60 * 60"
+          "doc['utc_time'].value.toInstant().toEpochMilli() + (1000) * 60 * 60"
         );
         await retry.try(async function () {
           expect(parseInt(await PageObjects.settings.getScriptedFieldsTabCount())).to.be(

--- a/test/functional/apps/management/_scripted_fields.js
+++ b/test/functional/apps/management/_scripted_fields.js
@@ -42,7 +42,6 @@ export default function ({ getService, getPageObjects }) {
 
   describe('scripted fields', function () {
     this.tags(['skipFirefox']);
-    this.onlyEsVersion('<=7');
 
     before(async function () {
       await browser.setWindowSize(1200, 800);


### PR DESCRIPTION
## Summary

A scripted field was relying on functionality deprecated since mid 6.x and removed in 8.0. Updating the painless code allows testing scripted fields on ES 8.0 from Kibana 7.17

Successful build against ES 8.0 - https://buildkite.com/elastic/kibana-7-dot-latest-es-8-dot-0-forward-compatibility/builds/33