### PR TITLE
[Exploratory view] Update constant from lens

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -144,7 +144,7 @@
 
 # Client Side Monitoring / Uptime (lives in APM directories but owned by Uptime)
 /x-pack/plugins/apm/public/application/uxApp.tsx @elastic/uptime
-/x-pack/plugins/apm/public/components/app/RumDashboard @elastic/uptime
+/x-pack/plugins/apm/public/components/app/rum_dashboard @elastic/uptime
 /x-pack/plugins/apm/server/lib/rum_client @elastic/uptime
 /x-pack/plugins/apm/server/routes/rum_client.ts @elastic/uptime
 /x-pack/plugins/apm/server/projections/rum_page_load_transactions.ts @elastic/uptime

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -141,6 +141,7 @@
 /x-pack/test/functional/es_archives/uptime @elastic/uptime
 /x-pack/test/functional/services/uptime @elastic/uptime
 /x-pack/test/api_integration/apis/uptime @elastic/uptime
+/x-pack/plugins/observability/public/components/shared/exploratory_view @elastic/uptime
 
 # Client Side Monitoring / Uptime (lives in APM directories but owned by Uptime)
 /x-pack/plugins/apm/public/application/uxApp.tsx @elastic/uptime

--- a/x-pack/plugins/apm/public/components/app/rum_dashboard/action_menu/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/rum_dashboard/action_menu/index.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { EuiHeaderLinks, EuiHeaderLink, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import {
+  RECORDS_FIELD,
   createExploratoryViewUrl,
   HeaderMenuPortal,
 } from '../../../../../../observability/public';
@@ -52,7 +53,7 @@ export function UXActionMenu({
           reportDefinitions: {
             [SERVICE_NAME]: serviceName ? [serviceName] : [],
           },
-          selectedMetricField: 'Records',
+          selectedMetricField: RECORDS_FIELD,
         },
       ],
     },

--- a/x-pack/plugins/observability/kibana.json
+++ b/x-pack/plugins/observability/kibana.json
@@ -35,7 +35,8 @@
     "data",
     "dataViews",
     "kibanaReact",
