### PR TITLE
[Security Solution] Remove .siem-signals alias from preview alerts indices

### DIFF
--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -223,6 +223,7 @@ export class Plugin implements ISecuritySolutionPlugin {
       ...ruleDataServiceOptions,
       additionalPrefix: '.preview',
       ilmPolicy: previewIlmPolicy,
+      secondaryAlias: undefined,
     });
 
     const securityRuleTypeOptions = {


### PR DESCRIPTION
## Summary

Removes the `.siem-signals` alias from preview alerts indices so the preview alerts don't show up when only real alerts are expected.

To test:
1. Add data in a source index
2. Start creating a query rule that will match the source data added in step 1
3. Preview the results
4. Preview histogram should show the proper results
5. In stack management -> Index management, search for `.preview.alerts` and click on the preview alerts index. The `Aliases` section should contain `.preview.alerts-security.alerts-<space name>` but **NOT** `.siem-signals-<space name>`. Prior to this PR, it contained both.

Fixes #124156