### PR TITLE
chore(NA): adds backport config for 8.2.0 bump

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,6 +3,7 @@
   "repoName": "kibana",
   "targetBranchChoices": [
     "main",
+    "8.1",
     "8.0",
     "7.17",
     "7.16",
@@ -37,7 +38,7 @@
     "backport"
   ],
   "branchLabelMapping": {
-    "^v8.1.0$": "main",
+    "^v8.2.0$": "main",
     "^v(\\d+).(\\d+).\\d+$": "$1.$2"
   },
   "autoMerge": true,


### PR DESCRIPTION
This PR setups the correct backport config after we bump 8.2.0