### PR TITLE
[SecuritySolution][Threat Hunting] Fix a couple of field ids for highlighted fields

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
@@ -174,32 +174,41 @@ describe('AlertSummaryView', () => {
     });
   });
   test('Behavior event code renders additional summary rows', () => {
+    const actualRuleDescription = 'The actual rule description';
     const renderProps = {
       ...props,
-      data: mockAlertDetailsData.map((item) => {
-        if (item.category === 'event' && item.field === 'event.code') {
-          return {
-            ...item,
-            values: ['behavior'],
-            originalValue: ['behavior'],
-          };
-        }
-        if (item.category === 'event' && item.field === 'event.category') {
-          return {
-            ...item,
-            values: ['malware', 'process', 'file'],
-            originalValue: ['malware', 'process', 'file'],
-          };
-        }
-        return item;
-      }) as TimelineEventsDetailsItem[],
+      data: [
+        ...mockAlertDetailsData.map((item) => {
+          if (item.category === 'event' && item.field === 'event.code') {
+            return {
+              ...item,
+              values: ['behavior'],
+              originalValue: ['behavior'],
+            };
+          }
+          if (item.category === 'event' && item.field === 'event.category') {
+            return {
+              ...item,
+              values: ['malware', 'process', 'file'],
+              originalValue: ['malware', 'process', 'file'],
+            };
+          }
+          return item;
+        }),
+        {
+          category: 'rule',
+          field: 'rule.description',
+          values: [actualRuleDescription],
+          originalValue: [actualRuleDescription],
+        },
+      ] as TimelineEventsDetailsItem[],
     };
     const { getByText } = render(
       <TestProvidersComponent>
         <AlertSummaryView {...renderProps} />
       </TestProvidersComponent>
     );
-    ['host.name', 'user.name', 'process.name'].forEach((fieldId) => {
+    ['host.name', 'user.name', 'process.name', actualRuleDescription].forEach((fieldId) => {
       expect(getByText(fieldId));
     });
   });

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
@@ -116,6 +116,40 @@ describe('AlertSummaryView', () => {
       expect(getByText(fieldId));
     });
   });
+
+  test('DNS event renders the correct summary rows', () => {
+    const renderProps = {
+      ...props,
+      data: [
+        ...(mockAlertDetailsData.map((item) => {
+          if (item.category === 'event' && item.field === 'event.category') {
+            return {
+              ...item,
+              values: ['dns'],
+              originalValue: ['dns'],
+            };
+          }
+          return item;
+        }) as TimelineEventsDetailsItem[]),
+        {
+          category: 'dns',
+          field: 'dns.question.name',
+          values: ['www.example.com'],
+          originalValue: ['www.example.com'],
+        } as TimelineEventsDetailsItem,
+      ],
+    };
+    const { getByText } = render(
+      <TestProvidersComponent>
+        <AlertSummaryView {...renderProps} />
+      </TestProvidersComponent>
+    );
+
+    ['dns.question.name', 'process.name'].forEach((fieldId) => {
+      expect(getByText(fieldId));
+    });
+  });
+
   test('Memory event code renders additional summary rows', () => {
     const renderProps = {
       ...props,

--- a/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
@@ -6,11 +6,7 @@
  */
 
 import { find, isEmpty, uniqBy } from 'lodash/fp';
-import {
-  ALERT_RULE_NAMESPACE,
-  ALERT_RULE_TYPE,
-  ALERT_RULE_DESCRIPTION,
-} from '@kbn/rule-data-utils';
+import { ALERT_RULE_NAMESPACE, ALERT_RULE_TYPE } from '@kbn/rule-data-utils';
 
 import * as i18n from './translations';
 import { BrowserFields } from '../../../../common/search_strategy/index_fields';
@@ -107,7 +103,7 @@ function getFieldsByEventCode(
   switch (eventCode) {
     case EventCode.BEHAVIOR:
       return [
-        { id: ALERT_RULE_DESCRIPTION, label: ALERTS_HEADERS_RULE_DESCRIPTION },
+        { id: 'rule.description', label: ALERTS_HEADERS_RULE_DESCRIPTION },
         // Resolve more fields based on the source event
         ...getFieldsByCategory({ ...eventCategories, primaryEventCategory: undefined }),
       ];

--- a/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
@@ -69,7 +69,7 @@ function getFieldsByCategory({
         { id: 'process.name' },
       ];
     case EventCategory.DNS:
-      return [{ id: 'dns.query.name' }, { id: 'process.name' }];
+      return [{ id: 'dns.question.name' }, { id: 'process.name' }];
     case EventCategory.REGISTRY:
       return [{ id: 'registry.key' }, { id: 'registry.value' }, { id: 'process.name' }];
     case EventCategory.MALWARE:


### PR DESCRIPTION
## Summary

1. We were using the wrong field id for DNS alerts in the alert flyout. The id should have been `dns.question.name` instead of `dns.query.name`.
2. Instead of showing `kibana.alert.rule.description` we're supposed to show `rule.description` for behavior alerts.

This PR fixes these ids and adds test for all of them


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios