### PR TITLE
[8.0] [DOCS] Remove 8.0.0 coming tag (#125229)

### DIFF
--- a/docs/migration/migrate_8_0.asciidoc
+++ b/docs/migration/migrate_8_0.asciidoc
@@ -7,8 +7,6 @@
 This section discusses the changes that you need to be aware of when migrating
 your application to Kibana 8.0.
 
-coming[8.0.0]
-
 See also <<whats-new>> and <<release-notes>>.
 
 * <<breaking_80_index_pattern_changes>>


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #125229

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
