### PR TITLE
[Response Ops][Cases] Fixing duplicate service initialization

### DIFF
--- a/x-pack/plugins/cases/server/client/factory.ts
+++ b/x-pack/plugins/cases/server/client/factory.ts
@@ -116,7 +116,7 @@ export class CasesClientFactory {
       caseConfigureService: new CaseConfigureService(this.logger),
       connectorMappingsService: new ConnectorMappingsService(this.logger),
       userActionService: new CaseUserActionService(this.logger),
-      attachmentService: new AttachmentService(this.logger),
+      attachmentService,
       logger: this.logger,
       lensEmbeddableFactory: this.options.lensEmbeddableFactory,
       authorization: auth,


### PR DESCRIPTION
This PR removes the attachment service from being created twice. Instead we should pass the first initialized service.