### PR TITLE
[DOCS] Fix typo in Kibana upgrade docs

### DIFF
--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -2,7 +2,7 @@
 == Upgrade {kib}
 
 To upgrade from 7.16 or earlier to {version}, 
-**You must first upgrade to {prev-major-last}**.
+**you must first upgrade to {prev-major-last}**.
 This enables you to use the Upgrade Assistant to
 {stack-ref}/upgrading-elastic-stack.html#prepare-to-upgrade[prepare to upgrade].
 You must resolve all critical issues identified by the Upgrade Assistant


### PR DESCRIPTION
Fixes a minor typo in the 8.x upgrade docs.