### PR TITLE
Fix EQL search strategy: omit enable_fields_emulation

### DIFF
--- a/src/plugins/data/server/search/strategies/eql_search/eql_search_strategy.ts
+++ b/src/plugins/data/server/search/strategies/eql_search/eql_search_strategy.ts
@@ -41,10 +41,13 @@ export const eqlSearchStrategyProvider = (
       const client = esClient.asCurrentUser.eql;
 
       const search = async () => {
-        const { track_total_hits: _, ...defaultParams } = await getDefaultSearchParams(
-          uiSettingsClient,
-          request.params?.body
-        );
+        // track_total_hits/enable_fields_emulation are not supported by _eql/search
+        const {
+          track_total_hits: tth,
+          enable_fields_emulation: efe,
+          ...defaultParams
+        } = await getDefaultSearchParams(uiSettingsClient, request.params?.body);
+
         const params = id
           ? getDefaultAsyncGetParams(null, options)
           : {
@@ -53,6 +56,7 @@ export const eqlSearchStrategyProvider = (
               ...getDefaultAsyncGetParams(null, options),
               ...request.params,
             };
+
         const promise = id
           ? client.get({ ...params, id }, request.options)
           : // @ts-expect-error EqlRequestParams | undefined is not assignable to EqlRequestParams


### PR DESCRIPTION
**Fixes:** https://github.com/elastic/kibana/issues/125059

## Summary

Fixes a bug in the EQL search strategy presumably introduced in https://github.com/elastic/kibana/pull/123267.

## Screenshots

**Before** (request to EQL search strategy is failing, and the rule creation form can't perform validation)

![](https://puu.sh/II2fT/0ffde0f0d6.png)

**After** (request to EQL search strategy is returning results, and the rule creation form can properly validate the query)

![](https://puu.sh/II2gJ/060ff92e77.png)

![](https://puu.sh/II2ex/d7fbb31517.png)

![](https://puu.sh/II2f2/09cc4483a3.png)

## Notes on testing

Create a test index and write a few documents to it:

```
PUT /test-eql
{
  "mappings": {
    "properties": {
      "@timestamp": {
        "type": "date"
      },
      "process": {
        "type": "object",
        "properties": {
          "name": {
            "type": "keyword"
          }
        }
      }
    }
  }  
}

POST /test-eql/_doc
{
  "@timestamp": "2022-02-05T10:00:08Z",
  "process": {
    "name": "mdworker"
  }
}
```