### PR TITLE
[8.0][Security Solution] Remove .siem-signals alias from preview alerts indices

### DIFF
--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -219,6 +219,7 @@ export class Plugin implements ISecuritySolutionPlugin {
       ...ruleDataServiceOptions,
       additionalPrefix: '.preview',
       ilmPolicy: previewIlmPolicy,
+      secondaryAlias: undefined,
     });
 
     const securityRuleTypeOptions = {


### PR DESCRIPTION
## Summary

see https://github.com/elastic/kibana/pull/124165

This PR created in parallel with above PR to unblock 8.0 RC2.
