### PR TITLE
[Lists] Add an instance of `ExceptionListClient` with server extension points turned off to context object provided to callbacks

### DIFF
--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
@@ -12,6 +12,7 @@ import {
   createExtensionPointStorageMock,
 } from '../extension_points/extension_point_storage.mock';
 import type { ExtensionPointCallbackDataArgument } from '../extension_points';
+import { httpServerMock } from '../../../../../../src/core/server/mocks';
 
 import {
   getCreateExceptionListItemOptionsMock,
@@ -49,13 +50,16 @@ describe('exception_list_client', () => {
   describe('server extension points execution', () => {
     let extensionPointStorageContext: ExtensionPointStorageContextMock;
     let exceptionListClient: ExceptionListClient;
+    let kibanaRequest: ReturnType<typeof httpServerMock.createKibanaRequest>;
 
     beforeEach(() => {
       extensionPointStorageContext = createExtensionPointStorageMock();
+      kibanaRequest = httpServerMock.createKibanaRequest();
     });
 
     it('should initialize class instance with `enableServerExtensionPoints` enabled by default', async () => {
       exceptionListClient = new ExceptionListClient({
+        request: kibanaRequest,
         savedObjectsClient: getExceptionListSavedObjectClientMock(),
         serverExtensionsClient: extensionPointStorageContext.extensionPointStorage.getClient(),
         user: 'elastic',
@@ -98,6 +102,7 @@ describe('exception_list_client', () => {
         describe('and server extension points are enabled', () => {
           beforeEach(() => {
             exceptionListClient = new ExceptionListClient({
+              request: kibanaRequest,
               savedObjectsClient: getExceptionListSavedObjectClientMock(),
               serverExtensionsClient:
                 extensionPointStorageContext.extensionPointStorage.getClient(),
@@ -109,6 +114,15 @@ describe('exception_list_client', () => {
             await callExceptionListClientMethod();
 
             expect(getExtensionPointCallback()).toHaveBeenCalled();
+          });
+
+          it('should provide `context` object to extension point callbacks', async () => {
+            await callExceptionListClientMethod();
+
+            expect(getExtensionPointCallback().mock.calls[0][0].context).toEqual({
+              exceptionListClient: expect.any(ExceptionListClient),
+              request: kibanaRequest,
+            });
           });
 
           it('should error if extension point callback throws an error', async () => {
@@ -157,6 +171,7 @@ describe('exception_list_client', () => {
           beforeEach(() => {
             exceptionListClient = new ExceptionListClient({
               enableServerExtensionPoints: false,
+              request: kibanaRequest,
               savedObjectsClient: getExceptionListSavedObjectClientMock(),
               serverExtensionsClient:
                 extensionPointStorageContext.extensionPointStorage.getClient(),
@@ -304,6 +319,7 @@ describe('exception_list_client', () => {
       (methodName, callExceptionListClientMethod, getExtensionPointCallback) => {
         beforeEach(() => {
           exceptionListClient = new ExceptionListClient({
+            request: kibanaRequest,
             savedObjectsClient: getExceptionListSavedObjectClientMock(),
             serverExtensionsClient: extensionPointStorageContext.extensionPointStorage.getClient(),
             user: 'elastic',
@@ -314,6 +330,15 @@ describe('exception_list_client', () => {
           await callExceptionListClientMethod();
 
           expect(getExtensionPointCallback()).toHaveBeenCalled();
+        });
+
+        it('should provide `context` object to extension point callbacks', async () => {
+          await callExceptionListClientMethod();
+
+          expect(getExtensionPointCallback().mock.calls[0][0].context).toEqual({
+            exceptionListClient: expect.any(ExceptionListClient),
+            request: kibanaRequest,
+          });
         });
 
         it('should error if extension point callback throws an error', async () => {
@@ -331,6 +356,7 @@ describe('exception_list_client', () => {
           beforeEach(() => {
             exceptionListClient = new ExceptionListClient({
               enableServerExtensionPoints: false,
+              request: kibanaRequest,
               savedObjectsClient: getExceptionListSavedObjectClientMock(),
               serverExtensionsClient:
                 extensionPointStorageContext.extensionPointStorage.getClient(),

--- a/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
+++ b/x-pack/plugins/lists/server/services/exception_lists/exception_list_client.ts
@@ -103,7 +103,24 @@ export class ExceptionListClient {
   }
 
   private getServerExtensionCallbackContext(): ServerExtensionCallbackContext {
+    const { user, serverExtensionsClient, savedObjectsClient, request } = this;
+    let exceptionListClient: undefined | ExceptionListClient;
+
     return {
+      // Lazy getter so that we only initialize a new instance of the class if needed
+      get exceptionListClient(): ExceptionListClient {
+        if (!exceptionListClient) {
+          exceptionListClient = new ExceptionListClient({
+            enableServerExtensionPoints: false,
+            request,
+            savedObjectsClient,
+            serverExtensionsClient,
+            user,
+          });
+        }
+
+        return exceptionListClient;
+      },
       request: this.request,
     };
   }

--- a/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/extension_point_storage.mock.ts
@@ -8,6 +8,7 @@
 import { MockedLogger, loggerMock } from '@kbn/logging/mocks';
 
 import { httpServerMock } from '../../../../../../src/core/server/mocks';
+import { ExceptionListClient } from '../exception_lists/exception_list_client';
 
 import { ExtensionPointStorage } from './extension_point_storage';
 import {
@@ -122,6 +123,7 @@ export const createExtensionPointStorageMock = (
 
   return {
     callbackContext: {
+      exceptionListClient: {} as unknown as ExceptionListClient,
       request: httpServerMock.createKibanaRequest(),
     },
     exceptionPreCreate,

--- a/x-pack/plugins/lists/server/services/extension_points/extension_point_storage_client.test.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/extension_point_storage_client.test.ts
@@ -138,9 +138,7 @@ describe('When using the ExtensionPointStorageClient', () => {
         if (extensionPointsMock.type === 'exceptionsListPreCreateItem') {
           expect(extensionPointsMock.callback).toHaveBeenCalledWith(
             expect.objectContaining({
-              context: {
-                request: expect.any(Object),
-              },
+              context: callbackContext,
             })
           );
         }

--- a/x-pack/plugins/lists/server/services/extension_points/types.ts
+++ b/x-pack/plugins/lists/server/services/extension_points/types.ts
@@ -19,6 +19,7 @@ import {
   UpdateExceptionListItemOptions,
 } from '../exception_lists/exception_list_client_types';
 import { PromiseFromStreams } from '../exception_lists/import_exception_list_and_items';
+import type { ExceptionListClient } from '../exception_lists/exception_list_client';
 
 /**
  * The `this` context provided to extension point's callback function
@@ -30,6 +31,13 @@ export interface ServerExtensionCallbackContext {
    * is not triggered via one of the HTTP handlers
    */
   request?: KibanaRequest;
+
+  /**
+   * An `ExceptionListClient` instance that **DOES NOT** execute server extension point callbacks.
+   * This client should be used when needing to access Exception List content from within an Extension
+   * Point to avoid circular infinite loops
+   */
+  exceptionListClient: ExceptionListClient;
 }
 
 export type ServerExtensionCallback<A extends object | void = void, R = A> = (args: {


### PR DESCRIPTION
## Summary

- Adds an instance of `ExceptionListClient` to the `context` object provided to Server Extension Point callbacks. This instance of the client has the processing of the extension points turn off in order to avoid infinite loops when business logic in extension point callbacks needs to access exception list content.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


