### PR TITLE
Remove tabify performance issue

### DIFF
--- a/src/plugins/data/common/search/tabify/tabify.test.ts
+++ b/src/plugins/data/common/search/tabify/tabify.test.ts
@@ -8,7 +8,7 @@
 
 import { tabifyAggResponse } from './tabify';
 import { IndexPattern } from '../..';
-import { AggConfigs, IAggConfig, IAggConfigs } from '../aggs';
+import { AggConfigs, BucketAggParam, IAggConfig, IAggConfigs } from '../aggs';
 import { mockAggTypesRegistry } from '../aggs/test_helpers';
 import { metricOnly, threeTermBuckets } from './fixtures/fake_hierarchical_data';
 
@@ -52,6 +52,42 @@ describe('tabifyAggResponse Integration', () => {
 
     expect(resp.rows[0]).toEqual({ 'col-0-1': 1000 });
     expect(resp.columns[0]).toHaveProperty('name', aggConfigs.aggs[0].makeLabel());
+  });
+
+  describe('scaleMetricValues performance check', () => {
+    beforeAll(() => {
+      typesRegistry.get('count').params.push({
+        name: 'scaleMetricValues',
+        default: false,
+        write: () => {},
+        advanced: true,
+      } as any as BucketAggParam<any>);
+    });
+    test('does not call write if scaleMetricValues is not set', () => {
+      const aggConfigs = createAggConfigs([{ type: 'count' } as any]);
+
+      const writeMock = jest.fn();
+      aggConfigs.getRequestAggs()[0].write = writeMock;
+
+      tabifyAggResponse(aggConfigs, metricOnly, {
+        metricsAtAllLevels: true,
+      });
+      expect(writeMock).not.toHaveBeenCalled();
+    });
+
+    test('does call write if scaleMetricValues is set', () => {
+      const aggConfigs = createAggConfigs([
+        { type: 'count', params: { scaleMetricValues: true } } as any,
+      ]);
+
+      const writeMock = jest.fn(() => ({}));
+      aggConfigs.getRequestAggs()[0].write = writeMock;
+
+      tabifyAggResponse(aggConfigs, metricOnly, {
+        metricsAtAllLevels: true,
+      });
+      expect(writeMock).toHaveBeenCalled();
+    });
   });
 
   describe('transforms a complex response', () => {

--- a/src/plugins/data/common/search/tabify/tabify.ts
+++ b/src/plugins/data/common/search/tabify/tabify.ts
@@ -37,8 +37,10 @@ export function tabifyAggResponse(
 
     if (column) {
       const agg = column.aggConfig;
-      const aggInfo = agg.write(aggs);
-      aggScale *= aggInfo.metricScale || 1;
+      if (agg.getParam('scaleMetricValues')) {
+        const aggInfo = agg.write(aggs);
+        aggScale *= aggInfo.metricScale || 1;
+      }
 
       switch (agg.type.type) {
         case AggGroupNames.Buckets:


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/123591

See details about the issue in https://github.com/elastic/kibana/issues/123591#issuecomment-1031718173

Before:
<img width="983" alt="Screenshot 2022-02-08 at 12 10 14" src="https://user-images.githubusercontent.com/1508364/152976081-0b508f20-bf69-4d15-bfd6-feb6c86b258c.png">

After:
<img width="303" alt="Screenshot 2022-02-08 at 12 09 38" src="https://user-images.githubusercontent.com/1508364/152976637-8c8fc46a-17ab-41c0-b3d5-7cec6d85d16f.png">

To test, configure a chart with lots of buckets (lots of time buckets plus lots of series). It should get noticeably faster.

The legacy setting that should still work (albeit with sub-optimal performance) is "scale metric values" for date histograms in Visualize (in case the configured interval is too small for the current time range and scaled up, like in this case from per second to hourly, the metrics are scaled in the same way):
<img width="1217" alt="Screenshot 2022-02-08 at 12 15 14" src="https://user-images.githubusercontent.com/1508364/152976446-20a25eae-e83c-45f0-8440-50b134e119c1.png">
<img width="1276" alt="Screenshot 2022-02-08 at 12 15 21" src="https://user-images.githubusercontent.com/1508364/152976451-9203d619-095c-419f-ae80-77f2ef90fc6c.png">
