### PR TITLE
[data views] don't allow single `*` index pattern

### DIFF
--- a/src/plugins/data_view_editor/public/components/form_schema.test.ts
+++ b/src/plugins/data_view_editor/public/components/form_schema.test.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { singleAstriskValidator } from './form_schema';
+import { ValidationFuncArg } from '../shared_imports';
+
+describe('validators', () => {
+  test('singleAstriskValidator should pass', async () => {
+    const result = singleAstriskValidator({ value: 'kibana*' } as ValidationFuncArg<any, any>);
+    expect(result).toBeUndefined();
+  });
+  test('singleAstriskValidator should fail', async () => {
+    const result = singleAstriskValidator({ value: '*' } as ValidationFuncArg<any, any>);
+    // returns error
+    expect(result).toBeDefined();
+  });
+});

--- a/src/plugins/data_view_editor/public/components/form_schema.ts
+++ b/src/plugins/data_view_editor/public/components/form_schema.ts
@@ -38,19 +38,6 @@ export const schema = {
 
           return value === '*' ? { code: 'ERR_FIELD_MISSING', path, message } : undefined;
         },
-
-        /*
-          if (Array.isArray(value)) {
-            return isEmptyArray(value) ? { code: 'ERR_FIELD_MISSING', path, message } : undefined;
-          }
-        },
-        /*
-        fieldValidators.emptyField(
-          i18n.translate('indexPatternEditor.validations.noSingleAstriskPattern', {
-            defaultMessage: "a single '*' is not an allowed index pattern",
-          })
-        ),
-        */
       },
     ],
   },

--- a/src/plugins/data_view_editor/public/components/form_schema.ts
+++ b/src/plugins/data_view_editor/public/components/form_schema.ts
@@ -7,7 +7,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { fieldValidators } from '../shared_imports';
+import { fieldValidators, ValidationFunc } from '../shared_imports';
 import { INDEX_PATTERN_TYPE } from '../types';
 
 export const schema = {
@@ -27,6 +27,30 @@ export const schema = {
             defaultMessage: 'A name is required.',
           })
         ),
+      },
+      {
+        validator: (...args: Parameters<ValidationFunc>): ReturnType<ValidationFunc> => {
+          const [{ value, path }] = args;
+
+          const message = i18n.translate('indexPatternEditor.validations.noSingleAstriskPattern', {
+            defaultMessage: "A single '*' is not an allowed index pattern",
+          });
+
+          return value === '*' ? { code: 'ERR_FIELD_MISSING', path, message } : undefined;
+        },
+
+        /*
+          if (Array.isArray(value)) {
+            return isEmptyArray(value) ? { code: 'ERR_FIELD_MISSING', path, message } : undefined;
+          }
+        },
+        /*
+        fieldValidators.emptyField(
+          i18n.translate('indexPatternEditor.validations.noSingleAstriskPattern', {
+            defaultMessage: "a single '*' is not an allowed index pattern",
+          })
+        ),
+        */
       },
     ],
   },

--- a/src/plugins/data_view_editor/public/components/form_schema.ts
+++ b/src/plugins/data_view_editor/public/components/form_schema.ts
@@ -10,6 +10,18 @@ import { i18n } from '@kbn/i18n';
 import { fieldValidators, ValidationFunc } from '../shared_imports';
 import { INDEX_PATTERN_TYPE } from '../types';
 
+export const singleAstriskValidator = (
+  ...args: Parameters<ValidationFunc>
+): ReturnType<ValidationFunc> => {
+  const [{ value, path }] = args;
+
+  const message = i18n.translate('indexPatternEditor.validations.noSingleAstriskPattern', {
+    defaultMessage: "A single '*' is not an allowed index pattern",
+  });
+
+  return value === '*' ? { code: 'ERR_FIELD_MISSING', path, message } : undefined;
+};
+
 export const schema = {
   title: {
     label: i18n.translate('indexPatternEditor.editor.form.titleLabel', {
@@ -29,15 +41,7 @@ export const schema = {
         ),
       },
       {
-        validator: (...args: Parameters<ValidationFunc>): ReturnType<ValidationFunc> => {
-          const [{ value, path }] = args;
-
-          const message = i18n.translate('indexPatternEditor.validations.noSingleAstriskPattern', {
-            defaultMessage: "A single '*' is not an allowed index pattern",
-          });
-
-          return value === '*' ? { code: 'ERR_FIELD_MISSING', path, message } : undefined;
-        },
+        validator: singleAstriskValidator,
       },
     ],
   },

--- a/src/plugins/data_view_editor/public/shared_imports.ts
+++ b/src/plugins/data_view_editor/public/shared_imports.ts
@@ -28,6 +28,7 @@ export type {
   ValidationFunc,
   FieldConfig,
   ValidationConfig,
+  ValidationFuncArg,
 } from '../../es_ui_shared/static/forms/hook_form_lib';
 export {
   useForm,


### PR DESCRIPTION
## Summary

The create data view flow was unable to fetch time fields for the index pattern `*` - Rather than fix this, its better to disallow it as searching a whole cluster for all its fields can have a negative performance impact and I can't think of a practical application of `*`.


Closes: https://github.com/elastic/kibana/issues/122899