### PR TITLE
[Maps] fix Unable to apply styles to vector tiles

### DIFF
--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_size_property.test.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_size_property.test.tsx
@@ -50,6 +50,9 @@ describe('renderLegendDetailRow', () => {
       supportsFieldMetaFromEs: () => {
         return true;
       },
+      supportsFieldMetaFromLocalData: () => {
+        return true;
+      },
     } as unknown as IField;
     const sizeProp = new DynamicSizeProperty(
       { minSize: 0, maxSize: 10, fieldMetaOptions: { isEnabled: true } },

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
@@ -298,10 +298,13 @@ export class DynamicStyleProperty<T>
     const fieldMetaOptions = _.get(this.getOptions(), 'fieldMetaOptions', { isEnabled: true });
 
     // In 8.0, UI changed to not allow setting isEnabled to false when fieldMeta from local not supported
-    // Saved objects created prior to 8.0 may have a configuration where 
+    // Saved objects created prior to 8.0 may have a configuration where
     // fieldMetaOptions.isEnabled is false and the field does not support fieldMeta from local.
     // In these cases, force isEnabled to true
-    if (!this._field.supportsFieldMetaFromLocalData()) {
+    // The exact case that spawned this fix is with ES_SEARCH sources and 8.0 where vector tiles switched
+    // from vector tiles generated via Kibana server to vector tiles generated via Elasticsearch.
+    // Kibana vector tiles supported fieldMeta from local while Elasticsearch vector tiles do not support fieldMeta from local.
+    if (this._field && !this._field.supportsFieldMetaFromLocalData()) {
       fieldMetaOptions.isEnabled = true;
     }
 

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
@@ -295,7 +295,17 @@ export class DynamicStyleProperty<T>
   }
 
   getFieldMetaOptions() {
-    return _.get(this.getOptions(), 'fieldMetaOptions', { isEnabled: true });
+    const fieldMetaOptions = _.get(this.getOptions(), 'fieldMetaOptions', { isEnabled: true });
+
+    // In 8.0, UI changed to not allow setting isEnabled to false when fieldMeta from local not supported
+    // Saved objects created prior to 8.0 may have a configuration where 
+    // fieldMetaOptions.isEnabled is false and the field does not support fieldMeta from local.
+    // In these cases, force isEnabled to true
+    if (!this._field.supportsFieldMetaFromLocalData()) {
+      fieldMetaOptions.isEnabled = true;
+    }
+
+    return fieldMetaOptions;
   }
 
   getDataMappingFunction() {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/124226

<img width="400" alt="Screen Shot 2022-02-01 at 3 41 31 PM" src="https://user-images.githubusercontent.com/373691/152047897-3cb5386a-3761-41c4-9fa4-b14572e87c01.png">

"Get min and max from data set" switch is disabled in UI when field does not support fieldMeta from local. The fix forces isEnabled to be true when fieldMeta is not supported in local
