### PR TITLE
[Maps] Deprecated IndexPattern imports replaced to DataView

### DIFF
--- a/x-pack/plugins/maps/common/elasticsearch_util/es_agg_utils.ts
+++ b/x-pack/plugins/maps/common/elasticsearch_util/es_agg_utils.ts
@@ -7,13 +7,13 @@
 
 import { i18n } from '@kbn/i18n';
 import _ from 'lodash';
-import type { IndexPattern, IndexPatternField } from 'src/plugins/data/common';
+import type { DataView, DataViewField } from 'src/plugins/data/common';
 import { AGG_TYPE, JOIN_FIELD_NAME_PREFIX, TOP_TERM_PERCENTAGE_SUFFIX } from '../constants';
 
 export type BucketProperties = Record<string | number, unknown>;
 export type PropertiesMap = Map<string, BucketProperties>;
 
-export function getField(indexPattern: IndexPattern, fieldName: string): IndexPatternField {
+export function getField(indexPattern: DataView, fieldName: string): DataViewField {
   const field = indexPattern.fields.getByName(fieldName);
   if (!field) {
     throw new Error(
@@ -26,7 +26,7 @@ export function getField(indexPattern: IndexPattern, fieldName: string): IndexPa
   return field;
 }
 
-export function addFieldToDSL(dsl: object, field: IndexPatternField) {
+export function addFieldToDSL(dsl: object, field: DataViewField) {
   return !field.scripted
     ? { ...dsl, field: field.name }
     : {

--- a/x-pack/plugins/maps/public/classes/fields/agg/agg_field.ts
+++ b/x-pack/plugins/maps/public/classes/fields/agg/agg_field.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { IndexPattern } from 'src/plugins/data/public';
+import { DataView } from 'src/plugins/data/common';
 import { AGG_TYPE } from '../../../../common/constants';
 import { TileMetaFeature } from '../../../../common/descriptor_types';
 import { CountAggField } from './count_agg_field';
@@ -61,7 +61,7 @@ export class AggField extends CountAggField {
     return this._aggType;
   }
 
-  getValueAggDsl(indexPattern: IndexPattern): unknown {
+  getValueAggDsl(indexPattern: DataView): unknown {
     const field = getField(indexPattern, this.getRootName());
     const aggType = this._getAggType();
     const aggBody = aggType === AGG_TYPE.TERMS ? { size: 1, shard_size: TERMS_AGG_SHARD_SIZE } : {};

--- a/x-pack/plugins/maps/public/classes/fields/agg/agg_field_types.ts
+++ b/x-pack/plugins/maps/public/classes/fields/agg/agg_field_types.ts
@@ -6,12 +6,12 @@
  */
 
 import { IField } from '../field';
-import { IndexPattern } from '../../../../../../../src/plugins/data/common';
+import { DataView } from '../../../../../../../src/plugins/data/common';
 import { IESAggSource } from '../../sources/es_agg_source';
 import { FIELD_ORIGIN } from '../../../../common/constants';
 
 export interface IESAggField extends IField {
-  getValueAggDsl(indexPattern: IndexPattern): unknown | null;
+  getValueAggDsl(indexPattern: DataView): unknown | null;
   getBucketCount(): number;
 }
 

--- a/x-pack/plugins/maps/public/classes/fields/agg/count_agg_field.ts
+++ b/x-pack/plugins/maps/public/classes/fields/agg/count_agg_field.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { IndexPattern } from 'src/plugins/data/public';
+import { DataView } from 'src/plugins/data/common';
 import { IESAggSource } from '../../sources/es_agg_source';
 import { IVectorSource } from '../../sources/vector_source';
 import { AGG_TYPE, FIELD_ORIGIN } from '../../../../common/constants';
@@ -83,7 +83,7 @@ export class CountAggField implements IESAggField {
     );
   }
 
-  getValueAggDsl(indexPattern: IndexPattern): unknown | null {
+  getValueAggDsl(indexPattern: DataView): unknown | null {
     return null;
   }
 

--- a/x-pack/plugins/maps/public/classes/fields/agg/percentile_agg_field.ts
+++ b/x-pack/plugins/maps/public/classes/fields/agg/percentile_agg_field.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { IndexPattern } from 'src/plugins/data/common';
+import { DataView } from 'src/plugins/data/common';
 import { i18n } from '@kbn/i18n';
 import { AGG_TYPE } from '../../../../common/constants';
 import { IESAggField, CountAggFieldParams } from './agg_field_types';
@@ -67,7 +67,7 @@ export class PercentileAggField extends AggField implements IESAggField {
     return `${super.getName()}_${this._percentile}`;
   }
 
-  getValueAggDsl(indexPattern: IndexPattern): unknown {
+  getValueAggDsl(indexPattern: DataView): unknown {
     const field = getField(indexPattern, this.getRootName());
     const dsl: Record<string, unknown> = addFieldToDSL({}, field);
     dsl.percents = [this._percentile];

--- a/x-pack/plugins/maps/public/classes/layers/wizards/choropleth_layer_wizard/layer_template.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/choropleth_layer_wizard/layer_template.tsx
@@ -18,7 +18,7 @@ import {
   EuiSpacer,
   EuiTitle,
 } from '@elastic/eui';
-import { IndexPatternField, IndexPattern } from 'src/plugins/data/public';
+import { DataViewField, DataView } from 'src/plugins/data/common';
 import { getDataViewLabel, getDataViewSelectPlaceholder } from '../../../../../common/i18n_getters';
 import { RenderWizardArguments } from '../layer_wizard_registry';
 import { EMSFileSelect } from '../../../../components/ems_file_select';
@@ -59,15 +59,15 @@ interface State {
   leftSource: BOUNDARIES_SOURCE;
   leftEmsFileId: string | null;
   leftEmsFields: Array<EuiComboBoxOptionOption<string>>;
-  leftIndexPattern: IndexPattern | null;
-  leftGeoFields: IndexPatternField[];
-  leftJoinFields: IndexPatternField[];
+  leftIndexPattern: DataView | null;
+  leftGeoFields: DataViewField[];
+  leftJoinFields: DataViewField[];
   leftGeoField: string | null;
   leftEmsJoinField: string | null;
   leftElasticsearchJoinField: string | null;
   rightIndexPatternId: string;
   rightIndexPatternTitle: string | null;
-  rightTermsFields: IndexPatternField[];
+  rightTermsFields: DataViewField[];
   rightJoinField: string | null;
 }
 
@@ -157,7 +157,7 @@ export class LayerTemplate extends Component<RenderWizardArguments, State> {
     );
   };
 
-  _onLeftIndexPatternChange = (indexPattern: IndexPattern) => {
+  _onLeftIndexPatternChange = (indexPattern: DataView) => {
     this.setState(
       {
         leftIndexPattern: indexPattern,

--- a/x-pack/plugins/maps/public/classes/sources/es_agg_source/es_agg_source.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_agg_source/es_agg_source.ts
@@ -14,7 +14,7 @@ import { esAggFieldsFactory, IESAggField } from '../../fields/agg';
 import { AGG_TYPE, COUNT_PROP_LABEL, FIELD_ORIGIN } from '../../../../common/constants';
 import { getSourceAggKey } from '../../../../common/get_agg_key';
 import { AbstractESAggSourceDescriptor, AggDescriptor } from '../../../../common/descriptor_types';
-import { IndexPattern } from '../../../../../../../src/plugins/data/public';
+import { DataView } from '../../../../../../../src/plugins/data/common';
 import { IField } from '../../fields/field';
 import { ITooltipProperty } from '../../tooltips/tooltip_property';
 
@@ -25,7 +25,7 @@ export interface IESAggSource extends IESSource {
   getAggLabel(aggType: AGG_TYPE, fieldLabel: string): string;
   getMetricFields(): IESAggField[];
   getMetricFieldForName(fieldName: string): IESAggField | null;
-  getValueAggsDsl(indexPattern: IndexPattern): { [key: string]: unknown };
+  getValueAggsDsl(indexPattern: DataView): { [key: string]: unknown };
 }
 
 export abstract class AbstractESAggSource extends AbstractESSource implements IESAggSource {
@@ -107,7 +107,7 @@ export abstract class AbstractESAggSource extends AbstractESSource implements IE
     return this.getMetricFields();
   }
 
-  getValueAggsDsl(indexPattern: IndexPattern, metricsFilter?: (metric: IESAggField) => boolean) {
+  getValueAggsDsl(indexPattern: DataView, metricsFilter?: (metric: IESAggField) => boolean) {
     const valueAggsDsl: { [key: string]: unknown } = {};
     this.getMetricFields()
       .filter((esAggMetric) => {

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/es_geo_grid_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/es_geo_grid_source.tsx
@@ -41,7 +41,7 @@ import {
 } from '../../../../common/descriptor_types';
 import { ImmutableSourceProperty, SourceEditorArgs } from '../source';
 import { ISearchSource } from '../../../../../../../src/plugins/data/common/search/search_source';
-import { IndexPattern } from '../../../../../../../src/plugins/data/common';
+import { DataView } from '../../../../../../../src/plugins/data/common';
 import { Adapters } from '../../../../../../../src/plugins/inspector/common/adapters';
 import { isValidStringConfig } from '../../util/valid_string_config';
 import { makePublicExecutionContext } from '../../../util';
@@ -211,7 +211,7 @@ export class ESGeoGridSource extends AbstractESAggSource implements IMvtVectorSo
   }: {
     searchSource: ISearchSource;
     searchSessionId?: string;
-    indexPattern: IndexPattern;
+    indexPattern: DataView;
     precision: number;
     layerName: string;
     registerCancelCallback: (callback: () => void) => void;
@@ -317,7 +317,7 @@ export class ESGeoGridSource extends AbstractESAggSource implements IMvtVectorSo
   }: {
     searchSource: ISearchSource;
     searchSessionId?: string;
-    indexPattern: IndexPattern;
+    indexPattern: DataView;
     precision: number;
     layerName: string;
     registerCancelCallback: (callback: () => void) => void;
@@ -385,7 +385,7 @@ export class ESGeoGridSource extends AbstractESAggSource implements IMvtVectorSo
       throw new Error('Cannot get GeoJson without searchFilter.buffer');
     }
 
-    const indexPattern: IndexPattern = await this.getIndexPattern();
+    const indexPattern: DataView = await this.getIndexPattern();
     const searchSource: ISearchSource = await this.makeSearchSource(searchFilters, 0);
     searchSource.setField('trackTotalHits', false);
 

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/create_source_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/create_source_editor.tsx
@@ -7,7 +7,7 @@
 
 import React, { Component } from 'react';
 
-import { IndexPattern } from 'src/plugins/data/public';
+import { DataView } from 'src/plugins/data/common';
 import { i18n } from '@kbn/i18n';
 import { EuiFormRow, EuiPanel } from '@elastic/eui';
 import { SingleFieldSelect } from '../../../components/single_field_select';
@@ -28,7 +28,7 @@ interface Props {
 }
 
 interface State {
-  indexPattern: IndexPattern | null;
+  indexPattern: DataView | null;
   geoField: string;
   splitField: string;
   sortField: string;
@@ -42,7 +42,7 @@ export class CreateSourceEditor extends Component<Props, State> {
     sortField: '',
   };
 
-  _onIndexPatternSelect = (indexPattern: IndexPattern) => {
+  _onIndexPatternSelect = (indexPattern: DataView) => {
     const pointFields = getGeoPointFields(indexPattern.fields);
     this.setState(
       {

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/geo_line_form.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/geo_line_form.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { IndexPattern } from 'src/plugins/data/public';
+import { DataView } from 'src/plugins/data/common';
 import { EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { SingleFieldSelect } from '../../../components/single_field_select';
@@ -15,7 +15,7 @@ import { getTermsFields } from '../../../index_pattern_util';
 import { indexPatterns } from '../../../../../../../src/plugins/data/public';
 
 interface Props {
-  indexPattern: IndexPattern;
+  indexPattern: DataView;
   onSortFieldChange: (fieldName: string) => void;
   onSplitFieldChange: (fieldName: string) => void;
   sortField: string;

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/update_source_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/update_source_editor.tsx
@@ -9,7 +9,7 @@ import React, { Fragment, Component } from 'react';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
-import type { IndexPatternField, IndexPattern } from 'src/plugins/data/public';
+import type { DataViewField, DataView } from 'src/plugins/data/common';
 import { indexPatterns } from '../../../../../../../src/plugins/data/public';
 import { MetricsEditor } from '../../../components/metrics_editor';
 import { getIndexPatternService } from '../../../kibana_services';
@@ -26,8 +26,8 @@ interface Props {
 }
 
 interface State {
-  indexPattern: IndexPattern | null;
-  fields: IndexPatternField[];
+  indexPattern: DataView | null;
+  fields: DataViewField[];
 }
 
 export class UpdateSourceEditor extends Component<Props, State> {

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/es_search_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/es_search_source.tsx
@@ -11,7 +11,7 @@ import rison from 'rison-node';
 import { i18n } from '@kbn/i18n';
 import { GeoJsonProperties, Geometry, Position } from 'geojson';
 import { type Filter, buildPhraseFilter } from '@kbn/es-query';
-import type { IndexPatternField, IndexPattern } from 'src/plugins/data/public';
+import type { DataViewField, DataView } from 'src/plugins/data/common';
 import { AbstractESSource } from '../es_source';
 import {
   getHttp,
@@ -193,7 +193,7 @@ export class ESSearchSource extends AbstractESSource implements IMvtVectorSource
   async getFields(): Promise<IField[]> {
     try {
       const indexPattern = await this.getIndexPattern();
-      const fields: IndexPatternField[] = indexPattern.fields.filter((field) => {
+      const fields: DataViewField[] = indexPattern.fields.filter((field) => {
         // Ensure fielddata is enabled for field.
         // Search does not request _source
         return field.aggregatable;
@@ -279,7 +279,7 @@ export class ESSearchSource extends AbstractESSource implements IMvtVectorSource
       throw new Error('Cannot _getTopHits without topHitsSplitField');
     }
 
-    const indexPattern: IndexPattern = await this.getIndexPattern();
+    const indexPattern: DataView = await this.getIndexPattern();
 
     const fieldNames = searchFilters.fieldNames.filter(
       (fieldName) => fieldName !== this._descriptor.geoField
@@ -315,7 +315,7 @@ export class ESSearchSource extends AbstractESSource implements IMvtVectorSource
       };
     }
 
-    const topHitsSplitField: IndexPatternField = getField(indexPattern, topHitsSplitFieldName);
+    const topHitsSplitField: DataViewField = getField(indexPattern, topHitsSplitFieldName);
     const cardinalityAgg = { precision_threshold: 1 };
     const termsAgg = {
       size: DEFAULT_MAX_BUCKETS_LIMIT,
@@ -570,7 +570,7 @@ export class ESSearchSource extends AbstractESSource implements IMvtVectorSource
     return this._tooltipFields.length > 0;
   }
 
-  async _loadTooltipProperties(docId: string | number, index: string, indexPattern: IndexPattern) {
+  async _loadTooltipProperties(docId: string | number, index: string, indexPattern: DataView) {
     if (this._tooltipFields.length === 0) {
       return {};
     }

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/top_hits/create_source_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/top_hits/create_source_editor.tsx
@@ -8,7 +8,7 @@
 import React, { Component } from 'react';
 import { EuiPanel } from '@elastic/eui';
 
-import type { IndexPattern, IndexPatternField } from 'src/plugins/data/public';
+import type { DataView, DataViewField } from 'src/plugins/data/common';
 import { SCALING_TYPES } from '../../../../../common/constants';
 import { GeoFieldSelect } from '../../../../components/geo_field_select';
 import { GeoIndexPatternSelect } from '../../../../components/geo_index_pattern_select';
@@ -23,13 +23,13 @@ interface Props {
 }
 
 interface State {
-  indexPattern: IndexPattern | null;
-  geoFields: IndexPatternField[];
+  indexPattern: DataView | null;
+  geoFields: DataViewField[];
   geoFieldName: string | null;
   sortField: string | null;
-  sortFields: IndexPatternField[];
+  sortFields: DataViewField[];
   sortOrder: SortDirection;
-  termFields: IndexPatternField[];
+  termFields: DataViewField[];
   topHitsSplitField: string | null;
   topHitsSize: number;
 }
@@ -47,7 +47,7 @@ export class CreateSourceEditor extends Component<Props, State> {
     topHitsSize: 1,
   };
 
-  _onIndexPatternSelect = (indexPattern: IndexPattern) => {
+  _onIndexPatternSelect = (indexPattern: DataView) => {
     const geoFields = getGeoFields(indexPattern.fields);
 
     this.setState(

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/util/get_docvalue_source_fields.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/util/get_docvalue_source_fields.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { IndexPattern } from '../../../../../../../../src/plugins/data/common';
+import { DataView } from '../../../../../../../../src/plugins/data/common';
 import { getField } from '../../../../../common/elasticsearch_util';
 
 export interface ScriptField {
@@ -14,7 +14,7 @@ export interface ScriptField {
 }
 
 export function getDocValueAndSourceFields(
-  indexPattern: IndexPattern,
+  indexPattern: DataView,
   fieldNames: string[],
   dateFormat: string
 ): {

--- a/x-pack/plugins/maps/public/classes/sources/es_source/es_source.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_source/es_source.ts
@@ -8,7 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import uuid from 'uuid/v4';
 import { Filter } from '@kbn/es-query';
-import { IndexPatternField, IndexPattern, ISearchSource } from 'src/plugins/data/public';
+import { DataViewField, DataView, ISearchSource } from 'src/plugins/data/common';
 import type { Query } from 'src/plugins/data/common';
 import type { KibanaExecutionContext } from 'kibana/public';
 import { AbstractVectorSource, BoundsRequestMeta } from '../vector_source';
@@ -48,7 +48,7 @@ export function isSearchSourceAbortError(error: Error) {
 export interface IESSource extends IVectorSource {
   isESSource(): true;
   getId(): string;
-  getIndexPattern(): Promise<IndexPattern>;
+  getIndexPattern(): Promise<DataView>;
   getIndexPatternId(): string;
   getGeoFieldName(): string;
   loadStylePropsMeta({
@@ -71,7 +71,7 @@ export interface IESSource extends IVectorSource {
 }
 
 export class AbstractESSource extends AbstractVectorSource implements IESSource {
-  indexPattern?: IndexPattern;
+  indexPattern?: DataView;
 
   readonly _descriptor: AbstractESSourceDescriptor;
 
@@ -346,7 +346,7 @@ export class AbstractESSource extends AbstractVectorSource implements IESSource 
     return this._descriptor.geoField;
   }
 
-  async getIndexPattern(): Promise<IndexPattern> {
+  async getIndexPattern(): Promise<DataView> {
     // Do we need this cache? Doesn't the IndexPatternService take care of this?
     if (this.indexPattern) {
       return this.indexPattern;
@@ -369,7 +369,7 @@ export class AbstractESSource extends AbstractVectorSource implements IESSource 
     }
   }
 
-  async _getGeoField(): Promise<IndexPatternField> {
+  async _getGeoField(): Promise<DataViewField> {
     const indexPattern = await this.getIndexPattern();
     const geoField = indexPattern.fields.getByName(this.getGeoFieldName());
     if (!geoField) {

--- a/x-pack/plugins/maps/public/classes/tooltips/es_agg_tooltip_property.ts
+++ b/x-pack/plugins/maps/public/classes/tooltips/es_agg_tooltip_property.ts
@@ -9,7 +9,7 @@ import { ESTooltipProperty } from './es_tooltip_property';
 import { AGG_TYPE } from '../../../common/constants';
 import { ITooltipProperty } from './tooltip_property';
 import { IESAggField } from '../fields/agg';
-import { IndexPattern } from '../../../../../../src/plugins/data/public';
+import { DataView } from '../../../../../../src/plugins/data/common';
 
 export class ESAggTooltipProperty extends ESTooltipProperty {
   private readonly _aggType: AGG_TYPE;
@@ -17,7 +17,7 @@ export class ESAggTooltipProperty extends ESTooltipProperty {
 
   constructor(
     tooltipProperty: ITooltipProperty,
-    indexPattern: IndexPattern,
+    indexPattern: DataView,
     field: IESAggField,
     aggType: AGG_TYPE,
     applyGlobalQuery: boolean

--- a/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.ts
+++ b/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.ts
@@ -9,17 +9,17 @@ import _ from 'lodash';
 import { type Filter, buildExistsFilter, buildPhraseFilter } from '@kbn/es-query';
 import { ITooltipProperty } from './tooltip_property';
 import { IField } from '../fields/field';
-import { IndexPattern, IndexPatternField } from '../../../../../../src/plugins/data/public';
+import { DataView, DataViewField } from '../../../../../../src/plugins/data/common';
 
 export class ESTooltipProperty implements ITooltipProperty {
   private readonly _tooltipProperty: ITooltipProperty;
-  private readonly _indexPattern: IndexPattern;
+  private readonly _indexPattern: DataView;
   private readonly _field: IField;
   private readonly _applyGlobalQuery: boolean;
 
   constructor(
     tooltipProperty: ITooltipProperty,
-    indexPattern: IndexPattern,
+    indexPattern: DataView,
     field: IField,
     applyGlobalQuery: boolean
   ) {
@@ -41,7 +41,7 @@ export class ESTooltipProperty implements ITooltipProperty {
     return this._tooltipProperty.getRawValue();
   }
 
-  _getIndexPatternField(): IndexPatternField | undefined {
+  _getIndexPatternField(): DataViewField | undefined {
     return this._indexPattern.fields.getByName(this._field.getRootName());
   }
 

--- a/x-pack/plugins/maps/public/components/geo_index_pattern_select.tsx
+++ b/x-pack/plugins/maps/public/components/geo_index_pattern_select.tsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { EuiCallOut, EuiFormRow, EuiLink, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { IndexPattern } from 'src/plugins/data/public';
+import { DataView } from 'src/plugins/data/common';
 import {
   getIndexPatternSelectComponent,
   getIndexPatternService,
@@ -19,7 +19,7 @@ import { getDataViewLabel, getDataViewSelectPlaceholder } from '../../common/i18
 import { ES_GEO_FIELD_TYPE, ES_GEO_FIELD_TYPES } from '../../common/constants';
 
 interface Props {
-  onChange: (indexPattern: IndexPattern) => void;
+  onChange: (indexPattern: DataView) => void;
   value: string | null;
   isGeoPointsOnly?: boolean;
 }

--- a/x-pack/plugins/maps/public/connected_components/edit_layer_panel/filter_editor/filter_editor.tsx
+++ b/x-pack/plugins/maps/public/connected_components/edit_layer_panel/filter_editor/filter_editor.tsx
@@ -23,7 +23,7 @@ import {
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import type { IndexPattern, Query } from 'src/plugins/data/public';
+import type { DataView, Query } from 'src/plugins/data/common';
 import { APP_ID } from '../../../../common/constants';
 import { getIndexPatternService, getData } from '../../../kibana_services';
 import { GlobalFilterCheckbox } from '../../../components/global_filter_checkbox';
@@ -39,7 +39,7 @@ export interface Props {
 
 interface State {
   isPopoverOpen: boolean;
-  indexPatterns: IndexPattern[];
+  indexPatterns: DataView[];
   isSourceTimeAware: boolean;
 }
 
@@ -64,7 +64,7 @@ export class FilterEditor extends Component<Props, State> {
   async _loadIndexPatterns() {
     // Filter only effects source so only load source indices.
     const indexPatternIds = this.props.layer.getSource().getIndexPatternIds();
-    const indexPatterns: IndexPattern[] = [];
+    const indexPatterns: DataView[] = [];
     const getIndexPatternPromises = indexPatternIds.map(async (indexPatternId) => {
       try {
         const indexPattern = await getIndexPatternService().get(indexPatternId);

--- a/x-pack/plugins/maps/public/connected_components/edit_layer_panel/join_editor/resources/join.tsx
+++ b/x-pack/plugins/maps/public/connected_components/edit_layer_panel/join_editor/resources/join.tsx
@@ -9,7 +9,7 @@ import _ from 'lodash';
 import React, { Component } from 'react';
 import { EuiFlexItem, EuiFlexGroup, EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type { IndexPatternField, IndexPattern, Query } from 'src/plugins/data/public';
+import type { DataViewField, DataView, Query } from 'src/plugins/data/common';
 import { JoinExpression } from './join_expression';
 import { MetricsExpression } from './metrics_expression';
 import { WhereExpression } from './where_expression';
@@ -39,8 +39,8 @@ interface Props {
 }
 
 interface State {
-  rightFields: IndexPatternField[];
-  indexPattern?: IndexPattern;
+  rightFields: DataViewField[];
+  indexPattern?: DataView;
   loadError?: string;
 }
 

--- a/x-pack/plugins/maps/public/connected_components/edit_layer_panel/join_editor/resources/where_expression.tsx
+++ b/x-pack/plugins/maps/public/connected_components/edit_layer_panel/join_editor/resources/where_expression.tsx
@@ -9,12 +9,12 @@ import React, { Component } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiButton, EuiPopover, EuiExpression, EuiFormHelpText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { IndexPattern, Query } from 'src/plugins/data/public';
+import { DataView, Query } from 'src/plugins/data/common';
 import { APP_ID } from '../../../../../common/constants';
 import { getData } from '../../../../kibana_services';
 
 interface Props {
-  indexPattern: IndexPattern;
+  indexPattern: DataView;
   onChange: (whereQuery?: Query) => void;
   whereQuery?: Query;
 }

--- a/x-pack/plugins/maps/public/embeddable/types.ts
+++ b/x-pack/plugins/maps/public/embeddable/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Filter } from '@kbn/es-query';
-import type { IndexPattern } from '../../../../../src/plugins/data/common';
+import type { DataView } from '../../../../../src/plugins/data/common';
 import {
   Embeddable,
   EmbeddableInput,
@@ -43,7 +43,7 @@ export type MapByReferenceInput = SavedObjectEmbeddableInput & {
 export type MapEmbeddableInput = MapByValueInput | MapByReferenceInput;
 
 export type MapEmbeddableOutput = EmbeddableOutput & {
-  indexPatterns: IndexPattern[];
+  indexPatterns: DataView[];
 };
 
 export type MapEmbeddableType = Embeddable<MapEmbeddableInput, MapEmbeddableOutput> & {

--- a/x-pack/plugins/maps/public/index_pattern_util.ts
+++ b/x-pack/plugins/maps/public/index_pattern_util.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { IndexPatternField, IndexPattern } from 'src/plugins/data/public';
+import type { DataViewField, DataView } from 'src/plugins/data/common';
 import { i18n } from '@kbn/i18n';
 import { asyncMap } from '@kbn/std';
 import { getIndexPatternService } from './kibana_services';
@@ -13,7 +13,7 @@ import { indexPatterns } from '../../../../src/plugins/data/public';
 import { ES_GEO_FIELD_TYPE, ES_GEO_FIELD_TYPES } from '../common/constants';
 import { getIsGoldPlus } from './licensed_features';
 
-export function getGeoTileAggNotSupportedReason(field: IndexPatternField): string | null {
+export function getGeoTileAggNotSupportedReason(field: DataViewField): string | null {
   if (!field.aggregatable) {
     return i18n.translate('xpack.maps.geoTileAgg.disabled.docValues', {
       defaultMessage:
@@ -30,12 +30,10 @@ export function getGeoTileAggNotSupportedReason(field: IndexPatternField): strin
   return null;
 }
 
-export async function getIndexPatternsFromIds(
-  indexPatternIds: string[] = []
-): Promise<IndexPattern[]> {
+export async function getIndexPatternsFromIds(indexPatternIds: string[] = []): Promise<DataView[]> {
   const results = await asyncMap(indexPatternIds, async (indexPatternId) => {
     try {
-      return (await getIndexPatternService().get(indexPatternId)) as IndexPattern;
+      return (await getIndexPatternService().get(indexPatternId)) as DataView;
     } catch (error) {
       // Unable to load index pattern, better to not throw error so map can render
       // Error will be surfaced by layer since it too will be unable to locate the index pattern
@@ -43,10 +41,10 @@ export async function getIndexPatternsFromIds(
     }
   });
 
-  return results.filter((r): r is IndexPattern => r !== null);
+  return results.filter((r): r is DataView => r !== null);
 }
 
-export function getTermsFields(fields: IndexPatternField[]): IndexPatternField[] {
+export function getTermsFields(fields: DataViewField[]): DataViewField[] {
   return fields.filter((field) => {
     return (
       field.aggregatable &&
@@ -56,7 +54,7 @@ export function getTermsFields(fields: IndexPatternField[]): IndexPatternField[]
   });
 }
 
-export function getSortFields(fields: IndexPatternField[]): IndexPatternField[] {
+export function getSortFields(fields: DataViewField[]): DataViewField[] {
   return fields.filter((field) => {
     return field.sortable && !indexPatterns.isNestedField(field);
   });
@@ -70,23 +68,23 @@ export function getAggregatableGeoFieldTypes(): string[] {
   return aggregatableFieldTypes;
 }
 
-export function getGeoFields(fields: IndexPatternField[]): IndexPatternField[] {
+export function getGeoFields(fields: DataViewField[]): DataViewField[] {
   return fields.filter((field) => {
     return !indexPatterns.isNestedField(field) && ES_GEO_FIELD_TYPES.includes(field.type);
   });
 }
 
-export function getGeoPointFields(fields: IndexPatternField[]): IndexPatternField[] {
+export function getGeoPointFields(fields: DataViewField[]): DataViewField[] {
   return fields.filter((field) => {
     return !indexPatterns.isNestedField(field) && ES_GEO_FIELD_TYPE.GEO_POINT === field.type;
   });
 }
 
-export function getFieldsWithGeoTileAgg(fields: IndexPatternField[]): IndexPatternField[] {
+export function getFieldsWithGeoTileAgg(fields: DataViewField[]): DataViewField[] {
   return fields.filter(supportsGeoTileAgg);
 }
 
-export function supportsGeoTileAgg(field?: IndexPatternField): boolean {
+export function supportsGeoTileAgg(field?: DataViewField): boolean {
   return (
     !!field &&
     !!field.aggregatable &&
@@ -95,7 +93,7 @@ export function supportsGeoTileAgg(field?: IndexPatternField): boolean {
   );
 }
 
-export function getSourceFields(fields: IndexPatternField[]): IndexPatternField[] {
+export function getSourceFields(fields: DataViewField[]): DataViewField[] {
   return fields.filter((field) => {
     // Multi fields are not stored in _source and only exist in index.
     return !field.isSubtypeMulti() && !field.isSubtypeNested();

--- a/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
+++ b/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
@@ -13,7 +13,7 @@ import { AppLeaveAction, AppMountParameters } from 'kibana/public';
 import { Adapters } from 'src/plugins/embeddable/public';
 import { Subscription } from 'rxjs';
 import { type Filter, FilterStateStore } from '@kbn/es-query';
-import type { Query, TimeRange, IndexPattern } from 'src/plugins/data/common';
+import type { Query, TimeRange, DataView } from 'src/plugins/data/common';
 import {
   getData,
   getCoreChrome,
@@ -87,7 +87,7 @@ export interface Props {
 
 export interface State {
   initialized: boolean;
-  indexPatterns: IndexPattern[];
+  indexPatterns: DataView[];
   savedQuery?: SavedQuery;
   isRefreshPaused: boolean;
   refreshInterval: number;


### PR DESCRIPTION
Part of: #124063

Removes usage of deprecated `IndexPattern` from Maps app and replacing it to `DataView`.

cc @nreese 