### PR TITLE
[APM] RUM documentation link is broken

### DIFF
--- a/x-pack/plugins/apm/common/tutorial/instructions/apm_agent_instructions.ts
+++ b/x-pack/plugins/apm/common/tutorial/instructions/apm_agent_instructions.ts
@@ -260,7 +260,7 @@ export const createJsAgentInstructions = (apmServerUrl = '') => [
 for details on how to enable RUM support.',
         values: {
           documentationLink:
-            '{config.docs.base_url}guide/en/apm/server/{config.docs.version}/configuration-rum.html',
+            '{config.docs.base_url}guide/en/apm/guide/{config.docs.version}/configuration-rum.html',
         },
       }
     ),

--- a/x-pack/plugins/apm/common/tutorial/instructions/apm_agent_instructions.ts
+++ b/x-pack/plugins/apm/common/tutorial/instructions/apm_agent_instructions.ts
@@ -257,7 +257,7 @@ export const createJsAgentInstructions = (apmServerUrl = '') => [
       {
         defaultMessage:
           'APM Server disables RUM support by default. See the [documentation]({documentationLink}) \
-for details on how to enable RUM support.',
+for details on how to enable RUM support. When using the APM integration with Fleet, RUM support is automatically enabled.',
         values: {
           documentationLink:
             '{config.docs.base_url}guide/en/apm/guide/{config.docs.version}/configuration-rum.html',


### PR DESCRIPTION
## Summary

The link in the RUM guide inside APM links to `https://www.elastic.co/guide/en/apm/server/7.17/configuration-rum.html` which is not available. The docs have moved to the `legacy APM server` docs. Also RUM is automatically enabled with the APM integration.

<img width="1139" alt="Screenshot 2022-02-02 at 16 39 39" src="https://user-images.githubusercontent.com/12175559/152300567-dee0dc2d-5a8f-4793-a006-104075868082.png">

