### PR TITLE
fix: the filters from the url are no longer overwritten by the filter…

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/header/search_bar.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/header/search_bar.spec.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { loginAndWaitForPage } from '../../tasks/login';
+import { loginAndWaitForPage, waitForPageWithoutDateRange } from '../../tasks/login';
 import { openAddFilterPopover, fillAddFilterForm } from '../../tasks/search_bar';
 import { GLOBAL_SEARCH_BAR_FILTER_ITEM } from '../../screens/search_bar';
 import { getHostIpFilter } from '../../objects/filter';
 
-import { HOSTS_URL } from '../../urls/navigation';
+import { HOSTS_URL, ALERTS_URL } from '../../urls/navigation';
 import { waitForAllHostsToBeLoaded } from '../../tasks/hosts/all_hosts';
 import { cleanKibana } from '../../tasks/common';
 
@@ -28,6 +28,16 @@ describe('SearchBar', () => {
     cy.get(GLOBAL_SEARCH_BAR_FILTER_ITEM).should(
       'have.text',
       `${getHostIpFilter().key}: ${getHostIpFilter().value}`
+    );
+  });
+
+  it('popluates the filters correctly from the URL', () => {
+    const testFilter = getHostIpFilter();
+    const filterParam = `sourcerer=(default:(id:security-solution-default,selectedPatterns:!('logs-*')))&filters=!(('$state':(store:appState),meta:(alias:!n,disabled:!f,key:${testFilter.key},negate:!f,params:(query:'${testFilter.value}'),type:phrase),query:(match_phrase:(${testFilter.key}:'${testFilter.value}'))))`;
+    waitForPageWithoutDateRange(`${ALERTS_URL}?${filterParam}`);
+    cy.get(GLOBAL_SEARCH_BAR_FILTER_ITEM).should(
+      'have.text',
+      `${testFilter.key}: ${testFilter.value}`
     );
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/search_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/search_bar/index.tsx
@@ -39,8 +39,6 @@ import { networkActions } from '../../../network/store';
 import { timelineActions } from '../../../timelines/store/timeline';
 import { useKibana } from '../../lib/kibana';
 
-const APP_STATE_STORAGE_KEY = 'securitySolution.searchBar.appState';
-
 interface SiemSearchBarProps {
   id: InputsModelId;
   indexPattern: DataViewBase;
@@ -81,7 +79,6 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
         },
         ui: { SearchBar },
       },
-      storage,
     } = useKibana().services;
 
     useEffect(() => {
@@ -243,16 +240,6 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
       }
     }, [savedQuery, updateSearch, id, toStr, end, fromStr, start, filterManager]);
 
-    const saveAppStateToStorage = useCallback(
-      (filters: Filter[]) => storage.set(APP_STATE_STORAGE_KEY, filters),
-      [storage]
-    );
-
-    const getAppStateFromStorage = useCallback(
-      () => storage.get(APP_STATE_STORAGE_KEY) ?? [],
-      [storage]
-    );
-
     useEffect(() => {
       let isSubscribed = true;
       const subscriptions = new Subscription();
@@ -261,7 +248,6 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
         filterManager.getUpdates$().subscribe({
           next: () => {
             if (isSubscribed) {
-              saveAppStateToStorage(filterManager.getAppFilters());
               setSearchBarFilter({
                 id,
                 filters: filterManager.getFilters(),
@@ -272,7 +258,6 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
       );
 
       // for the initial state
-      filterManager.setAppFilters(getAppStateFromStorage());
       setSearchBarFilter({
         id,
         filters: filterManager.getFilters(),


### PR DESCRIPTION

## Summary

Related issue: https://github.com/elastic/kibana/issues/123838

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
