### PR TITLE
[8.0] [maps] fix Can not style by date time with vector tiles (#124530)

### DIFF
--- a/x-pack/plugins/maps/server/mvt/merge_fields.ts
+++ b/x-pack/plugins/maps/server/mvt/merge_fields.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// can not use "import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey"
+// SearchRequest is incorrectly typed and does not support Field as object
+// https://github.com/elastic/elasticsearch-js/issues/1615
+export type Field =
+  | string
+  | {
+      field: string;
+      format: string;
+    };
+
+export function mergeFields(
+  fieldsList: Array<Field[] | undefined>,
+  excludeNames: string[]
+): Field[] {
+  const fieldNames: string[] = [];
+  const mergedFields: Field[] = [];
+
+  fieldsList.forEach((fields) => {
+    if (!fields) {
+      return;
+    }
+
+    fields.forEach((field) => {
+      const fieldName = typeof field === 'string' ? field : field.field;
+      if (!excludeNames.includes(fieldName) && !fieldNames.includes(fieldName)) {
+        fieldNames.push(fieldName);
+        mergedFields.push(field);
+      }
+    });
+  });
+
+  return mergedFields;
+}

--- a/x-pack/test/api_integration/apis/maps/get_tile.js
+++ b/x-pack/test/api_integration/apis/maps/get_tile.js
@@ -28,7 +28,7 @@ export default function ({ getService }) {
           `/api/maps/mvt/getTile/2/1/1.pbf\
 ?geometryFieldName=geo.coordinates\
 &index=logstash-*\
-&requestBody=(_source:!f,docvalue_fields:!(bytes,geo.coordinates,machine.os.raw),query:(bool:(filter:!((match_all:()),(range:(%27@timestamp%27:(format:strict_date_optional_time,gte:%272015-09-20T00:00:00.000Z%27,lte:%272015-09-20T01:00:00.000Z%27)))),must:!(),must_not:!(),should:!())),runtime_mappings:(),script_fields:(),size:10000,stored_fields:!(bytes,geo.coordinates,machine.os.raw))`
+&requestBody=(_source:!f,docvalue_fields:!(bytes,geo.coordinates,machine.os.raw,(field:'@timestamp',format:epoch_millis)),query:(bool:(filter:!((match_all:()),(range:(%27@timestamp%27:(format:strict_date_optional_time,gte:%272015-09-20T00:00:00.000Z%27,lte:%272015-09-20T01:00:00.000Z%27)))),must:!(),must_not:!(),should:!())),runtime_mappings:(),script_fields:(),size:10000,stored_fields:!(bytes,geo.coordinates,machine.os.raw,'@timestamp'))`
         )
         .set('kbn-xsrf', 'kibana')
         .responseType('blob')
@@ -48,6 +48,7 @@ export default function ({ getService }) {
       expect(feature.extent).to.be(4096);
       expect(feature.id).to.be(undefined);
       expect(feature.properties).to.eql({
+        '@timestamp': '1442709961071',
         _id: 'AU_x3_BsGFA8no6Qjjug',
         _index: 'logstash-2015.09.20',
         bytes: 9252,


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #124530

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
