### PR TITLE
[Fleet] fixed undefined error when missing policy vars in template

### DIFF
--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -748,7 +748,6 @@ describe('Fleet - validationHasErrors()', () => {
                     type: 'metrics',
                   },
                   enabled: true,
-                  id: 'linux/metrics-linux.memory-b0df6872-ff9a-443f-babc-5d7785e35b98',
                 },
               ],
               type: 'linux/metrics',

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -606,6 +606,132 @@ describe('Fleet - validatePackagePolicy()', () => {
         },
       });
     });
+
+    it('returns package policy validation error if input var does not exist', () => {
+      expect(
+        validatePackagePolicy(
+          {
+            description: 'Linux Metrics',
+            enabled: true,
+            inputs: [
+              {
+                enabled: true,
+                streams: [
+                  {
+                    data_stream: {
+                      dataset: 'linux.memory',
+                      type: 'metrics',
+                    },
+                    enabled: true,
+                  },
+                ],
+                type: 'linux/metrics',
+                vars: {
+                  period: {
+                    type: 'string',
+                    value: '1s',
+                  },
+                },
+              },
+            ],
+            name: 'linux-3d13ada6-a9ae-46df-8e57-ff5050f4b671',
+            namespace: 'default',
+            output_id: '',
+            package: {
+              name: 'linux',
+              title: 'Linux Metrics',
+              version: '0.6.2',
+            },
+            policy_id: 'b25cb6e0-8347-11ec-96f9-6590c25bacf9',
+          },
+          {
+            ...mockPackage,
+            name: 'linux',
+            policy_templates: [
+              {
+                name: 'system',
+                title: 'Linux kernel metrics',
+                description: 'Collect system metrics from Linux operating systems',
+                inputs: [
+                  {
+                    title: 'Collect system metrics from Linux instances',
+                    vars: [
+                      {
+                        name: 'system.hostfs',
+                        type: 'text',
+                        title: 'Proc Filesystem Directory',
+                        multi: false,
+                        required: false,
+                        show_user: true,
+                        description: 'The proc filesystem base directory.',
+                      },
+                    ],
+                    type: 'system/metrics',
+                    description:
+                      'Collecting Linux entropy, Network Summary, RAID, service, socket, and users metrics',
+                  },
+                  {
+                    title: 'Collect low-level system metrics from Linux instances',
+                    vars: [],
+                    type: 'linux/metrics',
+                    description: 'Collecting Linux conntrack, ksm, pageinfo metrics.',
+                  },
+                ],
+                multiple: true,
+              },
+            ],
+            data_streams: [
+              {
+                dataset: 'linux.memory',
+                package: 'linux',
+                path: 'memory',
+                streams: [
+                  {
+                    input: 'linux/metrics',
+                    title: 'Linux memory metrics',
+                    vars: [
+                      {
+                        name: 'period',
+                        type: 'text',
+                        title: 'Period',
+                        multi: false,
+                        required: true,
+                        show_user: true,
+                        default: '10s',
+                      },
+                    ],
+                    template_path: 'stream.yml.hbs',
+                    description: 'Linux paging and memory management metrics',
+                  },
+                ],
+                title: 'Linux-only memory metrics',
+                release: 'experimental',
+                type: 'metrics',
+              },
+            ],
+          },
+          safeLoad
+        )
+      ).toEqual({
+        description: null,
+        inputs: {
+          'linux/metrics': {
+            streams: {
+              'linux.memory': {
+                vars: {
+                  period: ['Period is required'],
+                },
+              },
+            },
+            vars: {
+              period: ['linux/metrics has no vars in policy template'],
+            },
+          },
+        },
+        name: null,
+        namespace: null,
+      });
+    });
   });
 
   describe('works for packages with multiple policy templates (aka integrations)', () => {
@@ -730,146 +856,5 @@ describe('Fleet - validationHasErrors()', () => {
         },
       })
     ).toBe(false);
