### PR TITLE
[Uptime] Fix uptime telemetry expensive query calls

### DIFF
--- a/x-pack/plugins/uptime/public/state/api/utils.ts
+++ b/x-pack/plugins/uptime/public/state/api/utils.ts
@@ -109,6 +109,8 @@ class ApiService {
       body: JSON.stringify(data),
     });
 
+    this.addInspectorRequest?.({ data: response, status: FETCH_STATUS.SUCCESS, loading: false });
+
     if (decodeType) {
       const decoded = decodeType.decode(response);
       if (isRight(decoded)) {

--- a/x-pack/plugins/uptime/server/lib/adapters/telemetry/types.ts
+++ b/x-pack/plugins/uptime/server/lib/adapters/telemetry/types.ts
@@ -12,6 +12,7 @@ export interface PageViewParams {
   autoRefreshEnabled: boolean;
   autorefreshInterval: number;
   refreshTelemetryHistory?: boolean;
+  refreshEsData?: boolean;
 }
 
 export interface Stats {

--- a/x-pack/plugins/uptime/server/rest_api/telemetry/log_page_view.ts
+++ b/x-pack/plugins/uptime/server/rest_api/telemetry/log_page_view.ts
@@ -21,18 +21,25 @@ export const createLogPageViewRoute: UMRestApiRouteFactory = () => ({
       dateEnd: schema.string(),
       autoRefreshEnabled: schema.boolean(),
       autorefreshInterval: schema.number(),
+      refreshEsData: schema.maybe(schema.boolean()),
       refreshTelemetryHistory: schema.maybe(schema.boolean()),
     }),
   },
   handler: async ({ savedObjectsClient, uptimeEsClient, request }): Promise<any> => {
     const pageView = request.body as PageViewParams;
     if (pageView.refreshTelemetryHistory) {
+      // this is primarily only used for API testing
       KibanaTelemetryAdapter.clearLocalTelemetry();
     }
-    await KibanaTelemetryAdapter.countNoOfUniqueMonitorAndLocations(
-      uptimeEsClient,
-      savedObjectsClient
-    );
+
+    if (pageView.refreshEsData) {
+      // this is primarily only used for API testing
+
+      await KibanaTelemetryAdapter.countNoOfUniqueMonitorAndLocations(
+        uptimeEsClient,
+        savedObjectsClient
+      );
+    }
     await KibanaTelemetryAdapter.countNoOfUniqueFleetManagedMonitors(uptimeEsClient);
     return KibanaTelemetryAdapter.countPageView(pageView as PageViewParams);
   },

--- a/x-pack/test/api_integration/apis/uptime/rest/telemetry_collectors.ts
+++ b/x-pack/test/api_integration/apis/uptime/rest/telemetry_collectors.ts
@@ -14,8 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const es = getService('es');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/111240
-  describe.skip('telemetry collectors heartbeat', () => {
+  describe('telemetry collectors heartbeat', () => {
     before('generating data', async () => {
       await getService('esArchiver').load('x-pack/test/functional/es_archives/uptime/blank');
 
@@ -69,7 +68,7 @@ export default function ({ getService }: FtrProviderContext) {
         'downMonitorId',
         1,
         1,
-        1,
+        10 * 1000,
         {
           observer,
           monitor: {
@@ -79,7 +78,15 @@ export default function ({ getService }: FtrProviderContext) {
         'down'
       );
 
-      await makeChecksWithStatus(es, 'mixMonitorId', 1, 1, 1, { observer: observer2 }, 'down');
+      await makeChecksWithStatus(
+        es,
+        'mixMonitorId',
+        1,
+        1,
+        30 * 1000,
+        { observer: observer2 },
+        'down'
+      );
       await es.indices.refresh();
     });
 
@@ -103,6 +110,7 @@ export default function ({ getService }: FtrProviderContext) {
           dateEnd: 'now/d',
           autoRefreshEnabled: true,
           refreshTelemetryHistory: true,
+          refreshEsData: true,
         })
         .expect(200);
 
@@ -111,7 +119,7 @@ export default function ({ getService }: FtrProviderContext) {
         monitor_page: 1,
         no_of_unique_monitors: 4,
         settings_page: 0,
-        monitor_frequency: [120, 0.001, 60, 60],
+        monitor_frequency: [10, 30, 60, 60],
         monitor_name_stats: { min_length: 7, max_length: 22, avg_length: 12 },
         no_of_unique_observer_locations: 3,
         observer_location_name_stats: { min_length: 2, max_length: 7, avg_length: 4.8 },

--- a/x-pack/test/api_integration/apis/uptime/rest/telemetry_collectors_fleet.ts
+++ b/x-pack/test/api_integration/apis/uptime/rest/telemetry_collectors_fleet.ts
@@ -175,6 +175,7 @@ export default function ({ getService }: FtrProviderContext) {
           dateEnd: 'now/d',
           autoRefreshEnabled: true,
           refreshTelemetryHistory: true,
+          refreshEsData: true,
         })
         .expect(200);
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/124089

Updates the query and make sure it doesn't run on every page loads.

it already runs as part of usageCollection background task.


### Testing

1. Go to Kibana advances settings
2. Scroll to bottom and Click `Cluster data`
3. Make sure uptime telemetry data still appears there

![image](https://user-images.githubusercontent.com/3505601/152026172-ec79459c-e470-45cd-b807-73fa1243b0ca.png)
