### PR TITLE
show panel index in aria label

### DIFF
--- a/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid.tsx
@@ -242,10 +242,11 @@ class DashboardGridUi extends React.Component<DashboardGridProps, State> {
       }
     });
 
-    const dashboardPanels = _.map(panelsInOrder, ({ explicitInput, type }) => (
+    const dashboardPanels = _.map(panelsInOrder, ({ explicitInput, type }, index) => (
       <DashboardGridItem
-        id={explicitInput.id}
         key={explicitInput.id}
+        id={explicitInput.id}
+        index={index + 1}
         type={type}
         container={container}
         PanelComponent={kibana.services.embeddable.EmbeddablePanel}

--- a/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid_item.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid_item.tsx
@@ -20,6 +20,7 @@ type DivProps = Pick<React.HTMLAttributes<HTMLDivElement>, 'className' | 'style'
 
 interface Props extends PanelProps, DivProps {
   id: DashboardPanelState['explicitInput']['id'];
+  index?: number;
   type: DashboardPanelState['type'];
   container: DashboardContainer;
   focusedPanelId?: string;
@@ -35,6 +36,7 @@ const Item = React.forwardRef<HTMLDivElement, Props>(
       expandedPanelId,
       focusedPanelId,
       id,
+      index,
       PanelComponent,
       type,
       isRenderable = true,
@@ -72,6 +74,7 @@ const Item = React.forwardRef<HTMLDivElement, Props>(
               // This key is used to force rerendering on embeddable type change while the id remains the same
               key={type}
               embeddableId={id}
+              index={index}
               {...{ container, PanelComponent }}
             />
             {children}

--- a/src/plugins/embeddable/public/lib/containers/embeddable_child_panel.tsx
+++ b/src/plugins/embeddable/public/lib/containers/embeddable_child_panel.tsx
@@ -17,6 +17,7 @@ import { EmbeddableStart } from '../../plugin';
 
 export interface EmbeddableChildPanelProps {
   embeddableId: string;
+  index?: number;
   className?: string;
   container: IContainer;
   PanelComponent: EmbeddableStart['EmbeddablePanel'];
@@ -64,7 +65,7 @@ export class EmbeddableChildPanel extends React.Component<EmbeddableChildPanelPr
   }
 
   public render() {
-    const { PanelComponent } = this.props;
+    const { PanelComponent, index } = this.props;
     const classes = classNames('embPanel', {
       'embPanel-isLoading': this.state.loading,
     });
@@ -74,7 +75,7 @@ export class EmbeddableChildPanel extends React.Component<EmbeddableChildPanelPr
         {this.state.loading || !this.embeddable ? (
           <EuiLoadingChart size="l" mono />
         ) : (
-          <PanelComponent embeddable={this.embeddable} />
+          <PanelComponent embeddable={this.embeddable} index={index} />
         )}
       </div>
     );

--- a/src/plugins/embeddable/public/lib/panel/embeddable_panel.tsx
+++ b/src/plugins/embeddable/public/lib/panel/embeddable_panel.tsx
@@ -67,6 +67,13 @@ export interface EmbeddableContainerContext {
 
 interface Props {
   embeddable: IEmbeddable<EmbeddableInput, EmbeddableOutput>;
+
+  /**
+   * Ordinal number of the embeddable in the container, used as a
+   * "title" when the panel has no title, i.e. "Panel {index}".
+   */
+  index?: number;
+
   getActions: UiActionsService['getTriggerCompatibleActions'];
   getEmbeddableFactory?: EmbeddableStart['getEmbeddableFactory'];
   getAllEmbeddableFactories?: EmbeddableStart['getEmbeddableFactories'];
@@ -286,6 +293,7 @@ export class EmbeddablePanel extends React.Component<Props, State> {
             }
             closeContextMenu={this.state.closeContextMenu}
             title={title}
+            index={this.props.index}
             badges={this.state.badges}
             notifications={this.state.notifications}
             embeddable={this.props.embeddable}

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
@@ -27,6 +27,7 @@ import { CustomizePanelTitleAction } from '.';
 
 export interface PanelHeaderProps {
   title?: string;
+  index?: number;
   isViewMode: boolean;
   hidePanelTitle: boolean;
   getActionContextMenuPanel: () => Promise<EuiContextMenuPanelDescriptor[]>;
@@ -114,6 +115,7 @@ function getViewDescription(embeddable: IEmbeddable | EmbeddableWithDescription)
 
 export function PanelHeader({
   title,
+  index,
   isViewMode,
   hidePanelTitle,
   getActionContextMenuPanel,
@@ -159,6 +161,7 @@ export function PanelHeader({
           isViewMode={isViewMode}
           closeContextMenu={closeContextMenu}
           title={title}
+          index={index}
         />
         <EuiScreenReaderOnly>{getAriaLabel()}</EuiScreenReaderOnly>
       </div>
@@ -228,6 +231,7 @@ export function PanelHeader({
           getActionContextMenuPanel={getActionContextMenuPanel}
           closeContextMenu={closeContextMenu}
           title={title}
+          index={index}
         />
       </figcaption>
     </span>

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_options_menu.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_options_menu.tsx
@@ -77,7 +77,7 @@ export class PanelOptionsMenu extends React.Component<PanelOptionsMenuProps, Sta
         ? i18n.translate('embeddableApi.panel.optionsMenu.panelOptionsButtonAriaLabel', {
             defaultMessage: 'Panel options',
           })
-        : i18n.translate('embeddableApi.panel.optionsMenu.panelOptionsButtonEnhancedAriaLabel', {
+        : i18n.translate('embeddableApi.panel.optionsMenu.panelOptionsButtonAriaLabelWithIndex', {
             defaultMessage: 'Options for panel {index}',
             values: { index },
           });

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_options_menu.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_options_menu.tsx
@@ -21,6 +21,7 @@ export interface PanelOptionsMenuProps {
   isViewMode: boolean;
   closeContextMenu: boolean;
   title?: string;
+  index?: number;
 }
 
 interface State {
@@ -63,7 +64,7 @@ export class PanelOptionsMenu extends React.Component<PanelOptionsMenuProps, Sta
   }
 
   public render() {
-    const { isViewMode, title } = this.props;
+    const { isViewMode, title, index } = this.props;
     const enhancedAriaLabel = i18n.translate(
       'embeddableApi.panel.optionsMenu.panelOptionsButtonEnhancedAriaLabel',
       {
@@ -71,12 +72,15 @@ export class PanelOptionsMenu extends React.Component<PanelOptionsMenuProps, Sta
         values: { title },
       }
     );
-    const ariaLabelWithoutTitle = i18n.translate(
-      'embeddableApi.panel.optionsMenu.panelOptionsButtonAriaLabel',
-      {
-        defaultMessage: 'Panel options',
-      }
-    );
+    const ariaLabelWithoutTitle =
+      index === undefined
+        ? i18n.translate('embeddableApi.panel.optionsMenu.panelOptionsButtonAriaLabel', {
+            defaultMessage: 'Panel options',
+          })
+        : i18n.translate('embeddableApi.panel.optionsMenu.panelOptionsButtonEnhancedAriaLabel', {
+            defaultMessage: 'Options for panel {index}',
+            values: { index },
+          });
 
     const button = (
       <EuiButtonIcon

--- a/src/plugins/embeddable/public/plugin.tsx
+++ b/src/plugins/embeddable/public/plugin.tsx
@@ -104,6 +104,7 @@ export type EmbeddablePanelHOC = React.FC<{
   embeddable: IEmbeddable;
   hideHeader?: boolean;
   containerContext?: EmbeddableContainerContext;
+  index?: number;
 }>;
 
 export class EmbeddablePublicPlugin implements Plugin<EmbeddableSetup, EmbeddableStart> {
@@ -167,15 +168,18 @@ export class EmbeddablePublicPlugin implements Plugin<EmbeddableSetup, Embeddabl
         embeddable,
         hideHeader,
         containerContext,
+        index,
       }: {
         embeddable: IEmbeddable;
         hideHeader?: boolean;
         containerContext?: EmbeddableContainerContext;
+        index?: number;
       }) =>
         (
           <EmbeddablePanel
             hideHeader={hideHeader}
             embeddable={embeddable}
+            index={index}
             stateTransfer={this.stateTransferService}
             getActions={uiActions.getTriggerCompatibleActions}
             getEmbeddableFactory={this.getEmbeddableFactory}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/116194

- This changes passes in panel index for each embeddable panel, so that index can be used as panel title (Panel X), if panel has no title.
- This change sets aria label for panel menu button to "Options for panel {index}", for panels that don't have a title.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
