### PR TITLE
Collect code coverage for server side

### DIFF
--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -11,7 +11,6 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
   buildkite-agent artifact upload 'target/junit/**/*'
   buildkite-agent artifact upload 'target/kibana-coverage/jest/**/*'
   buildkite-agent artifact upload 'target/kibana-coverage/functional/**/*'
-  buildkite-agent artifact upload 'target/kibana-coverage/server/**/*'
   buildkite-agent artifact upload 'target/kibana-*'
   buildkite-agent artifact upload 'target/kibana-security-solution/**/*.png'
   buildkite-agent artifact upload 'target/test-metrics/*'

--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -11,6 +11,7 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
   buildkite-agent artifact upload 'target/junit/**/*'
   buildkite-agent artifact upload 'target/kibana-coverage/jest/**/*'
   buildkite-agent artifact upload 'target/kibana-coverage/functional/**/*'
+  buildkite-agent artifact upload 'target/kibana-coverage/server/**/*'
   buildkite-agent artifact upload 'target/kibana-*'
   buildkite-agent artifact upload 'target/kibana-security-solution/**/*.png'
   buildkite-agent artifact upload 'target/test-metrics/*'

--- a/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
+++ b/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
@@ -31,6 +31,7 @@ NODE_OPTIONS=--max_old_space_size=14336 \
 
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/server" ]]; then
   echo "--- Server side code coverage collected"
+  mkdir -p target/kibana-coverage/functional
   mv target/kibana-coverage/server/coverage-final.json "target/kibana-coverage/functional/oss-${CI_GROUP}-server-coverage.json"
 fi
 

--- a/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
+++ b/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
@@ -20,8 +20,6 @@ export CODE_COVERAGE=1
 echo "--- OSS CI Group $CI_GROUP"
 echo " -> Running Functional tests with code coverage"
 
-
-
 NODE_OPTIONS=--max_old_space_size=14336 \
   ./node_modules/.bin/nyc \
   --nycrc-path src/dev/code_coverage/nyc_config/nyc.server.config.js \

--- a/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
+++ b/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
@@ -20,9 +20,17 @@ export CODE_COVERAGE=1
 echo "--- OSS CI Group $CI_GROUP"
 echo " -> Running Functional tests with code coverage"
 
-node scripts/functional_tests \
+
+
+NODE_OPTIONS=--max_old_space_size=14336 \
+  ./node_modules/.bin/nyc \
+  --nycrc-path src/dev/code_coverage/nyc_config/nyc.api_integration.config.js \
+  node scripts/functional_tests \
   --include-tag "ciGroup$CI_GROUP" \
   --exclude-tag "skipCoverage" || true
+
+if [[ -d "$KIBANA_DIR/target/kibana-coverage/server" ]]; then
+  echo "Server side code coverage collected"
 
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/functional" ]]; then
   echo "--- Merging code coverage for CI Group $CI_GROUP"

--- a/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
+++ b/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
@@ -31,6 +31,7 @@ NODE_OPTIONS=--max_old_space_size=14336 \
 
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/server" ]]; then
   echo "Server side code coverage collected"
+fi
 
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/functional" ]]; then
   echo "--- Merging code coverage for CI Group $CI_GROUP"

--- a/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
+++ b/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
@@ -24,7 +24,7 @@ echo " -> Running Functional tests with code coverage"
 
 NODE_OPTIONS=--max_old_space_size=14336 \
   ./node_modules/.bin/nyc \
-  --nycrc-path src/dev/code_coverage/nyc_config/nyc.api_integration.config.js \
+  --nycrc-path src/dev/code_coverage/nyc_config/nyc.server.config.js \
   node scripts/functional_tests \
   --include-tag "ciGroup$CI_GROUP" \
   --exclude-tag "skipCoverage" || true
@@ -32,7 +32,6 @@ NODE_OPTIONS=--max_old_space_size=14336 \
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/server" ]]; then
   echo "--- Server side code coverage collected"
   mv target/kibana-coverage/server/coverage-final.json "target/kibana-coverage/functional/oss-${CI_GROUP}-server-coverage.json"
