### PR TITLE
[Security Solution] Update trusted apps matches placeholder

### DIFF
--- a/x-pack/plugins/security_solution/common/utils/path_placeholder.ts
+++ b/x-pack/plugins/security_solution/common/utils/path_placeholder.ts
@@ -9,11 +9,11 @@ import { ConditionEntryField, OperatingSystem, TrustedAppEntryTypes } from '../e
 
 export const getPlaceholderText = () => ({
   windows: {
-    wildcard: 'C:\\sample\\**\\path.exe',
+    wildcard: 'C:\\sample\\*\\path.exe',
     exact: 'C:\\sample\\path.exe',
   },
   others: {
-    wildcard: '/opt/**/app',
+    wildcard: '/opt/*/app',
     exact: '/opt/bin',
   },
 });


### PR DESCRIPTION
## Summary

Update the placeholder in Trusted Apps for matches paths to be less confusing.

![image](https://user-images.githubusercontent.com/56395104/151580626-e16ac878-ee29-4dbb-852a-6054604363bf.png)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
