### PR TITLE
[Transform] Fix redirect to the wizard 

### DIFF
--- a/x-pack/plugins/transform/public/app/common/navigation.tsx
+++ b/x-pack/plugins/transform/public/app/common/navigation.tsx
@@ -13,5 +13,5 @@ import { SECTION_SLUG } from '../constants';
 export const RedirectToTransformManagement: FC = () => <Redirect to={`/${SECTION_SLUG.HOME}`} />;
 
 export const RedirectToCreateTransform: FC<{ savedObjectId: string }> = ({ savedObjectId }) => (
-  <Redirect to={`/${SECTION_SLUG.CREATE_TRANSFORM}/${savedObjectId}`} />
+  <Redirect push to={`/${SECTION_SLUG.CREATE_TRANSFORM}/${savedObjectId}`} />
 );


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/120242

Fixes redirect to the Transform wizard by pushing a change to the browser history instead of replacing it.

https://user-images.githubusercontent.com/5236598/152156120-d9acc7b5-f848-4b3c-ad4b-45fa7aed16eb.mov


