### PR TITLE
[Security Solution][Endpoint][Policy] Remove GET policy list api route

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/schema/policy.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/policy.ts
@@ -19,21 +19,3 @@ export const GetAgentPolicySummaryRequestSchema = {
     policy_id: schema.nullable(schema.string()),
   }),
 };
-
-const ListWithKuerySchema = schema.object({
-  page: schema.maybe(schema.number({ defaultValue: 1 })),
-  pageSize: schema.maybe(schema.number({ defaultValue: 20 })),
-  sort: schema.maybe(schema.string()),
-  sortOrder: schema.maybe(schema.oneOf([schema.literal('desc'), schema.literal('asc')])),
-  showUpgradeable: schema.maybe(schema.boolean()),
-  kuery: schema.maybe(
-    schema.oneOf([
-      schema.string(),
-      schema.any(), // KueryNode
-    ])
-  ),
-});
-
-export const GetEndpointPackagePolicyRequestSchema = {
-  query: ListWithKuerySchema,
-};

--- a/x-pack/plugins/security_solution/server/endpoint/routes/policy/handlers.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/policy/handlers.test.ts
@@ -12,12 +12,7 @@ import {
   createRouteHandlerContext,
 } from '../../mocks';
 import { createMockAgentClient, createMockAgentService } from '../../../../../fleet/server/mocks';
