### PR TITLE
[8.0] [Fleet] Fix preconfiguration error when renaming a preconfigured policy (#124953)

### DIFF
--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -334,7 +334,9 @@ export async function ensurePreconfiguredPackagesAndPolicies(
 
       const packagePoliciesToAdd = installedPackagePolicies.filter((installablePackagePolicy) => {
         return !(agentPolicyWithPackagePolicies?.package_policies as PackagePolicy[]).some(
-          (packagePolicy) => packagePolicy.name === installablePackagePolicy.name
+          (packagePolicy) =>
+            (packagePolicy.id !== undefined && packagePolicy.id === installablePackagePolicy.id) ||
+            packagePolicy.name === installablePackagePolicy.name
         );
       });
 


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #124953

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
