### PR TITLE
[8.0] [Fleet] Fix preconfiguration error when renaming a preconfigured policy (#124953)

### DIFF
--- a/x-pack/plugins/fleet/server/services/preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.test.ts
@@ -209,6 +209,7 @@ const spyAgentPolicyServicBumpAllAgentPoliciesForOutput = jest.spyOn(
 
 describe('policy preconfiguration', () => {
   beforeEach(() => {
+    mockedPackagePolicyService.getByIDs.mockReset();
     mockedPackagePolicyService.create.mockReset();
     mockInstalledPackages.clear();
     mockInstallPackageErrors.clear();
@@ -480,48 +481,52 @@ describe('policy preconfiguration', () => {
     const soClient = getPutPreconfiguredPackagesMock();
     const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
-    const { policies: policiesA, nonFatalErrors: nonFatalErrorsA } =
-      await ensurePreconfiguredPackagesAndPolicies(
-        soClient,
-        esClient,
-        [
-          {
-            name: 'Test policy',
-            namespace: 'default',
-            id: 'test-id',
-            package_policies: [],
-          },
-        ] as PreconfiguredAgentPolicy[],
-        [],
-        mockDefaultOutput,
-        DEFAULT_SPACE_ID
-      );
+    const {
+      policies: policiesA,
+      nonFatalErrors: nonFatalErrorsA,
+    } = await ensurePreconfiguredPackagesAndPolicies(
+      soClient,
+      esClient,
+      [
+        {
+          name: 'Test policy',
+          namespace: 'default',
+          id: 'test-id',
+          package_policies: [],
+        },
+      ] as PreconfiguredAgentPolicy[],
+      [],
+      mockDefaultOutput,
+      DEFAULT_SPACE_ID
+    );
 
     expect(policiesA.length).toEqual(1);
     expect(policiesA[0].id).toBe('test-id');
     expect(nonFatalErrorsA.length).toBe(0);
 
-    const { policies: policiesB, nonFatalErrors: nonFatalErrorsB } =
-      await ensurePreconfiguredPackagesAndPolicies(
-        soClient,
-        esClient,
-        [
-          {
-            name: 'Test policy redo',
-            namespace: 'default',
-            id: 'test-id',
-            package_policies: [
-              {
-                package: { name: 'some-uninstalled-package' },
-                name: 'This package is not installed',
-              },
-            ],
-          },
-        ] as PreconfiguredAgentPolicy[],
-        [],
-        mockDefaultOutput,
-        DEFAULT_SPACE_ID
-      );
+    const {
+      policies: policiesB,
+      nonFatalErrors: nonFatalErrorsB,
+    } = await ensurePreconfiguredPackagesAndPolicies(
+      soClient,
+      esClient,
+      [
+        {
+          name: 'Test policy redo',
+          namespace: 'default',
+          id: 'test-id',
+          package_policies: [
+            {
+              package: { name: 'some-uninstalled-package' },
+              name: 'This package is not installed',
+            },
+          ],
+        },
+      ] as PreconfiguredAgentPolicy[],
+      [],
+      mockDefaultOutput,
+      DEFAULT_SPACE_ID
+    );
 
     expect(policiesB.length).toEqual(1);
     expect(policiesB[0].id).toBe('test-id');
@@ -543,25 +548,269 @@ describe('policy preconfiguration', () => {
       is_managed: true,
     } as PreconfiguredAgentPolicy);
 
-    const { policies, nonFatalErrors: nonFatalErrorsB } =
-      await ensurePreconfiguredPackagesAndPolicies(
+    const {
+      policies,
+      nonFatalErrors: nonFatalErrorsB,
+    } = await ensurePreconfiguredPackagesAndPolicies(
+      soClient,
+      esClient,
+      [
+        {
+          name: 'Renamed Test policy',
+          description: 'Renamed Test policy description',
+          unenroll_timeout: 999,
+          namespace: 'default',
+          id: 'test-id',
+          is_managed: true,
+          package_policies: [],
+        },
+      ] as PreconfiguredAgentPolicy[],
+      [],
+      mockDefaultOutput,
+      DEFAULT_SPACE_ID
+    );
+    expect(spyAgentPolicyServiceUpdate).toBeCalled();
+    expect(spyAgentPolicyServiceUpdate).toBeCalledWith(
+      expect.anything(), // soClient
+      expect.anything(), // esClient
+      'test-id',
+      expect.objectContaining({
+        name: 'Renamed Test policy',
+        description: 'Renamed Test policy description',
+        unenroll_timeout: 999,
+      })
+    );
+    expect(policies.length).toEqual(1);
+    expect(policies[0].id).toBe('test-id');
+    expect(nonFatalErrorsB.length).toBe(0);
+  });
+
+  it('should not try to recreate preconfigure package policy that has been renamed', async () => {
+    const soClient = getPutPreconfiguredPackagesMock();
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+    mockedPackagePolicyService.getByIDs.mockResolvedValue([
+      { name: 'Renamed package policy', id: 'test_package1' } as PackagePolicy,
+    ]);
+
+    mockConfiguredPolicies.set('test-id', {
+      name: 'Test policy',
+      description: 'Test policy description',
+      unenroll_timeout: 120,
+      namespace: 'default',
+      id: 'test-id',
+      package_policies: [
+        {
+          name: 'test_package1',
+          id: 'test_package1',
+        },
+      ],
+      is_managed: true,
+    } as PreconfiguredAgentPolicy);
+
+    await ensurePreconfiguredPackagesAndPolicies(
+      soClient,
+      esClient,
+      [
+        {
+          name: 'Test policy',
+          namespace: 'default',
+          id: 'test-id',
+          is_managed: true,
+          package_policies: [
+            {
+              package: { name: 'test_package' },
+              name: 'test_package1',
+              id: 'test_package1',
+            },
+          ],
+        },
+      ] as PreconfiguredAgentPolicy[],
+      [{ name: 'test_package', version: '3.0.0' }],
+      mockDefaultOutput,
+      DEFAULT_SPACE_ID
+    );
+
+    expect(mockedPackagePolicyService.create).not.toBeCalled();
+  });
+
+  it('should throw an error when trying to install duplicate packages', async () => {
+    const soClient = getPutPreconfiguredPackagesMock();
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+    await expect(
+      ensurePreconfiguredPackagesAndPolicies(
         soClient,
         esClient,
-        [
-          {
-            name: 'Renamed Test policy',
-            description: 'Renamed Test policy description',
-            unenroll_timeout: 999,
-            namespace: 'default',
-            id: 'test-id',
-            is_managed: true,
-            package_policies: [],
-          },
-        ] as PreconfiguredAgentPolicy[],
         [],
+        [
+          { name: 'test_package', version: '3.0.0' },
+          { name: 'test_package', version: '2.0.0' },
+        ],
         mockDefaultOutput,
         DEFAULT_SPACE_ID
-      );
+      )
+    ).rejects.toThrow(
+      'Duplicate packages specified in configuration: test_package-3.0.0, test_package-2.0.0'
+    );
+  });
+
+  it('should not create a policy and throw an error if install fails for required package', async () => {
+    const soClient = getPutPreconfiguredPackagesMock();
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    const policies: PreconfiguredAgentPolicy[] = [
+      {
+        name: 'Test policy',
+        namespace: 'default',
+        id: 'test-id',
+        package_policies: [
+          {
+            package: { name: 'test_package' },
+            name: 'Test package',
+          },
+        ],
+      },
+    ];
+    mockInstallPackageErrors.set('test_package', 'REGISTRY ERROR');
+
+    await expect(
+      ensurePreconfiguredPackagesAndPolicies(
+        soClient,
+        esClient,
+        policies,
+        [{ name: 'test_package', version: '3.0.0' }],
+        mockDefaultOutput,
+        DEFAULT_SPACE_ID
+      )
+    ).rejects.toThrow(
+      '[Test policy] could not be added. [test_package] could not be installed due to error: [Error: REGISTRY ERROR]'
+    );
+  });
+
+  it('should not create a policy and throw an error if package is not installed for an unknown reason', async () => {
+    const soClient = getPutPreconfiguredPackagesMock();
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    const policies: PreconfiguredAgentPolicy[] = [
+      {
+        name: 'Test policy',
+        namespace: 'default',
+        id: 'test-id',
+        package_policies: [
+          {
+            id: 'test-package',
+            package: { name: 'test_package' },
+            name: 'Test package',
+          },
+        ],
+      },
+    ];
+
+    await expect(
+      ensurePreconfiguredPackagesAndPolicies(
+        soClient,
+        esClient,
+        policies,
+        [{ name: 'CANNOT_MATCH', version: 'x.y.z' }],
+        mockDefaultOutput,
+        DEFAULT_SPACE_ID
+      )
+    ).rejects.toThrow(
+      '[Test policy] could not be added. [test_package] is not installed, add [test_package] to [xpack.fleet.packages] or remove it from [Test package].'
+    );
+  });
+
+  it('should not attempt to recreate or modify an agent policy if its ID is unchanged', async () => {
+    const soClient = getPutPreconfiguredPackagesMock();
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+    const {
+      policies: policiesA,
+      nonFatalErrors: nonFatalErrorsA,
+    } = await ensurePreconfiguredPackagesAndPolicies(
+      soClient,
+      esClient,
+      [
+        {
+          name: 'Test policy',
+          namespace: 'default',
+          id: 'test-id',
+          package_policies: [],
+        },
+      ] as PreconfiguredAgentPolicy[],
+      [],
+      mockDefaultOutput,
+      DEFAULT_SPACE_ID
+    );
+
+    expect(policiesA.length).toEqual(1);
+    expect(policiesA[0].id).toBe('test-id');
+    expect(nonFatalErrorsA.length).toBe(0);
+
+    const {
+      policies: policiesB,
+      nonFatalErrors: nonFatalErrorsB,
+    } = await ensurePreconfiguredPackagesAndPolicies(
+      soClient,
+      esClient,
+      [
+        {
+          name: 'Test policy redo',
+          namespace: 'default',
+          id: 'test-id',
+          package_policies: [
+            {
+              package: { name: 'some-uninstalled-package' },
+              name: 'This package is not installed',
+            },
+          ],
+        },
+      ] as PreconfiguredAgentPolicy[],
+      [],
+      mockDefaultOutput,
+      DEFAULT_SPACE_ID
+    );
+
+    expect(policiesB.length).toEqual(1);
+    expect(policiesB[0].id).toBe('test-id');
+    expect(policiesB[0].updated_at).toEqual(policiesA[0].updated_at);
+    expect(nonFatalErrorsB.length).toBe(0);
+  });
+
+  it('should update a managed policy if top level fields are changed', async () => {
+    const soClient = getPutPreconfiguredPackagesMock();
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+    mockConfiguredPolicies.set('test-id', {
+      name: 'Test policy',
+      description: 'Test policy description',
+      unenroll_timeout: 120,
+      namespace: 'default',
+      id: 'test-id',
+      package_policies: [],
+      is_managed: true,
+    } as PreconfiguredAgentPolicy);
+
+    const {
+      policies,
+      nonFatalErrors: nonFatalErrorsB,
+    } = await ensurePreconfiguredPackagesAndPolicies(
+      soClient,
+      esClient,
+      [
+        {
+          name: 'Renamed Test policy',
+          description: 'Renamed Test policy description',
+          unenroll_timeout: 999,
+          namespace: 'default',
+          id: 'test-id',
+          is_managed: true,
+          package_policies: [],
+        },
+      ] as PreconfiguredAgentPolicy[],
+      [],
+      mockDefaultOutput,
+      DEFAULT_SPACE_ID
+    );
     expect(spyAgentPolicyServiceUpdate).toBeCalled();
     expect(spyAgentPolicyServiceUpdate).toBeCalledWith(
       expect.anything(), // soClient
@@ -590,20 +839,51 @@ describe('policy preconfiguration', () => {
     };
     mockConfiguredPolicies.set('test-id', policy);
 
-    const { policies, nonFatalErrors: nonFatalErrorsB } =
-      await ensurePreconfiguredPackagesAndPolicies(
-        soClient,
-        esClient,
-        [policy],
-        [],
-        mockDefaultOutput,
-        DEFAULT_SPACE_ID
-      );
+    const {
+      policies,
+      nonFatalErrors: nonFatalErrorsB,
+    } = await ensurePreconfiguredPackagesAndPolicies(
+      soClient,
+      esClient,
+      [policy],
+      [],
+      mockDefaultOutput,
+      DEFAULT_SPACE_ID
+    );
     expect(spyAgentPolicyServiceUpdate).not.toBeCalled();
     expect(policies.length).toEqual(1);
     expect(policies[0].id).toBe('test-id');
     expect(nonFatalErrorsB.length).toBe(0);
   });
+});
+
+it('should not update a managed policy if a top level field has not changed', async () => {
+  const soClient = getPutPreconfiguredPackagesMock();
+  const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+  const policy: PreconfiguredAgentPolicy = {
+    name: 'Test policy',
+    namespace: 'default',
+    id: 'test-id',
+    package_policies: [],
+    is_managed: true,
+  };
+  mockConfiguredPolicies.set('test-id', policy);
+
+  const {
+    policies,
+    nonFatalErrors: nonFatalErrorsB,
+  } = await ensurePreconfiguredPackagesAndPolicies(
+    soClient,
+    esClient,
+    [policy],
+    [],
+    mockDefaultOutput,
+    DEFAULT_SPACE_ID
+  );
+  expect(spyAgentPolicyServiceUpdate).not.toBeCalled();
+  expect(policies.length).toEqual(1);
+  expect(policies[0].id).toBe('test-id');
+  expect(nonFatalErrorsB.length).toBe(0);
 });
 
 describe('comparePreconfiguredPolicyToCurrent', () => {
@@ -685,20 +965,22 @@ describe('output preconfiguration', () => {
     mockedOutputService.delete.mockReset();
     mockedOutputService.getDefaultDataOutputId.mockReset();
     mockedOutputService.getDefaultESHosts.mockReturnValue(['http://default-es:9200']);
-    mockedOutputService.bulkGet.mockImplementation(async (soClient, id): Promise<Output[]> => {
-      return [
-        {
-          id: 'existing-output-1',
-          is_default: false,
-          is_default_monitoring: false,
-          name: 'Output 1',
-          // @ts-ignore
-          type: 'elasticsearch',
-          hosts: ['http://es.co:80'],
-          is_preconfigured: true,
-        },
-      ];
-    });
+    mockedOutputService.bulkGet.mockImplementation(
+      async (soClient, id): Promise<Output[]> => {
+        return [
+          {
+            id: 'existing-output-1',
+            is_default: false,
+            is_default_monitoring: false,
+            name: 'Output 1',
+            // @ts-ignore
+            type: 'elasticsearch',
+            hosts: ['http://es.co:80'],
+            is_preconfigured: true,
+          },
+        ];
+      }
+    );
   });
 
   it('should create preconfigured output that does not exists', async () => {

--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -334,7 +334,9 @@ export async function ensurePreconfiguredPackagesAndPolicies(
 
       const packagePoliciesToAdd = installedPackagePolicies.filter((installablePackagePolicy) => {
         return !(agentPolicyWithPackagePolicies?.package_policies as PackagePolicy[]).some(
-          (packagePolicy) => packagePolicy.name === installablePackagePolicy.name
+          (packagePolicy) =>
+            (packagePolicy.id !== undefined && packagePolicy.id === installablePackagePolicy.id) ||
+            packagePolicy.name === installablePackagePolicy.name
         );
       });
 


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #124953

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
