### PR TITLE
[7.15] update typo in watcher docs (#123690)

### DIFF
--- a/docs/management/watcher-ui/index.asciidoc
+++ b/docs/management/watcher-ui/index.asciidoc
@@ -8,7 +8,7 @@ Watches are helpful for analyzing mission-critical and business-critical
 streaming data. For example, you might watch application logs for performance
 outages or audit access logs for security threats.
 
-To get started, open then main menu,
+To get started, open the main menu,
 then click *Stack Management > Watcher*.
 With this UI, you can:
 
@@ -43,7 +43,7 @@ and either of these watcher roles:
 * `watcher_admin`. You can perform all Watcher actions, including create and edit watches.
 * `watcher_user`. You can view watches, but not create or edit them.
 
-To manage roles, open then main menu, then click *Stack Management > Roles*, or use the
+To manage roles, open the main menu, then click *Stack Management > Roles*, or use the
 <<role-management-api, Kibana Role Management API>>. Watches are shared between
 all users with the same role.
 


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.15` of:
 - #123690

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
