### PR TITLE
[8.1] [DOCS] Removes tags from 8.0.0 release docs (#125115)

### DIFF
--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -4,8 +4,6 @@
 This section summarizes the most important changes in each release. For the 
 full list, see <<release-notes>> and <<breaking-changes>>. 
 
-coming[8.0.0]
-
 //NOTE: The notable-highlights tagged regions are re-used in the
 //Installation and Upgrade Guide
 


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.1` of:
 - #125115

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
