### PR TITLE
[8.1] [DOCS] Removes tag from 8.0.0-rc2 release notes (#123743)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -20,8 +20,6 @@ Review important information about the {kib} 8.0.0 releases.
 [[release-notes-8.0.0-rc2]]
 == {kib} 8.0.0-rc2
 
-coming::[8.0.0-rc2]
-
 For information about the {kib} 8.0.0-rc2 release, review the following information.
 
 [float]


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.1` of:
 - #123743

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
