### PR TITLE
Fix anchor link for "Enable reporting" in Kibana Secure Reporting doc

### DIFF
--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -79,7 +79,7 @@ For more information, refer to {ref}/security-privileges.html[Security privilege
 
 .. Next to the applications you want to grant reporting privileges, click *All*.
 +
-If the *Reporting* option is unavailable, contact your administrator, or <<general-reporting-settings,enable the option in kibana.yml>>. 
+If the *Reporting* option is unavailable, contact your administrator, or <<general-reporting-settings,enable `xpack.reporting.enabled` in kibana.yml>>. 
 
 .. Click *Add {kib} privilege*.
 

--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -79,7 +79,7 @@ For more information, refer to {ref}/security-privileges.html[Security privilege
 
 .. Next to the applications you want to grant reporting privileges, click *All*.
 +
-If the *Reporting* option is unavailable, contact your administrator, or <<reporting-advanced-settings,enable the option in kibana.yml>>. 
+If the *Reporting* option is unavailable, contact your administrator, or <<general-reporting-settings,enable the option in kibana.yml>>. 
 
 .. Click *Add {kib} privilege*.
 


### PR DESCRIPTION
## Summary

This PR fix the anchor link from the Kibana Secure Reporting documentation that currently points to a reporting settings section which is not the good one.