### PR TITLE
[Security Solution][Lists] - Update exception list page text

### DIFF
--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -124,7 +124,7 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         navLinkStatus: AppNavLinkStatus.hidden,
         keywords: [
           i18n.translate('xpack.securitySolution.search.exceptions', {
-            defaultMessage: 'Exceptions',
+            defaultMessage: 'Exception lists',
           }),
         ],
         searchable: true,

--- a/x-pack/plugins/security_solution/public/app/translations.ts
+++ b/x-pack/plugins/security_solution/public/app/translations.ts
@@ -28,7 +28,7 @@ export const RULES = i18n.translate('xpack.securitySolution.navigation.rules', {
 });
 
 export const EXCEPTIONS = i18n.translate('xpack.securitySolution.navigation.exceptions', {
-  defaultMessage: 'Exceptions',
+  defaultMessage: 'Exception lists',
 });
 
 export const ALERTS = i18n.translate('xpack.securitySolution.navigation.alerts', {

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
@@ -158,7 +158,7 @@ describe('useSecuritySolutionNavigation', () => {
                 "href": "securitySolutionUI/exceptions?query=(language:kuery,query:'host.name:%22security-solution-es%22')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)))",
                 "id": "exceptions",
                 "isSelected": false,
-                "name": "Exceptions",
+                "name": "Exception lists",
                 "onClick": [Function],
               },
             ],

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
@@ -343,10 +343,7 @@ export const ExceptionListsTable = React.memo(() => {
     <>
       <EuiPageHeader
         pageTitle={i18n.ALL_EXCEPTIONS}
-        description={i18n.ALL_EXCEPTIONS_DESCRIPTION}
-        rightSideItems={[
-          <p>{timelines.getLastUpdated({ showUpdating: loading, updatedAt: lastUpdated })}</p>,
-        ]}
+        description={<p>{timelines.getLastUpdated({ showUpdating: loading, updatedAt: lastUpdated })}</p>}
       />
       <EuiHorizontalRule />
       <div data-test-subj="allExceptionListsPanel">

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
@@ -344,8 +344,8 @@ export const ExceptionListsTable = React.memo(() => {
       <EuiPageHeader
         pageTitle={i18n.ALL_EXCEPTIONS}
         description={
-        <p>{timelines.getLastUpdated({ showUpdating: loading, updatedAt: lastUpdated })}</p>
-      }
+          <p>{timelines.getLastUpdated({ showUpdating: loading, updatedAt: lastUpdated })}</p>
+        }
       />
       <EuiHorizontalRule />
       <div data-test-subj="allExceptionListsPanel">

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
@@ -343,7 +343,9 @@ export const ExceptionListsTable = React.memo(() => {
     <>
       <EuiPageHeader
         pageTitle={i18n.ALL_EXCEPTIONS}
-        description={<p>{timelines.getLastUpdated({ showUpdating: loading, updatedAt: lastUpdated })}</p>}
+        description={
+        <p>{timelines.getLastUpdated({ showUpdating: loading, updatedAt: lastUpdated })}</p>
+      }
       />
       <EuiHorizontalRule />
       <div data-test-subj="allExceptionListsPanel">

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/translations.ts
@@ -86,14 +86,7 @@ export const EXCEPTIONS_LISTS_SEARCH_PLACEHOLDER = i18n.translate(
 export const ALL_EXCEPTIONS = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allExceptions.tableTitle',
   {
-    defaultMessage: 'Exceptions',
-  }
-);
-
-export const ALL_EXCEPTIONS_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.rules.allExceptions.tableTitleDescription',
-  {
-    defaultMessage: 'Exceptions are automatically grouped into exception lists.',
+    defaultMessage: 'Exception lists',
   }
 );
 

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -22776,7 +22776,6 @@
     "xpack.securitySolution.detectionEngine.rules.allExceptionLists.search.placeholder": "検索例外リスト",
     "xpack.securitySolution.detectionEngine.rules.allExceptions.filters.noListsBody": "例外リストが見つかりませんでした。",
     "xpack.securitySolution.detectionEngine.rules.allExceptions.tableTitle": "例外",
-    "xpack.securitySolution.detectionEngine.rules.allExceptions.tableTitleDescription": "例外は自動的に例外リストにグループ化されます。",
     "xpack.securitySolution.detectionEngine.rules.allRules.actions.bulkActionFailedDescription": "一括アクションを実行できませんでした",
     "xpack.securitySolution.detectionEngine.rules.allRules.actions.deleteeRuleDescription": "ルールの削除",
     "xpack.securitySolution.detectionEngine.rules.allRules.actions.duplicateRuleDescription": "ルールの複製",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -23126,7 +23126,6 @@
     "xpack.securitySolution.detectionEngine.rules.allExceptionLists.search.placeholder": "搜索例外列表",
     "xpack.securitySolution.detectionEngine.rules.allExceptions.filters.noListsBody": "我们找不到任何例外列表。",
     "xpack.securitySolution.detectionEngine.rules.allExceptions.tableTitle": "例外",
-    "xpack.securitySolution.detectionEngine.rules.allExceptions.tableTitleDescription": "异常自动分组为异常列表。",
     "xpack.securitySolution.detectionEngine.rules.allRules.actions.bulkActionFailedDescription": "无法执行批量操作",
     "xpack.securitySolution.detectionEngine.rules.allRules.actions.deleteeRuleDescription": "删除规则",
     "xpack.securitySolution.detectionEngine.rules.allRules.actions.duplicateRuleDescription": "复制规则",


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/121756

- Changes exceptions list page title from "Exceptions" to "Exception lists"
- Removes subheader
- Moves page update text to be where subheader was instead of top right

<img width="1281" alt="Screen Shot 2022-01-31 at 2 34 04 PM" src="https://user-images.githubusercontent.com/10927944/151885018-e0419890-ae99-403b-b8d6-3bc0d3b00611.png">


### Checklist
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
