### PR TITLE
[Security Solution] Adds CCS privileges warning enable switch in advanced settings

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
@@ -124,6 +124,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'securitySolution:enableCcsWarning': {
+    type: 'boolean',
+    _meta: { description: 'Non-default value of setting.' },
+  },
   'search:includeFrozen': {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },

--- a/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
@@ -59,6 +59,7 @@ export interface UsageStats {
   'securitySolution:defaultAnomalyScore': number;
   'securitySolution:refreshIntervalDefaults': string;
   'securitySolution:enableNewsFeed': boolean;
+  'securitySolution:enableCcsWarning': boolean;
   'search:includeFrozen': boolean;
   'courier:maxConcurrentShardRequests': number;
   'courier:setRequestPreference': string;

--- a/src/plugins/telemetry/schema/oss_plugins.json
+++ b/src/plugins/telemetry/schema/oss_plugins.json
@@ -7337,6 +7337,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "securitySolution:enableCcsWarning": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
+        },
         "search:includeFrozen": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -170,6 +170,9 @@ export const DEFAULT_INDEX_PATTERN = [
 /** This Kibana Advanced Setting enables the `Security news` feed widget */
 export const ENABLE_NEWS_FEED_SETTING = 'securitySolution:enableNewsFeed' as const;
 
+/** This Kibana Advanced Setting enables the `Security news` feed widget */
+export const ENABLE_CCS_READ_WARNING_SETTING = 'securitySolution:enableCcsWarning' as const;
+
 /** This Kibana Advanced Setting sets the auto refresh interval for the detections all rules table */
 export const DEFAULT_RULES_TABLE_REFRESH_SETTING = 'securitySolution:rulesTableRefresh' as const;
 

--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -170,7 +170,7 @@ export const DEFAULT_INDEX_PATTERN = [
 /** This Kibana Advanced Setting enables the `Security news` feed widget */
 export const ENABLE_NEWS_FEED_SETTING = 'securitySolution:enableNewsFeed' as const;
 
-/** This Kibana Advanced Setting enables the `Security news` feed widget */
+/** This Kibana Advanced Setting enables the warnings for CCS read permissions */
 export const ENABLE_CCS_READ_WARNING_SETTING = 'securitySolution:enableCcsWarning' as const;
 
 /** This Kibana Advanced Setting sets the auto refresh interval for the detections all rules table */

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -155,6 +155,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 logger,
                 buildRuleMessage,
                 ruleExecutionLogger,
+                savedObjectsClient,
               });
 
               if (!wroteWarningStatus) {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -44,15 +44,7 @@ import { withSecuritySpan } from '../../../utils/with_security_span';
 
 /* eslint-disable complexity */
 export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
-  ({
-    lists,
-    logger,
-    config,
-    ruleDataClient,
-    eventLogService,
-    ruleExecutionLoggerFactory,
-    version,
-  }) =>
+  ({ lists, logger, config, ruleDataClient, eventLogService, ruleExecutionLoggerFactory }) =>
   (type) => {
     const { alertIgnoreFields: ignoreFields, alertMergeStrategy: mergeStrategy } = config;
     const persistenceRuleType = createPersistenceRuleTypeWrapper({ ruleDataClient, logger });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -80,7 +80,12 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
           } = options;
           let runState = state;
           const { from, maxSignals, meta, ruleId, timestampOverride, to } = params;
-          const { alertWithPersistence, savedObjectsClient, scopedClusterClient } = services;
+          const {
+            alertWithPersistence,
+            savedObjectsClient,
+            scopedClusterClient,
+            uiSettingsClient,
+          } = services;
           const searchAfterSize = Math.min(maxSignals, DEFAULT_SEARCH_AFTER_PAGE_SIZE);
 
           const esClient = scopedClusterClient.asCurrentUser;
@@ -163,8 +168,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 logger,
                 buildRuleMessage,
                 ruleExecutionLogger,
-                savedObjectsClient,
-                version,
+                uiSettingsClient,
               });
 
               if (!wroteWarningStatus) {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -44,7 +44,15 @@ import { withSecuritySpan } from '../../../utils/with_security_span';
 
 /* eslint-disable complexity */
 export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
-  ({ lists, logger, config, ruleDataClient, eventLogService, ruleExecutionLoggerFactory }) =>
+  ({
+    lists,
+    logger,
+    config,
+    ruleDataClient,
+    eventLogService,
+    ruleExecutionLoggerFactory,
+    version,
+  }) =>
   (type) => {
     const { alertIgnoreFields: ignoreFields, alertMergeStrategy: mergeStrategy } = config;
     const persistenceRuleType = createPersistenceRuleTypeWrapper({ ruleDataClient, logger });
@@ -156,6 +164,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 buildRuleMessage,
                 ruleExecutionLogger,
                 savedObjectsClient,
+                version,
               });
 
               if (!wroteWarningStatus) {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
@@ -40,7 +40,12 @@ describe('Custom Query Alerts', () => {
     config: createMockConfig(),
     ruleDataClient,
     eventLogService,
+<<<<<<< HEAD
     ruleExecutionLoggerFactory: () => ruleExecutionLogMock.forExecutors.create(),
+=======
+    ruleExecutionLoggerFactory: () => ruleExecutionLogMock.logger.create(),
+    version: '1.0.0',
+>>>>>>> 998fcc5e16e (adds flag to disable warning)
   });
   const eventsTelemetry = createMockTelemetryEventsSender(true);
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
@@ -41,7 +41,6 @@ describe('Custom Query Alerts', () => {
     ruleDataClient,
     eventLogService,
     ruleExecutionLoggerFactory: () => ruleExecutionLogMock.forExecutors.create(),
-    version: '1.0.0',
   });
   const eventsTelemetry = createMockTelemetryEventsSender(true);
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
@@ -40,12 +40,8 @@ describe('Custom Query Alerts', () => {
     config: createMockConfig(),
     ruleDataClient,
     eventLogService,
-<<<<<<< HEAD
     ruleExecutionLoggerFactory: () => ruleExecutionLogMock.forExecutors.create(),
-=======
-    ruleExecutionLoggerFactory: () => ruleExecutionLogMock.logger.create(),
     version: '1.0.0',
->>>>>>> 998fcc5e16e (adds flag to disable warning)
   });
   const eventsTelemetry = createMockTelemetryEventsSender(true);
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
@@ -100,7 +100,6 @@ export interface CreateSecurityRuleTypeWrapperProps {
   ruleDataClient: IRuleDataClient;
   eventLogService: IEventLogService;
   ruleExecutionLoggerFactory: RuleExecutionLogForExecutorsFactory;
-  version: string;
 }
 
 export type CreateSecurityRuleTypeWrapper = (

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
@@ -100,6 +100,7 @@ export interface CreateSecurityRuleTypeWrapperProps {
   ruleDataClient: IRuleDataClient;
   eventLogService: IEventLogService;
   ruleExecutionLoggerFactory: RuleExecutionLogForExecutorsFactory;
+  version: string;
 }
 
 export type CreateSecurityRuleTypeWrapper = (

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -93,8 +93,10 @@ export const hasReadIndexPrivileges = async (args: {
   logger: Logger;
   buildRuleMessage: BuildRuleMessage;
   ruleExecutionLogger: IRuleExecutionLogForExecutors;
+  savedObjectsClient: SavedObjectsClientContract;
 }): Promise<boolean> => {
-  const { privileges, logger, buildRuleMessage, ruleExecutionLogger } = args;
+  const { privileges, logger, buildRuleMessage, ruleExecutionLogger, savedObjectsClient } = args;
+  const isCcsWarningEnabled = await savedObjectsClient.get();
 
   const indexNames = Object.keys(privileges.index);
   const [, indexesWithNoReadPrivileges] = partition(

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -27,6 +27,7 @@ import {
 } from '../../../../common/detection_engine/schemas/common';
 import type {
   ElasticsearchClient,
+  IUiSettingsClient,
   Logger,
   SavedObjectsClientContract,
 } from '../../../../../../../src/core/server';
@@ -94,19 +95,12 @@ export const hasReadIndexPrivileges = async (args: {
   logger: Logger;
   buildRuleMessage: BuildRuleMessage;
   ruleExecutionLogger: IRuleExecutionLogForExecutors;
-  savedObjectsClient: SavedObjectsClientContract;
-  version: string;
+  uiSettingsClient: IUiSettingsClient;
 }): Promise<boolean> => {
-  const { privileges, logger, buildRuleMessage, ruleExecutionLogger, savedObjectsClient, version } =
-    args;
-  const config = await withSecuritySpan('getCcsWarningEnabled', () =>
-    savedObjectsClient.get<{ 'securitySolution:enableCcsWarning': boolean }>('config', version)
-  );
+  const { privileges, logger, buildRuleMessage, ruleExecutionLogger, uiSettingsClient } = args;
 
-  let isCcsPermissionWarningEnabled = true;
-  if (config.attributes != null && config.attributes[ENABLE_CCS_READ_WARNING_SETTING] != null) {
-    isCcsPermissionWarningEnabled = config.attributes[ENABLE_CCS_READ_WARNING_SETTING];
-  }
+  const isCcsPermissionWarningEnabled = await uiSettingsClient.get(ENABLE_CCS_READ_WARNING_SETTING);
+
   const indexNames = Object.keys(privileges.index);
   const filteredIndexNames = isCcsPermissionWarningEnabled
     ? indexNames

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -234,6 +234,7 @@ export class Plugin implements ISecuritySolutionPlugin {
       ruleDataClient,
       eventLogService,
       ruleExecutionLoggerFactory: ruleExecutionLogForExecutorsFactory,
+      version: pluginContext.env.packageInfo.version,
     };
 
     const securityRuleTypeWrapper = createSecurityRuleTypeWrapper(securityRuleTypeOptions);

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -234,7 +234,6 @@ export class Plugin implements ISecuritySolutionPlugin {
       ruleDataClient,
       eventLogService,
       ruleExecutionLoggerFactory: ruleExecutionLogForExecutorsFactory,
-      version: pluginContext.env.packageInfo.version,
     };
 
     const securityRuleTypeWrapper = createSecurityRuleTypeWrapper(securityRuleTypeOptions);

--- a/x-pack/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/plugins/security_solution/server/ui_settings.ts
@@ -221,11 +221,11 @@ export const initUiSettings = (
     },
     [ENABLE_CCS_READ_WARNING_SETTING]: {
       name: i18n.translate('xpack.securitySolution.uiSettings.enableCcsReadWarningLabel', {
-        defaultMessage: 'CCS Read Warning',
+        defaultMessage: 'CCS Rule Privileges Warning',
       }),
       value: true,
       description: i18n.translate('xpack.securitySolution.uiSettings.enableCcsWarningDescription', {
-        defaultMessage: '<p>Enables cross cluster search read warnings</p>',
+        defaultMessage: '<p>Enables privilege check warnings in rules for CCS indices</p>',
       }),
       type: 'boolean',
       category: [APP_ID],

--- a/x-pack/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/plugins/security_solution/server/ui_settings.ts
@@ -224,7 +224,7 @@ export const initUiSettings = (
         defaultMessage: 'CCS Read Warning',
       }),
       value: true,
-      description: i18n.translate('xpack.securitySolution.uiSettings.enableNewsFeedDescription', {
+      description: i18n.translate('xpack.securitySolution.uiSettings.enableCcsWarningDescription', {
         defaultMessage: '<p>Enables cross cluster search read warnings</p>',
       }),
       type: 'boolean',

--- a/x-pack/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/plugins/security_solution/server/ui_settings.ts
@@ -229,7 +229,7 @@ export const initUiSettings = (
       }),
       type: 'boolean',
       category: [APP_ID],
-      requiresPageReload: true,
+      requiresPageReload: false,
       schema: schema.boolean(),
     },
     // TODO: Remove this check once the experimental flag is removed

--- a/x-pack/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/plugins/security_solution/server/ui_settings.ts
@@ -32,6 +32,7 @@ import {
   IP_REPUTATION_LINKS_SETTING_DEFAULT,
   NEWS_FEED_URL_SETTING,
   NEWS_FEED_URL_SETTING_DEFAULT,
+  ENABLE_CCS_READ_WARNING_SETTING,
 } from '../common/constants';
 import { transformConfigSchema } from '../common/transforms/types';
 import { ExperimentalFeatures } from '../common/experimental_features';
@@ -217,6 +218,19 @@ export const initUiSettings = (
           url_template: schema.string(),
         })
       ),
+    },
+    [ENABLE_CCS_READ_WARNING_SETTING]: {
+      name: i18n.translate('xpack.securitySolution.uiSettings.enableCcsReadWarningLabel', {
+        defaultMessage: 'CCS Read Warning',
+      }),
+      value: true,
+      description: i18n.translate('xpack.securitySolution.uiSettings.enableNewsFeedDescription', {
+        defaultMessage: '<p>Enables cross cluster search read warnings</p>',
+      }),
+      type: 'boolean',
+      category: [APP_ID],
+      requiresPageReload: true,
+      schema: schema.boolean(),
     },
     // TODO: Remove this check once the experimental flag is removed
     ...(experimentalFeatures.metricsEntitiesEnabled


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/112032

Adds an advanced setting toggle to optionally disable cross cluster search read privilege warnings on rule execution. Default behavior is set to true and is how it the code currently functions. With it disabled, the cross cluster search indices are filtered out when logging any read privilege warnings. 

![Screen Shot 2022-02-02 at 2 45 09 PM](https://user-images.githubusercontent.com/56367316/152247497-399d4e76-488a-468d-8601-935f71cf5ad6.png)



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
