### PR TITLE
[Fleet] Removed dependency on specific package version in cypress test

### DIFF
--- a/x-pack/plugins/fleet/cypress/integration/integrations_real.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/integrations_real.spec.ts
@@ -34,14 +34,13 @@ describe('Add Integration - Real API', () => {
   });
 
   it('should install integration without policy', () => {
-    cy.visit('/app/integrations/detail/tomcat-1.3.0/settings');
+    cy.visit('/app/integrations/detail/tomcat/settings');
 
     cy.get('.euiButton').contains('Install Apache Tomcat assets').click();
     cy.get('.euiCallOut').contains('This action will install 1 assets');
     cy.getBySel(CONFIRM_MODAL_BTN).click();
 
     cy.get('.euiLoadingSpinner').should('not.exist');
-    cy.getBySel('installedVersion').contains('1.3.0');
 
     cy.get('.euiButton').contains('Uninstall Apache Tomcat').click();
     cy.getBySel(CONFIRM_MODAL_BTN).click();

--- a/x-pack/plugins/fleet/cypress/integration/package_policy.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/package_policy.spec.ts
@@ -10,7 +10,7 @@ describe('Edit package policy', () => {
     id: 'policy-1',
     name: 'fleet_server-1',
     namespace: 'default',
-    package: { name: 'fleet_server', title: 'Fleet Server', version: '1.1.1' },
+    package: { name: 'fleet_server', title: 'Fleet Server', version: '1.1.0' },
     enabled: true,
     policy_id: 'fleet-server-policy',
     output_id: 'fleet-default-output',
@@ -62,6 +62,47 @@ describe('Edit package policy', () => {
         monitoring_enabled: ['logs', 'metrics'],
         status: 'active',
         package_policies: [{ id: 'policy-1', name: 'fleet_server-1' }],
+      },
+    });
+    cy.intercept('/api/fleet/epm/packages/fleet_server*', {
+      item: {
+        name: 'fleet_server',
+        title: 'Fleet Server',
+        version: '1.1.0',
+        release: 'ga',
+        description: 'Centrally manage Elastic Agents with the Fleet Server integration',
+        type: 'integration',
+        download: '/epr/fleet_server/fleet_server-1.1.0.zip',
+        path: '/package/fleet_server/1.1.0',
+        icons: [],
+        conditions: { kibana: { version: '^7.16.0 || ^8.0.0' } },
+        owner: { github: 'elastic/ingest-management' },
+        categories: ['elastic_stack'],
+        format_version: '1.0.0',
+        readme: '/package/fleet_server/1.1.0/docs/README.md',
+        license: 'basic',
+        assets: {},
+        policy_templates: [
+          {
+            name: 'fleet_server',
+            title: 'Fleet Server',
+            description: 'Fleet Server setup',
+            inputs: [
+              {
+                type: 'fleet-server',
+                vars: [],
+                title: 'Fleet Server',
+                description: 'Fleet Server Configuration',
+                template_path: 'agent.yml.hbs',
+              },
+            ],
+            multiple: true,
+          },
+        ],
+        latestVersion: '1.1.0',
+        removable: true,
+        keepPoliciesUpToDate: false,
+        status: 'not_installed',
       },
     });
   });


### PR DESCRIPTION
## Summary

Fixing cypress test (failed in 8.1 branch) due to changing epm packages.
Removed dependency on a specific version and using mock.

Failed here: https://github.com/elastic/kibana/pull/124658

