### PR TITLE
[Security Solution] [Endpoint] Address some host isolation UX search issues

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/hooks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/hooks.ts
@@ -120,7 +120,7 @@ export function useFetchHostIsolationExceptionsList({
         filter: kql,
       });
     },
-    { enabled }
+    { enabled, keepPreviousData: true }
   );
 }
 

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.test.tsx
@@ -170,9 +170,10 @@ describe('When on the host isolation exceptions page', () => {
         await waitFor(() =>
           expect(getHostIsolationExceptionItemsMock).toHaveBeenLastCalledWith({
             http: mockedContext.coreStart.http,
-            filter: undefined,
+            filter:
+              '(exception-list-agnostic.attributes.item_id:(*this*does*not*exists*) OR exception-list-agnostic.attributes.name:(*this*does*not*exists*) OR exception-list-agnostic.attributes.description:(*this*does*not*exists*) OR exception-list-agnostic.attributes.entries.value:(*this*does*not*exists*))',
             page: 1,
-            perPage: 1,
+            perPage: 10,
           })
         );
 
@@ -206,9 +207,9 @@ describe('When on the host isolation exceptions page', () => {
         await waitFor(() =>
           expect(getHostIsolationExceptionItemsMock).toHaveBeenLastCalledWith({
             http: mockedContext.coreStart.http,
-            filter: undefined,
+            filter: `((exception-list-agnostic.attributes.tags:"policy:${firstPolicy.id}"))`,
             page: 1,
-            perPage: 1,
+            perPage: 10,
           })
         );
 

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.tsx
@@ -74,9 +74,7 @@ export const HostIsolationExceptionsList = () => {
 
   const [itemToDelete, setItemToDelete] = useState<ExceptionListItemSchema | null>(null);
 
-  const includedPoliciesParam = location.included_policies;
-
-  const { isLoading, data, error, refetch } = useFetchHostIsolationExceptionsList({
+  const { isLoading, isRefetching, data, error, refetch } = useFetchHostIsolationExceptionsList({
     filter: location.filter,
     page: location.page_index,
     perPage: location.page_size,

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.tsx
@@ -50,6 +50,7 @@ type HostIsolationExceptionPaginatedContent = PaginatedContentProps<
   typeof ExceptionItem
 >;
 
+/* eslint-disable complexity */
 export const HostIsolationExceptionsList = () => {
   const history = useHistory();
   const privileges = useUserPrivileges().endpointPrivileges;
@@ -73,6 +74,8 @@ export const HostIsolationExceptionsList = () => {
   }, [memoizedRouteState]);
 
   const [itemToDelete, setItemToDelete] = useState<ExceptionListItemSchema | null>(null);
+
+  const includedPoliciesParam = location.included_policies;
 
   const { isLoading, isRefetching, data, error, refetch } = useFetchHostIsolationExceptionsList({
     filter: location.filter,
@@ -196,7 +199,9 @@ export const HostIsolationExceptionsList = () => {
     [navigateCallback]
   );
 
-  if ((isLoading || isLoadingAll) && !hasDataToShow) {
+  const isSearchLoading = isLoading || isRefetching;
+
+  if ((isSearchLoading || isLoadingAll) && !hasDataToShow) {
     return <ManagementPageLoader data-test-subj="hostIsolationExceptionListLoader" />;
   }
 
@@ -276,7 +281,7 @@ export const HostIsolationExceptionsList = () => {
         itemComponentProps={handleItemComponentProps}
         onChange={handlePaginatedContentChange}
         error={error?.message}
-        loading={isLoading}
+        loading={isSearchLoading}
         pagination={pagination}
         contentClassName="host-isolation-exceptions-container"
         data-test-subj="hostIsolationExceptionsContent"

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/assign_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/assign_flyout.tsx
@@ -277,7 +277,7 @@ export const PolicyHostIsolationExceptionsAssignFlyout = ({
           data-test-subj="hostIsolationExceptions-assignable-list"
           artifacts={exceptionsRequest.data}
           selectedArtifactIds={selectedArtifactIds}
-          isListLoading={exceptionsRequest.isLoading}
+          isListLoading={exceptionsRequest.isLoading || exceptionsRequest.isRefetching}
           selectedArtifactsUpdated={handleSelectArtifact}
         />
 

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/empty_unassigned.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/empty_unassigned.tsx
@@ -7,27 +7,26 @@
 
 import { EuiButton, EuiEmptyPrompt, EuiLink, EuiPageTemplate } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React from 'react';
-import { useHistory } from 'react-router-dom';
-import { getPolicyHostIsolationExceptionsPath } from '../../../../../common/routing';
+import React, { useCallback } from 'react';
 import { PolicyData } from '../../../../../../../common/endpoint/types';
+import { usePolicyDetailsHostIsolationExceptionsNavigateCallback } from '../../policy_hooks';
+import { useGetLinkTo } from './use_policy_host_isolation_exceptions_empty_hooks';
 
 export const PolicyHostIsolationExceptionsEmptyUnassigned = ({
   policy,
-  toHostIsolationList,
 }: {
   policy: PolicyData;
-  toHostIsolationList: string;
 }) => {
-  const history = useHistory();
-
-  const onClickPrimaryButtonHandler = () =>
-    history.push(
-      getPolicyHostIsolationExceptionsPath(policy.id, {
-        ...location,
+  const { onClickHandler, toRouteUrl } = useGetLinkTo(policy.id, policy.name);
+  const navigateCallback = usePolicyDetailsHostIsolationExceptionsNavigateCallback();
+  const onClickPrimaryButtonHandler = useCallback(
+    () =>
+      navigateCallback({
         show: 'list',
-      })
-    );
+      }),
+    [navigateCallback]
+  );
+
   return (
     <EuiPageTemplate template="centeredContent">
       <EuiEmptyPrompt
@@ -60,7 +59,8 @@ export const PolicyHostIsolationExceptionsEmptyUnassigned = ({
               defaultMessage="Assign host isolation exceptions"
             />
           </EuiButton>,
-          <EuiLink href={toHostIsolationList}>
+          // eslint-disable-next-line @elastic/eui/href-or-on-click
+          <EuiLink onClick={onClickHandler} href={toRouteUrl}>
             <FormattedMessage
               id="xpack.securitySolution.endpoint.policy.hostIsolationExceptions.empty.unassigned.secondaryAction"
               defaultMessage="Manage host isolation exceptions"

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/empty_unexisting.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/empty_unexisting.tsx
@@ -8,12 +8,16 @@
 import { EuiButton, EuiEmptyPrompt, EuiPageTemplate } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
+import { PolicyData } from '../../../../../../../common/endpoint/types';
+import { useGetLinkTo } from './use_policy_host_isolation_exceptions_empty_hooks';
 
 export const PolicyHostIsolationExceptionsEmptyUnexisting = ({
-  toHostIsolationList,
+  policy,
 }: {
-  toHostIsolationList: string;
+  policy: PolicyData;
 }) => {
+  const { onClickHandler, toRouteUrl } = useGetLinkTo(policy.id, policy.name);
+
   return (
     <EuiPageTemplate template="centeredContent">
       <EuiEmptyPrompt
@@ -34,7 +38,8 @@ export const PolicyHostIsolationExceptionsEmptyUnexisting = ({
           />
         }
         actions={
-          <EuiButton color="primary" fill href={toHostIsolationList}>
+          // eslint-disable-next-line @elastic/eui/href-or-on-click
+          <EuiButton color="primary" fill onClick={onClickHandler} href={toRouteUrl}>
             <FormattedMessage
               id="xpack.securitySolution.endpoint.policy.hostIsolationExceptions.empty.unexisting.action"
               defaultMessage="Add host isolation exceptions"

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/list.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/list.test.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { FoundExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -19,10 +18,13 @@ import {
 } from '../../../../../../common/mock/endpoint';
 import { getPolicyHostIsolationExceptionsPath } from '../../../../../common/routing';
 import { PolicyHostIsolationExceptionsList } from './list';
+import { getHostIsolationExceptionItems } from '../../../../host_isolation_exceptions/service';
 
 jest.mock('../../../../../../common/components/user_privileges');
+jest.mock('../../../../host_isolation_exceptions/service');
 
 const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
+const getHostIsolationExceptionItemsMock = getHostIsolationExceptionItems as jest.Mock;
 
 const emptyList = {
   data: [],
@@ -33,15 +35,14 @@ const emptyList = {
 
 describe('Policy details host isolation exceptions tab', () => {
   let policyId: string;
-  let render: (
-    exceptions: FoundExceptionListItemSchema
-  ) => ReturnType<AppContextTestRender['render']>;
+  let render: () => ReturnType<AppContextTestRender['render']>;
   let renderResult: ReturnType<typeof render>;
   let history: AppContextTestRender['history'];
   let mockedContext: AppContextTestRender;
 
   beforeEach(() => {
     policyId = uuid.v4();
+    getHostIsolationExceptionItemsMock.mockClear();
     useUserPrivilegesMock.mockReturnValue({
       endpointPrivileges: {
         canIsolateHost: true,
@@ -49,9 +50,9 @@ describe('Policy details host isolation exceptions tab', () => {
     });
     mockedContext = createAppRootMockRenderer();
     ({ history } = mockedContext);
-    render = (exceptions: FoundExceptionListItemSchema) =>
+    render = () =>
       (renderResult = mockedContext.render(
-        <PolicyHostIsolationExceptionsList policyId={policyId} exceptions={exceptions} />
+        <PolicyHostIsolationExceptionsList policyId={policyId} />
       ));
 
     act(() => {
@@ -59,20 +60,22 @@ describe('Policy details host isolation exceptions tab', () => {
     });
   });
 
-  it('should display a searchbar and count even with no exceptions', () => {
-    render(emptyList);
+  it('should display a searchbar and count even with no exceptions', async () => {
+    getHostIsolationExceptionItemsMock.mockResolvedValue(emptyList);
+    render();
     expect(
-      renderResult.getByTestId('policyDetailsHostIsolationExceptionsSearchCount')
+      await renderResult.findByTestId('policyDetailsHostIsolationExceptionsSearchCount')
     ).toHaveTextContent('Showing 0 host isolation exceptions');
     expect(renderResult.getByTestId('searchField')).toBeTruthy();
   });
 
-  it('should render the list of exceptions collapsed and expand it when clicked', () => {
+  it('should render the list of exceptions collapsed and expand it when clicked', async () => {
     // render 3
-    render(getFoundExceptionListItemSchemaMock(3));
-    expect(renderResult.getAllByTestId('hostIsolationExceptions-collapsed-list-card')).toHaveLength(
-      3
-    );
+    getHostIsolationExceptionItemsMock.mockResolvedValue(getFoundExceptionListItemSchemaMock(3));
+    render();
+    expect(
+      await renderResult.findAllByTestId('hostIsolationExceptions-collapsed-list-card')
+    ).toHaveLength(3);
     expect(
       renderResult.queryAllByTestId(
         'hostIsolationExceptions-collapsed-list-card-criteriaConditions'
@@ -80,11 +83,12 @@ describe('Policy details host isolation exceptions tab', () => {
     ).toHaveLength(0);
   });
 
-  it('should expand an item when expand is clicked', () => {
-    render(getFoundExceptionListItemSchemaMock(1));
-    expect(renderResult.getAllByTestId('hostIsolationExceptions-collapsed-list-card')).toHaveLength(
-      1
-    );
+  it('should expand an item when expand is clicked', async () => {
+    getHostIsolationExceptionItemsMock.mockResolvedValue(getFoundExceptionListItemSchemaMock(1));
+    render();
+    expect(
+      await renderResult.findAllByTestId('hostIsolationExceptions-collapsed-list-card')
+    ).toHaveLength(1);
 
     userEvent.click(
       renderResult.getByTestId('hostIsolationExceptions-collapsed-list-card-header-expandCollapse')
@@ -97,28 +101,46 @@ describe('Policy details host isolation exceptions tab', () => {
     ).toHaveLength(1);
   });
 
-  it('should change the address location when a filter is applied', () => {
-    render(getFoundExceptionListItemSchemaMock(1));
-    userEvent.type(renderResult.getByTestId('searchField'), 'search me{enter}');
+  it('should change the address location when a filter is applied', async () => {
+    getHostIsolationExceptionItemsMock.mockResolvedValue(getFoundExceptionListItemSchemaMock(1));
+    render();
+    userEvent.type(await renderResult.findByTestId('searchField'), 'search me{enter}');
     expect(history.location.search).toBe('?filter=search%20me');
   });
 
-  it('should disable the "remove from policy" option to global exceptions', () => {
+  it('should apply a filter when requested from location search params', async () => {
+    history.push(getPolicyHostIsolationExceptionsPath(policyId, { filter: 'my filter' }));
+    getHostIsolationExceptionItemsMock.mockResolvedValue(() =>
+      getFoundExceptionListItemSchemaMock(4)
+    );
+    render();
+    expect(getHostIsolationExceptionItemsMock).toHaveBeenCalledWith({
+      filter: `((exception-list-agnostic.attributes.tags:"policy:${policyId}" OR exception-list-agnostic.attributes.tags:"policy:all")) AND ((exception-list-agnostic.attributes.item_id:(*my*filter*) OR exception-list-agnostic.attributes.name:(*my*filter*) OR exception-list-agnostic.attributes.description:(*my*filter*) OR exception-list-agnostic.attributes.entries.value:(*my*filter*)))`,
+      http: mockedContext.coreStart.http,
+      page: 1,
+      perPage: 10,
+    });
+  });
+
+  it('should disable the "remove from policy" option to global exceptions', async () => {
     const testException = getExceptionListItemSchemaMock({ tags: ['policy:all'] });
     const exceptions = {
       ...emptyList,
       data: [testException],
       total: 1,
     };
-    render(exceptions);
+    getHostIsolationExceptionItemsMock.mockResolvedValue(exceptions);
+    render();
     // click the actions button
     userEvent.click(
-      renderResult.getByTestId('hostIsolationExceptions-collapsed-list-card-header-actions-button')
+      await renderResult.findByTestId(
+        'hostIsolationExceptions-collapsed-list-card-header-actions-button'
+      )
     );
     expect(renderResult.getByTestId('remove-from-policy-action')).toBeDisabled();
   });
 
-  it('should enable the "remove from policy" option to policy-specific exceptions ', () => {
+  it('should enable the "remove from policy" option to policy-specific exceptions ', async () => {
     const testException = getExceptionListItemSchemaMock({
       tags: [`policy:${policyId}`, 'policy:1234', 'not-a-policy-tag'],
     });
@@ -127,24 +149,30 @@ describe('Policy details host isolation exceptions tab', () => {
       data: [testException],
       total: 1,
     };
-    render(exceptions);
+    getHostIsolationExceptionItemsMock.mockResolvedValue(exceptions);
+    render();
     // click the actions button
     userEvent.click(
-      renderResult.getByTestId('hostIsolationExceptions-collapsed-list-card-header-actions-button')
+      await renderResult.findByTestId(
+        'hostIsolationExceptions-collapsed-list-card-header-actions-button'
+      )
     );
     expect(renderResult.getByTestId('remove-from-policy-action')).toBeEnabled();
   });
 
-  it('should enable the "view full details" action', () => {
-    render(getFoundExceptionListItemSchemaMock(1));
+  it('should enable the "view full details" action', async () => {
+    getHostIsolationExceptionItemsMock.mockResolvedValue(getFoundExceptionListItemSchemaMock(1));
+    render();
     // click the actions button
     userEvent.click(
-      renderResult.getByTestId('hostIsolationExceptions-collapsed-list-card-header-actions-button')
+      await renderResult.findByTestId(
+        'hostIsolationExceptions-collapsed-list-card-header-actions-button'
+      )
     );
     expect(renderResult.queryByTestId('view-full-details-action')).toBeTruthy();
   });
 
-  it('should render the delete dialog when the "remove from policy" button is clicked', () => {
+  it('should render the delete dialog when the "remove from policy" button is clicked', async () => {
     const testException = getExceptionListItemSchemaMock({
       tags: [`policy:${policyId}`, 'policy:1234', 'not-a-policy-tag'],
     });
@@ -153,10 +181,13 @@ describe('Policy details host isolation exceptions tab', () => {
       data: [testException],
       total: 1,
     };
-    render(exceptions);
+    getHostIsolationExceptionItemsMock.mockResolvedValue(exceptions);
+    render();
     // click the actions button
     userEvent.click(
-      renderResult.getByTestId('hostIsolationExceptions-collapsed-list-card-header-actions-button')
+      await renderResult.findByTestId(
+        'hostIsolationExceptions-collapsed-list-card-header-actions-button'
+      )
     );
     userEvent.click(renderResult.getByTestId('remove-from-policy-action'));
 
@@ -173,11 +204,12 @@ describe('Policy details host isolation exceptions tab', () => {
       });
     });
 
-    it('should not display the delete action, do show the full details', () => {
-      render(getFoundExceptionListItemSchemaMock(1));
+    it('should not display the delete action, do show the full details', async () => {
+      getHostIsolationExceptionItemsMock.mockResolvedValue(getFoundExceptionListItemSchemaMock(1));
+      render();
       // click the actions button
       userEvent.click(
-        renderResult.getByTestId(
+        await renderResult.findByTestId(
           'hostIsolationExceptions-collapsed-list-card-header-actions-button'
         )
       );

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/list.tsx
@@ -7,10 +7,7 @@
 
 import { EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import {
-  ExceptionListItemSchema,
-  FoundExceptionListItemSchema,
-} from '@kbn/securitysolution-io-ts-list-types';
+import { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useAppUrl } from '../../../../../../common/lib/kibana';

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/use_policy_host_isolation_exceptions_empty_hooks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/use_policy_host_isolation_exceptions_empty_hooks.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import { useNavigateToAppEventHandler } from '../../../../../../common/hooks/endpoint/use_navigate_to_app_event_handler';
+import { useAppUrl } from '../../../../../../common/lib/kibana/hooks';
+import {
+  getPolicyHostIsolationExceptionsPath,
+  getHostIsolationExceptionsListPath,
+} from '../../../../../common/routing';
+import { APP_UI_ID } from '../../../../../../../common/constants';
+
+export const useGetLinkTo = (policyId: string, policyName: string) => {
+  const { getAppUrl } = useAppUrl();
+  const { toRoutePath, toRouteUrl } = useMemo(() => {
+    const path = getHostIsolationExceptionsListPath();
+    return {
+      toRoutePath: path,
+      toRouteUrl: getAppUrl({ path }),
+    };
+  }, [getAppUrl]);
+
+  const policyHostIsolationExceptionsPath = useMemo(
+    () => getPolicyHostIsolationExceptionsPath(policyId),
+    [policyId]
+  );
+  const policyHostIsolationExceptionsRouteState = useMemo(() => {
+    return {
+      backButtonLabel: i18n.translate(
+        'xpack.securitySolution.endpoint.policy.hostIsolationExceptions.empty.unassigned.backButtonLabel',
+        {
+          defaultMessage: 'Back to {policyName} policy',
+          values: {
+            policyName,
+          },
+        }
+      ),
+      onBackButtonNavigateTo: [
+        APP_UI_ID,
+        {
+          path: policyHostIsolationExceptionsPath,
+        },
+      ],
+      backButtonUrl: getAppUrl({
+        appId: APP_UI_ID,
+        path: policyHostIsolationExceptionsPath,
+      }),
+    };
+  }, [getAppUrl, policyName, policyHostIsolationExceptionsPath]);
+
+  const onClickHandler = useNavigateToAppEventHandler(APP_UI_ID, {
+    state: policyHostIsolationExceptionsRouteState,
+    path: toRoutePath,
+  });
+
+  return {
+    onClickHandler,
+    toRouteUrl,
+  };
+};

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/host_isolation_exceptions_tab.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/host_isolation_exceptions_tab.test.tsx
@@ -112,20 +112,6 @@ describe('Policy details host isolation exceptions tab', () => {
     ).toHaveTextContent('There are 4 host isolation exceptions associated with this policy');
   });
 
-  it('should apply a filter when requested from location search params', async () => {
-    history.push(getPolicyHostIsolationExceptionsPath(policyId, { filter: 'my filter' }));
-    getHostIsolationExceptionItemsMock.mockImplementation(() => {
-      return getFoundExceptionListItemSchemaMock(4);
-    });
-    render();
-    expect(getHostIsolationExceptionItemsMock).toHaveBeenLastCalledWith({
-      filter: `((exception-list-agnostic.attributes.tags:"policy:${policyId}" OR exception-list-agnostic.attributes.tags:"policy:all")) AND ((exception-list-agnostic.attributes.item_id:(*my*filter*) OR exception-list-agnostic.attributes.name:(*my*filter*) OR exception-list-agnostic.attributes.description:(*my*filter*) OR exception-list-agnostic.attributes.entries.value:(*my*filter*)))`,
-      http: mockedContext.coreStart.http,
-      page: 1,
-      perPage: 10,
-    });
-  });
-
   describe('and the user is trying to assign policies', () => {
     it('should not render the assign button if there are not existing exceptions', async () => {
       getHostIsolationExceptionItemsMock.mockReturnValue(emptyList);
@@ -153,7 +139,7 @@ describe('Policy details host isolation exceptions tab', () => {
       });
       render();
       await waitFor(() => {
-        expect(getHostIsolationExceptionItemsMock).toHaveBeenCalledTimes(2);
+        expect(getHostIsolationExceptionItemsMock).toHaveBeenCalledTimes(3);
       });
       expect(await renderResult.findByTestId('hostIsolationExceptions-assign-flyout')).toBeTruthy();
     });

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/host_isolation_exceptions_tab.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/host_isolation_exceptions_tab.tsx
@@ -59,13 +59,6 @@ export const PolicyHostIsolationExceptionsTab = ({ policy }: { policy: PolicyDat
     policies: [policyId, 'all'],
   });
 
-  const policySearchedExceptionsListRequest = useFetchHostIsolationExceptionsList({
-    filter: location.filter,
-    page: location.page_index,
-    perPage: location.page_size,
-    policies: [policyId, 'all'],
-  });
-
   const allExceptionsListRequest = useFetchHostIsolationExceptionsList({
     page: MANAGEMENT_DEFAULT_PAGE,
     perPage: MANAGEMENT_DEFAULT_PAGE_SIZE,
@@ -78,7 +71,7 @@ export const PolicyHostIsolationExceptionsTab = ({ policy }: { policy: PolicyDat
 
   const subTitle = useMemo(() => {
     const link = (
-      <EuiLink href={getAppUrl({ appId: APP_UI_ID, path: toHostIsolationList })} target="_blank">
+      <EuiLink href={toHostIsolationList} target="_blank">
         <FormattedMessage
           id="xpack.securitySolution.endpoint.policy.hostIsolationExceptions.list.viewAllLinkLabel"
           defaultMessage="view all host isolation exceptions"
@@ -86,7 +79,7 @@ export const PolicyHostIsolationExceptionsTab = ({ policy }: { policy: PolicyDat
       </EuiLink>
     );
 
-    return policySearchedExceptionsListRequest.data ? (
+    return allPolicyExceptionsListRequest.data ? (
       <FormattedMessage
         id="xpack.securitySolution.endpoint.policy.hostIsolationExceptions.list.about"
         defaultMessage="There {count, plural, one {is} other {are}} {count} {count, plural, =1 {host isolation exception} other {host isolation exceptions}} associated with this policy. Click here to {link}"
@@ -96,12 +89,7 @@ export const PolicyHostIsolationExceptionsTab = ({ policy }: { policy: PolicyDat
         }}
       />
     ) : null;
-  }, [
-    allPolicyExceptionsListRequest.data?.total,
-    getAppUrl,
-    policySearchedExceptionsListRequest.data,
-    toHostIsolationList,
-  ]);
+  }, [allPolicyExceptionsListRequest.data, toHostIsolationList]);
 
   const handleAssignButton = () => {
     history.push(
@@ -127,32 +115,24 @@ export const PolicyHostIsolationExceptionsTab = ({ policy }: { policy: PolicyDat
     ) : null;
 
   const isLoading =
-    policySearchedExceptionsListRequest.isLoading ||
-    allPolicyExceptionsListRequest.isLoading ||
-    allExceptionsListRequest.isLoading ||
-    !policy;
+    allPolicyExceptionsListRequest.isLoading || allExceptionsListRequest.isLoading || !policy;
 
   // render non-existent or non-assigned messages
   if (!isLoading && (hasNoAssignedOrExistingExceptions || hasNoExistingExceptions)) {
     if (hasNoExistingExceptions) {
-      return (
-        <PolicyHostIsolationExceptionsEmptyUnexisting toHostIsolationList={toHostIsolationList} />
-      );
+      return <PolicyHostIsolationExceptionsEmptyUnexisting policy={policy} />;
     } else {
       return (
         <>
           {assignFlyout}
-          <PolicyHostIsolationExceptionsEmptyUnassigned
-            policy={policy}
-            toHostIsolationList={toHostIsolationList}
-          />
+          <PolicyHostIsolationExceptionsEmptyUnassigned policy={policy} />
         </>
       );
     }
   }
 
   // render header and list
-  return !isLoading && policySearchedExceptionsListRequest.data ? (
+  return !isLoading ? (
     <div data-test-subj={'policyHostIsolationExceptionsTab'}>
       {assignFlyout}
       <EuiPageHeader alignItems="center">
@@ -201,10 +181,7 @@ export const PolicyHostIsolationExceptionsTab = ({ policy }: { policy: PolicyDat
         color="transparent"
         borderRadius="none"
       >
-        <PolicyHostIsolationExceptionsList
-          exceptions={policySearchedExceptionsListRequest.data}
-          policyId={policyId}
-        />
+        <PolicyHostIsolationExceptionsList policyId={policyId} />
       </EuiPageContent>
     </div>
   ) : (

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_hooks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_hooks.ts
@@ -18,6 +18,7 @@ import {
 import {
   getPolicyDetailsArtifactsListPath,
   getPolicyEventFiltersPath,
+  getPolicyHostIsolationExceptionsPath,
 } from '../../../common/routing';
 import {
   getCurrentArtifactsLocation,
@@ -74,6 +75,23 @@ export function usePolicyDetailsEventFiltersNavigateCallback() {
     (args: Partial<PolicyDetailsArtifactsPageLocation>) =>
       history.push(
         getPolicyEventFiltersPath(policyId, {
+          ...location,
+          ...args,
+        })
+      ),
+    [history, location, policyId]
+  );
+}
+
+export function usePolicyDetailsHostIsolationExceptionsNavigateCallback() {
+  const location = usePolicyDetailsSelector(getCurrentArtifactsLocation);
+  const history = useHistory();
+  const policyId = usePolicyDetailsSelector(policyIdFromParams);
+
+  return useCallback(
+    (args: Partial<PolicyDetailsArtifactsPageLocation>) =>
+      history.push(
+        getPolicyHostIsolationExceptionsPath(policyId, {
           ...location,
           ...args,
         })


### PR DESCRIPTION
## Summary

### Wrong link to the list page:

**Before**
![hie wrong link](https://user-images.githubusercontent.com/15727784/151766279-df754a0f-30a0-46c5-84c6-35de11f345dc.gif)

**After**
![hie wrong link fixed](https://user-images.githubusercontent.com/15727784/151791405-fc4a1aa0-e4ac-47c5-b645-2ef6f06762c8.gif)


### The whole tab reloads when searching:

**Before**
![hie whole tab reloads](https://user-images.githubusercontent.com/15727784/151766251-5e6de731-ca5e-458d-a7f2-d4767bfa72f0.gif)

**After**
![hie whole tab reloads fixed](https://user-images.githubusercontent.com/15727784/151791649-3e730206-4fe5-476e-a361-c717497f8710.gif)

### Wrong link losing back button on empty state:

**Before**
![empty state wrong link](https://user-images.githubusercontent.com/15727784/151791837-b16f53a6-668b-4134-87a6-f6207f205520.gif)


**After**
![empty state wrong link fixed](https://user-images.githubusercontent.com/15727784/151792044-e557845c-2d67-4843-b5d0-8c82b077dc1a.gif)


### Wrong link losing back button on unassigned state:

**Before**
![wrong link unassigned](https://user-images.githubusercontent.com/15727784/151792562-42366f78-b6b4-4f4b-81eb-b6ebf6eb13ea.gif)


**After**
![wrong link unassigned fixed](https://user-images.githubusercontent.com/15727784/151792582-fe3cd6be-0945-4f41-bf8e-2b4ee63ee73c.gif)




### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
