### PR TITLE
[Fleet] Tell users when assets are installed in a different space

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/assets/assets.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/assets/assets.tsx
@@ -39,10 +39,6 @@ export const AssetsPage = ({ packageInfo }: AssetsPanelProps) => {
   const { name, version } = packageInfo;
   const { spaces } = useKibana<StartPlugins>().services;
   const pkgkey = `${name}-${version}`;
-  const assetInstallSpaceId =
-    'savedObject' in packageInfo
-      ? packageInfo.savedObject.attributes.installed_kibana_space_id
-      : undefined;
   const {
     savedObjects: { client: savedObjectsClient },
   } = useStartServices();
@@ -63,6 +59,7 @@ export const AssetsPage = ({ packageInfo }: AssetsPanelProps) => {
       if ('savedObject' in packageInfo) {
         if (spaces) {
           const { id: spaceId } = await spaces.getActiveSpace();
+          const assetInstallSpaceId = packageInfo.savedObject.attributes.installed_kibana_space_id;
           // if assets are installed in a different space no need to attempt to load them.
           if (assetInstallSpaceId && assetInstallSpaceId !== spaceId) {
             setAssetsInstalledInCurrentSpace(false);
@@ -131,7 +128,7 @@ export const AssetsPage = ({ packageInfo }: AssetsPanelProps) => {
       }
     };
     fetchAssetSavedObjects();
-  }, [savedObjectsClient, packageInfo, spaces, assetInstallSpaceId]);
+  }, [savedObjectsClient, packageInfo, spaces]);
 
   // if they arrive at this page and the package is not installed, send them to overview
   // this happens if they arrive with a direct url or they uninstall while on this tab

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/assets/assets.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/assets/assets.tsx
@@ -13,9 +13,10 @@ import { groupBy } from 'lodash';
 
 import type { ResolvedSimpleSavedObject } from 'src/core/public';
 
+import { useKibana } from '../../../../../../../../../../../src/plugins/kibana_react/public';
 import { Loading, Error, ExtensionWrapper } from '../../../../../components';
 
-import type { PackageInfo } from '../../../../../types';
+import type { PackageInfo, StartPlugins } from '../../../../../types';
 import { InstallStatus } from '../../../../../types';
 
 import {
@@ -36,8 +37,12 @@ interface AssetsPanelProps {
 
 export const AssetsPage = ({ packageInfo }: AssetsPanelProps) => {
   const { name, version } = packageInfo;
+  const { spaces } = useKibana<StartPlugins>().services;
   const pkgkey = `${name}-${version}`;
-
+  const assetInstallSpaceId =
+    'savedObject' in packageInfo
+      ? packageInfo.savedObject.attributes.installed_kibana_space_id
+      : undefined;
   const {
     savedObjects: { client: savedObjectsClient },
   } = useStartServices();
@@ -47,6 +52,8 @@ export const AssetsPage = ({ packageInfo }: AssetsPanelProps) => {
   const getPackageInstallStatus = useGetPackageInstallStatus();
   const packageInstallStatus = getPackageInstallStatus(packageInfo.name);
 
+  // assume assets are installed in this space until we find otherwise
+  const [assetsInstalledInCurrentSpace, setAssetsInstalledInCurrentSpace] = useState<boolean>(true);
   const [assetSavedObjects, setAssetsSavedObjects] = useState<undefined | AssetSavedObject[]>();
   const [fetchError, setFetchError] = useState<undefined | Error>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -54,6 +61,16 @@ export const AssetsPage = ({ packageInfo }: AssetsPanelProps) => {
   useEffect(() => {
     const fetchAssetSavedObjects = async () => {
       if ('savedObject' in packageInfo) {
+        if (spaces) {
+          const { id: spaceId } = await spaces.getActiveSpace();
+          // if assets are installed in a different space no need to attempt to load them.
+          if (assetInstallSpaceId && assetInstallSpaceId !== spaceId) {
+            setAssetsInstalledInCurrentSpace(false);
+            setIsLoading(false);
+            return;
+          }
+        }
+
         const {
           savedObject: { attributes: packageAttributes },
         } = packageInfo;
@@ -114,7 +131,7 @@ export const AssetsPage = ({ packageInfo }: AssetsPanelProps) => {
       }
     };
     fetchAssetSavedObjects();
-  }, [savedObjectsClient, packageInfo]);
+  }, [savedObjectsClient, packageInfo, spaces, assetInstallSpaceId]);
 
   // if they arrive at this page and the package is not installed, send them to overview
   // this happens if they arrive with a direct url or they uninstall while on this tab
@@ -137,9 +154,20 @@ export const AssetsPage = ({ packageInfo }: AssetsPanelProps) => {
         error={fetchError}
       />
     );
+  } else if (!assetsInstalledInCurrentSpace) {
+    content = (
+      <EuiTitle>
+        <h2>
+          <FormattedMessage
+            id="xpack.fleet.epm.packageDetails.assets.assetsNotAvailableInCurrentSpace"
+            defaultMessage="This integration is installed, but no assets are available in this space"
+          />
+        </h2>
+      </EuiTitle>
+    );
   } else if (assetSavedObjects === undefined || assetSavedObjects.length === 0) {
     if (customAssetsExtension) {
-      // If a UI extension for custom asset entries is defined, render the custom component here depisite
+      // If a UI extension for custom asset entries is defined, render the custom component here despite
       // there being no saved objects found
       content = (
         <ExtensionWrapper>

--- a/x-pack/plugins/fleet/public/types/index.ts
+++ b/x-pack/plugins/fleet/public/types/index.ts
@@ -121,3 +121,4 @@ export { entries, ElasticsearchAssetType, KibanaAssetType, InstallStatus } from 
 export * from './intra_app_route_state';
 export * from './ui_extensions';
 export * from './in_memory_package_policy';
+export * from './start_plugins';

--- a/x-pack/plugins/fleet/public/types/start_plugins.ts
+++ b/x-pack/plugins/fleet/public/types/start_plugins.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SpacesPluginStart } from '../../../spaces/public';
+
+export interface StartPlugins {
+  spaces?: SpacesPluginStart;
+}


### PR DESCRIPTION
## Summary

Related to [#74353](https://github.com/elastic/kibana/issues/74353)
Previously, when an integration was installed in space 1, when viewing the assets in space 2 we would simply show "no assets found". We now display "This integration is installed, but no assets are available in this space".

<img width="1216" alt="Screenshot 2022-02-10 at 15 56 00" src="https://user-images.githubusercontent.com/3315046/153458469-1a3da6ca-24c8-4188-bced-544fcca6305d.png">

**Testing**
I don't believe we have any cypress tests that create spaces yet so this seemed like more work than this bugfix deserves? I also believe the assets component has too many side effects for unit tests to be a good use of time here

1. test the message is shown correctly:
- create a space "space2"
- install an integration in space2
- switch to the default space
- view the integrations assets, the new message should be displayed

2. test "no assets found" still displays correctly
- install "Custom UDP Logs" integration (doesnt have any assets)
- view the assets tab
- verify "No assets found" is displayed


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
