### PR TITLE
[Maps] Fix index pattern message in Create Index card tooltip

### DIFF
--- a/x-pack/plugins/maps/public/classes/layers/wizards/new_vector_layer_wizard/config.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/new_vector_layer_wizard/config.tsx
@@ -23,7 +23,7 @@ export const newVectorLayerWizardConfig: LayerWizard = {
   }),
   disabledReason: i18n.translate('xpack.maps.newVectorLayerWizard.disabledDesc', {
     defaultMessage:
-      'Unable to create index, you are missing the Kibana privilege "Index Pattern Management".',
+      'Unable to create index, you are missing the Kibana privilege "Data View Management".',
   }),
   getIsDisabled: async () => {
     const hasImportPermission = await getFileUpload().hasImportPermission({


### PR DESCRIPTION
Fixes #125058 

Replaces `Index Pattern` copy in the tool-tip of the `Create Index` card.
