### PR TITLE
[Maps][ML] Filter out kbn prop from tooltip

### DIFF
--- a/x-pack/plugins/maps/public/index.ts
+++ b/x-pack/plugins/maps/public/index.ts
@@ -20,6 +20,8 @@ export const plugin: PluginInitializer<MapsPluginSetup, MapsPluginStart> = (
 export { MAP_SAVED_OBJECT_TYPE } from '../common/constants';
 export type { PreIndexedShape } from '../common/elasticsearch_util';
 
+export { GEOJSON_FEATURE_ID_PROPERTY_NAME } from './classes/layers/vector_layer/geojson_vector_layer/assign_feature_ids';
+
 export type {
   ITooltipProperty,
   RenderTooltipContentParams,

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -274,7 +274,6 @@ export class AnomalySource implements IVectorSource {
 
   // -----------------
   // API ML probably can ignore
-  // API ML probably can ignore
   getAttributionProvider() {
     return null;
   }

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -15,7 +15,7 @@ import {
   VectorSourceRequestMeta,
 } from '../../../maps/common';
 import { AbstractSourceDescriptor, MapExtent } from '../../../maps/common/descriptor_types';
-import { ITooltipProperty } from '../../../maps/public';
+import { ITooltipProperty, GEOJSON_FEATURE_ID_PROPERTY_NAME } from '../../../maps/public';
 import {
   AnomalySourceField,
   AnomalySourceTooltipProperty,
@@ -247,6 +247,9 @@ export class AnomalySource implements IVectorSource {
   async getTooltipProperties(properties: { [p: string]: any } | null): Promise<ITooltipProperty[]> {
     const tooltipProperties: ITooltipProperty[] = [];
     for (const key in properties) {
+      if (key === GEOJSON_FEATURE_ID_PROPERTY_NAME) {
+        continue;
+      }
       if (properties.hasOwnProperty(key)) {
         const label = ANOMALY_SOURCE_FIELDS[key]?.label;
         if (label) {
@@ -270,6 +273,7 @@ export class AnomalySource implements IVectorSource {
   }
 
   // -----------------
+  // API ML probably can ignore
   // API ML probably can ignore
   getAttributionProvider() {
     return null;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/124292


This filters out the kbn-prop in the `anomaly_source.getTooltipProperties`-implementation.

Fixing this in _anomaly_source_ is mainly for consistency. All other Maps-sources have logic that handle what fields should have be displayed in a tooltip.

This could definitely be seen as a bug in the Maps-API, that it should _not_ supply the `__kbn__feature_id__` param. But this would open up a larger discussion. For now, since it is consistent with all other maps-sources, that's why we're proposing this fix.

