### PR TITLE
Adds dev doc builds

### DIFF
--- a/.github/workflows/dev-doc-builder.yml
+++ b/.github/workflows/dev-doc-builder.yml
@@ -1,0 +1,22 @@
+name: Dev docs
+on:
+  pull_request_target:
+    paths:
+      - '**.mdx'
+      - '**.docnav.json'
+      - '**.docapi.json'
+      - '**.devdocs.json'
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.gif'
+    types: [closed, opened, synchronize, reopened]
+
+jobs:
+  internal-docs:
+    uses: elastic/workflows/.github/workflows/dev-docs-builder.yml@main
+    secrets:
+      VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID_DOCS_DEV: ${{ secrets.VERCEL_PROJECT_ID_DOCS_DEV }}


### PR DESCRIPTION
## Summary

Adds dev doc builds.

Does not include PR previews until info sec can be handled (Okta).

Works on forks.

Green means the build is good to go! 

After merge, builds to internal docs within 3 minutes.

Please note the paths which will trigger a doc build:

```yml
    paths:
      - '**.mdx'
      - '**.docnav.json'
      - '**.docapi.json'
      - '**.devdocs.json'
      - '**.jpg'
      - '**.jpeg'
      - '**.png'
      - '**.gif'
```

This will prevent the build from running and possibly blocking unrelated work.

If this can be narrowed or specified more accurately, please advise. 🙃 

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
