### PR TITLE
[7.11] [DOCS] Clarified the upgrade path from 6.last (#124769)

### DIFF
--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -23,7 +23,7 @@ ifeval::[ "{version}" != "{minor-version}.0" ]
 |Upgrade to {version}
 endif::[]
 
-|7.0–7.16
+|7.0–7.10
 |Upgrade to {version}
 
 |6.8

--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -23,7 +23,7 @@ ifeval::[ "{version}" != "{minor-version}.0" ]
 |Upgrade to {version}
 endif::[]
 
-|7.0–7.13
+|7.0–7.16
 |Upgrade to {version}
 
 |6.8
@@ -49,10 +49,9 @@ a|
 . Upgrade to {version}
 |====
 
-[WARNING]
-====
-The upgrade path from 6.8 to 7.0 is *not* supported.
-====
+// tag::7.0-upgrade-warning[]
+WARNING: Upgrading from 6.8 to 7.0 is *not* supported. Upgrade directly to {version} instead.
+// end::7.0-upgrade-warning[]
 
 [float]
 [[upgrade-before-you-begin]]
@@ -73,20 +72,19 @@ Before you upgrade {kib}:
   the same Elasticseach index is unsupported. Upgrading while older {kib}
   instances are running can cause data loss or upgrade failures.
 
-To identify the changes you need to make to upgrade, and to enable you to
-perform an Elasticsearch rolling upgrade with no downtime, you must upgrade to
-6.7 before you upgrade to 7.0.
-
 For a comprehensive overview of the upgrade process, refer to
 *{stack-ref}/upgrading-elastic-stack.html[Upgrading the Elastic Stack]*.
 
 
 [float]
 [[upgrade-5x-earlier]]
-=== Upgrade from 5.x or earlier
-{es} can read indices created in the previous major version. Before you upgrade
-to 7.0.0, you must reindex or delete any indices created in 5.x or earlier.
-For more information, refer to
+=== Upgrade from 5.6 or earlier
+To identify the changes you need to make to upgrade, and to enable you to
+perform an Elasticsearch rolling upgrade with no downtime, you must upgrade to
+6.8 before you upgrade to {version}.
+
+{es} {version} can't read indices created in 5.6 or earlier versions. Before you
+upgrade from 6.8 to {version}, you must reindex or delete these indices. For more information, refer to
 {stack-ref}/upgrading-elastic-stack.html#oss-stack-upgrade[Upgrading the Elastic Stack].
 
 When your reindex is complete, follow the <<upgrade-standard, Standard upgrade>>
@@ -94,34 +92,39 @@ instructions.
 
 [float]
 [[upgrade-6x]]
-=== Upgrade from 6.x
+=== Upgrade from 6.7 or earlier
 
-The recommended path is to upgrade to 6.8 before upgrading to 7.0. This makes it
-easier to identify the required changes, and enables you to use the Upgrade
-Assistant to prepare for your upgrade to 7.0.
+The recommended path is to upgrade to 6.8 before upgrading to {version}. This
+makes it easier to identify the required changes and enables you to use the
+Upgrade Assistant to prepare for your upgrade.
 
-TIP: The ability to import {kib} 6.x saved searches, visualizations, and
-dashboards is supported.
+include::upgrade.asciidoc[tag=7.0-upgrade-warning]
+
+You can import {kib} 6.x saved searches, visualizations, and
+dashboards in {version}.
 
 [float]
 [[upgrade-67]]
 === Upgrade from 6.8
-To help you prepare for your upgrade to 7.0, 6.8 includes an https://www.elastic.co/guide/en/kibana/6.8/upgrade-assistant.html[Upgrade Assistant]
-To access the assistant, go to *Management > 7.0 Upgrade Assistant*.
+To help you prepare for your upgrade to {version}, 6.8 includes an
+https://www.elastic.co/guide/en/kibana/6.8/upgrade-assistant.html[Upgrade
+Assistant]. To access the assistant, go to *Management > 7.0 Upgrade Assistant*.
+
+include::upgrade.asciidoc[tag=7.0-upgrade-warning]
 
 After you have addressed any issues that were identified by the Upgrade
-Assistant, <<upgrade-standard,upgrade to 7.0>>.
+Assistant, <<upgrade-standard,upgrade to {version}>>.
 
 [float]
 === Known issues
 
 [float]
 ==== "shard failed" error when viewing {beats} dashboards in {kib}
-After upgrading to {es} 7.0, any indices created by {beats} 6.6 or older will not
+After upgrading to {es} {version}, any indices created by {beats} 6.6 or older will not
 work in {kib} dashboards until the `index.query.default_field` setting is added
 to each index. Indices created in {beats} 6.7 or later are unaffected.
 To add the setting to the index, you can use the 7.0
-{kibana-ref}/upgrade-assistant.html[Upgrade Assistant], or
+{kibana-ref-all}/6.8/upgrade-assistant.html[Upgrade Assistant] before upgrading, or
 //{beats-ref}/upgrading.html#dashboard-shard-failed[
 add the setting manually
 //]


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.11` of:
 - #124769

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
