### PR TITLE
[ML] Fix Data visualizer navigation to Lens broken due to records field migration

### DIFF
--- a/x-pack/plugins/data_visualizer/kibana.json
+++ b/x-pack/plugins/data_visualizer/kibana.json
@@ -30,7 +30,8 @@
     "esUiShared",
     "fieldFormats",
     "uiActions",
-    "cloud"
+    "cloud",
+    "lens"
   ],
   "owner": {
     "name": "Machine Learning UI",

--- a/x-pack/plugins/data_visualizer/public/application/common/components/field_data_row/action_menu/lens_utils.ts
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/field_data_row/action_menu/lens_utils.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../../../../../../lens/public';
 import { FieldVisConfig } from '../../stats_table/types';
 import { JOB_FIELD_TYPES } from '../../../../../../common/constants';
+import { DOCUMENT_FIELD_NAME } from '../../../../../../../lens/common/constants';
 
 interface ColumnsAndLayer {
   columns: Record<string, GenericIndexPatternColumn>;
@@ -52,7 +53,7 @@ export function getNumberSettings(item: FieldVisConfig, defaultIndexPattern: Ind
         label: COUNT,
         dataType: 'number',
         isBucketed: false,
-        sourceField: 'Records',
+        sourceField: DOCUMENT_FIELD_NAME,
         operationType: 'count',
       },
     };
@@ -107,7 +108,7 @@ export function getDateSettings(item: FieldVisConfig) {
       label: COUNT,
       operationType: 'count',
       scale: 'ratio',
-      sourceField: 'Records',
+      sourceField: DOCUMENT_FIELD_NAME,
     },
     col1: {
       dataType: 'date',
@@ -148,7 +149,7 @@ export function getKeywordSettings(item: FieldVisConfig) {
       label: COUNT,
       dataType: 'number',
       isBucketed: false,
-      sourceField: 'Records',
+      sourceField: DOCUMENT_FIELD_NAME,
       operationType: 'count',
     },
   };
@@ -181,7 +182,7 @@ export function getBooleanSettings(item: FieldVisConfig) {
       label: COUNT,
       dataType: 'number',
       isBucketed: false,
-      sourceField: 'Records',
+      sourceField: DOCUMENT_FIELD_NAME,
       operationType: 'count',
     },
   };


### PR DESCRIPTION
## Summary

This PR fixes an issue that was introduced after Lens's format for the records fields were updated https://github.com/elastic/kibana/pull/123894.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

