### PR TITLE
[Security Solution][Endpoint] Fix event filters create/update API body validator to allow for nested fields

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/exceptions_list_item_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/exceptions_list_item_generator.ts
@@ -165,13 +165,31 @@ export class ExceptionsListItemGenerator extends BaseDataGenerator<ExceptionList
   }
 
   generateEventFilter(overrides: Partial<ExceptionListItemSchema> = {}): ExceptionListItemSchema {
-    const eventFilter = this.generate(overrides);
-
-    return {
-      ...eventFilter,
+    return this.generate({
       name: `Event filter (${this.randomString(5)})`,
       list_id: ENDPOINT_EVENT_FILTERS_LIST_ID,
-    };
+      entries: [
+        {
+          field: 'process.pe.company',
+          operator: 'excluded',
+          type: 'match',
+          value: 'elastic',
+        },
+        {
+          entries: [
+            {
+              field: 'status',
+              operator: 'included',
+              type: 'match',
+              value: 'dfdfd',
+            },
+          ],
+          field: 'process.Ext.code_signature',
+          type: 'nested',
+        },
+      ],
+      ...overrides,
+    });
   }
 
   generateEventFilterForCreate(

--- a/x-pack/plugins/security_solution/server/lists_integration/endpoint/validators/event_filter_validator.ts
+++ b/x-pack/plugins/security_solution/server/lists_integration/endpoint/validators/event_filter_validator.ts
@@ -26,24 +26,17 @@ function validateField(field: string) {
   }
 }
 
-const EntrySchema = schema.object({
-  field: schema.string({ validate: validateField }),
-  operator: schema.oneOf([schema.literal('included'), schema.literal('excluded')]),
-  type: schema.oneOf([schema.literal('match'), schema.literal('match_any')]),
-  value: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
-});
-
-const NestedEntrySchema = schema.object({
-  field: schema.string({ validate: validateField }),
-  type: schema.literal('nested'),
-  entries: schema.arrayOf(EntrySchema),
-});
-
-const EntriesSchema = schema.oneOf([EntrySchema, NestedEntrySchema]);
-
 const EventFilterDataSchema = schema.object(
   {
-    entries: schema.arrayOf(EntriesSchema, { minSize: 1 }),
+    entries: schema.arrayOf(
+      schema.object(
+        {
+          field: schema.string({ validate: validateField }),
+        },
+        { unknowns: 'ignore' }
+      ),
+      { minSize: 1 }
+    ),
   },
   {
     unknowns: 'ignore',

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_artifacts/event_filters.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_artifacts/event_filters.ts
@@ -138,7 +138,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     describe('and has authorization to manage endpoint security', () => {
       for (const eventFilterCall of eventFilterCalls) {
-        it(`should error on [${eventFilterCall.method} if invalid field`, async () => {
+        it(`should error on [${eventFilterCall.method}] if invalid field`, async () => {
           const body = eventFilterCall.getBody({});
 
           body.entries[0].field = 'some.invalid.field';
@@ -148,7 +148,7 @@ export default function ({ getService }: FtrProviderContext) {
             .send(body)
             .expect(400)
             .expect(anEndpointArtifactError)
-            .expect(anErrorMessageWith(/types that failed validation:/));
+            .expect(anErrorMessageWith(/invalid field: some\.invalid\.field/));
         });
 
         it(`should error on [${eventFilterCall.method}] if more than one OS is set`, async () => {


### PR DESCRIPTION
## Summary

- Fix the Event Filters API validator (schema) for create/update APIs so that it validates fields only against the allowed set. (all other validations are already done in the List plugin)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
