### PR TITLE
[Security Solution][Endpoint] Remove check for `fleet.all` authz

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.ts
@@ -24,7 +24,7 @@ export const calculateEndpointAuthz = (
   userRoles: MaybeImmutable<string[]>
 ): EndpointAuthz => {
   const isPlatinumPlusLicense = licenseService.isPlatinumPlus();
-  const hasAllAccessToFleet = fleetAuthz.fleet.all || userRoles.includes('superuser');
+  const hasAllAccessToFleet = userRoles.includes('superuser');
 
   return {
     canAccessFleet: hasAllAccessToFleet,

--- a/x-pack/plugins/security_solution/server/endpoint/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/mocks.ts
@@ -100,6 +100,7 @@ export const createMockEndpointAppContextServiceStartContract =
     const logger = loggingSystemMock.create().get('mock_endpoint_app_context');
     const casesClientMock = createCasesClientMock();
     const savedObjectsStart = savedObjectsServiceMock.createStartContract();
+    const security = securityMock.createStart();
     const agentService = createMockAgentService();
     const agentPolicyService = createMockAgentPolicyService();
     const packagePolicyService = createPackagePolicyServiceMock();
@@ -129,6 +130,11 @@ export const createMockEndpointAppContextServiceStartContract =
       };
     });
 
+    // Make current user have `superuser` role by default
+    security.authc.getCurrentUser.mockReturnValue(
+      securityMock.createMockAuthenticatedUser({ roles: ['superuser'] })
+    );
+
     return {
       agentService,
       agentPolicyService,
@@ -139,7 +145,7 @@ export const createMockEndpointAppContextServiceStartContract =
       packageService,
       fleetAuthzService: createFleetAuthzServiceMock(),
       manifestManager: getManifestManagerMock(),
-      security: securityMock.createStart(),
+      security,
       alerting: alertsMock.createStart(),
       config,
       licenseService: createLicenseServiceMock(),

--- a/x-pack/plugins/security_solution/server/lists_integration/endpoint/validators/base_validator.test.ts
+++ b/x-pack/plugins/security_solution/server/lists_integration/endpoint/validators/base_validator.test.ts
@@ -20,6 +20,7 @@ import {
   BY_POLICY_ARTIFACT_TAG_PREFIX,
   GLOBAL_ARTIFACT_TAG,
 } from '../../../../common/endpoint/service/artifacts';
+import { securityMock } from '../../../../../security/server/mocks';
 
 describe('When using Artifacts Exceptions BaseValidator', () => {
   let endpointAppContextServices: EndpointAppContextService;
@@ -47,6 +48,9 @@ describe('When using Artifacts Exceptions BaseValidator', () => {
         const fleetAuthz = createFleetAuthzMock();
         fleetAuthz.fleet.all = false;
         (servicesStart.fleetAuthzService?.fromRequest as jest.Mock).mockResolvedValue(fleetAuthz);
+        (servicesStart.security.authc.getCurrentUser as jest.Mock).mockReturnValue(
+          securityMock.createMockAuthenticatedUser()
+        );
       }
 
       if (withBasicLicense) {


### PR DESCRIPTION
## Summary

- Removes the check done against `fleet.all` authz, ensuring that in order to access Endpoint management functionality (for now) remains ONLY tied to `superuser` role.


