### PR TITLE
[Security Solution][Endpoint] Extend base schema to validate host isolation exception entry

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/exceptions_list_item_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/exceptions_list_item_generator.ts
@@ -198,6 +198,7 @@ export class ExceptionsListItemGenerator extends BaseDataGenerator<ExceptionList
     return this.generate({
       name: `Host Isolation (${this.randomString(5)})`,
       list_id: ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_ID,
+      os_types: ['macos', 'linux', 'windows'],
       entries: [
         {
           field: 'destination.ip',

--- a/x-pack/plugins/security_solution/server/lists_integration/endpoint/validators/base_validator.ts
+++ b/x-pack/plugins/security_solution/server/lists_integration/endpoint/validators/base_validator.ts
@@ -19,7 +19,7 @@ import {
 import { OperatingSystem } from '../../../../common/endpoint/types';
 import { EndpointArtifactExceptionValidationError } from './errors';
 
-const BasicEndpointExceptionDataSchema = schema.object(
+export const BasicEndpointExceptionDataSchema = schema.object(
   {
     // must have a name
     name: schema.string({ minLength: 1, maxLength: 256 }),

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_artifacts/host_isolation_exceptions.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_artifacts/host_isolation_exceptions.ts
@@ -178,7 +178,18 @@ export default function ({ getService }: FtrProviderContext) {
             .expect(anErrorMessageWith(/invalid ip/));
         });
 
-        it(`should error on [${apiCall.method}] if more than one OS is set`, async () => {
+        it(`should work on [${apiCall.method}] and accept all OSs for os_types`, async () => {
+          const body = apiCall.getBody();
+
+          body.os_types = ['linux', 'windows', 'macos'];
+
+          await supertest[apiCall.method](apiCall.path)
+            .set('kbn-xsrf', 'true')
+            .send(body)
+            .expect(200);
+        });
+
+        it(`should not work on [${apiCall.method}] if all OSs for os_types are not included`, async () => {
           const body = apiCall.getBody();
 
           body.os_types = ['linux', 'windows'];
@@ -187,8 +198,8 @@ export default function ({ getService }: FtrProviderContext) {
             .set('kbn-xsrf', 'true')
             .send(body)
             .expect(400)
-            .expect(anEndpointArtifactError)
-            .expect(anErrorMessageWith(/\[osTypes\]: array size is \[2\]/));
+            .expect(anEndpointArtifactError);
+          expect(anErrorMessageWith(/\[osTypes\]: array size is \[3\]/));
         });
 
         it(`should error on [${apiCall.method}] if policy id is invalid`, async () => {


### PR DESCRIPTION
## Summary

Extends the base validation schema for endpoint artifacts to allow all OSs for host isolation exception entry.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
