### PR TITLE
[cloud] Get user email from saml metadata

### DIFF
--- a/x-pack/plugins/cloud/server/routes/chat.test.ts
+++ b/x-pack/plugins/cloud/server/routes/chat.test.ts
@@ -44,14 +44,16 @@ describe('chat route', () => {
       `);
   });
 
-  test('returns user information and a token', async () => {
+  test('returns user information taken from saml metadata and a token', async () => {
     const security = securityMock.createSetup();
     const username = 'user.name';
     const email = 'user@elastic.co';
 
     security.authc.getCurrentUser.mockReturnValueOnce({
       username,
-      email,
+      metadata: {
+        saml_email: [email],
+      },
     });
 
     const router = httpServiceMock.createRouter();


### PR DESCRIPTION
## Summary

> New version of #124260
> Related to #123772

As titled.  This PR is fixing the issue with getting user email in the cloud environment.

AuthenticatedUser object has field email which is set to null value even in the cloud env. Based on the internal slack discussion we find out that we can safely use `AuthenticatedUser.metadata.saml_name` property to obtain a user email.

Creating new PR to assist in build.