### PR TITLE
Click slower in timepicker

### DIFF
--- a/test/functional/page_objects/time_picker.ts
+++ b/test/functional/page_objects/time_picker.ts
@@ -29,6 +29,7 @@ export class TimePickerPageObject extends FtrService {
   private readonly retry = this.ctx.getService('retry');
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly header = this.ctx.getPageObject('header');
+  private readonly common = this.ctx.getPageObject('common');
   private readonly kibanaServer = this.ctx.getService('kibanaServer');
 
   private readonly quickSelectTimeMenuToggle = this.ctx.getService('menuToggle').create({
@@ -244,6 +245,9 @@ export class TimePickerPageObject extends FtrService {
     const panel = await this.getTimePickerPanel();
     await this.testSubjects.click('superDatePickerAbsoluteTab');
     const end = await this.testSubjects.getAttribute('superDatePickerAbsoluteDateInput', 'value');
+
+    // Wait until closing popover again to avoid https://github.com/elastic/eui/issues/5619
+    await this.common.sleep(2000);
 
     // get from time
     await this.testSubjects.click('superDatePickerstartDatePopoverButton');


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/124607

Opening both the from and to popover of the timepicker to check the current time doesn't work if the test goes too fast: https://github.com/elastic/eui/issues/5619

This PR makes sure it's waiting a bit before opening the second one to make sure it's not getting stuck like in the linked issue. Once it's fixed on EUI side, this can be removed?