### PR TITLE
[Draft] e2e test to show import failure

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/import_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/import_rules.ts
@@ -831,7 +831,41 @@ export default ({ getService }: FtrProviderContext): void => {
                     type: 'detection',
                     namespace_type: 'single',
                   },
-                  getImportExceptionsListItemSchemaMock('test_item_id', 'i_exist'),
+                  {
+                    comments: [
+                      {
+                        comment: 'This is an exception to the rule',
+                        created_at: '2022-02-04T02:27:40.938Z',
+                        created_by: 'elastic',
+                        id: '845fc456-91ff-4530-bcc1-5b7ebd2f75b5',
+                      },
+                    ],
+                    description: 'some description',
+                    entries: [
+                      {
+                        entries: [
+                          {
+                            field: 'nested.field',
+                            operator: 'included',
+                            type: 'match',
+                            value: 'some value',
+                          },
+                        ],
+                        field: 'some.parentField',
+                        type: 'nested',
+                      },
+                      {
+                        field: 'some.not.nested.field',
+                        operator: 'included',
+                        type: 'match',
+                        value: 'some value',
+                      },
+                    ],
+                    item_id: 'item_id_1',
+                    list_id: 'i_exist',
+                    name: 'Query with a rule id',
+                    type: 'simple',
+                  },
                 ])
               ),
               'rules.ndjson'


### PR DESCRIPTION
## Summary

[Draft] e2e test to show import failure so the person fixing it will have a failure test first and we avoid regressions later. 

This will fail the CI system on purpose to show that the test does indeed fail. Expect to see this failure:

```
24 passing (1.0m)
1 failing

1)    detection engine api security and spaces enabled

         import_rules
           importing rules with an index
             importing with exceptions
               should resolve exception references when importing into a clean slate:


       Error: expected { success: true,
   success_count: 1,
   errors: [],
   exceptions_errors: [ { list_id: '(unknown item_id)', error: [Object] } ],
   exceptions_success: false,
   exceptions_success_count: 1 } to sort of equal { success: true,
   success_count: 1,
   errors: [],
   exceptions_errors: [],
   exceptions_success: true,
   exceptions_success_count: 2 }
       + expected - actual

        {
          "errors": []
       -  "exceptions_errors": [
       -    {
       -      "error": {
       -        "message": "Error found importing exception list item: invalid keys \"created_at,created_by,id\""
       -        "status_code": 400
       -      }
       -      "list_id": "(unknown item_id)"
       -    }
       -  ]
       -  "exceptions_success": false
       -  "exceptions_success_count": 1
       +  "exceptions_errors": []
       +  "exceptions_success": true
       +  "exceptions_success_count": 2
          "success": true
          "success_count": 1
        }
```
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
