### PR TITLE
Add github action for adding tech debt items to Fleet project

### DIFF
--- a/.github/workflows/add-to-fleet-project.yml
+++ b/.github/workflows/add-to-fleet-project.yml
@@ -1,0 +1,28 @@
+name: Add to Fleet:Quality project
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    if: |
+      contains(github.event.issue.labels.*.name, 'Team:Fleet') && contains(github.event.issue.labels.*.name, 'technical debt')
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:String!,$contentid:String!) {
+              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          contentid: ${{ github.event.issue.node_id }}
+        env:
+          PROJECT_ID: "PN_kwDOAGc3Zs4AAsH6"
+          GITHUB_TOKEN: ${{ secrets.FLEET_TECH_KIBANA_USER_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a new Github action for adding items labeled with `Team:Fleet` and `technical debt` to our org-level project board. This is using Projects beta which requires different API calls than the generic project labeler in use today so I added a distinct workflow that mirrors the one used by APM currently.
