### PR TITLE
[7.17] Use sentence case in Index Management list titles (#125037)

### DIFF
--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/detail_panel/summary/summary.js
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/detail_panel/summary/summary.js
@@ -36,16 +36,16 @@ const getHeaders = () => {
       defaultMessage: 'Replicas',
     }),
     documents: i18n.translate('xpack.idxMgmt.summary.headers.documentsHeader', {
-      defaultMessage: 'Docs Count',
+      defaultMessage: 'Docs count',
     }),
     documents_deleted: i18n.translate('xpack.idxMgmt.summary.headers.deletedDocumentsHeader', {
-      defaultMessage: 'Docs Deleted',
+      defaultMessage: 'Docs deleted',
     }),
     size: i18n.translate('xpack.idxMgmt.summary.headers.storageSizeHeader', {
-      defaultMessage: 'Storage Size',
+      defaultMessage: 'Storage size',
     }),
     primary_size: i18n.translate('xpack.idxMgmt.summary.headers.primaryStorageSizeHeader', {
-      defaultMessage: 'Primary Storage Size',
+      defaultMessage: 'Primary storage size',
     }),
     aliases: i18n.translate('xpack.idxMgmt.summary.headers.aliases', {
       defaultMessage: 'Aliases',


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #125037

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
