### PR TITLE
[DOCS] Removes APM NodeJS and RUM Javascript modules

### DIFF
--- a/docs/apm/machine-learning.asciidoc
+++ b/docs/apm/machine-learning.asciidoc
@@ -52,9 +52,6 @@ That's it! After a few minutes, the job will begin calculating results;
 it might take additional time for results to appear on your service maps.
 Existing jobs can be managed in *Machine Learning jobs management*.
 
-APM specific anomaly detection wizards are also available for certain Agents.
-See the machine learning {ml-docs}/ootb-ml-jobs-apm.html[APM anomaly detection configurations] for more information.
-
 [float]
 [[warning-ml-integration]]
 === Anomaly detection warning


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/119945

The preconfigured machine learning jobs for APM agents have been removed, therefore this PR removes the related paragraph from https://www.elastic.co/guide/en/kibana/master/machine-learning-integration.html

### Preview

https://kibana_124180.docs-preview.app.elstc.co/guide/en/kibana/master/machine-learning-integration.html