### PR TITLE
[SecuritySolution] Enrich threshold data from `_source`

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
@@ -32,6 +32,7 @@ const props = {
   timelineId: 'detections-page',
   title: '',
   goToTable: jest.fn(),
+  rawEventData: {},
 };
 
 describe('AlertSummaryView', () => {
@@ -255,12 +256,39 @@ describe('AlertSummaryView', () => {
       {
         category: 'kibana',
         field: 'kibana.alert.threshold_result.terms',
-        values: ['{"field":"host.name","value":"Host-i120rdnmnw"}'],
-        originalValue: ['{"field":"host.name","value":"Host-i120rdnmnw"}'],
+        // value and originalValue don't matter here since the data comes from `_source` in the end
+        values: [''],
+        originalValue: [''],
+      },
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.cardinality',
+        // value and originalValue don't matter here since the data comes from `_source` in the end
+        values: [''],
+        originalValue: [''],
       },
     ] as TimelineEventsDetailsItem[];
     const renderProps = {
       ...props,
+      rawEventData: {
+        _source: {
+          'kibana.alert.threshold_result': {
+            cardinality: [
+              {
+                field: 'host.name',
+                value: 20,
+              },
+            ],
+            terms: [
+              {
+                field: 'host.name',
+                value: 'Host-i120rdnmnw',
+              },
+              { field: 'host.id', value: 'werw0r4hrj349r3j49r0' },
+            ],
+          },
+        },
+      },
       data: enhancedData,
     };
     const { getByText } = render(
@@ -269,7 +297,12 @@ describe('AlertSummaryView', () => {
       </TestProvidersComponent>
     );
 
-    ['Threshold Count', 'host.name [threshold]'].forEach((fieldId) => {
+    [
+      'Threshold Count',
+      'host.name [threshold]',
+      'host.id [threshold]',
+      'count(host.name) >= 20',
+    ].forEach((fieldId) => {
       expect(getByText(fieldId));
     });
   });

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -58,15 +58,25 @@ const summaryColumns: Array<EuiBasicTableColumn<SummaryRow>> = getSummaryColumns
 const AlertSummaryViewComponent: React.FC<{
   browserFields: BrowserFields;
   data: TimelineEventsDetailsItem[];
+  rawEventData: object | undefined;
   eventId: string;
   isDraggable?: boolean;
   timelineId: string;
   title: string;
   goToTable: () => void;
-}> = ({ browserFields, data, eventId, isDraggable, timelineId, title, goToTable }) => {
+}> = ({
+  browserFields,
+  data,
+  rawEventData,
+  eventId,
+  isDraggable,
+  timelineId,
+  title,
+  goToTable,
+}) => {
   const summaryRows = useMemo(
-    () => getSummaryRows({ browserFields, data, eventId, isDraggable, timelineId }),
-    [browserFields, data, eventId, isDraggable, timelineId]
+    () => getSummaryRows({ browserFields, data, rawEventData, eventId, isDraggable, timelineId }),
+    [browserFields, data, rawEventData, eventId, isDraggable, timelineId]
   );
 
   return (

--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -180,6 +180,7 @@ const EventDetailsComponent: React.FC<Props> = ({
                     timelineId,
                     title: i18n.HIGHLIGHTES_FIELDS,
                   }}
+                  rawEventData={rawEventData}
                   goToTable={goToTableTab}
                 />
 
@@ -212,6 +213,7 @@ const EventDetailsComponent: React.FC<Props> = ({
       isAlert,
       data,
       browserFields,
+      rawEventData,
       isDraggable,
       timelineId,
       enrichmentCount,


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/124813 and https://github.com/elastic/kibana/issues/124817 describe issues with threshold-related data not showing up in the alert flyout. The reason for these issues is that from `8.0` onward, the type of `threshold_result` has changed and can no longer rely on the JSON strings we had before in `kibana.alert.threshold_result.terms` and `(...).cardinality`.

As proposed in https://github.com/elastic/kibana/issues/124813#issuecomment-1033995085, the threshold data should be enriched by data from `_source`.

<img width="531" alt="Screenshot 2022-02-10 at 17 42 49" src="https://user-images.githubusercontent.com/68591/153455646-2203c16b-c8ae-4cc3-9887-7ec06889378a.png">

If you want to desk-test this issue, here's a threshold rule config for you that should work with data from the test generator:

<details>
<summary>Threshold config</summary>
<pre>
{"id":"65e00870-8a5f-11ec-b5a1-5b70b318f4fb","updated_at":"2022-02-10T10:52:47.772Z","updated_by":"elastic","created_at":"2022-02-10T10:51:27.743Z","created_by":"elastic","name":"Threshold [Multiple]","tags":[],"interval":"1m","enabled":true,"description":"threshold descr","risk_score":21,"severity":"low","license":"","output_index":".siem-signals-default","meta":{"from":"1h","kibana_siem_app_url":"http://localhost:5601/app/security"},"author":[],"false_positives":[],"from":"now-3660s","rule_id":"75b0c6b2-427c-46cb-a66a-9210ab310686","max_signals":100,"risk_score_mapping":[],"severity_mapping":[],"threat":[],"to":"now","references":[],"version":11,"exceptions_list":[],"immutable":false,"type":"threshold","language":"kuery","index":["apm-*-transaction*","traces-apm*","auditbeat-*","endgame-*","filebeat-*","logs-*","packetbeat-*","winlogbeat-*"],"query":"host.id: *","filters":[],"threshold":{"field":["host.name","host.id"],"value":1,"cardinality":[{"field":"host.id","value":1}]},"throttle":"no_actions","actions":[]}
{"exported_count":1,"exported_rules_count":1,"missing_rules":[],"missing_rules_count":0,"exported_exception_list_count":0,"exported_exception_list_item_count":0,"missing_exception_list_item_count":0,"missing_exception_list_items":[],"missing_exception_lists":[],"missing_exception_lists_count":0}
</pre>
</details>

**Note**: This PR only fixes the issue in `8.1`, the fix for `8.0.1` is a separate PR which I will link here, once it's created.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios