### PR TITLE
[RAC][LOG] Remove getDuration and use the shared formatDurationFromTimeUnitChar from o11y plugin

### DIFF
--- a/x-pack/plugins/infra/server/lib/alerting/log_threshold/reason_formatters.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/log_threshold/reason_formatters.ts
@@ -6,28 +6,13 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import * as moment from 'moment';
-import momentDurationFormatSetup from 'moment-duration-format';
-momentDurationFormatSetup(moment);
-
 import {
   Comparator,
   ComparatorToi18nMap,
   TimeUnit,
 } from '../../../../common/alerting/logs/log_threshold/types';
 
-const getDuration = (timeSize: number, timeUnit: TimeUnit): string => {
-  switch (timeUnit) {
-    case 's':
-      return moment.duration(timeSize, 'seconds').format('s [sec]');
-    case 'm':
-      return moment.duration(timeSize, 'minutes').format('m [min]');
-    case 'h':
-      return moment.duration(timeSize, 'hours').format('h [hr]');
-    case 'd':
-      return moment.duration(timeSize, 'days').format('d [day]');
-  }
-};
+import { formatDurationFromTimeUnitChar, TimeUnitChar } from '../../../../../observability/common';
 
 export const getReasonMessageForUngroupedCountAlert = (
   actualCount: number,
@@ -43,7 +28,7 @@ export const getReasonMessageForUngroupedCountAlert = (
       actualCount,
       expectedCount,
       translatedComparator: ComparatorToi18nMap[comparator],
-      duration: getDuration(timeSize, timeUnit),
+      duration: formatDurationFromTimeUnitChar(timeSize, timeUnit as TimeUnitChar),
     },
   });
 
@@ -63,7 +48,7 @@ export const getReasonMessageForGroupedCountAlert = (
       expectedCount,
       groupName,
       translatedComparator: ComparatorToi18nMap[comparator],
-      duration: getDuration(timeSize, timeUnit),
+      duration: formatDurationFromTimeUnitChar(timeSize, timeUnit as TimeUnitChar),
     },
   });
 
@@ -81,7 +66,7 @@ export const getReasonMessageForUngroupedRatioAlert = (
       actualRatio,
       expectedRatio,
       translatedComparator: ComparatorToi18nMap[comparator],
-      duration: getDuration(timeSize, timeUnit),
+      duration: formatDurationFromTimeUnitChar(timeSize, timeUnit as TimeUnitChar),
     },
   });
 
@@ -101,6 +86,6 @@ export const getReasonMessageForGroupedRatioAlert = (
       expectedRatio,
       groupName,
       translatedComparator: ComparatorToi18nMap[comparator],
-      duration: getDuration(timeSize, timeUnit),
+      duration: formatDurationFromTimeUnitChar(timeSize, timeUnit as TimeUnitChar),
     },
   });


### PR DESCRIPTION
## Summary

it fixes https://github.com/elastic/kibana/issues/123918 by using the shared `formatDurationFromTimeUnitChar` function  from o11y plugin instead of local `getDuration` function


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
