### PR TITLE
[Fleet] Update subtext on logs view for missing privileges case

### DIFF
--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/scrollable_log_text_stream_view.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/scrollable_log_text_stream_view.tsx
@@ -171,7 +171,7 @@ export class ScrollableLogTextStreamView extends React.PureComponent<
               defaultMessage: 'There are no log messages to display.',
             })}
             bodyText={i18n.translate('xpack.infra.logs.emptyView.noLogMessageDescription', {
-              defaultMessage: 'Try adjusting your filter.',
+              defaultMessage: 'Try adjusting your filter or checking your index privileges.',
             })}
             refetchText={i18n.translate('xpack.infra.logs.emptyView.checkForNewDataButtonLabel', {
               defaultMessage: 'Check for new data',


### PR DESCRIPTION
## Summary
Follow up of https://github.com/elastic/kibana/pull/122347

In the Agent details view, when the user doesn’t have access to read elastic agent logs, they get a UI that shows `There are no log messages to display` even if there actually are logs but they don’t have the privileges to read them:

![Screenshot 2022-02-02 at 17 16 40](https://user-images.githubusercontent.com/16084106/152193582-8f543a0b-b4fa-4f47-bfe9-30d5f8aa31fe.png)

This PR changes the subtext from `Try adjusting your filter` to `Try adjusting your filter or checking your index privileges`. 

In the next release this message will be improved once the necessary privileges will be determined.


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
