### PR TITLE
[8.0] change test to match current message when decryption fails (#122224)

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
+++ b/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
@@ -44,7 +44,7 @@ export default ({ getPageObjects, getService }) => {
           await retry.try(async () => {
             const executionFailureResultCallout = await testSubjects.find('executionFailureResult');
             expect(await executionFailureResultCallout.getVisibleText()).to.be(
-              'Test failed to run\nThe following error was found:\nerror sending email\nDetails:\nMail command failed: 550 5.7.1 Relaying denied'
+              'Test failed to run\nThe following error was found:\nerror validating action type connector: secrets must be defined'
             );
           });
           expect(true).to.be(true);


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #122224

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
