### PR TITLE
[8.1] [cloud] Get user email from saml metadata (#124301)

### DIFF
--- a/x-pack/plugins/cloud/server/routes/chat.test.ts
+++ b/x-pack/plugins/cloud/server/routes/chat.test.ts
@@ -44,14 +44,16 @@ describe('chat route', () => {
       `);
   });
 
-  test('returns user information and a token', async () => {
+  test('returns user information taken from saml metadata and a token', async () => {
     const security = securityMock.createSetup();
     const username = 'user.name';
     const email = 'user@elastic.co';
 
     security.authc.getCurrentUser.mockReturnValueOnce({
       username,
-      email,
+      metadata: {
+        saml_email: [email],
+      },
     });
 
     const router = httpServiceMock.createRouter();


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.1` of:
 - #124301

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
