### PR TITLE
[Lens] Show warning for completely static formula

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.test.tsx
@@ -840,7 +840,7 @@ describe('formula', () => {
             ...columnParams,
           } as FormulaIndexPatternColumn,
         },
-        columnOrder: [],
+        columnOrder: ['col1'],
         indexPatternId: '',
       };
     }
@@ -1386,6 +1386,45 @@ invalid: "
           )
         ).toEqual([`The first argument for ${fn} should be a operation name. Found no operation`]);
       }
+    });
+
+    it('returns an error if the formula is fully static and there is at least one bucket dimension', () => {
+      const formulaLayer = getNewLayerWithFormula('5 + 3 * 7');
+      expect(
+        formulaOperation.getErrorMessage!(
+          {
+            ...formulaLayer,
+            columns: {
+              ...formulaLayer.columns,
+              col0: {
+                dataType: 'date',
+                isBucketed: true,
+                label: '',
+                operationType: 'date_histogram',
+                references: [],
+                sourceField: 'ts',
+              },
+            },
+            columnOrder: ['col0', 'col1'],
+          },
+          'col1',
+          indexPattern,
+          operationDefinitionMap
+        )
+      ).toEqual([
+        'A layer with only static values will not show results, use at least one dynamic metric',
+      ]);
+    });
+
+    it('returns no error if the formula is fully static and there is no bucket dimension', () => {
+      expect(
+        formulaOperation.getErrorMessage!(
+          getNewLayerWithFormula('5 + 3 * 7'),
+          'col1',
+          indexPattern,
+          operationDefinitionMap
+        )
+      ).toEqual(undefined);
     });
 
     it('returns no error if a math operation is passed to fullReference operations', () => {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.tsx
@@ -86,6 +86,25 @@ export const formulaOperation: OperationDefinition<FormulaIndexPatternColumn, 'm
           return [];
         })
         .filter((marker) => marker);
+      const hasBuckets = layer.columnOrder.some((colId) => layer.columns[colId].isBucketed);
+      const hasOtherMetrics = layer.columnOrder.some((colId) => {
+        const col = layer.columns[colId];
+        return (
+          !col.isBucketed &&
+          !col.isStaticValue &&
+          col.operationType !== 'math' &&
+          col.operationType !== 'formula'
+        );
+      });
+
+      if (hasBuckets && !hasOtherMetrics) {
+        innerErrors.push({
+          message: i18n.translate('xpack.lens.indexPattern.noRealMetricError', {
+            defaultMessage:
+              'A layer with only static values will not show results, use at least one dynamic metric',
+          }),
+        });
+      }
 
       return innerErrors.length ? innerErrors.map(({ message }) => message) : undefined;
     },


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/118668

This PR shows a specific error message in case a layer has a static formula, bucket dimensions, but not a single metric dimension:
<img width="1671" alt="Screenshot 2022-02-01 at 12 59 49" src="https://user-images.githubusercontent.com/1508364/151964910-fecb4a14-a63b-4156-9af5-b0ca946c3daa.png">
<img width="1698" alt="Screenshot 2022-02-01 at 12 59 43" src="https://user-images.githubusercontent.com/1508364/151964919-b91e211b-4386-4a5a-bfae-13f367842310.png">

While testing, the most important thing is to make sure this error message is not showing up by accident in otherwise valid cases, breaking existing visualizations.