### PR TITLE
FTR - check ES security before creating system_indices_superuser

### DIFF
--- a/test/common/services/security/system_indices_user.ts
+++ b/test/common/services/security/system_indices_user.ts
@@ -25,6 +25,16 @@ export async function createSystemIndicesUser(ctx: FtrProviderContext) {
 
   const es = createEsClientForFtrConfig(config);
 
+  // There are cases where the test config file doesn't have security disabled
+  // but tests are still executed on ES without security. Checking this case
+  // by trying to fetch the users list.
+  try {
+    await es.security.getUser();
+  } catch (error) {
+    log.debug('Could not fetch users, assuming security is disabled');
+    return;
+  }
+
   log.debug('===============creating system indices role and user===============');
 
   await es.security.putRole({


### PR DESCRIPTION
## Summary

This PR adds a check if ES security is enabled before creating the system_indices_superuser in the security service.

### Details

We have cases where the ES deployment doesn't use the config file that is then used for test execution. As a result it's possible to execute the test runner with the same config on both, environments with and without ES security enabled. In the case of security disabled (with the config for security enabled) the security service tried to create the system_indices_superuser which failed. We can't easily access the ES configuration for an arbitrary existing deployment, so with this PR we try to fetch the list of users and if that fails we assume security is disabled and skip the user creation.

Related to #124008