### PR TITLE
[Visualize] guard against parse failures

### DIFF
--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
@@ -103,15 +103,19 @@ export class VisualizeEmbeddableFactory
       })`;
     },
     showSavedObject: (savedObject) => {
-      const typeName: string = JSON.parse(savedObject.attributes.visState).type;
-      const visType = getTypes().get(typeName);
-      if (!visType) {
+      try {
+        const typeName: string = JSON.parse(savedObject.attributes.visState).type;
+        const visType = getTypes().get(typeName);
+        if (!visType) {
+          return false;
+        }
+        if (getUISettings().get(VISUALIZE_ENABLE_LABS_SETTING)) {
+          return true;
+        }
+        return visType.stage !== 'experimental';
+      } catch {
         return false;
       }
-      if (getUISettings().get(VISUALIZE_ENABLE_LABS_SETTING)) {
-        return true;
-      }
-      return visType.stage !== 'experimental';
     },
     getSavedObjectSubType: (savedObject) => {
       return JSON.parse(savedObject.attributes.visState).type;


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/60252

To test, import this broken saved object (missing `visState`):
```
{"attributes":{"description":"","kibanaSavedObjectMeta":{"searchSourceJSON":"{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"},"title":"tobreak","uiStateJSON":"{}","version":1},"coreMigrationVersion":"8.1.0","id":"24937a70-8350-11ec-8ea6-4d114d12844f","migrationVersion":{"visualization":"8.0.0"},"references":[{"id":"d3d7af60-4c81-11e8-b3d7-01146121b73d","name":"kibanaSavedObjectMeta.searchSourceJSON.index","type":"index-pattern"}],"type":"visualization","updated_at":"2022-02-01T11:14:37.595Z","version":"WzEzNzEsMV0="}
{"excludedObjects":[],"excludedObjectsCount":0,"exportedCount":1,"missingRefCount":0,"missingReferences":[]}
```

Without this fix, the "Add from library" dialog on a dashboard keeps spinning. With this fix, it renders fine without showing the broken vis. In the visualization library it's showing up as "unknown vis type"