### PR TITLE
[ci] Fix state check for purge cloud deployments

### DIFF
--- a/.buildkite/scripts/steps/cloud/purge.js
+++ b/.buildkite/scripts/steps/cloud/purge.js
@@ -26,7 +26,7 @@ for (const deployment of prDeployments) {
     const lastCommit = pullRequest.commits.slice(-1)[0];
     const lastCommitTimestamp = new Date(lastCommit.committedDate).getTime() / 1000;
 
-    if (pullRequest.state !== 'open') {
+    if (pullRequest.state !== 'OPEN') {
       console.log(`Pull Request #${prNumber} is no longer open, will delete associated deployment`);
       deploymentsToPurge.push(deployment);
     } else if (!pullRequest.labels.filter((label) => label.name === 'ci:deploy-cloud')) {


### PR DESCRIPTION
Pull request state from GitHub returns 'OPEN' if a pull request is open.
This updates the capitalization when branching from state

```
~/dev/kibana (main*) » gh pr view 124699  --json state | cat                                                                                                                                               jon@xps
{"state":"OPEN"}
```