### PR TITLE
Fix minor typo in developer/contributing/development-documentation

### DIFF
--- a/docs/developer/contributing/development-documentation.asciidoc
+++ b/docs/developer/contributing/development-documentation.asciidoc
@@ -31,7 +31,7 @@ node scripts/docs.js --open
 
 REST APIs should be documented using the following recommended formats:
 
-* https://raw.githubusercontent.com/elastic/docs/master/shared/api-ref-ex.asciidoc[API doc templaate]
+* https://raw.githubusercontent.com/elastic/docs/master/shared/api-ref-ex.asciidoc[API doc template]
 * https://raw.githubusercontent.com/elastic/docs/master/shared/api-definitions-ex.asciidoc[API object definition template]
 
 [discrete]


### PR DESCRIPTION
## Summary

Fix minor typo in docs: `docs/developer/contributing/development-documentation.asciidoc`

### Checklist




### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
