### PR TITLE
Ensure logstash getNodes always contains a uuid

### DIFF
--- a/x-pack/plugins/monitoring/server/lib/logstash/get_nodes.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/logstash/get_nodes.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getNodes } from './get_nodes';
+import { STANDALONE_CLUSTER_CLUSTER_UUID } from '../../../common/constants';
+import { LegacyRequest } from '../../types';
+import sinon from 'sinon';
+
+jest.mock('../../static_globals', () => ({
+  Globals: {
+    app: {
+      config: {
+        ui: {
+          ccs: { enabled: true },
+        },
+      },
+    },
+  },
+}));
+
+describe('getNodes', () => {
+  it('ensures collapse key is present query responses', async () => {
+    const response = {};
+
+    const config = {
+      get: sinon.stub(),
+    };
+    config.get.withArgs('monitoring.ui.max_bucket_size').returns(10000);
+
+    const callWithRequest = jest.fn().mockResolvedValue(response);
+
+    const req = {
+      server: {
+        config() {
+          return config;
+        },
+        plugins: {
+          elasticsearch: {
+            getCluster: () => ({
+              callWithRequest,
+            }),
+          },
+        },
+      },
+      payload: {
+        // borrowed from detail_drawer.test.js
+        timeRange: {
+          min: 1516131138639,
+          max: 1516135440463,
+        },
+      },
+    } as unknown as LegacyRequest;
+
+    await getNodes(req, {
+      clusterUuid: STANDALONE_CLUSTER_CLUSTER_UUID,
+    });
+
+    expect(callWithRequest.mock.calls.length).toBe(1);
+    expect(callWithRequest.mock.calls[0].length).toBe(3);
+
+    const filters = callWithRequest.mock.calls[0][2].body.query.bool.filter;
+    expect(filters).toContainEqual(
+      expect.objectContaining({
+        exists: {
+          field: 'logstash_stats.logstash.uuid',
+        },
+      })
+    );
+  });
+});

--- a/x-pack/plugins/monitoring/server/lib/logstash/get_nodes.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/logstash/get_nodes.test.ts
@@ -23,13 +23,12 @@ jest.mock('../../static_globals', () => ({
 
 describe('getNodes', () => {
   it('ensures collapse key is present query responses', async () => {
-    const response = {};
-
     const configs: { [key: string]: number } = { 'monitoring.ui.max_bucket_size': 10000 };
     const config = {
       get: jest.fn().mockImplementation((key: string) => configs[key]),
     };
 
+    const response = {};
     const callWithRequest = jest.fn().mockResolvedValue(response);
 
     const req = {

--- a/x-pack/plugins/monitoring/server/lib/logstash/get_nodes.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/logstash/get_nodes.test.ts
@@ -8,7 +8,6 @@
 import { getNodes } from './get_nodes';
 import { STANDALONE_CLUSTER_CLUSTER_UUID } from '../../../common/constants';
 import { LegacyRequest } from '../../types';
-import sinon from 'sinon';
 
 jest.mock('../../static_globals', () => ({
   Globals: {
@@ -26,10 +25,10 @@ describe('getNodes', () => {
   it('ensures collapse key is present query responses', async () => {
     const response = {};
 
+    const configs: { [key: string]: number } = { 'monitoring.ui.max_bucket_size': 10000 };
     const config = {
-      get: sinon.stub(),
+      get: jest.fn().mockImplementation((key: string) => configs[key]),
     };
-    config.get.withArgs('monitoring.ui.max_bucket_size').returns(10000);
 
     const callWithRequest = jest.fn().mockResolvedValue(response);
 

--- a/x-pack/plugins/monitoring/server/lib/logstash/get_nodes.ts
+++ b/x-pack/plugins/monitoring/server/lib/logstash/get_nodes.ts
@@ -81,20 +81,28 @@ export async function getNodes(req: LegacyRequest, { clusterUuid }: { clusterUui
   const start = moment.utc(req.payload.timeRange.min).valueOf();
   const end = moment.utc(req.payload.timeRange.max).valueOf();
 
+  const query = createQuery({
+    type,
+    dsDataset: `${moduleType}.${dataset}`,
+    metricset: dataset,
+    start,
+    end,
+    clusterUuid,
+    metric: LogstashMetric.getMetricFields(),
+  });
+
+  query.bool.filter.push({
+    exists: {
+      field: 'logstash_stats.logstash.uuid',
+    },
+  });
+
   const params = {
     index: indexPatterns,
     size: config.get('monitoring.ui.max_bucket_size'), // FIXME
     ignore_unavailable: true,
     body: {
-      query: createQuery({
-        type,
-        dsDataset: `${moduleType}.${dataset}`,
-        metricset: dataset,
-        start,
-        end,
-        clusterUuid,
-        metric: LogstashMetric.getMetricFields(),
-      }),
+      query,
       collapse: {
         field: 'logstash_stats.logstash.uuid',
       },

--- a/x-pack/plugins/monitoring/server/lib/logstash/get_nodes.ts
+++ b/x-pack/plugins/monitoring/server/lib/logstash/get_nodes.ts
@@ -81,28 +81,23 @@ export async function getNodes(req: LegacyRequest, { clusterUuid }: { clusterUui
   const start = moment.utc(req.payload.timeRange.min).valueOf();
   const end = moment.utc(req.payload.timeRange.max).valueOf();
 
-  const query = createQuery({
-    type,
-    dsDataset: `${moduleType}.${dataset}`,
-    metricset: dataset,
-    start,
-    end,
-    clusterUuid,
-    metric: LogstashMetric.getMetricFields(),
-  });
-
-  query.bool.filter.push({
-    exists: {
-      field: 'logstash_stats.logstash.uuid',
-    },
-  });
+  const filters = [{ exists: { field: 'logstash_stats.logstash.uuid' } }];
 
   const params = {
     index: indexPatterns,
     size: config.get('monitoring.ui.max_bucket_size'), // FIXME
     ignore_unavailable: true,
     body: {
-      query,
+      query: createQuery({
+        type,
+        dsDataset: `${moduleType}.${dataset}`,
+        metricset: dataset,
+        filters,
+        start,
+        end,
+        clusterUuid,
+        metric: LogstashMetric.getMetricFields(),
+      }),
       collapse: {
         field: 'logstash_stats.logstash.uuid',
       },


### PR DESCRIPTION
## Summary

Ensures logstash getNodes API always has a UUID.

This is less of an issue on main since we've stopped querying `metricbeat-*` but might become important when we start doing agent testing.

On 8.0 it's easy to end up with logstash connection failures in the `metricbeat-*` index.

I'll mark the backport as the "fix" PR for the 8.0.0 issue once it's open.

Rel: https://github.com/elastic/kibana/issues/123785

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios