### PR TITLE
Fix agg filter for sibling pipeline aggs

### DIFF
--- a/src/plugins/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_helper.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_helper.ts
@@ -30,7 +30,7 @@ const metricAggFilter: string[] = [
   '!filtered_metric',
   '!single_percentile',
 ];
-const bucketAggFilter: string[] = [];
+const bucketAggFilter: string[] = ['!filter', '!sampler', '!diversified_sampler', '!multi_terms'];
 
 export const siblingPipelineType = i18n.translate(
   'data.search.aggs.metrics.siblingPipelineAggregationsSubtypeTitle',


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/122168 by specifying the agg filter for sibling pipeline aggs