### PR TITLE
[7.17] skip es_kibana_version_compatibility.test.ts pending backport

### DIFF
--- a/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/es_kibana_version_compatibility.test.ts
@@ -12,7 +12,8 @@ import {
   TestKibanaUtils,
 } from '../../../test_helpers/kbn_server';
 
-describe('esVersionCompatibleWithKibana', () => {
+// Temporarily skipped until https://github.com/elastic/kibana/pull/123337 is backported
+describe.skip('esVersionCompatibleWithKibana', () => {
   let esServer: TestElasticsearchUtils;
   let kibanaServer: TestKibanaUtils;
 


### PR DESCRIPTION
Testing against 8.0 requires system index write access introduced in
https://github.com/elastic/kibana/pull/123337.  This adds a temporary
skip while the backport is in progress.

There's similar coverage with the forward compatibility pipelines in buildkite in the interim.