### PR TITLE
[Uptime] [Synthetics e2e] overwrite SYNTHETICS_REMOTE_KIBANA_URL if defined in environment

### DIFF
--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -107,7 +107,7 @@ export SYNTHETICS_REMOTE_KIBANA_USERNAME
 SYNTHETICS_REMOTE_KIBANA_PASSWORD="$(retry 5 5 vault read -field=password secret/kibana-issues/dev/kibana-ci-synthetics-remote-credentials)"
 export SYNTHETICS_REMOTE_KIBANA_PASSWORD
 
-SYNTHETICS_REMOTE_KIBANA_URL="$(retry 5 5 vault read -field=url secret/kibana-issues/dev/kibana-ci-synthetics-remote-credentials)"
+SYNTHETICS_REMOTE_KIBANA_URL=${SYNTHETICS_REMOTE_KIBANA_URL-"$(retry 5 5 vault read -field=url secret/kibana-issues/dev/kibana-ci-synthetics-remote-credentials)"}
 export SYNTHETICS_REMOTE_KIBANA_URL
 
 # Setup Failed Test Reporter Elasticsearch credentials


### PR DESCRIPTION
## Summary

This PR prioritizes SYNTHETICS_REMOTE_KIBANA_URL defined in the environment over the default defined in the vault.

This is utilized by Synthetics e2e tests to create distinct pipelines for each environment.