### PR TITLE
[DOCS] Synced with stack upgrade changes

### DIFF
--- a/docs/management/upgrade-assistant/index.asciidoc
+++ b/docs/management/upgrade-assistant/index.asciidoc
@@ -17,7 +17,7 @@ IMPORTANT: To see the most up-to-date deprecation information before
 upgrading to 8.0, upgrade to the latest {prev-major-last} release.
 
 For more information about upgrading, 
-see {stack-ref}/upgrading-stack.html[Upgrading to Elastic {version}.]
+refer to {stack-ref}/upgrading-stack.html[Upgrading to Elastic {version}.]
 
 [discrete]
 === Required permissions

--- a/docs/management/upgrade-assistant/index.asciidoc
+++ b/docs/management/upgrade-assistant/index.asciidoc
@@ -11,10 +11,13 @@ enables you to see if you are using deprecated features,
 and guides you through the process of resolving issues.
 
 If you have indices that were created prior to 7.0,
-you can use the assistant to reindex them so they can be accessed from 8.0. 
+you can use the assistant to reindex them so they can be accessed from 8.0+. 
 
 IMPORTANT: To see the most up-to-date deprecation information before 
-upgrading to 8.0, upgrade to the latest 7.n release.
+upgrading to 8.0, upgrade to the latest {prev-major-last} release.
+
+For more information about upgrading, 
+see {stack-ref}/upgrading-stack.html[Upgrading to Elastic {version}.]
 
 [discrete]
 === Required permissions

--- a/docs/management/upgrade-assistant/index.asciidoc
+++ b/docs/management/upgrade-assistant/index.asciidoc
@@ -17,7 +17,7 @@ IMPORTANT: To see the most up-to-date deprecation information before
 upgrading to 8.0, upgrade to the latest {prev-major-last} release.
 
 For more information about upgrading, 
-refer to {stack-ref}/upgrading-stack.html[Upgrading to Elastic {version}.]
+refer to {stack-ref}/upgrading-elastic-stack.html[Upgrading to Elastic {version}.]
 
 [discrete]
 === Required permissions

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -385,3 +385,13 @@ This content has moved. Refer to <<managing-data-views>>.
 == Kibana role management.
 
 This content has moved. Refer to <<kibana-role-management>>.
+
+[role="exclude" logging-configuration-changes]
+== Logging configuration changes 
+
+This content has moved. Refer to <<logging-config-changes>>.
+
+[role="exclude" upgrade-migrations]
+== Upgrade migrations
+
+This content has moved. Refer to <<saved-object-migrations>>.

--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -1,79 +1,35 @@
 [[upgrade]]
 == Upgrade {kib}
 
-You can always upgrade to the latest patch release or from one minor version 
-to another within the same major version series.
+To upgrade from 7.16 or earlier to {version}, 
+**you must first upgrade to {prev-major-last}**.
+This enables you to use the Upgrade Assistant to <<prepare-to-upgrade, prepare to upgrade>>.
+You must resolve all critical issues identified by the Upgrade Assistant
+before proceeding with the upgrade. 
 
-For major version upgrades:
-
-. Upgrade to the last minor version released before the new major version.
-. Use the Upgrade Assistant to determine what changes you need to make before the major version upgrade.
-. When you've addressed all the critical issues, upgrade {es} and then upgrade {kib}.
-
-IMPORTANT: You can upgrade to pre-release versions of 8.0 for testing, 
-but upgrading from a pre-release to the final GA version is not supported.
-Pre-releases should only be used for testing in a temporary environment.
-
-[discrete]
-[[upgrade-paths]]
-=== Recommended upgrade paths to 8.0
-
-[cols="<1,3",options="header",]
-|====
-|Upgrading from   
-|Upgrade path 
-
-|7.16
-|Upgrade to 8.0
-
-|6.8–7.15
-a|
-
-. Upgrade to 7.16
-. Upgrade to 8.0
-
-|6.0–6.7
-a|
-
-. Upgrade to 6.8
-. Upgrade to 7.16
-. Upgrade to 8.0
-|====
-
-[float]
-[[upgrade-before-you-begin]]
-=== Before you begin
+{kib} does not support rolling upgrades. 
+You must shut down all Kibana instances, install the new software, and restart Kibana.
+Upgrading while older {kib} instances are running can cause data loss or upgrade failures.
 
 [WARNING]
 ====
-{kib} automatically runs upgrade migrations when required. To roll back to an
+{kib} automatically runs <<upgrade migrations, upgrade migrations>> when required. 
+To roll back to an
 earlier version in case of an upgrade failure, you **must** have a
 {ref}/snapshot-restore.html[backup snapshot] that includes the `kibana` feature
 state. Snapshots include this feature state by default.
-
-For more information, refer to <<upgrade-migrations, upgrade migrations>>.
 ====
 
-Before you upgrade {kib}:
+For more information about upgrading, 
+see {stack-ref}/upgrading-stack.html[Upgrading to Elastic {version}.]
 
-* Consult the <<breaking-changes,breaking changes>>.
-* {ref}/snapshots-take-snapshot.html[Take a snapshot] of your data. To roll back to an earlier version, the snapshot must include the `kibana` feature state.
-* Before you upgrade production servers, test the upgrades in a dev environment.
-* See <<preventing-migration-failures, preventing migration failures>> for common reasons upgrades fail and how to prevent these.
-* If you are using custom plugins, check that a compatible version is
-  available.
-* Shut down all {kib} instances. Running more than one {kib} version against
-  the same Elasticseach index is unsupported. Upgrading while older {kib}
-  instances are running can cause data loss or upgrade failures.
-  
-NOTE: {kib} logging system may have changed, depending on your target version. For details, see <<logging-configuration, Configure logging>>.
+IMPORTANT: You can upgrade to pre-release versions for testing, 
+but upgrading from a pre-release to the final GA version is not supported.
+Pre-releases should only be used for testing in a temporary environment.
 
-To identify the changes you need to make to upgrade, and to enable you to
-perform an Elasticsearch rolling upgrade with no downtime, you must upgrade to
-6.7 before you upgrade to 7.0.
 
-For a comprehensive overview of the upgrade process, refer to
-*{stack-ref}/upgrading-elastic-stack.html[Upgrading the Elastic Stack]*.
+
+
 
 [float]
 [[upgrade-5x-earlier]]
@@ -96,18 +52,6 @@ Assistant to prepare for your upgrade to 7.0.
 
 TIP: The ability to import {kib} 6.x saved searches, visualizations, and
 dashboards is supported.
-
-[float]
-[[upgrade-67]]
-=== Upgrade from 6.8
-To help you prepare for your upgrade to 7.0, 6.8 includes an https://www.elastic.co/guide/en/kibana/6.8/upgrade-assistant.html[Upgrade Assistant]
-To access the assistant, go to *Management > 7.0 Upgrade Assistant*.
-
-After you have addressed any issues that were identified by the Upgrade
-Assistant, <<upgrade-standard,upgrade to 7.0>>.
-
-
-include::upgrade/upgrade-standard.asciidoc[]
 
 include::upgrade/upgrade-migrations.asciidoc[]
 

--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -4,7 +4,7 @@
 To upgrade from 7.16 or earlier to {version}, 
 **You must first upgrade to {prev-major-last}**.
 This enables you to use the Upgrade Assistant to
-{stack-ref}/upgrading-stack.html#prepare-to-upgrade[prepare to upgrade].
+{stack-ref}/upgrading-elastic-stack.html#prepare-to-upgrade[prepare to upgrade].
 You must resolve all critical issues identified by the Upgrade Assistant
 before proceeding with the upgrade. 
 

--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -2,31 +2,31 @@
 == Upgrade {kib}
 
 To upgrade from 7.16 or earlier to {version}, 
-**you must first upgrade to {prev-major-last}**.
+**You must first upgrade to {prev-major-last}**.
 This enables you to use the Upgrade Assistant to
 {stack-ref}/upgrading-stack.html#prepare-to-upgrade[prepare to upgrade].
 You must resolve all critical issues identified by the Upgrade Assistant
 before proceeding with the upgrade. 
 
 {kib} does not support rolling upgrades. 
-You must shut down all Kibana instances, install the new software, and restart Kibana.
+You must shut down all {kib} instances, install the new software, and restart {kib}.
 Upgrading while older {kib} instances are running can cause data loss or upgrade failures.
 
 [WARNING]
 ====
 {kib} automatically runs <<saved-object-migrations, saved object migrations>> 
 when required. 
-To roll back to an
-earlier version in case of an upgrade failure, you **must** have a
+In case of an upgrade failure, you can roll back to an
+earlier version of {kib}. To roll back, you **must** have a
 {ref}/snapshot-restore.html[backup snapshot] that includes the `kibana` feature
 state. Snapshots include this feature state by default.
 ====
 
 For more information about upgrading, 
-see {stack-ref}/upgrading-stack.html[Upgrading to Elastic {version}.]
+refer to {stack-ref}/upgrading-stack.html[Upgrading to Elastic {version}.]
 
 IMPORTANT: You can upgrade to pre-release versions for testing, 
-but upgrading from a pre-release to the final GA version is not supported.
+but upgrading from a pre-release to the General Available version is not supported.
 Pre-releases should only be used for testing in a temporary environment.
 
 include::upgrade/upgrade-migrations.asciidoc[leveloffset=-1]

