### PR TITLE
[Security Solution][Endpoint] Unify remove artifact from policy message and fix back buttons

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/delete_modal/policy_event_filters_delete_modal.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/delete_modal/policy_event_filters_delete_modal.test.tsx
@@ -39,6 +39,7 @@ describe('Policy details event filter delete modal', () => {
         renderResult = mockedContext.render(
           <PolicyEventFiltersDeleteModal
             policyId={policyId}
+            policyName="fakeName"
             onCancel={onCancel}
             exception={exception}
           />

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/delete_modal/policy_event_filters_delete_modal.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/delete_modal/policy_event_filters_delete_modal.tsx
@@ -16,10 +16,12 @@ import { useBulkUpdateEventFilters } from '../hooks';
 
 export const PolicyEventFiltersDeleteModal = ({
   policyId,
+  policyName,
   exception,
   onCancel,
 }: {
   policyId: string;
+  policyName: string;
   exception: ExceptionListItemSchema;
   onCancel: () => void;
 }) => {
@@ -36,8 +38,8 @@ export const PolicyEventFiltersDeleteModal = ({
           text: i18n.translate(
             'xpack.securitySolution.endpoint.policy.eventFilters.list.removeDialog.successToastText',
             {
-              defaultMessage: '"{exception}" has been removed from policy',
-              values: { exception: exception.name },
+              defaultMessage: '"{eventFilterName}" has been removed from {policyName} policy',
+              values: { eventFilterName: exception.name, policyName },
             }
           ),
         });

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/policy_event_filters_empty_unexisting.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/policy_event_filters_empty_unexisting.tsx
@@ -16,7 +16,7 @@ interface CommonProps {
 }
 
 export const PolicyEventFiltersEmptyUnexisting = memo<CommonProps>(({ policyId, policyName }) => {
-  const { onClickHandler, toRouteUrl } = useGetLinkTo(policyId, policyName);
+  const { onClickHandler, toRouteUrl } = useGetLinkTo(policyId, policyName, { show: 'create' });
   return (
     <EuiPageTemplate template="centeredContent">
       <EuiEmptyPrompt

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/use_policy_event_filters_empty_hooks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/empty/use_policy_event_filters_empty_hooks.ts
@@ -11,16 +11,21 @@ import { useNavigateToAppEventHandler } from '../../../../../../common/hooks/end
 import { useAppUrl } from '../../../../../../common/lib/kibana/hooks';
 import { getPolicyEventFiltersPath, getEventFiltersListPath } from '../../../../../common/routing';
 import { APP_UI_ID } from '../../../../../../../common/constants';
+import { EventFiltersPageLocation } from '../../../../event_filters/types';
 
-export const useGetLinkTo = (policyId: string, policyName: string) => {
+export const useGetLinkTo = (
+  policyId: string,
+  policyName: string,
+  location?: Partial<EventFiltersPageLocation>
+) => {
   const { getAppUrl } = useAppUrl();
   const { toRoutePath, toRouteUrl } = useMemo(() => {
-    const path = getEventFiltersListPath();
+    const path = getEventFiltersListPath(location);
     return {
       toRoutePath: path,
       toRouteUrl: getAppUrl({ path }),
     };
-  }, [getAppUrl]);
+  }, [getAppUrl, location]);
 
   const policyEventFiltersPath = useMemo(() => getPolicyEventFiltersPath(policyId), [policyId]);
   const policyEventFilterRouteState = useMemo(() => {
@@ -55,5 +60,6 @@ export const useGetLinkTo = (policyId: string, policyName: string) => {
   return {
     onClickHandler,
     toRouteUrl,
+    state: policyEventFilterRouteState,
   };
 };

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/list/policy_event_filters_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/event_filters/list/policy_event_filters_list.tsx
@@ -33,6 +33,7 @@ import { PolicyEventFiltersDeleteModal } from '../delete_modal';
 import { isGlobalPolicyEffected } from '../../../../../components/effected_policy_select/utils';
 import { getEventFiltersListPath } from '../../../../../common/routing';
 import { useUserPrivileges } from '../../../../../../common/components/user_privileges';
+import { useGetLinkTo } from '../empty/use_policy_event_filters_empty_hooks';
 
 interface PolicyEventFiltersListProps {
   policy: ImmutableObject<PolicyData>;
@@ -47,6 +48,7 @@ export const PolicyEventFiltersList = React.memo<PolicyEventFiltersListProps>(({
   const [exceptionItemToDelete, setExceptionItemToDelete] = useState<
     ExceptionListItemSchema | undefined
   >();
+  const { state } = useGetLinkTo(policy.id, policy.name);
 
   const {
     data: eventFilters,
@@ -116,7 +118,7 @@ export const PolicyEventFiltersList = React.memo<PolicyEventFiltersListProps>(({
       ),
       href: getAppUrl({ appId: APP_UI_ID, path: viewUrlPath }),
       navigateAppId: APP_UI_ID,
-      navigateOptions: { path: viewUrlPath },
+      navigateOptions: { path: viewUrlPath, state },
       'data-test-subj': 'view-full-details-action',
     };
     const item = artifact as ExceptionListItemSchema;
@@ -159,6 +161,7 @@ export const PolicyEventFiltersList = React.memo<PolicyEventFiltersListProps>(({
       {exceptionItemToDelete && (
         <PolicyEventFiltersDeleteModal
           policyId={policy.id}
+          policyName={policy.name}
           exception={exceptionItemToDelete}
           onCancel={handleDeleteModalClose}
         />

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/delete_modal.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/delete_modal.test.tsx
@@ -43,6 +43,7 @@ describe('Policy details host isolation exceptions delete modal', () => {
       (renderResult = mockedContext.render(
         <PolicyHostIsolationExceptionsDeleteModal
           policyId={policyId}
+          policyName="fakeName"
           exception={exception}
           onCancel={onCancel}
         />

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/delete_modal.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/delete_modal.tsx
@@ -17,10 +17,12 @@ import { updateOneHostIsolationExceptionItem } from '../../../../host_isolation_
 
 export const PolicyHostIsolationExceptionsDeleteModal = ({
   policyId,
+  policyName,
   exception,
   onCancel,
 }: {
   policyId: string;
+  policyName: string;
   exception: ExceptionListItemSchema;
   onCancel: () => void;
 }) => {
@@ -51,8 +53,9 @@ export const PolicyHostIsolationExceptionsDeleteModal = ({
       text: i18n.translate(
         'xpack.securitySolution.endpoint.policy.hostIsolationExceptions.list.removeDialog.successToastText',
         {
-          defaultMessage: '"{exception}" has been removed from policy',
-          values: { exception: exception.name },
+          defaultMessage:
+            '"{hostIsolationExceptionName}" has been removed from {policyName} policy',
+          values: { hostIsolationExceptionName: exception.name, policyName },
         }
       ),
     });

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/empty_unexisting.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/empty_unexisting.tsx
@@ -16,7 +16,7 @@ export const PolicyHostIsolationExceptionsEmptyUnexisting = ({
 }: {
   policy: PolicyData;
 }) => {
-  const { onClickHandler, toRouteUrl } = useGetLinkTo(policy.id, policy.name);
+  const { onClickHandler, toRouteUrl } = useGetLinkTo(policy.id, policy.name, { show: 'create' });
 
   return (
     <EuiPageTemplate template="centeredContent">

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/list.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/list.test.tsx
@@ -52,7 +52,7 @@ describe('Policy details host isolation exceptions tab', () => {
     ({ history } = mockedContext);
     render = () =>
       (renderResult = mockedContext.render(
-        <PolicyHostIsolationExceptionsList policyId={policyId} />
+        <PolicyHostIsolationExceptionsList policyId={policyId} policyName="fakeName" />
       ));
 
     act(() => {

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/list.tsx
@@ -33,13 +33,22 @@ import { getCurrentArtifactsLocation } from '../../../store/policy_details/selec
 import { usePolicyDetailsSelector } from '../../policy_hooks';
 import { PolicyHostIsolationExceptionsDeleteModal } from './delete_modal';
 import { useFetchHostIsolationExceptionsList } from '../../../../host_isolation_exceptions/view/hooks';
+import { useGetLinkTo } from './use_policy_host_isolation_exceptions_empty_hooks';
 
-export const PolicyHostIsolationExceptionsList = ({ policyId }: { policyId: string }) => {
+export const PolicyHostIsolationExceptionsList = ({
+  policyId,
+  policyName,
+}: {
+  policyId: string;
+  policyName: string;
+}) => {
   const history = useHistory();
   const { getAppUrl } = useAppUrl();
 
   const privileges = useUserPrivileges().endpointPrivileges;
   const location = usePolicyDetailsSelector(getCurrentArtifactsLocation);
+
+  const { state } = useGetLinkTo(policyId, policyName);
 
   // load the list of policies>
   const policiesRequest = useGetEndpointSpecificPolicies();
@@ -127,7 +136,7 @@ export const PolicyHostIsolationExceptionsList = ({ policyId }: { policyId: stri
       ),
       href: getAppUrl({ appId: APP_UI_ID, path: viewUrlPath }),
       navigateAppId: APP_UI_ID,
-      navigateOptions: { path: viewUrlPath },
+      navigateOptions: { path: viewUrlPath, state },
       'data-test-subj': 'view-full-details-action',
     };
 
@@ -172,6 +181,7 @@ export const PolicyHostIsolationExceptionsList = ({ policyId }: { policyId: stri
       {exceptionItemToDelete ? (
         <PolicyHostIsolationExceptionsDeleteModal
           policyId={policyId}
+          policyName={policyName}
           exception={exceptionItemToDelete}
           onCancel={handleDeleteModalClose}
         />

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/use_policy_host_isolation_exceptions_empty_hooks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/components/use_policy_host_isolation_exceptions_empty_hooks.ts
@@ -14,16 +14,21 @@ import {
   getHostIsolationExceptionsListPath,
 } from '../../../../../common/routing';
 import { APP_UI_ID } from '../../../../../../../common/constants';
+import { HostIsolationExceptionsPageLocation } from '../../../../host_isolation_exceptions/types';
 
-export const useGetLinkTo = (policyId: string, policyName: string) => {
+export const useGetLinkTo = (
+  policyId: string,
+  policyName: string,
+  location?: Partial<HostIsolationExceptionsPageLocation>
+) => {
   const { getAppUrl } = useAppUrl();
   const { toRoutePath, toRouteUrl } = useMemo(() => {
-    const path = getHostIsolationExceptionsListPath();
+    const path = getHostIsolationExceptionsListPath(location);
     return {
       toRoutePath: path,
       toRouteUrl: getAppUrl({ path }),
     };
-  }, [getAppUrl]);
+  }, [getAppUrl, location]);
 
   const policyHostIsolationExceptionsPath = useMemo(
     () => getPolicyHostIsolationExceptionsPath(policyId),
@@ -61,5 +66,6 @@ export const useGetLinkTo = (policyId: string, policyName: string) => {
   return {
     onClickHandler,
     toRouteUrl,
+    state: policyHostIsolationExceptionsRouteState,
   };
 };

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/host_isolation_exceptions_tab.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/host_isolation_exceptions/host_isolation_exceptions_tab.tsx
@@ -181,7 +181,7 @@ export const PolicyHostIsolationExceptionsTab = ({ policy }: { policy: PolicyDat
         color="transparent"
         borderRadius="none"
       >
-        <PolicyHostIsolationExceptionsList policyId={policyId} />
+        <PolicyHostIsolationExceptionsList policyId={policyId} policyName={policy.name} />
       </EuiPageContent>
     </div>
   ) : (

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/empty/policy_trusted_apps_empty_unexisting.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/empty/policy_trusted_apps_empty_unexisting.tsx
@@ -16,7 +16,7 @@ interface CommonProps {
 }
 
 export const PolicyTrustedAppsEmptyUnexisting = memo<CommonProps>(({ policyId, policyName }) => {
-  const { onClickHandler, toRouteUrl } = useGetLinkTo(policyId, policyName);
+  const { onClickHandler, toRouteUrl } = useGetLinkTo(policyId, policyName, { show: 'create' });
   return (
     <EuiPageTemplate template="centeredContent">
       <EuiEmptyPrompt

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/empty/use_policy_trusted_apps_empty_hooks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/empty/use_policy_trusted_apps_empty_hooks.ts
@@ -11,16 +11,21 @@ import { useNavigateToAppEventHandler } from '../../../../../../common/hooks/end
 import { useAppUrl } from '../../../../../../common/lib/kibana/hooks';
 import { getPolicyTrustedAppsPath, getTrustedAppsListPath } from '../../../../../common/routing';
 import { APP_UI_ID } from '../../../../../../../common/constants';
+import { TrustedAppsListPageLocation } from '../../../../trusted_apps/state';
 
-export const useGetLinkTo = (policyId: string, policyName: string) => {
+export const useGetLinkTo = (
+  policyId: string,
+  policyName: string,
+  location?: Partial<TrustedAppsListPageLocation>
+) => {
   const { getAppUrl } = useAppUrl();
   const { toRoutePath, toRouteUrl } = useMemo(() => {
-    const path = getTrustedAppsListPath();
+    const path = getTrustedAppsListPath(location);
     return {
       toRoutePath: path,
       toRouteUrl: getAppUrl({ path }),
     };
-  }, [getAppUrl]);
+  }, [getAppUrl, location]);
 
   const policyTrustedAppsPath = useMemo(() => getPolicyTrustedAppsPath(policyId), [policyId]);
   const policyTrustedAppRouteState = useMemo(() => {
@@ -55,5 +60,6 @@ export const useGetLinkTo = (policyId: string, policyName: string) => {
   return {
     onClickHandler,
     toRouteUrl,
+    state: policyTrustedAppRouteState,
   };
 };

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/layout/policy_trusted_apps_layout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/layout/policy_trusted_apps_layout.tsx
@@ -166,7 +166,7 @@ export const PolicyTrustedAppsLayout = React.memo(() => {
             />
           )
         ) : displayHeaderAndContent ? (
-          <PolicyTrustedAppsList />
+          <PolicyTrustedAppsList policyId={policyItem.id} policyName={policyItem.name} />
         ) : (
           <ManagementPageLoader data-test-subj="policyTrustedAppsListLoader" />
         )}

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/list/policy_trusted_apps_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/list/policy_trusted_apps_list.test.tsx
@@ -87,7 +87,7 @@ describe('when rendering the PolicyTrustedAppsList', () => {
 
     mockedApis = policyDetailsPageAllApiHttpMocks(appTestContext.coreStart.http);
     waitForAction = appTestContext.middlewareSpy.waitForAction;
-    componentRenderProps = {};
+    componentRenderProps = { policyId: '9f08b220-342d-4c8d-8971-4cf96adcac29', policyName: 'test' };
 
     render = async (waitForLoadedState: boolean = true) => {
       appTestContext.history.push(

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/list/policy_trusted_apps_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/list/policy_trusted_apps_list.tsx
@@ -24,6 +24,7 @@ import {
   isPolicyTrustedAppListLoading,
   policyIdFromParams,
   getCurrentPolicyArtifactsFilter,
+  policyDetails,
 } from '../../../store/policy_details/selectors';
 import {
   getPolicyDetailPath,
@@ -39,21 +40,23 @@ import { ArtifactEntryCollapsibleCardProps } from '../../../../../components/art
 import { useTestIdGenerator } from '../../../../../components/hooks/use_test_id_generator';
 import { RemoveTrustedAppFromPolicyModal } from './remove_trusted_app_from_policy_modal';
 import { useUserPrivileges } from '../../../../../../common/components/user_privileges';
+import { useGetLinkTo } from '../empty/use_policy_trusted_apps_empty_hooks';
 
 const DATA_TEST_SUBJ = 'policyTrustedAppsGrid';
 
 export interface PolicyTrustedAppsListProps {
   hideTotalShowingLabel?: boolean;
+  policyId: string;
+  policyName: string;
 }
 
 export const PolicyTrustedAppsList = memo<PolicyTrustedAppsListProps>(
-  ({ hideTotalShowingLabel = false }) => {
+  ({ hideTotalShowingLabel = false, policyId, policyName }) => {
     const getTestId = useTestIdGenerator(DATA_TEST_SUBJ);
     const toasts = useToasts();
     const history = useHistory();
     const { getAppUrl } = useAppUrl();
     const { canCreateArtifactsByPolicy } = useUserPrivileges().endpointPrivileges;
-    const policyId = usePolicyDetailsSelector(policyIdFromParams);
     const isLoading = usePolicyDetailsSelector(isPolicyTrustedAppListLoading);
     const defaultFilter = usePolicyDetailsSelector(getCurrentPolicyArtifactsFilter);
     const trustedAppItems = usePolicyDetailsSelector(getPolicyTrustedAppList);
@@ -62,6 +65,7 @@ export const PolicyTrustedAppsList = memo<PolicyTrustedAppsListProps>(
     const allPoliciesById = usePolicyDetailsSelector(getTrustedAppsAllPoliciesById);
     const trustedAppsApiError = usePolicyDetailsSelector(getPolicyTrustedAppListError);
     const navigateCallback = usePolicyDetailsNavigateCallback();
+    const { state } = useGetLinkTo(policyId, policyName);
 
     const [isCardExpanded, setCardExpanded] = useState<Record<string, boolean>>({});
     const [trustedAppsForRemoval, setTrustedAppsForRemoval] = useState<typeof trustedAppItems>([]);
@@ -152,7 +156,7 @@ export const PolicyTrustedAppsList = memo<PolicyTrustedAppsListProps>(
             ),
             href: getAppUrl({ appId: APP_UI_ID, path: viewUrlPath }),
             navigateAppId: APP_UI_ID,
-            navigateOptions: { path: viewUrlPath },
+            navigateOptions: { path: viewUrlPath, state },
             'data-test-subj': getTestId('viewFullDetailsAction'),
           },
         ];
@@ -201,6 +205,7 @@ export const PolicyTrustedAppsList = memo<PolicyTrustedAppsListProps>(
       isCardExpanded,
       trustedAppItems,
       canCreateArtifactsByPolicy,
+      state,
     ]);
 
     const provideCardProps = useCallback<Required<ArtifactCardGridProps>['cardComponentProps']>(

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/list/policy_trusted_apps_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/list/policy_trusted_apps_list.tsx
@@ -22,9 +22,7 @@ import {
   getPolicyTrustedAppsListPagination,
   getTrustedAppsAllPoliciesById,
   isPolicyTrustedAppListLoading,
-  policyIdFromParams,
   getCurrentPolicyArtifactsFilter,
-  policyDetails,
 } from '../../../store/policy_details/selectors';
 import {
   getPolicyDetailPath,


### PR DESCRIPTION
## Summary

- Unify messages when removing an artifact from policy:
![unify remove from policy messages](https://user-images.githubusercontent.com/15727784/152981190-d957730f-c8f0-4370-ab6f-203054cd976e.gif)


- Open creation flyout when adding artifacts from policy view:
![open creation flyout from policy view](https://user-images.githubusercontent.com/15727784/152981243-59fcf85f-4519-4539-a1a6-d616356a4aad.gif)


- Adds back button when clicking on view full details from policy view:
![adds back button for full details](https://user-images.githubusercontent.com/15727784/152981297-c418655c-7db1-4910-98d2-81971c3661c5.gif)



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
