### PR TITLE
[Lens] Fixes label autocommit while typing a custom text

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -638,7 +638,6 @@ export function DimensionEditor(props: DimensionEditorProps) {
     () =>
       String(
         selectedColumn &&
-          !selectedColumn.customLabel &&
           operationDefinitionMap[selectedColumn.operationType].getDefaultLabel(
             selectedColumn,
             state.indexPatterns[state.layers[layerId].indexPatternId],


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/124166

This PR fixes the problem described on the issue. Specifically, when the user is typing a custom label, it was autocommited, creating some weird ux behavior. Now it works as before.
![demo_lens2](https://user-images.githubusercontent.com/17003240/151969403-eb384323-5897-4ebd-ab26-be75deeb7787.gif)

But it comes with a cost :D
There was a reason for that line. When you add a Top Values dimension (on a string field), add a custom label, switch to Rarity and remove the custom label, the placeholder now is the custom value (instead of `Rare values of...`. 
![image](https://user-images.githubusercontent.com/17003240/151969189-f16b6ed5-e443-4aef-ad44-054dfdf21c5c.png)

I can't think of any good way to fix them both tbh. We discussed it with @flash1293 and for now, we think that the second one is an edge case and not so weird comparing to the bug described to the issue.