### PR TITLE
[SecuritySolution][Investigations] Always propagate the search bar with filters from the URL

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/header/search_bar.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/header/search_bar.spec.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { loginAndWaitForPage } from '../../tasks/login';
+import { loginAndWaitForPage, waitForPageWithoutDateRange } from '../../tasks/login';
 import { openAddFilterPopover, fillAddFilterForm } from '../../tasks/search_bar';
 import { GLOBAL_SEARCH_BAR_FILTER_ITEM } from '../../screens/search_bar';
 import { getHostIpFilter } from '../../objects/filter';
 
-import { HOSTS_URL } from '../../urls/navigation';
+import { HOSTS_URL, ALERTS_URL } from '../../urls/navigation';
 import { waitForAllHostsToBeLoaded } from '../../tasks/hosts/all_hosts';
 import { cleanKibana } from '../../tasks/common';
 
@@ -28,6 +28,16 @@ describe('SearchBar', () => {
     cy.get(GLOBAL_SEARCH_BAR_FILTER_ITEM).should(
       'have.text',
       `${getHostIpFilter().key}: ${getHostIpFilter().value}`
+    );
+  });
+
+  it('popluates the filters correctly from the URL', () => {
+    const testFilter = getHostIpFilter();
+    const filterParam = `sourcerer=(default:(id:security-solution-default,selectedPatterns:!('logs-*')))&filters=!(('$state':(store:appState),meta:(alias:!n,disabled:!f,key:${testFilter.key},negate:!f,params:(query:'${testFilter.value}'),type:phrase),query:(match_phrase:(${testFilter.key}:'${testFilter.value}'))))`;
+    waitForPageWithoutDateRange(`${ALERTS_URL}?${filterParam}`);
+    cy.get(GLOBAL_SEARCH_BAR_FILTER_ITEM).should(
+      'have.text',
+      `${testFilter.key}: ${testFilter.value}`
     );
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/search_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/search_bar/index.tsx
@@ -39,8 +39,6 @@ import { networkActions } from '../../../network/store';
 import { timelineActions } from '../../../timelines/store/timeline';
 import { useKibana } from '../../lib/kibana';
 
-const APP_STATE_STORAGE_KEY = 'securitySolution.searchBar.appState';
-
 interface SiemSearchBarProps {
   id: InputsModelId;
   indexPattern: DataViewBase;
@@ -81,7 +79,6 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
         },
         ui: { SearchBar },
       },
-      storage,
     } = useKibana().services;
 
     useEffect(() => {
@@ -243,16 +240,6 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
       }
     }, [savedQuery, updateSearch, id, toStr, end, fromStr, start, filterManager]);
 
-    const saveAppStateToStorage = useCallback(
-      (filters: Filter[]) => storage.set(APP_STATE_STORAGE_KEY, filters),
-      [storage]
-    );
-
-    const getAppStateFromStorage = useCallback(
-      () => storage.get(APP_STATE_STORAGE_KEY) ?? [],
-      [storage]
-    );
-
     useEffect(() => {
       let isSubscribed = true;
       const subscriptions = new Subscription();
@@ -261,7 +248,6 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
         filterManager.getUpdates$().subscribe({
           next: () => {
             if (isSubscribed) {
-              saveAppStateToStorage(filterManager.getAppFilters());
               setSearchBarFilter({
                 id,
                 filters: filterManager.getFilters(),
@@ -272,7 +258,6 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
       );
 
       // for the initial state
-      filterManager.setAppFilters(getAppStateFromStorage());
       setSearchBarFilter({
         id,
         filters: filterManager.getFilters(),


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/123838 describes an issue where the filters from the URL would not actually show up in the the search bar.

Observation: It all works correctly when the user that set the filters reloads the page. If you open the page on a different machine or in a private tab, the filter is not displayed correctly.

My first hypothesis was, as described in the issue above, that the url is not decoded properly. I checked out the diff of the original url and the url after the user signed in from a private window. They were identical, so that couldn't be the issue. 

My next hunch was that some information might get lost when parsing the url parts after sign-in. So I looked for the piece of code that parses the individual parts of the url. The parsing of the filters is done in [here](https://github.com/elastic/kibana/blob/fcac5d60fe29cf1c051c73ceddb52d0c1c45dd13/x-pack/plugins/security_solution/public/common/components/url_state/initialize_redux_by_url.tsx#L89). It turned out the output for the signed-in user and the not signed-in user is identical, so that wasn't it either.

As a next step: I looked at where that filter component is getting its state from. I was suspecting a race-condition of some sort. The relevant component appears to be [SearchBar](https://github.com/elastic/kibana/blob/main/src/plugins/data/public/ui/search_bar/search_bar.tsx#L350). When logging  `this.props.filters` in its render method, I observed a difference in the two scenarios.

The output from the original window:
<img width="943" alt="Screenshot 2022-02-03 at 12 48 51" src="https://user-images.githubusercontent.com/68591/152337564-15a25224-1e58-472b-9401-8f7b63b7c223.png">

The output from the incognito window:
<img width="1119" alt="Screenshot 2022-02-03 at 12 50 43" src="https://user-images.githubusercontent.com/68591/152337584-dfdbc489-50f4-4f25-a537-7e72531ef79e.png">


It's interesting that the state is parsed correctly and then somehow reset back to an empty array. There must be some sort of side-effect that resets the filter. On a hunch I checked out the localStorage of both tabs and found `securitySolution.searchBar.appState` which appeared to be different in both tabs. The original tab contains the JSON representation of the filters whereas the private tab only contains an empty array. 🤔

I then had a closer look and found [this piece of code](https://github.com/elastic/kibana/blob/65c724808f2bbe5c53557954e2b80b3ef50be484/x-pack/plugins/security_solution/public/common/components/search_bar/index.tsx#L260) that sets the filter to whatever is in saved in localStorage. Therefore it will never populate with the filter from the url.

That behaviour was implemented to fix [this issue](https://github.com/elastic/kibana/issues/75142) where the filters from the url were not actually filtering the results. It is unclear however why the filters need to be persisted in localStorage. 

As a fix for the reported issue I now removed the piece of code that would persist the filters and read from local storage. Instead, the filters from the url will now be properly propagated:

<img width="1147" alt="Screenshot 2022-02-03 at 12 52 45" src="https://user-images.githubusercontent.com/68591/152338019-002c4755-5dd0-40da-83fc-e0817d078a10.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
