### PR TITLE
[Fleet] Fix package policy merge logic for boolean values

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.test.ts
@@ -1993,6 +1993,10 @@ describe('Package policy service', () => {
                   type: 'text',
                   value: ['/var/log/logfile.log'],
                 },
+                is_value_enabled: {
+                  type: 'bool',
+                  value: false,
+                },
               },
               streams: [],
             },
@@ -2023,6 +2027,10 @@ describe('Package policy service', () => {
                       name: 'path',
                       type: 'text',
                     },
+                    {
+                      name: 'is_value_enabled',
+                      type: 'bool',
+                    },
                   ],
                 },
               ],
@@ -2042,6 +2050,10 @@ describe('Package policy service', () => {
                 type: 'text',
                 value: '/var/log/new-logfile.log',
               },
+              is_value_enabled: {
+                type: 'bool',
+                value: 'true',
+              },
             },
           },
         ];
@@ -2055,6 +2067,7 @@ describe('Package policy service', () => {
           false
         );
         expect(result.inputs[0]?.vars?.path.value).toEqual(['/var/log/logfile.log']);
+        expect(result.inputs[0]?.vars?.is_value_enabled.value).toEqual(false);
       });
     });
 

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -1369,7 +1369,7 @@ function deepMergeVars(original: any, override: any, keepOriginalValue = false):
 
     // Ensure that any value from the original object is persisted on the newly merged resulting object,
     // even if we merge other data about the given variable
-    if (keepOriginalValue && originalVar?.value) {
+    if (keepOriginalValue && originalVar?.value !== undefined) {
       result.vars[name].value = originalVar.value;
     }
   }


### PR DESCRIPTION
## Summary

Fixes #123945

Fixes a bug where Fleet's "merge" logic when upgrading package policies was unintentionally ignoring explicitly `false` boolean values on the original policy objects. In cases where a value was set to `false` on the original policy and defaulted to `true` in the package's manifest, we'd overwrite the `false` value with `true`.

## To test

Create a policy on an older version of APM, e.g. 7.16.2. Flip the `RUM Enabled` switch to `false` and save your policy. Then, upgrade it to the latest version of APM. The `RUM Enabled` switch should remain `false` after the upgrade.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios