### PR TITLE
[cloud] Get user email for chat from metadata saml name

### DIFF
--- a/x-pack/plugins/cloud/server/routes/chat.test.ts
+++ b/x-pack/plugins/cloud/server/routes/chat.test.ts
@@ -52,7 +52,7 @@ describe('chat route', () => {
     security.authc.getCurrentUser.mockReturnValueOnce({
       username,
       metadata: {
-        saml_name: [email],
+        saml_email: [email],
       },
     });
 

--- a/x-pack/plugins/cloud/server/routes/chat.test.ts
+++ b/x-pack/plugins/cloud/server/routes/chat.test.ts
@@ -44,14 +44,16 @@ describe('chat route', () => {
       `);
   });
 
-  test('returns user information and a token', async () => {
+  test('returns user information taken from saml metadata and a token', async () => {
     const security = securityMock.createSetup();
     const username = 'user.name';
     const email = 'user@elastic.co';
 
     security.authc.getCurrentUser.mockReturnValueOnce({
       username,
-      email,
+      metadata: {
+        saml_name: [email],
+      },
     });
 
     const router = httpServiceMock.createRouter();

--- a/x-pack/plugins/cloud/server/routes/chat.ts
+++ b/x-pack/plugins/cloud/server/routes/chat.ts
@@ -13,6 +13,9 @@ import { generateSignedJwt } from '../util/generate_jwt';
 
 type MetaWithSaml = AuthenticatedUser['metadata'] & {
   saml_name: [string];
+  saml_email: [string];
+  saml_roles: [string];
+  saml_principal: [string];
 };
 
 export const registerChatRoute = ({
@@ -39,7 +42,7 @@ export const registerChatRoute = ({
       const user = security.authc.getCurrentUser(request);
       const { metadata, username } = user || {};
       let userId = username;
-      let [userEmail] = (metadata as MetaWithSaml)?.saml_name || [];
+      let [userEmail] = (metadata as MetaWithSaml)?.saml_email || [];
 
       // In local development, these values are not populated.  This is a workaround
       // to allow for local testing.

--- a/x-pack/plugins/cloud/server/routes/chat.ts
+++ b/x-pack/plugins/cloud/server/routes/chat.ts
@@ -6,10 +6,14 @@
  */
 
 import { IRouter } from '../../../../../src/core/server';
-import type { SecurityPluginSetup } from '../../../security/server';
+import type { SecurityPluginSetup, AuthenticatedUser } from '../../../security/server';
 import { GET_CHAT_USER_DATA_ROUTE_PATH } from '../../common/constants';
 import type { GetChatUserDataResponseBody } from '../../common/types';
 import { generateSignedJwt } from '../util/generate_jwt';
+
+type MetaWithSaml = AuthenticatedUser['metadata'] & {
+  saml_name: [string];
+};
 
 export const registerChatRoute = ({
   router,
@@ -33,7 +37,9 @@ export const registerChatRoute = ({
     },
     async (_context, request, response) => {
       const user = security.authc.getCurrentUser(request);
-      let { email: userEmail, username: userId } = user || {};
+      const { metadata, username } = user || {};
+      let userId = username;
+      let [userEmail] = (metadata as MetaWithSaml)?.saml_name || [];
 
       // In local development, these values are not populated.  This is a workaround
       // to allow for local testing.


### PR DESCRIPTION
## Summary
Related to #123772

This PR is fixing the issue with getting user email in the cloud environment.

`AuthenticatedUser` object has field `email` which is set to `null` value even in the cloud env. Based on the internal slack discussion we find out that we can safely use `AuthenticatedUser.metadata.saml_name` property to obtain a user email.


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
