### PR TITLE
[APM] Add e2e tests for feature flags

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/power_user/feature_flag/comparison.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/power_user/feature_flag/comparison.ts
@@ -9,7 +9,6 @@ import { synthtrace } from '../../../../synthtrace';
 import { opbeans } from '../../../fixtures/synthtrace/opbeans';
 
 const settingsPath = '/app/management/kibana/settings';
-const apmBasePath = '/app/apm';
 
 const start = '2021-10-10T00:00:00.000Z';
 const end = '2021-10-10T00:15:00.000Z';
@@ -44,19 +43,19 @@ describe('Comparison feature flag', () => {
     });
 
     it('shows the comparison feature enabled in services overview', () => {
-      cy.visit(`${apmBasePath}/services`);
+      cy.visit('/app/apm/services');
       cy.get('input[type="checkbox"]#comparison').should('be.checked');
       cy.get('[data-test-subj="comparisonSelect"]').should('not.be.disabled');
     });
 
     it('shows the comparison feature enabled in services overview', () => {
-      cy.visit(`${apmBasePath}/backends`);
+      cy.visit('/app/apm/backends');
       cy.get('input[type="checkbox"]#comparison').should('be.checked');
       cy.get('[data-test-subj="comparisonSelect"]').should('not.be.disabled');
     });
 
     it('shows the comparison feature disabled in service map overview page', () => {
-      cy.visit(`${apmBasePath}/service-map`);
+      cy.visit('/app/apm/service-map');
       cy.get('input[type="checkbox"]#comparison').should('be.checked');
       cy.get('[data-test-subj="comparisonSelect"]').should('not.be.disabled');
     });
