### PR TITLE
[Fleet] [8.0.1] Fix navigation to blank screen when creating inline Agent Policy after clicking "Add Integration" on integration settings page

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
@@ -24,7 +24,7 @@ import {
 import type { EuiStepProps } from '@elastic/eui/src/components/steps/step';
 import { safeLoad } from 'js-yaml';
 
-import { splitPkgKey } from '../../../../../../common';
+import { PLUGIN_ID, splitPkgKey } from '../../../../../../common';
 import type {
   AgentPolicy,
   NewPackagePolicy,
@@ -317,7 +317,14 @@ export const CreatePackagePolicyPage: React.FunctionComponent = () => {
             mappingOptions: routeState.onSaveQueryParams,
             paramsToApply,
           });
-          navigateToApp(appId, { ...options, path: pathWithQueryString });
+
+          // In the case of a new policy creation, we always navigate to the Fleet agent policy details page
+          // for the newly-created policy
+          if (wasNewAgentPolicyCreated) {
+            navigateToApp(PLUGIN_ID, { ...options, path: pathWithQueryString });
+          } else {
+            navigateToApp(appId, { ...options, path: pathWithQueryString });
+          }
         } else {
           navigateToApp(...routeState.onSaveNavigateTo);
         }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/124784

Fix bug with navigation when creating an inline Agent Policy after entering the "Create Policy" flow from the Integration Details screen.

**PR is filed directly to 8.0 because this UI has fundamentally changed in 8.1 after https://github.com/elastic/kibana/pull/121628 - and this bug is no longer present**