### PR TITLE
[8.0] [Workplace Search] Fix bug where modal visible after deleting a group (#123976)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
@@ -210,11 +210,13 @@ describe('GroupLogic', () => {
     describe('deleteGroup', () => {
       beforeEach(() => {
         GroupLogic.actions.onInitializeGroup(group);
+        GroupLogic.actions.showConfirmDeleteModal();
       });
       it('deletes a group', async () => {
         http.delete.mockReturnValue(Promise.resolve(true));
 
         GroupLogic.actions.deleteGroup();
+        expect(GroupLogic.values.confirmDeleteModalVisible).toEqual(false);
         expect(http.delete).toHaveBeenCalledWith('/internal/workplace_search/groups/123');
 
         await nextTick();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
@@ -122,6 +122,7 @@ export const GroupLogic = kea<MakeLogicType<GroupValues, GroupActions>>({
       {
         showConfirmDeleteModal: () => true,
         hideConfirmDeleteModal: () => false,
+        deleteGroup: () => false,
       },
     ],
     groupNameInputValue: [


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #123976

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
