### PR TITLE
Switch transform plugin to use locators

### DIFF
--- a/src/plugins/discover/public/index.ts
+++ b/src/plugins/discover/public/index.ts
@@ -28,5 +28,10 @@ export { SEARCH_EMBEDDABLE_TYPE } from './embeddable';
 export { loadSharingDataHelpers } from './utils';
 
 export type { DiscoverUrlGeneratorState } from './url_generator';
+
+/**
+ * @deprecated
+ */
 export { DISCOVER_APP_URL_GENERATOR } from './url_generator';
+export { DISCOVER_APP_LOCATOR } from './locator';
 export type { DiscoverAppLocator, DiscoverAppLocatorParams } from './locator';

--- a/src/plugins/discover/public/url_generator.ts
+++ b/src/plugins/discover/public/url_generator.ts
@@ -12,8 +12,14 @@ import { esFilters } from '../../data/public';
 import { setStateToKbnUrl } from '../../kibana_utils/public';
 import { VIEW_MODE } from './components/view_mode_toggle';
 
+/**
+ * @deprecated
+ */
 export const DISCOVER_APP_URL_GENERATOR = 'DISCOVER_APP_URL_GENERATOR';
 
+/**
+ * @deprecated
+ */
 export interface DiscoverUrlGeneratorState {
   /**
    * Optionally set saved search ID.
@@ -87,6 +93,9 @@ interface Params {
 
 export const SEARCH_SESSION_ID_QUERY_PARAM = 'searchSessionId';
 
+/**
+ * @deprecated
+ */
 export class DiscoverUrlGenerator
   implements UrlGeneratorsDefinition<typeof DISCOVER_APP_URL_GENERATOR>
 {

--- a/src/plugins/share/common/url_service/locators/locator.ts
+++ b/src/plugins/share/common/url_service/locators/locator.ts
@@ -118,6 +118,15 @@ export class Locator<P extends SerializableRecord> implements LocatorPublic<P> {
     });
   }
 
+  public navigateSync(locatorParams: P, navigationParams: LocatorNavigationParams = {}): void {
+    this.navigate(locatorParams, navigationParams).catch((error) => {
+      // eslint-disable-next-line no-console
+      console.log(`Failed to navigate [locator = ${this.id}].`, locatorParams, navigationParams);
+      // eslint-disable-next-line no-console
+      console.error(error);
+    });
+  }
+
   public readonly useUrl = (
     params: P,
     getUrlParams?: LocatorGetUrlParams,

--- a/src/plugins/share/common/url_service/locators/types.ts
+++ b/src/plugins/share/common/url_service/locators/types.ts
@@ -99,6 +99,16 @@ export interface LocatorPublic<P extends SerializableRecord> extends Persistable
   navigate(params: P, navigationParams?: LocatorNavigationParams): Promise<void>;
 
   /**
+   * Synchronous fire-and-forget navigation method. Use it when you want to
+   * navigate without waiting for the navigation to complete and you don't
+   * care to process any async promise errors.
+   *
+   * @param params URL locator parameters.
+   * @param navigationParams Navigation parameters.
+   */
+  navigateSync(params: P, navigationParams?: LocatorNavigationParams): void;
+
+  /**
    * React hook which returns a URL string given locator parameters. Returns
    * empty string if URL is being loaded or an error happened.
    */

--- a/src/plugins/share/public/mocks.ts
+++ b/src/plugins/share/public/mocks.ts
@@ -70,6 +70,7 @@ const createLocator = <T extends SerializableRecord = SerializableRecord>(): jes
   getRedirectUrl: jest.fn(),
   useUrl: jest.fn(),
   navigate: jest.fn(),
+  navigateSync: jest.fn(),
   extract: jest.fn(),
   inject: jest.fn(),
   telemetry: jest.fn(),

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_create/step_create_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_create/step_create_form.tsx
@@ -26,10 +26,7 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { toMountPoint } from '../../../../../../../../../src/plugins/kibana_react/public';
 
-import {
-  DISCOVER_APP_URL_GENERATOR,
-  DiscoverUrlGeneratorState,
-} from '../../../../../../../../../src/plugins/discover/public';
+import { DISCOVER_APP_LOCATOR } from '../../../../../../../../../src/plugins/discover/public';
 
 import type { PutTransformsResponseSchema } from '../../../../../../common/api_schemas/transforms';
 import {
@@ -96,9 +93,9 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
     const [discoverLink, setDiscoverLink] = useState<string>();
 
     const deps = useAppDependencies();
+    const { share } = deps;
     const indexPatterns = deps.data.indexPatterns;
     const toastNotifications = useToastNotifications();
-    const { getUrlGenerator } = deps.share.urlGenerators;
     const isDiscoverAvailable = deps.application.capabilities.discover?.show ?? false;
 
     useEffect(() => {
@@ -107,19 +104,14 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
       onChange({ created, started, indexPatternId });
 
       const getDiscoverUrl = async (): Promise<void> => {
-        const state: DiscoverUrlGeneratorState = {
+        const locator = share.url.locators.get(DISCOVER_APP_LOCATOR);
+
+        if (!locator) return;
+
+        const discoverUrl = await locator.getUrl({
           indexPatternId,
-        };
+        });
 
-        let discoverUrlGenerator;
-        try {
-          discoverUrlGenerator = getUrlGenerator(DISCOVER_APP_URL_GENERATOR);
-        } catch (error) {
-          // ignore error thrown when url generator is not available
-          return;
-        }
-
-        const discoverUrl = await discoverUrlGenerator.createUrl(state);
         if (!unmounted) {
           setDiscoverLink(discoverUrl);
         }


### PR DESCRIPTION
## Summary

Updates `transform` plugin to use Discover locator instead of deprecated Discover URL generator.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
