### PR TITLE
[Uptime] Use `formatErrors` from utils instead of the default io-ts PathReporter

### DIFF
--- a/x-pack/plugins/uptime/public/state/api/utils.ts
+++ b/x-pack/plugins/uptime/public/state/api/utils.ts
@@ -5,40 +5,10 @@
  * 2.0.
  */
 
-import { PathReporter } from 'io-ts/lib/PathReporter';
 import { isRight } from 'fp-ts/lib/Either';
+import { formatErrors } from '@kbn/securitysolution-io-ts-utils';
 import { HttpFetchQuery, HttpSetup } from 'src/core/public';
-import * as t from 'io-ts';
 import { FETCH_STATUS, AddInspectorRequest } from '../../../../observability/public';
-
-function isObject(value: unknown) {
-  const type = typeof value;
-  return value != null && (type === 'object' || type === 'function');
-}
-
-/**
- * @deprecated Use packages/kbn-securitysolution-io-ts-utils/src/format_errors/index.ts
- */
-export const formatErrors = (errors: t.Errors): string[] => {
-  return errors.map((error) => {
-    if (error.message != null) {
-      return error.message;
-    } else {
-      const keyContext = error.context
-        .filter(
-          (entry) => entry.key != null && !Number.isInteger(+entry.key) && entry.key.trim() !== ''
-        )
-        .map((entry) => entry.key)
-        .join('.');
-
-      const nameContext = error.context.find((entry) => entry.type?.name?.length > 0);
-      const suppliedValue =
-        keyContext !== '' ? keyContext : nameContext != null ? nameContext.type.name : '';
-      const value = isObject(error.value) ? JSON.stringify(error.value) : error.value;
-      return `Invalid value "${value}" supplied to "${suppliedValue}"`;
-    }
-  });
-};
 
 class ApiService {
   private static instance: ApiService;
@@ -116,7 +86,7 @@ class ApiService {
       } else {
         // eslint-disable-next-line no-console
         console.warn(
-          `API ${apiUrl} is not returning expected response, ${PathReporter.report(decoded)}`
+          `API ${apiUrl} is not returning expected response, ${formatErrors(decoded.left)}`
         );
       }
     }
@@ -136,7 +106,7 @@ class ApiService {
       } else {
         // eslint-disable-next-line no-console
         console.warn(
-          `API ${apiUrl} is not returning expected response, ${PathReporter.report(decoded)}`
+          `API ${apiUrl} is not returning expected response, ${formatErrors(decoded.left)}`
         );
       }
     }

--- a/x-pack/plugins/uptime/server/rest_api/synthetics_service/monitor_validation.ts
+++ b/x-pack/plugins/uptime/server/rest_api/synthetics_service/monitor_validation.ts
@@ -6,7 +6,7 @@
  */
 
 import { isLeft } from 'fp-ts/lib/Either';
-import { PathReporter } from 'io-ts/lib/PathReporter';
+import { formatErrors } from '@kbn/securitysolution-io-ts-utils';
 
 import {
   BrowserFieldsCodec,
@@ -49,7 +49,7 @@ export function validateMonitor(monitorFields: MonitorFields): {
     return {
       valid: false,
       reason: `Monitor type is invalid`,
-      details: PathReporter.report(decodedType).join(' | '),
+      details: formatErrors(decodedType.left).join(' | '),
       payload: monitorFields,
     };
   }
@@ -72,7 +72,7 @@ export function validateMonitor(monitorFields: MonitorFields): {
     return {
       valid: false,
       reason: `Monitor is not a valid monitor of type ${monitorType}`,
-      details: PathReporter.report(decodedMonitor).join(' | '),
+      details: formatErrors(decodedMonitor.left).join(' | '),
       payload: monitorFields,
     };
   }


### PR DESCRIPTION
## Summary

The default schema validation error reporter from **io-ts** package (_PathReporter_) is quite verbose and it's very difficult to spot the validation failure. This PR uses the `formatErrors` from utils ( `import { formatErrors } from '@kbn/securitysolution-io-ts-utils';` ) which only outputs the narrowed down version of the schema validation error.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