-    "kibanaUtils"
+    "kibanaUtils",
+    "lens"
   ],
   "extraPublicDirs": [
     "common"

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/constants/constants.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/constants/constants.ts
@@ -63,10 +63,11 @@ import {
   SYNTHETICS_STEP_DURATION,
   SYNTHETICS_STEP_NAME,
 } from './field_names/synthetics';
+import { DOCUMENT_FIELD_NAME } from '../../../../../../../lens/common/constants';
 
 export const DEFAULT_TIME = { from: 'now-1h', to: 'now' };
 
-export const RECORDS_FIELD = 'Records';
+export const RECORDS_FIELD = DOCUMENT_FIELD_NAME;
 export const RECORDS_PERCENTAGE_FIELD = 'RecordsPercentage';
 
 export const FieldLabels: Record<string, string> = {

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.test.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.test.ts
@@ -394,7 +394,7 @@ describe('Lens Attribute', () => {
             label: 'Part of count() / overall_sum(count())',
             operationType: 'count',
             scale: 'ratio',
-            sourceField: 'Records',
+            sourceField: RECORDS_FIELD,
           },
           'y-axis-column-layer0X1': {
             customLabel: true,
@@ -408,7 +408,7 @@ describe('Lens Attribute', () => {
             label: 'Part of count() / overall_sum(count())',
             operationType: 'count',
             scale: 'ratio',
-            sourceField: 'Records',
+            sourceField: RECORDS_FIELD,
           },
           'y-axis-column-layer0X2': {
             customLabel: true,
@@ -609,7 +609,7 @@ describe('Lens Attribute', () => {
             label: 'Part of count() / overall_sum(count())',
             operationType: 'count',
             scale: 'ratio',
-            sourceField: 'Records',
+            sourceField: RECORDS_FIELD,
           },
           'y-axis-column-layer0X1': {
             customLabel: true,
@@ -623,7 +623,7 @@ describe('Lens Attribute', () => {
             label: 'Part of count() / overall_sum(count())',
             operationType: 'count',
             scale: 'ratio',
-            sourceField: 'Records',
+            sourceField: RECORDS_FIELD,
           },
           'y-axis-column-layer0X2': {
             customLabel: true,

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_columns/overall_column.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_columns/overall_column.tsx
@@ -12,6 +12,7 @@ import {
   FormulaIndexPatternColumn,
   OverallSumIndexPatternColumn,
 } from '../../../../../../../lens/public';
+import { RECORDS_FIELD } from '../constants';
 
 export function getDistributionInPercentageColumn({
   label,
@@ -50,7 +51,7 @@ export function getDistributionInPercentageColumn({
     operationType: 'count',
     isBucketed: false,
     scale: 'ratio',
-    sourceField: 'Records',
+    sourceField: RECORDS_FIELD,
     customLabel: true,
     filter: { query: columnFilter ?? '', language: 'kuery' },
   };

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/test_data/sample_attribute.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/test_data/sample_attribute.ts
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { RECORDS_FIELD } from '../constants';
+
 export const sampleAttribute = {
   description: '',
   references: [
@@ -88,7 +90,7 @@ export const sampleAttribute = {
                 label: 'Part of count() / overall_sum(count())',
                 operationType: 'count',
                 scale: 'ratio',
-                sourceField: 'Records',
+                sourceField: RECORDS_FIELD,
               },
               'y-axis-column-layer0X1': {
                 customLabel: true,
@@ -102,7 +104,7 @@ export const sampleAttribute = {
                 label: 'Part of count() / overall_sum(count())',
                 operationType: 'count',
                 scale: 'ratio',
-                sourceField: 'Records',
+                sourceField: RECORDS_FIELD,
               },
               'y-axis-column-layer0X2': {
                 customLabel: true,

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/test_data/sample_attribute_cwv.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/test_data/sample_attribute_cwv.ts
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { RECORDS_FIELD } from '../constants';
+
 export const sampleAttributeCoreWebVital = {
   description: '',
   references: [
@@ -59,7 +61,7 @@ export const sampleAttributeCoreWebVital = {
                 label: 'Average',
                 operationType: 'count',
                 scale: 'ratio',
-                sourceField: 'Records',
+                sourceField: RECORDS_FIELD,
               },
               'y-axis-column-2': {
                 dataType: 'number',
@@ -71,7 +73,7 @@ export const sampleAttributeCoreWebVital = {
                 label: 'Poor',
                 operationType: 'count',
                 scale: 'ratio',
-                sourceField: 'Records',
+                sourceField: RECORDS_FIELD,
               },
               'y-axis-column-layer0': {
                 dataType: 'number',
@@ -84,7 +86,7 @@ export const sampleAttributeCoreWebVital = {
                 label: 'Good',
                 operationType: 'count',
                 scale: 'ratio',
-                sourceField: 'Records',
+                sourceField: RECORDS_FIELD,
               },
             },
             incompleteColumns: {},

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/test_data/sample_attribute_kpi.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/test_data/sample_attribute_kpi.ts
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { RECORDS_FIELD } from '../constants';
+
 export const sampleAttributeKpi = {
   description: '',
   references: [
@@ -46,7 +48,7 @@ export const sampleAttributeKpi = {
                 label: 'Page views',
                 operationType: 'count',
                 scale: 'ratio',
-                sourceField: 'Records',
+                sourceField: RECORDS_FIELD,
               },
             },
             incompleteColumns: {},

--- a/x-pack/plugins/observability/public/index.ts
+++ b/x-pack/plugins/observability/public/index.ts
@@ -102,5 +102,7 @@ export type { SeriesConfig, ConfigProps } from './components/shared/exploratory_
 export {
   ReportTypes,
   REPORT_METRIC_FIELD,
+  RECORDS_PERCENTAGE_FIELD,
+  RECORDS_FIELD,
 } from './components/shared/exploratory_view/configurations/constants';
 export { ExploratoryViewContextProvider } from './components/shared/exploratory_view/contexts/exploratory_view_config';


### PR DESCRIPTION
## Summary

This is in relation to https://github.com/elastic/kibana/issues/124221

Lens updated the `Records` field constant.  Instead of hard-coding, we are not importing from lens to reuse that constant. 