--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -3,7 +3,8 @@
 
 To upgrade from 7.16 or earlier to {version}, 
 **you must first upgrade to {prev-major-last}**.
-This enables you to use the Upgrade Assistant to <<prepare-to-upgrade, prepare to upgrade>>.
+This enables you to use the Upgrade Assistant to
+{stack-ref}/upgrading-stack.html#prepare-to-upgrade[prepare to upgrade].
 You must resolve all critical issues identified by the Upgrade Assistant
 before proceeding with the upgrade. 
 
@@ -13,7 +14,8 @@ Upgrading while older {kib} instances are running can cause data loss or upgrade
 
 [WARNING]
 ====
-{kib} automatically runs <<upgrade migrations, upgrade migrations>> when required. 
+{kib} automatically runs <<saved-object-migrations, saved object migrations>> 
+when required. 
 To roll back to an
 earlier version in case of an upgrade failure, you **must** have a
 {ref}/snapshot-restore.html[backup snapshot] that includes the `kibana` feature
@@ -27,32 +29,6 @@ IMPORTANT: You can upgrade to pre-release versions for testing,
 but upgrading from a pre-release to the final GA version is not supported.
 Pre-releases should only be used for testing in a temporary environment.
 
-
-
-
-
-[float]
-[[upgrade-5x-earlier]]
-=== Upgrade from 5.x or earlier
-{es} can read indices created in the previous major version. Before you upgrade
-to 7.0.0, you must reindex or delete any indices created in 5.x or earlier.
-For more information, refer to
-{stack-ref}/upgrading-elastic-stack.html[Upgrading the Elastic Stack].
-
-When your reindex is complete, follow the <<upgrade-standard, Standard upgrade>>
-instructions.
-
-[float]
-[[upgrade-6x]]
-=== Upgrade from 6.x
-
-The recommended path is to upgrade to 6.8 before upgrading to 7.0. This makes it
-easier to identify the required changes, and enables you to use the Upgrade
-Assistant to prepare for your upgrade to 7.0.
-
-TIP: The ability to import {kib} 6.x saved searches, visualizations, and
-dashboards is supported.
-
-include::upgrade/upgrade-migrations.asciidoc[]
+include::upgrade/upgrade-migrations.asciidoc[leveloffset=-1]
 
 include::upgrade/logging-configuration-changes.asciidoc[]

--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -23,7 +23,7 @@ state. Snapshots include this feature state by default.
 ====
 
 For more information about upgrading, 
-refer to {stack-ref}/upgrading-stack.html[Upgrading to Elastic {version}.]
+refer to {stack-ref}/upgrading-elastic-stack.html[Upgrading to Elastic {version}.]
 
 IMPORTANT: You can upgrade to pre-release versions for testing, 
 but upgrading from a pre-release to the General Available version is not supported.

--- a/docs/setup/upgrade/logging-configuration-changes.asciidoc
+++ b/docs/setup/upgrade/logging-configuration-changes.asciidoc
@@ -1,4 +1,5 @@
-[[logging-configuration-changes]]
+[discrete]
+[[logging-conf-changes]]
 === Logging configuration changes
 
 WARNING: {kib} 8.0 and later uses a new logging system. Be sure to read the documentation for your version of {kib} before proceeding.

--- a/docs/setup/upgrade/logging-configuration-changes.asciidoc
+++ b/docs/setup/upgrade/logging-configuration-changes.asciidoc
@@ -1,5 +1,5 @@
 [discrete]
-[[logging-conf-changes]]
+[[logging-config-changes]]
 === Logging configuration changes
 
 WARNING: {kib} 8.0 and later uses a new logging system. Be sure to read the documentation for your version of {kib} before proceeding.

--- a/docs/setup/upgrade/upgrade-migrations.asciidoc
+++ b/docs/setup/upgrade/upgrade-migrations.asciidoc
@@ -1,4 +1,4 @@
-[discrete]
+[float]
 [[saved-object-migrations]]
 === Saved object migrations
 

--- a/docs/setup/upgrade/upgrade-migrations.asciidoc
+++ b/docs/setup/upgrade/upgrade-migrations.asciidoc
@@ -1,5 +1,6 @@
-[[upgrade-migrations]]
-=== Upgrade migrations
+[discrete]
+[[saved-object-migrations]]
+=== Saved object migrations
 
 Every time {kib} is upgraded it will perform an upgrade migration to ensure that all <<managing-saved-objects,saved objects>> are compatible with the new version.
 


### PR DESCRIPTION
Updated to reference the consolidated upgrade instructions in the Stack upgrade guide and make it clear that you must upgrade to 7.17 before upgrading to 8.0+. 

 Relates to: https://github.com/elastic/stack-docs/pull/1970