### PR TITLE
[7.16] [Infra UI] Avoid eager async imports in metric alert registrations (#123285)

### DIFF
--- a/x-pack/plugins/infra/common/alerting/metrics/types.ts
+++ b/x-pack/plugins/infra/common/alerting/metrics/types.ts
@@ -80,3 +80,7 @@ export interface InventoryMetricThresholdParams {
   sourceId?: string;
   alertOnNoData?: boolean;
 }
+
+export const QUERY_INVALID: unique symbol = Symbol('QUERY_INVALID');
+
+export type FilterQuery = string | typeof QUERY_INVALID;

--- a/x-pack/plugins/infra/public/alerting/inventory/components/expression.tsx
+++ b/x-pack/plugins/infra/public/alerting/inventory/components/expression.tsx
@@ -40,6 +40,10 @@ import {
   IErrorObject,
   AlertTypeParamsExpressionProps,
 } from '../../../../../triggers_actions_ui/public';
+import {
+  FilterQuery,
+  QUERY_INVALID,
+} from '../../../../common/alerting/metrics';
 import { MetricsExplorerKueryBar } from '../../../pages/metrics/metrics_explorer/components/kuery_bar';
 import { useSourceViaHttp } from '../../../containers/metrics_source/use_source_via_http';
 import { sqsMetricTypes } from '../../../../common/inventory_models/aws_sqs/toolbar_items';
@@ -70,7 +74,6 @@ import { useKibanaContextForPlugin } from '../../../hooks/use_kibana';
 
 import { ExpressionChart } from './expression_chart';
 const FILTER_TYPING_DEBOUNCE_MS = 500;
-export const QUERY_INVALID = Symbol('QUERY_INVALID');
 
 export interface AlertContextMeta {
   options?: Partial<InfraWaffleMapOptions>;
@@ -85,7 +88,7 @@ type Props = Omit<
     {
       criteria: Criteria;
       nodeType: InventoryItemType;
-      filterQuery?: string | symbol;
+      filterQuery?: FilterQuery;
       filterQueryText?: string;
       sourceId: string;
       alertOnNoData?: boolean;

--- a/x-pack/plugins/infra/public/alerting/inventory/components/expression.tsx
+++ b/x-pack/plugins/infra/public/alerting/inventory/components/expression.tsx
@@ -40,10 +40,7 @@ import {
   IErrorObject,
   AlertTypeParamsExpressionProps,
 } from '../../../../../triggers_actions_ui/public';
-import {
-  FilterQuery,
-  QUERY_INVALID,
-} from '../../../../common/alerting/metrics';
+import { FilterQuery, QUERY_INVALID } from '../../../../common/alerting/metrics';
 import { MetricsExplorerKueryBar } from '../../../pages/metrics/metrics_explorer/components/kuery_bar';
 import { useSourceViaHttp } from '../../../containers/metrics_source/use_source_via_http';
 import { sqsMetricTypes } from '../../../../common/inventory_models/aws_sqs/toolbar_items';

--- a/x-pack/plugins/infra/public/alerting/inventory/components/validation.tsx
+++ b/x-pack/plugins/infra/public/alerting/inventory/components/validation.tsx
@@ -13,14 +13,14 @@ import {
 } from '../../../../server/lib/alerting/inventory_metric_threshold/types';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { ValidationResult } from '../../../../../triggers_actions_ui/public/types';
-import { QUERY_INVALID } from './expression';
+import { FilterQuery, QUERY_INVALID } from '../../../../common/alerting/metrics';
 
 export function validateMetricThreshold({
   criteria,
   filterQuery,
 }: {
   criteria: InventoryMetricConditions[];
-  filterQuery?: string | symbol;
+  filterQuery?: FilterQuery;
 }): ValidationResult {
   const validationResult = { errors: {} };
   const errors: {

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression.tsx
@@ -30,6 +30,7 @@ import {
   AlertTypeParams,
   AlertTypeParamsExpressionProps,
 } from '../../../../../triggers_actions_ui/public';
+import { QUERY_INVALID } from '../../../../common/alerting/metrics';
 import { MetricsExplorerKueryBar } from '../../../pages/metrics/metrics_explorer/components/kuery_bar';
 import { MetricsExplorerOptions } from '../../../pages/metrics/metrics_explorer/hooks/use_metrics_explorer_options';
 import { MetricsExplorerGroupBy } from '../../../pages/metrics/metrics_explorer/components/group_by';
@@ -42,7 +43,6 @@ import { ExpressionChart } from './expression_chart';
 import { useKibanaContextForPlugin } from '../../../hooks/use_kibana';
 
 const FILTER_TYPING_DEBOUNCE_MS = 500;
-export const QUERY_INVALID = Symbol('QUERY_INVALID');
 
 type Props = Omit<
   AlertTypeParamsExpressionProps<AlertTypeParams & AlertParams, AlertContextMeta>,

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/validation.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/validation.tsx
@@ -13,14 +13,17 @@ import {
 } from '../../../../server/lib/alerting/metric_threshold/types';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { ValidationResult } from '../../../../../triggers_actions_ui/public/types';
-import { QUERY_INVALID } from './expression';
+import {
+  FilterQuery,
+  QUERY_INVALID,
+} from '../../../../common/alerting/metrics';
 
 export function validateMetricThreshold({
   criteria,
   filterQuery,
 }: {
   criteria: MetricExpressionParams[];
-  filterQuery?: string | symbol;
+  filterQuery?: FilterQuery;
 }): ValidationResult {
   const validationResult = { errors: {} };
   const errors: {

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/validation.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/validation.tsx
@@ -13,10 +13,7 @@ import {
 } from '../../../../server/lib/alerting/metric_threshold/types';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { ValidationResult } from '../../../../../triggers_actions_ui/public/types';
-import {
-  FilterQuery,
-  QUERY_INVALID,
-} from '../../../../common/alerting/metrics';
+import { FilterQuery, QUERY_INVALID } from '../../../../common/alerting/metrics';
 
 export function validateMetricThreshold({
   criteria,

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/types.ts
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/types.ts
@@ -10,6 +10,7 @@ import {
   // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 } from '../../../server/lib/alerting/metric_threshold/types';
 import { MetricsExplorerOptions } from '../../pages/metrics/metrics_explorer/hooks/use_metrics_explorer_options';
+import { FilterQuery } from '../../../common/alerting/metrics';
 import { MetricsExplorerSeries } from '../../../common/http_api/metrics_explorer';
 
 export interface AlertContextMeta {
@@ -57,7 +58,7 @@ export interface ExpressionChartData {
 export interface AlertParams {
   criteria: MetricExpression[];
   groupBy?: string | string[];
-  filterQuery?: string | symbol;
+  filterQuery?: FilterQuery;
   sourceId: string;
   filterQueryText?: string;
   alertOnNoData?: boolean;

--- a/x-pack/plugins/infra/public/plugin.ts
+++ b/x-pack/plugins/infra/public/plugin.ts
@@ -10,6 +10,9 @@ import { AppMountParameters, PluginInitializerContext } from 'kibana/public';
 import { from } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { DEFAULT_APP_CATEGORIES } from '../../../../src/core/public';
+import { createInventoryMetricAlertType } from './alerting/inventory';
+import { createLogThresholdAlertType } from './alerting/log_threshold';
+import { createMetricThresholdAlertType } from './alerting/metric_threshold';
 import { LOG_STREAM_EMBEDDABLE } from './components/log_stream/log_stream_embeddable';
 import { LogStreamEmbeddableFactoryDefinition } from './components/log_stream/log_stream_embeddable_factory';
 import { createMetricsFetchData, createMetricsHasData } from './metrics_overview_fetchers';
@@ -26,14 +29,10 @@ import { getLogsHasDataFetcher, getLogsOverviewDataFetcher } from './utils/logs_
 export class Plugin implements InfraClientPluginClass {
   constructor(_context: PluginInitializerContext) {}
 
-  async setup(core: InfraClientCoreSetup, pluginsSetup: InfraClientSetupDeps) {
+  setup(core: InfraClientCoreSetup, pluginsSetup: InfraClientSetupDeps) {
     if (pluginsSetup.home) {
       registerFeatures(pluginsSetup.home);
     }
-
-    const { createInventoryMetricAlertType } = await import('./alerting/inventory');
-    const { createLogThresholdAlertType } = await import('./alerting/log_threshold');
-    const { createMetricThresholdAlertType } = await import('./alerting/metric_threshold');
 
     pluginsSetup.observability.observabilityRuleTypeRegistry.register(
       createInventoryMetricAlertType()


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Infra UI] Avoid eager async imports in metric alert registrations (#123285)

:information_source: Due to the significant amount of conflicts, this is a more focused subset of the changes made in original PR.