### PR TITLE
[ML] Functional tests - reduce job run time in date nanos and categorization tests

### DIFF
--- a/x-pack/test/functional/apps/ml/anomaly_detection/categorization_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/categorization_job.ts
@@ -21,7 +21,7 @@ export default function ({ getService }: FtrProviderContext) {
   const detectorTypeIdentifier = 'Rare';
   const categorizationFieldIdentifier = 'field1';
   const categorizationExampleCount = 5;
-  const bucketSpan = '15m';
+  const bucketSpan = '1d';
   const memoryLimit = '15mb';
 
   function getExpectedRow(expectedJobId: string, expectedJobGroups: string[]) {
@@ -29,32 +29,32 @@ export default function ({ getService }: FtrProviderContext) {
       id: expectedJobId,
       description: jobDescription,
       jobGroups: [...new Set(expectedJobGroups)].sort(),
-      recordCount: '1,501',
+      recordCount: '1,000',
       memoryStatus: 'ok',
       jobState: 'closed',
       datafeedState: 'stopped',
-      latestTimestamp: '2019-11-21 06:01:13',
+      latestTimestamp: '2019-11-21 00:01:13',
     };
   }
 
   function getExpectedCounts(expectedJobId: string) {
     return {
       job_id: expectedJobId,
-      processed_record_count: '1,501',
-      processed_field_count: '1,501',
-      input_bytes: '335.4 KB',
-      input_field_count: '1,501',
+      processed_record_count: '1,000',
+      processed_field_count: '1,000',
+      input_bytes: '148.8 KB',
+      input_field_count: '1,000',
       invalid_date_count: '0',
       missing_field_count: '0',
       out_of_order_timestamp_count: '0',
-      empty_bucket_count: '21,428',
+      empty_bucket_count: '23',
       sparse_bucket_count: '0',
-      bucket_count: '22,059',
+      bucket_count: '230',
       earliest_record_timestamp: '2019-04-05 11:25:35',
-      latest_record_timestamp: '2019-11-21 06:01:13',
-      input_record_count: '1,501',
-      latest_bucket_timestamp: '2019-11-21 06:00:00',
-      latest_empty_bucket_timestamp: '2019-11-21 05:45:00',
+      latest_record_timestamp: '2019-11-21 00:01:13',
+      input_record_count: '1,000',
+      latest_bucket_timestamp: '2019-11-21 00:00:00',
+      latest_empty_bucket_timestamp: '2019-11-17 00:00:00',
     };
   }
 
@@ -68,7 +68,7 @@ export default function ({ getService }: FtrProviderContext) {
       total_partition_field_count: '2',
       bucket_allocation_failures_count: '0',
       memory_status: 'ok',
-      timestamp: '2019-11-21 05:45:00',
+      timestamp: '2019-11-20 00:00:00',
     };
   }
 
@@ -77,8 +77,8 @@ export default function ({ getService }: FtrProviderContext) {
   describe('categorization', function () {
     this.tags(['mlqa']);
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/categorization');
-      await ml.testResources.createIndexPatternIfNeeded('ft_categorization', '@timestamp');
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/categorization_small');
+      await ml.testResources.createIndexPatternIfNeeded('ft_categorization_small', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -87,7 +87,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_categorization');
+      await ml.testResources.deleteIndexPatternByTitle('ft_categorization_small');
     });
 
     it('job creation loads the categorization wizard for the source data', async () => {
@@ -100,7 +100,7 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.jobManagement.navigateToNewJobSourceSelection();
 
       await ml.testExecution.logTestStep('job creation loads the job type selection page');
-      await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob('ft_categorization');
+      await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob('ft_categorization_small');
 
       await ml.testExecution.logTestStep('job creation loads the categorization job wizard page');
       await ml.jobTypeSelection.selectCategorizationJob();
@@ -113,7 +113,7 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('job creation sets the time range');
       await ml.jobWizardCommon.clickUseFullDataButton(
         'Apr 5, 2019 @ 11:25:35.770',
-        'Nov 21, 2019 @ 06:01:13.914'
+        'Nov 21, 2019 @ 00:01:13.923'
       );
 
       await ml.testExecution.logTestStep('job creation displays the event rate chart');
@@ -235,7 +235,7 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('job cloning sets the time range');
       await ml.jobWizardCommon.clickUseFullDataButton(
         'Apr 5, 2019 @ 11:25:35.770',
-        'Nov 21, 2019 @ 06:01:13.914'
+        'Nov 21, 2019 @ 00:01:13.923'
       );
 
       await ml.testExecution.logTestStep('job cloning displays the event rate chart');

--- a/x-pack/test/functional/apps/ml/anomaly_detection/date_nanos_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/date_nanos_job.ts
@@ -57,7 +57,7 @@ export default function ({ getService }: FtrProviderContext) {
       jobSource: 'ft_event_rate_gen_trend_nanos',
       jobId: `event_rate_nanos_count_1_${Date.now()}`,
       jobDescription:
-        'Create advanced job based on the event rate dataset with a date_nanos time field, 30m bucketspan and count',
+        'Create advanced job based on the event rate dataset with a date_nanos time field, 1d bucketspan and count',
       jobGroups: ['automated', 'event-rate', 'date-nanos'],
       pickFieldsConfig: {
         detectors: [
@@ -69,7 +69,7 @@ export default function ({ getService }: FtrProviderContext) {
         ],
         summaryCountField: 'count',
         influencers: [],
-        bucketSpan: '30m',
+        bucketSpan: '1d',
         memoryLimit: '10mb',
       } as PickFieldsConfig,
       datafeedConfig: {} as DatafeedConfig,
@@ -94,7 +94,7 @@ export default function ({ getService }: FtrProviderContext) {
           out_of_order_timestamp_count: '0',
           empty_bucket_count: '0',
           sparse_bucket_count: '0',
-          bucket_count: '17,520',
+          bucket_count: '365',
           earliest_record_timestamp: '2015-01-01 00:10:00',
           latest_record_timestamp: '2016-01-01 00:00:00',
           input_record_count: '105,120',
@@ -108,7 +108,7 @@ export default function ({ getService }: FtrProviderContext) {
           total_partition_field_count: '2',
           bucket_allocation_failures_count: '0',
           memory_status: 'ok',
-          timestamp: '2015-12-31 23:30:00',
+          timestamp: '2015-12-31 00:00:00',
         },
       },
     },

--- a/x-pack/test/functional/apps/ml/index.ts
+++ b/x-pack/test/functional/apps/ml/index.ts
@@ -26,7 +26,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
-      await esArchiver.unload('x-pack/test/functional/es_archives/ml/categorization');
+      await esArchiver.unload('x-pack/test/functional/es_archives/ml/categorization_small');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/event_rate_nanos');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/bm_classification');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/ihp_outlier');


### PR DESCRIPTION
## Summary

This PR stabilizes the date nanos job and categorization job tests for cloud execution by reducing the job run time.

### Details

* In cloud environments, the job execution time sometimes exceeded the test timeout.
* Job run time is reduced by setting an increased bucket span of `1d` and switching to the (already available) smaller categorization data archive
