### PR TITLE
[Security Solution] Advanced policy options for Mac NetworkExtensions

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -847,7 +847,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.kernel.network_extension.enable_content_filtering',
       {
         defaultMessage:
-          'Enable or disable the network content filter, this will enable/disable network eventing, additionally host isolation will fail if this option is disabled. Default: true',
+          'Enable or disable the network content filter, this will enable/disable network eventing. Host isolation will fail if this option is disabled. Default: true',
       }
     ),
   },

--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -840,4 +840,26 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       }
     ),
   },
+  {
+    key: 'mac.advanced.kernel.network_extension.enable_content_filtering',
+    first_supported_version: '8.1',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.kernel.network_extension.enable_content_filtering',
+      {
+        defaultMessage:
+          'Enable or disable the network content filter, this will enable/disable network eventing, additionally host isolation will fail if this option is disabled. Default: true',
+      }
+    ),
+  },
+  {
+    key: 'mac.advanced.kernel.network_extension.enable_packet_filtering',
+    first_supported_version: '8.1',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.kernel.network_extension.enable_packet_filtering',
+      {
+        defaultMessage:
+          'Enable or disable the network packet filter. Host isolation will fail if this option is disabled. Default: true',
+      }
+    ),
+  },
 ];


### PR DESCRIPTION
## Summary
Adds advanced options for the Mac NetworkExtensions feature on the Security Endpoint.

![image](https://user-images.githubusercontent.com/56395104/152054003-5799f49a-09f1-41ac-a826-9e15fa83e3fc.png)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
