### PR TITLE
[Fleet] fix fleet server host placeholder

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
@@ -461,7 +461,7 @@ export const AddFleetServerHostStepContent = ({
         <EuiFlexItem>
           <EuiFieldText
             fullWidth
-            placeholder={'e.g. http://127.0.0.1:8220'}
+            placeholder={'e.g. https://127.0.0.1:8220'}
             value={fleetServerHost}
             isInvalid={!!error}
             onChange={onChange}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/123356

Updated Fleet Server host placeholder to show `https`

![image](https://user-images.githubusercontent.com/90178898/151974171-0af81a9d-e8f2-42ca-96cb-4dc40940f16e.png)

