### PR TITLE
[ML] Transforms: Fix destination ingest pipeline form input placeholder.

### DIFF
--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_details/step_details_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_details/step_details_form.tsx
@@ -486,18 +486,20 @@ export const StepDetailsForm: FC<StepDetailsFormProps> = React.memo(
                 aria-label={i18n.translate(
                   'xpack.transform.stepDetailsForm.destinationIngestPipelineAriaLabel',
                   {
-                    defaultMessage: 'Select an ingest pipeline',
+                    defaultMessage: 'Select an ingest pipeline (optional)',
                   }
                 )}
                 placeholder={i18n.translate(
                   'xpack.transform.stepDetailsForm.destinationIngestPipelineComboBoxPlaceholder',
                   {
-                    defaultMessage: 'Select an ingest pipeline',
+                    defaultMessage: 'Select an ingest pipeline (optional)',
                   }
                 )}
                 singleSelection={{ asPlainText: true }}
                 options={ingestPipelineNames.map((label: string) => ({ label }))}
-                selectedOptions={[{ label: destinationIngestPipeline }]}
+                selectedOptions={
+                  destinationIngestPipeline !== '' ? [{ label: destinationIngestPipeline }] : []
+                }
                 onChange={(options) => setDestinationIngestPipeline(options[0]?.label ?? '')}
               />
             </EuiFormRow>


### PR DESCRIPTION
## Summary

Fix to pass on an empty array for the form elements options to show the placeholder text.

<img src="https://user-images.githubusercontent.com/230104/152345123-60a50013-8e79-4a54-a9b1-dcd9b0538143.png" width="50%" />

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
