### PR TITLE
[App Search] Fix bugs where non-owner/admins shown schema actions they can't access

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.test.tsx
@@ -30,6 +30,7 @@ describe('SchemaCallouts', () => {
       hasErrors: false,
       activeReindexJobId: 'some-id',
     },
+    myRole: { canManageEngines: true },
   };
 
   beforeEach(() => {
@@ -78,6 +79,31 @@ describe('SchemaCallouts', () => {
     const wrapper = shallow(<SchemaCallouts />);
 
     expect(wrapper.find(UnconfirmedFieldsCallout)).toHaveLength(1);
+  });
+
+  describe('non-owner/admins', () => {
+    it('does not render an unsearched fields callout if user does not have access', () => {
+      setMockValues({
+        ...values,
+        hasUnconfirmedFields: true,
+        hasNewUnsearchedFields: true,
+        myRole: { canManageEngines: false },
+      });
+      const wrapper = shallow(<SchemaCallouts />);
+
+      expect(wrapper.find(UnsearchedFieldsCallout)).toHaveLength(0);
+    });
+
+    it('does not render an unconfirmed fields callout if user does not have access', () => {
+      setMockValues({
+        ...values,
+        hasUnconfirmedFields: true,
+        myRole: { canManageEngines: false },
+      });
+      const wrapper = shallow(<SchemaCallouts />);
+
+      expect(wrapper.find(UnconfirmedFieldsCallout)).toHaveLength(0);
+    });
   });
 
   describe('UnsearchedFieldsCallout', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
@@ -14,12 +14,16 @@ import { i18n } from '@kbn/i18n';
 
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';
 import { SchemaErrorsCallout } from '../../../../shared/schema';
+import { AppLogic } from '../../../app_logic';
 import { ENGINE_RELEVANCE_TUNING_PATH, ENGINE_REINDEX_JOB_PATH } from '../../../routes';
 import { generateEnginePath } from '../../engine';
 
 import { SchemaLogic } from '../schema_logic';
 
 export const SchemaCallouts: React.FC = () => {
+  const {
+    myRole: { canManageEngines },
+  } = useValues(AppLogic);
   const {
     hasUnconfirmedFields,
     hasNewUnsearchedFields,
@@ -38,7 +42,7 @@ export const SchemaCallouts: React.FC = () => {
           <EuiSpacer />
         </>
       )}
-      {hasUnconfirmedFields && (
+      {hasUnconfirmedFields && canManageEngines && (
         <>
           {hasNewUnsearchedFields ? <UnsearchedFieldsCallout /> : <UnconfirmedFieldsCallout />}
           <EuiSpacer />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_table.test.tsx
@@ -21,6 +21,7 @@ describe('SchemaTable', () => {
   const values = {
     schema: {},
     unconfirmedFields: [],
+    myRole: { canManageEngines: true },
   };
   const actions = {
     updateSchemaFieldType: jest.fn(),
@@ -81,5 +82,18 @@ describe('SchemaTable', () => {
 
     expect(wrapper.find(EuiHealth)).toHaveLength(1);
     expect(wrapper.find(EuiHealth).childAt(0).prop('children')).toEqual('Recently added');
+  });
+
+  it('disables table actions if access disallowed', () => {
+    setMockValues({
+      ...values,
+      schema: {
+        some_text_field: 'text',
+      },
+      myRole: { canManageEngines: false },
+    });
+    const wrapper = shallow(<SchemaTable />);
+
+    expect(wrapper.find(SchemaFieldTypeSelect).at(0).prop('disabled')).toEqual(true);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_table.tsx
@@ -24,9 +24,14 @@ import { i18n } from '@kbn/i18n';
 import { SchemaFieldTypeSelect } from '../../../../shared/schema';
 import { FIELD_NAME, FIELD_TYPE } from '../../../../shared/schema/constants';
 
+import { AppLogic } from '../../../app_logic';
+
 import { SchemaLogic } from '../schema_logic';
 
 export const SchemaTable: React.FC = () => {
+  const {
+    myRole: { canManageEngines },
+  } = useValues(AppLogic);
   const { schema, unconfirmedFields } = useValues(SchemaLogic);
   const { updateSchemaFieldType } = useActions(SchemaLogic);
 
@@ -75,6 +80,7 @@ export const SchemaTable: React.FC = () => {
                 <SchemaFieldTypeSelect
                   fieldName={fieldName}
                   fieldType={fieldType}
+                  disabled={!canManageEngines}
                   updateExistingFieldType={updateSchemaFieldType}
                   aria-labelledby="schemaFieldType"
                 />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/schema.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/schema.test.tsx
@@ -29,6 +29,7 @@ describe('Schema', () => {
     hasSchemaChanged: false,
     isUpdating: false,
     isModalOpen: false,
+    myRole: { canManageEngines: true },
   };
   const actions = {
     loadSchema: jest.fn(),
@@ -60,13 +61,21 @@ describe('Schema', () => {
   describe('page action buttons', () => {
     const subject = () => getPageHeaderActions(shallow(<Schema />));
 
-    it('renders', () => {
+    it('renders buttons when access allows', () => {
       const wrapper = subject();
+
       expect(wrapper.find(EuiButton)).toHaveLength(2);
     });
 
+    it('does not render buttons when access disallowed', () => {
+      setMockValues({ ...values, myRole: { canManageEngines: false } });
+      const wrapper = subject();
+
+      expect(wrapper.find(EuiButton)).toHaveLength(0);
+    });
+
     it('renders loading/disabled state when schema is updating', () => {
-      setMockValues({ isUpdating: true });
+      setMockValues({ ...values, isUpdating: true });
       const wrapper = subject();
 
       expect(wrapper.find('[data-test-subj="updateSchemaButton"]').prop('isLoading')).toBe(true);
@@ -115,7 +124,7 @@ describe('Schema', () => {
   });
 
   it('renders a modal that lets a user add a new schema field', () => {
-    setMockValues({ isModalOpen: true });
+    setMockValues({ ...values, isModalOpen: true });
     const wrapper = shallow(<Schema />);
 
     expect(wrapper.find(SchemaAddFieldModal)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/schema.tsx
@@ -13,6 +13,7 @@ import { EuiButton } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { SchemaAddFieldModal } from '../../../../shared/schema';
+import { AppLogic } from '../../../app_logic';
 import { getEngineBreadcrumbs } from '../../engine';
 import { AppSearchPageTemplate } from '../../layout';
 
@@ -21,6 +22,9 @@ import { SCHEMA_TITLE } from '../constants';
 import { SchemaLogic } from '../schema_logic';
 
 export const Schema: React.FC = () => {
+  const {
+    myRole: { canManageEngines },
+  } = useValues(AppLogic);
   const { loadSchema, updateSchema, addSchemaField, openModal, closeModal } =
     useActions(SchemaLogic);
   const { dataLoading, isUpdating, hasSchema, hasSchemaChanged, isModalOpen } =
@@ -29,6 +33,32 @@ export const Schema: React.FC = () => {
   useEffect(() => {
     loadSchema();
   }, []);
+
+  const schemaActions = [
+    <EuiButton
+      fill
+      disabled={!hasSchemaChanged}
+      isLoading={isUpdating}
+      onClick={() => updateSchema()}
+      data-test-subj="updateSchemaButton"
+    >
+      {i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.updateSchemaButtonLabel', {
+        defaultMessage: 'Save changes',
+      })}
+    </EuiButton>,
+    <EuiButton
+      color="success"
+      iconType="plusInCircle"
+      disabled={isUpdating}
+      onClick={openModal}
+      data-test-subj="addSchemaFieldModalButton"
+    >
+      {i18n.translate(
+        'xpack.enterpriseSearch.appSearch.engine.schema.createSchemaFieldButtonLabel',
+        { defaultMessage: 'Create a schema field' }
+      )}
+    </EuiButton>,
+  ];
 
   return (
     <AppSearchPageTemplate
@@ -41,32 +71,7 @@ export const Schema: React.FC = () => {
           'xpack.enterpriseSearch.appSearch.engine.schema.pageDescription',
           { defaultMessage: 'Add new fields or change the types of existing ones.' }
         ),
-        rightSideItems: [
-          <EuiButton
-            fill
-            disabled={!hasSchemaChanged}
-            isLoading={isUpdating}
-            onClick={() => updateSchema()}
-            data-test-subj="updateSchemaButton"
-          >
-            {i18n.translate(
-              'xpack.enterpriseSearch.appSearch.engine.schema.updateSchemaButtonLabel',
-              { defaultMessage: 'Save changes' }
-            )}
-          </EuiButton>,
-          <EuiButton
-            color="success"
-            iconType="plusInCircle"
-            disabled={isUpdating}
-            onClick={openModal}
-            data-test-subj="addSchemaFieldModalButton"
-          >
-            {i18n.translate(
-              'xpack.enterpriseSearch.appSearch.engine.schema.createSchemaFieldButtonLabel',
-              { defaultMessage: 'Create a schema field' }
-            )}
-          </EuiButton>,
-        ],
+        rightSideItems: canManageEngines ? schemaActions : [],
       }}
       isLoading={dataLoading}
       isEmptyState={!hasSchema}


### PR DESCRIPTION
closes https://github.com/elastic/app-search-team/issues/2048
closes https://github.com/elastic/app-search-team/issues/1717

## Summary

This PR fixes a couple of bugs where non-owner/admins are shown schema actions that they do not have access to. Specifically, it:

1. Hides schema actions for non-admin/owners (https://github.com/elastic/kibana/commit/8f889793e9108060a14484706ab20797125c2c5e)
2. Disable schema table row actions for non-owner/admins (https://github.com/elastic/kibana/commit/670dcd0ea7bc0848f358eec6d6bc802afd8ff3a8)
3. Hides actionable callouts for non-owner/admins (https://github.com/elastic/kibana/commit/a38efdfaf00b7df84bd6a54343d1408712049ad3)

| Before | After |
| ------------- | ------------- |
| ![s-before](https://user-images.githubusercontent.com/1869731/151873385-e47d29dc-a747-4e23-88bb-376fee988add.png)  | ![s-after](https://user-images.githubusercontent.com/1869731/151873395-5e228d4e-c0fd-44d0-b26f-f600a3994e9b.png)  |

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Release note
Fixes a bug where non-owner/admins shown schema actions they can't access