### PR TITLE
Fix sorting behavior in color ranges when auto max is enabled

### DIFF
--- a/x-pack/plugins/lens/public/shared_components/coloring/color_ranges/utils/utils.test.ts
+++ b/x-pack/plugins/lens/public/shared_components/coloring/color_ranges/utils/utils.test.ts
@@ -41,6 +41,9 @@ describe('utils', () => {
       { color: '#ccc', start: 60, end: 90 },
       { color: '#bbb', start: 90, end: Infinity },
     ]);
+
+    colorRanges = [{ color: '#aaa', start: 90, end: 55 }];
+    expect(sortColorRanges(colorRanges)).toEqual([{ color: '#aaa', start: 55, end: 90 }]);
   });
 
   it('calculateMaxStep', () => {

--- a/x-pack/plugins/lens/public/shared_components/coloring/color_ranges/utils/utils.test.ts
+++ b/x-pack/plugins/lens/public/shared_components/coloring/color_ranges/utils/utils.test.ts
@@ -30,6 +30,17 @@ describe('utils', () => {
       { color: '#ccc', start: 60, end: 80 },
       { color: '#bbb', start: 80, end: 90 },
     ]);
+
+    colorRanges = [
+      { color: '#aaa', start: 55, end: 90 },
+      { color: '#bbb', start: 90, end: 60 },
+      { color: '#ccc', start: 60, end: Infinity },
+    ];
+    expect(sortColorRanges(colorRanges)).toEqual([
+      { color: '#aaa', start: 55, end: 60 },
+      { color: '#ccc', start: 60, end: 90 },
+      { color: '#bbb', start: 90, end: Infinity },
+    ]);
   });
 
   it('calculateMaxStep', () => {

--- a/x-pack/plugins/lens/public/shared_components/coloring/color_ranges/utils/utils.ts
+++ b/x-pack/plugins/lens/public/shared_components/coloring/color_ranges/utils/utils.ts
@@ -27,10 +27,17 @@ export const isLastItem = (accessor: ColorRangeAccessor) => accessor === 'end';
 export const sortColorRanges = (colorRanges: ColorRange[]) => {
   const lastRange = colorRanges[colorRanges.length - 1];
 
-  return [...colorRanges, { start: lastRange.end, color: lastRange.color }]
+  // we should add last end as new start because we should include it on sorting
+  return [...colorRanges, { start: lastRange.end, color: lastRange.color, end: undefined }]
     .sort(({ start: startA }, { start: startB }) => Number(startA) - Number(startB))
     .reduce((sortedColorRange, newColorRange, i, array) => {
-      const color = i === array.length - 2 ? array[i + 1].color : newColorRange.color;
+      // we should pick correct color for the last range.
+      // If after sorting we don't change last value we should just take color in array order
+      // In another case we should get the next one.
+      let color = newColorRange.color;
+      if (i === array.length - 2 && array[i + 1].start !== lastRange.end) {
+        color = array[i + 1].color;
+      }
       if (i !== array.length - 1) {
         sortedColorRange.push({
           color,

--- a/x-pack/plugins/lens/public/shared_components/coloring/utils.ts
+++ b/x-pack/plugins/lens/public/shared_components/coloring/utils.ts
@@ -414,7 +414,8 @@ export function roundValue(value: number, fractionDigits: number = 2) {
 export function getStepValue(colorStops: ColorStop[], newColorStops: ColorStop[], max: number) {
   const length = newColorStops.length;
   // workout the steps from the last 2 items
-  const dataStep = newColorStops[length - 1].stop - newColorStops[length - 2].stop || 1;
+  const dataStep =
+    length > 1 ? newColorStops[length - 1].stop - newColorStops[length - 2].stop || 1 : 1;
   let step = Number(dataStep.toFixed(2));
   if (max < colorStops[length - 1].stop + step) {
     const diffToMax = max - colorStops[length - 1].stop;


### PR DESCRIPTION
## Summary

It appears that changing a range value to be greater than the penultimate range value, but less than maximum range value, causes the color for the range value being changed to incorrectly receive the penultimate range value's assigned color (when its original color should be unaffected).

![penultimate-bug](https://user-images.githubusercontent.com/3884767/152217275-4975a3ff-88d7-458b-84b7-dc5506e70c9b.gif)


**After fix:**

https://user-images.githubusercontent.com/16915480/152314085-2f46b890-4a5e-4df8-940f-d3d4df402b02.mp4





