### PR TITLE
[8.0] [Upgrade Assistant] Update upgrade guide doc links (#123953) (#124029)

### DIFF
--- a/docs/development/core/public/kibana-plugin-core-public.doclinksstart.links.md
+++ b/docs/development/core/public/kibana-plugin-core-public.doclinksstart.links.md
@@ -11,7 +11,8 @@ readonly links: {
         readonly settings: string;
         readonly elasticStackGetStarted: string;
         readonly upgrade: {
-            readonly upgradingElasticStack: string;
+            readonly upgradingStackOnPrem: string;
+            readonly upgradingStackOnCloud: string;
         };
         readonly apm: {
             readonly kibanaSettings: string;

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -20,7 +20,6 @@ export class DocLinksService {
   public start({ injectedMetadata }: StartDeps): DocLinksStart {
     const DOC_LINK_VERSION = injectedMetadata.getKibanaBranch();
     const ELASTIC_WEBSITE_URL = 'https://www.elastic.co/';
-    const STACK_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/elastic-stack/${DOC_LINK_VERSION}/`;
     const ELASTICSEARCH_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/reference/${DOC_LINK_VERSION}/`;
     const KIBANA_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/`;
     const FLEET_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/fleet/${DOC_LINK_VERSION}/`;
@@ -39,7 +38,8 @@ export class DocLinksService {
         settings: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/settings.html`,
         elasticStackGetStarted: `${STACK_GETTING_STARTED}get-started-elastic-stack.html`,
         upgrade: {
-          upgradingElasticStack: `${STACK_DOCS}upgrading-elastic-stack.html`,
+          upgradingStackOnPrem: `${ELASTIC_WEBSITE_URL}guide/en/elastic-stack/8.0/upgrading-elastic-stack-on-prem.html`,
+          upgradingStackOnCloud: `${ELASTIC_WEBSITE_URL}guide/en/elastic-stack/8.0/upgrade-elastic-stack-for-elastic-cloud.html`,
         },
         apm: {
           kibanaSettings: `${KIBANA_DOCS}apm-settings-in-kibana.html`,
@@ -602,7 +602,8 @@ export interface DocLinksStart {
     readonly settings: string;
     readonly elasticStackGetStarted: string;
     readonly upgrade: {
-      readonly upgradingElasticStack: string;
+      readonly upgradingStackOnPrem: string;
+      readonly upgradingStackOnCloud: string;
     };
     readonly apm: {
       readonly kibanaSettings: string;

--- a/src/core/public/public.api.md
+++ b/src/core/public/public.api.md
@@ -482,7 +482,8 @@ export interface DocLinksStart {
         readonly settings: string;
         readonly elasticStackGetStarted: string;
         readonly upgrade: {
-            readonly upgradingElasticStack: string;
+            readonly upgradingStackOnPrem: string;
+            readonly upgradingStackOnCloud: string;
         };
         readonly apm: {
             readonly kibanaSettings: string;

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -27599,7 +27599,6 @@
     "xpack.upgradeAssistant.overview.upgradeStepCloudLink": "クラウドでアップグレード",
     "xpack.upgradeAssistant.overview.upgradeStepDescription": "重要な問題をすべて解決し、アプリケーションの準備を確認した後に、Elastic 8.xにアップグレードできます。アップグレードする前に、必ずもう一度データをバックアップしたことを確認してください。",
     "xpack.upgradeAssistant.overview.upgradeStepDescriptionForCloud": "重要な問題をすべて解決し、アプリケーションの準備を確認した後に、Elastic 8.xにアップグレードできます。アップグレードする前に、必ずもう一度データをバックアップしたことを確認してください。Elastic Cloudでデプロイをアップグレードします。",
-    "xpack.upgradeAssistant.overview.upgradeStepLink": "詳細",
     "xpack.upgradeAssistant.overview.upgradeStepTitle": "Elastic 8.xへのアップグレード",
     "xpack.upgradeAssistant.overview.verifyChanges.calloutBody": "変更した後、カウンターをリセットして監視を続け、廃止予定の機能を使用していないことを確認します。",
     "xpack.upgradeAssistant.overview.verifyChanges.calloutTitle": "{previousCheck}以降{warningsCount, plural, =0 {0} other {{warningsCount}}}件の廃止予定{warningsCount, plural, other {件の問題}}",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -28071,7 +28071,6 @@
     "xpack.upgradeAssistant.overview.upgradeStepCloudLink": "在 Cloud 上升级",
     "xpack.upgradeAssistant.overview.upgradeStepDescription": "解决所有紧急问题并确认您的应用程序就绪后，便可以升级到 Elastic 8.x。在升级之前，请确保再次备份您的数据。",
     "xpack.upgradeAssistant.overview.upgradeStepDescriptionForCloud": "解决所有紧急问题并确认您的应用程序就绪后，便可以升级到 Elastic 8.x。在升级之前，请确保再次备份您的数据。在 Elastic Cloud 上升级您的部署。",
-    "xpack.upgradeAssistant.overview.upgradeStepLink": "了解详情",
     "xpack.upgradeAssistant.overview.upgradeStepTitle": "升级到 Elastic 8.x",
     "xpack.upgradeAssistant.overview.verifyChanges.calloutBody": "做出更改后，请重置计数器并继续监测，以确认您不再使用过时功能。",
     "xpack.upgradeAssistant.overview.verifyChanges.calloutTitle": "自 {previousCheck} 以来出现 {warningsCount, plural, other {{warningsCount}}} 个弃用{warningsCount, plural, other {问题}} ",

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/upgrade_step/upgrade_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/upgrade_step/upgrade_step.tsx
@@ -35,9 +35,6 @@ const i18nTexts = {
         "Once you've resolved all critical issues and verified that your applications are ready, you can upgrade to Elastic 8.x. Be sure to back up your data again before upgrading. Upgrade your deployment on Elastic Cloud.",
     }
   ),
-  upgradeStepLink: i18n.translate('xpack.upgradeAssistant.overview.upgradeStepLink', {
-    defaultMessage: 'Learn more',
-  }),
   upgradeStepCloudLink: i18n.translate('xpack.upgradeAssistant.overview.upgradeStepCloudLink', {
     defaultMessage: 'Upgrade on Cloud',
   }),
@@ -110,7 +107,7 @@ const UpgradeStep = () => {
 
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty
-              href={docLinks.links.upgrade.upgradingElasticStack}
+              href={docLinks.links.upgrade.upgradingStackOnCloud}
               target="_blank"
               data-test-subj="upgradeSetupDocsLink"
               iconSide="right"
@@ -125,13 +122,13 @@ const UpgradeStep = () => {
   } else {
     callToAction = (
       <EuiButton
-        href={docLinks.links.upgrade.upgradingElasticStack}
+        href={docLinks.links.upgrade.upgradingStackOnPrem}
         target="_blank"
         data-test-subj="upgradeSetupDocsLink"
         iconSide="right"
         iconType="popout"
       >
-        {i18nTexts.upgradeStepLink}
+        {i18nTexts.upgradeGuideLink}
       </EuiButton>
     );
   }


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #124029

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
