### PR TITLE
[Vega] Remove legacy import

### DIFF
--- a/src/plugins/vis_types/vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_types/vega/public/vega_view/vega_base_view.js
@@ -15,8 +15,8 @@ import { version as vegaLiteVersion } from 'vega-lite';
 import { Utils } from '../data_model/utils';
 import { euiPaletteColorBlind } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { buildQueryFilter, compareFilters } from '@kbn/es-query';
 import { TooltipHandler } from './vega_tooltip';
-import { esFilters } from '../../../../data/public';
 
 import { getEnableExternalUrls, getData } from '../services';
 import { extractIndexPatternsFromSpec } from '../lib/extract_index_pattern';
@@ -344,7 +344,7 @@ export class VegaBaseView {
    */
   async addFilterHandler(query, index, alias) {
     const indexId = await this.findIndex(index);
-    const filter = esFilters.buildQueryFilter(query, indexId, alias);
+    const filter = buildQueryFilter(query, indexId, alias);
 
     this._fireEvent({ name: 'applyFilter', data: { filters: [filter] } });
   }
@@ -355,12 +355,10 @@ export class VegaBaseView {
    */
   async removeFilterHandler(query, index) {
     const indexId = await this.findIndex(index);
-    const filterToRemove = esFilters.buildQueryFilter(query, indexId);
+    const filterToRemove = buildQueryFilter(query, indexId);
 
     const currentFilters = this._filterManager.getFilters();
-    const existingFilter = currentFilters.find((filter) =>
-      esFilters.compareFilters(filter, filterToRemove)
-    );
+    const existingFilter = currentFilters.find((filter) => compareFilters(filter, filterToRemove));
 
     if (!existingFilter) return;
 


### PR DESCRIPTION
Removes a forgotten import of `esFilters` in JS land