### PR TITLE
[7.17] [Index Management] Fix cluster_nodes API test (#123491)

### DIFF
--- a/x-pack/test/api_integration/apis/management/index_management/cluster_nodes.ts
+++ b/x-pack/test/api_integration/apis/management/index_management/cluster_nodes.ts
@@ -19,7 +19,7 @@ export default function ({ getService }: FtrProviderContext) {
     it('should fetch the nodes plugins', async () => {
       const { body } = await getNodesPlugins().expect(200);
 
-      expect(body).eql([]);
+      expect(Array.isArray(body)).to.be(true);
     });
   });
 }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [Index Management] Fix cluster_nodes API test (#123491)