### PR TITLE
[TSVB] Only overwrite index pattern on setup if it is not set

### DIFF
--- a/src/plugins/vis_types/timeseries/public/metrics_type.ts
+++ b/src/plugins/vis_types/timeseries/public/metrics_type.ts
@@ -58,7 +58,7 @@ async function withDefaultIndexPattern(
   const { indexPatterns } = getDataStart();
 
   const defaultIndex = await indexPatterns.getDefault();
-  if (!defaultIndex || !defaultIndex.id) return vis;
+  if (!defaultIndex || !defaultIndex.id || vis.params.index_pattern) return vis;
   vis.params.index_pattern = {
     id: defaultIndex.id,
   };


### PR DESCRIPTION
Follow-up on https://github.com/elastic/kibana/pull/123997

Only sets the default index pattern on load if it's not set yet (e.g. for existing visualizations)