### PR TITLE
[8.1] String replace from "experimental" to "technical preview" (#124311)

### DIFF
--- a/docs/management/connectors/action-types/index.asciidoc
+++ b/docs/management/connectors/action-types/index.asciidoc
@@ -105,7 +105,7 @@ experimental[] {kib} offers a preconfigured index connector to facilitate indexi
 
 [WARNING]
 ==================================================
-This functionality is experimental and may be changed or removed completely in a future release.
+This functionality is in technical preview and may be changed or removed completely in a future release.
 ==================================================
 
 To use this connector, set the <<action-settings, `xpack.actions.preconfiguredAlertHistoryEsIndex`>> configuration to `true`.

--- a/docs/settings/task-manager-settings.asciidoc
+++ b/docs/settings/task-manager-settings.asciidoc
@@ -33,7 +33,7 @@ This flag will enable automatic warn and error logging if task manager self dete
 The amount of seconds we allow a task to delay before printing a warning server log.  Defaults to 60.
 
 `xpack.task_manager.ephemeral_tasks.enabled`::
-Enables an experimental feature that executes a limited (and configurable) number of actions in the same task as the alert which triggered them.
+Enables a technical preview feature that executes a limited (and configurable) number of actions in the same task as the alert which triggered them.
 These action tasks will reduce the latency of the time it takes an action to run after it's triggered, but are not persisted as SavedObjects.
 These non-persisted action tasks have a risk that they won't be run at all if the Kibana instance running them exits unexpectedly. Defaults to false.
 

--- a/packages/elastic-apm-synthtrace/README.md
+++ b/packages/elastic-apm-synthtrace/README.md
@@ -1,6 +1,6 @@
 # @elastic/apm-synthtrace
 
-`@elastic/apm-synthtrace` is an experimental tool to generate synthetic APM data. It is intended to be used for development and testing of the Elastic APM app in Kibana.
+`@elastic/apm-synthtrace` is a tool in technical preview to generate synthetic APM data. It is intended to be used for development and testing of the Elastic APM app in Kibana.
 
 At a high-level, the module works by modeling APM events/metricsets with [a fluent API](https://en.wikipedia.org/wiki/Fluent_interface). The models can then be serialized and converted to Elasticsearch documents. In the future we might support APM Server as an output as well.
 
@@ -98,19 +98,20 @@ Via the CLI, you can upload scenarios, either using a fixed time range or contin
 For a fixed time window:
 `$ node packages/elastic-apm-synthtrace/src/scripts/run packages/elastic-apm-synthtrace/src/scripts/examples/01_simple_trace.ts --target=http://admin:changeme@localhost:9200 --from=now-24h --to=now`
 
-The script will try to automatically find bootstrapped APM indices. __If these indices do not exist, the script will exit with an error. It will not bootstrap the indices itself.__
+The script will try to automatically find bootstrapped APM indices. **If these indices do not exist, the script will exit with an error. It will not bootstrap the indices itself.**
 
 The following options are supported:
-| Option            | Description                                             | Default      |
-| ------------------| ------------------------------------------------------- | ------------ |
-| `--target`        | Elasticsearch target, including username/password.      | **Required** |
-| `--from`          | The start of the time window.                           | `now - 15m`  |
-| `--to`            | The end of the time window.                             | `now`        |
-| `--live`          | Continously ingest data                                 | `false`      |
-| `--clean`         | Clean APM indices before indexing new data.             | `false`      |
-| `--workers`       | Amount of Node.js worker threads                        | `5`          |
-| `--bucketSize`    | Size of bucket for which to generate data.              | `15m`        |
-| `--interval`      | The interval at which to index data.                    | `10s`        |
-| `--clientWorkers` | Number of simultaneously connected ES clients           | `5`          |
-| `--batchSize`     | Number of documents per bulk index request              | `1000`       |
-| `--logLevel`      | Log level.                                              | `info`       |
+
+| Option            | Description                                        | Default      |
+| ----------------- | -------------------------------------------------- | ------------ |
+| `--target`        | Elasticsearch target, including username/password. | **Required** |
+| `--from`          | The start of the time window.                      | `now - 15m`  |
+| `--to`            | The end of the time window.                        | `now`        |
+| `--live`          | Continously ingest data                            | `false`      |
+| `--clean`         | Clean APM indices before indexing new data.        | `false`      |
+| `--workers`       | Amount of Node.js worker threads                   | `5`          |
+| `--bucketSize`    | Size of bucket for which to generate data.         | `15m`        |
+| `--interval`      | The interval at which to index data.               | `10s`        |
+| `--clientWorkers` | Number of simultaneously connected ES clients      | `5`          |
+| `--batchSize`     | Number of documents per bulk index request         | `1000`       |
+| `--logLevel`      | Log level.                                         | `info`       |

--- a/src/plugins/advanced_settings/public/management_app/components/call_outs/__snapshots__/call_outs.test.tsx.snap
+++ b/src/plugins/advanced_settings/public/management_app/components/call_outs/__snapshots__/call_outs.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`CallOuts should render normally 1`] = `
   >
     <p>
       <FormattedMessage
-        defaultMessage="Be careful in here, these settings are for very advanced users only. Tweaks you make here can break large portions of Kibana. Some of these settings may be undocumented, unsupported or experimental. If a field has a default value, blanking the field will reset it to its default which may be unacceptable given other configuration directives. Deleting a custom setting will permanently remove it from Kibana's config."
+        defaultMessage="Be careful in here, these settings are for very advanced users only. Tweaks you make here can break large portions of Kibana. Some of these settings may be undocumented, unsupported or in technical preview. If a field has a default value, blanking the field will reset it to its default which may be unacceptable given other configuration directives. Deleting a custom setting will permanently remove it from Kibana's config."
         id="advancedSettings.callOutCautionDescription"
         values={Object {}}
       />

--- a/src/plugins/advanced_settings/public/management_app/components/call_outs/call_outs.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/call_outs/call_outs.tsx
@@ -29,7 +29,7 @@ export const CallOuts = () => {
             id="advancedSettings.callOutCautionDescription"
             defaultMessage="Be careful in here, these settings are for very advanced users only.
             Tweaks you make here can break large portions of Kibana.
-            Some of these settings may be undocumented, unsupported or experimental.
+            Some of these settings may be undocumented, unsupported or in technical preview.
             If a field has a default value, blanking the field will reset it to its default which may be
             unacceptable given other configuration directives.
             Deleting a custom setting will permanently remove it from Kibana's config."

--- a/src/plugins/dashboard/server/ui_settings.ts
+++ b/src/plugins/dashboard/server/ui_settings.ts
@@ -22,7 +22,7 @@ export const getUISettings = (): Record<string, UiSettingsParams<boolean>> => ({
     }),
     description: i18n.translate('dashboard.labs.enableLabsDescription', {
       defaultMessage:
-        'This flag determines if the viewer has access to the Labs button, a quick way to enable and disable experimental features in Dashboard.',
+        'This flag determines if the viewer has access to the Labs button, a quick way to enable and disable technical preview features in Dashboard.',
     }),
     value: false,
     type: 'boolean',

--- a/src/plugins/presentation_util/public/i18n/labs.tsx
+++ b/src/plugins/presentation_util/public/i18n/labs.tsx
@@ -89,7 +89,7 @@ export const LabsStrings = {
         }),
       getDescriptionMessage: () =>
         i18n.translate('presentationUtil.labs.components.descriptionMessage', {
-          defaultMessage: 'Try out our features that are in progress or experimental.',
+          defaultMessage: 'Try out features that are in progress or in technical preview.',
         }),
       getResetToDefaultLabel: () =>
         i18n.translate('presentationUtil.labs.components.resetToDefaultLabel', {

--- a/src/plugins/vis_types/timelion/server/ui_settings.ts
+++ b/src/plugins/vis_types/timelion/server/ui_settings.ts
@@ -14,7 +14,7 @@ import { UI_SETTINGS } from '../common/constants';
 import { configSchema } from '../config';
 
 const experimentalLabel = i18n.translate('timelion.uiSettings.experimentalLabel', {
-  defaultMessage: 'experimental',
+  defaultMessage: 'technical preview',
 });
 
 export function getUiSettings(

--- a/src/plugins/vis_types/vega/public/components/experimental_map_vis_info.tsx
+++ b/src/plugins/vis_types/vega/public/components/experimental_map_vis_info.tsx
@@ -20,7 +20,9 @@ export const ExperimentalMapLayerInfo = () => (
     title={
       <FormattedMessage
         id="visTypeVega.mapView.experimentalMapLayerInfo"
-        defaultMessage="Map layer is experimental and is not subject to the support SLA of official GA features.
+        defaultMessage="This functionality is in technical preview and may be changed or removed completely in a future release.
+        Elastic will take a best effort approach to fix any issues, but features in technical preview are
+        are not subject to the support SLA of official GA features.
         For feedback, please create an issue in {githubLink}."
         values={{
           githubLink: (

--- a/src/plugins/visualizations/public/visualize_app/components/experimental_vis_info.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/experimental_vis_info.tsx
@@ -15,7 +15,9 @@ export const InfoComponent = () => {
     <>
       <FormattedMessage
         id="visualizations.experimentalVisInfoText"
-        defaultMessage="This visualization is experimental and is not subject to the support SLA of official GA features.
+        defaultMessage="This functionality is in technical preview and may be changed or removed completely in a future release.
+          Elastic will take a best effort approach to fix any issues, but features in technical preview
+          are not subject to the support SLA of official GA features.
           For feedback, please create an issue in {githubLink}."
         values={{
           githubLink: (

--- a/src/plugins/visualizations/public/visualize_app/utils/get_table_columns.tsx
+++ b/src/plugins/visualizations/public/visualize_app/utils/get_table_columns.tsx
@@ -59,11 +59,11 @@ const getBadge = (item: VisualizationListItem) => {
         className="visListingTable__experimentalIcon"
         label="E"
         title={i18n.translate('visualizations.listing.experimentalTitle', {
-          defaultMessage: 'Experimental',
+          defaultMessage: 'Technical preview',
         })}
         tooltipContent={i18n.translate('visualizations.listing.experimentalTooltip', {
           defaultMessage:
-            'This visualization might be changed or removed in a future release and is not subject to the support SLA.',
+            'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
         })}
       />
     );

--- a/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
@@ -238,10 +238,10 @@ const ToolsGroup = ({ visType, onVisTypeSelected, showExperimental }: VisCardPro
                 iconType="beaker"
                 tooltipContent={i18n.translate('visualizations.newVisWizard.experimentalTooltip', {
                   defaultMessage:
-                    'This visualization might be changed or removed in a future release and is not subject to the support SLA.',
+                    'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
                 })}
                 label={i18n.translate('visualizations.newVisWizard.experimentalTitle', {
-                  defaultMessage: 'Experimental',
+                  defaultMessage: 'Technical preview',
                 })}
               />
             </EuiFlexItem>

--- a/src/plugins/visualizations/server/plugin.ts
+++ b/src/plugins/visualizations/server/plugin.ts
@@ -55,12 +55,12 @@ export class VisualizationsPlugin
     core.uiSettings.register({
       [VISUALIZE_ENABLE_LABS_SETTING]: {
         name: i18n.translate('visualizations.advancedSettings.visualizeEnableLabsTitle', {
-          defaultMessage: 'Enable experimental visualizations',
+          defaultMessage: 'Enable technical preview visualizations',
         }),
         value: true,
         description: i18n.translate('visualizations.advancedSettings.visualizeEnableLabsText', {
-          defaultMessage: `Allows users to create, view, and edit experimental visualizations. If disabled,
-            only visualizations that are considered production-ready are available to the user.`,
+          defaultMessage: `Allows users to create, view, and edit visualizations that are in technical preview.
+            If disabled, only visualizations that are considered production-ready are available to the user.`,
         }),
         category: ['visualization'],
         schema: schema.boolean(),

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -302,14 +302,14 @@ function useTabs({ selectedTab }: { selectedTab: Tab['key'] }) {
               label={i18n.translate(
                 'xpack.apm.serviceDetails.profilingTabExperimentalLabel',
                 {
-                  defaultMessage: 'Experimental',
+                  defaultMessage: 'Technical preview',
                 }
               )}
               tooltipContent={i18n.translate(
                 'xpack.apm.serviceDetails.profilingTabExperimentalDescription',
                 {
                   defaultMessage:
-                    'Profiling is highly experimental and for internal use only.',
+                    'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
                 }
               )}
             />

--- a/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.test.tsx
@@ -110,7 +110,7 @@ describe('getAlertAnnotations', () => {
           setSelectedAlertId,
           theme,
         })![0].props.dataValues[0].header
-      ).toEqual('Alert - Experimental');
+      ).toEqual('Alert - Technical preview');
     });
 
     it('uses the reason in the annotation details', () => {
@@ -191,7 +191,7 @@ describe('getAlertAnnotations', () => {
           setSelectedAlertId,
           theme,
         })![0].props.dataValues[0].header
-      ).toEqual('Warning Alert - Experimental');
+      ).toEqual('Warning Alert - Technical preview');
     });
   });
 
@@ -224,7 +224,7 @@ describe('getAlertAnnotations', () => {
           setSelectedAlertId,
           theme,
         })![0].props.dataValues[0].header
-      ).toEqual('Critical Alert - Experimental');
+      ).toEqual('Critical Alert - Technical preview');
     });
   });
 });

--- a/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.tsx
@@ -107,7 +107,7 @@ export function getAlertAnnotations({
     const color = getAlertColor({ severityLevel, theme });
     const experimentalLabel = i18n.translate(
       'xpack.apm.alertAnnotationTooltipExperimentalText',
-      { defaultMessage: 'Experimental' }
+      { defaultMessage: 'Technical preview' }
     );
     const header = `${getAlertHeader({
       severityLevel,

--- a/x-pack/plugins/canvas/server/ui_settings.ts
+++ b/x-pack/plugins/canvas/server/ui_settings.ts
@@ -21,7 +21,7 @@ export const getUISettings = (): Record<string, UiSettingsParams<boolean>> => ({
     }),
     description: i18n.translate('xpack.canvas.labs.enableLabsDescription', {
       defaultMessage:
-        'This flag determines if the viewer has access to the Labs button, a quick way to enable and disable experimental features in Canvas.',
+        'This flag determines if the viewer has access to the Labs button, a quick way to enable and disable technical preview features in Canvas.',
     }),
     value: false,
     type: 'boolean',

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/release_badge.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/release_badge.ts
@@ -14,7 +14,7 @@ export const RELEASE_BADGE_LABEL: { [key in Exclude<RegistryRelease, 'ga'>]: str
     defaultMessage: 'Beta',
   }),
   experimental: i18n.translate('xpack.fleet.epm.releaseBadge.experimentalLabel', {
-    defaultMessage: 'Experimental',
+    defaultMessage: 'Technical preview',
   }),
 };
 
@@ -23,6 +23,7 @@ export const RELEASE_BADGE_DESCRIPTION: { [key in Exclude<RegistryRelease, 'ga'>
     defaultMessage: 'This integration is not recommended for use in production environments.',
   }),
   experimental: i18n.translate('xpack.fleet.epm.releaseBadge.experimentalDescription', {
-    defaultMessage: 'This integration may have breaking changes or be removed in a future release.',
+    defaultMessage:
+      'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
   }),
 };

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
@@ -366,7 +366,7 @@ export const ChartSwitch = memo(function ChartSwitch(props: Props) {
                               <EuiBadge color="hollow">
                                 <FormattedMessage
                                   id="xpack.lens.chartSwitch.experimentalLabel"
-                                  defaultMessage="Experimental"
+                                  defaultMessage="Technical preview"
                                 />
                               </EuiBadge>
                             </EuiFlexItem>

--- a/x-pack/plugins/ml/public/application/routing/routes/trained_models/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/routing/routes/trained_models/models_list.tsx
@@ -62,7 +62,7 @@ const PageWrapper: FC<PageProps> = ({ location, deps }) => {
           <EuiFlexItem grow={false}>
             <EuiBetaBadge
               label={i18n.translate('xpack.ml.navMenu.trainedModelsTabBetaLabel', {
-                defaultMessage: 'Experimental',
+                defaultMessage: 'Technical preview',
               })}
               size="m"
               color="hollow"
@@ -70,7 +70,7 @@ const PageWrapper: FC<PageProps> = ({ location, deps }) => {
                 'xpack.ml.navMenu.trainedModelsTabBetaTooltipContent',
                 {
                   defaultMessage:
-                    "Model Management is an experimental feature and subject to change. We'd love to hear your feedback.",
+                    'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
                 }
               )}
               tooltipPosition={'right'}

--- a/x-pack/plugins/ml/public/application/routing/routes/trained_models/nodes_list.tsx
+++ b/x-pack/plugins/ml/public/application/routing/routes/trained_models/nodes_list.tsx
@@ -60,7 +60,7 @@ const PageWrapper: FC<PageProps> = ({ location, deps }) => {
           <EuiFlexItem grow={false}>
             <EuiBetaBadge
               label={i18n.translate('xpack.ml.navMenu.trainedModelsTabBetaLabel', {
-                defaultMessage: 'Experimental',
+                defaultMessage: 'Technical preview',
               })}
               size="m"
               color="hollow"
@@ -68,7 +68,7 @@ const PageWrapper: FC<PageProps> = ({ location, deps }) => {
                 'xpack.ml.navMenu.trainedModelsTabBetaTooltipContent',
                 {
                   defaultMessage:
-                    "Model Management is an experimental feature and subject to change. We'd love to hear your feedback.",
+                    'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
                 }
               )}
               tooltipPosition={'right'}

--- a/x-pack/plugins/observability/public/components/shared/experimental_badge.tsx
+++ b/x-pack/plugins/observability/public/components/shared/experimental_badge.tsx
@@ -13,11 +13,11 @@ export function ExperimentalBadge() {
   return (
     <EuiBetaBadge
       label={i18n.translate('xpack.observability.experimentalBadgeLabel', {
-        defaultMessage: 'Experimental',
+        defaultMessage: 'Technical preview',
       })}
       tooltipContent={i18n.translate('xpack.observability.experimentalBadgeDescription', {
         defaultMessage:
-          'This functionality is experimental and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features.',
+          'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
       })}
     />
   );

--- a/x-pack/plugins/observability/public/pages/alerts/components/alerts_disclaimer.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/components/alerts_disclaimer.tsx
@@ -35,14 +35,13 @@ export function AlertsDisclaimer() {
         <EuiCallOut
           data-test-subj="o11yExperimentalDisclaimer"
           title={i18n.translate('xpack.observability.alertsDisclaimerTitle', {
-            defaultMessage:
-              'Alert history is currently an experimental feature within Observability',
+            defaultMessage: 'Technical preview',
           })}
           color="warning"
         >
           <FormattedMessage
             id="xpack.observability.alertsDisclaimerText"
-            defaultMessage="This functionality may change or be removed completely in a future release. We value your {feedback} as we work to add new capabilities. "
+            defaultMessage="This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features. Provide {feedback}."
             values={{
               feedback: (
                 <EuiLink href="https://discuss.elastic.co/c/observability/82" target="_blank">

--- a/x-pack/plugins/security_solution/public/common/experimental_features_service.ts
+++ b/x-pack/plugins/security_solution/public/common/experimental_features_service.ts
@@ -24,7 +24,7 @@ export class ExperimentalFeaturesService {
 
   private static throwUninitializedError(): never {
     throw new Error(
-      'Experimental features services not initialized - are you trying to import this module from outside of the Security Solution app?'
+      'Technical preview features services not initialized - are you trying to import this module from outside of the Security Solution app?'
     );
   }
 }

--- a/x-pack/plugins/security_solution/public/common/mock/endpoint/app_context_render.tsx
+++ b/x-pack/plugins/security_solution/public/common/mock/endpoint/app_context_render.tsx
@@ -62,7 +62,7 @@ export interface AppContextTestRender {
   render: UiRender;
 
   /**
-   * Set experimental features on/off. Calling this method updates the Store with the new values
+   * Set technical preview features on/off. Calling this method updates the Store with the new values
    * for the given feature flags
    * @param flags
    */
@@ -70,7 +70,7 @@ export interface AppContextTestRender {
 }
 
 // Defined a private custom reducer that reacts to an action that enables us to updat the
-// store with new values for experimental features/flags. Because the `action.type` is a `Symbol`,
+// store with new values for technical preview features/flags. Because the `action.type` is a `Symbol`,
 // and its not exported the action can only be `dispatch`'d from this module
 const UpdateExperimentalFeaturesTestActionType = Symbol('updateExperimentalFeaturesTestAction');
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/translations.ts
@@ -24,7 +24,7 @@ export const BACK_TO_RULES = i18n.translate(
 export const EXPERIMENTAL = i18n.translate(
   'xpack.securitySolution.detectionEngine.ruleDetails.experimentalDescription',
   {
-    defaultMessage: 'Experimental',
+    defaultMessage: 'Technical preview',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -55,7 +55,7 @@ export const PAGE_TITLE = i18n.translate('xpack.securitySolution.detectionEngine
 export const EXPERIMENTAL_ON = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.experimentalOn',
   {
-    defaultMessage: 'Experimental: On',
+    defaultMessage: 'Technical preview: On',
   }
 );
 
@@ -63,14 +63,14 @@ export const EXPERIMENTAL_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.experimentalDescription',
   {
     defaultMessage:
-      'The experimental rules table view allows for advanced sorting capabilities. If you experience performance issues when working with the table, you can turn this setting off.',
+      'The experimental rules table view is in technical preview and allows for advanced sorting capabilities. If you experience performance issues when working with the table, you can turn this setting off.',
   }
 );
 
 export const EXPERIMENTAL_OFF = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.experimentalOff',
   {
-    defaultMessage: 'Experimental: Off',
+    defaultMessage: 'Technical preview: Off',
   }
 );
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/get_input_output_index.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/get_input_output_index.test.ts
@@ -99,7 +99,7 @@ describe('get_input_output_index', () => {
       expect(inputIndex).toEqual(DEFAULT_INDEX_PATTERN);
     });
 
-    test('Returns a saved object inputIndex default along with experimental features when uebaEnabled=true', async () => {
+    test('Returns a saved object inputIndex default along with technical preview features when uebaEnabled=true', async () => {
       servicesMock.savedObjectsClient.get.mockImplementation(async (type: string, id: string) => ({
         id,
         type,

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/experimental/0.1.0/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/experimental/0.1.0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
-name: experimental 
+name: experimental
 title: experimental integration
-description: This is a test package for testing experimental packages
+description: This is a test package for testing technical preview packages
 version: 0.1.0
 categories: []
 release: experimental


### PR DESCRIPTION
Backports the following commits to 8.1:
 - String replace from "experimental" to "technical preview" (#124311)