### PR TITLE
[Fleet] fixed bug where fleet server instructions were incorrectly shown

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.mocks.ts
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.mocks.ts
@@ -13,6 +13,7 @@ jest.mock('../../hooks/use_request', () => {
     sendGetFleetStatus: jest.fn(),
     sendGetOneAgentPolicy: jest.fn(),
     useGetAgents: jest.fn(),
+    useGetAgentPolicies: jest.fn(),
   };
 });
 

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.tsx
@@ -21,6 +21,7 @@ import {
   sendGetFleetStatus,
   sendGetOneAgentPolicy,
   useGetAgents,
+  useGetAgentPolicies,
 } from '../../hooks/use_request';
 import { FleetStatusProvider, ConfigContext } from '../../hooks';
 
@@ -101,6 +102,10 @@ describe('<AgentEnrollmentFlyout />', () => {
       data: { items: [{ policy_id: 'fleet-server-policy' }] },
     });
 
+    (useGetAgentPolicies as jest.Mock).mockReturnValue?.({
+      data: { items: [{ id: 'fleet-server-policy' }] },
+    });
+
     await act(async () => {
       testBed = await setup({
         agentPolicies: [{ id: 'fleet-server-policy' } as AgentPolicy],
@@ -139,6 +144,25 @@ describe('<AgentEnrollmentFlyout />', () => {
         const { exists } = testBed;
         expect(exists('agentEnrollmentFlyout')).toBe(true);
         expect(AgentPolicySelectionStep).not.toHaveBeenCalled();
+        expect(AgentEnrollmentKeySelectionStep).toHaveBeenCalled();
+      });
+    });
+
+    describe('with a specific policy when no agentPolicies set', () => {
+      beforeEach(async () => {
+        jest.clearAllMocks();
+        await act(async () => {
+          testBed = await setup({
+            agentPolicy: testAgentPolicy,
+            onClose: jest.fn(),
+          });
+          testBed.component.update();
+        });
+      });
+
+      it('should not show fleet server instructions', () => {
+        const { exists } = testBed;
+        expect(exists('agentEnrollmentFlyout')).toBe(true);
         expect(AgentEnrollmentKeySelectionStep).toHaveBeenCalled();
       });
     });

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
@@ -11,7 +11,13 @@ import type { EuiContainedStepProps } from '@elastic/eui/src/components/steps/st
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { useGetOneEnrollmentAPIKey, useLink, useFleetStatus, useGetAgents } from '../../hooks';
+import {
+  useGetOneEnrollmentAPIKey,
+  useLink,
+  useFleetStatus,
+  useGetAgents,
+  useGetAgentPolicies,
+} from '../../hooks';
 
 import { ManualInstructions } from '../../components/enrollment_instructions';
 import {
@@ -81,14 +87,24 @@ export const ManagedInstructions = React.memo<Props>(
       showInactive: false,
     });
 
+    const { data: agentPoliciesData, isLoading: isLoadingAgentPolicies } = useGetAgentPolicies({
+      page: 1,
+      perPage: 1000,
+      full: true,
+    });
+
     const fleetServers = useMemo(() => {
-      const fleetServerAgentPolicies: string[] = (agentPolicies ?? [])
+      let policies = agentPolicies;
+      if (!agentPolicies && !isLoadingAgentPolicies) {
+        policies = agentPoliciesData?.items;
+      }
+      const fleetServerAgentPolicies: string[] = (policies ?? [])
         .filter((pol) => policyHasFleetServer(pol))
         .map((pol) => pol.id);
       return (agents?.items ?? []).filter((agent) =>
         fleetServerAgentPolicies.includes(agent.policy_id ?? '')
       );
-    }, [agents, agentPolicies]);
+    }, [agents, agentPolicies, agentPoliciesData, isLoadingAgentPolicies]);
 
     const fleetServerSteps = useMemo(() => {
       const {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/125339

Bug introduced in https://github.com/elastic/kibana/pull/121628

Pre-requirements:

1. ELK setup should be completed.
2. Two different policies should be there:
  -   One policy with Fleet Server integration.
  -   One policy with only System integration.
5. Fleet Server should be installed.

Steps to reproduce:

1. Login to Kibana and navigate to Fleet>Agent Policies.
2. Navigate to the policy with only System integration.
3. Click Add Agent button.

Expected Result:
Respective policy should be selected on clicking Add Agent button from Agent Policies tab.

Fleet Server instructions should not be visible.

Root cause: Add Agent flyout is sometimes used without `agentPolicies` prop, and the logic to show Fleet Server instructions was relying on that.
As a fix, querying `agentPolicies` to make sure it is always set.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
