### PR TITLE
[SecuritySolution] Close field editor when page context is lost

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.test.tsx
@@ -33,6 +33,11 @@ jest.mock('../../../timelines/containers', () => ({
 
 jest.mock('../../components/url_state/normalize_time_range.ts');
 
+const mockUseCreateFieldButton = jest.fn().mockReturnValue(<></>);
+jest.mock('../../../timelines/components/create_field_button', () => ({
+  useCreateFieldButton: (...params: unknown[]) => mockUseCreateFieldButton(...params),
+}));
+
 const mockUseResizeObserver: jest.Mock = useResizeObserver as jest.Mock;
 jest.mock('use-resize-observer/polyfilled');
 mockUseResizeObserver.mockImplementation(() => ({}));
@@ -86,5 +91,22 @@ describe('StatefulEventsViewer', () => {
 
       expect(wrapper.find(`InspectButtonContainer`).exists()).toBe(true);
     });
+  });
+
+  test('it closes field editor when unmounted', async () => {
+    const mockCloseEditor = jest.fn();
+    mockUseCreateFieldButton.mockImplementation((_, __, fieldEditorActionsRef) => {
+      fieldEditorActionsRef.current = { closeEditor: mockCloseEditor };
+      return <></>;
+    });
+
+    const wrapper = mount(
+      <TestProviders>
+        <StatefulEventsViewer {...testProps} />
+      </TestProviders>
+    );
+    wrapper.unmount();
+
+    expect(mockCloseEditor).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.test.tsx
@@ -105,8 +105,9 @@ describe('StatefulEventsViewer', () => {
         <StatefulEventsViewer {...testProps} />
       </TestProviders>
     );
-    wrapper.unmount();
+    expect(mockCloseEditor).not.toHaveBeenCalled();
 
+    wrapper.unmount();
     expect(mockCloseEditor).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useEffect } from 'react';
+import React, { useRef, useCallback, useMemo, useEffect } from 'react';
 import { connect, ConnectedProps, useDispatch } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 import styled from 'styled-components';
@@ -29,7 +29,10 @@ import { CellValueElementProps } from '../../../timelines/components/timeline/ce
 import { FIELDS_WITHOUT_CELL_ACTIONS } from '../../lib/cell_actions/constants';
 import { useKibana } from '../../lib/kibana';
 import { GraphOverlay } from '../../../timelines/components/graph_overlay';
-import { useCreateFieldButton } from '../../../timelines/components/create_field_button';
+import {
+  CreateFieldEditorActions,
+  useCreateFieldButton,
+} from '../../../timelines/components/create_field_button';
 
 const EMPTY_CONTROL_COLUMNS: ControlColumnProps[] = [];
 
@@ -106,6 +109,8 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
   unit,
 }) => {
   const dispatch = useDispatch();
+  const editorActionsRef = useRef<CreateFieldEditorActions>(null);
+
   const { timelines: timelinesUi } = useKibana().services;
   const {
     browserFields,
@@ -137,6 +142,10 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
     }
     return () => {
       deleteEventQuery({ id, inputId: 'global' });
+      if (editorActionsRef.current) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        editorActionsRef.current.closeEditor();
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -167,7 +176,7 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
   }, [id, timelineQuery, globalQuery]);
   const bulkActions = useMemo(() => ({ onAlertStatusActionSuccess }), [onAlertStatusActionSuccess]);
 
-  const createFieldComponent = useCreateFieldButton(scopeId, id);
+  const createFieldComponent = useCreateFieldButton(scopeId, id, editorActionsRef);
 
   return (
     <>

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -109,8 +109,6 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
   unit,
 }) => {
   const dispatch = useDispatch();
-  const editorActionsRef = useRef<CreateFieldEditorActions>(null);
-
   const { timelines: timelinesUi } = useKibana().services;
   const {
     browserFields,
@@ -126,6 +124,8 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
   const tGridEventRenderedViewEnabled = useIsExperimentalFeatureEnabled(
     'tGridEventRenderedViewEnabled'
   );
+  const editorActionsRef = useRef<CreateFieldEditorActions>(null);
+
   useEffect(() => {
     if (createTimeline != null) {
       createTimeline({

--- a/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.test.tsx
@@ -110,9 +110,9 @@ describe('CreateFieldButton', () => {
   });
 
   it("stores 'closeEditor' in the actions ref when editor is open", async () => {
-    const closeEditorDummyFn = () => {};
+    const mockCloseEditor = jest.fn();
     useKibanaMock().services.data.dataViews.get = () => Promise.resolve({} as DataView);
-    useKibanaMock().services.dataViewFieldEditor.openEditor = () => closeEditorDummyFn;
+    useKibanaMock().services.dataViewFieldEditor.openEditor = () => mockCloseEditor;
 
     const editorActionsRef: MutableRefObject<CreateFieldEditorActions> = React.createRef();
     await act(async () => {
@@ -130,7 +130,16 @@ describe('CreateFieldButton', () => {
       await runAllPromises();
     });
 
+    expect(editorActionsRef?.current).toBeNull();
+
     fireEvent.click(screen.getByRole('button'));
-    expect(editorActionsRef?.current?.closeEditor).toBe(closeEditorDummyFn);
+
+    expect(mockCloseEditor).not.toHaveBeenCalled();
+    expect(editorActionsRef?.current?.closeEditor).toBeDefined();
+
+    editorActionsRef!.current!.closeEditor();
+
+    expect(mockCloseEditor).toHaveBeenCalled();
+    expect(editorActionsRef!.current).toBeNull();
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.test.tsx
@@ -6,8 +6,8 @@
  */
 
 import { render, fireEvent, act, screen } from '@testing-library/react';
-import React from 'react';
-import { CreateFieldButton } from './index';
+import React, { MutableRefObject } from 'react';
+import { CreateFieldButton, CreateFieldEditorActions } from './index';
 import {
   indexPatternFieldEditorPluginMock,
   Start,
@@ -107,5 +107,30 @@ describe('CreateFieldButton', () => {
 
     fireEvent.click(screen.getByRole('button'));
     expect(onClickParam).toHaveBeenCalled();
+  });
+
+  it("stores 'closeEditor' in the actions ref when editor is open", async () => {
+    const closeEditorDummyFn = () => {};
+    useKibanaMock().services.data.dataViews.get = () => Promise.resolve({} as DataView);
+    useKibanaMock().services.dataViewFieldEditor.openEditor = () => closeEditorDummyFn;
+
+    const editorActionsRef: MutableRefObject<CreateFieldEditorActions> = React.createRef();
+    await act(async () => {
+      render(
+        <CreateFieldButton
+          selectedDataViewId={'dataViewId'}
+          onClick={() => undefined}
+          timelineId={TimelineId.detectionsPage}
+          editorActionsRef={editorActionsRef}
+        />,
+        {
+          wrapper: TestProviders,
+        }
+      );
+      await runAllPromises();
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(editorActionsRef?.current?.closeEditor).toBe(closeEditorDummyFn);
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
@@ -56,7 +56,7 @@ export const CreateFieldButton = React.memo<CreateFieldButtonProps>(
 
     const onClick = useCallback(() => {
       if (dataView) {
-        const closeEditor = dataViewFieldEditor?.openEditor({
+        const closeFieldEditor = dataViewFieldEditor?.openEditor({
           ctx: { dataView },
           onSave: async (field: DataViewField) => {
             // Fetch the updated list of fields
@@ -77,7 +77,12 @@ export const CreateFieldButton = React.memo<CreateFieldButtonProps>(
           },
         });
         if (editorActionsRef) {
-          editorActionsRef.current = { closeEditor };
+          editorActionsRef.current = {
+            closeEditor: () => {
+              editorActionsRef.current = null;
+              closeFieldEditor();
+            },
+          };
         }
       }
       onClickParam();

--- a/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
@@ -24,7 +24,7 @@ import { DEFAULT_COLUMN_MIN_WIDTH } from '../timeline/body/constants';
 import { defaultColumnHeaderType } from '../timeline/body/column_headers/default_headers';
 
 export type CreateFieldEditorActions = { closeEditor: () => void } | null;
-export type CreateFieldEditorActionsRef = MutableRefObject<CreateFieldEditorActions>;
+type CreateFieldEditorActionsRef = MutableRefObject<CreateFieldEditorActions>;
 
 interface CreateFieldButtonProps {
   selectedDataViewId: string;

--- a/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/create_field_button/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { MutableRefObject, useCallback, useEffect, useMemo, useState } from 'react';
 import { EuiButton } from '@elastic/eui';
 import styled from 'styled-components';
 
@@ -23,17 +23,21 @@ import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../timeline/body/constants';
 import { defaultColumnHeaderType } from '../timeline/body/column_headers/default_headers';
 
+export type CreateFieldEditorActions = { closeEditor: () => void } | null;
+export type CreateFieldEditorActionsRef = MutableRefObject<CreateFieldEditorActions>;
+
 interface CreateFieldButtonProps {
   selectedDataViewId: string;
   onClick: () => void;
   timelineId: TimelineId;
+  editorActionsRef?: CreateFieldEditorActionsRef;
 }
 const StyledButton = styled(EuiButton)`
   margin-left: ${({ theme }) => theme.eui.paddingSizes.m};
 `;
 
 export const CreateFieldButton = React.memo<CreateFieldButtonProps>(
-  ({ selectedDataViewId, onClick: onClickParam, timelineId }) => {
+  ({ selectedDataViewId, onClick: onClickParam, timelineId, editorActionsRef }) => {
     const [dataView, setDataView] = useState<DataView | null>(null);
     const dispatch = useDispatch();
 
@@ -52,7 +56,7 @@ export const CreateFieldButton = React.memo<CreateFieldButtonProps>(
 
     const onClick = useCallback(() => {
       if (dataView) {
-        dataViewFieldEditor?.openEditor({
+        const closeEditor = dataViewFieldEditor?.openEditor({
           ctx: { dataView },
           onSave: async (field: DataViewField) => {
             // Fetch the updated list of fields
@@ -72,6 +76,9 @@ export const CreateFieldButton = React.memo<CreateFieldButtonProps>(
             );
           },
         });
+        if (editorActionsRef) {
+          editorActionsRef.current = { closeEditor };
+        }
       }
       onClickParam();
     }, [
@@ -82,6 +89,7 @@ export const CreateFieldButton = React.memo<CreateFieldButtonProps>(
       selectedDataViewId,
       dispatch,
       timelineId,
+      editorActionsRef,
     ]);
 
     if (
@@ -116,7 +124,8 @@ CreateFieldButton.displayName = 'CreateFieldButton';
  */
 export const useCreateFieldButton = (
   sourcererScope: SourcererScopeName,
-  timelineId: TimelineId
+  timelineId: TimelineId,
+  editorActionsRef?: CreateFieldEditorActionsRef
 ) => {
   const scopeIdSelector = useMemo(() => sourcererSelectors.scopeIdSelector(), []);
   const { missingPatterns, selectedDataViewId } = useDeepEqualSelector((state) =>
@@ -133,9 +142,10 @@ export const useCreateFieldButton = (
         selectedDataViewId={selectedDataViewId}
         onClick={onClick}
         timelineId={timelineId}
+        editorActionsRef={editorActionsRef}
       />
     );
 
     return CreateFieldButtonComponent;
-  }, [missingPatterns.length, selectedDataViewId, timelineId]);
+  }, [missingPatterns.length, selectedDataViewId, timelineId, editorActionsRef]);
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/__snapshots__/index.test.tsx.snap
@@ -658,6 +658,7 @@ exports[`ColumnHeaders rendering renders correctly against snapshot 1`] = `
     ]
   }
   onSelectAll={[Function]}
+  show={true}
   showEventsSelect={false}
   showSelectAllCheckbox={false}
   sort={

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.test.tsx
@@ -254,8 +254,8 @@ describe('ColumnHeaders', () => {
     });
   });
 
-  describe('Fields', () => {
-    test('Closes field editor when the timeline is closed', () => {
+  describe('Field Editor', () => {
+    test('Closes field editor when the timeline is unmounted', () => {
       const mockCloseEditor = jest.fn();
       mockUseCreateFieldButton.mockImplementation((_, __, fieldEditorActionsRef) => {
         fieldEditorActionsRef.current = { closeEditor: mockCloseEditor };
@@ -267,12 +267,29 @@ describe('ColumnHeaders', () => {
           <ColumnHeadersComponent {...defaultProps} />
         </TestProviders>
       );
-      wrapper.setProps({ ...defaultProps, show: false });
+      expect(mockCloseEditor).not.toHaveBeenCalled();
 
-      // let useEffect hook execute
-      setTimeout(() => {
-        expect(mockCloseEditor).toHaveBeenCalled();
-      }, 0);
+      wrapper.unmount();
+      expect(mockCloseEditor).toHaveBeenCalled();
+    });
+
+    test('Closes field editor when the timeline is closed', () => {
+      const mockCloseEditor = jest.fn();
+      mockUseCreateFieldButton.mockImplementation((_, __, fieldEditorActionsRef) => {
+        fieldEditorActionsRef.current = { closeEditor: mockCloseEditor };
+        return <></>;
+      });
+
+      const Proxy = (props: ColumnHeadersComponentProps) => (
+        <TestProviders>
+          <ColumnHeadersComponent {...props} />
+        </TestProviders>
+      );
+      const wrapper = mount(<Proxy {...defaultProps} />);
+      expect(mockCloseEditor).not.toHaveBeenCalled();
+
+      wrapper.setProps({ ...defaultProps, show: false });
+      expect(mockCloseEditor).toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.test.tsx
@@ -16,7 +16,7 @@ import { Sort } from '../sort';
 import { TestProviders } from '../../../../../common/mock/test_providers';
 import { useMountAppended } from '../../../../../common/utils/use_mount_appended';
 
-import { ColumnHeadersComponent } from '.';
+import { ColumnHeadersComponent, ColumnHeadersComponentProps } from '.';
 import { cloneDeep } from 'lodash/fp';
 import { timelineActions } from '../../../../store/timeline';
 import { TimelineTabs } from '../../../../../../common/types/timeline';
@@ -24,8 +24,14 @@ import { Direction } from '../../../../../../common/search_strategy';
 import { getDefaultControlColumn } from '../control_columns';
 import { testTrailingControlColumns } from '../../../../../common/mock/mock_timeline_control_columns';
 import { HeaderActions } from '../actions/header_actions';
+import { act } from 'react-dom/test-utils';
 
 jest.mock('../../../../../common/lib/kibana');
+
+const mockUseCreateFieldButton = jest.fn().mockReturnValue(<></>);
+jest.mock('../../../create_field_button', () => ({
+  useCreateFieldButton: (...params: unknown[]) => mockUseCreateFieldButton(...params),
+}));
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
@@ -46,33 +52,34 @@ describe('ColumnHeaders', () => {
     ...x,
     headerCellRender: HeaderActions,
   }));
+  const sort: Sort[] = [
+    {
+      columnId: '@timestamp',
+      columnType: 'number',
+      sortDirection: Direction.desc,
+    },
+  ];
+  const defaultProps: ColumnHeadersComponentProps = {
+    actionsColumnWidth,
+    browserFields: mockBrowserFields,
+    columnHeaders: defaultHeaders,
+    isSelectAllChecked: false,
+    onSelectAll: jest.fn,
+    show: true,
+    showEventsSelect: false,
+    showSelectAllCheckbox: false,
+    sort,
+    tabType: TimelineTabs.query,
+    timelineId,
+    leadingControlColumns,
+    trailingControlColumns: [],
+  };
 
   describe('rendering', () => {
-    const sort: Sort[] = [
-      {
-        columnId: '@timestamp',
-        columnType: 'number',
-        sortDirection: Direction.desc,
-      },
-    ];
-
     test('renders correctly against snapshot', () => {
       const wrapper = shallow(
         <TestProviders>
-          <ColumnHeadersComponent
-            actionsColumnWidth={actionsColumnWidth}
-            browserFields={mockBrowserFields}
-            columnHeaders={defaultHeaders}
-            isSelectAllChecked={false}
-            onSelectAll={jest.fn}
-            showEventsSelect={false}
-            showSelectAllCheckbox={false}
-            sort={sort}
-            tabType={TimelineTabs.query}
-            timelineId={timelineId}
-            leadingControlColumns={leadingControlColumns}
-            trailingControlColumns={[]}
-          />
+          <ColumnHeadersComponent {...defaultProps} />
         </TestProviders>
       );
       expect(wrapper.find('ColumnHeadersComponent')).toMatchSnapshot();
@@ -81,20 +88,7 @@ describe('ColumnHeaders', () => {
     test('it renders the field browser', () => {
       const wrapper = mount(
         <TestProviders>
-          <ColumnHeadersComponent
-            actionsColumnWidth={actionsColumnWidth}
-            browserFields={mockBrowserFields}
-            columnHeaders={defaultHeaders}
-            isSelectAllChecked={false}
-            onSelectAll={jest.fn}
-            showEventsSelect={false}
-            showSelectAllCheckbox={false}
-            sort={sort}
-            tabType={TimelineTabs.query}
-            timelineId={timelineId}
-            leadingControlColumns={leadingControlColumns}
-            trailingControlColumns={[]}
-          />
+          <ColumnHeadersComponent {...defaultProps} />
         </TestProviders>
       );
 
@@ -104,20 +98,7 @@ describe('ColumnHeaders', () => {
     test('it renders every column header', () => {
       const wrapper = mount(
         <TestProviders>
-          <ColumnHeadersComponent
-            actionsColumnWidth={actionsColumnWidth}
-            browserFields={mockBrowserFields}
-            columnHeaders={defaultHeaders}
-            isSelectAllChecked={false}
-            onSelectAll={jest.fn}
-            showEventsSelect={false}
-            showSelectAllCheckbox={false}
-            sort={sort}
-            tabType={TimelineTabs.query}
-            timelineId={timelineId}
-            leadingControlColumns={leadingControlColumns}
-            trailingControlColumns={[]}
-          />
+          <ColumnHeadersComponent {...defaultProps} />
         </TestProviders>
       );
 
@@ -166,18 +147,7 @@ describe('ColumnHeaders', () => {
       const wrapper = mount(
         <TestProviders>
           <ColumnHeadersComponent
-            actionsColumnWidth={actionsColumnWidth}
-            browserFields={mockBrowserFields}
-            columnHeaders={mockDefaultHeaders}
-            isSelectAllChecked={false}
-            onSelectAll={jest.fn}
-            showEventsSelect={false}
-            showSelectAllCheckbox={false}
-            sort={mockSort}
-            tabType={TimelineTabs.query}
-            timelineId={timelineId}
-            leadingControlColumns={leadingControlColumns}
-            trailingControlColumns={[]}
+            {...{ ...defaultProps, columnHeaders: mockDefaultHeaders, sort: mockSort }}
           />
         </TestProviders>
       );
@@ -210,18 +180,7 @@ describe('ColumnHeaders', () => {
       const wrapper = mount(
         <TestProviders>
           <ColumnHeadersComponent
-            actionsColumnWidth={actionsColumnWidth}
-            browserFields={mockBrowserFields}
-            columnHeaders={mockDefaultHeaders}
-            isSelectAllChecked={false}
-            onSelectAll={jest.fn()}
-            showEventsSelect={false}
-            showSelectAllCheckbox={false}
-            sort={mockSort}
-            tabType={TimelineTabs.query}
-            timelineId={timelineId}
-            leadingControlColumns={leadingControlColumns}
-            trailingControlColumns={[]}
+            {...{ ...defaultProps, columnHeaders: mockDefaultHeaders, sort: mockSort }}
           />
         </TestProviders>
       );
@@ -249,18 +208,11 @@ describe('ColumnHeaders', () => {
       const wrapper = mount(
         <TestProviders>
           <ColumnHeadersComponent
-            actionsColumnWidth={actionsColumnWidth}
-            browserFields={mockBrowserFields}
-            columnHeaders={mockDefaultHeaders}
-            isSelectAllChecked={false}
-            onSelectAll={jest.fn()}
-            showEventsSelect={false}
-            showSelectAllCheckbox={false}
-            sort={mockSort}
-            tabType={TimelineTabs.query}
-            timelineId={timelineId}
-            leadingControlColumns={leadingControlColumns}
-            trailingControlColumns={[]}
+            {...{
+              ...defaultProps,
+              columnHeaders: mockDefaultHeaders,
+              sort: mockSort,
+            }}
           />
         </TestProviders>
       );
@@ -287,24 +239,46 @@ describe('ColumnHeaders', () => {
       const wrapper = mount(
         <TestProviders>
           <ColumnHeadersComponent
-            actionsColumnWidth={actionsColumnWidth}
-            browserFields={mockBrowserFields}
-            columnHeaders={mockDefaultHeaders}
-            isSelectAllChecked={false}
-            onSelectAll={jest.fn()}
-            showEventsSelect={false}
-            showSelectAllCheckbox={false}
-            sort={mockSort}
-            tabType={TimelineTabs.query}
-            timelineId={timelineId}
-            leadingControlColumns={[]}
-            trailingControlColumns={testTrailingControlColumns}
+            {...{
+              ...defaultProps,
+              columnHeaders: mockDefaultHeaders,
+              sort: mockSort,
+              leadingControlColumns: [],
+              trailingControlColumns: testTrailingControlColumns,
+            }}
           />
         </TestProviders>
       );
 
       expect(wrapper.exists('[data-test-subj="field-browser"]')).toBeFalsy();
       expect(wrapper.exists('[data-test-subj="test-header-action-cell"]')).toBeTruthy();
+    });
+  });
+
+  describe('hiding', () => {
+    beforeEach(() => {
+      mockUseCreateFieldButton.mockClear();
+    });
+
+    test('Calls closeEditor ref function when the timeline is closed', () => {
+      const mockCloseEditor = jest.fn();
+      mockUseCreateFieldButton.mockImplementation((_, __, fieldEditorActionsRef) => {
+        fieldEditorActionsRef.current = { closeEditor: mockCloseEditor };
+      });
+
+      const wrapper = mount(
+        <TestProviders>
+          <ColumnHeadersComponent {...defaultProps} />
+        </TestProviders>
+      );
+      act(() => {
+        wrapper.setProps({ ...defaultProps, show: false });
+        wrapper.update();
+      });
+
+      setTimeout(() => {
+        expect(mockCloseEditor).toHaveBeenCalled();
+      }, 0);
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.test.tsx
@@ -24,7 +24,6 @@ import { Direction } from '../../../../../../common/search_strategy';
 import { getDefaultControlColumn } from '../control_columns';
 import { testTrailingControlColumns } from '../../../../../common/mock/mock_timeline_control_columns';
 import { HeaderActions } from '../actions/header_actions';
-import { act } from 'react-dom/test-utils';
 
 jest.mock('../../../../../common/lib/kibana');
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.test.tsx
@@ -255,15 +255,12 @@ describe('ColumnHeaders', () => {
     });
   });
 
-  describe('hiding', () => {
-    beforeEach(() => {
-      mockUseCreateFieldButton.mockClear();
-    });
-
-    test('Calls closeEditor ref function when the timeline is closed', () => {
+  describe('Fields', () => {
+    test('Closes field editor when the timeline is closed', () => {
       const mockCloseEditor = jest.fn();
       mockUseCreateFieldButton.mockImplementation((_, __, fieldEditorActionsRef) => {
         fieldEditorActionsRef.current = { closeEditor: mockCloseEditor };
+        return <></>;
       });
 
       const wrapper = mount(
@@ -271,11 +268,9 @@ describe('ColumnHeaders', () => {
           <ColumnHeadersComponent {...defaultProps} />
         </TestProviders>
       );
-      act(() => {
-        wrapper.setProps({ ...defaultProps, show: false });
-        wrapper.update();
-      });
+      wrapper.setProps({ ...defaultProps, show: false });
 
+      // let useEffect hook execute
       setTimeout(() => {
         expect(mockCloseEditor).toHaveBeenCalled();
       }, 0);

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.tsx
@@ -106,6 +106,15 @@ export const ColumnHeadersComponent = ({
   const fieldEditorActionsRef = useRef<CreateFieldEditorActions>(null);
 
   useEffect(() => {
+    return () => {
+      if (fieldEditorActionsRef.current) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        fieldEditorActionsRef.current.closeEditor();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     if (!show && fieldEditorActionsRef.current) {
       fieldEditorActionsRef.current.closeEditor();
     }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import deepEqual from 'fast-deep-equal';
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Droppable, DraggableChildrenFn } from 'react-beautiful-dnd';
 
 import { DragEffects } from '../../../../../common/components/drag_and_drop/draggable_wrapper';
@@ -34,15 +34,16 @@ import { Sort } from '../sort';
 import { ColumnHeader } from './column_header';
 
 import { SourcererScopeName } from '../../../../../common/store/sourcerer/model';
-import { useCreateFieldButton } from '../../../create_field_button';
+import { CreateFieldEditorActions, useCreateFieldButton } from '../../../create_field_button';
 
-interface Props {
+export interface ColumnHeadersComponentProps {
   actionsColumnWidth: number;
   browserFields: BrowserFields;
   columnHeaders: ColumnHeaderOptions[];
   isEventViewer?: boolean;
   isSelectAllChecked: boolean;
   onSelectAll: OnSelectAll;
+  show: boolean;
   showEventsSelect: boolean;
   showSelectAllCheckbox: boolean;
   sort: Sort[];
@@ -92,6 +93,7 @@ export const ColumnHeadersComponent = ({
   isEventViewer = false,
   isSelectAllChecked,
   onSelectAll,
+  show,
   showEventsSelect,
   showSelectAllCheckbox,
   sort,
@@ -99,8 +101,15 @@ export const ColumnHeadersComponent = ({
   timelineId,
   leadingControlColumns,
   trailingControlColumns,
-}: Props) => {
+}: ColumnHeadersComponentProps) => {
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const fieldEditorActionsRef = useRef<CreateFieldEditorActions>(null);
+
+  useEffect(() => {
+    if (!show && fieldEditorActionsRef.current) {
+      fieldEditorActionsRef.current.closeEditor();
+    }
+  }, [show]);
 
   const renderClone: DraggableChildrenFn = useCallback(
     (dragProvided, _dragSnapshot, rubric) => {
@@ -174,7 +183,8 @@ export const ColumnHeadersComponent = ({
 
   const createFieldComponent = useCreateFieldButton(
     SourcererScopeName.timeline,
-    timelineId as TimelineId
+    timelineId as TimelineId,
+    fieldEditorActionsRef
   );
 
   const LeadingHeaderActions = useMemo(() => {
@@ -300,6 +310,7 @@ export const ColumnHeaders = React.memo(
     prevProps.isEventViewer === nextProps.isEventViewer &&
     prevProps.isSelectAllChecked === nextProps.isSelectAllChecked &&
     prevProps.onSelectAll === nextProps.onSelectAll &&
+    prevProps.show === nextProps.show &&
     prevProps.showEventsSelect === nextProps.showEventsSelect &&
     prevProps.showSelectAllCheckbox === nextProps.showSelectAllCheckbox &&
     deepEqual(prevProps.sort, nextProps.sort) &&

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.test.tsx
@@ -146,6 +146,7 @@ describe('Body', () => {
     selectedEventIds: {},
     setSelected: jest.fn() as unknown as StatefulBodyProps['setSelected'],
     sort: mockSort,
+    show: true,
     showCheckboxes: false,
     tabType: TimelineTabs.query,
     totalPages: 1,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.tsx
@@ -89,6 +89,7 @@ export const BodyComponent = React.memo<StatefulBodyProps>(
     setSelected,
     clearSelected,
     onRuleChange,
+    show,
     showCheckboxes,
     refetch,
     renderCellValue,
@@ -244,6 +245,7 @@ export const BodyComponent = React.memo<StatefulBodyProps>(
               isEventViewer={isEventViewer}
               isSelectAllChecked={isSelectAllChecked}
               onSelectAll={onSelectAll}
+              show={show}
               showEventsSelect={false}
               showSelectAllCheckbox={showCheckboxes}
               sort={sort}
@@ -298,7 +300,8 @@ export const BodyComponent = React.memo<StatefulBodyProps>(
     prevProps.renderCellValue === nextProps.renderCellValue &&
     prevProps.rowRenderers === nextProps.rowRenderers &&
     prevProps.showCheckboxes === nextProps.showCheckboxes &&
-    prevProps.tabType === nextProps.tabType
+    prevProps.tabType === nextProps.tabType &&
+    prevProps.show === nextProps.show
 );
 
 BodyComponent.displayName = 'BodyComponent';
@@ -321,6 +324,7 @@ const makeMapStateToProps = () => {
       pinnedEventIds,
       selectedEventIds,
       showCheckboxes,
+      show,
     } = timeline;
 
     return {
@@ -333,6 +337,7 @@ const makeMapStateToProps = () => {
       pinnedEventIds,
       selectedEventIds,
       showCheckboxes,
+      show,
     };
   };
   return mapStateToProps;


### PR DESCRIPTION
## Summary
issue: https://github.com/elastic/kibana/issues/123209

Implemented the close action on the field editor, by leveraging the returned function from the `dataViewFieldEditor.openEditor` function call.

The reference is needed here because the button that triggers the field editor flyout is unmounted when it is clicked. The `closeEditor` action needs to be triggered when the original component that opened the "fieldBrowser" in the first place is unmounted (alerts tables) or it is hidden (timeline):

https://user-images.githubusercontent.com/17747913/152200434-9c7d6b46-ce4e-41e1-9868-b0f805406d1d.mov


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

