### PR TITLE
Move plugins/saved_objects ownerhip

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -278,7 +278,7 @@
 /src/plugins/advanced_settings/ @elastic/kibana-core
 /x-pack/plugins/global_search_bar/ @elastic/kibana-core
 #CC# /src/core/server/csp/ @elastic/kibana-core
-#CC# /src/plugins/saved_objects/ @elastic/kibana-core
+#CC# /src/plugins/saved_objects/ @elastic/kibana-vis-editors
 #CC# /x-pack/plugins/cloud/ @elastic/kibana-core
 #CC# /x-pack/plugins/features/ @elastic/kibana-core
 #CC# /x-pack/plugins/global_search/ @elastic/kibana-core

--- a/src/plugins/saved_objects/kibana.json
+++ b/src/plugins/saved_objects/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "savedObjects",
   "owner": {
-    "name": "Kibana Core",
-    "githubTeam": "kibana-core"
+    "name": "Kibana Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "version": "kibana",
   "server": true,

--- a/src/plugins/saved_objects/public/finder/saved_object_finder.tsx
+++ b/src/plugins/saved_objects/public/finder/saved_object_finder.tsx
@@ -40,6 +40,10 @@ import {
 
 import { LISTING_LIMIT_SETTING } from '../../common';
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export interface SavedObjectMetaData<T = unknown> {
   type: string;
   name: string;
@@ -96,11 +100,19 @@ interface SavedObjectFinderInitialPageSize extends BaseSavedObjectFinder {
 
 export type SavedObjectFinderProps = SavedObjectFinderFixedPage | SavedObjectFinderInitialPageSize;
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export type SavedObjectFinderUiProps = {
   savedObjects: CoreStart['savedObjects'];
   uiSettings: CoreStart['uiSettings'];
 } & SavedObjectFinderProps;
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 class SavedObjectFinderUi extends React.Component<
   SavedObjectFinderUiProps,
   SavedObjectFinderState
@@ -525,6 +537,10 @@ class SavedObjectFinderUi extends React.Component<
   }
 }
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 const getSavedObjectFinder = (savedObject: SavedObjectsStart, uiSettings: IUiSettingsClient) => {
   return (props: SavedObjectFinderProps) => (
     <SavedObjectFinderUi {...props} savedObjects={savedObject} uiSettings={uiSettings} />

--- a/src/plugins/saved_objects/public/plugin.ts
+++ b/src/plugins/saved_objects/public/plugin.ts
@@ -19,18 +19,42 @@ import { DataViewsPublicPluginStart } from '../../data_views/public';
 import { PER_PAGE_SETTING, LISTING_LIMIT_SETTING } from '../common';
 import { SavedObject } from './types';
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export interface SavedObjectSetup {
+  /**
+   * @deprecated
+   * @removeBy 8.0
+   */
   registerDecorator: (config: SavedObjectDecoratorConfig<any>) => void;
 }
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export interface SavedObjectsStart {
-  /** @deprecated */
+  /**
+   * @deprecated
+   * @removeBy 8.0
+   */
   SavedObjectClass: new (raw: Record<string, any>) => SavedObject;
-  /** @deprecated */
+  /**
+   * @deprecated
+   * @removeBy 8.0
+   */
   settings: {
-    /** @deprecated */
+    /**
+     * @deprecated
+     * @removeBy 8.0
+     */
     getPerPage: () => number;
-    /** @deprecated */
+    /**
+     * @deprecated
+     * @removeBy 8.0
+     */
     getListingLimit: () => number;
   };
 }
@@ -52,6 +76,10 @@ export class SavedObjectsPublicPlugin
   }
   public start(core: CoreStart, { data, dataViews }: SavedObjectsStartDeps) {
     return {
+      /**
+       * @deprecated
+       * @removeBy 8.0
+       */
       SavedObjectClass: createSavedObjectClass(
         {
           dataViews,

--- a/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
+++ b/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
@@ -31,6 +31,10 @@ import React from 'react';
 import { EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ * */
 export interface OnSaveProps {
   newTitle: string;
   newCopyOnSave: boolean;
@@ -55,6 +59,10 @@ interface Props {
   isValid?: boolean;
 }
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ * */
 export interface SaveModalState {
   title: string;
   copyOnSave: boolean;
@@ -66,7 +74,10 @@ export interface SaveModalState {
 
 const generateId = htmlIdGenerator();
 
-/** @deprecated */
+/**
+ * @deprecated
+ * @removeBy 8.0
+ * */
 export class SavedObjectSaveModal extends React.Component<Props, SaveModalState> {
   private warning = React.createRef<HTMLDivElement>();
   public readonly state = {

--- a/src/plugins/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx
+++ b/src/plugins/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx
@@ -19,6 +19,10 @@ interface SaveModalDocumentInfo {
   description?: string;
 }
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export interface OriginSaveModalProps {
   originatingApp?: string;
   getAppNameFromId?: (appId: string) => string | undefined;
@@ -31,6 +35,10 @@ export interface OriginSaveModalProps {
   onSave: (props: OnSaveProps & { returnToOrigin: boolean }) => void;
 }
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export function SavedObjectSaveModalOrigin(props: OriginSaveModalProps) {
   const [returnToOriginMode, setReturnToOriginMode] = useState(Boolean(props.originatingApp));
   const { documentInfo } = props;

--- a/src/plugins/saved_objects/public/save_modal/show_saved_object_save_modal.tsx
+++ b/src/plugins/saved_objects/public/save_modal/show_saved_object_save_modal.tsx
@@ -17,6 +17,9 @@ import { I18nStart } from '../../../../core/public';
  * Contains an `id` if persisting was successful. If `id` and
  * `error` are undefined, persisting was not successful, but the
  * modal can still recover (e.g. the name of the saved object was already taken).
+ *
+ * @deprecated
+ * @removeBy 8.0
  */
 export type SaveResult = { id?: string } | { error: Error };
 
@@ -29,6 +32,10 @@ interface MinimalSaveModalProps {
   onClose: () => void;
 }
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export function showSaveModal(
   saveModal: React.ReactElement<MinimalSaveModalProps>,
   I18nContext: I18nStart['Context'],

--- a/src/plugins/saved_objects/public/saved_object/decorators/registry.ts
+++ b/src/plugins/saved_objects/public/saved_object/decorators/registry.ts
@@ -10,6 +10,10 @@ import { PublicMethodsOf } from '@kbn/utility-types';
 import { SavedObjectDecoratorFactory } from './types';
 import { SavedObjectKibanaServices, SavedObject } from '../../types';
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export interface SavedObjectDecoratorConfig<T extends SavedObject = SavedObject> {
   /**
    * The id of the decorator
@@ -28,6 +32,10 @@ export interface SavedObjectDecoratorConfig<T extends SavedObject = SavedObject>
 
 export type ISavedObjectDecoratorRegistry = PublicMethodsOf<SavedObjectDecoratorRegistry>;
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export class SavedObjectDecoratorRegistry {
   private readonly registry = new Map<string, SavedObjectDecoratorConfig<any>>();
 

--- a/src/plugins/saved_objects/public/saved_object/decorators/types.ts
+++ b/src/plugins/saved_objects/public/saved_object/decorators/types.ts
@@ -8,6 +8,10 @@
 
 import { SavedObject, SavedObjectKibanaServices, SavedObjectConfig } from '../../types';
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export interface SavedObjectDecorator<T extends SavedObject = SavedObject> {
   /**
    * Id of the decorator
@@ -28,6 +32,10 @@ export interface SavedObjectDecorator<T extends SavedObject = SavedObject> {
   decorateObject: (object: T) => void;
 }
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export type SavedObjectDecoratorFactory<T extends SavedObject = SavedObject> = (
   services: SavedObjectKibanaServices
 ) => SavedObjectDecorator<T>;

--- a/src/plugins/saved_objects/public/saved_object/helpers/check_for_duplicate_title.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/check_for_duplicate_title.ts
@@ -12,6 +12,9 @@ import { SAVE_DUPLICATE_REJECTED } from '../../constants';
 import { displayDuplicateTitleConfirmModal } from './display_duplicate_title_confirm_modal';
 
 /**
+ * @deprecated
+ * @removeBy 8.0
+ *
  * check for an existing SavedObject with the same title in ES
  * returns Promise<true> when it's no duplicate, or the modal displaying the warning
  * that's there's a duplicate is confirmed, else it returns a rejected Promise<ErrorMsg>

--- a/src/plugins/saved_objects/public/saved_object/helpers/save_saved_object.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/save_saved_object.ts
@@ -17,6 +17,8 @@ import { createSource } from './create_source';
 import { checkForDuplicateTitle } from './check_for_duplicate_title';
 
 /**
+ * @deprecated
+ * @removeBy 8.0
  * @param error {Error} the error
  * @return {boolean}
  */

--- a/src/plugins/saved_objects/public/saved_object/helpers/save_with_confirmation.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/save_with_confirmation.ts
@@ -18,6 +18,9 @@ import { OVERWRITE_REJECTED } from '../../constants';
 import { confirmModalPromise } from './confirm_modal_promise';
 
 /**
+ * @deprecated
+ * @removeBy 8.0
+ *
  * Attempts to create the current object using the serialized source. If an object already
  * exists, a warning message requests an overwrite confirmation.
  * @param source - serialized version of this object what will be indexed into elasticsearch.

--- a/src/plugins/saved_objects/public/saved_object/saved_object.ts
+++ b/src/plugins/saved_objects/public/saved_object/saved_object.ts
@@ -20,6 +20,10 @@ import { SavedObject, SavedObjectConfig, SavedObjectKibanaServices } from '../ty
 import { ISavedObjectDecoratorRegistry } from './decorators';
 import { buildSavedObject } from './helpers/build_saved_object';
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export function createSavedObjectClass(
   services: SavedObjectKibanaServices,
   decoratorRegistry: ISavedObjectDecoratorRegistry

--- a/src/plugins/saved_objects/public/saved_object/saved_object_loader.ts
+++ b/src/plugins/saved_objects/public/saved_object/saved_object_loader.ts
@@ -15,6 +15,10 @@ import {
 import { SavedObject } from '../types';
 import { StringUtils } from './helpers/string_utils';
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export interface SavedObjectLoaderFindOptions {
   size?: number;
   fields?: string[];
@@ -23,6 +27,8 @@ export interface SavedObjectLoaderFindOptions {
 
 /**
  * @deprecated
+ * @removeBy 8.0
+ *
  * The SavedObjectLoader class provides some convenience functions
  * to load and save one kind of saved objects (specified in the constructor).
  *

--- a/src/plugins/saved_objects/public/types.ts
+++ b/src/plugins/saved_objects/public/types.ts
@@ -21,7 +21,10 @@ import {
 } from '../../data/public';
 import { DataViewsContract } from '../../data_views/public';
 
-/** @deprecated */
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export interface SavedObject {
   _serialize: () => { attributes: SavedObjectAttributes; references: SavedObjectReference[] };
   _source: Record<string, unknown>;
@@ -49,6 +52,10 @@ export interface SavedObject {
   unresolvedIndexPatternReference?: SavedObjectReference;
 }
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export interface SavedObjectSaveOpts {
   confirmOverwrite?: boolean;
   isTitleDuplicateConfirmed?: boolean;
@@ -74,6 +81,10 @@ export interface SavedObjectAttributesAndRefs {
   references: SavedObjectReference[];
 }
 
+/**
+ * @deprecated
+ * @removeBy 8.0
+ */
 export interface SavedObjectConfig {
   // is only used by visualize
   afterESResp?: (savedObject: SavedObject) => Promise<SavedObject>;


### PR DESCRIPTION
## Summary

When creating the NP the Core team decided not to port `src/legacy/ui/public/saved_objects/` https://github.com/elastic/kibana/issues/46435 due to concerns with the architecture, code quality and test coverage. In order to unblock teams this code was temporarily moved into a new saved_objects plugin  https://github.com/elastic/kibana/pull/57452

The ownership of this plugin was first assigned to app-services and then later moved to core. However, in practise core isn't maintaining this code and have been pushing teams to remove their dependency on the plugin. Given that this is tech debt which needs to be removed by other teams I think it makes more sense to move ownership of the plugin to the teams who are still relying on it. Unfortunately we don't have a kibana-analytics team on Github. But given that the vis-editors team has done most of the work to remove dependencies on this plugin I suggest changing ownership over to them.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
