### PR TITLE
Adds developer docs for uiSettings

### DIFF
--- a/docs/developer/architecture/core/uisettings-service.asciidoc
+++ b/docs/developer/architecture/core/uisettings-service.asciidoc
@@ -3,14 +3,68 @@
 
 NOTE: The UI settings service is available both server and client side.
 
-=== Server side usage
+=== Overview
 
-The program interface to <<advanced-options, UI settings>>.
-It makes it possible for Kibana plugins to extend Kibana UI Settings Management with custom settings.
+UI settings are configurable from the Advanced Settings page in Management and control the behavior of {kib}. `uiSettings` are stored in a `config` saved object and, as such, conform to the same conditions as other saved objects.
+
+There are several ways to configure an advanced setting:
+
+- Through the <<advanced-options, Advanced Settings UI>> (security restrictions apply)
+- Locked via kibana.yml's {kib-repo}blob/{branch}/src/core/server/ui_settings/ui_settings_defaults_client.ts[uiSettings.overrides.<key>]
+- Through the client-side `uiSettings` Service
+- Through the server-side `uiSettings` Service
+
+When a setting is configured as an override in kibana.yml, it will override any other value stored in the config saved object. If an override is misconfigured, it will fail config validation and will prevent Kibana from starting up. The override applies to Kibana as a whole for all spaces and users and the option will be disabled in the Advanced Settings page. We refer to these as "global" overrides.
+
+The `uiSettings` service is the programming interface to {kib} <<advanced-options, Advanced Settings UI>>. {kib} plugins use the service to extend Kibana UI Settings Management with custom settings for their plugin.
+
+=== Client side usage
+
+On the client, the `uiSettings` service is exposed directly from `core`.
+
+Users can adjust the settings via Management Advanced Settings UI. The client-side {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.iuisettingsclient.md[`uiSettings` client] provides plugins access to the `config` entries stored in elasticsearch.
+
+In the interest of performance, `uiSettings` are cached. Any changes that require cache refreshes (or for whatever other reason) should register an instruction to reload the page when settings are configured in Advanced Settings using the `requiresPageReload` parameter.
 
 See:
 
-- {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsservicesetup.register.md[UI settings service Setup API docs]
+- {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.uisettingsparams.md[UiSettings parameters defined by plugins]
+
+[source,typescript]
+----
+import { CoreSetup, Plugin } from 'src/core/public';
+
+export class MyPlugin implements Plugin<MyPluginSetup, MyPluginStart> {
+  public setup(core: CoreSetup): MyPluginSetup {
+    …
+    core.uiSettings.getUpdate$().subscribe(({ key, newValue }) => {
+      if (key === 'custom') {
+        // do something with changes...
+        myPluginService.register({
+          …
+        })
+      }
+    });
+    …
+  }
+  
+  public start(core: CoreStart): MyPluginStart {
+    return {
+      …
+      settings: {
+        getCustomValue: () => core.uiSettings.get('custom'),
+        …
+      },
+    };
+  }
+}
+
+----
+
+=== Server side usage
+On the server, `uiSettings` are exposed directly from `core`.
+
+The following example shows how to register a new `uiSetting` that will surface a `Custom` setting with a default value of '42'.
 
 [source,typescript]
 ----
@@ -38,3 +92,66 @@ export class MyPlugin implements Plugin {
 }
 
 ----
+
+Registeration only requires a schema for validation on read and write, all {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsparams.md[other parameters] are optional.
+
+See:
+
+- {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsservicesetup.register.md[UI settings service Setup API docs]
+
+==== Migrations
+Because `uiSettings` are persisted in the `config` saved object, changing or removing a setting requires a migration of the whole saved object. For example, if we wanted to remove the `custom` setting in the example above and then also rename `my_setting:fourtyTwo` to `my_other_setting:fourtyTwo`, we'd have two migration entries, one for each change targeting the required versions:
+[source,typescript]
+----
+export const migrations = {
+  ...
+  '8.1.0': (doc: SavedObjectUnsanitizedDoc<any>): SavedObjectSanitizedDoc<any> => ({
+  ...doc,
+  ...(doc.attributes && {
+    attributes: Object.keys(doc.attributes).reduce(
+      (acc, key) =>
+        [ // other settings to remove for 8.1.0...
+          // owner: Team:Custom setting team owner
+          'custom',
+        ].includes(key)
+          ? {
+              ...acc,
+            }
+          : {
+              ...acc,
+              [key]: doc.attributes[key],
+            },
+      {}
+    ),
+  }),
+  references: doc.references || [],
+  }),
+  '8.2.0': (doc: SavedObjectUnsanitizedDoc<any>): SavedObjectSanitizedDoc<any> => ({
+    ...doc,
+    ...(doc.attributes && {
+      attributes: Object.keys(doc.attributes).reduce(
+        (acc, key) =>
+          key.startsWith('my_setting:')
+            ? {
+                ...acc,
+                [key.replace('my_setting', 'my_other_setting')]: doc.attributes[key],
+              }
+            : {
+                ...acc,
+                [key]: doc.attributes[key],
+              },
+        {}
+      ),
+    }),
+    references: doc.references || [],
+  }),
+  …
+}
+----
+{kib-repo}blob/{branch}/src/core/server/ui_settings/saved_objects/migrations.ts[`uiSettings` migrations] are declared directly in the `uiSettings` service.
+
+==== Security-related consideration
+Configuration through the Advanced settings UI is restricted to users authorised to access the Advanced Settings page. Users who don't have permissions to change these values default to using the settings configured to the space they are in.
+Config saved objects can be shared between spaces.
+
+

--- a/docs/developer/architecture/core/uisettings-service.asciidoc
+++ b/docs/developer/architecture/core/uisettings-service.asciidoc
@@ -23,7 +23,7 @@ The uiSettings service is the programmatic interface to Kibana's Advanced Settin
 Configuration through the Advanced Settings UI is restricted to users authorised to acces the Advanced Settings page. Users who don't have permissions to change these values default to using the settings configured to the space they are in. Config saved objects can be shared between spaces.
 
 [[uisettings-overrides]]
-==== Configuration with UI settings overrides
+=== Configuration with UI settings overrides
 When a setting is configured as an override in kibana.yml, it will override any other value stored in the config saved object. If an override is misconfigured, it will fail config validation and prevent Kibana from starting up. The override applies to Kibana as a whole for all spaces and users and the option will be disabled in the Advanced Settings page. We refer to these as "global" overrides.
 
 [[client-side-usage]]
@@ -67,7 +67,7 @@ export class MyPlugin implements Plugin<MyPluginSetup, MyPluginStart> {
 === Server side usage
 On the server, `uiSettings` are exposed directly from `core`.
 
-The following example shows how to {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsservicesetup.register.md[register] a new `custom` setting with a default value of '42'. When registering a new setting, you must provide a schema against which validations are performed on read and write. All {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsparams.md[parameters][other parameters] are optional.
+The following example shows how to {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsservicesetup.register.md[register] a new `custom` setting with a default value of '42'. When registering a new setting, you must provide a schema against which validations are performed on read and write. All the other {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsparams.md[parameters] are optional.
 
 [source,typescript]
 ----
@@ -97,16 +97,17 @@ export class MyPlugin implements Plugin {
 ----
 
 [[uisettings-migrations]]
-==== Migrations
+=== Migrations
 
 [IMPORTANT]
 ==============================================
-Migrations for 3rd party plugin advanced settings is not currently supported. If a 3rd party plugin registers an advanced setting, the setting is essentially permanent and cannot be fixed without a manual intervention.
+Migrations for 3rd party plugin advanced settings are not currently supported. If a 3rd party plugin registers an advanced setting, the setting is essentially permanent and cannot be fixed without manual intervention.
 ==============================================
 
 To change or remove a `uiSetting`, the whole `config` saved object needs to be migrated. `uiSettings` {kib-repo}blob/{branch}/src/core/server/ui_settings/saved_objects/migrations.ts[migrations] are declared directly in the service.
 
 For example, if we wanted to remove a `custom` setting, or rename `my_setting:fourtyTwo` to `my_other_setting:fourtyTwo`, we'd need two migration entries, one for each change targeting the version in which these changes apply:
+
 [source,typescript]
 ----
 export const migrations = {
@@ -116,8 +117,8 @@ export const migrations = {
   ...(doc.attributes && {
     attributes: Object.keys(doc.attributes).reduce(
       (acc, key) =>
-        [ // other settings to remove for 8.1.0...
-          // owner: Team:Custom setting team owner
+        [ 
+          // other settings to remove for 8.1.0...
           'custom',
         ].includes(key)
           ? {
@@ -155,5 +156,7 @@ export const migrations = {
 }
 ----
 
-Plugins can leverage the optional deprecation parameter on registration for handling deprecation notices and renames. The deprecation warnings are rendered in the Advanced Settings UI. Please remember that we also need to warn about future deprecations in the Configure Kibana guide.
-
+[TIP]
+==============================================
+Plugins can leverage the optional deprecation parameter on registration for handling deprecation notices and renames. The deprecation warnings are rendered in the Advanced Settings UI and should also be added to the Configure Kibana guide.
+==============================================

--- a/docs/developer/architecture/core/uisettings-service.asciidoc
+++ b/docs/developer/architecture/core/uisettings-service.asciidoc
@@ -5,30 +5,23 @@ NOTE: The UI settings service is available both server and client side.
 
 === Overview
 
-UI settings are configurable from the Advanced Settings page in Management and control the behavior of {kib}. `uiSettings` are stored in a `config` saved object and, as such, conform to the same conditions as other saved objects.
+UI settings control the behavior of {kib}, are configurable and non-default values are stored in a `config` saved object. The `uiSettings` service is the programmatic interface to {kib} <<advanced-options, Advanced Settings UI>>. {kib} plugins use the service to extend Kibana UI Settings Management with custom settings for their plugin.
 
 There are several ways to configure an advanced setting:
 
-- Through the <<advanced-options, Advanced Settings UI>> (security restrictions apply)
-- Locked via kibana.yml's {kib-repo}blob/{branch}/src/core/server/ui_settings/ui_settings_defaults_client.ts[uiSettings.overrides.<key>]
-- Through the client-side `uiSettings` Service
-- Through the server-side `uiSettings` Service
+- Through the <<client-side-usage, client-side>> `uiSettings` Service
+- Through the <<server-side-usage, server-side>> `uiSettings` Service
+- Through the <<advanced-options, Advanced Settings UI>>
+- Locked with <<uisettings-overrides, uiSettings.overrides>> in kibana.yml
 
-When a setting is configured as an override in kibana.yml, it will override any other value stored in the config saved object. If an override is misconfigured, it will fail config validation and will prevent Kibana from starting up. The override applies to Kibana as a whole for all spaces and users and the option will be disabled in the Advanced Settings page. We refer to these as "global" overrides.
-
-The `uiSettings` service is the programming interface to {kib} <<advanced-options, Advanced Settings UI>>. {kib} plugins use the service to extend Kibana UI Settings Management with custom settings for their plugin.
-
+[[client-side-usage]]
 === Client side usage
 
 On the client, the `uiSettings` service is exposed directly from `core`.
 
-Users can adjust the settings via Management Advanced Settings UI. The client-side {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.iuisettingsclient.md[`uiSettings` client] provides plugins access to the `config` entries stored in elasticsearch.
+Users can adjust the settings via Management Advanced Settings UI. The client-side `uiSettings` {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.iuisettingsclient.md[client] provides plugins access to the `config` entries stored in {es}.
 
-In the interest of performance, `uiSettings` are cached. Any changes that require cache refreshes (or for whatever other reason) should register an instruction to reload the page when settings are configured in Advanced Settings using the `requiresPageReload` parameter.
-
-See:
-
-- {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.uisettingsparams.md[UiSettings parameters defined by plugins]
+In the interest of performance, `uiSettings` are cached. Any changes that require cache refreshes should register an instruction to reload the page when settings are configured in Advanced Settings using the `requiresPageReload` {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.uisettingsparams.md[parameter].
 
 [source,typescript]
 ----
@@ -61,10 +54,11 @@ export class MyPlugin implements Plugin<MyPluginSetup, MyPluginStart> {
 
 ----
 
+[[server-side-usage]]
 === Server side usage
 On the server, `uiSettings` are exposed directly from `core`.
 
-The following example shows how to register a new `uiSetting` that will surface a `Custom` setting with a default value of '42'.
+The following example shows how to {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsservicesetup.register.md[register] a new `uiSetting` that will surface a `Custom` setting with a default value of '42'.
 
 [source,typescript]
 ----
@@ -93,14 +87,10 @@ export class MyPlugin implements Plugin {
 
 ----
 
-Registeration only requires a schema for validation on read and write, all {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsparams.md[other parameters] are optional.
-
-See:
-
-- {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsservicesetup.register.md[UI settings service Setup API docs]
+Registration only requires a schema for validation on read and write, all other {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsparams.md[parameters] are optional.
 
 ==== Migrations
-Because `uiSettings` are persisted in the `config` saved object, changing or removing a setting requires a migration of the whole saved object. For example, if we wanted to remove the `custom` setting in the example above and then also rename `my_setting:fourtyTwo` to `my_other_setting:fourtyTwo`, we'd have two migration entries, one for each change targeting the required versions:
+To change or remove a `uiSetting`, the whole `config` saved object needs to be migrated. For example, if we wanted to remove a `custom` setting, or rename `my_setting:fourtyTwo` to `my_other_setting:fourtyTwo`, we'd need two migration entries, one for each change targeting the version in which these changes apply:
 [source,typescript]
 ----
 export const migrations = {
@@ -148,9 +138,20 @@ export const migrations = {
   …
 }
 ----
-{kib-repo}blob/{branch}/src/core/server/ui_settings/saved_objects/migrations.ts[`uiSettings` migrations] are declared directly in the `uiSettings` service.
+`uiSettings` {kib-repo}blob/{branch}/src/core/server/ui_settings/saved_objects/migrations.ts[migrations] are declared directly in the service.
 
-==== Security-related consideration
+[[uisettings-overrides]]
+==== Overrides
+
+[IMPORTANT]
+==============================================
+Overrides should only be used when there is no other way to configure a setting or if the setting is to be applied to Kibana globally. Overrides are not validated to the same extent as through the public APIs. Deprecated and malformed override keys will not be detected.
+==============================================
+
+When a setting is configured as an override in kibana.yml, all other values set for the setting are ignored. Overrides apply to Kibana as a whole and the option will be disabled in the Advanced Settings page for all spaces. We refer to these as "global" overrides.
+
+[[security-related-considerations]]
+==== Security-related considerations
 Configuration through the Advanced settings UI is restricted to users authorised to access the Advanced Settings page. Users who don't have permissions to change these values default to using the settings configured to the space they are in.
 Config saved objects can be shared between spaces.
 

--- a/docs/developer/architecture/core/uisettings-service.asciidoc
+++ b/docs/developer/architecture/core/uisettings-service.asciidoc
@@ -5,7 +5,7 @@ NOTE: The UI settings service is available both server and client side.
 
 === Overview
 
-UI settings are confuigurable from the Advanced Settings page in Management and control the behavior of {kib}. uiSettings are stored in a config saved object and, as such, conform to the same conditions as other saved objects.
+UI settings are configurable from the Advanced Settings page in Management and control the behavior of {kib}. uiSettings are stored in a config saved object and, as such, conform to the same conditions as other <<saved-objects-service, Saved Objects>>.
 
 There are several ways to configure an advanced setting:
 
@@ -18,19 +18,17 @@ Keep in mind that once you add a new advanced setting, you cannot change or remo
 
 [[advanced-settings-ui]]
 === Configuration with Advanced Settings UI
-The uiSettings service is the programmatic interface to Kibana's Advanced Settings UI. Kibana plugins use the service to extend Kibana UI Settings Management with custom settings for thei plugin.
+The uiSettings service is the programmatic interface to Kibana's Advanced Settings UI. Kibana plugins use the service to extend Kibana UI Settings Management with custom settings for their plugin.
 
 Configuration through the Advanced Settings UI is restricted to users authorised to acces the Advanced Settings page. Users who don't have permissions to change these values default to using the settings configured to the space they are in. Config saved objects can be shared between spaces.
 
 [[uisettings-overrides]]
-==== Overrides
-When a setting is configured as an override in kibana.yml, it will override any other value stored in the config saved object. If an override is misconfigured, it will fail config validation and will prevent Kibana from starting up. The override applies to Kibana as a whole for all spaces and users and the option will be disabled in the Advanced Settings page. We refer to these as "global" overrides.
+==== Configuration with UI settings overrides
+When a setting is configured as an override in kibana.yml, it will override any other value stored in the config saved object. If an override is misconfigured, it will fail config validation and prevent Kibana from starting up. The override applies to Kibana as a whole for all spaces and users and the option will be disabled in the Advanced Settings page. We refer to these as "global" overrides.
 
 [[client-side-usage]]
 === Client side usage
-On the client, the `uiSettings` service is exposed directly from `core`.
-
-Users can adjust the settings via Management Advanced Settings UI. The client-side `uiSettings` {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.iuisettingsclient.md[client] provides plugins access to the `config` entries stored in {es}.
+On the client, the `uiSettings` service is exposed directly from `core` and the {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.iuisettingsclient.md[client] provides plugins access to the `config` entries stored in {es}.
 
 In the interest of performance, `uiSettings` are cached. Any changes that require cache refreshes should register an instruction to reload the page when settings are configured in Advanced Settings using the `requiresPageReload` {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.uisettingsparams.md[parameter].
 
@@ -69,7 +67,7 @@ export class MyPlugin implements Plugin<MyPluginSetup, MyPluginStart> {
 === Server side usage
 On the server, `uiSettings` are exposed directly from `core`.
 
-The following example shows how to {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsservicesetup.register.md[register] a new `uiSetting` that will surface a `Custom` setting with a default value of '42'.
+The following example shows how to {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsservicesetup.register.md[register] a new `custom` setting with a default value of '42'. When registering a new setting, you must provide a schema against which validations are performed on read and write. All {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsparams.md[parameters][other parameters] are optional.
 
 [source,typescript]
 ----
@@ -98,11 +96,17 @@ export class MyPlugin implements Plugin {
 
 ----
 
-Registration only requires a schema for validation on read and write, all other {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsparams.md[parameters] are optional.
-
 [[uisettings-migrations]]
 ==== Migrations
-To change or remove a `uiSetting`, the whole `config` saved object needs to be migrated. For example, if we wanted to remove a `custom` setting, or rename `my_setting:fourtyTwo` to `my_other_setting:fourtyTwo`, we'd need two migration entries, one for each change targeting the version in which these changes apply:
+
+[IMPORTANT]
+==============================================
+Migrations for 3rd party plugin advanced settings is not currently supported. If a 3rd party plugin registers an advanced setting, the setting is essentially permanent and cannot be fixed without a manual intervention.
+==============================================
+
+To change or remove a `uiSetting`, the whole `config` saved object needs to be migrated. `uiSettings` {kib-repo}blob/{branch}/src/core/server/ui_settings/saved_objects/migrations.ts[migrations] are declared directly in the service.
+
+For example, if we wanted to remove a `custom` setting, or rename `my_setting:fourtyTwo` to `my_other_setting:fourtyTwo`, we'd need two migration entries, one for each change targeting the version in which these changes apply:
 [source,typescript]
 ----
 export const migrations = {
@@ -150,5 +154,6 @@ export const migrations = {
   …
 }
 ----
-`uiSettings` {kib-repo}blob/{branch}/src/core/server/ui_settings/saved_objects/migrations.ts[migrations] are declared directly in the service.
+
+Plugins can leverage the optional deprecation parameter on registration for handling deprecation notices and renames. The deprecation warnings are rendered in the Advanced Settings UI. Please remember that we also need to warn about future deprecations in the Configure Kibana guide.
 

--- a/docs/developer/architecture/core/uisettings-service.asciidoc
+++ b/docs/developer/architecture/core/uisettings-service.asciidoc
@@ -5,18 +5,29 @@ NOTE: The UI settings service is available both server and client side.
 
 === Overview
 
-UI settings control the behavior of {kib}, are configurable and non-default values are stored in a `config` saved object. The `uiSettings` service is the programmatic interface to {kib} <<advanced-options, Advanced Settings UI>>. {kib} plugins use the service to extend Kibana UI Settings Management with custom settings for their plugin.
+UI settings are confuigurable from the Advanced Settings page in Management and control the behavior of {kib}. uiSettings are stored in a config saved object and, as such, conform to the same conditions as other saved objects.
 
 There are several ways to configure an advanced setting:
 
-- Through the <<client-side-usage, client-side>> `uiSettings` Service
-- Through the <<server-side-usage, server-side>> `uiSettings` Service
-- Through the <<advanced-options, Advanced Settings UI>>
-- Locked with <<uisettings-overrides, uiSettings.overrides>> in kibana.yml
+- <<advanced-settings-ui, Through the Advanced Settings UI>>
+- <<uisettings-overrides, Locked via kibana.yml's uiSettings.overrides>>
+- <<client-side-usage, Through the client-side uiSettings Service>>
+- <<server-side-usage, Through the server-side uiSettings Service>>
+
+Keep in mind that once you add a new advanced setting, you cannot change or remove it without <<uisettings-migrations, registering a migration in core>>.
+
+[[advanced-settings-ui]]
+=== Configuration with Advanced Settings UI
+The uiSettings service is the programmatic interface to Kibana's Advanced Settings UI. Kibana plugins use the service to extend Kibana UI Settings Management with custom settings for thei plugin.
+
+Configuration through the Advanced Settings UI is restricted to users authorised to acces the Advanced Settings page. Users who don't have permissions to change these values default to using the settings configured to the space they are in. Config saved objects can be shared between spaces.
+
+[[uisettings-overrides]]
+==== Overrides
+When a setting is configured as an override in kibana.yml, it will override any other value stored in the config saved object. If an override is misconfigured, it will fail config validation and will prevent Kibana from starting up. The override applies to Kibana as a whole for all spaces and users and the option will be disabled in the Advanced Settings page. We refer to these as "global" overrides.
 
 [[client-side-usage]]
 === Client side usage
-
 On the client, the `uiSettings` service is exposed directly from `core`.
 
 Users can adjust the settings via Management Advanced Settings UI. The client-side `uiSettings` {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.iuisettingsclient.md[client] provides plugins access to the `config` entries stored in {es}.
@@ -89,6 +100,7 @@ export class MyPlugin implements Plugin {
 
 Registration only requires a schema for validation on read and write, all other {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.uisettingsparams.md[parameters] are optional.
 
+[[uisettings-migrations]]
 ==== Migrations
 To change or remove a `uiSetting`, the whole `config` saved object needs to be migrated. For example, if we wanted to remove a `custom` setting, or rename `my_setting:fourtyTwo` to `my_other_setting:fourtyTwo`, we'd need two migration entries, one for each change targeting the version in which these changes apply:
 [source,typescript]
@@ -139,20 +151,4 @@ export const migrations = {
 }
 ----
 `uiSettings` {kib-repo}blob/{branch}/src/core/server/ui_settings/saved_objects/migrations.ts[migrations] are declared directly in the service.
-
-[[uisettings-overrides]]
-==== Overrides
-
-[IMPORTANT]
-==============================================
-Overrides should only be used when there is no other way to configure a setting or if the setting is to be applied to Kibana globally. Overrides are not validated to the same extent as through the public APIs. Deprecated and malformed override keys will not be detected.
-==============================================
-
-When a setting is configured as an override in kibana.yml, all other values set for the setting are ignored. Overrides apply to Kibana as a whole and the option will be disabled in the Advanced Settings page for all spaces. We refer to these as "global" overrides.
-
-[[security-related-considerations]]
-==== Security-related considerations
-Configuration through the Advanced settings UI is restricted to users authorised to access the Advanced Settings page. Users who don't have permissions to change these values default to using the settings configured to the space they are in.
-Config saved objects can be shared between spaces.
-
 

--- a/docs/developer/architecture/core/uisettings-service.asciidoc
+++ b/docs/developer/architecture/core/uisettings-service.asciidoc
@@ -24,7 +24,7 @@ Configuration through the Advanced Settings UI is restricted to users authorised
 
 [[uisettings-overrides]]
 === Configuration with UI settings overrides
-When a setting is configured as an override in kibana.yml, it will override any other value stored in the config saved object. If an override is misconfigured, it will fail config validation and prevent Kibana from starting up. The override applies to Kibana as a whole for all spaces and users and the option will be disabled in the Advanced Settings page. We refer to these as "global" overrides.
+experimental[] When a setting is configured as an override in kibana.yml, it will override any other value stored in the config saved object. If an override is misconfigured, it will fail config validation and prevent Kibana from starting up. The override applies to Kibana as a whole for all spaces and users and the option will be disabled in the Advanced Settings page. We refer to these as "global" overrides.
 
 [[client-side-usage]]
 === Client side usage
@@ -104,7 +104,7 @@ export class MyPlugin implements Plugin {
 Migrations for 3rd party plugin advanced settings are not currently supported. If a 3rd party plugin registers an advanced setting, the setting is essentially permanent and cannot be fixed without manual intervention.
 ==============================================
 
-To change or remove a `uiSetting`, the whole `config` saved object needs to be migrated. `uiSettings` {kib-repo}blob/{branch}/src/core/server/ui_settings/saved_objects/migrations.ts[migrations] are declared directly in the service.
+To change or remove a `uiSetting`, the whole `config` Saved Object needs to be migrated. `uiSettings` {kib-repo}blob/{branch}/src/core/server/ui_settings/saved_objects/migrations.ts[migrations] are declared directly in the service.
 
 For example, if we wanted to remove a `custom` setting, or rename `my_setting:fourtyTwo` to `my_other_setting:fourtyTwo`, we'd need two migration entries, one for each change targeting the version in which these changes apply:
 
@@ -158,5 +158,5 @@ export const migrations = {
 
 [TIP]
 ==============================================
-Plugins can leverage the optional deprecation parameter on registration for handling deprecation notices and renames. The deprecation warnings are rendered in the Advanced Settings UI and should also be added to the Configure Kibana guide.
+Plugins can leverage the optional deprecation parameter on registration for handling deprecation notices and renames. The deprecation warnings are rendered in the Advanced Settings UI and should also be added to the <<settings,Configure Kibana>> guide.
 ==============================================


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/123243
This PR fleshes out the `uiSettings` developer documentation adding sections for:
 - overview
- client-side usage
- server side usage
- migrations
- security concerns