### PR TITLE
Add github action for labeling Fleet issues for QA team

### DIFF
--- a/.github/workflows/label-qa-fixed-in.yml
+++ b/.github/workflows/label-qa-fixed-in.yml
@@ -41,8 +41,8 @@ jobs:
       - uses: sergeysova/jq-action@v2
         id: issues_to_label
         with:
-          # Filter closing issues to only include the ones that are labeled with "bug" and then map to the issue's node id
-          cmd: echo $CLOSING_ISSUES | jq -c '.repository.pullRequest.closingIssuesReferences.nodes | map(select(.labels | any(map(.name == "bug")))) | map(.id)'
+          # Map to the issues' node id
+          cmd: echo $CLOSING_ISSUES | jq -c '.repository.pullRequest.closingIssuesReferences.nodes | map(.id)'
           multiline: true
         env:
           CLOSING_ISSUES: ${{ steps.closing_issues.outputs.data }}

--- a/.github/workflows/label-qa-fixed-in.yml
+++ b/.github/workflows/label-qa-fixed-in.yml
@@ -1,0 +1,78 @@
+name: Add QA labels to Fleet issues
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  fetch_issues_to_label:
+    runs-on: ubuntu-latest
+    # Only run on PRs that were merged for the Fleet team
+    if: |
+      github.event.pull_request.merged_at &&
+      contains(github.event.pull_request.labels.*.name, 'Team:Fleet')
+    outputs:
+      matrix: ${{ steps.issues_to_label.outputs.value }}
+      label_ids: ${{ steps.label_ids.outputs.value }}
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: closing_issues
+        with:
+          query: |
+            query closingIssueNumbersQuery($prnumber: Int!) {
+              repository(owner: "elastic", name: "kibana") {
+                pullRequest(number: $prnumber) {
+                  closingIssuesReferences(first: 10) {
+                    nodes {
+                      id
+                      labels(first: 20) {
+                        nodes {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          prnumber: ${{ github.event.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: sergeysova/jq-action@v2
+        id: issues_to_label
+        with:
+          # Filter closing issues to only include the ones that are labeled with "bug" and then map to the issue's node id
+          cmd: echo $CLOSING_ISSUES | jq -c '.repository.pullRequest.closingIssuesReferences.nodes | map(select(.labels | any(map(.name == "bug")))) | map(.id)'
+          multiline: true
+        env:
+          CLOSING_ISSUES: ${{ steps.closing_issues.outputs.data }}
+      - uses: sergeysova/jq-action@v2
+        id: label_ids
+        with:
+          # Get list of version labels on pull request and map to label's node id, append 'QA:Ready For Testing' id ("MDU6TGFiZWwyNTQ1NjcwOTI4")
+          cmd: echo $PR_LABELS | jq -c 'map(select(.name | test("v[0-9]+\\.[0-9]+\\.[0-9]+")) | .node_id) + ["MDU6TGFiZWwyNTQ1NjcwOTI4"]'
+          multiline: true
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+
+  label_issues:
+    needs: fetch_issues_to_label
+    runs-on: ubuntu-latest
+    # For each issue closed by the PR run this job
+    strategy:
+      matrix:
+        issueNodeId: ${{ fromJSON(needs.fetch_issues_to_label.outputs.matrix) }}
+    name: Label issue ${{ matrix.issueNodeId }}
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_labels_to_closed_issue
+        with:
+          query: |
+            mutation add_label($issueid:String!, $labelids:[String!]!) {
+              addLabelsToLabelable(input: {labelableId: $issueid, labelIds: $labelids}) {
+                clientMutationId
+              }
+            }
+          issueid: ${{ matrix.issueNodeId }}
+          labelids: ${{ needs.fetch_issues_to_label.outputs.label_ids }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This new Github Action will do the following to help with automating QAS's workflow:
- Whenever a PR is merged with the `Team:Fleet` label **and** the PR closes an issue(s):
	- Copy the `vX.X.X` labels to the closed issue(s)
	- Add the `QA:Ready for Testing` label to the closed issue(s)