### PR TITLE
[main] [ML] Functional tests - only check expected fields in jobs_summary response (#123939)

### DIFF
--- a/x-pack/test/api_integration/apis/ml/jobs/jobs_summary.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/jobs_summary.ts
@@ -304,7 +304,10 @@ export default ({ getService }: FtrProviderContext) => {
             if (expectedJob.fullJob) {
               expect(actualJob).to.have.property('fullJob');
               expect(actualJob.fullJob).to.have.property('analysis_config');
-              expect(actualJob.fullJob.analysis_config).to.eql(expectedJob.fullJob.analysis_config);
+              // only validate the expected parts of the analysis_config, ignore additional fields
+              for (const [key, value] of Object.entries(expectedJob.fullJob.analysis_config)) {
+                expect(actualJob.fullJob.analysis_config).to.have.property(key).eql(value);
+              }
             } else {
               expect(actualJob).not.to.have.property('fullJob');
             }


### PR DESCRIPTION
# Backport

This is an automatic backport to `main` of:
 - #123939

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
