### PR TITLE
[Fleet] Fix fleet server hosts client validation

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.test.tsx
@@ -26,7 +26,9 @@ describe('useFleetServerHostsForm', () => {
     const onSucess = jest.fn();
     const { result } = testRenderer.renderHook(() => useFleetServerHostsForm([], onSucess));
 
-    act(() => result.current.fleetServerHostsInput.setValue(['http://test.fr', 'http://test.fr']));
+    act(() =>
+      result.current.fleetServerHostsInput.props.onChange(['http://test.fr', 'http://test.fr'])
+    );
 
     await act(() => result.current.submit());
 
@@ -52,7 +54,7 @@ describe('useFleetServerHostsForm', () => {
     testRenderer.startServices.http.post.mockResolvedValue({});
     const { result } = testRenderer.renderHook(() => useFleetServerHostsForm([], onSucess));
 
-    act(() => result.current.fleetServerHostsInput.setValue(['http://test.fr']));
+    act(() => result.current.fleetServerHostsInput.props.onChange(['http://test.fr']));
 
     await act(() => result.current.submit());
     expect(onSucess).toBeCalled();
@@ -64,13 +66,15 @@ describe('useFleetServerHostsForm', () => {
     testRenderer.startServices.http.post.mockResolvedValue({});
     const { result } = testRenderer.renderHook(() => useFleetServerHostsForm([], onSucess));
 
-    act(() => result.current.fleetServerHostsInput.setValue(['http://test.fr', 'http://test.fr']));
+    act(() =>
+      result.current.fleetServerHostsInput.props.onChange(['http://test.fr', 'http://test.fr'])
+    );
 
     await act(() => result.current.submit());
     expect(onSucess).not.toBeCalled();
     expect(result.current.isDisabled).toBeTruthy();
 
-    act(() => result.current.fleetServerHostsInput.setValue(['http://test.fr']));
+    act(() => result.current.fleetServerHostsInput.props.onChange(['http://test.fr']));
     expect(result.current.isDisabled).toBeFalsy();
 
     await act(() => result.current.submit());

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act } from 'react-test-renderer';
+
+import { createFleetTestRendererMock } from '../../../../../../mock';
+
+import { useFleetServerHostsForm } from './use_fleet_server_host_form';
+
+jest.mock('../../services/agent_and_policies_count', () => ({
+  ...jest.requireActual('../../services/agent_and_policies_count'),
+  getAgentAndPolicyCount: () => ({ agentCount: 0, agentPolicyCount: 0 }),
+}));
+jest.mock('../../hooks/use_confirm_modal', () => ({
+  ...jest.requireActual('../../hooks/use_confirm_modal'),
+  useConfirmModal: () => ({ confirm: () => true }),
+}));
+
+describe('useFleetServerHostsForm', () => {
+  it('should not allow to submit an invalid form', async () => {
+    const testRenderer = createFleetTestRendererMock();
+    const onSucess = jest.fn();
+    const { result } = testRenderer.renderHook(() => useFleetServerHostsForm([], onSucess));
+
+    act(() => result.current.fleetServerHostsInput.setValue(['http://test.fr', 'http://test.fr']));
+
+    await act(() => result.current.submit());
+
+    expect(result.current.fleetServerHostsInput.props.errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "index": 0,
+          "message": "Duplicate URL",
+        },
+        Object {
+          "index": 1,
+          "message": "Duplicate URL",
+        },
+      ]
+    `);
+    expect(onSucess).not.toBeCalled();
+  });
+
+  it('should submit a valid form', async () => {
+    const testRenderer = createFleetTestRendererMock();
+    const onSucess = jest.fn();
+    testRenderer.startServices.http.post.mockResolvedValue({});
+    const { result } = testRenderer.renderHook(() => useFleetServerHostsForm([], onSucess));
+
+    act(() => result.current.fleetServerHostsInput.setValue(['http://test.fr']));
+
+    await act(() => result.current.submit());
+    expect(onSucess).toBeCalled();
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.test.tsx
@@ -43,6 +43,7 @@ describe('useFleetServerHostsForm', () => {
       ]
     `);
     expect(onSucess).not.toBeCalled();
+    expect(result.current.isDisabled).toBeTruthy();
   });
 
   it('should submit a valid form', async () => {
@@ -52,6 +53,25 @@ describe('useFleetServerHostsForm', () => {
     const { result } = testRenderer.renderHook(() => useFleetServerHostsForm([], onSucess));
 
     act(() => result.current.fleetServerHostsInput.setValue(['http://test.fr']));
+
+    await act(() => result.current.submit());
+    expect(onSucess).toBeCalled();
+  });
+
+  it('should allow the user to correct and submit a invalid form', async () => {
+    const testRenderer = createFleetTestRendererMock();
+    const onSucess = jest.fn();
+    testRenderer.startServices.http.post.mockResolvedValue({});
+    const { result } = testRenderer.renderHook(() => useFleetServerHostsForm([], onSucess));
+
+    act(() => result.current.fleetServerHostsInput.setValue(['http://test.fr', 'http://test.fr']));
+
+    await act(() => result.current.submit());
+    expect(onSucess).not.toBeCalled();
+    expect(result.current.isDisabled).toBeTruthy();
+
+    act(() => result.current.fleetServerHostsInput.setValue(['http://test.fr']));
+    expect(result.current.isDisabled).toBeFalsy();
 
     await act(() => result.current.submit());
     expect(onSucess).toBeCalled();

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.tsx
@@ -142,7 +142,7 @@ export function useFleetServerHostsForm(
 
   const submit = useCallback(async () => {
     try {
-      if (!validate) {
+      if (!validate()) {
         return;
       }
       const { agentCount, agentPolicyCount } = await getAgentAndPolicyCount();

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -178,9 +178,12 @@ export function useFleetServerHostsForm(
     }
   }, [fleetServerHostsInput.value, validate, notifications, confirm, onSuccess]);
 
+  const isDisabled =
+    isLoading || !fleetServerHostsInput.hasChanged || fleetServerHostsInput.props.isInvalid;
+
   return {
     isLoading,
-    isDisabled: isLoading || !fleetServerHostsInput.hasChanged,
+    isDisabled,
     submit,
     fleetServerHostsInput,
   };

--- a/x-pack/plugins/fleet/public/hooks/use_input.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_input.ts
@@ -125,11 +125,22 @@ export function useComboInput(
 
   const isInvalid = errors !== undefined;
 
+  const validateCallback = useCallback(() => {
+    if (validate) {
+      const newErrors = validate(value);
+      setErrors(newErrors);
+
+      return newErrors === undefined;
+    }
+
+    return true;
+  }, [validate, value]);
+
   const onChange = useCallback(
     (newValues: string[]) => {
       setValue(newValues);
-      if (errors && validate && validate(newValues) === undefined) {
-        setErrors(undefined);
+      if (errors && validate) {
+        setErrors(validate(newValues));
       }
     },
     [validate, errors]
@@ -149,16 +160,7 @@ export function useComboInput(
       setValue([]);
     },
     setValue,
-    validate: () => {
-      if (validate) {
-        const newErrors = validate(value);
-        setErrors(newErrors);
-
-        return newErrors === undefined;
-      }
-
-      return true;
-    },
+    validate: validateCallback,
     hasChanged,
   };
 }


### PR DESCRIPTION
## Summary

Resolve #122216 

Fleet server hosts were not validated client side, that PR fix that and add missing test.

<img width="814" alt="Screen Shot 2022-02-09 at 9 51 44 AM" src="https://user-images.githubusercontent.com/1336873/153226683-c451528d-828e-4862-8983-0b84d88cb7d9.png">
