### PR TITLE
[Visualize] Coloring tooltips in Pie are not properly positioned

### DIFF
--- a/src/plugins/chart_expressions/expression_pie/public/components/pie_vis_component.tsx
+++ b/src/plugins/chart_expressions/expression_pie/public/components/pie_vis_component.tsx
@@ -42,7 +42,8 @@ import {
   PieContainerDimensions,
 } from '../../common/types/expression_renderers';
 import {
-  getColorPicker,
+  LegendColorPickerWrapper,
+  LegendColorPickerWrapperContext,
   getLayers,
   getLegendActions,
   canFilter,
@@ -261,28 +262,6 @@ const PieComponent = (props: PieComponentProps) => {
   };
   const legendPosition = visParams.legendPosition ?? Position.Right;
 
-  const legendColorPicker = useMemo(
-    () =>
-      getColorPicker(
-        legendPosition,
-        setColor,
-        bucketColumns,
-        visParams.palette.name,
-        visData.rows,
-        props.uiState,
-        visParams.distinctColors
-      ),
-    [
-      legendPosition,
-      setColor,
-      bucketColumns,
-      visParams.palette.name,
-      visParams.distinctColors,
-      visData.rows,
-      props.uiState,
-    ]
-  );
-
   const splitChartColumnAccessor = visParams.dimensions.splitColumn
     ? getSplitDimensionAccessor(
         services.fieldFormats,
@@ -332,81 +311,93 @@ const PieComponent = (props: PieComponentProps) => {
         <VisualizationNoResults hasNegativeValues={hasNegative} />
       ) : (
         <div css={pieChartWrapperStyle} ref={parentRef}>
-          <LegendToggle
-            onClick={toggleLegend}
-            showLegend={showLegend}
-            legendPosition={legendPosition}
-          />
-          <Chart size="100%">
-            <ChartSplit
-              splitColumnAccessor={splitChartColumnAccessor}
-              splitRowAccessor={splitChartRowAccessor}
-            />
-            <Settings
-              debugState={window._echDebugStateFlag ?? false}
+          <LegendColorPickerWrapperContext.Provider
+            value={{
+              legendPosition,
+              setColor,
+              bucketColumns,
+              palette: visParams.palette.name,
+              data: visData.rows,
+              uiState: props.uiState,
+              distinctColors: visParams.distinctColors,
+            }}
+          >
+            <LegendToggle
+              onClick={toggleLegend}
               showLegend={showLegend}
               legendPosition={legendPosition}
-              legendMaxDepth={visParams.nestedLegend ? undefined : 1}
-              legendColorPicker={props.uiState ? legendColorPicker : undefined}
-              flatLegend={Boolean(splitChartDimension)}
-              tooltip={tooltip}
-              onElementClick={(args) => {
-                handleSliceClick(
-                  args[0][0] as LayerValue[],
-                  bucketColumns,
-                  visData,
-                  splitChartDimension,
-                  splitChartFormatter
-                );
-              }}
-              legendAction={getLegendActions(
-                canFilter,
-                getLegendActionEventData(visData),
-                handleLegendAction,
-                visParams,
-                services.data.actions,
-                services.fieldFormats
-              )}
-              theme={[
-                // Chart background should be transparent for the usage at Canvas.
-                { background: { color: 'transparent' } },
-                themeOverrides,
-                chartTheme,
-                {
-                  legend: {
-                    labelOptions: {
-                      maxLines: visParams.truncateLegend ? visParams.maxLegendLines ?? 1 : 0,
+            />
+            <Chart size="100%">
+              <ChartSplit
+                splitColumnAccessor={splitChartColumnAccessor}
+                splitRowAccessor={splitChartRowAccessor}
+              />
+              <Settings
+                debugState={window._echDebugStateFlag ?? false}
+                showLegend={showLegend}
+                legendPosition={legendPosition}
+                legendMaxDepth={visParams.nestedLegend ? undefined : 1}
+                legendColorPicker={props.uiState ? LegendColorPickerWrapper : undefined}
+                flatLegend={Boolean(splitChartDimension)}
+                tooltip={tooltip}
+                onElementClick={(args) => {
+                  handleSliceClick(
+                    args[0][0] as LayerValue[],
+                    bucketColumns,
+                    visData,
+                    splitChartDimension,
+                    splitChartFormatter
+                  );
+                }}
+                legendAction={getLegendActions(
+                  canFilter,
+                  getLegendActionEventData(visData),
+                  handleLegendAction,
+                  visParams,
+                  services.data.actions,
+                  services.fieldFormats
+                )}
+                theme={[
+                  // Chart background should be transparent for the usage at Canvas.
+                  { background: { color: 'transparent' } },
+                  themeOverrides,
+                  chartTheme,
+                  {
+                    legend: {
+                      labelOptions: {
+                        maxLines: visParams.truncateLegend ? visParams.maxLegendLines ?? 1 : 0,
+                      },
                     },
                   },
-                },
-              ]}
-              baseTheme={chartBaseTheme}
-              onRenderChange={onRenderChange}
-            />
-            <Partition
-              id="pie"
-              smallMultiples={SMALL_MULTIPLES_ID}
-              data={visData.rows}
-              layout={PartitionLayout.sunburst}
-              specialFirstInnermostSector={false}
-              valueAccessor={(d: Datum) => getSliceValue(d, metricColumn)}
-              percentFormatter={(d: number) => percentFormatter.convert(d / 100)}
-              valueGetter={
-                !visParams.labels.show ||
-                visParams.labels.valuesFormat === ValueFormats.VALUE ||
-                !visParams.labels.values
-                  ? undefined
-                  : 'percent'
-              }
-              valueFormatter={(d: number) =>
-                !visParams.labels.show || !visParams.labels.values
-                  ? ''
-                  : metricFieldFormatter.convert(d)
-              }
-              layers={layers}
-              topGroove={!visParams.labels.show ? 0 : undefined}
-            />
-          </Chart>
+                ]}
+                baseTheme={chartBaseTheme}
+                onRenderChange={onRenderChange}
+              />
+              <Partition
+                id="pie"
+                smallMultiples={SMALL_MULTIPLES_ID}
+                data={visData.rows}
+                layout={PartitionLayout.sunburst}
+                specialFirstInnermostSector={false}
+                valueAccessor={(d: Datum) => getSliceValue(d, metricColumn)}
+                percentFormatter={(d: number) => percentFormatter.convert(d / 100)}
+                valueGetter={
+                  !visParams.labels.show ||
+                  visParams.labels.valuesFormat === ValueFormats.VALUE ||
+                  !visParams.labels.values
+                    ? undefined
+                    : 'percent'
+                }
+                valueFormatter={(d: number) =>
+                  !visParams.labels.show || !visParams.labels.values
+                    ? ''
+                    : metricFieldFormatter.convert(d)
+                }
+                layers={layers}
+                topGroove={!visParams.labels.show ? 0 : undefined}
+              />
+            </Chart>
+          </LegendColorPickerWrapperContext.Provider>
         </div>
       )}
     </div>

--- a/src/plugins/chart_expressions/expression_pie/public/utils/get_color_picker.tsx
+++ b/src/plugins/chart_expressions/expression_pie/public/utils/get_color_picker.tsx
@@ -6,10 +6,10 @@
  * Side Public License, v 1.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, createContext, useContext } from 'react';
 import Color from 'color';
 import { LegendColorPicker, Position } from '@elastic/charts';
-import { PopoverAnchorPosition, EuiPopover, EuiOutsideClickDetector } from '@elastic/eui';
+import { PopoverAnchorPosition, EuiWrappingPopover, EuiOutsideClickDetector } from '@elastic/eui';
 import type { DatatableRow } from '../../../../expressions/public';
 import type { PersistedState } from '../../../../visualizations/public';
 import { ColorPicker } from '../../../../charts/public';
@@ -48,71 +48,90 @@ function isOnInnerLayer(
   return data.find((d) => firstBucket.id && d[firstBucket.id] === seriesKey);
 }
 
-export const getColorPicker =
-  (
-    legendPosition: Position,
-    setColor: (newColor: string | null, seriesKey: string | number) => void,
-    bucketColumns: Array<Partial<BucketColumns>>,
-    palette: string,
-    data: DatatableRow[],
-    uiState: PersistedState,
-    distinctColors: boolean
-  ): LegendColorPicker =>
-  ({ anchor, color, onClose, onChange, seriesIdentifiers: [seriesIdentifier] }) => {
-    const seriesName = seriesIdentifier.key;
-    const overwriteColors: Record<string, string> = uiState?.get('vis.colors', {}) ?? {};
-    const colorIsOverwritten = Object.keys(overwriteColors).includes(seriesName.toString());
-    let keyDownEventOn = false;
-    const handleChange = (newColor: string | null) => {
-      if (newColor) {
-        onChange(newColor);
-      }
-      setColor(newColor, seriesName);
-      // close the popover if no color is applied or the user has clicked a color
-      if (!newColor || !keyDownEventOn) {
-        onClose();
-      }
-    };
+export interface LegendColorPickerWrapperContextType {
+  legendPosition: Position;
+  setColor: (newColor: string | null, seriesKey: string | number) => void;
+  bucketColumns: Array<Partial<BucketColumns>>;
+  palette: string;
+  data: DatatableRow[];
+  uiState: PersistedState;
+  distinctColors: boolean;
+}
 
-    const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
-      if (e.keyCode === KEY_CODE_ENTER) {
-        onClose?.();
-      }
-      keyDownEventOn = true;
-    };
+export const LegendColorPickerWrapperContext = createContext<
+  LegendColorPickerWrapperContextType | undefined
+>(undefined);
 
-    const handleOutsideClick = useCallback(() => {
-      onClose?.();
-    }, [onClose]);
+export const LegendColorPickerWrapper: LegendColorPicker = ({
+  anchor,
+  color,
+  onClose,
+  onChange,
+  seriesIdentifiers: [seriesIdentifier],
+}) => {
+  const seriesName = seriesIdentifier.key;
+  const colorPickerWrappingContext = useContext(LegendColorPickerWrapperContext);
 
-    if (!distinctColors) {
-      const enablePicker =
-        isOnInnerLayer(bucketColumns[0], data, seriesName) || !bucketColumns[0].id;
-      if (!enablePicker) return null;
+  const handleOutsideClick = useCallback(() => {
+    onClose?.();
+  }, [onClose]);
+
+  if (!colorPickerWrappingContext) {
+    return null;
+  }
+
+  const { legendPosition, setColor, bucketColumns, palette, data, uiState, distinctColors } =
+    colorPickerWrappingContext;
+
+  const overwriteColors: Record<string, string> = uiState?.get('vis.colors', {}) ?? {};
+  const colorIsOverwritten = Object.keys(overwriteColors).includes(seriesName.toString());
+  let keyDownEventOn = false;
+
+  const handleChange = (newColor: string | null) => {
+    if (newColor) {
+      onChange(newColor);
     }
-    const hexColor = new Color(color).hex();
-    return (
-      <EuiOutsideClickDetector onOutsideClick={handleOutsideClick}>
-        <EuiPopover
-          isOpen
-          ownFocus
-          display="block"
-          button={anchor}
-          anchorPosition={getAnchorPosition(legendPosition)}
-          closePopover={onClose}
-          panelPaddingSize="s"
-        >
-          <ColorPicker
-            color={palette === 'kibana_palette' ? hexColor : hexColor.toLowerCase()}
-            onChange={handleChange}
-            label={seriesName}
-            maxDepth={bucketColumns.length}
-            layerIndex={getLayerIndex(seriesName, data, bucketColumns)}
-            useLegacyColors={palette === 'kibana_palette'}
-            colorIsOverwritten={colorIsOverwritten}
-            onKeyDown={onKeyDown}
-          />
-        </EuiPopover>
-      </EuiOutsideClickDetector>
-    );
+    setColor(newColor, seriesName);
+    // close the popover if no color is applied or the user has clicked a color
+    if (!newColor || !keyDownEventOn) {
+      onClose();
+    }
   };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    if (e.keyCode === KEY_CODE_ENTER) {
+      onClose?.();
+    }
+    keyDownEventOn = true;
+  };
+
+  if (!distinctColors) {
+    const enablePicker = isOnInnerLayer(bucketColumns[0], data, seriesName) || !bucketColumns[0].id;
+    if (!enablePicker) return null;
+  }
+  const hexColor = new Color(color).hex();
+  return (
+    <EuiOutsideClickDetector onOutsideClick={handleOutsideClick}>
+      <EuiWrappingPopover
+        isOpen
+        ownFocus
+        display="block"
+        button={anchor}
+        anchorPosition={getAnchorPosition(legendPosition)}
+        closePopover={onClose}
+        panelPaddingSize="s"
+      >
+        <ColorPicker
+          color={palette === 'kibana_palette' ? hexColor : hexColor.toLowerCase()}
+          onChange={handleChange}
+          label={seriesName}
+          maxDepth={bucketColumns.length}
+          layerIndex={getLayerIndex(seriesName, data, bucketColumns)}
+          useLegacyColors={palette === 'kibana_palette'}
+          colorIsOverwritten={colorIsOverwritten}
+          onKeyDown={onKeyDown}
+        />
+      </EuiWrappingPopover>
+    </EuiOutsideClickDetector>
+  );
+};

--- a/src/plugins/chart_expressions/expression_pie/public/utils/index.ts
+++ b/src/plugins/chart_expressions/expression_pie/public/utils/index.ts
@@ -7,7 +7,7 @@
  */
 
 export { getLayers } from './get_layers';
-export { getColorPicker } from './get_color_picker';
+export { LegendColorPickerWrapper, LegendColorPickerWrapperContext } from './get_color_picker';
 export { getLegendActions } from './get_legend_actions';
 export { canFilter, getFilterClickData, getFilterEventData } from './filter_helpers';
 export { getPartitionTheme } from './get_partition_theme';


### PR DESCRIPTION
Closes: #116748

## Summary

Steps to reproduce: 
1. Create a pie chart with a visible legend.
2. Set up a legend to be on the top or bottom.
3. try to change a color by clicking on a color indicator

Screen:

https://user-images.githubusercontent.com/20072247/152141716-734fffa3-0fc9-4cf8-a829-971e1ffce8f9.mov


What was changed: 
- `EuiPopover` -> `EuiWrappingPopover`
- Created a `LegendColorPickerWrapperContext` context. This context is used instead of useMemo patterrn
- `useMemo` for `getColorPicker` was removed;

Related to https://github.com/elastic/eui/issues/4367