### PR TITLE
[Lens] Label placeholder always defaults to the lens proposed text

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -638,7 +638,6 @@ export function DimensionEditor(props: DimensionEditorProps) {
     () =>
       String(
         selectedColumn &&
-          !selectedColumn.customLabel &&
           operationDefinitionMap[selectedColumn.operationType].getDefaultLabel(
             selectedColumn,
             state.indexPatterns[state.layers[layerId].indexPatternId],

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -767,6 +767,7 @@ export function DimensionEditor(props: DimensionEditorProps) {
               // re-render the input from scratch to obtain new "initial value" if the underlying default label changes
               key={defaultLabel}
               value={selectedColumn.label}
+              defaultValue={defaultLabel}
               onChange={(value) => {
                 updateLayer({
                   columns: {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimensions_editor_helpers.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimensions_editor_helpers.tsx
@@ -33,11 +33,17 @@ export function isQuickFunction(operationType: string) {
 export const LabelInput = ({
   value,
   onChange,
+  defaultValue,
 }: {
   value: string;
   onChange: (value: string) => void;
+  defaultValue?: string;
 }) => {
-  const { inputValue, handleInputChange, initialValue } = useDebouncedValue({ onChange, value });
+  const { inputValue, handleInputChange, initialValue } = useDebouncedValue({
+    onChange,
+    value,
+    defaultValue,
+  });
 
   return (
     <EuiFormRow

--- a/x-pack/plugins/lens/public/shared_components/debounced_value.ts
+++ b/x-pack/plugins/lens/public/shared_components/debounced_value.ts
@@ -21,9 +21,11 @@ export const useDebouncedValue = <T>(
   {
     onChange,
     value,
+    defaultValue,
   }: {
     onChange: (val: T) => void;
     value: T;
+    defaultValue?: T;
   },
   { allowFalsyValue }: { allowFalsyValue?: boolean } = {}
 ) => {
@@ -32,7 +34,7 @@ export const useDebouncedValue = <T>(
   const shouldUpdateWithFalsyValue = Boolean(allowFalsyValue);
 
   // Save the initial value
-  const initialValue = useRef(value);
+  const initialValue = useRef(defaultValue ?? value);
 
   const flushChangesTimeout = useRef<NodeJS.Timeout | undefined>();
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/124166

This PR fixes the problem described on the issue. Specifically, when the user is typing a custom label, it was autocommited, creating some weird ux behavior. Now it works as before.
It also changes a bit the behavior of the placeholder. Currently if the user closes the flyout, the value is submitted. If he re-opens it and removes the custom label, the placeholder has the custom value.
This PR stores the default value and display that if the custom label is not applied. 

It works like that:

![image](https://user-images.githubusercontent.com/17003240/152110025-f88415a1-75ef-4a74-a0b1-0e3e3550b084.png)

Discussion about the change of behavior here https://github.com/elastic/kibana/pull/124218