-  # rm -rf target/kibana-coverage/server/*
 fi
 
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/functional" ]]; then

--- a/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
+++ b/.buildkite/scripts/steps/code_coverage/oss_cigroup.sh
@@ -30,7 +30,9 @@ NODE_OPTIONS=--max_old_space_size=14336 \
   --exclude-tag "skipCoverage" || true
 
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/server" ]]; then
-  echo "Server side code coverage collected"
+  echo "--- Server side code coverage collected"
+  mv target/kibana-coverage/server/coverage-final.json "target/kibana-coverage/functional/oss-${CI_GROUP}-server-coverage.json"
+  # rm -rf target/kibana-coverage/server/*
 fi
 
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/functional" ]]; then

--- a/.buildkite/scripts/steps/code_coverage/xpack_cigroup.sh
+++ b/.buildkite/scripts/steps/code_coverage/xpack_cigroup.sh
@@ -22,11 +22,20 @@ echo " -> Running X-Pack functional tests with code coverage"
 
 cd "$XPACK_DIR"
 
-node scripts/functional_tests \
+NODE_OPTIONS=--max_old_space_size=14336 \
+  ./../node_modules/.bin/nyc \
+  --nycrc-path ./../src/dev/code_coverage/nyc_config/nyc.api_integration.config.js \
+  node scripts/functional_tests \
   --include-tag "ciGroup$CI_GROUP" \
   --exclude-tag "skipCoverage" || true
 
 cd "$KIBANA_DIR"
+
+if [[ -d "$KIBANA_DIR/target/kibana-coverage/server" ]]; then
+  echo "--- Server side code coverage collected"
+  mv target/kibana-coverage/server/coverage-final.json "target/kibana-coverage/functional/xpack-${CI_GROUP}-server-coverage.json"
+  # rm -rf target/kibana-coverage/server/*
+fi
 
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/functional" ]]; then
   echo "--- Merging code coverage for CI Group $CI_GROUP"

--- a/.buildkite/scripts/steps/code_coverage/xpack_cigroup.sh
+++ b/.buildkite/scripts/steps/code_coverage/xpack_cigroup.sh
@@ -33,6 +33,7 @@ cd "$KIBANA_DIR"
 
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/server" ]]; then
   echo "--- Server side code coverage collected"
+  mkdir -p target/kibana-coverage/functional
   mv target/kibana-coverage/server/coverage-final.json "target/kibana-coverage/functional/xpack-${CI_GROUP}-server-coverage.json"
 fi
 

--- a/.buildkite/scripts/steps/code_coverage/xpack_cigroup.sh
+++ b/.buildkite/scripts/steps/code_coverage/xpack_cigroup.sh
@@ -24,7 +24,7 @@ cd "$XPACK_DIR"
 
 NODE_OPTIONS=--max_old_space_size=14336 \
   ./../node_modules/.bin/nyc \
-  --nycrc-path ./../src/dev/code_coverage/nyc_config/nyc.api_integration.config.js \
+  --nycrc-path ./../src/dev/code_coverage/nyc_config/nyc.server.config.js \
   node scripts/functional_tests \
   --include-tag "ciGroup$CI_GROUP" \
   --exclude-tag "skipCoverage" || true
@@ -34,7 +34,6 @@ cd "$KIBANA_DIR"
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/server" ]]; then
   echo "--- Server side code coverage collected"
   mv target/kibana-coverage/server/coverage-final.json "target/kibana-coverage/functional/xpack-${CI_GROUP}-server-coverage.json"
-  # rm -rf target/kibana-coverage/server/*
 fi
 
 if [[ -d "$KIBANA_DIR/target/kibana-coverage/functional" ]]; then

