### PR TITLE
Add Tail-based sampling settings

### DIFF
--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/index.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/index.tsx
@@ -13,7 +13,10 @@ import {
   getRUMSettings,
   isRUMFormValid,
 } from './settings_definition/rum_settings';
-import { getTailSamplingSettings } from './settings_definition/tail_sampling_settings';
+import {
+  getTailSamplingSettings,
+  isTailBasedSamplingValid,
+} from './settings_definition/tail_sampling_settings';
 import {
   getTLSSettings,
   isTLSFormValid,
@@ -60,7 +63,8 @@ export function APMPolicyForm({
       isSettingsFormValid(apmSettings, newVars) &&
       isRUMFormValid(newVars, rumSettings) &&
       isTLSFormValid(newVars, tlsSettings) &&
-      isSettingsFormValid(agentAuthorizationSettings, newVars);
+      isSettingsFormValid(agentAuthorizationSettings, newVars) &&
+      isTailBasedSamplingValid(newVars, tailSamplingSettings);
 
     updateAPMPolicy(newVars, isFormValid);
   }

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/index.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/index.tsx
@@ -13,6 +13,7 @@ import {
   getRUMSettings,
   isRUMFormValid,
 } from './settings_definition/rum_settings';
+import { getTailSamplingSettings } from './settings_definition/tail_sampling_settings';
 import {
   getTLSSettings,
   isTLSFormValid,
@@ -32,17 +33,23 @@ export function APMPolicyForm({
   isCloudPolicy,
   updateAPMPolicy,
 }: Props) {
-  const { apmSettings, rumSettings, tlsSettings, agentAuthorizationSettings } =
-    useMemo(() => {
-      return {
-        apmSettings: getApmSettings({ isCloudPolicy }),
-        rumSettings: getRUMSettings(),
-        tlsSettings: getTLSSettings(),
-        agentAuthorizationSettings: getAgentAuthorizationSettings({
-          isCloudPolicy,
-        }),
-      };
-    }, [isCloudPolicy]);
+  const {
+    apmSettings,
+    rumSettings,
+    tlsSettings,
+    agentAuthorizationSettings,
+    tailSamplingSettings,
+  } = useMemo(() => {
+    return {
+      apmSettings: getApmSettings({ isCloudPolicy }),
+      rumSettings: getRUMSettings(),
+      tlsSettings: getTLSSettings(),
+      agentAuthorizationSettings: getAgentAuthorizationSettings({
+        isCloudPolicy,
+      }),
+      tailSamplingSettings: getTailSamplingSettings(),
+    };
+  }, [isCloudPolicy]);
 
   function handleFormChange(key: string, value: any) {
     // Merge new key/value with the rest of fields
@@ -59,6 +66,21 @@ export function APMPolicyForm({
   }
 
   const settingsSections: SettingsSection[] = [
+    {
+      id: 'tailSampling',
+      title: i18n.translate(
+        'xpack.apm.fleet_integration.settings.tailSampling.settings.title',
+        { defaultMessage: 'Tail-based sampling' }
+      ),
+      subtitle: i18n.translate(
+        'xpack.apm.fleet_integration.settings.tailSampling.settings.subtitle',
+        {
+          defaultMessage: 'Manage tail-based sampling for services and traces.',
+        }
+      ),
+      settings: tailSamplingSettings,
+      isBeta: true,
+    },
     {
       id: 'apm',
       title: i18n.translate(

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/index.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/index.tsx
@@ -14,6 +14,7 @@ import {
   isRUMFormValid,
 } from './settings_definition/rum_settings';
 import {
+  TAIL_SAMPLING_ENABLED_KEY,
   getTailSamplingSettings,
   isTailBasedSamplingValid,
 } from './settings_definition/tail_sampling_settings';
@@ -71,22 +72,6 @@ export function APMPolicyForm({
 
   const settingsSections: SettingsSection[] = [
     {
-      id: 'tailSampling',
-      title: i18n.translate(
-        'xpack.apm.fleet_integration.settings.tailSampling.settings.title',
-        { defaultMessage: 'Tail-based sampling' }
-      ),
-      subtitle: i18n.translate(
-        'xpack.apm.fleet_integration.settings.tailSampling.settings.subtitle',
-        {
-          defaultMessage: 'Manage tail-based sampling for services and traces.',
-        }
-      ),
-      settings: tailSamplingSettings,
-      isBeta: true,
-      isPlatinumLicence: true,
-    },
-    {
       id: 'apm',
       title: i18n.translate(
         'xpack.apm.fleet_integration.settings.apm.settings.title',
@@ -130,6 +115,27 @@ export function APMPolicyForm({
       ),
       settings: agentAuthorizationSettings,
     },
+    ...(vars[TAIL_SAMPLING_ENABLED_KEY]
+      ? [
+          {
+            id: 'tailSampling',
+            title: i18n.translate(
+              'xpack.apm.fleet_integration.settings.tailSampling.settings.title',
+              { defaultMessage: 'Tail-based sampling' }
+            ),
+            subtitle: i18n.translate(
+              'xpack.apm.fleet_integration.settings.tailSampling.settings.subtitle',
+              {
+                defaultMessage:
+                  'Manage tail-based sampling for services and traces.',
+              }
+            ),
+            settings: tailSamplingSettings,
+            isBeta: true,
+            isPlatinumLicence: true,
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/index.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/index.tsx
@@ -84,6 +84,7 @@ export function APMPolicyForm({
       ),
       settings: tailSamplingSettings,
       isBeta: true,
+      isPlatinumLicence: true,
     },
     {
       id: 'apm',

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.test.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.test.ts
@@ -18,7 +18,7 @@ describe('tail_sampling_settings - isTailBasedSamplingFormValid', () => {
         tail_sampling_enabled: { value: true, type: 'bool' },
         tail_sampling_interval: { value: '3s', type: 'text' },
         tail_sampling_policies: {
-          value: 'policies:\n  - sample_rate: 0.1',
+          value: 'testValue',
           type: 'yaml',
         },
       },
@@ -34,7 +34,7 @@ describe('tail_sampling_settings - isTailBasedSamplingFormValid', () => {
         tail_sampling_enabled: { value: true, type: 'bool' },
         tail_sampling_interval: { value: '1ms', type: 'text' },
         tail_sampling_policies: {
-          value: 'policies:\n  - sample_rate: 0.1',
+          value: 'testValue',
           type: 'yaml',
         },
       },

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.test.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  getTailSamplingSettings,
+  isTailBasedSamplingValid,
+} from './tail_sampling_settings';
+
+describe('tail_sampling_settings - isTailBasedSamplingFormValid', () => {
+  it('return true when tail_sampling_interval is greater than 1s', () => {
+    const settings = getTailSamplingSettings();
+    const isValid = isTailBasedSamplingValid(
+      {
+        tail_sampling_enabled: { value: true, type: 'bool' },
+        tail_sampling_interval: { value: '3s', type: 'text' },
+        tail_sampling_policies: {
+          value: 'policies:\n  - sample_rate: 0.1',
+          type: 'yaml',
+        },
+      },
+      settings
+    );
+    expect(isValid).toBe(true);
+  });
+
+  it('return false when tail_sampling_interval is less than 1s', () => {
+    const settings = getTailSamplingSettings();
+    const isValid = isTailBasedSamplingValid(
+      {
+        tail_sampling_enabled: { value: true, type: 'bool' },
+        tail_sampling_interval: { value: '1ms', type: 'text' },
+        tail_sampling_policies: {
+          value: 'policies:\n  - sample_rate: 0.1',
+          type: 'yaml',
+        },
+      },
+      settings
+    );
+    expect(isValid).toBe(false);
+  });
+
+  it('returns true when tail_sampling_enabled is disabled', () => {
+    const settings = getTailSamplingSettings();
+    const isValid = isTailBasedSamplingValid(
+      { tail_sampling_enabled: { value: false, type: 'bool' } },
+      settings
+    );
+    expect(isValid).toBe(true);
+  });
+});

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -72,14 +72,14 @@ export function getTailSamplingSettings(): SettingsRow[] {
             }
           ),
           placeholder:
-            '- service.name: string\n         service.environment: string\n         trace.name: string\n         trace.outcome: string\n         sample_rate: number',
+            'service.name: string\nservice.environment: string\ntrace.name: string\ntrace.outcome: string\nsample_rate: number',
           labelAppendLink: i18n.translate(
             'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingHelpText',
             {
               defaultMessage: 'Learn more',
             }
           ),
-          // required: true,
+          required: true,
           defaultValue: 'sample_rate: 0.1',
         },
       ],

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 import { i18n } from '@kbn/i18n';
-import { OPTIONAL_LABEL } from '../settings_form/utils';
-import { SettingsRow } from '../typings';
+import { isSettingsFormValid, OPTIONAL_LABEL } from '../settings_form/utils';
+import { PackagePolicyVars, SettingsRow } from '../typings';
 
 const TAIL_SAMPLING_ENABLED_KEY = 'tail_sampling_enabled';
 
@@ -44,6 +44,12 @@ export function getTailSamplingSettings(): SettingsRow[] {
                 'Interval for syncronisation between multiple APM Servers. Should be in the order of tens of seconds or low minutes.',
             }
           ),
+          placeholder: i18n.translate(
+            'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingIntervalPlaceholder',
+            {
+              defaultMessage: '1m',
+            }
+          ),
           labelAppend: OPTIONAL_LABEL,
           required: false,
         },
@@ -66,16 +72,28 @@ export function getTailSamplingSettings(): SettingsRow[] {
             }
           ),
           placeholder:
-            'policies:\n       - service.name: string\n         service.environment: string\n         trace.name: string\n         trace.outcome: string\n         sample_rate: number',
+            '- service.name: string\n         service.environment: string\n         trace.name: string\n         trace.outcome: string\n         sample_rate: number',
           labelAppendLink: i18n.translate(
             'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingHelpText',
             {
               defaultMessage: 'Learn more',
             }
           ),
-          required: true,
+          // required: true,
+          defaultValue: 'sample_rate: 0.1',
         },
       ],
     },
   ];
+}
+
+export function isTailBasedSamplingValid(
+  newVars: PackagePolicyVars,
+  tailSamplingSettings: SettingsRow[]
+) {
+  // only validates TBS when its flag is enabled
+  return (
+    !newVars[TAIL_SAMPLING_ENABLED_KEY].value ||
+    isSettingsFormValid(tailSamplingSettings, newVars)
+  );
 }

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -20,7 +20,7 @@ export function getTailSamplingSettings(): SettingsRow[] {
       ),
       rowDescription: i18n.translate(
         'xpack.apm.fleet_integration.settings.tailSampling.enableTailSamplingDescription',
-        { defaultMessage: 'Enable tail based sampling.' }
+        { defaultMessage: 'Enable tail-based sampling.' }
       ),
       type: 'boolean',
       settings: [

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -68,7 +68,7 @@ export function getTailSamplingSettings(): SettingsRow[] {
             'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingPoliciesDescription',
             {
               defaultMessage:
-                'Events are matched in the exact order of how policies are specified. Every policy needs to specify a sample rate. A trace needs to match all policy constraints to match a policy. Specify one policy at the end of the list with only a sample rate. This policy is applied to all traces that do not match a more fine grained policy.',
+                'Policies map trace events to a sample rate. Each policy must specify a sample rate. Trace events are matched to policies in the order specified. All policy conditions must be true for a trace event to match. Each policy list should conclude with a policy that only specifies a sample rate. This final policy is used to catch remaining trace events that don't match a stricter policy.',
             }
           ),
           placeholder:

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -41,7 +41,7 @@ export function getTailSamplingSettings(): SettingsRow[] {
             'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingIntervalDescription',
             {
               defaultMessage:
-                'Interval for syncronisation between multiple APM Servers. Should be in the order of tens of seconds or low minutes.',
+                'Interval for synchronization between multiple APM Servers. Should be in the order of tens of seconds or low minutes.',
             }
           ),
           placeholder: i18n.translate(

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { i18n } from '@kbn/i18n';
+import { OPTIONAL_LABEL } from '../settings_form/utils';
+import { SettingsRow } from '../typings';
+
+const TAIL_SAMPLING_ENABLED_KEY = 'tail_sampling_enabled';
+
+export function getTailSamplingSettings(): SettingsRow[] {
+  return [
+    {
+      key: TAIL_SAMPLING_ENABLED_KEY, // change to tail sampling key!!!
+      rowTitle: i18n.translate(
+        'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingEnabledTitle',
+        { defaultMessage: 'Enable tail-based sampling' }
+      ),
+      rowDescription: i18n.translate(
+        'xpack.apm.fleet_integration.settings.tailSampling.enableTailSamplingDescription',
+        { defaultMessage: 'Enable tail based sampling.' }
+      ),
+      type: 'boolean',
+      settings: [
+        {
+          key: 'tail_sampling_interval',
+          type: 'duration',
+          label: i18n.translate(
+            'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingInterval',
+            {
+              defaultMessage: 'Tail sampling interval',
+            }
+          ),
+          rowTitle: i18n.translate(
+            'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingIntervalTitle',
+            { defaultMessage: 'Interval' }
+          ),
+          rowDescription: i18n.translate(
+            'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingIntervalDescription',
+            {
+              defaultMessage:
+                'Interval for syncronisation between multiple APM Servers. Should be in the order of tens of seconds or low minutes.',
+            }
+          ),
+          labelAppend: OPTIONAL_LABEL,
+          required: false,
+        },
+        {
+          key: 'tail_sampling_policies',
+          type: 'area',
+          label: i18n.translate(
+            'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingPolicies',
+            { defaultMessage: 'Tail sampling policies' }
+          ),
+          rowTitle: i18n.translate(
+            'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingPoliciesTitle',
+            { defaultMessage: 'Policies' }
+          ),
+          rowDescription: i18n.translate(
+            'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingPoliciesDescription',
+            {
+              defaultMessage:
+                'Events are matched in the exact order of how policies are specified. Every policy needs to specify a sample rate. A trace needs to match all policy constraints to match a policy. Specify one policy at the end of the list with only a sample rate. This policy is applied to all traces that do not match a more fine grained policy.',
+            }
+          ),
+          placeholder:
+            'policies:\n       - service.name: string\n         service.environment: string\n         trace.name: string\n         trace.outcome: string\n         sample_rate: number',
+          labelAppendLink: i18n.translate(
+            'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingHelpText',
+            {
+              defaultMessage: 'Learn more',
+            }
+          ),
+          required: true,
+        },
+      ],
+    },
+  ];
+}

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -9,12 +9,12 @@ import { isSettingsFormValid, OPTIONAL_LABEL } from '../settings_form/utils';
 import { PackagePolicyVars, SettingsRow } from '../typings';
 import { getDurationRt } from '../../../../../common/agent_configuration/runtime_types/duration_rt';
 
-const TAIL_SAMPLING_ENABLED_KEY = 'tail_sampling_enabled';
+export const TAIL_SAMPLING_ENABLED_KEY = 'tail_sampling_enabled';
 
 export function getTailSamplingSettings(): SettingsRow[] {
   return [
     {
-      key: TAIL_SAMPLING_ENABLED_KEY, // change to tail sampling key!!!
+      key: TAIL_SAMPLING_ENABLED_KEY,
       rowTitle: i18n.translate(
         'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingEnabledTitle',
         { defaultMessage: 'Enable tail-based sampling' }

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -7,6 +7,7 @@
 import { i18n } from '@kbn/i18n';
 import { isSettingsFormValid, OPTIONAL_LABEL } from '../settings_form/utils';
 import { PackagePolicyVars, SettingsRow } from '../typings';
+import { getDurationRt } from '../../../../../common/agent_configuration/runtime_types/duration_rt';
 
 const TAIL_SAMPLING_ENABLED_KEY = 'tail_sampling_enabled';
 
@@ -52,10 +53,11 @@ export function getTailSamplingSettings(): SettingsRow[] {
           ),
           labelAppend: OPTIONAL_LABEL,
           required: false,
+          validation: getDurationRt({ min: '1s' }),
         },
         {
           key: 'tail_sampling_policies',
-          type: 'area',
+          type: 'yaml',
           label: i18n.translate(
             'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingPolicies',
             { defaultMessage: 'Tail sampling policies' }
@@ -80,7 +82,7 @@ export function getTailSamplingSettings(): SettingsRow[] {
             }
           ),
           required: true,
-          defaultValue: 'sample_rate: 0.1',
+          defaultValue: 'policies:\n  - sample_rate: 0.1',
         },
       ],
     },

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -45,12 +45,6 @@ export function getTailSamplingSettings(): SettingsRow[] {
                 'Interval for synchronization between multiple APM Servers. Should be in the order of tens of seconds or low minutes.',
             }
           ),
-          placeholder: i18n.translate(
-            'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingIntervalPlaceholder',
-            {
-              defaultMessage: '1m',
-            }
-          ),
           labelAppend: OPTIONAL_LABEL,
           required: false,
           validation: getDurationRt({ min: '1s' }),
@@ -73,8 +67,6 @@ export function getTailSamplingSettings(): SettingsRow[] {
                 'Policies map trace events to a sample rate. Each policy must specify a sample rate. Trace events are matched to policies in the order specified. All policy conditions must be true for a trace event to match. Each policy list should conclude with a policy that only specifies a sample rate. This final policy is used to catch remaining trace events that don’t match a stricter policy.',
             }
           ),
-          placeholder:
-            'service.name: string\nservice.environment: string\ntrace.name: string\ntrace.outcome: string\nsample_rate: number',
           labelAppendLink: i18n.translate(
             'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingHelpText',
             {
@@ -82,7 +74,6 @@ export function getTailSamplingSettings(): SettingsRow[] {
             }
           ),
           required: true,
-          defaultValue: 'policies:\n  - sample_rate: 0.1',
         },
       ],
     },

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -67,12 +67,6 @@ export function getTailSamplingSettings(): SettingsRow[] {
                 'Policies map trace events to a sample rate. Each policy must specify a sample rate. Trace events are matched to policies in the order specified. All policy conditions must be true for a trace event to match. Each policy list should conclude with a policy that only specifies a sample rate. This final policy is used to catch remaining trace events that don’t match a stricter policy.',
             }
           ),
-          labelAppendLink: i18n.translate(
-            'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingHelpText',
-            {
-              defaultMessage: 'Learn more',
-            }
-          ),
           required: true,
         },
       ],

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.ts
@@ -68,7 +68,7 @@ export function getTailSamplingSettings(): SettingsRow[] {
             'xpack.apm.fleet_integration.settings.tailSampling.tailSamplingPoliciesDescription',
             {
               defaultMessage:
-                'Policies map trace events to a sample rate. Each policy must specify a sample rate. Trace events are matched to policies in the order specified. All policy conditions must be true for a trace event to match. Each policy list should conclude with a policy that only specifies a sample rate. This final policy is used to catch remaining trace events that don't match a stricter policy.',
+                'Policies map trace events to a sample rate. Each policy must specify a sample rate. Trace events are matched to policies in the order specified. All policy conditions must be true for a trace event to match. Each policy list should conclude with a policy that only specifies a sample rate. This final policy is used to catch remaining trace events that don’t match a stricter policy.',
             }
           ),
           placeholder:

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/form_row_setting.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/form_row_setting.tsx
@@ -62,6 +62,7 @@ export function FormRowSetting({ row, value, onChange }: Props) {
     case 'area': {
       return (
         <EuiTextArea
+          placeholder={row.placeholder}
           value={value}
           onChange={(e) => {
             onChange(row.key, e.target.value);

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/form_row_setting.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/form_row_setting.tsx
@@ -51,6 +51,7 @@ export function FormRowSetting({ row, value, onChange }: Props) {
       return (
         <EuiFieldText
           readOnly={row.readOnly}
+          placeholder={row.placeholder}
           value={value}
           prepend={row.readOnly ? <EuiIcon type="lock" /> : undefined}
           onChange={(e) => {
@@ -64,6 +65,7 @@ export function FormRowSetting({ row, value, onChange }: Props) {
         <EuiTextArea
           placeholder={row.placeholder}
           value={value}
+          defaultValue={row.defaultValue}
           onChange={(e) => {
             onChange(row.key, e.target.value);
           }}
@@ -74,6 +76,7 @@ export function FormRowSetting({ row, value, onChange }: Props) {
     case 'integer': {
       return (
         <EuiFieldNumber
+          placeholder={row.placeholder}
           value={value}
           onChange={(e) => {
             onChange(row.key, e.target.value);

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/form_row_setting.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/form_row_setting.tsx
@@ -57,7 +57,6 @@ export function FormRowSetting({ row, value, onChange }: Props) {
       return (
         <EuiFieldText
           readOnly={row.readOnly}
-          placeholder={row.placeholder}
           value={value}
           prepend={row.readOnly ? <EuiIcon type="lock" /> : undefined}
           onChange={(e) => {
@@ -69,9 +68,7 @@ export function FormRowSetting({ row, value, onChange }: Props) {
     case 'area': {
       return (
         <EuiTextArea
-          placeholder={row.placeholder}
           value={value}
-          defaultValue={row.defaultValue}
           onChange={(e) => {
             onChange(row.key, e.target.value);
           }}
@@ -82,7 +79,6 @@ export function FormRowSetting({ row, value, onChange }: Props) {
     case 'integer': {
       return (
         <EuiFieldNumber
-          placeholder={row.placeholder}
           value={value}
           onChange={(e) => {
             onChange(row.key, e.target.value);
@@ -123,7 +119,7 @@ export function FormRowSetting({ row, value, onChange }: Props) {
             languageId="yaml"
             width="100%"
             height="300px"
-            value={value || row.defaultValue}
+            value={value}
             onChange={(val) => {
               onChange(row.key, val);
             }}

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/form_row_setting.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/form_row_setting.tsx
@@ -15,8 +15,14 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
+import styled from 'styled-components';
 import { FormRowOnChange } from './';
 import { SettingsRow } from '../typings';
+import { CodeEditor } from '../../../../../../../../src/plugins/kibana_react/public';
+
+const FixedHeightDiv = styled.div`
+  height: 300px;
+`;
 
 interface Props {
   row: SettingsRow;
@@ -108,6 +114,43 @@ export function FormRowSetting({ row, value, onChange }: Props) {
           }}
           isClearable={true}
         />
+      );
+    }
+    case 'yaml': {
+      return (
+        <FixedHeightDiv>
+          <CodeEditor
+            languageId="yaml"
+            width="100%"
+            height="300px"
+            value={value || row.defaultValue}
+            onChange={(val) => {
+              onChange(row.key, val);
+            }}
+            options={{
+              minimap: {
+                enabled: false,
+              },
+              ariaLabel: i18n.translate(
+                'xpack.apm.fleet_integration.settings.yamlCodeEditor',
+                {
+                  defaultMessage: 'YAML Code Editor',
+                }
+              ),
+              scrollBeyondLastLine: false,
+              wordWrap: 'off',
+              wrappingIndent: 'indent',
+              tabSize: 2,
+              // To avoid left margin
+              lineNumbers: 'off',
+              lineNumbersMinChars: 0,
+              glyphMargin: false,
+              folding: false,
+              lineDecorationsWidth: 0,
+              overviewRulerBorder: false,
+            }}
+          />
+        </FixedHeightDiv>
       );
     }
     default:

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/form_row_setting.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/form_row_setting.tsx
@@ -124,23 +124,17 @@ export function FormRowSetting({ row, value, onChange }: Props) {
               onChange(row.key, val);
             }}
             options={{
-              minimap: {
-                enabled: false,
-              },
               ariaLabel: i18n.translate(
                 'xpack.apm.fleet_integration.settings.yamlCodeEditor',
                 {
                   defaultMessage: 'YAML Code Editor',
                 }
               ),
-              scrollBeyondLastLine: false,
               wordWrap: 'off',
-              wrappingIndent: 'indent',
               tabSize: 2,
               // To avoid left margin
               lineNumbers: 'off',
               lineNumbersMinChars: 0,
-              glyphMargin: false,
               folding: false,
               lineDecorationsWidth: 0,
               overviewRulerBorder: false,

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/index.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/index.tsx
@@ -14,6 +14,8 @@ import {
   EuiPanel,
   EuiText,
   EuiTitle,
+  EuiBetaBadge,
+  EuiLink,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
@@ -64,9 +66,16 @@ function FormRow({
             error={isValid ? undefined : message}
             helpText={<EuiText size="xs">{row.helpText}</EuiText>}
             labelAppend={
-              <EuiText size="xs" color="subdued">
-                {row.labelAppend}
-              </EuiText>
+              row.labelAppendLink ? (
+                <EuiText size="xs">
+                  {' '}
+                  <EuiLink>{row.labelAppendLink}</EuiLink>
+                </EuiText>
+              ) : (
+                <EuiText size="xs" color="subdued">
+                  {row.labelAppend}
+                </EuiText>
+              )
             }
           >
             <FormRowSetting row={row} onChange={onChange} value={value} />
@@ -86,6 +95,7 @@ export interface SettingsSection {
   title: string;
   subtitle?: string;
   settings: SettingsRow[];
+  isBeta?: boolean;
 }
 
 interface Props {
@@ -95,13 +105,22 @@ interface Props {
 }
 
 export function SettingsForm({ settingsSection, vars, onChange }: Props) {
-  const { title, subtitle, settings } = settingsSection;
+  const { title, subtitle, settings, isBeta } = settingsSection;
   return (
     <EuiPanel>
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem>
           <EuiTitle size="s">
-            <h3>{title}</h3>
+            <h3>
+              {title} &nbsp;
+              {isBeta && (
+                <EuiBetaBadge
+                  color="subdued"
+                  label="Beta"
+                  tooltipContent="This module is not GA. Please help us by reporting any bugs."
+                />
+              )}
+            </h3>
           </EuiTitle>
         </EuiFlexItem>
         {subtitle && (

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/index.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/index.tsx
@@ -96,6 +96,7 @@ export interface SettingsSection {
   subtitle?: string;
   settings: SettingsRow[];
   isBeta?: boolean;
+  isPlatinumLicence?: boolean;
 }
 
 interface Props {
@@ -105,7 +106,8 @@ interface Props {
 }
 
 export function SettingsForm({ settingsSection, vars, onChange }: Props) {
-  const { title, subtitle, settings, isBeta } = settingsSection;
+  const { title, subtitle, settings, isBeta, isPlatinumLicence } =
+    settingsSection;
   return (
     <EuiPanel>
       <EuiFlexGroup direction="column" gutterSize="s">
@@ -113,11 +115,40 @@ export function SettingsForm({ settingsSection, vars, onChange }: Props) {
           <EuiTitle size="s">
             <h3>
               {title} &nbsp;
+              {isPlatinumLicence && (
+                <EuiBetaBadge
+                  label={i18n.translate(
+                    'xpack.apm.fleet_integration.settings.platinumBadgeLabel',
+                    {
+                      defaultMessage: 'Platinum',
+                    }
+                  )}
+                  tooltipContent={i18n.translate(
+                    'xpack.apm.fleet_integration.settings.platinumBadgeDescription',
+                    {
+                      defaultMessage:
+                        'Configurations are saved but ignored if your Kibana licence is not Platinum.',
+                    }
+                  )}
+                />
+              )}
+              &nbsp;
               {isBeta && (
                 <EuiBetaBadge
                   color="subdued"
-                  label="Beta"
-                  tooltipContent="This module is not GA. Please help us by reporting any bugs."
+                  label={i18n.translate(
+                    'xpack.apm.fleet_integration.settings.betaBadgeLabel',
+                    {
+                      defaultMessage: 'Beta',
+                    }
+                  )}
+                  tooltipContent={i18n.translate(
+                    'xpack.apm.fleet_integration.settings.betaBadgeTooltip',
+                    {
+                      defaultMessage:
+                        'This module is not GA. Please help us by reporting any bugs.',
+                    }
+                  )}
                 />
               )}
             </h3>

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/index.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/index.tsx
@@ -15,7 +15,6 @@ import {
   EuiText,
   EuiTitle,
   EuiBetaBadge,
-  EuiLink,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
@@ -66,16 +65,9 @@ function FormRow({
             error={isValid ? undefined : message}
             helpText={<EuiText size="xs">{row.helpText}</EuiText>}
             labelAppend={
-              row.labelAppendLink ? (
-                <EuiText size="xs">
-                  {' '}
-                  <EuiLink>{row.labelAppendLink}</EuiLink>
-                </EuiText>
-              ) : (
-                <EuiText size="xs" color="subdued">
-                  {row.labelAppend}
-                </EuiText>
-              )
+              <EuiText size="xs" color="subdued">
+                {row.labelAppend}
+              </EuiText>
             }
           >
             <FormRowSetting row={row} onChange={onChange} value={value} />

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/index.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/index.tsx
@@ -123,8 +123,14 @@ export function SettingsForm({ settingsSection, vars, onChange }: Props) {
                       defaultMessage: 'Platinum',
                     }
                   )}
+                  title={i18n.translate(
+                    'xpack.apm.fleet_integration.settings.platinumBadgeTooltipTitle',
+                    {
+                      defaultMessage: 'Platinum license required',
+                    }
+                  )}
                   tooltipContent={i18n.translate(
-                    'xpack.apm.fleet_integration.settings.platinumBadgeDescription',
+                    'xpack.apm.fleet_integration.settings.platinumBadgeTooltipDescription',
                     {
                       defaultMessage:
                         'Configurations are saved but ignored if your Kibana licence is not Platinum.',

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/typings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/typings.ts
@@ -35,7 +35,8 @@ export interface BasicSettingRow {
     | 'boolean'
     | 'integer'
     | 'bytes'
-    | 'duration';
+    | 'duration'
+    | 'yaml';
   key: string;
   rowTitle?: string;
   rowDescription?: string;

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/typings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/typings.ts
@@ -43,6 +43,7 @@ export interface BasicSettingRow {
   helpText?: string;
   placeholder?: string;
   labelAppend?: string;
+  labelAppendLink?: string;
   settings?: SettingsRow[];
   validation?: SettingValidation;
   required?: boolean;

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/typings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/typings.ts
@@ -48,6 +48,7 @@ export interface BasicSettingRow {
   validation?: SettingValidation;
   required?: boolean;
   readOnly?: boolean;
+  defaultValue?: any;
 }
 
 export type SettingsRow = BasicSettingRow | AdvancedSettingRow;

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/typings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/typings.ts
@@ -44,7 +44,6 @@ export interface BasicSettingRow {
   helpText?: string;
   placeholder?: string;
   labelAppend?: string;
-  labelAppendLink?: string;
   settings?: SettingsRow[];
   validation?: SettingValidation;
   required?: boolean;

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/typings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/typings.ts
@@ -49,7 +49,6 @@ export interface BasicSettingRow {
   validation?: SettingValidation;
   required?: boolean;
   readOnly?: boolean;
-  defaultValue?: any;
 }
 
 export type SettingsRow = BasicSettingRow | AdvancedSettingRow;

--- a/x-pack/plugins/apm/server/routes/fleet/get_apm_package_policy_definition.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/get_apm_package_policy_definition.ts
@@ -279,4 +279,16 @@ export const apmConfigMapping: Record<
     name: 'anonymous_rate_limit_event_limit',
     type: 'integer',
   },
+  'apm-server.sampling.tail.enabled': {
+    name: 'tail_sampling_enabled',
+    type: 'bool',
+  },
+  'apm-server.sampling.tail.interval': {
+    name: 'tail_sampling_interval',
+    type: 'text',
+  },
+  'apm-server.sampling.tail.policies': {
+    name: 'tail_sampling_policies',
+    type: 'yaml',
+  },
 };


### PR DESCRIPTION
## Summary
Adds new configuration options for tail-based sampling to the APM Integration.

Requires `8.1.0-dev3` version of the `apmpackage`.

https://user-images.githubusercontent.com/5831975/151856820-86629e11-4b22-453d-8a19-8f8be84489a9.mov

Closes #121534

## Todo
- [ ] Add a link to the docs for the tail sampling policies field (Learn more)