### PR TITLE
[Dashboard] Fix URL App State Removal

### DIFF
--- a/src/plugins/dashboard/public/application/lib/sync_dashboard_url_state.ts
+++ b/src/plugins/dashboard/public/application/lib/sync_dashboard_url_state.ts
@@ -94,13 +94,13 @@ const loadDashboardUrlState = ({
   if (!awaitingRemoval) {
     awaitingRemoval = true;
     kbnUrlStateStorage.kbnUrlControls.updateAsync((nextUrl) => {
+      awaitingRemoval = false;
       if (nextUrl.includes(DASHBOARD_STATE_STORAGE_KEY)) {
         return replaceUrlHashQuery(nextUrl, (query) => {
           delete query[DASHBOARD_STATE_STORAGE_KEY];
           return query;
         });
       }
-      awaitingRemoval = false;
       return nextUrl;
     }, true);
   }


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/124815

The issue was caused by app state not being properly removed from the URL. When a dashboard is saved as new, the URL changes to the view URL of the newly created ID. This is in edit mode. Normally the app state from the URL is consumed and removed, but a bug introduced in https://github.com/elastic/kibana/pull/118213 caused the app state from the initial save to stick around. 

Additionally, https://github.com/elastic/kibana/pull/109354 injected the state from the URL into the dashboard state on soft refreshes. These two issues combined to create the issue that this PR fixes 
