### PR TITLE
[8.1]  [Upgrade Assistant] Update logic for handling reindex failures (#125246)

### DIFF
--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/flyout/checklist_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/flyout/checklist_step.tsx
@@ -109,7 +109,6 @@ export const ChecklistFlyoutStep: React.FunctionComponent<{
         )}
         {(hasFetchFailed || hasReindexingFailed) && (
           <>
-            <EuiSpacer />
             <EuiCallOut
               color="danger"
               iconType="alert"
@@ -130,6 +129,7 @@ export const ChecklistFlyoutStep: React.FunctionComponent<{
             >
               {reindexState.errorMessage}
             </EuiCallOut>
+            <EuiSpacer />
           </>
         )}
         <EuiText>

--- a/x-pack/plugins/upgrade_assistant/server/lib/reindexing/reindex_service.ts
+++ b/x-pack/plugins/upgrade_assistant/server/lib/reindexing/reindex_service.ts
@@ -293,12 +293,8 @@ export const reindexServiceFactory = (
       // Do any other cleanup work necessary
       reindexOp = await cleanupChanges(reindexOp);
     } else {
-      // Check that it reindexed all documents
-      const {
-        body: { count },
-      } = await esClient.count({ index: reindexOp.attributes.indexName });
-
-      if (taskResponse.task.status!.created < count) {
+      // Check that no failures occurred
+      if (taskResponse.response?.failures?.length) {
         // Include the entire task result in the error message. This should be guaranteed
         // to be JSON-serializable since it just came back from Elasticsearch.
         throw error.reindexTaskFailed(`Reindexing failed: ${JSON.stringify(taskResponse)}`);


### PR DESCRIPTION
Backports the following commits to 8.1:
 -  [Upgrade Assistant] Update logic for handling reindex failures (#125246)