### PR TITLE
[8.0] [Upgrade Assistant] Minimize reindex attributes used to create credential hash (#123727) (#123864)

### DIFF
--- a/x-pack/plugins/upgrade_assistant/server/lib/reindexing/credential_store.ts
+++ b/x-pack/plugins/upgrade_assistant/server/lib/reindexing/credential_store.ts
@@ -16,10 +16,14 @@ import { ReindexSavedObject, ReindexStatus } from '../../../common/types';
 export type Credential = Record<string, any>;
 
 // Generates a stable hash for the reindex operation's current state.
-const getHash = (reindexOp: ReindexSavedObject) =>
-  createHash('sha256')
-    .update(stringify({ id: reindexOp.id, ...reindexOp.attributes }))
+const getHash = (reindexOp: ReindexSavedObject) => {
+  // Remove reindexOptions from the SO attributes as it creates an unstable hash
+  // This needs further investigation, see: https://github.com/elastic/kibana/issues/123752
+  const { reindexOptions, ...attributes } = reindexOp.attributes;
+  return createHash('sha256')
+    .update(stringify({ id: reindexOp.id, ...attributes }))
     .digest('base64');
+};
 
 // Returns a base64-encoded API key string or undefined
 const getApiKey = async ({


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #123864

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
