### PR TITLE
[Fleet] support setting id in new agent policy API

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3764,6 +3764,9 @@
         "title": "New agent policy",
         "type": "object",
         "properties": {
+          "id": {
+            "type": "string"
+          },
           "name": {
             "type": "string"
           },
@@ -3783,7 +3786,11 @@
               ]
             }
           }
-        }
+        },
+        "required": [
+          "name",
+          "namespace"
+        ]
       },
       "new_package_policy": {
         "title": "New package policy",

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2363,6 +2363,8 @@ components:
       title: New agent policy
       type: object
       properties:
+        id:
+          type: string
         name:
           type: string
         namespace:
@@ -2376,6 +2378,9 @@ components:
             enum:
               - metrics
               - logs
+      required:
+        - name
+        - namespace
     new_package_policy:
       title: New package policy
       type: object

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/new_agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/new_agent_policy.yaml
@@ -1,6 +1,8 @@
 title: New agent policy
 type: object
 properties:
+  id:
+    type: string
   name:
     type: string
   namespace:
@@ -14,3 +16,6 @@ properties:
       enum:
         - metrics
         - logs
+required:
+  - name
+  - namespace

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -14,6 +14,7 @@ import type { Output } from './output';
 export type AgentPolicyStatus = typeof agentPolicyStatuses;
 
 export interface NewAgentPolicy {
+  id?: string;
   name: string;
   namespace: string;
   description?: string;
@@ -28,7 +29,7 @@ export interface NewAgentPolicy {
   monitoring_output_id?: string;
 }
 
-export interface AgentPolicy extends NewAgentPolicy {
+export interface AgentPolicy extends Omit<NewAgentPolicy, 'id'> {
   id: string;
   status: ValueOf<AgentPolicyStatus>;
   package_policies: string[] | PackagePolicy[];

--- a/x-pack/plugins/fleet/common/types/models/preconfiguration.ts
+++ b/x-pack/plugins/fleet/common/types/models/preconfiguration.ts
@@ -20,7 +20,7 @@ export type InputsOverride = Partial<NewPackagePolicyInput> & {
   vars?: Array<NewPackagePolicyInput['vars'] & { name: string }>;
 };
 
-export interface PreconfiguredAgentPolicy extends Omit<NewAgentPolicy, 'namespace'> {
+export interface PreconfiguredAgentPolicy extends Omit<NewAgentPolicy, 'namespace' | 'id'> {
   id: string | number;
   namespace?: string;
   package_policies: Array<

--- a/x-pack/plugins/fleet/server/services/agent_policy_create.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy_create.test.ts
@@ -208,4 +208,35 @@ describe('createAgentPolicyWithPackages', () => {
       expect.anything()
     );
   });
+
+  it('should create policy with id', async () => {
+    const response = await createAgentPolicyWithPackages({
+      esClient: esClientMock,
+      soClient: soClientMock,
+      newPolicy: { id: 'policy-1', name: 'Agent policy 1', namespace: 'default' },
+      withSysMonitoring: false,
+      spaceId: 'default',
+      monitoringEnabled: [],
+    });
+
+    expect(response.id).toEqual('policy-1');
+  });
+
+  it('should create policy with fleet_server and id', async () => {
+    const response = await createAgentPolicyWithPackages({
+      esClient: esClientMock,
+      soClient: soClientMock,
+      newPolicy: {
+        id: 'new_fleet_server_policy',
+        name: 'Fleet Server policy',
+        namespace: 'default',
+      },
+      hasFleetServer: true,
+      withSysMonitoring: false,
+      monitoringEnabled: [],
+      spaceId: 'default',
+    });
+
+    expect(response.id).toEqual('new_fleet_server_policy');
+  });
 });

--- a/x-pack/plugins/fleet/server/services/agent_policy_create.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy_create.ts
@@ -94,12 +94,12 @@ export async function createAgentPolicyWithPackages({
   spaceId,
   user,
 }: CreateAgentPolicyParams) {
-  let agentPolicyId;
+  let agentPolicyId = newPolicy.id;
   const packagesToInstall = [];
   if (hasFleetServer) {
     packagesToInstall.push(FLEET_SERVER_PACKAGE);
 
-    agentPolicyId = await getFleetServerAgentPolicyId(soClient);
+    agentPolicyId = agentPolicyId || (await getFleetServerAgentPolicyId(soClient));
     if (agentPolicyId === FLEET_SERVER_POLICY_ID) {
       // setting first fleet server policy to default, so that fleet server can enroll without setting policy_id
       newPolicy.is_default_fleet_server = true;
@@ -120,7 +120,9 @@ export async function createAgentPolicyWithPackages({
     });
   }
 
-  const agentPolicy = await agentPolicyService.create(soClient, esClient, newPolicy, {
+  const { id, ...policy } = newPolicy; // omit id from create object
+
+  const agentPolicy = await agentPolicyService.create(soClient, esClient, policy, {
     user,
     id: agentPolicyId,
   });

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -12,6 +12,7 @@ import { agentPolicyStatuses, dataTypes } from '../../../common';
 import { PackagePolicySchema, NamespaceSchema } from './package_policy';
 
 export const AgentPolicyBaseSchema = {
+  id: schema.maybe(schema.string()),
   name: schema.string({ minLength: 1 }),
   namespace: NamespaceSchema,
   description: schema.maybe(schema.string()),

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -141,7 +141,7 @@ export default function (providerContext: FtrProviderContext) {
           .set('kbn-xsrf', 'xxxx')
           .send({
             id: 'test-id',
-            name: 'TEST',
+            name: 'TEST ID',
             namespace: 'default',
           })
           .expect(200);
@@ -154,7 +154,7 @@ export default function (providerContext: FtrProviderContext) {
           .set('kbn-xsrf', 'xxxx')
           .send({
             id: 'test-id',
-            name: 'TEST 2',
+            name: 'TEST 2 ID',
             namespace: 'default',
           })
           .expect(409);

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -133,6 +133,33 @@ export default function (providerContext: FtrProviderContext) {
           .expect(409);
       });
 
+      it('should create policy with provided id and return 409 the second time', async () => {
+        const {
+          body: { item: createdPolicy },
+        } = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            id: 'test-id',
+            name: 'TEST',
+            namespace: 'default',
+          })
+          .expect(200);
+
+        expect(createdPolicy.id).to.equal('test-id');
+
+        // second one fails because id exists
+        await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            id: 'test-id',
+            name: 'TEST 2',
+            namespace: 'default',
+          })
+          .expect(409);
+      });
+
       it('should allow to create policy with the system integration policy and increment correctly the name if there is more than 10 package policy', async () => {
         // load a bunch of fake system integration policy
         for (let i = 0; i < 10; i++) {

--- a/x-pack/test/fleet_api_integration/apis/epm/setup.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/setup.ts
@@ -82,13 +82,12 @@ export default function (providerContext: FtrProviderContext) {
         .set('Authorization', `Bearer ${token.value}`)
         .set('kbn-xsrf', 'xxx')
         .expect(200);
-      const resp = await supertest
+      await supertest
         .post('/api/fleet/agent_policies')
         .set('Authorization', `Bearer ${token.value}`)
         .set('kbn-xsrf', 'xxx')
-        .send({ name: 'Agent policy', namespace: 'default' })
+        .send({ id: 'policy-1', name: 'Agent policy 1', namespace: 'default' })
         .expect(200);
-      const agentPolicyId = resp.body.item.id;
       await supertestWithoutAuth
         .get('/api/fleet/enrollment_api_keys')
         .set('Authorization', `Bearer ${token.value}`)
@@ -98,7 +97,7 @@ export default function (providerContext: FtrProviderContext) {
         .post('/api/fleet/enrollment_api_keys')
         .set('Authorization', `Bearer ${token.value}`)
         .set('kbn-xsrf', 'xxx')
-        .send({ policy_id: agentPolicyId })
+        .send({ policy_id: 'policy-1' })
         .expect(200);
       const enrollmentApiKeyId = response.body.item.id;
       await supertestWithoutAuth


### PR DESCRIPTION
## Summary

Support an optional id in create agent policy API

Came up during this discussion: https://github.com/elastic/kibana/pull/121628#issuecomment-1017364790

To verify:
1. Send a new agent policy request with id, verify the response contains the sent id:
```
POST http://elastic:changeme@localhost:5620/api/fleet/agent_policies
kbn-xsrf: kibana

{"id": "my-agent-policy", "namespace":"default", "name":"My agent policy"}
```
2. Send a new agent policy request without id, verify it succeeds (no regression)
```
POST http://elastic:changeme@localhost:5620/api/fleet/agent_policies
kbn-xsrf: kibana

{"namespace":"default", "name":"My agent policy 2"}
```

3. Send a new agent policy request with id and has_fleet_server, verify that the response contains the sent id:
```
POST http://elastic:changeme@localhost:5620/api/fleet/agent_policies
kbn-xsrf: kibana

{"id": "my-fleet-server-policy", "namespace":"default", "name":"My fleet server policy", "has_fleet_server": true}
```


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
