### PR TITLE
[ML] Fix anomaly detector jobs list filter delay

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/jobs_list_view/jobs_list_view.js
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/jobs_list_view/jobs_list_view.js
@@ -7,7 +7,6 @@
 
 import React, { Component } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import { debounce } from 'lodash';
 
 import { ml } from '../../../../services/ml_api_service';
 import { checkForAutoStartDatafeed, filterJobs, loadFullJob } from '../utils';
@@ -34,11 +33,6 @@ import { CloseJobsConfirmModal } from '../confirm_modals/close_jobs_confirm_moda
 import { AnomalyDetectionEmptyState } from '../anomaly_detection_empty_state';
 
 let blockingJobsRefreshTimeout = null;
-
-const filterJobsDebounce = debounce((jobsSummaryList, filterClauses, callback) => {
-  const ss = filterJobs(jobsSummaryList, filterClauses);
-  callback(ss);
-}, 500);
 
 // 'isManagementTable' bool prop to determine when to configure table for use in Kibana management page
 export class JobsListView extends Component {
@@ -291,19 +285,10 @@ export class JobsListView extends Component {
       return;
     }
 
-    if (this._isFiltersSet === true) {
-      filterJobsDebounce(this.state.jobsSummaryList, filterClauses, (jobsSummaryList) => {
-        this.setState({ filteredJobsSummaryList: jobsSummaryList, filterClauses }, () => {
-          this.refreshSelectedJobs();
-        });
-      });
-    } else {
-      // first use after page load, do not debounce.
-      const filteredJobsSummaryList = filterJobs(this.state.jobsSummaryList, filterClauses);
-      this.setState({ filteredJobsSummaryList, filterClauses }, () => {
-        this.refreshSelectedJobs();
-      });
-    }
+    const filteredJobsSummaryList = filterJobs(this.state.jobsSummaryList, filterClauses);
+    this.setState({ filteredJobsSummaryList, filterClauses }, () => {
+      this.refreshSelectedJobs();
+    });
 
     this._isFiltersSet = true;
   };


### PR DESCRIPTION
Removes the debounce which is no longer needed when typing into the AD jobs list filter bar.
The debounce was in the wrong location, rather than being on user's keypresses, the delay was deeper inside the filtering function which caused problems when the input was wiped.

Our other filter bars do not use a debounce and performance does not seem to be affected by its removal.

Fixes https://github.com/elastic/kibana/issues/123210

