### PR TITLE
[8.0] [Fleet] Use a docker registry for fleet integration test (#124405)

### DIFF
--- a/x-pack/plugins/fleet/server/integration_tests/docker_registry_helper.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/docker_registry_helper.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+
+import fetch from 'node-fetch';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export function useDockerRegistry() {
+  const packageRegistryPort = process.env.FLEET_PACKAGE_REGISTRY_PORT || '8081';
+
+  if (!packageRegistryPort.match(/^[0-9]{4}/)) {
+    throw new Error('Invalid FLEET_PACKAGE_REGISTRY_PORT');
+  }
+
+  let dockerProcess: ChildProcess | undefined;
+  async function startDockerRegistryServer() {
+    const dockerImage = `docker.elastic.co/package-registry/distribution@sha256:de952debe048d903fc73e8a4472bb48bb95028d440cba852f21b863d47020c61`;
+
+    const args = ['run', '--rm', '-p', `${packageRegistryPort}:8080`, dockerImage];
+
+    dockerProcess = spawn('docker', args, { stdio: 'inherit' });
+
+    let isExited = dockerProcess.exitCode !== null;
+    dockerProcess.once('exit', () => {
+      isExited = true;
+    });
+
+    let retries = 0;
+    while (!isExited && retries++ <= 20) {
+      try {
+        const res = await fetch(`http://localhost:${packageRegistryPort}/`);
+        if (res.status === 200) {
+          return;
+        }
+      } catch (err) {
+        // swallow errors
+      }
+
+      await delay(3000);
+    }
+
+    dockerProcess.kill();
+    throw new Error('Unable to setup docker registry');
+  }
+
+  async function cleanupDockerRegistryServer() {
+    if (dockerProcess && !dockerProcess.killed) {
+      dockerProcess.kill();
+    }
+  }
+
+  beforeAll(async () => {
+    jest.setTimeout(5 * 60 * 1000); // 5 minutes timeout
+    await startDockerRegistryServer();
+  });
+
+  afterAll(async () => {
+    await cleanupDockerRegistryServer();
+  });
+
+  return `http://localhost:${packageRegistryPort}`;
+}

--- a/x-pack/plugins/fleet/server/integration_tests/reset_preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/reset_preconfiguration.test.ts
@@ -67,6 +67,7 @@ describe('Fleet preconfiguration rest', () => {
         {
           xpack: {
             fleet: {
+              registryUrl,
               // Preconfigure two policies test-12345 and test-456789
               agentPolicies: [
                 {

--- a/x-pack/plugins/fleet/server/integration_tests/reset_preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/reset_preconfiguration.test.ts
@@ -14,6 +14,8 @@ import type { HttpMethod } from 'src/core/test_helpers/kbn_server';
 
 import type { AgentPolicySOAttributes } from '../types';
 
+import { useDockerRegistry } from './docker_registry_helper';
+
 const logFilePath = Path.join(__dirname, 'logs.log');
 
 type Root = ReturnType<typeof kbnTestServer.createRoot>;
@@ -45,6 +47,8 @@ const waitForFleetSetup = async (root: Root) => {
 describe('Fleet preconfiguration rest', () => {
   let esServer: kbnTestServer.TestElasticsearchUtils;
   let kbnServer: kbnTestServer.TestKibanaUtils;
+
+  const registryUrl = useDockerRegistry();
 
   const startServers = async () => {
     const { startES } = kbnTestServer.createTestServers({


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #124405

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
