### PR TITLE
[ResponseOps] Fix cases CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -341,8 +341,8 @@
 /docs/user/alerting/ @elastic/response-ops
 /docs/management/connectors/ @elastic/response-ops
 #CC# /x-pack/plugins/stack_alerts @elastic/response-ops
-/x-pack/plugins/cases @elastic/response-ops
-/x-pack/test/cases_api_integration @elastic/response-ops
+/x-pack/plugins/cases/ @elastic/response-ops
+/x-pack/test/cases_api_integration/ @elastic/response-ops
 
 # Enterprise Search
 /x-pack/plugins/enterprise_search @elastic/enterprise-search-frontend


### PR DESCRIPTION
## Summary

Appends an `/` on cases plugin paths.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
