### PR TITLE
Refactor saved query request to not set page size of 10000

### DIFF
--- a/src/plugins/data/public/query/saved_query/saved_query_service.test.ts
+++ b/src/plugins/data/public/query/saved_query/saved_query_service.test.ts
@@ -67,9 +67,7 @@ describe('saved query service', () => {
       });
       const result = await getAllSavedQueries();
       expect(http.post).toBeCalled();
-      expect(http.post).toHaveBeenCalledWith('/api/saved_query/_find', {
-        body: '{"perPage":10000}',
-      });
+      expect(http.post).toHaveBeenCalledWith('/api/saved_query/_all');
       expect(result).toEqual([{ attributes: savedQueryAttributes }]);
     });
   });

--- a/src/plugins/data/public/query/saved_query/saved_query_service.ts
+++ b/src/plugins/data/public/query/saved_query/saved_query_service.ts
@@ -28,8 +28,7 @@ export const createSavedQueryService = (http: HttpStart) => {
   // we have to tell the saved objects client how many to fetch, otherwise it defaults to fetching 20 per page
   const getAllSavedQueries = async (): Promise<SavedQuery[]> => {
     const { savedQueries } = await http.post<{ savedQueries: SavedQuery[] }>(
-      '/api/saved_query/_find',
-      { body: JSON.stringify({ perPage: 10000 }) }
+      '/api/saved_query/_all'
     );
     return savedQueries;
   };

--- a/src/plugins/data/server/query/route_handler_context.ts
+++ b/src/plugins/data/server/query/route_handler_context.ts
@@ -142,7 +142,7 @@ export function registerSavedQueryRouteHandlerContext(context: RequestHandlerCon
       perPage: 100,
     });
 
-    const savedObjects: SavedObject<SavedQueryAttributes>[] = [];
+    const savedObjects: Array<SavedObject<SavedQueryAttributes>> = [];
     for await (const response of finder.find()) {
       savedObjects.push(...(response.saved_objects ?? []));
     }

--- a/src/plugins/data/server/query/route_handler_context.ts
+++ b/src/plugins/data/server/query/route_handler_context.ts
@@ -136,6 +136,22 @@ export function registerSavedQueryRouteHandlerContext(context: RequestHandlerCon
     return { total, savedQueries };
   };
 
+  const getAllSavedQueries = async () => {
+    const finder = context.core.savedObjects.client.createPointInTimeFinder<SavedQueryAttributes>({
+      type: 'query',
+      perPage: 100,
+    });
+
+    const savedObjects: SavedObject<SavedQueryAttributes>[] = [];
+    for await (const response of finder.find()) {
+      savedObjects.push(...(response.saved_objects ?? []));
+    }
+    await finder.close();
+
+    const savedQueries = savedObjects.map(injectReferences);
+    return { total: savedQueries.length, savedQueries };
+  };
+
   const deleteSavedQuery = (id: string) => {
     return context.core.savedObjects.client.delete('query', id);
   };
@@ -146,6 +162,7 @@ export function registerSavedQueryRouteHandlerContext(context: RequestHandlerCon
     get: getSavedQuery,
     count: getSavedQueriesCount,
     find: findSavedQueries,
+    getAll: getAllSavedQueries,
     delete: deleteSavedQuery,
   };
 }

--- a/src/plugins/data/server/query/routes.ts
+++ b/src/plugins/data/server/query/routes.ts
@@ -123,6 +123,22 @@ export function registerSavedQueryRoutes({ http }: CoreSetup): void {
     }
   );
 
+  router.post(
+    {
+      path: `${SAVED_QUERY_PATH}/_all`,
+      validate: {},
+    },
+    async (context, request, response) => {
+      try {
+        const body = await context.savedQuery.getAll();
+        return response.ok({ body });
+      } catch (e) {
+        // TODO: Handle properly
+        return response.customError(e);
+      }
+    }
+  );
+
   router.delete(
     {
       path: `${SAVED_QUERY_PATH}/{id}`,


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/93770.

Refactors the saved query service to not send a "perPage" of 10000. Instead, it uses the core [paginate service](https://github.com/elastic/kibana/pull/92981) to paginate through the result set.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
