### PR TITLE
[Stack Monitoring] Replace deprecated esKuery and IFieldType usages

### DIFF
--- a/x-pack/plugins/monitoring/public/alerts/components/param_details_form/use_derived_index_pattern.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/components/param_details_form/use_derived_index_pattern.tsx
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
+import { DataViewFieldBase } from '@kbn/es-query';
 import { useEffect, useState } from 'react';
-import { DataPublicPluginStart, IFieldType, IIndexPattern } from 'src/plugins/data/public';
+import { DataPublicPluginStart, IIndexPattern } from 'src/plugins/data/public';
+import { prefixIndexPattern } from '../../../../common/ccs_utils';
 import {
   INDEX_PATTERN_BEATS,
   INDEX_PATTERN_ELASTICSEARCH,
   INDEX_PATTERN_KIBANA,
   INDEX_PATTERN_LOGSTASH,
 } from '../../../../common/constants';
-import { prefixIndexPattern } from '../../../../common/ccs_utils';
 import { MonitoringConfig } from '../../../types';
 
 const INDEX_PATTERNS = `${INDEX_PATTERN_ELASTICSEARCH},${INDEX_PATTERN_KIBANA},${INDEX_PATTERN_LOGSTASH},${INDEX_PATTERN_BEATS}`;
@@ -24,7 +25,7 @@ export const useDerivedIndexPattern = (
 ): { loading: boolean; derivedIndexPattern: IIndexPattern } => {
   const indexPattern = prefixIndexPattern(config || ({} as MonitoringConfig), INDEX_PATTERNS, '*');
   const [loading, setLoading] = useState<boolean>(true);
-  const [fields, setFields] = useState<IFieldType[]>([]);
+  const [fields, setFields] = useState<DataViewFieldBase[]>([]);
   useEffect(() => {
     (async function fetchData() {
       const result = await data.indexPatterns.getFieldsForWildcard({

--- a/x-pack/plugins/monitoring/public/components/kuery_bar/index.tsx
+++ b/x-pack/plugins/monitoring/public/components/kuery_bar/index.tsx
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
+import { fromKueryExpression } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
-
 import React, { useEffect, useState } from 'react';
-import { WithKueryAutocompletion } from './with_kuery_autocompletion';
+import { IIndexPattern, QuerySuggestion } from '../../../../../../src/plugins/data/public';
 import { AutocompleteField } from './autocomplete_field';
-import { esKuery, IIndexPattern, QuerySuggestion } from '../../../../../../src/plugins/data/public';
+import { WithKueryAutocompletion } from './with_kuery_autocompletion';
 
 type LoadSuggestionsFn = (
   e: string,
@@ -31,7 +31,7 @@ interface Props {
 
 function validateQuery(query: string) {
   try {
-    esKuery.fromKueryExpression(query);
+    fromKueryExpression(query);
   } catch (err) {
     return false;
   }

--- a/x-pack/plugins/monitoring/public/lib/kuery.ts
+++ b/x-pack/plugins/monitoring/public/lib/kuery.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { esKuery, IIndexPattern } from '../../../../../src/plugins/data/public';
+import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
+import { IIndexPattern } from '../../../../../src/plugins/data/public';
 
 export const convertKueryToElasticSearchQuery = (
   kueryExpression: string,
@@ -13,9 +14,7 @@ export const convertKueryToElasticSearchQuery = (
 ) => {
   try {
     return kueryExpression
-      ? JSON.stringify(
-          esKuery.toElasticsearchQuery(esKuery.fromKueryExpression(kueryExpression), indexPattern)
-        )
+      ? JSON.stringify(toElasticsearchQuery(fromKueryExpression(kueryExpression), indexPattern))
       : '';
   } catch (err) {
     return '';


### PR DESCRIPTION
## :memo: Summary

This replaces usages of the deprecated `esKuery` and `IFieldType` exports of the `data` plugin.

closes #124168
part of #119356

## :female_detective: Review notes

The import of `fromKueryExpression` and `toElasticsearchQuery` from `@kbn/es-query` unfortunately increases the size of the async chunks quite a bit, because `data` is still a dependency and still contains the deprecated code. Once that is removed the `data` plugin bundle size should decrease accordingly. Alternatively, the introduction of tree shaking could help as well. But short of that I can't think of a clean way to avoid the size increase.

There are other imports of deprecated classes (such as `IIndexPattern`) in these files, but I focused this PR on the items in this list:

![image](https://user-images.githubusercontent.com/973741/152067406-f7e5a7f6-25a3-4c3b-9550-d1335536270c.png)
