### PR TITLE
[8.0] chore(NA): adds backport config for 8.2.0 bump (#124411)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,8 @@
 {
   "upstream": "elastic/kibana",
   "targetBranchChoices": [
-    { "name": "master", "checked": true },
+    "main",
+    "8.1",
     "8.0",
     "7.17",
     "7.16",
@@ -34,7 +35,7 @@
   ],
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
-    "^v8.1.0$": "master",
+    "^v8.2.0$": "main",
     "^v(\\d+).(\\d+).\\d+$": "$1.$2"
   },
   "autoMerge": true,


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #124411

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
