### PR TITLE
[Security Solution] Runtime field error catching and navigation to data view

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -180,6 +180,7 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
             bulkActions,
             columns,
             dataProviders,
+            dataViewId: selectedDataViewId || undefined,
             defaultCellActions,
             deletedEventIds,
             disabledCellActions: FIELDS_WITHOUT_CELL_ACTIONS,

--- a/x-pack/plugins/security_solution/public/common/containers/events/last_event_time/index.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/events/last_event_time/index.ts
@@ -26,6 +26,7 @@ import {
 import * as i18n from './translations';
 import { DocValueFields } from '../../../../../common/search_strategy';
 import { useAppToasts } from '../../../hooks/use_app_toasts';
+import { useCatchRuntimeFieldError } from '../../../hooks/useCatchRuntimeFieldError';
 
 export interface UseTimelineLastEventTimeArgs {
   lastSeen: string | null;
@@ -67,6 +68,7 @@ export const useTimelineLastEventTime = ({
       errorMessage: undefined,
     });
   const { addError, addWarning } = useAppToasts();
+  const { catchRuntimeFieldError } = useCatchRuntimeFieldError();
 
   const timelineLastEventTimeSearch = useCallback(
     (request: TimelineEventsLastEventTimeRequestOptions) => {
@@ -99,6 +101,7 @@ export const useTimelineLastEventTime = ({
             },
             error: (msg) => {
               setLoading(false);
+              catchRuntimeFieldError(msg.err);
               addError(msg, {
                 title: i18n.FAIL_LAST_EVENT_TIME,
               });
@@ -114,7 +117,7 @@ export const useTimelineLastEventTime = ({
       asyncSearch();
       refetch.current = asyncSearch;
     },
-    [data.search, addError, addWarning]
+    [data.search, addWarning, catchRuntimeFieldError, addError]
   );
 
   useEffect(() => {

--- a/x-pack/plugins/security_solution/public/common/hooks/useCatchRuntimeFieldError.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/useCatchRuntimeFieldError.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
+import { mountReactNode } from '../../../../../../src/core/public/utils';
+import { IEsError } from '../../../../../../src/plugins/data/public';
+import { getScopeFromPath, useSourcererDataView } from '../containers/sourcerer';
+import { useNavigateTo } from '../lib/kibana';
+import { useAppToasts } from './use_app_toasts';
+
+const ERROR_RUNTIME_FIELD_TIMELINE_EVENTS = i18n.translate(
+  'xpack.securitySolution.runtimeFieldError.toastTitle',
+  {
+    defaultMessage: 'Runtime field error',
+  }
+);
+
+const ERROR_RUNTIME_MANAGE_DATA_VIEW = i18n.translate(
+  'xpack.securitySolution.runtimeFieldError.toastButton',
+  {
+    defaultMessage: 'Manage Data View',
+  }
+);
+
+// export const useCatchRuntimeFieldError = (dataViewId?: string) => {
+export const useCatchRuntimeFieldError = () => {
+  const { addWarning, api: toastsApi } = useAppToasts();
+  const { navigateTo } = useNavigateTo();
+  // TODO remove useSourcererDataView and use dataViewId from parameter
+  const { pathname } = useLocation();
+  const { dataViewId } = useSourcererDataView(getScopeFromPath(pathname));
+
+  const catchRuntimeFieldError = useCallback(
+    (error: IEsError) => {
+      const runtimeFieldErrorReason = getRuntimeFieldErrorReason(error);
+      if (dataViewId && runtimeFieldErrorReason) {
+        const toast = addWarning({
+          iconType: 'alert',
+          title: ERROR_RUNTIME_FIELD_TIMELINE_EVENTS,
+          toastLifeTimeMs: 300000,
+          text: mountReactNode(
+            <>
+              <p>{runtimeFieldErrorReason}</p>
+              <div className="eui-textRight">
+                <EuiButton
+                  size="s"
+                  color="warning"
+                  onClick={() => {
+                    navigateTo({
+                      appId: 'management',
+                      path: `kibana/dataViews/dataView/${dataViewId}`,
+                    });
+                    toastsApi.remove(toast);
+                  }}
+                >
+                  {ERROR_RUNTIME_MANAGE_DATA_VIEW}
+                </EuiButton>
+              </div>
+            </>
+          ),
+        });
+      }
+    },
+    [addWarning, dataViewId, navigateTo, toastsApi]
+  );
+  return { catchRuntimeFieldError };
+};
+
+/**
+ * Returns the reason string if the error is a runtime script missing field error
+ */
+function getRuntimeFieldErrorReason(error: IEsError): string | null {
+  const failedShards = error?.attributes?.caused_by?.failed_shards;
+  if (failedShards && failedShards.length > 0) {
+    const runtimeFieldFailedShard = failedShards?.find((failedShard) =>
+      failedShard.reason?.caused_by?.reason?.match(`A document doesn't have a value for a field!`)
+    );
+    if (runtimeFieldFailedShard) {
+      return runtimeFieldFailedShard?.reason?.caused_by?.reason ?? null;
+    }
+  }
+  return null;
+}

--- a/x-pack/plugins/security_solution/public/timelines/containers/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/details/index.tsx
@@ -25,6 +25,7 @@ import { useAppToasts } from '../../../common/hooks/use_app_toasts';
 import * as i18n from './translations';
 import { EntityType } from '../../../../../timelines/common';
 import { Ecs } from '../../../../common/ecs';
+import { useCatchRuntimeFieldError } from '../../../common/hooks/useCatchRuntimeFieldError';
 
 export interface EventsArgs {
   detailsData: TimelineEventsDetailsItem[] | null;
@@ -61,6 +62,7 @@ export const useTimelineEventsDetails = ({
   const [timelineDetailsRequest, setTimelineDetailsRequest] =
     useState<TimelineEventsDetailsRequestOptions | null>(null);
   const { addError, addWarning } = useAppToasts();
+  const { catchRuntimeFieldError } = useCatchRuntimeFieldError();
 
   const [timelineDetailsResponse, setTimelineDetailsResponse] =
     useState<EventsArgs['detailsData']>(null);
@@ -102,6 +104,7 @@ export const useTimelineEventsDetails = ({
             },
             error: (msg) => {
               setLoading(false);
+              catchRuntimeFieldError(msg.err);
               addError(msg, { title: i18n.FAIL_TIMELINE_SEARCH_DETAILS });
               searchSubscription$.current.unsubscribe();
             },
@@ -112,7 +115,7 @@ export const useTimelineEventsDetails = ({
       asyncSearch();
       refetch.current = asyncSearch;
     },
-    [data.search, addError, addWarning, skip]
+    [skip, data.search, addWarning, catchRuntimeFieldError, addError]
   );
 
   useEffect(() => {

--- a/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
@@ -44,6 +44,7 @@ import {
   TimelineEqlResponse,
 } from '../../../common/search_strategy/timeline/events/eql';
 import { useAppToasts } from '../../common/hooks/use_app_toasts';
+import { useCatchRuntimeFieldError } from '../../common/hooks/useCatchRuntimeFieldError';
 
 export interface TimelineArgs {
   events: TimelineItem[];
@@ -208,6 +209,7 @@ export const useTimelineEvents = ({
     updatedAt: 0,
   });
   const { addError, addWarning } = useAppToasts();
+  const { catchRuntimeFieldError } = useCatchRuntimeFieldError();
 
   // TODO: Once we are past experimental phase this code should be removed
   const ruleRegistryEnabled = useIsExperimentalFeatureEnabled('ruleRegistryEnabled');
@@ -265,6 +267,7 @@ export const useTimelineEvents = ({
             },
             error: (msg) => {
               setLoading(false);
+              catchRuntimeFieldError(msg.err);
               addError(msg, {
                 title: i18n.FAIL_TIMELINE_EVENTS,
               });
@@ -323,6 +326,7 @@ export const useTimelineEvents = ({
       data.search,
       setUpdated,
       addWarning,
+      catchRuntimeFieldError,
       addError,
       refetchGrid,
       wrappedLoadPage,

--- a/x-pack/plugins/security_solution/public/timelines/containers/kpis/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/kpis/index.tsx
@@ -22,6 +22,7 @@ import {
 import { ESQuery } from '../../../../common/typed_json';
 import { isCompleteResponse, isErrorResponse } from '../../../../../../../src/plugins/data/public';
 import { useAppToasts } from '../../../common/hooks/use_app_toasts';
+import { useCatchRuntimeFieldError } from '../../../common/hooks/useCatchRuntimeFieldError';
 import * as i18n from './translations';
 
 export interface UseTimelineKpiProps {
@@ -50,6 +51,7 @@ export const useTimelineKpis = ({
   const [timelineKpiResponse, setTimelineKpiResponse] =
     useState<TimelineKpiStrategyResponse | null>(null);
   const { addError, addWarning } = useAppToasts();
+  const { catchRuntimeFieldError } = useCatchRuntimeFieldError();
 
   const timelineKpiSearch = useCallback(
     (request: TimelineKpiStrategyRequest | null) => {
@@ -79,6 +81,7 @@ export const useTimelineKpis = ({
             },
             error: (msg) => {
               setLoading(false);
+              catchRuntimeFieldError(msg.err);
               addError(msg, { title: i18n.FAIL_TIMELINE_KPI_SEARCH_DETAILS });
               searchSubscription$.current.unsubscribe();
             },
@@ -89,7 +92,7 @@ export const useTimelineKpis = ({
       asyncSearch();
       refetch.current = asyncSearch;
     },
-    [data.search, addError, addWarning]
+    [data.search, addWarning, catchRuntimeFieldError, addError]
   );
 
   useEffect(() => {

--- a/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
@@ -101,6 +101,7 @@ export interface TGridIntegratedProps {
   createFieldComponent?: CreateFieldComponentType;
   data?: DataPublicPluginStart;
   dataProviders: DataProvider[];
+  dataViewId?: string;
   defaultCellActions?: TGridCellAction[];
   deletedEventIds: Readonly<string[]>;
   disabledCellActions: string[];
@@ -145,6 +146,7 @@ const TGridIntegratedComponent: React.FC<TGridIntegratedProps> = ({
   columns,
   data,
   dataProviders,
+  dataViewId,
   defaultCellActions,
   deletedEventIds,
   disabledCellActions,
@@ -236,6 +238,7 @@ const TGridIntegratedComponent: React.FC<TGridIntegratedProps> = ({
       // We rely on entityType to determine Events vs Alerts
       alertConsumers: SECURITY_ALERTS_CONSUMERS,
       data,
+      dataViewId,
       docValueFields,
       endDate: end,
       entityType,

--- a/x-pack/plugins/timelines/public/container/index.tsx
+++ b/x-pack/plugins/timelines/public/container/index.tsx
@@ -420,13 +420,13 @@ const getRuntimeFieldSortWarningToast = ({
 }) => ({
   iconType: 'alert',
   title: i18n.ERROR_RUNTIME_FIELD_TIMELINE_EVENTS,
-  toastLifeTimeMs: Infinity,
+  toastLifeTimeMs: 300000,
   text: mountReactNode(
     <>
       <p>{text}</p>
       <div className="eui-textRight">
         <EuiButton size="s" color="warning" onClick={resetSort}>
-          {i18n.ERROR_RUNTIME_FIELD_RESET_SORT}
+          {i18n.ERROR_RUNTIME_FIELD_CLEAR_SORTING}
         </EuiButton>
       </div>
     </>

--- a/x-pack/plugins/timelines/public/container/translations.ts
+++ b/x-pack/plugins/timelines/public/container/translations.ts
@@ -20,3 +20,17 @@ export const FAIL_TIMELINE_EVENTS = i18n.translate(
     defaultMessage: `Failed to run search on timeline events`,
   }
 );
+
+export const ERROR_RUNTIME_FIELD_TIMELINE_EVENTS = i18n.translate(
+  'xpack.timelines.timelineEvents.errorRuntimeFieldSearchDescription',
+  {
+    defaultMessage: 'Runtime field error',
+  }
+);
+
+export const ERROR_RUNTIME_FIELD_RESET_SORT = i18n.translate(
+  'xpack.timelines.timelineEvents.errorRuntimeFieldSearchButton',
+  {
+    defaultMessage: 'Reset sort',
+  }
+);

--- a/x-pack/plugins/timelines/public/container/translations.ts
+++ b/x-pack/plugins/timelines/public/container/translations.ts
@@ -22,15 +22,15 @@ export const FAIL_TIMELINE_EVENTS = i18n.translate(
 );
 
 export const ERROR_RUNTIME_FIELD_TIMELINE_EVENTS = i18n.translate(
-  'xpack.timelines.timelineEvents.errorRuntimeFieldSearchDescription',
+  'xpack.timelines.timelineEvents.errorRuntimeFieldToastTitle',
   {
     defaultMessage: 'Runtime field error',
   }
 );
 
-export const ERROR_RUNTIME_FIELD_CLEAR_SORTING = i18n.translate(
-  'xpack.timelines.timelineEvents.errorRuntimeFieldSearchButton',
+export const ERROR_RUNTIME_MANAGE_DATA_VIEW = i18n.translate(
+  'xpack.timelines.timelineEvents.errorRuntimeFieldToastButton',
   {
-    defaultMessage: 'Clear sorting',
+    defaultMessage: 'Manage Data View',
   }
 );

--- a/x-pack/plugins/timelines/public/container/translations.ts
+++ b/x-pack/plugins/timelines/public/container/translations.ts
@@ -28,9 +28,9 @@ export const ERROR_RUNTIME_FIELD_TIMELINE_EVENTS = i18n.translate(
   }
 );
 
-export const ERROR_RUNTIME_FIELD_RESET_SORT = i18n.translate(
+export const ERROR_RUNTIME_FIELD_CLEAR_SORTING = i18n.translate(
   'xpack.timelines.timelineEvents.errorRuntimeFieldSearchButton',
   {
-    defaultMessage: 'Reset sort',
+    defaultMessage: 'Clear sorting',
   }
 );


### PR DESCRIPTION
## Summary
issue: https://github.com/elastic/kibana/issues/122990

The PR catches the runtime field error and shows a warning message to inform the user about the workaround, and a button to navigate to the data view. The flow is the following:

https://user-images.githubusercontent.com/17747913/152014297-985f9918-6bcf-4097-b8c3-3772a13bf37f.mov


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
