### PR TITLE
[TSVB] Formatting in the left axis is not respected when I have two separate axis

### DIFF
--- a/src/plugins/vis_types/timeseries/public/application/components/lib/check_if_series_have_same_formatters.test.ts
+++ b/src/plugins/vis_types/timeseries/public/application/components/lib/check_if_series_have_same_formatters.test.ts
@@ -52,6 +52,20 @@ describe('checkIfSeriesHaveSameFormatters(seriesModel, fieldFormatMap)', () => {
     expect(result).toBe(true);
   });
 
+  it('should return true in case of separate y-axis and different field formatters', () => {
+    const seriesModel = [
+      { formatter: DATA_FORMATTERS.DEFAULT, metrics: [{ type: 'avg', field: 'someField' }] },
+      {
+        formatter: DATA_FORMATTERS.DEFAULT,
+        separate_axis: 1,
+        metrics: [{ id: 'avg', field: 'anotherField' }],
+      },
+    ] as Series[];
+    const result = checkIfSeriesHaveSameFormatters(seriesModel, fieldFormatMap);
+
+    expect(result).toBeTruthy();
+  });
+
   it('should return false for the different field formatters', () => {
     const seriesModel = [
       { formatter: DATA_FORMATTERS.DEFAULT, metrics: [{ type: 'avg', field: 'someField' }] },

--- a/src/plugins/vis_types/timeseries/public/application/components/lib/check_if_series_have_same_formatters.ts
+++ b/src/plugins/vis_types/timeseries/public/application/components/lib/check_if_series_have_same_formatters.ts
@@ -18,24 +18,26 @@ export const checkIfSeriesHaveSameFormatters = (
   const uniqFormatters = new Set();
 
   seriesModel.forEach((seriesGroup) => {
-    if (seriesGroup.formatter === DATA_FORMATTERS.DEFAULT) {
-      const activeMetric = seriesGroup.metrics[seriesGroup.metrics.length - 1];
-      const aggMeta = aggs.find((agg) => agg.id === activeMetric.type);
+    if (!seriesGroup.separate_axis) {
+      if (seriesGroup.formatter === DATA_FORMATTERS.DEFAULT) {
+        const activeMetric = seriesGroup.metrics[seriesGroup.metrics.length - 1];
+        const aggMeta = aggs.find((agg) => agg.id === activeMetric.type);
 
-      if (
-        activeMetric.field &&
-        aggMeta?.meta.isFieldRequired &&
-        fieldFormatMap?.[activeMetric.field]
-      ) {
-        return uniqFormatters.add(JSON.stringify(fieldFormatMap[activeMetric.field]));
+        if (
+          activeMetric.field &&
+          aggMeta?.meta.isFieldRequired &&
+          fieldFormatMap?.[activeMetric.field]
+        ) {
+          return uniqFormatters.add(JSON.stringify(fieldFormatMap[activeMetric.field]));
+        }
       }
+      uniqFormatters.add(
+        JSON.stringify({
+          // requirement: in the case of using TSVB formatters, we do not need to check the value_template, just formatter!
+          formatter: seriesGroup.formatter,
+        })
+      );
     }
-    uniqFormatters.add(
-      JSON.stringify({
-        // requirement: in the case of using TSVB formatters, we do not need to check the value_template, just formatter!
-        formatter: seriesGroup.formatter,
-      })
-    );
   });
 
   return uniqFormatters.size === 1;


### PR DESCRIPTION
Closes: #123891

## Summary

When I create 2 layers with formatters and assign the second layer into a separate right axis, the formatting in the left is not respected. If I select to have the first layer in the left axis, then the formatting works fine

**Steps to reproduce:**
1. Create a layer with `Bytes` formatter
2. Create a second layer with `Percent`
3. Change the settings of the second layer to be placed on a separate right axis
4. Check the chart
![image](https://user-images.githubusercontent.com/17003240/151310272-e8980978-aa5f-4336-81ba-97aaefcf045f.png)

Formatting works fine now


