### PR TITLE
[8.0] [DOCS] Removes tags from 8.0.0 release docs (#125115)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -21,8 +21,6 @@ Review important information about the {kib} 8.0.0 releases.
 [[release-notes-8.0.0]]
 == {kib} 8.0.0
 
-coming::[8.0.0]
-
 Review the {kib} 8.0.0 changes, then use the {kibana-ref-all}/7.17/upgrade-assistant.html[Upgrade Assistant] to complete the upgrade.
 
 [float]

--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -5,8 +5,6 @@ Here are the highlights of what's new and improved in {minor-version}.
 For detailed information about this release,
 check the <<release-notes, release notes>>.
 
-coming[8.0.0]
-
 //NOTE: The notable-highlights tagged regions are re-used in the
 //Installation and Upgrade Guide
 


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #125115

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
