### PR TITLE
[Uptime][Monitor Management UI]Add sorting to Monitor Management monitors list table.

### DIFF
--- a/x-pack/plugins/uptime/common/runtime_types/monitor_management/state.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/monitor_management/state.ts
@@ -10,6 +10,8 @@ import * as t from 'io-ts';
 export const FetchMonitorManagementListQueryArgsType = t.partial({
   page: t.number,
   perPage: t.number,
+  sortField: t.string,
+  sortOrder: t.union([t.literal('desc'), t.literal('asc')]),
   search: t.string,
   searchFields: t.array(t.string),
 });

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/actions.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/actions.test.tsx
@@ -18,11 +18,11 @@ import { spyOnUseFetcher } from '../../../lib/helper/spy_use_fetcher';
 import { Actions } from './actions';
 
 describe('<Actions />', () => {
-  const setRefresh = jest.fn();
+  const onUpdate = jest.fn();
   const useFetcher = spyOnUseFetcher({});
 
   it('navigates to edit monitor flow on edit pencil', () => {
-    render(<Actions id="test-id" setRefresh={setRefresh} />);
+    render(<Actions id="test-id" onUpdate={onUpdate} />);
 
     expect(screen.getByLabelText('Edit monitor')).toHaveAttribute(
       'href',
@@ -34,7 +34,7 @@ describe('<Actions />', () => {
     useFetcher.mockImplementation(originalUseFetcher);
     const deleteMonitor = jest.spyOn(fetchers, 'deleteMonitor');
     const id = 'test-id';
-    render(<Actions id={id} setRefresh={setRefresh} />);
+    render(<Actions id={id} onUpdate={onUpdate} />);
 
     expect(deleteMonitor).not.toBeCalled();
 
@@ -45,11 +45,11 @@ describe('<Actions />', () => {
 
   it('calls set refresh when deletion is successful', () => {
     const id = 'test-id';
-    render(<Actions id={id} setRefresh={setRefresh} />);
+    render(<Actions id={id} onUpdate={onUpdate} />);
 
     userEvent.click(screen.getByLabelText('Delete monitor'));
 
-    expect(setRefresh).toBeCalledWith(true);
+    expect(onUpdate).toBeCalledWith(true);
   });
 
   it('shows loading spinner while waiting for monitor to delete', () => {
@@ -59,7 +59,7 @@ describe('<Actions />', () => {
       status: FETCH_STATUS.LOADING,
       refetch: () => {},
     });
-    render(<Actions id={id} setRefresh={setRefresh} />);
+    render(<Actions id={id} onUpdate={onUpdate} />);
 
     expect(screen.getByLabelText('Deleting monitor...')).toBeInTheDocument();
   });

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/actions.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/actions.test.tsx
@@ -49,7 +49,7 @@ describe('<Actions />', () => {
 
     userEvent.click(screen.getByLabelText('Delete monitor'));
 
-    expect(onUpdate).toBeCalledWith(true);
+    expect(onUpdate).toHaveBeenCalled();
   });
 
   it('shows loading spinner while waiting for monitor to delete', () => {

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/actions.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/actions.tsx
@@ -15,11 +15,11 @@ import { useKibana } from '../../../../../../../src/plugins/kibana_react/public'
 
 interface Props {
   id: string;
-  setRefresh: React.Dispatch<React.SetStateAction<boolean>>;
+  onUpdate: React.Dispatch<React.SetStateAction<boolean>>;
   isDisabled?: boolean;
 }
 
-export const Actions = ({ id, setRefresh, isDisabled }: Props) => {
+export const Actions = ({ id, onUpdate, isDisabled }: Props) => {
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
   const { basePath } = useContext(UptimeSettingsContext);
 
@@ -46,13 +46,13 @@ export const Actions = ({ id, setRefresh, isDisabled }: Props) => {
         toastLifeTimeMs: 3000,
       });
     } else if (status === FETCH_STATUS.SUCCESS) {
-      setRefresh(true);
+      onUpdate();
       notifications.toasts.success({
         title: <p data-test-subj="uptimeDeleteMonitorSuccess">{MONITOR_DELETE_SUCCESS_LABEL}</p>,
         toastLifeTimeMs: 3000,
       });
     }
-  }, [setIsDeleting, setRefresh, notifications.toasts, status]);
+  }, [setIsDeleting, onUpdate, notifications.toasts, status]);
 
   // TODO: Add popovers to icons
   return (

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/actions.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/actions.tsx
@@ -15,8 +15,8 @@ import { useKibana } from '../../../../../../../src/plugins/kibana_react/public'
 
 interface Props {
   id: string;
-  onUpdate: React.Dispatch<React.SetStateAction<boolean>>;
   isDisabled?: boolean;
+  onUpdate: () => void;
 }
 
 export const Actions = ({ id, onUpdate, isDisabled }: Props) => {

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_enabled.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_enabled.test.tsx
@@ -15,7 +15,7 @@ import { spyOnUseFetcher } from '../../../lib/helper/spy_use_fetcher';
 import { MonitorEnabled } from './monitor_enabled';
 
 describe('<MonitorEnabled />', () => {
-  const setRefresh = jest.fn();
+  const onUpdate = jest.fn();
   const testMonitor = {
     [ConfigKey.MONITOR_TYPE]: DataStream.HTTP,
     [ConfigKey.ENABLED]: true,
@@ -34,7 +34,7 @@ describe('<MonitorEnabled />', () => {
   });
 
   it('correctly renders "enabled" state', () => {
-    render(<MonitorEnabled id="test-id" monitor={testMonitor} setRefresh={setRefresh} />);
+    render(<MonitorEnabled id="test-id" monitor={testMonitor} onUpdate={onUpdate} />);
 
     const switchButton = screen.getByRole('switch') as HTMLButtonElement;
     assertMonitorEnabled(switchButton);
@@ -45,7 +45,7 @@ describe('<MonitorEnabled />', () => {
       <MonitorEnabled
         id="test-id"
         monitor={{ ...testMonitor, [ConfigKey.ENABLED]: false }}
-        setRefresh={setRefresh}
+        onUpdate={onUpdate}
       />
     );
 
@@ -54,7 +54,7 @@ describe('<MonitorEnabled />', () => {
   });
 
   it('toggles on click', () => {
-    render(<MonitorEnabled id="test-id" monitor={testMonitor} setRefresh={setRefresh} />);
+    render(<MonitorEnabled id="test-id" monitor={testMonitor} onUpdate={onUpdate} />);
 
     const switchButton = screen.getByRole('switch') as HTMLButtonElement;
     userEvent.click(switchButton);
@@ -70,7 +70,7 @@ describe('<MonitorEnabled />', () => {
       refetch: () => {},
     });
 
-    render(<MonitorEnabled id="test-id" monitor={testMonitor} setRefresh={setRefresh} />);
+    render(<MonitorEnabled id="test-id" monitor={testMonitor} onUpdate={onUpdate} />);
     const switchButton = screen.getByRole('switch') as HTMLButtonElement;
     userEvent.click(switchButton);
 

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_enabled.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_enabled.tsx
@@ -16,11 +16,11 @@ import { setMonitor } from '../../../state/api';
 interface Props {
   id: string;
   monitor: SyntheticsMonitor;
-  setRefresh: React.Dispatch<React.SetStateAction<boolean>>;
+  onUpdate: () => void;
   isDisabled?: boolean;
 }
 
-export const MonitorEnabled = ({ id, monitor, setRefresh, isDisabled }: Props) => {
+export const MonitorEnabled = ({ id, monitor, onUpdate, isDisabled }: Props) => {
   const [isEnabled, setIsEnabled] = useState<boolean | null>(null);
 
   const { notifications } = useKibana();
@@ -53,7 +53,7 @@ export const MonitorEnabled = ({ id, monitor, setRefresh, isDisabled }: Props) =
         ),
         toastLifeTimeMs: 3000,
       });
-      setRefresh(true);
+      onUpdate();
     }
   }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.test.tsx
@@ -101,76 +101,19 @@ describe('<MonitorManagementList />', () => {
     expect(onPageStateChange).toBeCalledWith(expect.objectContaining({ pageSize: 10 }));
   });
 
-  it.skip('handles refreshing and changing page when navigating to the next page', async () => {
-    render(
+  it('handles refreshing and changing page when navigating to the next page', async () => {
+    const { getByTestId } = render(
       <MonitorManagementList
         onUpdate={onUpdate}
         onPageStateChange={onPageStateChange}
         monitorList={state.monitorManagementList}
-        pageState={pageState}
+        pageState={{ ...pageState, pageSize: 3, pageIndex: 1 }}
       />,
       { state }
     );
 
-    userEvent.click(screen.getByTestId('pagination-button-next'));
+    userEvent.click(getByTestId('pagination-button-next'));
 
     expect(onPageStateChange).toBeCalledWith(expect.objectContaining({ pageIndex: 2 }));
   });
-
-  it.each([
-    [DataStream.BROWSER, ConfigKey.SOURCE_INLINE],
-    [DataStream.HTTP, ConfigKey.URLS],
-    [DataStream.TCP, ConfigKey.HOSTS],
-    [DataStream.ICMP, ConfigKey.HOSTS],
-  ])(
-    'appends inline to the monitor id for browser monitors and omits for lightweight checks',
-    (type, configKey) => {
-      const id = '123456';
-      const name = 'sample monitor';
-      const browserState = {
-        monitorManagementList: {
-          ...state.monitorManagementList,
-          list: {
-            ...state.monitorManagementList.list,
-            monitors: [
-              {
-                id,
-                attributes: {
-                  name,
-                  schedule: {
-                    unit: ScheduleUnit.MINUTES,
-                    number: '1',
-                  },
-                  [configKey]: 'test',
-                  type,
-                  tags: [`tag-1`],
-                },
-              },
-            ],
-          },
-        },
-      };
-
-      render(
-        <MonitorManagementList
-          onUpdate={onUpdate}
-          onPageStateChange={onPageStateChange}
-          monitorList={browserState.monitorManagementList as unknown as MonitorManagementListState}
-          pageState={{ ...pageState, pageIndex: 1 }}
-        />,
-        { state: browserState }
-      );
-
-      const link = screen.getByText(name) as HTMLAnchorElement;
-
-      expect(link.href).toEqual(
-        expect.stringContaining(
-          `/app/uptime/monitor/${Buffer.from(
-            `${id}${type === DataStream.BROWSER ? `-inline` : ''}`,
-            'utf8'
-          ).toString('base64')}`
-        )
-      );
-    }
-  );
 });

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.test.tsx
@@ -22,6 +22,7 @@ describe('<MonitorManagementList />', () => {
       id: `test-monitor-id-${i}`,
       attributes: {
         name: `test-monitor-${i}`,
+        enabled: true,
         schedule: {
           unit: ScheduleUnit.MINUTES,
           number: `${i}`,
@@ -58,10 +59,6 @@ describe('<MonitorManagementList />', () => {
     sortField: ConfigKey.NAME,
     sortOrder: 'asc',
   };
-
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
 
   it.each(monitors)('navigates to edit monitor flow on edit pencil', (monitor) => {
     render(
@@ -104,13 +101,13 @@ describe('<MonitorManagementList />', () => {
     expect(onPageStateChange).toBeCalledWith(expect.objectContaining({ pageSize: 10 }));
   });
 
-  it('handles refreshing and changing page when navigating to the next page', () => {
+  it.skip('handles refreshing and changing page when navigating to the next page', async () => {
     render(
       <MonitorManagementList
         onUpdate={onUpdate}
         onPageStateChange={onPageStateChange}
         monitorList={state.monitorManagementList}
-        pageState={{ ...pageState, pageIndex: 1 }}
+        pageState={pageState}
       />,
       { state }
     );

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
@@ -105,7 +105,6 @@ export const MonitorManagementList = ({
           {name}
         </EuiLink>
       ),
-      truncateText: true,
     },
     {
       align: 'left' as const,
@@ -148,6 +147,7 @@ export const MonitorManagementList = ({
       sortable: true,
       render: (urls, { hosts }) => urls || hosts,
       truncateText: true,
+      textOnly: true,
     },
     {
       align: 'left' as const,
@@ -183,7 +183,7 @@ export const MonitorManagementList = ({
         itemId="monitor_id"
         items={monitors}
         columns={columns}
-        tableLayout={'auto'}
+        tableLayout={'fixed'}
         pagination={pagination}
         sorting={sorting}
         onChange={handleOnChange}

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
@@ -18,7 +18,6 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import {
   CommonFields,
   ConfigKey,
-  DataStream,
   FetchMonitorManagementListQueryArgs,
   ICMPSimpleFields,
   MonitorFields,
@@ -29,7 +28,6 @@ import {
 import { UptimeSettingsContext } from '../../../contexts';
 import { useBreakpoints } from '../../../hooks';
 import { MonitorManagementList as MonitorManagementListState } from '../../../state/reducers/monitor_management';
-import { DataStream, MonitorFields, SyntheticsMonitor } from '../../../../common/runtime_types';
 import * as labels from '../../overview/monitor_list/translations';
 import { Actions } from './actions';
 import { MonitorEnabled } from './monitor_enabled';
@@ -172,7 +170,12 @@ export const MonitorManagementList = ({
         defaultMessage: 'Enabled',
       }),
       render: (_enabled: boolean, monitor: SyntheticsMonitorWithId) => (
-        <MonitorEnabled id={monitor.id} monitor={monitor} isDisabled={!canEdit} onUpdate={onUpdate} />
+        <MonitorEnabled
+          id={monitor.id}
+          monitor={monitor}
+          isDisabled={!canEdit}
+          onUpdate={onUpdate}
+        />
       ),
     },
     {

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
@@ -27,7 +27,7 @@ import {
   TCPSimpleFields,
 } from '../../../../common/runtime_types';
 import { UptimeSettingsContext } from '../../../contexts';
-import { MonitorManagementPageAction } from '../../../pages/monitor_management/monitor_management';
+import { useBreakpoints } from '../../../hooks';
 import { MonitorManagementList as MonitorManagementListState } from '../../../state/reducers/monitor_management';
 import { DataStream, MonitorFields, SyntheticsMonitor } from '../../../../common/runtime_types';
 import * as labels from '../../overview/monitor_list/translations';
@@ -62,6 +62,7 @@ export const MonitorManagementList = ({
   onUpdate,
 }: Props) => {
   const { basePath } = useContext(UptimeSettingsContext);
+  const isXl = useBreakpoints().up('xl');
 
   const { total } = list as MonitorManagementListState['list'];
   const monitors: SyntheticsMonitorWithId[] = useMemo(
@@ -198,7 +199,7 @@ export const MonitorManagementList = ({
         itemId="monitor_id"
         items={monitors}
         columns={columns}
-        tableLayout={'fixed'}
+        tableLayout={isXl ? 'auto' : 'fixed'}
         pagination={pagination}
         sorting={sorting}
         onChange={handleOnChange}

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
@@ -4,12 +4,21 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useContext, useMemo, useCallback } from 'react';
+import { Criteria, EuiBasicTable, EuiLink, EuiPanel, EuiSpacer } from '@elastic/eui';
+import { EuiTableSortingType } from '@elastic/eui/src/components/basic_table/table_types';
 import { i18n } from '@kbn/i18n';
-import { EuiBasicTable, EuiPanel, EuiSpacer, EuiLink } from '@elastic/eui';
-import { SyntheticsMonitorSavedObject } from '../../../../common/types';
+import React, { useCallback, useContext, useMemo } from 'react';
+import {
+  CommonFields,
+  ConfigKey,
+  DataStream,
+  FetchMonitorManagementListQueryArgs,
+  SyntheticsMonitorWithId,
+} from '../../../../common/runtime_types';
+import { UptimeSettingsContext } from '../../../contexts';
+import { MonitorManagementPageAction } from '../../../pages/monitor_management/monitor_management';
 import { MonitorManagementList as MonitorManagementListState } from '../../../state/reducers/monitor_management';
-import { MonitorFields, SyntheticsMonitor } from '../../../../common/runtime_types';
+import { DataStream, MonitorFields, SyntheticsMonitor } from '../../../../common/runtime_types';
 import { UptimeSettingsContext } from '../../../contexts';
 import { Actions } from './actions';
 import { MonitorLocations } from './monitor_locations';
@@ -18,63 +27,78 @@ import { MonitorEnabled } from './monitor_enabled';
 import * as labels from '../../overview/monitor_list/translations';
 import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
 
+export interface MonitorManagementListPageState {
+  pageIndex: number;
+  pageSize: number;
+  sortField: keyof typeof CommonFields;
+  sortOrder: FetchMonitorManagementListQueryArgs['sortOrder'];
+}
+
 interface Props {
-  setPageSize: React.Dispatch<React.SetStateAction<number>>;
-  setPageIndex: React.Dispatch<React.SetStateAction<number>>;
-  setRefresh: React.Dispatch<React.SetStateAction<boolean>>;
+  pageState: MonitorManagementListPageState;
   monitorList: MonitorManagementListState;
+  onPageStateChange: (state: MonitorManagementListPageState) => void;
+  onUpdate: () => void;
 }
 
 export const MonitorManagementList = ({
+  pageState: { pageIndex, pageSize, sortField, sortOrder },
   monitorList: {
     list,
     error: { monitorList: error },
     loading: { monitorList: loading },
   },
-  setRefresh,
-  setPageSize,
-  setPageIndex,
+  onPageStateChange,
+  onUpdate,
 }: Props) => {
-  const { total, perPage, page: pageIndex } = list as MonitorManagementListState['list'];
-  const monitors = list.monitors as SyntheticsMonitorSavedObject[];
   const { basePath } = useContext(UptimeSettingsContext);
 
-  const pagination = useMemo(
-    () => ({
-      pageIndex: pageIndex - 1, // page index for EuiBasicTable is base 0
-      pageSize: perPage,
-      totalItemCount: total || 0,
-      pageSizeOptions: [10, 25, 50, 100],
-    }),
-    [pageIndex, perPage, total]
+  const { total } = list as MonitorManagementListState['list'];
+  const monitors: SyntheticsMonitorWithId[] = useMemo(
+    () => list.monitors.map((monitor) => ({ ...monitor.attributes, id: monitor.id })),
+    [list.monitors]
   );
 
   const handleOnChange = useCallback(
-    ({ page = {} }) => {
+    ({ page = {}, sort = {} }: Criteria) => {
       const { index, size } = page;
+      const { field, direction } = sort;
 
-      setPageIndex(index + 1); // page index for Saved Objects is base 1
-      setPageSize(size);
-      setRefresh(true);
+      onPageStateChange({
+        pageIndex: index + 1, // page index for Saved Objects is base 1
+        pageSize: size,
+        sortField: field,
+        sortOrder: direction,
+      });
     },
-    [setPageIndex, setPageSize, setRefresh]
+    [onPageStateChange]
   );
+
+  const pagination = {
+    pageIndex: pageIndex - 1, // page index for EuiBasicTable is base 0
+    pageSize,
+    totalItemCount: total || 0,
+    pageSizeOptions: [10, 25, 50, 100],
+  };
+
+  const sorting: EuiTableSortingType<SyntheticsMonitorWithId> = {
+    sort: {
+      field: sortField,
+      direction: sortOrder,
+    },
+  };
 
   const canEdit: boolean = !!useKibana().services?.application?.capabilities.uptime.save;
 
-  const columns = [
+  const columns: EuiBasicTableColumn<SyntheticsMonitorWithId> = [
     {
       align: 'left' as const,
+      field: ConfigKey.NAME,
       name: i18n.translate('xpack.uptime.monitorManagement.monitorList.monitorName', {
         defaultMessage: 'Monitor name',
       }),
-      render: ({
-        attributes: { name },
-        id,
-      }: {
-        attributes: Partial<MonitorFields>;
-        id: string;
-      }) => (
+      sortable: true,
+      render: (name, { id }) => (
         <EuiLink
           href={`${basePath}/app/uptime/monitor/${Buffer.from(id, 'utf8').toString('base64')}`}
         >
@@ -85,59 +109,54 @@ export const MonitorManagementList = ({
     },
     {
       align: 'left' as const,
-      field: 'attributes',
+      field: ConfigKey.MONITOR_TYPE,
       name: i18n.translate('xpack.uptime.monitorManagement.monitorList.monitorType', {
         defaultMessage: 'Monitor type',
       }),
-      render: ({ type }: SyntheticsMonitor) => type,
+      sortable: true,
     },
     {
       align: 'left' as const,
-      field: 'attributes',
+      field: ConfigKey.TAGS,
       name: i18n.translate('xpack.uptime.monitorManagement.monitorList.tags', {
         defaultMessage: 'Tags',
       }),
-      render: ({ tags }: SyntheticsMonitor) => (tags ? <MonitorTags tags={tags} /> : null),
+      render: (tags) => (tags ? <MonitorTags tags={tags} /> : null),
     },
     {
       align: 'left' as const,
-      field: 'attributes',
+      field: ConfigKey.LOCATIONS,
       name: i18n.translate('xpack.uptime.monitorManagement.monitorList.locations', {
         defaultMessage: 'Locations',
       }),
-      render: ({ locations }: SyntheticsMonitor) =>
-        locations ? <MonitorLocations locations={locations} /> : null,
+      render: (locations) => (locations ? <MonitorLocations locations={locations} /> : null),
     },
     {
       align: 'left' as const,
-      field: 'attributes',
+      field: ConfigKey.SCHEDULE,
       name: i18n.translate('xpack.uptime.monitorManagement.monitorList.schedule', {
         defaultMessage: 'Schedule',
       }),
-      render: ({ schedule }: SyntheticsMonitor) => `@every ${schedule?.number}${schedule?.unit}`,
+      render: (schedule) => `@every ${schedule?.number}${schedule?.unit}`,
     },
     {
       align: 'left' as const,
-      field: 'attributes',
+      field: ConfigKey.URLS,
       name: i18n.translate('xpack.uptime.monitorManagement.monitorList.URL', {
         defaultMessage: 'URL',
       }),
-      render: (attributes: MonitorFields) => attributes.urls || attributes.hosts,
+      sortable: true,
+      render: (urls, { hosts }) => urls || hosts,
       truncateText: true,
     },
     {
       align: 'left' as const,
-      field: 'attributes',
+      field: ConfigKey.ENABLED,
       name: i18n.translate('xpack.uptime.monitorManagement.monitorList.enabled', {
         defaultMessage: 'Enabled',
       }),
-      render: (attributes: SyntheticsMonitor, record: SyntheticsMonitorSavedObject) => (
-        <MonitorEnabled
-          id={record.id}
-          monitor={attributes}
-          setRefresh={setRefresh}
-          isDisabled={!canEdit}
-        />
+      render: (_enabled, monitor) => (
+        <MonitorEnabled id={monitor.id} monitor={monitor} isDisabled={!canEdit} onUpdate={onUpdate} />
       ),
     },
     {
@@ -146,7 +165,7 @@ export const MonitorManagementList = ({
       name: i18n.translate('xpack.uptime.monitorManagement.monitorList.actions', {
         defaultMessage: 'Actions',
       }),
-      render: (id: string) => <Actions id={id} setRefresh={setRefresh} isDisabled={!canEdit} />,
+      render: (id: string) => <Actions id={id} isDisabled={!canEdit} onUpdate={onUpdate} />,
     },
   ];
 
@@ -166,6 +185,7 @@ export const MonitorManagementList = ({
         columns={columns}
         tableLayout={'auto'}
         pagination={pagination}
+        sorting={sorting}
         onChange={handleOnChange}
         noItemsMessage={loading ? labels.LOADING : labels.NO_DATA_MESSAGE}
       />

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_locations.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_locations.tsx
@@ -22,13 +22,13 @@ export const MonitorLocations = ({ locations }: Props) => {
   const locationsToDisplay = locations.slice(0, toDisplay);
 
   return (
-    <EuiBadgeGroup>
+    <EuiBadgeGroup css={{ width: '100%' }}>
       {locationsToDisplay.map((location: ServiceLocation) => (
         <EuiBadge
           key={location.id}
           color="hollow"
           className="eui-textTruncate"
-          style={{ maxWidth: 120 }}
+          css={{ display: 'flex', maxWidth: 120 }}
         >
           {location.label}
         </EuiBadge>

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/tags.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/tags.tsx
@@ -19,10 +19,15 @@ export const MonitorTags = ({ tags }: Props) => {
   const tagsToDisplay = tags.slice(0, toDisplay);
 
   return (
-    <EuiBadgeGroup>
+    <EuiBadgeGroup css={{ width: '100%' }}>
       {tagsToDisplay.map((tag) => (
         // filtering only makes sense in monitor list, where we have summary
-        <EuiBadge key={tag} color="hollow" className="eui-textTruncate" style={{ maxWidth: 120 }}>
+        <EuiBadge
+          key={tag}
+          color="hollow"
+          className="eui-textTruncate"
+          css={{ display: 'flex', maxWidth: 120 }}
+        >
           {tag}
         </EuiBadge>
       ))}

--- a/x-pack/plugins/uptime/public/pages/monitor_management/monitor_management.tsx
+++ b/x-pack/plugins/uptime/public/pages/monitor_management/monitor_management.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useReducer, Reducer } from 'react';
+import React, { useEffect, useReducer, useCallback, Reducer } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTrackPageview } from '../../../../observability/public';
 import { ConfigKey } from '../../../common/runtime_types';
@@ -28,6 +28,17 @@ export const MonitorManagementPage: React.FC = () => {
     }
   );
 
+  const onPageStateChange = useCallback(
+    (state) => {
+      dispatchPageAction({ type: 'update', payload: state });
+    },
+    [dispatchPageAction]
+  );
+
+  const onUpdate = useCallback(() => {
+    dispatchPageAction({ type: 'refresh' });
+  }, [dispatchPageAction]);
+
   useTrackPageview({ app: 'uptime', path: 'manage-monitors' });
   useTrackPageview({ app: 'uptime', path: 'manage-monitors', delay: 15000 });
   useMonitorManagementBreadcrumbs();
@@ -38,14 +49,14 @@ export const MonitorManagementPage: React.FC = () => {
 
   useEffect(() => {
     dispatch(getMonitors({ page: pageIndex, perPage: pageSize, sortField, sortOrder }));
-  }, [dispatch, pageIndex, pageSize, sortField, sortOrder]);
+  }, [dispatch, pageState, pageIndex, pageSize, sortField, sortOrder]);
 
   return (
     <MonitorManagementList
       pageState={pageState}
       monitorList={monitorList}
-      onPageStateChange={(state) => dispatchPageAction({ type: 'update', payload: state })}
-      onUpdate={() => dispatchPageAction({ type: 'refresh' })}
+      onPageStateChange={onPageStateChange}
+      onUpdate={onUpdate}
     />
   );
 };

--- a/x-pack/plugins/uptime/public/pages/monitor_management/monitor_management.tsx
+++ b/x-pack/plugins/uptime/public/pages/monitor_management/monitor_management.tsx
@@ -70,6 +70,6 @@ const monitorManagementPageReducer: Reducer<
     case 'refresh':
       return { ...state };
     default:
-      throw new Error(`Action "${(action as unknown)?.type}" not recognizable`);
+      throw new Error(`Action "${(action as MonitorManagementPageAction)?.type}" not recognizable`);
   }
 };

--- a/x-pack/plugins/uptime/public/pages/monitor_management/monitor_management.tsx
+++ b/x-pack/plugins/uptime/public/pages/monitor_management/monitor_management.tsx
@@ -18,15 +18,15 @@ import {
 import { useMonitorManagementBreadcrumbs } from './use_monitor_management_breadcrumbs';
 
 export const MonitorManagementPage: React.FC = () => {
-  const [pageState, dispatchPageAction] = useReducer<
-    typeof monitorManagementPageReducer,
-    MonitorManagementListPageState
-  >(monitorManagementPageReducer, {
-    pageIndex: 1, // saved objects page index is base 1
-    pageSize: 10,
-    sortOrder: 'asc',
-    sortField: ConfigKey.NAME,
-  });
+  const [pageState, dispatchPageAction] = useReducer<typeof monitorManagementPageReducer>(
+    monitorManagementPageReducer,
+    {
+      pageIndex: 1, // saved objects page index is base 1
+      pageSize: 10,
+      sortOrder: 'asc',
+      sortField: ConfigKey.NAME,
+    }
+  );
 
   useTrackPageview({ app: 'uptime', path: 'manage-monitors' });
   useTrackPageview({ app: 'uptime', path: 'manage-monitors', delay: 15000 });
@@ -34,7 +34,7 @@ export const MonitorManagementPage: React.FC = () => {
   const dispatch = useDispatch();
   const monitorList = useSelector(monitorManagementListSelector);
 
-  const { pageIndex, pageSize, sortField, sortOrder } = pageState as MonitorManagementPageState;
+  const { pageIndex, pageSize, sortField, sortOrder } = pageState as MonitorManagementListPageState;
 
   useEffect(() => {
     dispatch(getMonitors({ page: pageIndex, perPage: pageSize, sortField, sortOrder }));
@@ -58,9 +58,9 @@ type MonitorManagementPageAction =
   | { type: 'refresh' };
 
 const monitorManagementPageReducer: Reducer<
-  MonitorManagementPageState,
+  MonitorManagementListPageState,
   MonitorManagementPageAction
-> = (state: MonitorManagementPageState, action: MonitorManagementPageAction) => {
+> = (state: MonitorManagementListPageState, action: MonitorManagementPageAction) => {
   switch (action.type) {
     case 'update':
       return {
@@ -70,6 +70,6 @@ const monitorManagementPageReducer: Reducer<
     case 'refresh':
       return { ...state };
     default:
-      throw new Error(`Action "${action.type}" not recognizable`);
+      throw new Error(`Action "${(action as unknown)?.type}" not recognizable`);
   }
 };

--- a/x-pack/plugins/uptime/server/rest_api/synthetics_service/get_monitor.ts
+++ b/x-pack/plugins/uptime/server/rest_api/synthetics_service/get_monitor.ts
@@ -41,12 +41,13 @@ export const getAllSyntheticsMonitorRoute: UMRestApiRouteFactory = () => ({
     query: schema.object({
       page: schema.maybe(schema.number()),
       perPage: schema.maybe(schema.number()),
+      sortField: schema.maybe(schema.string()),
+      sortOrder: schema.maybe(schema.oneOf([schema.literal('desc'), schema.literal('asc')])),
       search: schema.maybe(schema.string()),
     }),
   },
   handler: async ({ request, savedObjectsClient }): Promise<any> => {
-    const { perPage = 50, page, search } = request.query;
-
+    const { perPage = 50, page, sortField, sortOrder, search } = request.query;
     // TODO: add query/filtering params
     const {
       saved_objects: monitors,
@@ -56,6 +57,8 @@ export const getAllSyntheticsMonitorRoute: UMRestApiRouteFactory = () => ({
       type: syntheticsMonitorType,
       perPage,
       page,
+      sortField,
+      sortOrder,
       filter: search ? `${syntheticsMonitorType}.attributes.name: ${search}` : '',
     });
     return {


### PR DESCRIPTION
Fixes #121117

## Summary

- Adds default sorting on monitor management list with records sorted _ascending_ by `name`.
- This will also fix the uncontrolled reordering of records when monitors are enabled/disabled inline.
- Makes name, type and url columns sortable.
- Adjusts column truncation and wrapping.

| Before | After |
|:---:|:---:|
|![Screenshot 2022-01-31 at 12 31 20](https://user-images.githubusercontent.com/2748376/151838482-1a29d1ec-ae36-4335-b560-8ee0c0164d0a.png)|![Screenshot 2022-01-31 at 12 10 35](https://user-images.githubusercontent.com/2748376/151838855-3ce51584-d055-4cb5-bad9-a7c205ea788b.png)|


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))





### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
