### PR TITLE
Update x-pack readme to fix broken link

### DIFF
--- a/x-pack/README.md
+++ b/x-pack/README.md
@@ -16,7 +16,7 @@ By default, this will also set the password for native realm accounts to the pas
 
 # Testing
 
-For information on testing, see [the Elastic functional test development guide](https://www.elastic.co/guide/en/kibana/current/development-functional-tests.html).
+For information on testing, see [the Elastic functional test development guide](https://www.elastic.co/guide/en/kibana/current/development-tests.html).
 
 #### Running functional tests
 


### PR DESCRIPTION
## Summary

This PR fixes a broken link I happened to notice. Functional testing info is now available at https://www.elastic.co/guide/en/kibana/current/development-tests.html in the Kibana Developer Guide (currently the 7.17 guide).



