### PR TITLE
Disabled import button while no file is attached

### DIFF
--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/flyout.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/flyout.test.tsx.snap
@@ -378,6 +378,7 @@ exports[`Flyout should render import step 1`] = `
         <EuiButton
           data-test-subj="importSavedObjectsImportBtn"
           fill={true}
+          isDisabled={true}
           isLoading={false}
           onClick={[Function]}
           size="s"

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
@@ -92,6 +92,52 @@ describe('Flyout', () => {
     expect(component.state('file')).toBe(undefined);
   });
 
+  it('should only allow import once a file is selected', async () => {
+    const component = shallowRender(defaultProps);
+
+    // Ensure all promises resolve
+    await Promise.resolve();
+    // Ensure state changes are reflected
+    component.update();
+
+    expect(component.state('file')).toBe(undefined);
+    const importButton = await component.find(
+      'EuiButton[data-test-subj="importSavedObjectsImportBtn"]'
+    );
+    expect(importButton.prop('isDisabled')).toBe(true);
+    component.find('EuiFilePicker').simulate('change', [mockFile]);
+
+    // Ensure state changes are reflected
+    component.update();
+    const enabledImportButton = await component.find(
+      'EuiButton[data-test-subj="importSavedObjectsImportBtn"]'
+    );
+    expect(enabledImportButton.prop('isDisabled')).toBe(false);
+  });
+
+  it('should show "missing_file" error on import if import button is bypassed and no file is selected', async () => {
+    const component = shallowRender(defaultProps);
+
+    // Ensure all promises resolve
+    await new Promise((resolve) => process.nextTick(resolve));
+    // Ensure the state changes are reflected
+    component.update();
+
+    // Go through the import flow
+    await component.instance().import();
+    component.update();
+    // Ensure all promises resolve
+    await Promise.resolve();
+
+    expect(component.state('error')).toBe('missing_file');
+    expect(component.state('status')).toBe('error');
+
+    const callOutText = await component
+      .find('p[data-test-subj="importSavedObjectsErrorText"]')
+      .text();
+    expect(callOutText).toBe('missing_file');
+  });
+
   describe('conflicts', () => {
     beforeEach(() => {
       importFileMock.mockImplementation(() => ({

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
@@ -146,11 +146,18 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
   import = async () => {
     const { http } = this.props;
     const { file, importMode } = this.state;
+    if (file === undefined) {
+      this.setState({
+        status: 'error',
+        error: 'missing_file',
+      });
+      return;
+    }
     this.setState({ status: 'loading', error: undefined });
 
     // Import the file
     try {
-      const response = await importFile(http, file!, importMode);
+      const response = await importFile(http, file, importMode);
       this.setState(processImportResponse(response), () => {
         // Resolve import errors right away if there's no index patterns to match
         // This will ask about overwriting each object, etc
@@ -486,7 +493,7 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
   }
 
   renderFooter() {
-    const { status } = this.state;
+    const { status, file } = this.state;
     const { done, close } = this.props;
 
     let confirmButton;
@@ -521,6 +528,7 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
           onClick={this.import}
           size="s"
           fill
+          isDisabled={file === undefined}
           isLoading={status === 'loading'}
           data-test-subj="importSavedObjectsImportBtn"
         >

--- a/test/functional/apps/management/_import_objects.ts
+++ b/test/functional/apps/management/_import_objects.ts
@@ -207,6 +207,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const isSavedObjectImported = objects.includes('saved object imported with index pattern');
         expect(isSavedObjectImported).to.be(true);
       });
+
+      it('should not allow import without a file added', async function () {
+        const importActionDisabled = await PageObjects.savedObjects.importDisabled();
+        expect(importActionDisabled).to.eql('true');
+      });
     });
   });
 }

--- a/test/functional/page_objects/management/saved_objects_page.ts
+++ b/test/functional/page_objects/management/saved_objects_page.ts
@@ -58,6 +58,15 @@ export class SavedObjectsPageObject extends FtrService {
     await this.header.waitUntilLoadingHasFinished();
   }
 
+  async importDisabled() {
+    this.log.debug(`tryImport`);
+    this.log.debug(`Finding import action`);
+    await this.testSubjects.click('importObjects');
+    this.log.debug(`Finding import button`);
+    const importButton = await this.testSubjects.find('importSavedObjectsImportBtn');
+    return await importButton.getAttribute('disabled');
+  }
+
   async checkImportSucceeded() {
     await this.testSubjects.existOrFail('importSavedObjectsSuccess', { timeout: 20000 });
   }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/125013

Importing saved objects from files is used regularly. There are validation checks on the file type and contents being imported, but the UI doesn't guard against triggering the import action if there isn't a file to import from.

If this does happen, payload validation in the `import` route fails and the UI shows the error as 
`"Bad Request: [request body.file]: expected value of type [Stream] but got [string]"`.

(refer to https://github.com/elastic/kibana/issues/125013#issuecomment-1033038188 for code details)

This PR:
- disables the import button until a file is added (Import disabled image)
- handles a case where the disabled button is bypassed by, for example, changing the disabled state in the browser's dev tools, and renders a "missing_file" client-side error instead (Missing file error: UI text)
- adds unit and functional tests to guard against regression

**Import disabled image**
<img width="229" alt="disabled_import_button" src="https://user-images.githubusercontent.com/11909450/153320854-c3b05511-3267-496e-8545-fd3ad9871bc9.png">

**Missing file error: UI text**
![missing_file_error_text](https://user-images.githubusercontent.com/11909450/153319923-8b4d8ca7-245b-4e95-b986-5af09c1ab9b2.png)

### How to test this:
- start es and kibana
- navigate to the Saved Objects Management page
- open the flyout to import saved objects
- observe that the import button is disabled
- add a file to import
- observe that the import button is now enabled

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Disabled state on the UI is overridden or removed | Low | Low | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) (no changes)
