### PR TITLE
[Lens] Fixes heatmap tests flakiness

### DIFF
--- a/x-pack/test/functional/apps/lens/heatmap.ts
+++ b/x-pack/test/functional/apps/lens/heatmap.ts
@@ -9,13 +9,12 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const PageObjects = getPageObjects(['visualize', 'lens', 'common', 'header']);
+  const PageObjects = getPageObjects(['visualize', 'lens', 'common']);
   const elasticChart = getService('elasticChart');
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/124075
-  describe.skip('lens heatmap', () => {
+  describe('lens heatmap', () => {
     before(async () => {
       await PageObjects.visualize.navigateToNewVisualization();
       await PageObjects.visualize.clickVisType('lens');
@@ -99,7 +98,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should not change when passing from percentage to number', async () => {
       await testSubjects.click('lnsPalettePanel_dynamicColoring_rangeType_groups_number');
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.lens.waitForVisualization();
 
       const debugState = await PageObjects.lens.getCurrentChartDebugState();
 
@@ -125,7 +124,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.setValue('lnsPalettePanel_dynamicColoring_range_value_0', '0', {
         clearWithKeyboard: true,
       });
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.lens.waitForVisualization();
 
       const debugState = await PageObjects.lens.getCurrentChartDebugState();
 
@@ -145,7 +144,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should reset stop numbers when changing palette', async () => {
       await PageObjects.lens.changePaletteTo('status');
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.lens.waitForVisualization();
 
       const debugState = await PageObjects.lens.getCurrentChartDebugState();
 
@@ -165,7 +164,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should not change when passing from number to percent', async () => {
       await testSubjects.click('lnsPalettePanel_dynamicColoring_rangeType_groups_percent');
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.lens.waitForVisualization();
 
       const debugState = await PageObjects.lens.getCurrentChartDebugState();
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/124075

This test is flaky because the chart hasn't applied the changed depicted to the color stops UI. I changed it to wait for the chart to load and not the header. I also changed all other tests that are using header and not lens function.

Flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/124
(I run it 100 times)

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios