### PR TITLE
[ci] Increase timeout for on_merge step

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -12,7 +12,7 @@ steps:
     label: Default Build and Metrics
     agents:
       queue: c2-8
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90
 
   - command: .buildkite/scripts/steps/on_merge_ts_refs_api_docs.sh
     label: Build TS Refs and Check Public API Docs


### PR DESCRIPTION
Seeing timeouts at 1 hour: https://buildkite.com/elastic/kibana-on-merge/builds/12037#1e12a735-9286-45c3-90b2-d56dfdae745b/492-882