### PR TITLE
[Visualize] Coloring tooltip in Heatmap is not working for ">= n" values

### DIFF
--- a/src/plugins/chart_expressions/expression_heatmap/public/components/heatmap_component.tsx
+++ b/src/plugins/chart_expressions/expression_heatmap/public/components/heatmap_component.tsx
@@ -287,15 +287,21 @@ export const HeatmapComponent: FC<HeatmapRenderProps> = memo(
 
     const bands = ranges.map((start, index, array) => {
       // by default the last range is right-open
-      let end = index === array.length - 1 ? Infinity : array[index + 1];
+      let end = index === array.length - 1 ? Number.POSITIVE_INFINITY : array[index + 1];
       // if the lastRangeIsRightOpen is set to false, we need to set the last range to the max value
       if (args.lastRangeIsRightOpen === false) {
-        const lastBand = max === start ? Infinity : endValue;
+        const lastBand = max === start ? Number.POSITIVE_INFINITY : endValue;
         end = index === array.length - 1 ? lastBand : array[index + 1];
       }
-      const overwriteArrayIdx = `${metricFormatter.convert(start)} - ${metricFormatter.convert(
-        end
-      )}`;
+
+      let overwriteArrayIdx;
+
+      if (end === Number.POSITIVE_INFINITY) {
+        overwriteArrayIdx = `≥ ${start}`;
+      } else {
+        overwriteArrayIdx = `${metricFormatter.convert(start)} - ${metricFormatter.convert(end)}`;
+      }
+
       const overwriteColor = overwriteColors?.[overwriteArrayIdx];
       return {
         // with the default continuity:above the every range is left-closed


### PR DESCRIPTION
## Summary

This PR fixes broken [Case 2](https://github.com/elastic/kibana/issues/124481#issuecomment-1028837148) which was mentioned it that comment

Steps to reproduce:

1. Create a heatmap chart with a visible legend.
```
Important: 
chart should render only 1 element with >= n value
```
like e.g. 
![image](https://user-images.githubusercontent.com/20072247/152348144-c22f9bd6-116c-4131-a676-32c9b110e6a9.png)

2. Try to change color using the `Coloring tooltip`

**Expected:** user should be able to override the default color 


## Screen

https://user-images.githubusercontent.com/20072247/152348309-e82caba0-f5d5-4962-9993-edb41758bbb9.mov


