### PR TITLE
[Security Solution] Update the copy text of the permission check for Endpoint

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/index.tsx
@@ -46,7 +46,7 @@ const NoPermissions = memo(() => {
           <EuiText color="subdued">
             <FormattedMessage
               id="xpack.securitySolution.endpointManagement.noPermissionsSubText"
-              defaultMessage="It looks like Fleet is disabled. Fleet must be enabled to use this feature. If you do not have permissions to enable Fleet, contact your Kibana administrator."
+              defaultMessage="You must have the superuser role to use this feature. If you do not have the superuser role and do not have permissions to edit user roles, contact your Kibana administrator."
             />
           </EuiText>
         }


### PR DESCRIPTION
## Summary

The Endpoint Management tab in the Security Solution now checks for `superuser` role directly.  This is because Fleet is introducing their own, finer grained Kibana permission checks.  We now need to check for `superuser` directly while we define our own Kibana permissions.

Old text:
![image](https://user-images.githubusercontent.com/56395104/151809491-8d5b8018-f121-4be9-851d-10682e15e7ad.png)

New text:
![image](https://user-images.githubusercontent.com/56395104/151802090-97d1f08f-8bbf-4b2c-a418-f4269b5a7e2d.png)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
