### PR TITLE
[Uptime][Monitor Management UI] Fix bug where monitor type dropdown doesn't work in Firefox.

### DIFF
--- a/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useMemo, memo } from 'react';
+import React, { useMemo, memo, useState, useLayoutEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -57,6 +57,14 @@ export const CustomFields = memo<Props>(
   ({ validate, dataStreams = [], children, appendAdvancedFields }) => {
     const { monitorType, setMonitorType, isTLSEnabled, setIsTLSEnabled, isEditable } =
       usePolicyConfigContext();
+
+    // The following workaround is needed to fix a bug which only occurs in Firefox, see issue: elastic/uptime/issues/444
+    const [monitorTypeInterimState, setMonitorTypeInterimState] = useState<DataStream | undefined>(
+      monitorType
+    );
+    useLayoutEffect(() => {
+      setMonitorTypeInterimState(undefined);
+    }, []);
 
     const isHTTP = monitorType === DataStream.HTTP;
     const isTCP = monitorType === DataStream.TCP;
@@ -128,7 +136,7 @@ export const CustomFields = memo<Props>(
                 >
                   <EuiSelect
                     options={dataStreamOptions}
-                    value={monitorType}
+                    value={monitorTypeInterimState}
                     onChange={(event) => setMonitorType(event.target.value as DataStream)}
                     data-test-subj="syntheticsMonitorTypeField"
                   />


### PR DESCRIPTION
Fixes https://github.com/elastic/uptime/issues/444

## Summary

In Firefox, the Monitor Type dropdown doesn't work as reported in the linked issue. This PR uses a workaround to fix that behavior.

In Monitor Management

https://user-images.githubusercontent.com/2748376/152539985-1c4368f6-913a-4424-b15c-68ef57f6315d.mov

In Fleet

https://user-images.githubusercontent.com/2748376/152540020-74842875-20b8-4632-a7ad-43ee04b0ced0.mov




### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
