### PR TITLE
[7.17] Fixes missing border in kql bar in Firefox

### DIFF
--- a/src/plugins/data/public/ui/query_string_input/_query_bar.scss
+++ b/src/plugins/data/public/ui/query_string_input/_query_bar.scss
@@ -42,7 +42,6 @@
   // Firefox adds margin to textarea
   margin: 0;
 
-
   @include kbnThemeStyle('v7') {
     padding-top: $euiSizeS + 2px;
   }

--- a/src/plugins/data/public/ui/query_string_input/_query_bar.scss
+++ b/src/plugins/data/public/ui/query_string_input/_query_bar.scss
@@ -39,6 +39,9 @@
   // shadow to line up correctly.
   padding: $euiSizeS;
   box-shadow: 0 0 0 1px $euiFormBorderColor;
+  // Firefox adds margin to textarea
+  margin: 0;
+
 
   @include kbnThemeStyle('v7') {
     padding-top: $euiSizeS + 2px;


### PR DESCRIPTION
This problem does not exist on main, only on late-era 7.x versions of Kibana. Firefox applies a 1 pixel margin to the top/bottom of textareas. This causes it to go from 38->40 pixels in total box size, and will expand 2px beyond it's containers overflow.

@spenceralger made the fix in for main when we switched up the themes. This small bit just needs to exist in the old code as well. https://github.com/elastic/kibana/pull/113570

hat tip to @mfinkle, the forever firefox user who spotted the issue.

![image](https://user-images.githubusercontent.com/324519/151481385-1aa1b49d-6808-4fc8-82f0-1013c56f4550.png)

## BEFORE

![image](https://user-images.githubusercontent.com/324519/151481516-78a81339-383c-442c-9c25-e6b2591d3d6a.png)

## AFTER

![image](https://user-images.githubusercontent.com/324519/151481638-12bf2ec6-b242-4d40-a9cd-17030fb20a25.png)

