### PR TITLE
[ML] Assert Lens show chart after navigation from Index data visualizer

### DIFF
--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
@@ -14,6 +14,7 @@ import {
   farequoteLuceneSearchTestData,
   sampleLogTestData,
 } from './index_test_data';
+import { ML_JOB_FIELD_TYPES } from '../../../../../plugins/ml/common/constants/field_types';
 
 export default function ({ getPageObject, getService }: FtrProviderContext) {
   const headerPage = getPageObject('header');
@@ -219,6 +220,56 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
         await ml.navigation.navigateToDataVisualizer();
       });
       runTests(sampleLogTestData);
+    });
+
+    describe('with view in lens action ', function () {
+      const testData = farequoteDataViewTestData;
+      // Run tests on full ft_module_sample_logs index.
+      it(`${testData.suiteTitle} loads the data visualizer selector page`, async () => {
+        // Start navigation from the base of the ML app.
+        await ml.navigation.navigateToMl();
+        await ml.navigation.navigateToDataVisualizer();
+      });
+
+      it(`${testData.suiteTitle} loads the source data in the data visualizer`, async () => {
+        await ml.testExecution.logTestStep(
+          `${testData.suiteTitle} loads the saved search selection page`
+        );
+        await ml.dataVisualizer.navigateToIndexPatternSelection();
+
+        await ml.testExecution.logTestStep(
+          `${testData.suiteTitle} loads the index data visualizer page`
+        );
+        await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(
+          testData.sourceIndexOrSavedSearch
+        );
+
+        await ml.testExecution.logTestStep(`${testData.suiteTitle} loads data for full time range`);
+        await ml.dataVisualizerIndexBased.clickUseFullDataButton(
+          testData.expected.totalDocCountFormatted
+        );
+        await headerPage.waitUntilLoadingHasFinished();
+
+        await ml.testExecution.logTestStep('navigate to Lens');
+        const lensMetricField = testData.expected.metricFields![0];
+
+        if (lensMetricField) {
+          await ml.dataVisualizerTable.assertLensActionShowChart(
+            lensMetricField.type,
+            lensMetricField.fieldName
+          );
+        }
+        const lensNonMetricField = testData.expected.nonMetricFields?.find(
+          (f) => f.type === ML_JOB_FIELD_TYPES.KEYWORD
+        );
+
+        if (lensNonMetricField) {
+          await ml.dataVisualizerTable.assertLensActionShowChart(
+            lensNonMetricField.type,
+            lensNonMetricField.fieldName
+          );
+        }
+      });
     });
   });
 }

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
@@ -231,7 +231,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
         await ml.navigation.navigateToDataVisualizer();
       });
 
-      it(`${testData.suiteTitle} loads the source data in the data visualizer`, async () => {
+      it(`${testData.suiteTitle} loads lens charts`, async () => {
         await ml.testExecution.logTestStep(
           `${testData.suiteTitle} loads the saved search selection page`
         );
@@ -254,20 +254,16 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
         const lensMetricField = testData.expected.metricFields![0];
 
         if (lensMetricField) {
-          await ml.dataVisualizerTable.assertLensActionShowChart(
-            lensMetricField.type,
-            lensMetricField.fieldName
-          );
+          await ml.dataVisualizerTable.assertLensActionShowChart(lensMetricField.fieldName);
+          await ml.navigation.browserBackTo('dataVisualizerTable');
         }
         const lensNonMetricField = testData.expected.nonMetricFields?.find(
           (f) => f.type === ML_JOB_FIELD_TYPES.KEYWORD
         );
 
         if (lensNonMetricField) {
-          await ml.dataVisualizerTable.assertLensActionShowChart(
-            lensNonMetricField.type,
-            lensNonMetricField.fieldName
-          );
+          await ml.dataVisualizerTable.assertLensActionShowChart(lensNonMetricField.fieldName);
+          await ml.navigation.browserBackTo('dataVisualizerTable');
         }
       });
     });

--- a/x-pack/test/functional/services/ml/data_visualizer_table.ts
+++ b/x-pack/test/functional/services/ml/data_visualizer_table.ts
@@ -565,6 +565,18 @@ export function MachineLearningDataVisualizerTableProvider(
       }
     }
 
+    public async assertLensActionShowChart(fieldType: string, fieldName: string) {
+      await retry.tryForTime(10 * 1000, async () => {
+        await testSubjects.clickWhenNotDisabled(
+          this.rowSelector(fieldName, 'dataVisualizerActionViewInLensButton')
+        );
+        await testSubjects.existOrFail('lnsVisualizationContainer', {
+          timeout: 1000,
+        });
+        await browser.goBack();
+      });
+    }
+
     public async ensureNumRowsPerPage(n: 10 | 25 | 50) {
       const paginationButton = 'dataVisualizerTable > tablePaginationPopoverButton';
       await retry.tryForTime(10000, async () => {

--- a/x-pack/test/functional/services/ml/data_visualizer_table.ts
+++ b/x-pack/test/functional/services/ml/data_visualizer_table.ts
@@ -565,15 +565,14 @@ export function MachineLearningDataVisualizerTableProvider(
       }
     }
 
-    public async assertLensActionShowChart(fieldType: string, fieldName: string) {
-      await retry.tryForTime(10 * 1000, async () => {
+    public async assertLensActionShowChart(fieldName: string) {
+      await retry.tryForTime(30 * 1000, async () => {
         await testSubjects.clickWhenNotDisabled(
           this.rowSelector(fieldName, 'dataVisualizerActionViewInLensButton')
         );
         await testSubjects.existOrFail('lnsVisualizationContainer', {
-          timeout: 1000,
+          timeout: 15 * 1000,
         });
-        await browser.goBack();
       });
     }
 

--- a/x-pack/test/functional/services/ml/navigation.ts
+++ b/x-pack/test/functional/services/ml/navigation.ts
@@ -17,7 +17,7 @@ export function MachineLearningNavigationProvider({
   const browser = getService('browser');
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
-  const PageObjects = getPageObjects(['common']);
+  const PageObjects = getPageObjects(['common', 'header']);
 
   return {
     async navigateToMl() {
@@ -263,6 +263,12 @@ export function MachineLearningNavigationProvider({
         expectedUrlPart,
         `Expected the current URL "${currentUrl}" to not include ${expectedUrlPart}`
       );
+    },
+
+    async browserBackTo(backTestSubj: string) {
+      await browser.goBack();
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await testSubjects.existOrFail(backTestSubj, { timeout: 10 * 1000 });
     },
   };
 }


### PR DESCRIPTION
## Summary

This PR adds extra coverage to the current Index data visualizer table by navigating to lens using the action and check if the charts actually show up.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
