### PR TITLE
[Uptime Monitor management] Update test configs

### DIFF
--- a/x-pack/plugins/uptime/e2e/config.ts
+++ b/x-pack/plugins/uptime/e2e/config.ts
@@ -8,6 +8,12 @@
 import { FtrConfigProviderContext } from '@kbn/test';
 
 import { CA_CERT_PATH } from '@kbn/dev-utils';
+import { readKibanaConfig } from './tasks/read_kibana_config';
+
+const MANIFEST_KEY = 'xpack.uptime.service.manifestUrl';
+const SERVICE_PASSWORD = 'xpack.uptime.service.password';
+const SERVICE_USERNAME = 'xpack.uptime.service.username';
+
 async function config({ readConfigFile }: FtrConfigProviderContext) {
   const kibanaCommonTestsConfig = await readConfigFile(
     require.resolve('../../../../test/common/config.js')
@@ -15,6 +21,12 @@ async function config({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalTestsConfig = await readConfigFile(
     require.resolve('../../../test/functional/config.js')
   );
+
+  const kibanaConfig = readKibanaConfig();
+
+  const manifestUrl = process.env.SYNTHETICS_SERVICE_MANIFEST ?? kibanaConfig[MANIFEST_KEY];
+  const serviceUsername = process.env.SYNTHETICS_SERVICE_USERNAME ?? kibanaConfig[SERVICE_USERNAME];
+  const servicPassword = process.env.SYNTHETICS_SERVICE_PASSWORD ?? kibanaConfig[SERVICE_PASSWORD];
 
   return {
     ...kibanaCommonTestsConfig.getAll(),
@@ -44,9 +56,9 @@ async function config({ readConfigFile }: FtrConfigProviderContext) {
         `--elasticsearch.username=kibana_system`,
         `--elasticsearch.password=changeme`,
         '--xpack.reporting.enabled=false',
-        `--xpack.uptime.service.manifestUrl=${process.env.SYNTHETICS_SERVICE_MANIFEST}`,
-        `--xpack.uptime.service.username=${process.env.SYNTHETICS_SERVICE_USERNAME}`,
-        `--xpack.uptime.service.password=${process.env.SYNTHETICS_SERVICE_PASSWORD}`,
+        `--xpack.uptime.service.manifestUrl=${manifestUrl}`,
+        `--xpack.uptime.service.username=${serviceUsername}`,
+        `--xpack.uptime.service.password=${servicPassword}`,
         '--xpack.uptime.ui.monitorManagement.enabled=true',
       ],
     },

--- a/x-pack/plugins/uptime/e2e/tasks/read_kibana_config.ts
+++ b/x-pack/plugins/uptime/e2e/tasks/read_kibana_config.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+export type KibanaConfig = ReturnType<typeof readKibanaConfig>;
+
+export const readKibanaConfig = () => {
+  const kibanaConfigDir = path.join(__filename, '../../../../../../config');
+  const kibanaDevConfig = path.join(kibanaConfigDir, 'kibana.dev.yml');
+  const kibanaConfig = path.join(kibanaConfigDir, 'kibana.yml');
+
+  return (yaml.safeLoad(
+    fs.readFileSync(fs.existsSync(kibanaDevConfig) ? kibanaDevConfig : kibanaConfig, 'utf8')
+  ) || {}) as Record<string, string>;
+};

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.ts
@@ -16,7 +16,7 @@ import { UptimeServerSetup } from '../adapters/framework';
 export async function getServiceLocations(server: UptimeServerSetup) {
   const locations: ServiceLocations = [];
 
-  if (!server.config.service!.manifestUrl!) {
+  if (!server.config.service?.manifestUrl) {
     return { locations };
   }
 

--- a/x-pack/test/api_integration/config.ts
+++ b/x-pack/test/api_integration/config.ts
@@ -37,7 +37,6 @@ export async function getApiIntegrationConfig({ readConfigFile }: FtrConfigProvi
         '--xpack.ruleRegistry.write.cache.enabled=false',
         '--xpack.uptime.ui.monitorManagement.enabled=true',
         '--xpack.uptime.service.password=test',
-        '--xpack.uptime.service.manifestUrl=http://test.com',
         '--xpack.uptime.service.username=localKibanaIntegrationTestsUser',
         `--xpack.securitySolution.enableExperimental=${JSON.stringify(['ruleRegistryEnabled'])}`,
       ],


### PR DESCRIPTION
## Summary

Update test configs for synthetics tests.

Removed reference to test.com

Also simplified running e2e test locally. 
