### PR TITLE
[Fleet] Remove usage of IFieldType in Fleet

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.tsx
@@ -9,7 +9,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 
 import { fromKueryExpression } from '@kbn/es-query';
 
-import type { IFieldType } from '../../../../../../../src/plugins/data/public';
+import type { FieldSpec } from '../../../../../../../src/plugins/data/common';
 import { QueryStringInput } from '../../../../../../../src/plugins/data/public';
 import { useStartServices } from '../hooks';
 import { INDEX_NAME, AGENTS_PREFIX } from '../constants';
@@ -32,7 +32,7 @@ export const SearchBar: React.FunctionComponent<Props> = ({
   indexPattern = INDEX_NAME,
 }) => {
   const { data } = useStartServices();
-  const [indexPatternFields, setIndexPatternFields] = useState<IFieldType[]>();
+  const [indexPatternFields, setIndexPatternFields] = useState<FieldSpec[]>();
 
   const isQueryValid = useMemo(() => {
     if (!value || value === '') {
@@ -50,7 +50,7 @@ export const SearchBar: React.FunctionComponent<Props> = ({
   useEffect(() => {
     const fetchFields = async () => {
       try {
-        const _fields: IFieldType[] = await data.indexPatterns.getFieldsForWildcard({
+        const _fields: FieldSpec[] = await data.dataViews.getFieldsForWildcard({
           pattern: indexPattern,
         });
         const fields = (_fields || []).filter((field) => {
@@ -69,7 +69,7 @@ export const SearchBar: React.FunctionComponent<Props> = ({
       }
     };
     fetchFields();
-  }, [data.indexPatterns, fieldPrefix, indexPattern]);
+  }, [data.dataViews, fieldPrefix, indexPattern]);
 
   return (
     <QueryStringInput

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/query_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/query_bar.tsx
@@ -8,7 +8,7 @@
 import React, { memo, useState, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 
-import type { IFieldType } from '../../../../../../../../../../../src/plugins/data/public';
+import type { FieldSpec } from '../../../../../../../../../../../src/plugins/data/common';
 import { QueryStringInput } from '../../../../../../../../../../../src/plugins/data/public';
 import { useStartServices } from '../../../../../hooks';
 
@@ -27,15 +27,15 @@ export const LogQueryBar: React.FunctionComponent<{
   onUpdateQuery: (query: string, runQuery?: boolean) => void;
 }> = memo(({ query, isQueryValid, onUpdateQuery }) => {
   const { data } = useStartServices();
-  const [indexPatternFields, setIndexPatternFields] = useState<IFieldType[]>();
+  const [indexPatternFields, setIndexPatternFields] = useState<FieldSpec[]>();
 
   useEffect(() => {
     const fetchFields = async () => {
       try {
         const fields = (
-          ((await data.indexPatterns.getFieldsForWildcard({
+          (await data.dataViews.getFieldsForWildcard({
             pattern: AGENT_LOG_INDEX_PATTERN,
-          })) as IFieldType[]) || []
+          })) || []
         ).filter((field) => {
           return !EXCLUDED_FIELDS.includes(field.name);
         });
@@ -45,7 +45,7 @@ export const LogQueryBar: React.FunctionComponent<{
       }
     };
     fetchFields();
-  }, [data.indexPatterns]);
+  }, [data.dataViews]);
 
   return (
     <QueryStringInput


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/119356 

Remove usage of deprecated IFieldType in fleet, tested the autocompletes bar and everything seems to work as before.

