### PR TITLE
[Security Solution] Use timelineId to tell when investigate in timeline is in a table

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/investigate_in_timeline_action.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/investigate_in_timeline_action.tsx
@@ -22,6 +22,7 @@ interface InvestigateInTimelineActionProps {
   alertIds?: string[];
   buttonType?: 'text' | 'icon';
   onInvestigateInTimelineAlertClick?: () => void;
+  timelineId?: string;
 }
 
 const InvestigateInTimelineActionComponent: React.FC<InvestigateInTimelineActionProps> = ({
@@ -30,11 +31,13 @@ const InvestigateInTimelineActionComponent: React.FC<InvestigateInTimelineAction
   ecsRowData,
   buttonType,
   onInvestigateInTimelineAlertClick,
+  timelineId,
 }) => {
   const { investigateInTimelineAlertClick } = useInvestigateInTimeline({
     ecsRowData,
     alertIds,
     onInvestigateInTimelineAlertClick,
+    timelineId,
   });
 
   return (

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
@@ -27,12 +27,14 @@ interface UseInvestigateInTimelineActionProps {
   nonEcsRowData?: TimelineNonEcsData[];
   alertIds?: string[] | null | undefined;
   onInvestigateInTimelineAlertClick?: () => void;
+  timelineId?: string;
 }
 
 export const useInvestigateInTimeline = ({
   ecsRowData,
   alertIds,
   onInvestigateInTimelineAlertClick,
+  timelineId,
 }: UseInvestigateInTimelineActionProps) => {
   const {
     data: { search: searchStrategyClient, query },
@@ -78,7 +80,7 @@ export const useInvestigateInTimeline = ({
   const showInvestigateInTimelineAction = alertIds != null;
   const { isLoading: isFetchingAlertEcs, alertsEcsData } = useFetchEcsAlertsData({
     alertIds,
-    skip: alertIds == null,
+    skip: alertIds == null || timelineId !== undefined,
   });
 
   const investigateInTimelineAlertClick = useCallback(async () => {

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_fetch_ecs_alerts_data.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_fetch_ecs_alerts_data.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { isEmpty } from 'lodash';
 
@@ -25,10 +25,11 @@ export const useFetchEcsAlertsData = ({
 }): { isLoading: boolean | null; alertsEcsData: Ecs[] | null } => {
   const [isLoading, setIsLoading] = useState<boolean | null>(null);
   const [alertsEcsData, setAlertEcsData] = useState<Ecs[] | null>(null);
+  const abortCtrl = useRef(new AbortController());
 
   useEffect(() => {
     let isSubscribed = true;
-    const abortCtrl = new AbortController();
+    const controller = abortCtrl.current;
 
     const fetchAlert = async () => {
       try {
@@ -72,7 +73,7 @@ export const useFetchEcsAlertsData = ({
 
     return (): void => {
       isSubscribed = false;
-      abortCtrl.abort();
+      controller.abort();
     };
   }, [alertIds, onError, skip]);
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.tsx
@@ -169,6 +169,7 @@ const ActionsComponent: React.FC<ActionProps> = ({
             key="investigate-in-timeline"
             alertIds={alertIds}
             ecsRowData={ecsData}
+            timelineId={timelineId}
           />
         )}
 


### PR DESCRIPTION
## Summary

Fixes #124307 by preventing event tables from making event detail requests when in a timeline by skipping the data fetching hook when the action is in a timeline.
0 calls to the detection detail api when viewing just the table:
![image](https://user-images.githubusercontent.com/56408403/152084212-4b61fb5d-240b-4921-9842-61f3e505d7c7.png)
1 made when opening the detail flyout:
![image](https://user-images.githubusercontent.com/56408403/152084244-d94ac8f5-c336-458a-b1a2-3a2780e102f4.png)


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



