### PR TITLE
[8.1] [ResponseOps] Improves check interval tooltip (#124671)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_form/alert_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_form/alert_form.tsx
@@ -585,7 +585,8 @@ export const AlertForm = ({
         position="right"
         type="questionInCircle"
         content={i18n.translate('xpack.triggersActionsUI.sections.alertForm.checkWithTooltip', {
-          defaultMessage: 'Define how often to evaluate the condition.',
+          defaultMessage:
+            'Define how often to evaluate the condition. Checks are queued; they run as close to the defined value as capacity allows.',
         })}
       />
     </>


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [ResponseOps] Improves check interval tooltip (#124671)