### PR TITLE
[Fleet] Fix docker registry timeout in integration tests

### DIFF
--- a/x-pack/plugins/fleet/server/integration_tests/docker_registry_helper.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/docker_registry_helper.ts
@@ -12,6 +12,8 @@ import fetch from 'node-fetch';
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const DOCKER_START_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+
 export function useDockerRegistry() {
   const packageRegistryPort = process.env.FLEET_PACKAGE_REGISTRY_PORT || '8081';
 
@@ -32,8 +34,9 @@ export function useDockerRegistry() {
       isExited = true;
     });
 
-    let retries = 0;
-    while (!isExited && retries++ <= 20) {
+    const startedAt = Date.now();
+
+    while (!isExited && Date.now() - startedAt <= DOCKER_START_TIMEOUT) {
       try {
         const res = await fetch(`http://localhost:${packageRegistryPort}/`);
         if (res.status === 200) {


### PR DESCRIPTION
## Summary

Resolve #124780 #124781 #124779 

Adjust the timeout for the startup time for the docker registry to 5 minutes instead of `~1minutes` as pulling the registry image can take some time.