-import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../../../../fleet/common';
-import {
-  getHostPolicyResponseHandler,
-  getAgentPolicySummaryHandler,
-  getPolicyListHandler,
-} from './handlers';
+import { getHostPolicyResponseHandler, getAgentPolicySummaryHandler } from './handlers';
 import {
   KibanaResponseFactory,
   SavedObjectsClientContract,
@@ -38,7 +33,6 @@ import { AgentClient, AgentService } from '../../../../../fleet/server/services'
 import { get } from 'lodash';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { ScopedClusterClientMock } from '../../../../../../../src/core/server/elasticsearch/client/mocks';
-import { PackagePolicyServiceInterface } from '../../../../../fleet/server';
 
 describe('test policy response handler', () => {
   let endpointAppContextService: EndpointAppContextService;
@@ -239,88 +233,6 @@ describe('test policy response handler', () => {
           package: 'endpoint',
           versions_count: { '8.0.0': 2, '8.1.0': 1 },
         },
-      });
-    });
-  });
-  describe('test GET policy list handler', () => {
-    let mockPackagePolicyService: jest.Mocked<PackagePolicyServiceInterface>;
-    let policyHandler: ReturnType<typeof getPolicyListHandler>;
-
-    beforeEach(() => {
-      const endpointAppContextServiceStartContract =
-        createMockEndpointAppContextServiceStartContract();
-
-      mockScopedClient = elasticsearchServiceMock.createScopedClusterClient();
-      mockSavedObjectClient = savedObjectsClientMock.create();
-      mockResponse = httpServerMock.createResponseFactory();
-
-      if (endpointAppContextServiceStartContract.packagePolicyService) {
-        mockPackagePolicyService =
-          endpointAppContextServiceStartContract.packagePolicyService as jest.Mocked<PackagePolicyServiceInterface>;
-      } else {
-        expect(endpointAppContextServiceStartContract.packagePolicyService).toBeTruthy();
-      }
-
-      mockPackagePolicyService.list.mockImplementation(() => {
-        return Promise.resolve({
-          items: [],
-          total: 0,
-          page: 1,
-          perPage: 10,
-        });
-      });
-      endpointAppContextService = new EndpointAppContextService();
-      endpointAppContextService.setup(createMockEndpointAppContextServiceSetupContract());
-      endpointAppContextService.start(endpointAppContextServiceStartContract);
-      policyHandler = getPolicyListHandler({
-        logFactory: loggingSystemMock.create(),
-        service: endpointAppContextService,
-        config: () => Promise.resolve(createMockConfig()),
-        experimentalFeatures: parseExperimentalConfigValue(createMockConfig().enableExperimental),
-      });
-    });
-
-    afterEach(() => endpointAppContextService.stop());
-
-    it('should return a list of endpoint package policies', async () => {
-      const mockRequest = httpServerMock.createKibanaRequest({
-        query: {},
-      });
-
-      await policyHandler(
-        createRouteHandlerContext(mockScopedClient, mockSavedObjectClient),
-        mockRequest,
-        mockResponse
-      );
-      expect(mockPackagePolicyService.list).toHaveBeenCalled();
-      expect(mockPackagePolicyService.list.mock.calls[0][1]).toEqual({
-        kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`,
-        perPage: undefined,
-        sortField: undefined,
-      });
-      expect(mockResponse.ok).toBeCalled();
-      expect(mockResponse.ok.mock.calls[0][0]?.body).toEqual({
-        items: [],
-        total: 0,
-        page: 1,
-        perPage: 10,
-      });
-    });
-
-    it('should add endpoint-specific kuery to the requests kuery', async () => {
-      const mockRequest = httpServerMock.createKibanaRequest({
-        query: { kuery: 'some query' },
-      });
-
-      await policyHandler(
-        createRouteHandlerContext(mockScopedClient, mockSavedObjectClient),
-        mockRequest,
-        mockResponse
-      );
-      expect(mockPackagePolicyService.list.mock.calls[0][1]).toEqual({
-        kuery: `(some query) and ${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`,
-        perPage: undefined,
-        sortField: undefined,
       });
     });
   });

--- a/x-pack/plugins/security_solution/server/endpoint/routes/policy/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/policy/handlers.ts
@@ -11,13 +11,10 @@ import { policyIndexPattern } from '../../../../common/endpoint/constants';
 import {
   GetPolicyResponseSchema,
   GetAgentPolicySummaryRequestSchema,
-  GetEndpointPackagePolicyRequestSchema,
 } from '../../../../common/endpoint/schema/policy';
 import { EndpointAppContext } from '../../types';
 import { getAgentPolicySummary, getPolicyResponseByAgentId } from './service';
 import { GetAgentSummaryResponse } from '../../../../common/endpoint/types';
-import { wrapErrorIfNeeded } from '../../utils';
-import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../../../../fleet/common';
 
 export const getHostPolicyResponseHandler = function (): RequestHandler<
   undefined,
@@ -63,35 +60,5 @@ export const getAgentPolicySummaryHandler = function (
     return response.ok({
       body,
     });
-  };
-};
-
-export const getPolicyListHandler = function (
-  endpointAppContext: EndpointAppContext
-): RequestHandler<
-  undefined,
-  TypeOf<typeof GetEndpointPackagePolicyRequestSchema.query>,
-  undefined
-> {
-  return async (context, request, response) => {
-    const soClient = context.core.savedObjects.client;
-    const fleetServices = endpointAppContext.service.getScopedFleetServices(request);
-    const endpointFilteredKuery = `${
-      request?.query?.kuery ? `(${request.query.kuery}) and ` : ''
-    }${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`;
-    try {
-      const listResponse = await fleetServices.packagePolicy.list(soClient, {
-        ...request.query,
-        perPage: request.query.pageSize,
-        sortField: request.query.sort,
-        kuery: endpointFilteredKuery,
-      });
-
-      return response.ok({
-        body: listResponse,
-      });
-    } catch (error) {
-      throw wrapErrorIfNeeded(error);
-    }
   };
 };

--- a/x-pack/plugins/security_solution/server/endpoint/routes/policy/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/policy/index.ts
@@ -10,16 +10,10 @@ import { EndpointAppContext } from '../../types';
 import {
   GetPolicyResponseSchema,
   GetAgentPolicySummaryRequestSchema,
-  GetEndpointPackagePolicyRequestSchema,
 } from '../../../../common/endpoint/schema/policy';
-import {
-  getHostPolicyResponseHandler,
-  getAgentPolicySummaryHandler,
-  getPolicyListHandler,
-} from './handlers';
+import { getHostPolicyResponseHandler, getAgentPolicySummaryHandler } from './handlers';
 import {
   AGENT_POLICY_SUMMARY_ROUTE,
-  BASE_POLICY_ROUTE,
   BASE_POLICY_RESPONSE_ROUTE,
 } from '../../../../common/endpoint/constants';
 import { withEndpointAuthz } from '../with_endpoint_authz';
@@ -52,19 +46,6 @@ export function registerPolicyRoutes(router: IRouter, endpointAppContext: Endpoi
       { all: ['canAccessEndpointManagement'] },
       logger,
       getAgentPolicySummaryHandler(endpointAppContext)
-    )
-  );
-
-  router.get(
-    {
-      path: BASE_POLICY_ROUTE,
-      validate: GetEndpointPackagePolicyRequestSchema,
-      options: { authRequired: true },
-    },
-    withEndpointAuthz(
-      { all: ['canAccessEndpointManagement'] },
-      logger,
-      getPolicyListHandler(endpointAppContext)
     )
   );
 }

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
@@ -63,11 +63,6 @@ export default function ({ getService }: FtrProviderContext) {
         body: undefined,
       },
       {
-        method: 'get',
-        path: '/api/endpoint/policy',
-        body: undefined,
-      },
-      {
         method: 'post',
         path: '/api/endpoint/isolate',
         body: { endpoint_ids: ['one'] },


### PR DESCRIPTION
## Summary

We have decided to move away from creating our own endpoint specific package policy related API routes in favor of continuing to use the fleet package policy API routes. This removes the additions created in this pr: https://github.com/elastic/kibana/pull/119545

