### PR TITLE
[Fleet] Remove unwanted overflow on Integrations screenshots

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/screenshots.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/screenshots.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React, { useState, useMemo, memo } from 'react';
+import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiFlexGroup, EuiFlexItem, EuiImage, EuiText, EuiPagination } from '@elastic/eui';
@@ -17,6 +18,9 @@ interface ScreenshotProps {
   packageName: string;
   version: string;
 }
+const Pagination = styled(EuiPagination)`
+  max-width: 130px;
+`;
 
 export const Screenshots: React.FC<ScreenshotProps> = memo(({ images, packageName, version }) => {
   const { toPackageImage } = useLinks();
@@ -48,7 +52,7 @@ export const Screenshots: React.FC<ScreenshotProps> = memo(({ images, packageNam
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiPagination
+            <Pagination
               aria-label={i18n.translate('xpack.fleet.epm.screenshotPaginationAriaLabel', {
                 defaultMessage: '{packageName} screenshot pagination',
                 values: {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/122202

A recent [change](https://github.com/elastic/eui/pull/5362) in EuiPagination introduced an unwanted overflow in the screenshots column in Integrations details view, since it added two buttons to quickly navigate to first and last page.

I just added a `max-width` property to fit the buttons in the column.

#### Before
![Before](https://user-images.githubusercontent.com/16084106/153021067-576b955a-876a-48ba-964b-460c5fab52b8.png)

#### After
![After](https://user-images.githubusercontent.com/16084106/153021131-bde10948-0ff1-4764-beec-b00168164b49.png)