@@ -76,19 +75,19 @@ describe('Comparison feature flag', () => {
     });
 
     it('shows the comparison feature disabled in services overview', () => {
-      cy.visit(`${apmBasePath}/services`);
+      cy.visit('/app/apm/services');
       cy.get('input[type="checkbox"]#comparison').should('not.be.checked');
       cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
     });
 
     it('shows the comparison feature disabled in dependencies overview page', () => {
-      cy.visit(`${apmBasePath}/backends`);
+      cy.visit('/app/apm/backends');
       cy.get('input[type="checkbox"]#comparison').should('not.be.checked');
       cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
     });
 
     it('shows the comparison feature disabled in service map overview page', () => {
-      cy.visit(`${apmBasePath}/service-map`);
+      cy.visit('/app/apm/service-map');
       cy.get('input[type="checkbox"]#comparison').should('not.be.checked');
       cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
     });

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/power_user/feature_flag/comparison.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/power_user/feature_flag/comparison.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { synthtrace } from '../../../../synthtrace';
+import { opbeans } from '../../../fixtures/synthtrace/opbeans';
+
+const settingsPath = '/app/management/kibana/settings';
+const apmBasePath = '/app/apm';
+
+const start = '2021-10-10T00:00:00.000Z';
+const end = '2021-10-10T00:15:00.000Z';
+describe('Comparison feature flag', () => {
+  const comparisonToggle =
+    '[data-test-subj="advancedSetting-editField-observability:enableComparisonByDefault"]';
+
+  before(async () => {
+    await synthtrace.index(
+      opbeans({
+        from: new Date(start).getTime(),
+        to: new Date(end).getTime(),
+      })
+    );
+  });
+
+  after(async () => {
+    await synthtrace.clean();
+  });
+
+  beforeEach(() => {
+    cy.loginAsPowerUser();
+  });
+
+  describe('when comparison feature is enabled', () => {
+    it('shows the flag as enabled in kibana advanced settings', () => {
+      cy.visit(settingsPath);
+
+      cy.get(comparisonToggle)
+        .should('have.attr', 'aria-checked')
+        .and('equal', 'true');
+    });
+
+    it('shows the comparison feature enabled in services overview', () => {
+      cy.visit(`${apmBasePath}/services`);
+      cy.get('input[type="checkbox"]#comparison').should('be.checked');
+      cy.get('[data-test-subj="comparisonSelect"]').should('not.be.disabled');
+    });
+
+    it('shows the comparison feature enabled in services overview', () => {
+      cy.visit(`${apmBasePath}/backends`);
+      cy.get('input[type="checkbox"]#comparison').should('be.checked');
+      cy.get('[data-test-subj="comparisonSelect"]').should('not.be.disabled');
+    });
+
+    it('shows the comparison feature disabled in service map overview page', () => {
+      cy.visit(`${apmBasePath}/service-map`);
+      cy.get('input[type="checkbox"]#comparison').should('be.checked');
+      cy.get('[data-test-subj="comparisonSelect"]').should('not.be.disabled');
+    });
+  });
+
+  describe('when comparison feature is disabled', () => {
+    it('shows the flag as disabled in kibana advanced settings', () => {
+      cy.visit(settingsPath);
+      cy.get(comparisonToggle).click();
+      cy.contains('Save changes').should('not.be.disabled');
+      cy.contains('Save changes').click();
+      cy.get(comparisonToggle).should('not.be.checked');
+
+      cy.get(comparisonToggle)
+        .should('have.attr', 'aria-checked')
+        .and('equal', 'false');
+    });
+
+    it('shows the comparison feature disabled in services overview', () => {
+      cy.visit(`${apmBasePath}/services`);
+      cy.get('input[type="checkbox"]#comparison').should('not.be.checked');
+      cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
+    });
+
+    it('shows the comparison feature disabled in dependencies overview page', () => {
+      cy.visit(`${apmBasePath}/backends`);
+      cy.get('input[type="checkbox"]#comparison').should('not.be.checked');
+      cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
+    });
+
+    it('shows the comparison feature disabled in service map overview page', () => {
+      cy.visit(`${apmBasePath}/service-map`);
+      cy.get('input[type="checkbox"]#comparison').should('not.be.checked');
+      cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
+    });
+  });
+});

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/power_user/feature_flag/infrastructure.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/power_user/feature_flag/infrastructure.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { synthtrace } from '../../../../synthtrace';
+import { opbeans } from '../../../fixtures/synthtrace/opbeans';
+
+const settingsPath = '/app/management/kibana/settings';
+const serviceOverviewPath = '/app/apm/services/opbeans-python/overview';
+
+const start = '2021-10-10T00:00:00.000Z';
+const end = '2021-10-10T00:15:00.000Z';
+
+describe('Infrastracture feature flag', () => {
+  const infraToggle =
+    '[data-test-subj="advancedSetting-editField-observability:enableInfrastructureView"]';
+
+  before(async () => {
+    await synthtrace.index(
+      opbeans({
+        from: new Date(start).getTime(),
+        to: new Date(end).getTime(),
+      })
+    );
+  });
+
+  after(async () => {
+    await synthtrace.clean();
+  });
+
+  beforeEach(() => {
+    cy.loginAsPowerUser();
+  });
+
+  describe('when infrastracture feature is enabled', () => {
+    it('shows the flag as enabled in kibana advanced settings', () => {
+      cy.visit(settingsPath);
+
+      cy.get(infraToggle)
+        .should('have.attr', 'aria-checked')
+        .and('equal', 'true');
+    });
+
+    it('shows infrastructure tab in service overview page', () => {
+      cy.visit(serviceOverviewPath);
+      cy.contains('a[role="tab"]', 'Infrastructure').click();
+    });
+  });
+
+  describe('when infrastracture feature is disabled', () => {
+    it('shows the flag as disabled in kibana advanced settings', () => {
+      cy.visit(settingsPath);
+      cy.get(infraToggle).click();
+      cy.contains('Save changes').should('not.be.disabled');
+      cy.contains('Save changes').click();
+
+      cy.get(infraToggle)
+        .should('have.attr', 'aria-checked')
+        .and('equal', 'false');
+    });
+
+    it('hides infrastructure tab in service overview page', () => {
+      cy.visit(serviceOverviewPath);
+      cy.contains('a[role="tab"]', 'Infrastructure').should('not.exist');
+    });
+  });
+});


### PR DESCRIPTION
### Summary
closes https://github.com/elastic/apm/issues/591 
e2e tests for feature flags

1. comparison feature 
2. infrastructure feature