--- a/package.json
+++ b/package.json
@@ -454,6 +454,7 @@
     "@elastic/synthetics": "^1.0.0-beta.16",
     "@emotion/babel-preset-css-prop": "^11.2.0",
     "@emotion/jest": "^11.3.0",
+    "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@istanbuljs/schema": "^0.1.2",
     "@jest/console": "^26.6.2",
     "@jest/reporters": "^26.6.2",

--- a/scripts/functional_tests.js
+++ b/scripts/functional_tests.js
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line no-restricted-syntax
-const alwaysImportedTests = [
+require('../src/setup_node_env');
+require('@kbn/test').runTestsCli([
   require.resolve('../test/functional/config.js'),
   require.resolve('../test/plugin_functional/config.ts'),
   require.resolve('../test/ui_capabilities/newsfeed_err/config.ts'),
@@ -28,14 +28,4 @@ const alwaysImportedTests = [
   require.resolve('../test/api_integration/config.js'),
   require.resolve('../test/interpreter_functional/config.ts'),
   require.resolve('../test/examples/config.js'),
-];
-// eslint-disable-next-line no-restricted-syntax
-const onlyNotInCoverageTests = [];
-
-require('../src/setup_node_env');
-require('@kbn/test').runTestsCli([
-  // eslint-disable-next-line no-restricted-syntax
-  ...alwaysImportedTests,
-  // eslint-disable-next-line no-restricted-syntax
-  ...(!!process.env.CODE_COVERAGE ? [] : onlyNotInCoverageTests),
 ]);

--- a/scripts/functional_tests.js
+++ b/scripts/functional_tests.js
@@ -25,10 +25,10 @@ const alwaysImportedTests = [
   require.resolve(
     '../test/interactive_setup_functional/manual_configuration_without_tls.config.ts'
   ),
+  require.resolve('../test/api_integration/config.js'),
 ];
 // eslint-disable-next-line no-restricted-syntax
 const onlyNotInCoverageTests = [
-  require.resolve('../test/api_integration/config.js'),
   require.resolve('../test/interpreter_functional/config.ts'),
   require.resolve('../test/examples/config.js'),
 ];

--- a/scripts/functional_tests.js
+++ b/scripts/functional_tests.js
@@ -26,12 +26,11 @@ const alwaysImportedTests = [
     '../test/interactive_setup_functional/manual_configuration_without_tls.config.ts'
   ),
   require.resolve('../test/api_integration/config.js'),
-];
-// eslint-disable-next-line no-restricted-syntax
-const onlyNotInCoverageTests = [
   require.resolve('../test/interpreter_functional/config.ts'),
   require.resolve('../test/examples/config.js'),
 ];
+// eslint-disable-next-line no-restricted-syntax
+const onlyNotInCoverageTests = [];
 
 require('../src/setup_node_env');
 require('@kbn/test').runTestsCli([

--- a/src/dev/code_coverage/nyc_config/nyc.api_integration.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.api_integration.config.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module.exports = {
+  extends: '@istanbuljs/nyc-config-typescript',
+  reporter: ['json'],
+  'report-dir': 'target/kibana-coverage/server',
+};

--- a/src/dev/code_coverage/nyc_config/nyc.functional.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.functional.config.js
@@ -9,7 +9,8 @@
 const defaultExclude = require('@istanbuljs/schema/default-exclude');
 const extraExclude = [
   'data/optimize/**',
-  '**/{__test__,__snapshots__,__examples__,*mock*,.storybook,target,tests,test_helpers,integration_tests,types}/**/*',
+  '**/{__jest__,__test__,__examples__,__fixtures__ ,__snapshots__,__stories__ ,*mock*,.storybook,target,types}/**/*',
+  '**/{integration_tests,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,scripts}/**/*',
   '**/*mock*.{ts,tsx}',
   '**/*.test.{ts,tsx}',
   '**/*.spec.{ts,tsx}',

--- a/src/dev/code_coverage/nyc_config/nyc.functional.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.functional.config.js
@@ -10,7 +10,8 @@ const defaultExclude = require('@istanbuljs/schema/default-exclude');
 const extraExclude = [
   'data/optimize/**',
   '**/{__jest__,__test__,__examples__,__fixtures__ ,__snapshots__,__stories__ ,*mock*,.storybook,target,types}/**/*',
-  '**/{integration_tests,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,scripts}/**/*',
+  '**/{integration_tests,test,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,scripts}/**/*',
+  '**/{__fixtures__,__stories__}/**',
   '**/*mock*.{ts,tsx}',
   '**/*.test.{ts,tsx}',
   '**/*.spec.{ts,tsx}',

--- a/src/dev/code_coverage/nyc_config/nyc.functional.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.functional.config.js
@@ -7,7 +7,16 @@
  */
 
 const defaultExclude = require('@istanbuljs/schema/default-exclude');
-const extraExclude = ['data/optimize/**', '**/{test, types}/**/*'];
+const extraExclude = [
+  'data/optimize/**',
+  '**/{__test__,__snapshots__,__examples__,*mock*,.storybook,target,tests,test_helpers,integration_tests,types}/**/*',
+  '**/*mock*.{ts,tsx}',
+  '**/*.test.{ts,tsx}',
+  '**/*.spec.{ts,tsx}',
+  '**/types.ts',
+  '**/*.d.ts',
+  '**/index.{js,ts,tsx}',
+];
 const path = require('path');
 
 module.exports = {
@@ -16,5 +25,9 @@ module.exports = {
     : 'target/kibana-coverage/functional',
   'report-dir': 'target/kibana-coverage/functional-combined',
   reporter: ['html', 'json-summary'],
+  include: [
+    'src/{core,plugins}/**/*.{js,mjs,jsx,ts,tsx}',
+    'x-pack/plugins/**/*.{js,mjs,jsx,ts,tsx}',
+  ],
   exclude: extraExclude.concat(defaultExclude),
 };

--- a/src/dev/code_coverage/nyc_config/nyc.functional.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.functional.config.js
@@ -9,13 +9,12 @@
 const defaultExclude = require('@istanbuljs/schema/default-exclude');
 const extraExclude = ['data/optimize/**', '**/{test, types}/**/*'];
 const path = require('path');
-const untils = require('@kbn/utils');
 
 module.exports = {
   'temp-dir': process.env.COVERAGE_TEMP_DIR
     ? path.resolve(process.env.COVERAGE_TEMP_DIR, 'functional')
-    : path.resolve(untils.REPO_ROOT, 'target/kibana-coverage/functional'),
-  'report-dir': path.resolve(untils.REPO_ROOT, 'target/kibana-coverage/functional-combined'),
+    : 'target/kibana-coverage/functional',
+  'report-dir': 'target/kibana-coverage/functional-combined',
   reporter: ['html', 'json-summary'],
   exclude: extraExclude.concat(defaultExclude),
 };

--- a/src/dev/code_coverage/nyc_config/nyc.functional.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.functional.config.js
@@ -7,14 +7,15 @@
  */
 
 const defaultExclude = require('@istanbuljs/schema/default-exclude');
-const extraExclude = ['data/optimize/**', 'src/core/server/**', '**/{test, types}/**/*'];
+const extraExclude = ['data/optimize/**', '**/{test, types}/**/*'];
 const path = require('path');
+const untils = require('@kbn/utils');
 
 module.exports = {
   'temp-dir': process.env.COVERAGE_TEMP_DIR
     ? path.resolve(process.env.COVERAGE_TEMP_DIR, 'functional')
-    : 'target/kibana-coverage/functional',
-  'report-dir': 'target/kibana-coverage/functional-combined',
+    : path.resolve(untils.REPO_ROOT, 'target/kibana-coverage/functional'),
+  'report-dir': path.resolve(untils.REPO_ROOT, 'target/kibana-coverage/functional-combined'),
   reporter: ['html', 'json-summary'],
   exclude: extraExclude.concat(defaultExclude),
 };

--- a/src/dev/code_coverage/nyc_config/nyc.functional.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.functional.config.js
@@ -9,9 +9,9 @@
 const defaultExclude = require('@istanbuljs/schema/default-exclude');
 const extraExclude = [
   'data/optimize/**',
-  '**/{__jest__,__test__,__examples__,__fixtures__ ,__snapshots__,__stories__ ,*mock*,.storybook,target,types}/**/*',
-  '**/{integration_tests,test,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,scripts}/**/*',
-  '**/{__fixtures__,__stories__}/**',
+  '**/{__jest__,__test__,__examples__,__fixtures__,__snapshots__,__stories__,*mock*,*storybook,target,types}/**/*',
+  '**/{integration_tests,test,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,*scripts}/**/*',
+  '**/{*e2e*,fixtures,manual_tests,stubs}/**',
   '**/*mock*.{ts,tsx}',
   '**/*.test.{ts,tsx}',
   '**/*.spec.{ts,tsx}',

--- a/src/dev/code_coverage/nyc_config/nyc.functional.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.functional.config.js
@@ -11,7 +11,7 @@ const extraExclude = [
   'data/optimize/**',
   '**/{__jest__,__test__,__examples__,__fixtures__,__snapshots__,__stories__,*mock*,*storybook,target,types}/**/*',
   '**/{integration_tests,test,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,*scripts}/**/*',
-  '**/{*e2e*,fixtures,manual_tests,stubs}/**',
+  '**/{*e2e*,fixtures,manual_tests,stub*}/**',
   '**/*mock*.{ts,tsx}',
   '**/*.test.{ts,tsx}',
   '**/*.spec.{ts,tsx}',

--- a/src/dev/code_coverage/nyc_config/nyc.jest.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.jest.config.js
@@ -7,12 +7,11 @@
  */
 
 const path = require('path');
-const untils = require('@kbn/utils');
 
 module.exports = {
   'temp-dir': process.env.COVERAGE_TEMP_DIR
     ? path.resolve(process.env.COVERAGE_TEMP_DIR, 'jest')
-    : path.resolve(untils.REPO_ROOT, 'target/kibana-coverage/jest'),
-  'report-dir': path.resolve(untils.REPO_ROOT, 'target/kibana-coverage/jest-combined'),
+    : 'target/kibana-coverage/jest',
+  'report-dir': 'target/kibana-coverage/jest-combined',
   reporter: ['html', 'json-summary'],
 };

--- a/src/dev/code_coverage/nyc_config/nyc.jest.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.jest.config.js
@@ -7,11 +7,12 @@
  */
 
 const path = require('path');
+const untils = require('@kbn/utils');
 
 module.exports = {
   'temp-dir': process.env.COVERAGE_TEMP_DIR
     ? path.resolve(process.env.COVERAGE_TEMP_DIR, 'jest')
-    : 'target/kibana-coverage/jest',
-  'report-dir': 'target/kibana-coverage/jest-combined',
+    : path.resolve(untils.REPO_ROOT, 'target/kibana-coverage/jest'),
+  'report-dir': path.resolve(untils.REPO_ROOT, 'target/kibana-coverage/jest-combined'),
   reporter: ['html', 'json-summary'],
 };

--- a/src/dev/code_coverage/nyc_config/nyc.server.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.server.config.js
@@ -7,10 +7,11 @@
  */
 
 const path = require('path');
-const untils = require('@kbn/utils');
 
 module.exports = {
   extends: '@istanbuljs/nyc-config-typescript',
+  'report-dir': process.env.KIBANA_DIR
+    ? path.resolve(process.env.KIBANA_DIR, 'target/kibana-coverage/server')
+    : 'target/kibana-coverage/server',
   reporter: ['json'],
-  'report-dir': path.resolve(untils.REPO_ROOT, 'target/kibana-coverage/server'),
 };

--- a/src/dev/code_coverage/nyc_config/nyc.server.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.server.config.js
@@ -6,8 +6,11 @@
  * Side Public License, v 1.
  */
 
+const path = require('path');
+const untils = require('@kbn/utils');
+
 module.exports = {
   extends: '@istanbuljs/nyc-config-typescript',
   reporter: ['json'],
-  'report-dir': 'target/kibana-coverage/server',
+  'report-dir': path.resolve(untils.REPO_ROOT, 'target/kibana-coverage/server'),
 };

--- a/src/dev/code_coverage/nyc_config/nyc.server.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.server.config.js
@@ -14,4 +14,18 @@ module.exports = {
     ? path.resolve(process.env.KIBANA_DIR, 'target/kibana-coverage/server')
     : 'target/kibana-coverage/server',
   reporter: ['json'],
+  all: true,
+  include: [
+    'src/{core,plugins}/**/*.{js,mjs,jsx,ts,tsx}',
+    'x-pack/plugins/**/*.{js,mjs,jsx,ts,tsx}',
+  ],
+  exclude: [
+    '**/{__test__,__snapshots__,__examples__,*mock*,.storybook,target,tests,test_helpers,integration_tests,types}/**/*',
+    '**/*mock*.{ts,tsx}',
+    '**/*.test.{ts,tsx}',
+    '**/*.spec.{ts,tsx}',
+    '**/types.ts',
+    '**/*.d.ts',
+    '**/index.{js,ts,tsx}',
+  ],
 };

--- a/src/dev/code_coverage/nyc_config/nyc.server.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.server.config.js
@@ -20,7 +20,8 @@ module.exports = {
     'x-pack/plugins/**/*.{js,mjs,jsx,ts,tsx}',
   ],
   exclude: [
-    '**/{__test__,__snapshots__,__examples__,*mock*,.storybook,target,tests,test_helpers,integration_tests,types}/**/*',
+    '**/{__jest__,__test__,__examples__,__fixtures__ ,__snapshots__,__stories__ ,*mock*,.storybook,target,types}/**/*',
+    '**/{integration_tests,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,scripts}/**/*',
     '**/*mock*.{ts,tsx}',
     '**/*.test.{ts,tsx}',
     '**/*.spec.{ts,tsx}',

--- a/src/dev/code_coverage/nyc_config/nyc.server.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.server.config.js
@@ -21,7 +21,8 @@ module.exports = {
   ],
   exclude: [
     '**/{__jest__,__test__,__examples__,__fixtures__ ,__snapshots__,__stories__ ,*mock*,.storybook,target,types}/**/*',
-    '**/{integration_tests,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,scripts}/**/*',
+    '**/{integration_tests,test,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,scripts}/**/*',
+    '**/{__fixtures__,__stories__}/**',
     '**/*mock*.{ts,tsx}',
     '**/*.test.{ts,tsx}',
     '**/*.spec.{ts,tsx}',

--- a/src/dev/code_coverage/nyc_config/nyc.server.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.server.config.js
@@ -22,7 +22,7 @@ module.exports = {
   exclude: [
     '**/{__jest__,__test__,__examples__,__fixtures__,__snapshots__,__stories__,*mock*,*storybook,target,types}/**/*',
     '**/{integration_tests,test,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,*scripts}/**/*',
-    '**/{*e2e*,fixtures,manual_tests,stubs}/**',
+    '**/{*e2e*,fixtures,manual_tests,stub*}/**',
     '**/*mock*.{ts,tsx}',
     '**/*.test.{ts,tsx}',
     '**/*.spec.{ts,tsx}',

--- a/src/dev/code_coverage/nyc_config/nyc.server.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.server.config.js
@@ -20,9 +20,9 @@ module.exports = {
     'x-pack/plugins/**/*.{js,mjs,jsx,ts,tsx}',
   ],
   exclude: [
-    '**/{__jest__,__test__,__examples__,__fixtures__ ,__snapshots__,__stories__ ,*mock*,.storybook,target,types}/**/*',
-    '**/{integration_tests,test,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,scripts}/**/*',
-    '**/{__fixtures__,__stories__}/**',
+    '**/{__jest__,__test__,__examples__,__fixtures__,__snapshots__,__stories__,*mock*,*storybook,target,types}/**/*',
+    '**/{integration_tests,test,tests,test_helpers,test_data,test_samples,test_utils,test_utilities,*scripts}/**/*',
+    '**/{*e2e*,fixtures,manual_tests,stubs}/**',
     '**/*mock*.{ts,tsx}',
     '**/*.test.{ts,tsx}',
     '**/*.spec.{ts,tsx}',

--- a/x-pack/scripts/functional_tests.js
+++ b/x-pack/scripts/functional_tests.js
@@ -25,8 +25,6 @@ const alwaysImportedTests = [
   require.resolve('../test/usage_collection/config.ts'),
   require.resolve('../test/fleet_functional/config.ts'),
   require.resolve('../test/functional_synthetics/config.js'),
-];
-const onlyNotInCoverageTests = [
   require.resolve('../test/api_integration/config_security_basic.ts'),
   require.resolve('../test/api_integration/config_security_trial.ts'),
   require.resolve('../test/api_integration/config.ts'),
@@ -94,6 +92,7 @@ const onlyNotInCoverageTests = [
   require.resolve('../test/examples/config.ts'),
   require.resolve('../test/functional_execution_context/config.ts'),
 ];
+const onlyNotInCoverageTests = [];
 
 require('../../src/setup_node_env');
 require('@kbn/test').runTestsCli([

--- a/x-pack/scripts/functional_tests.js
+++ b/x-pack/scripts/functional_tests.js
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-const alwaysImportedTests = [
+require('../../src/setup_node_env');
+require('@kbn/test').runTestsCli([
   require.resolve('../test/functional/config.js'),
   require.resolve('../test/functional_basic/config.ts'),
   require.resolve('../test/security_solution_endpoint/config.ts'),
@@ -91,11 +92,4 @@ const alwaysImportedTests = [
   require.resolve('../test/saved_object_tagging/api_integration/tagging_api/config.ts'),
   require.resolve('../test/examples/config.ts'),
   require.resolve('../test/functional_execution_context/config.ts'),
-];
-const onlyNotInCoverageTests = [];
-
-require('../../src/setup_node_env');
-require('@kbn/test').runTestsCli([
-  ...alwaysImportedTests,
-  ...(!!process.env.CODE_COVERAGE ? [] : onlyNotInCoverageTests),
 ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3195,6 +3195,13 @@
     js-yaml "^3.13.1"
     resolve-from "^5.0.0"
 
+"@istanbuljs/nyc-config-typescript@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.2.tgz#1f5235b28540a07219ae0dd42014912a0b19cf89"
+  integrity sha512-iKGIyMoyJuFnJRSVTZ78POIRvNnwZaWIf8vG4ZS3rQq58MMDrqEX2nnzx0R28V2X8JvmKYiqY9FP2hlJsm8A0w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+
 "@istanbuljs/schema@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"


### PR DESCRIPTION
## Summary

Closes #83903

This PR collects code coverage on Kibana server side for FTR-based tests, both e2e and API.

Adding `nyc-config-typescript` to instrument ts-based project and calling `scripts/functiona_tests` with nyc allows us to start coverage collection in `global.__coverage__`, which is saved into json on process exit.

As a final step, this json is merged together with the json files collected on client-side from `window.__coverage__` during e2e tests execution.

The final `functional` code coverage  report will include server files:

<img width="1611" alt="Screenshot 2022-02-01 at 18 44 36" src="https://user-images.githubusercontent.com/10977896/152022180-1df96fc2-d850-43a3-8f55-ca9bf099413f.png">

To verify coverage please check the [recent report](https://kibana-coverage.elastic.dev/2022-02-02T08:27:00Z/functional-combined/index.html)

