### PR TITLE
[Table] Inspector displays only visible content

### DIFF
--- a/src/plugins/vis_types/table/public/table_vis_fn.ts
+++ b/src/plugins/vis_types/table/public/table_vis_fn.ts
@@ -127,8 +127,8 @@ export const createTableVisFn = (): TableExpressionFunctionDefinition => ({
   fn(input, args, handlers) {
     const convertedData = tableVisResponseHandler(input, args);
     const inspectorData = {
-      rows: convertedData?.table?.rows,
-      columns: convertedData?.table?.columns,
+      rows: convertedData?.table?.rows ?? input.rows,
+      columns: convertedData?.table?.columns ?? input.columns,
       type: 'datatable',
     } as Datatable;
 

--- a/src/plugins/vis_types/table/public/table_vis_fn.ts
+++ b/src/plugins/vis_types/table/public/table_vis_fn.ts
@@ -126,6 +126,11 @@ export const createTableVisFn = (): TableExpressionFunctionDefinition => ({
   },
   fn(input, args, handlers) {
     const convertedData = tableVisResponseHandler(input, args);
+    const inspectorData = {
+      rows: convertedData?.table?.rows,
+      columns: convertedData?.table?.columns,
+      type: 'datatable',
+    } as Datatable;
 
     if (handlers?.inspectorAdapters?.tables) {
       const argsTable: Dimension[] = [
@@ -158,7 +163,7 @@ export const createTableVisFn = (): TableExpressionFunctionDefinition => ({
           }),
         ]);
       }
-      const logTable = prepareLogTable(input, argsTable);
+      const logTable = prepareLogTable(inspectorData, argsTable);
       handlers.inspectorAdapters.tables.logDatatable('default', logTable);
     }
     return {


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/121947

This PR makes sure that we send the correct data to the table inspector.
When you enable the `partial rows` setting, the computation follows the same path as the 'different metrics per bucket' but we don't want to display the intermediary columns neither on the chart nor the inspector. https://github.com/elastic/kibana/blob/main/src/plugins/vis_types/table/public/to_ast.ts#L32

Although we take this under consideration on the chart, on the inspector table we send all columns. This PR makes sure that we log only the visible content.

Inspector with the partial rows on but the `Show metrics for every bucket/level` off
![image](https://user-images.githubusercontent.com/17003240/152519726-c55f6cff-4b16-44b7-a3ac-6e0c8358859d.png)
