### PR TITLE
[Workplace Search] Fix bug where modal visible after deleting a group

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
@@ -210,11 +210,13 @@ describe('GroupLogic', () => {
     describe('deleteGroup', () => {
       beforeEach(() => {
         GroupLogic.actions.onInitializeGroup(group);
+        GroupLogic.actions.showConfirmDeleteModal();
       });
       it('deletes a group', async () => {
         http.delete.mockReturnValue(Promise.resolve(true));
 
         GroupLogic.actions.deleteGroup();
+        expect(GroupLogic.values.confirmDeleteModalVisible).toEqual(false);
         expect(http.delete).toHaveBeenCalledWith('/internal/workplace_search/groups/123');
 
         await nextTick();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
@@ -122,6 +122,7 @@ export const GroupLogic = kea<MakeLogicType<GroupValues, GroupActions>>({
       {
         showConfirmDeleteModal: () => true,
         hideConfirmDeleteModal: () => false,
+        deleteGroup: () => false,
       },
     ],
     groupNameInputValue: [


### PR DESCRIPTION
fixes https://github.com/elastic/enterprise-search-team/issues/1221

## Summary

This PR fixes a bug in Workplace Search where, after you delete a group, the next group you click into will automatically show the delete modal for that group.

**Before**

https://user-images.githubusercontent.com/1869731/151443785-4a2c30af-a506-464a-aa22-d9a6385765c2.mp4

**After**

https://user-images.githubusercontent.com/1869731/151443819-f25ce1d7-b5c8-456b-8d49-e13e13fccc1f.mp4

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
