### PR TITLE
[8.0] [DOCS] Fix typo (#124872)

### DIFF
--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -2,7 +2,7 @@
 == Upgrade {kib}
 
 To upgrade from 7.16 or earlier to {version}, 
-**You must first upgrade to {prev-major-last}**.
+**you must first upgrade to {prev-major-last}**.
 This enables you to use the Upgrade Assistant to
 {stack-ref}/upgrading-elastic-stack.html#prepare-to-upgrade[prepare to upgrade].
 You must resolve all critical issues identified by the Upgrade Assistant


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #124872

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
