### PR TITLE
[Fleet] Improve privileges integration testing

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/agents/actions.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/actions.ts
@@ -7,11 +7,13 @@
 
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { testUsers } from '../test_users';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const esArchiver = getService('esArchiver');
   const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
 
   describe('fleet_agents_actions', () => {
     before(async () => {
@@ -96,6 +98,20 @@ export default function (providerContext: FtrProviderContext) {
           },
         })
         .expect(404);
+    });
+
+    it('should return a 403 if user lacks fleet all permissions', async () => {
+      await supertestWithoutAuth
+        .post(`/api/fleet/agents/agent1/actions`)
+        .set('kbn-xsrf', 'xx')
+        .auth(testUsers.fleet_no_access.username, testUsers.fleet_no_access.password)
+        .send({
+          action: {
+            type: 'POLICY_CHANGE',
+            data: { data: 'action_data' },
+          },
+        })
+        .expect(403);
     });
   });
 }

--- a/x-pack/test/fleet_api_integration/apis/agents/delete.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/delete.ts
@@ -18,7 +18,8 @@ export default function ({ getService }: FtrProviderContext) {
     fleet_user: {
       permissions: {
         feature: {
-          fleet: ['read'],
+          fleet: ['all'],
+          fleetv2: ['none'],
         },
         spaces: ['*'],
       },
@@ -26,9 +27,9 @@ export default function ({ getService }: FtrProviderContext) {
       password: 'changeme',
     },
     fleet_admin: {
-      roles: ['superuser'],
       permissions: {
         feature: {
+          fleetv2: ['all'],
           fleet: ['all'],
         },
         spaces: ['*'],
@@ -63,8 +64,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await esArchiver.unload('x-pack/test/functional/es_archives/fleet/agents');
     });
-
-    it('should return a 403 if user lacks fleet-write permissions', async () => {
+    it('should return a 403 if user lacks fleet all permissions', async () => {
       const { body: apiResponse } = await supertest
         .delete(`/api/fleet/agents/agent1`)
         .auth(users.fleet_user.username, users.fleet_user.password)

--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -23,11 +23,10 @@ export default function ({ getService }: FtrProviderContext) {
       await esArchiver.unload('x-pack/test/functional/es_archives/fleet/agents');
     });
 
-    // Only superuser can access Fleet for now.
     it.skip('should return a 200 if a user with the fleet all try to access the list', async () => {
       await supertest
         .get(`/api/fleet/agents`)
-        .auth(testUsers.fleet_all.username, testUsers.fleet_all.password)
+        .auth(testUsers.fleet_all_only.username, testUsers.fleet_all_only.password)
         .expect(200);
     });
 

--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -37,7 +37,7 @@ export default function ({ getService }: FtrProviderContext) {
         .expect(403);
     });
 
-    it('should return the list of agents when requesting as a superuser', async () => {
+    it('should return the list of agents when requesting as admin', async () => {
       const { body: apiResponse } = await supertest.get(`/api/fleet/agents`).expect(200);
 
       expect(apiResponse).to.have.keys('page', 'total', 'items', 'list');

--- a/x-pack/test/fleet_api_integration/apis/agents/reassign.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/reassign.ts
@@ -8,11 +8,13 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { setupFleetAndAgents } from './services';
+import { testUsers } from '../test_users';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const esArchiver = getService('esArchiver');
   const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
 
   describe('reassign agent(s)', () => {
     before(async () => {
@@ -204,6 +206,18 @@ export default function (providerContext: FtrProviderContext) {
             policy_id: 'INVALID_ID',
           })
           .expect(404);
+      });
+
+      it('should return a 403 if user lacks fleet all permissions', async () => {
+        await supertestWithoutAuth
+          .post(`/api/fleet/agents/bulk_reassign`)
+          .auth(testUsers.fleet_no_access.username, testUsers.fleet_no_access.password)
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            agents: ['agent2', 'agent3'],
+            policy_id: 'policy2',
+          })
+          .expect(403);
       });
     });
   });

--- a/x-pack/test/fleet_api_integration/apis/enrollment_api_keys/crud.ts
+++ b/x-pack/test/fleet_api_integration/apis/enrollment_api_keys/crud.ts
@@ -11,6 +11,8 @@ import { FtrProviderContext } from '../../../api_integration/ftr_provider_contex
 import { setupFleetAndAgents, getEsClientForAPIKey } from '../agents/services';
 import { skipIfNoDockerRegistry } from '../../helpers';
 
+import { testUsers } from '../test_users';
+
 const ENROLLMENT_KEY_ID = 'ed22ca17-e178-4cfe-8b02-54ea29fbd6d0';
 
 export default function (providerContext: FtrProviderContext) {
@@ -18,6 +20,7 @@ export default function (providerContext: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const es = getService('es');
   const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
 
   describe('fleet_enrollment_api_keys_crud', () => {
     before(async () => {
@@ -41,6 +44,20 @@ export default function (providerContext: FtrProviderContext) {
         expect(apiResponse.items[0]).to.have.keys('id', 'api_key_id', 'name');
         expect(apiResponse).to.have.keys('items');
       });
+
+      it('should return 200 if the user has correct permissions', async () => {
+        await supertestWithoutAuth
+          .get(`/api/fleet/enrollment_api_keys`)
+          .auth(testUsers.setup.username, testUsers.setup.password)
+          .expect(200);
+      });
+
+      it('should return 403 if the user does not have correct permissions', async () => {
+        await supertestWithoutAuth
+          .get(`/api/fleet/enrollment_api_keys`)
+          .auth(testUsers.integr_all_only.username, testUsers.integr_all_only.password)
+          .expect(403);
+      });
     });
 
     describe('GET /fleet/enrollment_api_keys/{id}', async () => {
@@ -50,6 +67,20 @@ export default function (providerContext: FtrProviderContext) {
           .expect(200);
 
         expect(apiResponse.item).to.have.keys('id', 'api_key_id', 'name');
+      });
+
+      it('should return 200 if the user has correct permissions', async () => {
+        await supertestWithoutAuth
+          .get(`/api/fleet/enrollment_api_keys/${ENROLLMENT_KEY_ID}`)
+          .auth(testUsers.setup.username, testUsers.setup.password)
+          .expect(200);
+      });
+
+      it('should return 403 if the user does not have correct permissions', async () => {
+        await supertestWithoutAuth
+          .get(`/api/fleet/enrollment_api_keys/${ENROLLMENT_KEY_ID}`)
+          .auth(testUsers.integr_all_only.username, testUsers.integr_all_only.password)
+          .expect(403);
       });
     });
 
@@ -78,6 +109,14 @@ export default function (providerContext: FtrProviderContext) {
 
         expect(apiKeys).length(1);
         expect(apiKeys[0].invalidated).eql(true);
+      });
+
+      it('should return 403 if the user does not have correct permissions', async () => {
+        await supertestWithoutAuth
+          .delete(`/api/fleet/enrollment_api_keys/${keyId}`)
+          .auth(testUsers.integr_all_only.username, testUsers.integr_all_only.password)
+          .set('kbn-xsrf', 'xxx')
+          .expect(403);
       });
     });
 
@@ -114,6 +153,17 @@ export default function (providerContext: FtrProviderContext) {
           .expect(200);
 
         expect(apiResponse.item).to.have.keys('id', 'api_key', 'api_key_id', 'name', 'policy_id');
+      });
+
+      it('should return 403 if the user does not have correct permissions', async () => {
+        await supertestWithoutAuth
+          .post(`/api/fleet/enrollment_api_keys`)
+          .auth(testUsers.integr_all_only.username, testUsers.integr_all_only.password)
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            policy_id: 'policy1',
+          })
+          .expect(403);
       });
 
       it('should allow to create an enrollment api key with agent policy and unique name', async () => {

--- a/x-pack/test/fleet_api_integration/apis/epm/bulk_upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/bulk_upgrade.ts
@@ -46,10 +46,17 @@ export default function (providerContext: FtrProviderContext) {
       it('should return 400 if no packages are requested for upgrade', async function () {
         await supertest.post(`/api/fleet/epm/packages/_bulk`).set('kbn-xsrf', 'xxxx').expect(400);
       });
-      it('should return 403 if read only user requests upgrade', async function () {
+      it('should return 403 if user without integrations all requests upgrade', async function () {
         await supertestWithoutAuth
           .post(`/api/fleet/epm/packages/_bulk`)
-          .auth(testUsers.fleet_read_only.username, testUsers.fleet_read_only.password)
+          .auth(testUsers.fleet_all_int_read.username, testUsers.fleet_all_int_read.password)
+          .set('kbn-xsrf', 'xxxx')
+          .expect(403);
+      });
+      it('should return 403 if user without fleet access requests upgrade', async function () {
+        await supertestWithoutAuth
+          .post(`/api/fleet/epm/packages/_bulk`)
+          .auth(testUsers.integr_all_only.username, testUsers.integr_all_only.password)
           .set('kbn-xsrf', 'xxxx')
           .expect(403);
       });

--- a/x-pack/test/fleet_api_integration/apis/epm/delete.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/delete.ts
@@ -56,10 +56,18 @@ export default function (providerContext: FtrProviderContext) {
         .expect(200);
     });
 
-    it('should return 403 for read-only users', async () => {
+    it('should return 403 for users without integrations all permissions', async () => {
       await supertestWithoutAuth
         .delete(`/api/fleet/epm/packages/${requiredPackage}/${pkgVersion}`)
-        .auth(testUsers.fleet_read_only.username, testUsers.fleet_read_only.password)
+        .auth(testUsers.fleet_all_int_read.username, testUsers.fleet_all_int_read.password)
+        .set('kbn-xsrf', 'xxxx')
+        .expect(403);
+    });
+
+    it('should return 403 for users without fleet all permissions', async () => {
+      await supertestWithoutAuth
+        .delete(`/api/fleet/epm/packages/${requiredPackage}/${pkgVersion}`)
+        .auth(testUsers.integr_all_only.username, testUsers.integr_all_only.password)
         .set('kbn-xsrf', 'xxxx')
         .expect(403);
     });

--- a/x-pack/test/fleet_api_integration/apis/epm/get.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/get.ts
@@ -96,10 +96,22 @@ export default function (providerContext: FtrProviderContext) {
       await supertest.get('/api/fleet/epm/packages/endpoint/0.1.0.1.2.3').expect(400);
     });
 
-    it('allows user with only read permission to access', async () => {
+    it('allows user with only fleet permission to access', async () => {
       await supertestWithoutAuth
         .get(`/api/fleet/epm/packages/${testPkgName}/${testPkgVersion}`)
-        .auth(testUsers.fleet_read_only.username, testUsers.fleet_read_only.password)
+        .auth(testUsers.fleet_all_only.username, testUsers.fleet_all_only.password)
+        .expect(200);
+    });
+    it('allows user with only integrations permission to access', async () => {
+      await supertestWithoutAuth
+        .get(`/api/fleet/epm/packages/${testPkgName}/${testPkgVersion}`)
+        .auth(testUsers.integr_all_only.username, testUsers.integr_all_only.password)
+        .expect(200);
+    });
+    it('allows user with integrations read permission to access', async () => {
+      await supertestWithoutAuth
+        .get(`/api/fleet/epm/packages/${testPkgName}/${testPkgVersion}`)
+        .auth(testUsers.fleet_all_int_read.username, testUsers.fleet_all_int_read.password)
         .expect(200);
     });
 

--- a/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
@@ -184,7 +184,18 @@ export default function (providerContext: FtrProviderContext) {
       const buf = fs.readFileSync(testPkgArchiveTgz);
       await supertestWithoutAuth
         .post(`/api/fleet/epm/packages`)
-        .auth(testUsers.fleet_read_only.username, testUsers.fleet_read_only.password)
+        .auth(testUsers.fleet_all_int_read.username, testUsers.fleet_all_int_read.password)
+        .set('kbn-xsrf', 'xxxx')
+        .type('application/gzip')
+        .send(buf)
+        .expect(403);
+    });
+
+    it('should not allow non superusers', async () => {
+      const buf = fs.readFileSync(testPkgArchiveTgz);
+      await supertestWithoutAuth
+        .post(`/api/fleet/epm/packages`)
+        .auth(testUsers.fleet_all_int_all.username, testUsers.fleet_all_int_all.password)
         .set('kbn-xsrf', 'xxxx')
         .type('application/gzip')
         .send(buf)

--- a/x-pack/test/fleet_api_integration/apis/epm/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/list.ts
@@ -57,10 +57,22 @@ export default function (providerContext: FtrProviderContext) {
         expect(listResponse.items.sort()).to.eql(['endpoint'].sort());
       });
 
-      it('allows user with only read permission to access', async () => {
+      it('allows user with only fleet permission to access', async () => {
         await supertestWithoutAuth
           .get('/api/fleet/epm/packages')
-          .auth(testUsers.fleet_read_only.username, testUsers.fleet_read_only.password)
+          .auth(testUsers.fleet_all_only.username, testUsers.fleet_all_only.password)
+          .expect(200);
+      });
+      it('allows user with only integrations permission to access', async () => {
+        await supertestWithoutAuth
+          .get('/api/fleet/epm/packages')
+          .auth(testUsers.integr_all_only.username, testUsers.integr_all_only.password)
+          .expect(200);
+      });
+      it('allows user with integrations read permission to access', async () => {
+        await supertestWithoutAuth
+          .get('/api/fleet/epm/packages')
+          .auth(testUsers.fleet_all_int_read.username, testUsers.fleet_all_int_read.password)
           .expect(200);
       });
     });

--- a/x-pack/test/fleet_api_integration/apis/epm/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/list.ts
@@ -75,6 +75,12 @@ export default function (providerContext: FtrProviderContext) {
           .auth(testUsers.fleet_all_int_read.username, testUsers.fleet_all_int_read.password)
           .expect(200);
       });
+      it('does not allow user with the correct permissions', async () => {
+        await supertestWithoutAuth
+          .get('/api/fleet/epm/packages')
+          .auth(testUsers.fleet_no_access.username, testUsers.fleet_no_access.password)
+          .expect(403);
+      });
     });
   });
 }

--- a/x-pack/test/fleet_api_integration/apis/test_users.ts
+++ b/x-pack/test/fleet_api_integration/apis/test_users.ts
@@ -20,24 +20,46 @@ export const testUsers: {
     username: 'fleet_no_access',
     password: 'changeme',
   },
-  fleet_read_only: {
+  fleet_all_only: {
     permissions: {
       feature: {
+        fleetv2: ['all'],
+      },
+      spaces: ['*'],
+    },
+    username: 'fleet_all_only',
+    password: 'changeme',
+  },
+  fleet_all_int_read: {
+    permissions: {
+      feature: {
+        fleetv2: ['all'],
         fleet: ['read'],
       },
       spaces: ['*'],
     },
-    username: 'fleet_read_only',
+    username: 'fleet_all_int_read',
     password: 'changeme',
   },
-  fleet_all: {
+  fleet_all_int_all: {
+    permissions: {
+      feature: {
+        fleetv2: ['all'],
+        fleet: ['all'],
+      },
+      spaces: ['*'],
+    },
+    username: 'fleet_all_int_all',
+    password: 'changeme',
+  },
+  integr_all_only: {
     permissions: {
       feature: {
         fleet: ['all'],
       },
       spaces: ['*'],
     },
-    username: 'fleet_all',
+    username: 'integr_all',
     password: 'changeme',
   },
 };

--- a/x-pack/test/fleet_api_integration/apis/test_users.ts
+++ b/x-pack/test/fleet_api_integration/apis/test_users.ts
@@ -10,6 +10,28 @@ import type { SecurityService } from '../../../../test/common/services/security/
 export const testUsers: {
   [rollName: string]: { username: string; password: string; permissions?: any };
 } = {
+  fleet_all_int_all: {
+    permissions: {
+      feature: {
+        fleetv2: ['all'],
+        fleet: ['all'],
+      },
+      spaces: ['*'],
+    },
+    username: 'fleet_all_int_all',
+    password: 'changeme',
+  },
+  setup: {
+    permissions: {
+      feature: {
+        fleetv2: ['all', 'setup'],
+        fleet: ['all'],
+      },
+      spaces: ['*'],
+    },
+    username: 'setup',
+    password: 'changeme',
+  },
   fleet_no_access: {
     permissions: {
       feature: {
@@ -39,17 +61,6 @@ export const testUsers: {
       spaces: ['*'],
     },
     username: 'fleet_all_int_read',
-    password: 'changeme',
-  },
-  fleet_all_int_all: {
-    permissions: {
-      feature: {
-        fleetv2: ['all'],
-        fleet: ['all'],
-      },
-      spaces: ['*'],
-    },
-    username: 'fleet_all_int_all',
     password: 'changeme',
   },
   integr_all_only: {


### PR DESCRIPTION
## Summary

Improve integration testing of privileges on API endpoints.

- Added users and roles based on the new privileges.
- Added permission testing on some endpoint that didn't have it already.

Follow up on https://github.com/elastic/kibana/pull/122347