### PR TITLE
[Lens] Improve mock

### DIFF
--- a/x-pack/plugins/lens/public/mocks/data_plugin_mock.ts
+++ b/x-pack/plugins/lens/public/mocks/data_plugin_mock.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { isEqual } from 'lodash';
 import { Observable, Subject } from 'rxjs';
 import moment from 'moment';
 import { isFilterPinned, Filter } from '@kbn/es-query';
@@ -79,8 +80,9 @@ export function mockDataPlugin(
         if (subscriber) subscriber();
       }),
       setAppFilters: jest.fn((newFilters: unknown[]) => {
+        const isDifferent = !isEqual(newFilters, filters);
         filters = newFilters;
-        if (subscriber) subscriber();
+        if (isDifferent && subscriber) subscriber();
       }),
       getFilters: () => filters,
       getGlobalFilters: () => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/124173

During initializing Lens would set the app filters: https://github.com/elastic/kibana/blob/efc07eed86584219d62df2c9641d0e274d6b7fd5/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts#L167

However in the mock filter service used for this test, this used to always triggers subscribers, even if the filters don't change (because an empty array and changed to an empty array). On filter changes, a new search session is created on debounce - this means by chance it's possible the second search session is created before the test finishes running, causing this failure.

This PR fixes the problem by only calling subscribers of the mock if the filters actually changed