### PR TITLE
[Visualize] Coloring tooltips in Heatmap are not properly positioned

### DIFF
--- a/src/plugins/chart_expressions/expression_heatmap/public/components/heatmap_component.tsx
+++ b/src/plugins/chart_expressions/expression_heatmap/public/components/heatmap_component.tsx
@@ -29,7 +29,10 @@ import type { DatatableColumn } from '../../../../expressions/public';
 import { ExpressionValueVisDimension } from '../../../../visualizations/public';
 import type { HeatmapRenderProps, FilterEvent, BrushEvent } from '../../common';
 import { applyPaletteParams, findMinMaxByColumnId, getSortPredicate } from './helpers';
-import { getColorPicker } from '../utils/get_color_picker';
+import {
+  LegendColorPickerWrapperContext,
+  LegendColorPickerWrapper,
+} from '../utils/get_color_picker';
 import { DEFAULT_PALETTE_NAME, defaultPaletteParams } from '../constants';
 import { HeatmapIcon } from './heatmap_icon';
 import './index.scss';
@@ -172,10 +175,6 @@ export const HeatmapComponent: FC<HeatmapRenderProps> = memo(
       [uiState]
     );
 
-    const legendColorPicker = useMemo(
-      () => getColorPicker(args.legend.position, setColor, uiState),
-      [args.legend.position, setColor, uiState]
-    );
     const table = data;
     const valueAccessor = args.valueAccessor
       ? getAccessor(args.valueAccessor, table.columns)
@@ -484,55 +483,63 @@ export const HeatmapComponent: FC<HeatmapRenderProps> = memo(
             legendPosition={args.legend.position}
           />
         )}
-        <Chart>
-          <Settings
-            onElementClick={interactive ? (onElementClick as ElementClickListener) : undefined}
-            showLegend={showLegend ?? args.legend.isVisible}
-            legendPosition={args.legend.position}
-            legendColorPicker={uiState ? legendColorPicker : undefined}
-            debugState={window._echDebugStateFlag ?? false}
-            tooltip={tooltip}
-            theme={[themeOverrides, chartTheme]}
-            xDomain={{
-              min:
-                dateHistogramMeta && dateHistogramMeta.timeRange
-                  ? new Date(dateHistogramMeta.timeRange.from).getTime()
-                  : NaN,
-              max:
-                dateHistogramMeta && dateHistogramMeta.timeRange
-                  ? new Date(dateHistogramMeta.timeRange.to).getTime()
-                  : NaN,
-            }}
-            onBrushEnd={interactive ? (onBrushEnd as BrushEndListener) : undefined}
-          />
-          <Heatmap
-            id="heatmap"
-            name={valueColumn.name}
-            colorScale={{
-              type: 'bands',
-              bands,
-            }}
-            timeZone={timeZone}
-            data={chartData}
-            xAccessor={xAccessor}
-            yAccessor={yAccessor || 'unifiedY'}
-            valueAccessor={valueAccessor}
-            valueFormatter={valueFormatter}
-            xScale={xScale}
-            ySortPredicate={yAxisColumn ? getSortPredicate(yAxisColumn) : 'dataIndex'}
-            xSortPredicate={xAxisColumn ? getSortPredicate(xAxisColumn) : 'dataIndex'}
-            xAxisLabelName={xAxisColumn?.name}
-            yAxisLabelName={yAxisColumn?.name}
-            xAxisTitle={args.gridConfig.isXAxisTitleVisible ? xAxisTitle : undefined}
-            yAxisTitle={args.gridConfig.isYAxisTitleVisible ? yAxisTitle : undefined}
-            xAxisLabelFormatter={(v) => `${xValuesFormatter.convert(v) ?? ''}`}
-            yAxisLabelFormatter={
-              yAxisColumn
-                ? (v) => `${formatFactory(yAxisColumn.meta.params).convert(v) ?? ''}`
-                : undefined
-            }
-          />
-        </Chart>
+        <LegendColorPickerWrapperContext.Provider
+          value={{
+            uiState,
+            setColor,
+            legendPosition: args.legend.position,
+          }}
+        >
+          <Chart>
+            <Settings
+              onElementClick={interactive ? (onElementClick as ElementClickListener) : undefined}
+              showLegend={showLegend ?? args.legend.isVisible}
+              legendPosition={args.legend.position}
+              legendColorPicker={uiState ? LegendColorPickerWrapper : undefined}
+              debugState={window._echDebugStateFlag ?? false}
+              tooltip={tooltip}
+              theme={[themeOverrides, chartTheme]}
+              xDomain={{
+                min:
+                  dateHistogramMeta && dateHistogramMeta.timeRange
+                    ? new Date(dateHistogramMeta.timeRange.from).getTime()
+                    : NaN,
+                max:
+                  dateHistogramMeta && dateHistogramMeta.timeRange
+                    ? new Date(dateHistogramMeta.timeRange.to).getTime()
+                    : NaN,
+              }}
+              onBrushEnd={interactive ? (onBrushEnd as BrushEndListener) : undefined}
+            />
+            <Heatmap
+              id="heatmap"
+              name={valueColumn.name}
+              colorScale={{
+                type: 'bands',
+                bands,
+              }}
+              timeZone={timeZone}
+              data={chartData}
+              xAccessor={xAccessor}
+              yAccessor={yAccessor || 'unifiedY'}
+              valueAccessor={valueAccessor}
+              valueFormatter={valueFormatter}
+              xScale={xScale}
+              ySortPredicate={yAxisColumn ? getSortPredicate(yAxisColumn) : 'dataIndex'}
+              xSortPredicate={xAxisColumn ? getSortPredicate(xAxisColumn) : 'dataIndex'}
+              xAxisLabelName={xAxisColumn?.name}
+              yAxisLabelName={yAxisColumn?.name}
+              xAxisTitle={args.gridConfig.isXAxisTitleVisible ? xAxisTitle : undefined}
+              yAxisTitle={args.gridConfig.isYAxisTitleVisible ? yAxisTitle : undefined}
+              xAxisLabelFormatter={(v) => `${xValuesFormatter.convert(v) ?? ''}`}
+              yAxisLabelFormatter={
+                yAxisColumn
+                  ? (v) => `${formatFactory(yAxisColumn.meta.params).convert(v) ?? ''}`
+                  : undefined
+              }
+            />
+          </Chart>
+        </LegendColorPickerWrapperContext.Provider>
       </>
     );
   }


### PR DESCRIPTION
## Summary

Steps to reproduce: 
1. Create a `heatmap` chart with a visible legend.
2. Set up a legend to be on the top or bottom.
3. try to change a color by clicking on a color indicator

Screen:

https://user-images.githubusercontent.com/20072247/152332843-3274b74e-f6e2-4184-a821-68c6062e85ea.mov

What was changed: 
- `EuiPopover` -> `EuiWrappingPopover`
- Created a `LegendColorPickerWrapperContext` context. This context is used instead of useMemo pattern
- `useMemo` for `getColorPicker` was removed;

Related to https://github.com/elastic/eui/issues/4367