### PR TITLE
[NOT FOR MERGE] TSVB abort is not working

### DIFF
--- a/examples/search_examples/public/search/app.tsx
+++ b/examples/search_examples/public/search/app.tsx
@@ -409,6 +409,11 @@ export const SearchExamplesApp = ({
     if (!dataView || !selectedNumericField) return;
     const abortController = new AbortController();
     setAbortController(abortController);
+
+    setTimeout(() => {
+      abortController.abort();
+    }, 400);
+
     setIsLoading(true);
     try {
       const res = await http.get(SERVER_SEARCH_ROUTE_PATH, {

--- a/examples/search_examples/server/routes/server_search_route.ts
+++ b/examples/search_examples/server/routes/server_search_route.ts
@@ -28,10 +28,13 @@ export function registerServerSearchRoute(router: IRouter<DataRequestHandlerCont
     async (context, request, response) => {
       const { index, field } = request.query;
 
+      request.events.aborted$.subscribe(() => {
+        console.log('examples: abort is working!');
+      });
       // User may abort the request without waiting for the results
       // we need to handle this scenario by aborting underlying server requests
       const abortSignal = getRequestAbortedSignal(request.events.aborted$);
-
+      await new Promise((res) => setTimeout(res, 1000));
       try {
         const res = await context
           .search!.search(

--- a/src/plugins/vis_types/timeseries/public/request_handler.ts
+++ b/src/plugins/vis_types/timeseries/public/request_handler.ts
@@ -52,6 +52,11 @@ export const metricsRequestHandler = async ({
 
     try {
       const searchSessionOptions = dataSearch.session.getSearchOptions(searchSessionId);
+      const controller = new AbortController();
+
+      setTimeout(() => {
+        controller.abort();
+      }, 400);
 
       const visData: TimeseriesVisData = await getCoreStart().http.post(ROUTES.VIS_DATA, {
         body: JSON.stringify({
@@ -68,6 +73,7 @@ export const metricsRequestHandler = async ({
           }),
         }),
         context: executionContext,
+        signal: controller.signal,
       });
 
       inspectorAdapters?.requests?.reset();

--- a/src/plugins/vis_types/timeseries/server/routes/vis.ts
+++ b/src/plugins/vis_types/timeseries/server/routes/vis.ts
@@ -33,6 +33,17 @@ export const visDataRoutes = (router: VisTypeTimeseriesRouter, framework: Framew
         });
       }
 
+      // My question here, for some reason this one is not working for TSVB
+      request.events.aborted$.subscribe(() => {
+        console.log('tsvb: abort is not working');
+      });
+
+      request.events.completed$.subscribe(() => {
+        console.log('tsvb: completed$ is working');
+      });
+
+      await new Promise((res) => setTimeout(res, 1000));
+
       const results = await getVisData(requestContext, request, framework);
       return response.ok({ body: results });
     }


### PR DESCRIPTION
## Summary

I made similar changes in two places, for some reason it works in examples but doesn't work in TSVB

**TSVB:** 
To play just open any TSVB visualization and see console. 
**Expected:**  I expect to see '`tsvb: abort is not working'` in console

https://user-images.githubusercontent.com/20072247/153208126-4be0f0e2-0f82-4f6c-8d80-51f6b18a8aef.mov


**Examples:**
1. Go to app `/app/searchExamples/search`
2. Scroll to the end of page and execute `Request from low-level client on the server`

https://user-images.githubusercontent.com/20072247/153207745-31076e40-addd-478d-9368-03aad0d489cd.mov


