### PR TITLE
Reenable alert_create_flyout create alert test

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
@@ -105,8 +105,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     await testSubjects.click('test.always-firing-SelectOption');
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/89397
-  describe.skip('create alert', function () {
+  describe('create alert', function () {
     before(async () => {
       await pageObjects.common.navigateToApp('triggersActions');
       await testSubjects.click('rulesTab');

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
@@ -111,6 +111,13 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       await testSubjects.click('rulesTab');
     });
 
+    afterEach(async () => {
+      // Reset the Rules tab without reloading the entire page
+      // This is safer than trying to close the alert flyout, which may or may not be open at the end of a test
+      await testSubjects.click('connectorsTab');
+      await testSubjects.click('rulesTab');
+    });
+
     it('should create an alert', async () => {
       const alertName = generateUniqueKey();
       await defineIndexThresholdAlert(alertName);


### PR DESCRIPTION
## Summary

Fixes #89397

The `alert_create_flyout` test was failing because the alert flyout wasn't reliably being closed and reset to its original state in between tests. This reenables the test and fixes the issue.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

