### PR TITLE
[Fleet] do not allow empty name for agent policy

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
@@ -206,7 +206,12 @@ export const CreatePackagePolicyPage: React.FunctionComponent = () => {
     updatedAgentPolicy: NewAgentPolicy
   ) => {
     if (selectedTab === SelectedPolicyTab.NEW) {
-      if (!updatedAgentPolicy.name || !updatedAgentPolicy.namespace) {
+      if (
+        !updatedAgentPolicy.name ||
+        updatedAgentPolicy.name.trim() === '' ||
+        !updatedAgentPolicy.namespace ||
+        updatedAgentPolicy.namespace.trim() === ''
+      ) {
         setHasAgentPolicyError(true);
       } else {
         setHasAgentPolicyError(false);

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -11,9 +11,15 @@ import { agentPolicyStatuses, dataTypes } from '../../../common';
 
 import { PackagePolicySchema, NamespaceSchema } from './package_policy';
 
+function validateNonEmptyString(val: string) {
+  if (val.trim() === '') {
+    return 'Invalid empty string';
+  }
+}
+
 export const AgentPolicyBaseSchema = {
   id: schema.maybe(schema.string()),
-  name: schema.string({ minLength: 1 }),
+  name: schema.string({ minLength: 1, validate: validateNonEmptyString }),
   namespace: NamespaceSchema,
   description: schema.maybe(schema.string()),
   is_managed: schema.maybe(schema.boolean()),

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -101,6 +101,17 @@ export default function (providerContext: FtrProviderContext) {
           .expect(400);
       });
 
+      it('should return a 400 with an empty name', async () => {
+        await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: '  ',
+            namespace: 'default',
+          })
+          .expect(400);
+      });
+
       it('should return a 400 with an invalid namespace', async () => {
         await supertest
           .post(`/api/fleet/agent_policies`)


### PR DESCRIPTION
## Summary

Resolve #124679 

Do not allow to create an agent policy with only space in the name

This is fixed in the UI by blocking the click on save and in the API by returning a 400.

<img width="1625" alt="Screen Shot 2022-02-07 at 12 50 40 PM" src="https://user-images.githubusercontent.com/1336873/152844246-8b25cf92-b795-433b-aacd-9b355cb989fd.png">

