### PR TITLE
[ML] Maps: Add query support to anomalies layer

### DIFF
--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -108,7 +108,7 @@ export class AnomalySource implements IVectorSource {
   destroy(): void {}
 
   getApplyGlobalQuery(): boolean {
-    return false;
+    return true;
   }
 
   getApplyForceRefresh(): boolean {
@@ -323,8 +323,7 @@ export class AnomalySource implements IVectorSource {
   }
 
   isQueryAware(): boolean {
-    // IGNORE: This is only relevant if your source is backed by an index-pattern
-    return false;
+    return true;
   }
 
   isRefreshTimerAware(): boolean {


### PR DESCRIPTION
## Summary

Adds query support for the anomalies layer in maps, allowing filtering on the partitioning field values used in the anomaly detection job.

![image](https://user-images.githubusercontent.com/7405507/151543985-1cc39512-ec83-4122-8c8a-7fe141037b53.png)

Related meta issue: #123492

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


