### PR TITLE
[Cases] Show settting "sync alert" in user actions

### DIFF
--- a/x-pack/plugins/cases/public/components/case_view/translations.ts
+++ b/x-pack/plugins/cases/public/components/case_view/translations.ts
@@ -17,6 +17,14 @@ export const CHANGED_FIELD = i18n.translate('xpack.cases.caseView.actionLabel.ch
   defaultMessage: 'changed',
 });
 
+export const ENABLED_SETTING = i18n.translate('xpack.cases.caseView.actionLabel.enabledSetting', {
+  defaultMessage: 'enabled',
+});
+
+export const DISABLED_SETTING = i18n.translate('xpack.cases.caseView.actionLabel.disableSetting', {
+  defaultMessage: 'disabled',
+});
+
 export const SELECTED_THIRD_PARTY = (thirdParty: string) =>
   i18n.translate('xpack.cases.caseView.actionLabel.selectedThirdParty', {
     values: {
@@ -117,6 +125,10 @@ export const CHANGED_CONNECTOR_FIELD = i18n.translate('xpack.cases.caseView.fiel
 
 export const SYNC_ALERTS = i18n.translate('xpack.cases.caseView.syncAlertsLabel', {
   defaultMessage: `Sync alerts`,
+});
+
+export const SYNC_ALERTS_LC = i18n.translate('xpack.cases.caseView.syncAlertsLowercaseLabel', {
+  defaultMessage: `sync alerts`,
 });
 
 export const DOES_NOT_EXIST_TITLE = i18n.translate('xpack.cases.caseView.doesNotExist.title', {

--- a/x-pack/plugins/cases/public/components/user_actions/builder.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/builder.tsx
@@ -9,6 +9,7 @@ import { createCommentUserActionBuilder } from './comment/comment';
 import { createConnectorUserActionBuilder } from './connector';
 import { createDescriptionUserActionBuilder } from './description';
 import { createPushedUserActionBuilder } from './pushed';
+import { createSettingsUserActionBuilder } from './settings';
 import { createStatusUserActionBuilder } from './status';
 import { createTagsUserActionBuilder } from './tags';
 import { createTitleUserActionBuilder } from './title';
@@ -22,4 +23,5 @@ export const builderMap: UserActionBuilderMap = {
   pushed: createPushedUserActionBuilder,
   comment: createCommentUserActionBuilder,
   description: createDescriptionUserActionBuilder,
+  settings: createSettingsUserActionBuilder,
 };

--- a/x-pack/plugins/cases/public/components/user_actions/common.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/common.tsx
@@ -52,38 +52,37 @@ export const createCommonUpdateUserActionBuilder = ({
   icon,
   handleOutlineComment,
 }: BuilderArgs): ReturnType<UserActionBuilder> => {
-  const CommonUpdateUserActionBuilder = () => [
-    {
-      username: (
-        <UserActionUsernameWithAvatar
-          username={userAction.createdBy.username}
-          fullName={userAction.createdBy.fullName}
-        />
-      ),
-      type: 'update' as const,
-      event: label,
-      'data-test-subj': `${userAction.type}-${userAction.action}-action-${userAction.actionId}`,
-      timestamp: <UserActionTimestamp createdAt={userAction.createdAt} />,
-      timelineIcon: icon,
-      actions: (
-        <EuiFlexGroup responsive={false}>
-          <EuiFlexItem grow={false}>
-            <UserActionCopyLink id={userAction.actionId} />
-          </EuiFlexItem>
-          {showMoveToReference(userAction.action, userAction.commentId) && (
-            <EuiFlexItem grow={false}>
-              <UserActionMoveToReference
-                id={userAction.commentId}
-                outlineComment={handleOutlineComment}
-              />
-            </EuiFlexItem>
-          )}
-        </EuiFlexGroup>
-      ),
-    },
-  ];
-  CommonUpdateUserActionBuilder.displayName = 'CommonUpdateUserActionBuilder';
   return {
-    build: CommonUpdateUserActionBuilder,
+    // eslint-disable-next-line react/display-name
+    build: () => [
+      {
+        username: (
+          <UserActionUsernameWithAvatar
+            username={userAction.createdBy.username}
+            fullName={userAction.createdBy.fullName}
+          />
+        ),
+        type: 'update' as const,
+        event: label,
+        'data-test-subj': `${userAction.type}-${userAction.action}-action-${userAction.actionId}`,
+        timestamp: <UserActionTimestamp createdAt={userAction.createdAt} />,
+        timelineIcon: icon,
+        actions: (
+          <EuiFlexGroup responsive={false}>
+            <EuiFlexItem grow={false}>
+              <UserActionCopyLink id={userAction.actionId} />
+            </EuiFlexItem>
+            {showMoveToReference(userAction.action, userAction.commentId) && (
+              <EuiFlexItem grow={false}>
+                <UserActionMoveToReference
+                  id={userAction.commentId}
+                  outlineComment={handleOutlineComment}
+                />
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        ),
+      },
+    ],
   };
 };

--- a/x-pack/plugins/cases/public/components/user_actions/common.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/common.tsx
@@ -51,10 +51,8 @@ export const createCommonUpdateUserActionBuilder = ({
   label,
   icon,
   handleOutlineComment,
-}: BuilderArgs): ReturnType<UserActionBuilder> => ({
-  // TODO: Fix this manually. Issue #123375
-  // eslint-disable-next-line react/display-name
-  build: () => [
+}: BuilderArgs): ReturnType<UserActionBuilder> => {
+  const CommonUpdateUserActionBuilder = () => [
     {
       username: (
         <UserActionUsernameWithAvatar
@@ -83,5 +81,9 @@ export const createCommonUpdateUserActionBuilder = ({
         </EuiFlexGroup>
       ),
     },
-  ],
-});
+  ];
+  CommonUpdateUserActionBuilder.displayName = 'CommonUpdateUserActionBuilder';
+  return {
+    build: CommonUpdateUserActionBuilder,
+  };
+};

--- a/x-pack/plugins/cases/public/components/user_actions/constants.ts
+++ b/x-pack/plugins/cases/public/components/user_actions/constants.ts
@@ -11,7 +11,7 @@ import { SupportedUserActionTypes } from './types';
 
 export const DRAFT_COMMENT_STORAGE_ID = 'xpack.cases.commentDraft';
 
-export const UNSUPPORTED_ACTION_TYPES = ['create_case', 'delete_case', 'settings'] as const;
+export const UNSUPPORTED_ACTION_TYPES = ['create_case', 'delete_case'] as const;
 export const SUPPORTED_ACTION_TYPES: SupportedUserActionTypes[] = Object.keys(
   omit(ActionTypes, UNSUPPORTED_ACTION_TYPES)
 ) as SupportedUserActionTypes[];

--- a/x-pack/plugins/cases/public/components/user_actions/helpers.test.ts
+++ b/x-pack/plugins/cases/public/components/user_actions/helpers.test.ts
@@ -63,7 +63,7 @@ describe('helpers', () => {
       ['tags', true],
       ['title', true],
       ['status', true],
-      ['settings', false],
+      ['settings', true],
       ['create_case', false],
       ['delete_case', false],
     ];

--- a/x-pack/plugins/cases/public/components/user_actions/settings.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/settings.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiCommentList } from '@elastic/eui';
+import React from 'react';
+import { Actions } from '../../../common/api';
+import { AppMockRenderer, createAppMockRenderer } from '../../common/mock';
+import { getUserAction } from '../../containers/mock';
+import { getMockBuilderArgs } from './mock';
+import { createSettingsUserActionBuilder } from './settings';
+
+jest.mock('../../common/lib/kibana');
+jest.mock('../../common/navigation/hooks');
+
+describe('createStatusUserActionBuilder ', () => {
+  const builderArgs = getMockBuilderArgs();
+  let appMock: AppMockRenderer;
+
+  beforeEach(() => {
+    appMock = createAppMockRenderer();
+    jest.clearAllMocks();
+  });
+
+  const tests = [
+    [false, 'disabled'],
+    [true, 'enabled'],
+  ];
+
+  it.each(tests)(
+    'renders correctly when changed setting sync-alerts to %s',
+    async (syncAlerts, label) => {
+      const userAction = getUserAction('settings', Actions.update, {
+        payload: { settings: { syncAlerts } },
+      });
+      const builder = createSettingsUserActionBuilder({
+        ...builderArgs,
+        userAction,
+      });
+
+      const createdUserAction = builder.build();
+      const result = appMock.render(<EuiCommentList comments={createdUserAction} />);
+
+      expect(result.getByTestId('settings-update-action-settings-update')).toBeTruthy();
+      expect(result.getByText(`${label} sync alerts`)).toBeTruthy();
+    }
+  );
+});

--- a/x-pack/plugins/cases/public/components/user_actions/settings.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/settings.tsx
@@ -13,7 +13,7 @@ import { createCommonUpdateUserActionBuilder } from './common';
 import { DISABLED_SETTING, ENABLED_SETTING, SYNC_ALERTS_LC } from './translations';
 
 function getSettingsLabel(userAction: UserActionResponse<SettingsUserAction>): ReactNode {
-  if (typeof userAction?.payload?.settings?.syncAlerts === 'boolean') {
+  if (userAction?.payload?.settings?.syncAlerts !== undefined) {
     if (userAction.payload.settings.syncAlerts) {
       return `${ENABLED_SETTING} ${SYNC_ALERTS_LC}`;
     } else {

--- a/x-pack/plugins/cases/public/components/user_actions/settings.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/settings.tsx
@@ -13,14 +13,11 @@ import { createCommonUpdateUserActionBuilder } from './common';
 import { DISABLED_SETTING, ENABLED_SETTING, SYNC_ALERTS_LC } from './translations';
 
 function getSettingsLabel(userAction: UserActionResponse<SettingsUserAction>): ReactNode {
-  if (userAction?.payload?.settings?.syncAlerts !== undefined) {
-    if (userAction.payload.settings.syncAlerts) {
-      return `${ENABLED_SETTING} ${SYNC_ALERTS_LC}`;
-    } else {
-      return `${DISABLED_SETTING} ${SYNC_ALERTS_LC}`;
-    }
+  if (userAction.payload.settings.syncAlerts) {
+    return `${ENABLED_SETTING} ${SYNC_ALERTS_LC}`;
+  } else {
+    return `${DISABLED_SETTING} ${SYNC_ALERTS_LC}`;
   }
-  return '';
 }
 
 export const createSettingsUserActionBuilder: UserActionBuilder = ({
@@ -28,13 +25,19 @@ export const createSettingsUserActionBuilder: UserActionBuilder = ({
   handleOutlineComment,
 }) => ({
   build: () => {
-    const commonBuilder = createCommonUpdateUserActionBuilder({
-      userAction,
-      handleOutlineComment,
-      label: getSettingsLabel(userAction as UserActionResponse<SettingsUserAction>),
-      icon: 'gear',
-    });
+    const action = userAction as UserActionResponse<SettingsUserAction>;
+    if (action?.payload?.settings?.syncAlerts !== undefined) {
+      const commonBuilder = createCommonUpdateUserActionBuilder({
+        userAction,
+        handleOutlineComment,
+        label: getSettingsLabel(action),
+        icon: 'gear',
+      });
 
-    return commonBuilder.build();
+      return commonBuilder.build();
+    }
+
+    // if new settings are introduced. they won't be rendered
+    return [];
   },
 });

--- a/x-pack/plugins/cases/public/components/user_actions/settings.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/settings.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ReactNode } from 'react';
+import { SettingsUserAction } from '../../../common/api';
+import { UserActionBuilder, UserActionResponse } from './types';
+
+import { createCommonUpdateUserActionBuilder } from './common';
+import { DISABLED_SETTING, ENABLED_SETTING, SYNC_ALERTS_LC } from './translations';
+
+function getSettingsLabel(userAction: UserActionResponse<SettingsUserAction>): ReactNode {
+  if (typeof userAction?.payload?.settings?.syncAlerts === 'boolean') {
+    if (userAction.payload.settings.syncAlerts) {
+      return `${ENABLED_SETTING} ${SYNC_ALERTS_LC}`;
+    } else {
+      return `${DISABLED_SETTING} ${SYNC_ALERTS_LC}`;
+    }
+  }
+  return '';
+}
+
+export const createSettingsUserActionBuilder: UserActionBuilder = ({
+  userAction,
+  handleOutlineComment,
+}) => ({
+  build: () => {
+    const commonBuilder = createCommonUpdateUserActionBuilder({
+      userAction,
+      handleOutlineComment,
+      label: getSettingsLabel(userAction as UserActionResponse<SettingsUserAction>),
+      icon: 'dot',
+    });
+
+    return commonBuilder.build();
+  },
+});

--- a/x-pack/plugins/cases/public/components/user_actions/settings.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/settings.tsx
@@ -32,7 +32,7 @@ export const createSettingsUserActionBuilder: UserActionBuilder = ({
       userAction,
       handleOutlineComment,
       label: getSettingsLabel(userAction as UserActionResponse<SettingsUserAction>),
-      icon: 'dot',
+      icon: 'gear',
     });
 
     return commonBuilder.build();


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/87608

Show the user action if the sync alert setting was enabled or disabled by the user. Previously this was not shown in the user actions list.
![image](https://user-images.githubusercontent.com/227916/151828463-981445df-6abc-4e3a-b509-e1af2ebfda88.png)



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
