### PR TITLE
[Security Solution] Data view override for sourcerer

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/sourcerer/routes/index.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/sourcerer/routes/index.test.ts
@@ -168,6 +168,35 @@ describe('sourcerer route', () => {
         expect(response.body).toEqual(mockDataViewsTransformed);
       });
 
+      test('passes override=true on create and save', async () => {
+        const getMock = jest.fn();
+        getMock.mockResolvedValueOnce(null);
+        getMock.mockResolvedValueOnce(mockPattern);
+        const mockCreateAndSave = jest.fn();
+        const getStartServicesSpecial = jest.fn().mockResolvedValue([
+          null,
+          {
+            data: {
+              indexPatterns: {
+                dataViewsServiceFactory: () => ({
+                  getIdsWithTitle: () =>
+                    new Promise((rs) => rs(mockDataViews.filter((v) => v.id !== mockPattern.id))),
+                  get: getMock,
+                  createAndSave: mockCreateAndSave.mockImplementation(
+                    () => new Promise((rs) => rs(mockPattern))
+                  ),
+                  updateSavedObject: () => new Promise((rs, rj) => rj(new Error('error'))),
+                }),
+              },
+            },
+          },
+        ] as unknown) as StartServicesAccessor<StartPlugins>;
+        createSourcererDataViewRoute(server.router, getStartServicesSpecial);
+        await server.inject(getSourcererRequest(mockPatternList), context);
+        expect(mockCreateAndSave).toHaveBeenCalled();
+        expect(mockCreateAndSave.mock.calls[0][1]).toEqual(true);
+      });
+
       test('returns sourcerer formatted Data Views when SIEM Data View exists', async () => {
         createSourcererDataViewRoute(server.router, getStartServices);
         const response = await server.inject(getSourcererRequest(mockPatternList), context);

--- a/x-pack/plugins/security_solution/server/lib/sourcerer/routes/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/sourcerer/routes/index.ts
@@ -72,12 +72,15 @@ export const createSourcererDataViewRoute = (
         const siemDataViewTitle = siemDataView ? siemDataView.title.split(',').sort().join() : '';
         if (siemDataView == null) {
           try {
-            siemDataView = await dataViewService.createAndSave({
-              allowNoIndex: true,
-              id: dataViewId,
-              title: patternListAsTitle,
-              timeFieldName: DEFAULT_TIME_FIELD,
-            });
+            siemDataView = await dataViewService.createAndSave(
+              {
+                allowNoIndex: true,
+                id: dataViewId,
+                title: patternListAsTitle,
+                timeFieldName: DEFAULT_TIME_FIELD,
+              },
+              true
+            );
           } catch (err) {
             const error = transformError(err);
             if (err.name === 'DuplicateDataViewError' || error.statusCode === 409) {

--- a/x-pack/plugins/security_solution/server/lib/sourcerer/routes/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/sourcerer/routes/index.ts
@@ -79,6 +79,8 @@ export const createSourcererDataViewRoute = (
                 title: patternListAsTitle,
                 timeFieldName: DEFAULT_TIME_FIELD,
               },
+              // Override property - if a data view exists with the security solution pattern
+              // delete it and replace it with our data view
               true
             );
           } catch (err) {


### PR DESCRIPTION
## Summary

Fixes Issue https://github.com/elastic/kibana/issues/122009

Watch video from bug issue above. 

**To test:** Go to Security App. Go to Stack Management > Data Views. Delete the Default Security Data View and create a new data view with the same exact index pattern. Navigate back to Security App.

Before: error
After: no error

The Data View api does not allow for Data Views with identical index patterns, but there is an `override` property that we can pass to get around this. The only way to test for this would be functional, and its an edge case so I do not think it is necessary.