-  });
-
-  it('returns package policy validation error if input var does not exist', () => {
-    expect(
-      validatePackagePolicy(
-        {
-          description: 'Linux Metrics',
-          enabled: true,
-          inputs: [
-            {
-              enabled: true,
-              streams: [
-                {
-                  data_stream: {
-                    dataset: 'linux.memory',
-                    type: 'metrics',
-                  },
-                  enabled: true,
-                },
-              ],
-              type: 'linux/metrics',
-              vars: {
-                period: {
-                  type: 'string',
-                  value: '1s',
-                },
-              },
-            },
-          ],
-          name: 'linux-3d13ada6-a9ae-46df-8e57-ff5050f4b671',
-          namespace: 'default',
-          output_id: '',
-          package: {
-            name: 'linux',
-            title: 'Linux Metrics',
-            version: '0.6.2',
-          },
-          policy_id: 'b25cb6e0-8347-11ec-96f9-6590c25bacf9',
-        },
-        {
-          format_version: '1.0.0',
-          name: 'linux',
-          title: 'Linux Metrics',
-          version: '0.6.2',
-          license: 'basic',
-          description: 'Collect metrics from Linux servers with Elastic Agent.',
-          type: 'integration',
-          categories: ['os_system'],
-          release: 'beta',
-          policy_templates: [
-            {
-              name: 'system',
-              title: 'Linux kernel metrics',
-              description: 'Collect system metrics from Linux operating systems',
-              inputs: [
-                {
-                  title: 'Collect system metrics from Linux instances',
-                  vars: [
-                    {
-                      name: 'system.hostfs',
-                      type: 'text',
-                      title: 'Proc Filesystem Directory',
-                      multi: false,
-                      required: false,
-                      show_user: true,
-                      description: 'The proc filesystem base directory.',
-                    },
-                  ],
-                  type: 'system/metrics',
-                  description:
-                    'Collecting Linux entropy, Network Summary, RAID, service, socket, and users metrics',
-                },
-                {
-                  title: 'Collect low-level system metrics from Linux instances',
-                  vars: [],
-                  type: 'linux/metrics',
-                  description: 'Collecting Linux conntrack, ksm, pageinfo metrics.',
-                },
-              ],
-              multiple: true,
-            },
-          ],
-          owner: {
-            github: 'elastic/integrations',
-          },
-          readme: '/package/linux/0.6.2/docs/README.md',
-          data_streams: [
-            {
-              dataset: 'linux.memory',
-              package: 'linux',
-              path: 'memory',
-              streams: [
-                {
-                  input: 'linux/metrics',
-                  title: 'Linux memory metrics',
-                  vars: [
-                    {
-                      name: 'period',
-                      type: 'text',
-                      title: 'Period',
-                      multi: false,
-                      required: true,
-                      show_user: true,
-                      default: '10s',
-                    },
-                  ],
-                  template_path: 'stream.yml.hbs',
-                  description: 'Linux paging and memory management metrics',
-                },
-              ],
-              title: 'Linux-only memory metrics',
-              release: 'experimental',
-              type: 'metrics',
-            },
-          ],
-          latestVersion: '0.6.2',
-          removable: true,
-          keepPoliciesUpToDate: false,
-          status: 'installed',
-        },
-        safeLoad
-      )
-    ).toEqual({
-      description: null,
-      inputs: {
-        'linux/metrics': {
-          streams: {
-            'linux.memory': {
-              vars: {
-                period: ['Period is required'],
-              },
-            },
-          },
-          vars: {
-            period: ['linux/metrics has no vars in policy template'],
-          },
-        },
-      },
-      name: null,
-      namespace: null,
-    });
   });
 });

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -779,9 +779,6 @@ describe('Fleet - validationHasErrors()', () => {
           type: 'integration',
           categories: ['os_system'],
           release: 'beta',
-          conditions: {
-            'kibana.version': '^7.14.0 || ^8.0.0',
-          },
           policy_templates: [
             {
               name: 'system',

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -731,4 +731,149 @@ describe('Fleet - validationHasErrors()', () => {
       })
     ).toBe(false);
   });
+
+  it('returns package policy validation error if input var does not exist', () => {
+    expect(
+      validatePackagePolicy(
+        {
+          description: 'Linux Metrics',
+          enabled: true,
+          inputs: [
+            {
+              enabled: true,
+              streams: [
+                {
+                  data_stream: {
+                    dataset: 'linux.memory',
+                    type: 'metrics',
+                  },
+                  enabled: true,
+                  id: 'linux/metrics-linux.memory-b0df6872-ff9a-443f-babc-5d7785e35b98',
+                },
+              ],
+              type: 'linux/metrics',
+              vars: {
+                period: {
+                  type: 'string',
+                  value: '1s',
+                },
+              },
+            },
+          ],
+          name: 'linux-3d13ada6-a9ae-46df-8e57-ff5050f4b671',
+          namespace: 'default',
+          output_id: '',
+          package: {
+            name: 'linux',
+            title: 'Linux Metrics',
+            version: '0.6.2',
+          },
+          policy_id: 'b25cb6e0-8347-11ec-96f9-6590c25bacf9',
+        },
+        {
+          format_version: '1.0.0',
+          name: 'linux',
+          title: 'Linux Metrics',
+          version: '0.6.2',
+          license: 'basic',
+          description: 'Collect metrics from Linux servers with Elastic Agent.',
+          type: 'integration',
+          categories: ['os_system'],
+          release: 'beta',
+          conditions: {
+            'kibana.version': '^7.14.0 || ^8.0.0',
+          },
+          policy_templates: [
+            {
+              name: 'system',
+              title: 'Linux kernel metrics',
+              description: 'Collect system metrics from Linux operating systems',
+              inputs: [
+                {
+                  title: 'Collect system metrics from Linux instances',
+                  vars: [
+                    {
+                      name: 'system.hostfs',
+                      type: 'text',
+                      title: 'Proc Filesystem Directory',
+                      multi: false,
+                      required: false,
+                      show_user: true,
+                      description: 'The proc filesystem base directory.',
+                    },
+                  ],
+                  type: 'system/metrics',
+                  description:
+                    'Collecting Linux entropy, Network Summary, RAID, service, socket, and users metrics',
+                },
+                {
+                  title: 'Collect low-level system metrics from Linux instances',
+                  vars: [],
+                  type: 'linux/metrics',
+                  description: 'Collecting Linux conntrack, ksm, pageinfo metrics.',
+                },
+              ],
+              multiple: true,
+            },
+          ],
+          owner: {
+            github: 'elastic/integrations',
+          },
+          readme: '/package/linux/0.6.2/docs/README.md',
+          data_streams: [
+            {
+              dataset: 'linux.memory',
+              package: 'linux',
+              path: 'memory',
+              streams: [
+                {
+                  input: 'linux/metrics',
+                  title: 'Linux memory metrics',
+                  vars: [
+                    {
+                      name: 'period',
+                      type: 'text',
+                      title: 'Period',
+                      multi: false,
+                      required: true,
+                      show_user: true,
+                      default: '10s',
+                    },
+                  ],
+                  template_path: 'stream.yml.hbs',
+                  description: 'Linux paging and memory management metrics',
+                },
+              ],
+              title: 'Linux-only memory metrics',
+              release: 'experimental',
+              type: 'metrics',
+            },
+          ],
+          latestVersion: '0.6.2',
+          removable: true,
+          keepPoliciesUpToDate: false,
+          status: 'installed',
+        },
+        safeLoad
+      )
+    ).toEqual({
+      description: null,
+      inputs: {
+        'linux/metrics': {
+          streams: {
+            'linux.memory': {
+              vars: {
+                period: ['Period is required'],
+              },
+            },
+          },
+          vars: {
+            period: ['linux/metrics has no vars in policy template'],
+          },
+        },
+      },
+      name: null,
+      namespace: null,
+    });
+  });
 });

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -724,7 +724,7 @@ describe('Fleet - validatePackagePolicy()', () => {
               },
             },
             vars: {
-              period: ['linux/metrics has no vars in policy template'],
+              period: ['period var definition does not exist'],
             },
           },
         },

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -147,7 +147,6 @@ export const validatePackagePolicy = (
                   defaultMessage: '{inputKey} has no vars in policy template',
                   values: {
                     inputKey,
-                    name,
                   },
                 }),
               ]

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -143,7 +143,7 @@ export const validatePackagePolicy = (
         results[name] = input.enabled
           ? validatePackagePolicyConfig(
               configEntry,
-              inputVarDefsByPolicyTemplateAndType[inputKey][name],
+              (inputVarDefsByPolicyTemplateAndType[inputKey] ?? {})[name],
               name,
               safeLoadYaml
             )

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -141,21 +141,12 @@ export const validatePackagePolicy = (
     if (inputVars.length) {
       inputValidationResults.vars = inputVars.reduce((results, [name, configEntry]) => {
         results[name] = input.enabled
-          ? inputVarDefsByPolicyTemplateAndType[inputKey] === undefined
-            ? [
-                i18n.translate('xpack.fleet.packagePolicyValidation.missingInputKeyMessage', {
-                  defaultMessage: '{inputKey} has no vars in policy template',
-                  values: {
-                    inputKey,
-                  },
-                }),
-              ]
-            : validatePackagePolicyConfig(
-                configEntry,
-                inputVarDefsByPolicyTemplateAndType[inputKey][name],
-                name,
-                safeLoadYaml
-              )
+          ? validatePackagePolicyConfig(
+              configEntry,
+              (inputVarDefsByPolicyTemplateAndType[inputKey] ?? {})[name],
+              name,
+              safeLoadYaml
+            )
           : null;
         return results;
       }, {} as ValidationEntry);
@@ -219,10 +210,15 @@ export const validatePackagePolicyConfig = (
   }
 
   if (varDef === undefined) {
-    // eslint-disable-next-line no-console
-    console.debug(`No variable definition for ${varName} found`);
-
-    return null;
+    errors.push(
+      i18n.translate('xpack.fleet.packagePolicyValidation.nonExistentVarMessage', {
+        defaultMessage: '{varName} var definition does not exist',
+        values: {
+          varName,
+        },
+      })
+    );
+    return errors;
   }
 
   if (varDef.required) {

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -141,12 +141,22 @@ export const validatePackagePolicy = (
     if (inputVars.length) {
       inputValidationResults.vars = inputVars.reduce((results, [name, configEntry]) => {
         results[name] = input.enabled
-          ? validatePackagePolicyConfig(
-              configEntry,
-              (inputVarDefsByPolicyTemplateAndType[inputKey] ?? {})[name],
-              name,
-              safeLoadYaml
-            )
+          ? inputVarDefsByPolicyTemplateAndType[inputKey] === undefined
+            ? [
+                i18n.translate('xpack.fleet.packagePolicyValidation.missingInputKeyMessage', {
+                  defaultMessage: '{inputKey} has no vars in policy template',
+                  values: {
+                    inputKey,
+                    name,
+                  },
+                }),
+              ]
+            : validatePackagePolicyConfig(
+                configEntry,
+                inputVarDefsByPolicyTemplateAndType[inputKey][name],
+                name,
+                safeLoadYaml
+              )
           : null;
         return results;
       }, {} as ValidationEntry);


### PR DESCRIPTION
## Summary

@mdelapenya reported an issue in e2e-tests that seems to be surfaced by [improving package policy validation](https://github.com/elastic/kibana/pull/123153)

When trying to create a package policy with this request body, there is an undefined error coming:

```
POST http://elastic:changeme@localhost:5620/api/fleet/package_policies
kbn-xsrf: kibana

{
   "description": "Linux Metrics",
   "enabled": true,
   "inputs": [
      {
         "enabled": true,
         "streams": [
            {
               "data_stream": {
                  "dataset": "linux.memory",
                  "type": "metrics"
               },
               "enabled": true,
               "id": "linux/metrics-linux.memory-b0df6872-ff9a-443f-babc-5d7785e35b98"
            }
         ],
         "type": "linux/metrics",
         "vars": {
            "period": {
               "type": "string",
               "value": "1s"
            }
         }
      }
   ],
   "name": "linux-3d13ada6-a9ae-46df-8e57-ff5050f4b671",
   "namespace": "default",
   "output_id": "",
   "package": {
      "name": "linux",
      "title": "Linux Metrics",
      "version": "0.6.2"
   },
   "policy_id": "b25cb6e0-8347-11ec-96f9-6590c25bacf9"
}
```
Response:
```
{
   "statusCode": 500,
   "error": "Internal Server Error",
   "message": "Cannot read properties of undefined (reading 'period')"
 }
```

Stack trace:
```
 │ proc [kibana] [2022-02-01T13:02:19.415+01:00][ERROR][plugins.fleet] TypeError: Cannot read properties of undefined (reading 'period')
 │ proc [kibana]     at reduce (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/common/services/validate_package_policy.ts:146:15)
 │ proc [kibana]     at Array.reduce (<anonymous>)
 │ proc [kibana]     at forEach (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/common/services/validate_package_policy.ts:142:47)
 │ proc [kibana]     at Array.forEach (<anonymous>)
 │ proc [kibana]     at validatePackagePolicy (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/common/services/validate_package_policy.ts:129:24)
 │ proc [kibana]     at validatePackagePolicyOrThrow (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/services/package_policy.ts:702:63)
 │ proc [kibana]     at PackagePolicyService.create (/Users/juliabardi/kibana/kibana/x-pack/plugins/fleet/server/services/package_policy.ts:119:7)

```

There seems to be a nullcheck missing. After adding it, a more meaningful validation error comes:

```
 {
   "statusCode": 400,
   "error": "Bad Request",
   "message": "Package policy is invalid: inputs.linux/metrics.streams.linux.memory.vars.period: Period is required"
 }
```


