### PR TITLE
[Lens] Version-aware sorting to data table

### DIFF
--- a/x-pack/plugins/lens/common/expressions/datatable/datatable_column.ts
+++ b/x-pack/plugins/lens/common/expressions/datatable/datatable_column.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Direction } from '@elastic/eui';
+import { SortingHint } from '../..';
 import type {
   CustomPaletteState,
   PaletteOutput,
@@ -28,6 +29,7 @@ export type ColumnConfigArg = Omit<ColumnState, 'palette'> & {
   type: 'lens_datatable_column';
   palette?: PaletteOutput<CustomPaletteState>;
   summaryRowValue?: unknown;
+  sortingHint?: SortingHint;
 };
 
 export interface ColumnState {
@@ -53,7 +55,7 @@ export type DatatableColumnResult = ColumnState & { type: 'lens_datatable_column
 export const datatableColumn: ExpressionFunctionDefinition<
   'lens_datatable_column',
   null,
-  ColumnState,
+  ColumnState & { sortingHint?: SortingHint },
   DatatableColumnResult
 > = {
   name: 'lens_datatable_column',
@@ -64,6 +66,7 @@ export const datatableColumn: ExpressionFunctionDefinition<
   args: {
     columnId: { types: ['string'], help: '' },
     alignment: { types: ['string'], help: '' },
+    sortingHint: { types: ['string'], help: '' },
     hidden: { types: ['boolean'], help: '' },
     width: { types: ['number'], help: '' },
     isTransposed: { types: ['boolean'], help: '' },

--- a/x-pack/plugins/lens/common/expressions/datatable/datatable_fn.ts
+++ b/x-pack/plugins/lens/common/expressions/datatable/datatable_fn.ts
@@ -64,11 +64,13 @@ export const datatableFn =
     }
 
     if (sortBy && columnsReverseLookup[sortBy] && sortDirection !== 'none') {
+      const sortingHint = args.columns.find((col) => col.columnId === sortBy)?.sortingHint;
       // Sort on raw values for these types, while use the formatted value for the rest
       const sortingCriteria = getSortingCriteria(
-        isRange(columnsReverseLookup[sortBy]?.meta)
-          ? 'range'
-          : columnsReverseLookup[sortBy]?.meta?.type,
+        sortingHint ??
+          (isRange(columnsReverseLookup[sortBy]?.meta)
+            ? 'range'
+            : columnsReverseLookup[sortBy]?.meta?.type),
         sortBy,
         formatters[sortBy],
         sortDirection

--- a/x-pack/plugins/lens/common/expressions/datatable/sorting.test.tsx
+++ b/x-pack/plugins/lens/common/expressions/datatable/sorting.test.tsx
@@ -24,7 +24,7 @@ function testSorting({
   input: unknown[];
   output: unknown[];
   direction: 'asc' | 'desc';
-  type: DatatableColumnType | 'range';
+  type: DatatableColumnType | 'range' | 'version';
   keepLast?: boolean; // special flag to handle values that should always be last no matter the direction
   reverseOutput?: boolean;
 }) {
@@ -101,6 +101,37 @@ describe('Data sorting criteria', () => {
         output: [now, now - 150000, 0, null, undefined, Number.NaN],
         direction: 'desc',
         type: 'number',
+        reverseOutput: false,
+      });
+    });
+  });
+
+  describe('Version sorting', () => {
+    for (const direction of ['asc', 'desc'] as const) {
+      it(`should provide the version criteria for terms values (${direction})`, () => {
+        testSorting({
+          input: ['1.21.0', '1.1.0', '1.112.0', '1.0.0'],
+          output: ['1.0.0', '1.1.0', '1.21.0', '1.112.0'],
+          direction,
+          type: 'version',
+        });
+      });
+    }
+
+    it('should sort non-version stuff to the end', () => {
+      testSorting({
+        input: ['1.21.0', undefined, '1.1.0', null, '1.112.0', '__other__', '1.0.0'],
+        output: ['1.0.0', '1.1.0', '1.21.0', '1.112.0', undefined, null, '__other__'],
+        direction: 'asc',
+        type: 'version',
+        reverseOutput: false,
+      });
+
+      testSorting({
+        input: ['1.21.0', undefined, '1.1.0', null, '1.112.0', '__other__', '1.0.0'],
+        output: ['1.112.0', '1.21.0', '1.1.0', '1.0.0', undefined, null, '__other__'],
+        direction: 'desc',
+        type: 'version',
         reverseOutput: false,
       });
     });

--- a/x-pack/plugins/lens/common/types.ts
+++ b/x-pack/plugins/lens/common/types.ts
@@ -47,6 +47,8 @@ export interface ColorStop {
   stop: number;
 }
 
+export type SortingHint = 'version';
+
 export interface CustomPaletteParams {
   name?: string;
   reverse?: boolean;

--- a/x-pack/plugins/lens/public/datatable_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/datatable_visualization/visualization.tsx
@@ -363,6 +363,7 @@ export const getDatatableVisualization = ({
                     : [],
                 reverse: false, // managed at UI level
               };
+              const sortingHint = datasource!.getOperationForColumnId(column.columnId)!.sortingHint;
 
               const hasNoSummaryRow = column.summaryRow == null || column.summaryRow === 'none';
 
@@ -388,6 +389,7 @@ export const getDatatableVisualization = ({
                       summaryLabel: hasNoSummaryRow
                         ? []
                         : [column.summaryLabel ?? getDefaultSummaryLabel(column.summaryRow!)],
+                      sortingHint: sortingHint ? [sortingHint] : [],
                     },
                   },
                 ],

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
@@ -86,7 +86,10 @@ export function columnToOperation(
     scale,
     label: uniqueLabel || label,
     isStaticValue: operationType === 'static_value',
-    sortingHint: fieldTypes?.includes(ES_FIELD_TYPES.VERSION) ? 'version' : undefined,
+    sortingHint:
+      column.dataType === 'string' && fieldTypes?.includes(ES_FIELD_TYPES.VERSION)
+        ? 'version'
+        : undefined,
   };
 }
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
@@ -48,12 +48,17 @@ import { getVisualDefaultsForLayer, isColumnInvalid } from './utils';
 import { normalizeOperationDataType, isDraggedField } from './pure_utils';
 import { LayerPanel } from './layerpanel';
 import { GenericIndexPatternColumn, getErrorMessages, insertNewColumn } from './operations';
-import { IndexPatternField, IndexPatternPrivateState, IndexPatternPersistedState } from './types';
+import {
+  IndexPatternField,
+  IndexPatternPrivateState,
+  IndexPatternPersistedState,
+  IndexPattern,
+} from './types';
 import {
   KibanaContextProvider,
   KibanaThemeProvider,
 } from '../../../../../src/plugins/kibana_react/public';
-import { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
+import { DataPublicPluginStart, ES_FIELD_TYPES } from '../../../../../src/plugins/data/public';
 import { VisualizeFieldContext } from '../../../../../src/plugins/ui_actions/public';
 import { mergeLayer } from './state_helpers';
 import { Datasource, StateSetter } from '../types';
@@ -69,15 +74,19 @@ export { deleteColumn } from './operations';
 
 export function columnToOperation(
   column: GenericIndexPatternColumn,
-  uniqueLabel?: string
+  uniqueLabel?: string,
+  dataView?: IndexPattern
 ): Operation {
   const { dataType, label, isBucketed, scale, operationType } = column;
+  const fieldTypes =
+    'sourceField' in column ? dataView?.getFieldByName(column.sourceField)?.esTypes : undefined;
   return {
     dataType: normalizeOperationDataType(dataType),
     isBucketed,
     scale,
     label: uniqueLabel || label,
     isStaticValue: operationType === 'static_value',
+    sortingHint: fieldTypes?.includes(ES_FIELD_TYPES.VERSION) ? 'version' : undefined,
   };
 }
 
@@ -446,7 +455,11 @@ export function getIndexPatternDatasource({
 
           if (layer && layer.columns[columnId]) {
             if (!isReferenced(layer, columnId)) {
-              return columnToOperation(layer.columns[columnId], columnLabelMap[columnId]);
+              return columnToOperation(
+                layer.columns[columnId],
+                columnLabelMap[columnId],
+                state.indexPatterns[layer.indexPatternId]
+              );
             }
           }
           return null;

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -18,7 +18,7 @@ import type {
   Datatable,
 } from '../../../../src/plugins/expressions/public';
 import { DraggingIdentifier, DragDropIdentifier, DragContextState } from './drag_drop';
-import type { DateRange, LayerType } from '../common';
+import type { DateRange, LayerType, SortingHint } from '../common';
 import type { Query } from '../../../../src/plugins/data/public';
 import type {
   RangeSelectContext,
@@ -436,6 +436,7 @@ export type DataType = 'string' | 'number' | 'date' | 'boolean' | FieldOnlyDataT
 export interface Operation extends OperationMetadata {
   // User-facing label for the operation
   label: string;
+  sortingHint?: SortingHint;
 }
 
 export interface OperationMetadata {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/124015

This PR adds version-aware sorting to the client side data table sorting in Lens:
<img width="837" alt="Screenshot 2022-02-11 at 12 06 21" src="https://user-images.githubusercontent.com/1508364/153581156-8e4fa08b-651d-4bad-8c48-80fd6a3a9071.png">

The information about whether a column contains version number wasn't passed to the table so far. This PR introduces a `sortingHint` to the datasource operation meta data (as the datasource is aware of index patterns, it knows whether an underlying field has the version type) which is read by the datatable toExpression function and passed to the datatable function as an additional argument. In there, already existing `semver` and `compare-versions` packages are used to check for valid versions and sort accordingly.