### PR TITLE
[ML] Add codeowner for docs screenshots

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -184,6 +184,8 @@
 /x-pack/test/functional_with_es_ssl/apps/ml/ @elastic/ml-ui
 /x-pack/test/alerting_api_integration/spaces_only/tests/alerting/ml_rule_types/ @elastic/ml-ui
 /x-pack/test/alerting_api_integration/spaces_only/tests/alerting/transform_rule_types/ @elastic/ml-ui
+/x-pack/test/screenshot_creation/apps/ml_docs @elastic/ml-ui
+/x-pack/test/screenshot_creation/services/ml_screenshots.ts @elastic/ml-ui
 
 # ML team owns and maintains the transform plugin despite it living in the Data management section.
 /x-pack/plugins/transform/  @elastic/ml-ui


### PR DESCRIPTION
## Summary

This PR adds `elastic/ml-ui` as code owner for the ML specific bits of the `screenshot_creation` directory.
