### PR TITLE
Deprecate usage of search within the scoped cluster client execution service

### DIFF
--- a/x-pack/plugins/alerting/README.md
+++ b/x-pack/plugins/alerting/README.md
@@ -111,7 +111,7 @@ This is the primary function for a rule type. Whenever the rule needs to execute
 
 |Property|Description|
 |---|---|
-|services.scopedClusterClient|This is an instance of the Elasticsearch client. Use this to do Elasticsearch queries in the context of the user who created the alert when security is enabled.|
+|services.scopedClusterClient|This service is an instance of the scoped cluster client. Use this to make non-search Elasticsearch requests. When using asCurrentUser, the requests are in the context of the user who created the alert when security is enabled. Usage of "search" is deprecated because the queries do not abort when cancelling the rule execution, use services.search instead.|
 |services.savedObjectsClient|This is an instance of the saved objects client. This provides the ability to perform CRUD operations on any saved object that lives in the same space as the rule.<br><br>The scope of the saved objects client is tied to the user who created the rule (only when security is enabled).|
 |services.alertInstanceFactory(id)|This [alert factory](#alert-factory) creates alerts and must be used in order to execute actions. The id you give to the alert factory is a unique identifier for the alert.|
 |services.log(tags, [data], [timestamp])|Use this to create server logs. (This is the same function as server.log)|

--- a/x-pack/plugins/alerting/server/index.ts
+++ b/x-pack/plugins/alerting/server/index.ts
@@ -29,7 +29,7 @@ export type {
   AlertingApiRequestHandlerContext,
   RuleParamsAndRefs,
   ScopedClusterClientService,
-  EleasticsearchClientService,
+  ElasticsearchClientService,
 } from './types';
 export { DEFAULT_MAX_EPHEMERAL_ACTIONS_PER_ALERT } from './config';
 export type { PluginSetupContract, PluginStartContract } from './plugin';

--- a/x-pack/plugins/alerting/server/index.ts
+++ b/x-pack/plugins/alerting/server/index.ts
@@ -28,6 +28,8 @@ export type {
   AlertInstanceContext,
   AlertingApiRequestHandlerContext,
   RuleParamsAndRefs,
+  ScopedClusterClientService,
+  EleasticsearchClientService,
 } from './types';
 export { DEFAULT_MAX_EPHEMERAL_ACTIONS_PER_ALERT } from './config';
 export type { PluginSetupContract, PluginStartContract } from './plugin';

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -13,6 +13,7 @@ import { PluginSetupContract, PluginStartContract } from './plugin';
 import { RulesClient } from './rules_client';
 export * from '../common';
 import {
+  ElasticsearchClient,
   IScopedClusterClient,
   KibanaRequest,
   SavedObjectAttributes,
@@ -64,9 +65,21 @@ export interface AlertingRequestHandlerContext extends RequestHandlerContext {
  */
 export type AlertingRouter = IRouter<AlertingRequestHandlerContext>;
 
+export type EleasticsearchClientService = {
+  /**
+   * @deprecated Usage of "search" is deprecated because the queries do not abort when cancelling the rule execution, use services.search instead. (https://github.com/elastic/kibana/issues/111259).
+   */
+  search: ElasticsearchClient['search'];
+} & Omit<ElasticsearchClient, 'search'>;
+
+export interface ScopedClusterClientService extends IScopedClusterClient {
+  asInternalUser: EleasticsearchClientService;
+  asCurrentUser: EleasticsearchClientService;
+}
+
 export interface Services {
   savedObjectsClient: SavedObjectsClientContract;
-  scopedClusterClient: IScopedClusterClient;
+  scopedClusterClient: ScopedClusterClientService;
 }
 
 export interface AlertServices<

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -65,7 +65,7 @@ export interface AlertingRequestHandlerContext extends RequestHandlerContext {
  */
 export type AlertingRouter = IRouter<AlertingRequestHandlerContext>;
 
-export type EleasticsearchClientService = {
+export type ElasticsearchClientService = {
   /**
    * @deprecated Usage of "search" is deprecated because the queries do not abort when cancelling the rule execution, use services.search instead. (https://github.com/elastic/kibana/issues/111259).
    */
@@ -73,8 +73,8 @@ export type EleasticsearchClientService = {
 } & Omit<ElasticsearchClient, 'search'>;
 
 export interface ScopedClusterClientService extends IScopedClusterClient {
-  asInternalUser: EleasticsearchClientService;
-  asCurrentUser: EleasticsearchClientService;
+  asInternalUser: ElasticsearchClientService;
+  asCurrentUser: ElasticsearchClientService;
 }
 
 export interface Services {


### PR DESCRIPTION
Fixes #123604.

In this PR, I'm deprecating the `services.scopedClusterClient.asCurrentUser.search` function in TypeScript where some IDEs will put a strikethrough on the function name. I also updated the README docs to discourage usage of "search" within the scopedClusterClient.

Example in VSCode:
<img width="821" alt="Screen Shot 2022-01-27 at 9 41 29 AM" src="https://user-images.githubusercontent.com/3694571/151381124-d14667c6-7977-43a3-949b-affbfb441294.png">

Side note:
Some rule type executors have their searches happening within 2-3+ functions deep. They end up using the core plugin's `ElasticsearchClient` interface to accept our scoped cluster client as a parameter ([example](https://github.com/elastic/kibana/blob/main/x-pack/plugins/infra/server/lib/alerting/inventory_metric_threshold/evaluate_condition.ts#L42)). By doing so, it removes the deprecation message that this PR adds. I am not sure given that if there is much value or a different way we could pass it along. Open to ideas?

To verify if using VSCode:
1. Add `services.scopedClusterClient.asCurrentUser.search();` to an empty line within the index threshold executor ([here for example](https://github.com/elastic/kibana/blob/main/x-pack/plugins/stack_alerts/server/alert_types/index_threshold/alert_type.ts#L138))
2. Notice "search" has a strikethrough on the text
3. Hover over "search" and notice the deprecation message