### PR TITLE
[TSVB] Fix metric contrast

### DIFF
--- a/src/plugins/vis_types/timeseries/public/application/_variables.scss
+++ b/src/plugins/vis_types/timeseries/public/application/_variables.scss
@@ -1,7 +1,7 @@
 $tvbLineColor: transparentize($euiColorFullShade, .8);
 $tvbLineColorReversed: transparentize($euiColorEmptyShade, .6);
 
-$tvbTextColor: transparentize($euiColorFullShade, .6);
+$tvbTextColor: transparentize($euiColorFullShade, .4);
 $tvbTextColorReversed: transparentize($euiColorEmptyShade, .4);
 
 $tvbValueColor: transparentize($euiColorFullShade, .3);


### PR DESCRIPTION
Fixes contrast of metric labels in TSVB:
<img width="340" alt="Screenshot 2022-02-03 at 12 19 01" src="https://user-images.githubusercontent.com/1508364/152334056-2e981d23-368c-4aed-9b58-e1b07bdc969e.png">
<img width="353" alt="Screenshot 2022-02-03 at 12 19 16" src="https://user-images.githubusercontent.com/1508364/152334063-0cece5e2-de8c-4ab0-943f-0aad98952abf.png">
