### PR TITLE
[Reporting] Additional CSV job output metrics

### DIFF
--- a/x-pack/plugins/reporting/common/types/index.ts
+++ b/x-pack/plugins/reporting/common/types/index.ts
@@ -36,6 +36,7 @@ export interface ReportOutput extends TaskRunResult {
 export interface TaskRunResult {
   content_type: string | null;
   csv_contains_formulas?: boolean;
+  csv_rows?: number;
   max_size_reached?: boolean;
   warnings?: string[];
 }
@@ -130,6 +131,7 @@ export interface JobSummary {
   title: ReportSource['payload']['title'];
   maxSizeReached: TaskRunResult['max_size_reached'];
   csvContainsFormulas: TaskRunResult['csv_contains_formulas'];
+  csvRows: TaskRunResult['csv_rows'];
 }
 
 export interface JobSummarySet {

--- a/x-pack/plugins/reporting/public/lib/__snapshots__/stream_handler.test.ts.snap
+++ b/x-pack/plugins/reporting/public/lib/__snapshots__/stream_handler.test.ts.snap
@@ -4,18 +4,18 @@ exports[`stream handler findChangedStatusJobs finds changed status jobs 1`] = `
 Object {
   "completed": Array [
     Object {
-      "csvContainsFormulas": true,
-      "csvRows": 42000000,
-      "id": "job-source-mock4",
+      "csvContainsFormulas": false,
+      "csvRows": undefined,
+      "id": "job-source-mock1",
       "jobtype": undefined,
       "maxSizeReached": false,
       "status": "completed",
       "title": "specimen",
     },
     Object {
-      "csvContainsFormulas": false,
-      "csvRows": undefined,
-      "id": "job-source-mock1",
+      "csvContainsFormulas": true,
+      "csvRows": 42000000,
+      "id": "job-source-mock4",
       "jobtype": undefined,
       "maxSizeReached": false,
       "status": "completed",

--- a/x-pack/plugins/reporting/public/lib/__snapshots__/stream_handler.test.ts.snap
+++ b/x-pack/plugins/reporting/public/lib/__snapshots__/stream_handler.test.ts.snap
@@ -4,7 +4,17 @@ exports[`stream handler findChangedStatusJobs finds changed status jobs 1`] = `
 Object {
   "completed": Array [
     Object {
+      "csvContainsFormulas": true,
+      "csvRows": 42000000,
+      "id": "job-source-mock4",
+      "jobtype": undefined,
+      "maxSizeReached": false,
+      "status": "completed",
+      "title": "specimen",
+    },
+    Object {
       "csvContainsFormulas": false,
+      "csvRows": undefined,
       "id": "job-source-mock1",
       "jobtype": undefined,
       "maxSizeReached": false,
@@ -15,6 +25,7 @@ Object {
   "failed": Array [
     Object {
       "csvContainsFormulas": false,
+      "csvRows": undefined,
       "id": "job-source-mock2",
       "jobtype": undefined,
       "maxSizeReached": false,

--- a/x-pack/plugins/reporting/public/lib/job.tsx
+++ b/x-pack/plugins/reporting/public/lib/job.tsx
@@ -55,6 +55,7 @@ export class Job {
   public size?: ReportOutput['size'];
   public content_type?: TaskRunResult['content_type'];
   public csv_contains_formulas?: TaskRunResult['csv_contains_formulas'];
+  public csv_rows?: TaskRunResult['csv_rows'];
   public max_size_reached?: TaskRunResult['max_size_reached'];
   public warnings?: TaskRunResult['warnings'];
 
@@ -87,6 +88,7 @@ export class Job {
     this.isDeprecated = report.payload.isDeprecated || false;
     this.spaceId = report.payload.spaceId;
     this.csv_contains_formulas = report.output?.csv_contains_formulas;
+    this.csv_rows = report.output?.csv_rows;
     this.max_size_reached = report.output?.max_size_reached;
     this.warnings = report.output?.warnings;
     this.locatorParams = (report.payload as BaseParamsV2).locatorParams;

--- a/x-pack/plugins/reporting/public/lib/stream_handler.test.ts
+++ b/x-pack/plugins/reporting/public/lib/stream_handler.test.ts
@@ -24,6 +24,7 @@ const mockJobsFound: Job[] = [
   { id: 'job-source-mock1', status: 'completed', output: { csv_contains_formulas: false, max_size_reached: false }, payload: { title: 'specimen' } },
   { id: 'job-source-mock2', status: 'failed', output: { csv_contains_formulas: false, max_size_reached: false }, payload: { title: 'specimen' } },
   { id: 'job-source-mock3', status: 'pending', output: { csv_contains_formulas: false, max_size_reached: false }, payload: { title: 'specimen' } },
+  { id: 'job-source-mock4', status: 'completed', output: { csv_contains_formulas: true, csv_rows: 42000000, max_size_reached: false }, payload: { title: 'specimen' } },
 ].map((j) => new Job(j as ReportApiJSON)); // prettier-ignore
 
 const coreSetup = coreMock.createSetup();
@@ -74,6 +75,7 @@ describe('stream handler', () => {
         'job-source-mock1',
         'job-source-mock2',
         'job-source-mock3',
+        'job-source-mock4',
       ]);
 
       findJobs.subscribe((data) => {

--- a/x-pack/plugins/reporting/public/lib/stream_handler.ts
+++ b/x-pack/plugins/reporting/public/lib/stream_handler.ts
@@ -33,6 +33,7 @@ function getReportStatus(src: Job): JobSummary {
     jobtype: src.prettyJobTypeName ?? src.jobtype,
     maxSizeReached: src.max_size_reached,
     csvContainsFormulas: src.csv_contains_formulas,
+    csvRows: src.csv_rows,
   };
 }
 

--- a/x-pack/plugins/reporting/public/management/components/report_info_flyout_content.tsx
+++ b/x-pack/plugins/reporting/public/management/components/report_info_flyout_content.tsx
@@ -50,6 +50,7 @@ export const ReportInfoFlyoutContent: FunctionComponent<Props> = ({ info }) => {
 
   const formatDate = createDateFormatter(uiSettings.get('dateFormat'), timezone);
 
+  const hasCsvRows = info.csv_rows != null;
   const hasScreenshot = USES_HEADLESS_JOB_TYPES.includes(info.jobtype);
 
   const outputInfo = [
@@ -93,6 +94,12 @@ export const ReportInfoFlyoutContent: FunctionComponent<Props> = ({ info }) => {
         defaultMessage: 'Size in bytes',
       }),
       description: info.size?.toString() || NA,
+    },
+    hasCsvRows && {
+      title: i18n.translate('xpack.reporting.listing.infoPanel.csvRows', {
+        defaultMessage: 'CSV rows',
+      }),
+      description: info.csv_rows?.toString() || NA,
     },
 
     hasScreenshot && {

--- a/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
@@ -397,6 +397,7 @@ export class CsvGenerator {
     return {
       content_type: CONTENT_TYPE_CSV,
       csv_contains_formulas: this.csvContainsFormulas && !escapeFormulaValues,
+      csv_rows: this.csvRowCount,
       max_size_reached: this.maxSizeReached,
       warnings,
     };

--- a/x-pack/plugins/reporting/server/lib/event_logger/logger.test.ts
+++ b/x-pack/plugins/reporting/server/lib/event_logger/logger.test.ts
@@ -116,7 +116,7 @@ describe('Event Logger', () => {
     jest.spyOn(logger.completionLogger, 'stopTiming');
     logger.logExecutionStart();
 
-    const result = logger.logExecutionComplete({ byteSize: 444 });
+    const result = logger.logExecutionComplete({ byteSize: 444, csvRows: 440000 });
     expect([result.event, result.kibana.reporting, result.message]).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -125,6 +125,7 @@ describe('Event Logger', () => {
         Object {
           "actionType": "execute-complete",
           "byteSize": 444,
+          "csvRows": 440000,
           "id": "12348",
           "jobType": "csv",
         },

--- a/x-pack/plugins/reporting/server/lib/event_logger/types.ts
+++ b/x-pack/plugins/reporting/server/lib/event_logger/types.ts
@@ -8,19 +8,21 @@
 import { LogMeta } from 'src/core/server';
 import { ActionType } from './';
 
-interface ActionBase<A extends ActionType> {
+export interface ReportingAction<A extends ActionType> extends LogMeta {
   event: {
     timezone: string;
   };
   message: string;
   kibana: {
     reporting: {
-      actionType?: A;
+      actionType: A;
       id?: string; // "immediate download" exports have no ID
       jobType: string;
       byteSize?: number;
+      csvRows?: number;
     };
-  } & { task?: { id?: string } };
+    task?: { id?: string };
+  };
   user?: { name: string };
 }
 
@@ -30,8 +32,6 @@ export interface ErrorAction {
   stack_trace?: string;
   type?: string;
 }
-
-export type ReportingAction<A extends ActionType> = ActionBase<A> & LogMeta;
 
 export type ScheduledTask = ReportingAction<ActionType.SCHEDULE_TASK>;
 export type StartedExecution = ReportingAction<ActionType.EXECUTE_START>;

--- a/x-pack/plugins/reporting/server/lib/tasks/execute_report.ts
+++ b/x-pack/plugins/reporting/server/lib/tasks/execute_report.ts
@@ -221,6 +221,7 @@ export class ExecuteReportTask implements ReportingTask {
       docOutput.content_type = output.content_type || unknownMime;
       docOutput.max_size_reached = output.max_size_reached;
       docOutput.csv_contains_formulas = output.csv_contains_formulas;
+      docOutput.csv_rows = output.csv_rows;
       docOutput.size = output.size;
       docOutput.warnings =
         output.warnings && output.warnings.length > 0 ? output.warnings : undefined;
@@ -363,7 +364,10 @@ export class ExecuteReportTask implements ReportingTask {
             report._seq_no = stream.getSeqNo()!;
             report._primary_term = stream.getPrimaryTerm()!;
 
-            eventLog.logExecutionComplete({ byteSize: stream.bytesWritten });
+            eventLog.logExecutionComplete({
+              byteSize: stream.bytesWritten,
+              csvRows: output?.csv_rows,
+            });
 
             if (output) {
               this.logger.debug(`Job output size: ${stream.bytesWritten} bytes.`);

--- a/x-pack/plugins/reporting/server/routes/generate/csv_searchsource_immediate.ts
+++ b/x-pack/plugins/reporting/server/routes/generate/csv_searchsource_immediate.ts
@@ -81,14 +81,17 @@ export function registerGenerateCsvFromSavedObjectImmediate(
         try {
           eventLog.logExecutionStart();
           const taskPromise = runTaskFn(null, req.body, context, stream, req)
-            .then(() => {
+            .then((output) => {
               logger.info(`Job output size: ${stream.bytesWritten} bytes.`);
 
               if (!stream.bytesWritten) {
                 logger.warn('CSV Job Execution created empty content result');
               }
 
-              eventLog.logExecutionComplete({ byteSize: stream.bytesWritten });
+              eventLog.logExecutionComplete({
+                byteSize: stream.bytesWritten,
+                csvRows: output.csv_rows,
+              });
             })
             .finally(() => stream.end());
 

--- a/x-pack/plugins/reporting/server/routes/lib/get_document_payload.test.ts
+++ b/x-pack/plugins/reporting/server/routes/lib/get_document_payload.test.ts
@@ -76,6 +76,7 @@ describe('getDocumentPayload', () => {
           output: {
             content_type: 'text/csv',
             csv_contains_formulas: true,
+            csv_rows: 42000000,
             max_size_reached: true,
             size: 1024,
           },


### PR DESCRIPTION
## Summary

~~Depends on https://github.com/elastic/kibana/pull/124762~~

Addresses the CSV part of https://github.com/elastic/kibana/issues/121468

This PR adds job metrics which are used for:
 - Job info panel in Stack Management > Reporting
 - Telemetry: understanding the scale of reporting in the field
 - Monitoring of Reporting: understanding how long it takes to generate a report as a function of what it consists of


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

## TODO
- [x] Remove Event Log integration, per https://github.com/elastic/kibana/issues/124753

## Screenshots
1. CSV rows in the Job Info panel:
![image](https://user-images.githubusercontent.com/908371/152448558-fde961fc-66e2-449c-8833-e03bdfa50a0c.png)
