### PR TITLE
[ML] Fix Trained Model stats and pipelines tab 

### DIFF
--- a/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
@@ -163,7 +163,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
         />
       ),
       content: (
-        <>
+        <div data-test-subj={'mlTrainedModelDetailsContent'}>
           <EuiSpacer size={'s'} />
           <EuiFlexGrid columns={2} gutterSize={'m'}>
             <EuiFlexItem>
@@ -205,7 +205,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
               </EuiFlexItem>
             ) : null}
           </EuiFlexGrid>
-        </>
+        </div>
       ),
     },
     ...(inferenceConfig
@@ -220,7 +220,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
               />
             ),
             content: (
-              <>
+              <div data-test-subj={'mlTrainedModelInferenceConfigContent'}>
                 <EuiSpacer size={'s'} />
                 <EuiFlexGrid columns={2} gutterSize={'m'}>
                   <EuiFlexItem>
@@ -264,7 +264,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
                     </EuiFlexItem>
                   )}
                 </EuiFlexGrid>
-              </>
+              </div>
             ),
           },
         ]
@@ -281,7 +281,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
               />
             ),
             content: (
-              <>
+              <div data-test-subj={'mlTrainedModelStatsContent'}>
                 <EuiSpacer size={'s'} />
 
                 <EuiFlexGrid columns={2} gutterSize={'m'}>
@@ -321,8 +321,29 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
                       </EuiPanel>
                     </EuiFlexItem>
                   ) : null}
+                  {isPopulatedObject(stats.model_size_stats) &&
+                  !isPopulatedObject(stats.inference_stats) ? (
+                    <EuiFlexItem>
+                      <EuiPanel>
+                        <EuiTitle size={'xs'}>
+                          <h5>
+                            <FormattedMessage
+                              id="xpack.ml.trainedModels.modelsList.expandedRow.modelSizeStatsTitle"
+                              defaultMessage="Model size stats"
+                            />
+                          </h5>
+                        </EuiTitle>
+                        <EuiSpacer size={'m'} />
+                        <EuiDescriptionList
+                          compressed={true}
+                          type="column"
+                          listItems={formatToListItems(stats.model_size_stats)}
+                        />
+                      </EuiPanel>
+                    </EuiFlexItem>
+                  ) : null}
                 </EuiFlexGrid>
-              </>
+              </div>
             ),
           },
         ]
@@ -342,10 +363,10 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
               </>
             ),
             content: (
-              <>
+              <div data-test-subj={'mlTrainedModelPipelinesContent'}>
                 <EuiSpacer size={'s'} />
                 <ModelPipelines pipelines={pipelines!} ingestStats={stats.ingest} />
-              </>
+              </div>
             ),
           },
         ]

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
@@ -18,6 +18,7 @@ import {
   EuiSpacer,
   EuiTabbedContent,
   EuiTitle,
+  EuiTabbedContentTab,
 } from '@elastic/eui';
 import type { EuiDescriptionListProps } from '@elastic/eui/src/components/description_list/description_list';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -151,9 +152,10 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
     [stats.deployment_stats]
   );
 
-  const tabs = [
+  const tabs: EuiTabbedContentTab[] = [
     {
       id: 'details',
+      'data-test-subj': 'mlTrainedModelDetails',
       name: (
         <FormattedMessage
           id="xpack.ml.trainedModels.modelsList.expandedRow.detailsTabLabel"
@@ -210,6 +212,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
       ? [
           {
             id: 'config',
+            'data-test-subj': 'mlTrainedModelInferenceConfig',
             name: (
               <FormattedMessage
                 id="xpack.ml.trainedModels.modelsList.expandedRow.configTabLabel"
@@ -270,6 +273,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
       ? [
           {
             id: 'stats',
+            'data-test-subj': 'mlTrainedModelStats',
             name: (
               <FormattedMessage
                 id="xpack.ml.trainedModels.modelsList.expandedRow.statsTabLabel"
@@ -327,6 +331,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
       ? [
           {
             id: 'pipelines',
+            'data-test-subj': 'mlTrainedModelPipelines',
             name: (
               <>
                 <FormattedMessage
@@ -355,6 +360,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
       initialSelectedTab={tabs[0]}
       autoFocus="selected"
       onTabClick={(tab) => {}}
+      data-test-subj={'mlTrainedModelRowDetails'}
     />
   );
 };

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
@@ -348,7 +348,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
           },
         ]
       : []),
-    ...((pipelines && Object.keys(pipelines).length > 0) || stats.ingest
+    ...(pipelines && Object.keys(pipelines).length > 0
       ? [
           {
             id: 'pipelines',

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
@@ -348,7 +348,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
           },
         ]
       : []),
-    ...(pipelines && Object.keys(pipelines).length > 0
+    ...((pipelines && Object.keys(pipelines).length > 0) || stats.ingest
       ? [
           {
             id: 'pipelines',

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/pipelines/pipelines.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/pipelines/pipelines.tsx
@@ -57,6 +57,7 @@ export const ModelPipelines: FC<ModelPipelinesProps> = ({ pipelines, ingestStats
               extraAction={
                 pipelineDefinition ? (
                   <EuiButtonEmpty
+                    data-test-subj={`mlTrainedModelPipelineEditButton_${pipelineName}`}
                     onClick={() => {
                       const locator = share.url.locators.get('INGEST_PIPELINES_APP_LOCATOR');
                       if (!locator) return;
@@ -81,7 +82,7 @@ export const ModelPipelines: FC<ModelPipelinesProps> = ({ pipelines, ingestStats
             >
               <EuiFlexGrid columns={2}>
                 {ingestStats?.pipelines ? (
-                  <EuiFlexItem>
+                  <EuiFlexItem data-test-subj={`mlTrainedModelPipelineIngestStats_${pipelineName}`}>
                     <EuiPanel>
                       <EuiTitle size={'xxs'}>
                         <h6>
@@ -98,7 +99,7 @@ export const ModelPipelines: FC<ModelPipelinesProps> = ({ pipelines, ingestStats
                 ) : null}
 
                 {pipelineDefinition ? (
-                  <EuiFlexItem>
+                  <EuiFlexItem data-test-subj={`mlTrainedModelPipelineDefinition_${pipelineName}`}>
                     <EuiPanel>
                       <EuiTitle size={'xxs'}>
                         <h6>

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/pipelines/pipelines.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/pipelines/pipelines.tsx
@@ -23,7 +23,7 @@ import { ProcessorsStats } from './expanded_row';
 export type IngestStatsResponse = Exclude<ModelItem['stats'], undefined>['ingest'];
 
 interface ModelPipelinesProps {
-  pipelines: Exclude<ModelItem['pipelines'], null | undefined>;
+  pipelines: ModelItem['pipelines'];
   ingestStats: IngestStatsResponse;
 }
 
@@ -32,11 +32,18 @@ export const ModelPipelines: FC<ModelPipelinesProps> = ({ pipelines, ingestStats
     services: { share },
   } = useMlKibana();
 
+  const pipelineNames = Object.keys(pipelines ?? ingestStats?.pipelines ?? {});
+
+  if (!pipelineNames.length) return null;
+
   return (
     <>
-      {Object.entries(pipelines).map(([pipelineName, pipelineDefinition], i) => {
+      {pipelineNames.map((pipelineName, i) => {
         // Expand first 3 pipelines by default
         const initialIsOpen = i <= 2;
+
+        const pipelineDefinition = pipelines?.[pipelineName];
+
         return (
           <>
             <EuiAccordion
@@ -48,24 +55,26 @@ export const ModelPipelines: FC<ModelPipelinesProps> = ({ pipelines, ingestStats
                 </EuiTitle>
               }
               extraAction={
-                <EuiButtonEmpty
-                  onClick={() => {
-                    const locator = share.url.locators.get('INGEST_PIPELINES_APP_LOCATOR');
-                    if (!locator) return;
-                    locator.navigate({
-                      page: 'pipeline_edit',
-                      pipelineId: pipelineName,
-                      absolute: true,
-                    });
-                  }}
-                  iconType={'documentEdit'}
-                  iconSide="left"
-                >
-                  <FormattedMessage
-                    id="xpack.ml.trainedModels.modelsList.expandedRow.editPipelineLabel"
-                    defaultMessage="Edit"
-                  />
-                </EuiButtonEmpty>
+                pipelineDefinition ? (
+                  <EuiButtonEmpty
+                    onClick={() => {
+                      const locator = share.url.locators.get('INGEST_PIPELINES_APP_LOCATOR');
+                      if (!locator) return;
+                      locator.navigate({
+                        page: 'pipeline_edit',
+                        pipelineId: pipelineName,
+                        absolute: true,
+                      });
+                    }}
+                    iconType={'documentEdit'}
+                    iconSide="left"
+                  >
+                    <FormattedMessage
+                      id="xpack.ml.trainedModels.modelsList.expandedRow.editPipelineLabel"
+                      defaultMessage="Edit"
+                    />
+                  </EuiButtonEmpty>
+                ) : undefined
               }
               paddingSize="l"
               initialIsOpen={initialIsOpen}
@@ -88,27 +97,29 @@ export const ModelPipelines: FC<ModelPipelinesProps> = ({ pipelines, ingestStats
                   </EuiFlexItem>
                 ) : null}
 
-                <EuiFlexItem>
-                  <EuiPanel>
-                    <EuiTitle size={'xxs'}>
-                      <h6>
-                        <FormattedMessage
-                          id="xpack.ml.trainedModels.modelsList.expandedRow.processorsTitle"
-                          defaultMessage="Definition"
-                        />
-                      </h6>
-                    </EuiTitle>
-                    <EuiCodeBlock
-                      language="json"
-                      fontSize="m"
-                      paddingSize="m"
-                      overflowHeight={300}
-                      isCopyable
-                    >
-                      {JSON.stringify(pipelineDefinition, null, 2)}
-                    </EuiCodeBlock>
-                  </EuiPanel>
-                </EuiFlexItem>
+                {pipelineDefinition ? (
+                  <EuiFlexItem>
+                    <EuiPanel>
+                      <EuiTitle size={'xxs'}>
+                        <h6>
+                          <FormattedMessage
+                            id="xpack.ml.trainedModels.modelsList.expandedRow.processorsTitle"
+                            defaultMessage="Definition"
+                          />
+                        </h6>
+                      </EuiTitle>
+                      <EuiCodeBlock
+                        language="json"
+                        fontSize="m"
+                        paddingSize="m"
+                        overflowHeight={300}
+                        isCopyable
+                      >
+                        {JSON.stringify(pipelineDefinition, null, 2)}
+                      </EuiCodeBlock>
+                    </EuiPanel>
+                  </EuiFlexItem>
+                ) : null}
               </EuiFlexGrid>
             </EuiAccordion>
           </>

--- a/x-pack/test/functional/apps/ml/model_management/index.ts
+++ b/x-pack/test/functional/apps/ml/model_management/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('model management', function () {
-    this.tags(['mlqa', 'skipFirefox', 'dima']);
+    this.tags(['mlqa', 'skipFirefox']);
 
     loadTestFile(require.resolve('./model_list'));
   });

--- a/x-pack/test/functional/apps/ml/model_management/index.ts
+++ b/x-pack/test/functional/apps/ml/model_management/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('model management', function () {
-    this.tags(['mlqa', 'skipFirefox']);
+    this.tags(['mlqa', 'skipFirefox', 'dima']);
 
     loadTestFile(require.resolve('./model_list'));
   });

--- a/x-pack/test/functional/apps/ml/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/model_management/model_list.ts
@@ -56,18 +56,18 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('renders expanded row content correctly for model with pipelines', async () => {
       await ml.trainedModelsTable.ensureRowIsExpanded(modelWithPipelineData.modelId);
-      await ml.trainedModelsTable.assertDetailsTabVisible();
-      await ml.trainedModelsTable.assertInferenceConfigTabVisible();
-      await ml.trainedModelsTable.assertStatsTabVisible();
-      await ml.trainedModelsTable.assertPipelinesTabVisible();
+      await ml.trainedModelsTable.assertDetailsTabContent();
+      await ml.trainedModelsTable.assertInferenceConfigTabContent();
+      await ml.trainedModelsTable.assertStatsTabContent();
+      await ml.trainedModelsTable.assertPipelinesTabContent();
     });
 
     it('renders expanded row content correctly for model without pipelines', async () => {
       await ml.trainedModelsTable.ensureRowIsExpanded(modelWithoutPipelineData.modelId);
-      await ml.trainedModelsTable.assertDetailsTabVisible();
-      await ml.trainedModelsTable.assertInferenceConfigTabVisible();
-      await ml.trainedModelsTable.assertStatsTabVisible();
-      await ml.trainedModelsTable.assertPipelinesTabVisible(false);
+      await ml.trainedModelsTable.assertDetailsTabContent();
+      await ml.trainedModelsTable.assertInferenceConfigTabContent();
+      await ml.trainedModelsTable.assertStatsTabContent();
+      await ml.trainedModelsTable.assertPipelinesTabContent(false);
     });
 
     it('displays the built-in model and no actions are enabled', async () => {

--- a/x-pack/test/functional/apps/ml/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/model_management/model_list.ts
@@ -69,7 +69,9 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.trainedModelsTable.assertDetailsTabContent();
         await ml.trainedModelsTable.assertInferenceConfigTabContent();
         await ml.trainedModelsTable.assertStatsTabContent();
-        await ml.trainedModelsTable.assertPipelinesTabContent();
+        await ml.trainedModelsTable.assertPipelinesTabContent(true, [
+          { pipelineName: `pipeline_${modelWithPipelineData.modelId}`, expectDefinition: true },
+        ]);
       });
 
       it('renders expanded row content correctly for model without pipelines', async () => {
@@ -182,7 +184,9 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.trainedModelsTable.assertDetailsTabContent();
         await ml.trainedModelsTable.assertInferenceConfigTabContent();
         await ml.trainedModelsTable.assertStatsTabContent();
-        await ml.trainedModelsTable.assertPipelinesTabContent(false);
+        await ml.trainedModelsTable.assertPipelinesTabContent(true, [
+          { pipelineName: `pipeline_${modelWithPipelineData.modelId}`, expectDefinition: false },
+        ]);
       });
     });
   });

--- a/x-pack/test/functional/apps/ml/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/model_management/model_list.ts
@@ -54,6 +54,22 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.trainedModels.assertRowsNumberPerPage(10);
     });
 
+    it('renders expanded row content correctly for model with pipelines', async () => {
+      await ml.trainedModelsTable.ensureRowIsExpanded(modelWithPipelineData.modelId);
+      await ml.trainedModelsTable.assertDetailsTabVisible();
+      await ml.trainedModelsTable.assertInferenceConfigTabVisible();
+      await ml.trainedModelsTable.assertStatsTabVisible();
+      await ml.trainedModelsTable.assertPipelinesTabVisible();
+    });
+
+    it('renders expanded row content correctly for model without pipelines', async () => {
+      await ml.trainedModelsTable.ensureRowIsExpanded(modelWithoutPipelineData.modelId);
+      await ml.trainedModelsTable.assertDetailsTabVisible();
+      await ml.trainedModelsTable.assertInferenceConfigTabVisible();
+      await ml.trainedModelsTable.assertStatsTabVisible();
+      await ml.trainedModelsTable.assertPipelinesTabVisible(false);
+    });
+
     it('displays the built-in model and no actions are enabled', async () => {
       await ml.testExecution.logTestStep('should display the model in the table');
       await ml.trainedModelsTable.filterWithSearchString(builtInModelData.modelId, 1);

--- a/x-pack/test/functional/apps/ml/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/model_management/model_list.ts
@@ -42,112 +42,148 @@ export default function ({ getService }: FtrProviderContext) {
       modelTypes: ['regression', 'tree_ensemble'],
     };
 
-    it('renders trained models list', async () => {
-      await ml.testExecution.logTestStep(
-        'should display the stats bar with the total number of models'
-      );
-      // +1 because of the built-in model
-      await ml.trainedModels.assertStats(31);
-
-      await ml.testExecution.logTestStep('should display the table');
-      await ml.trainedModels.assertTableExists();
-      await ml.trainedModels.assertRowsNumberPerPage(10);
-    });
-
-    it('renders expanded row content correctly for model with pipelines', async () => {
-      await ml.trainedModelsTable.ensureRowIsExpanded(modelWithPipelineData.modelId);
-      await ml.trainedModelsTable.assertDetailsTabContent();
-      await ml.trainedModelsTable.assertInferenceConfigTabContent();
-      await ml.trainedModelsTable.assertStatsTabContent();
-      await ml.trainedModelsTable.assertPipelinesTabContent();
-    });
-
-    it('renders expanded row content correctly for model without pipelines', async () => {
-      await ml.trainedModelsTable.ensureRowIsExpanded(modelWithoutPipelineData.modelId);
-      await ml.trainedModelsTable.assertDetailsTabContent();
-      await ml.trainedModelsTable.assertInferenceConfigTabContent();
-      await ml.trainedModelsTable.assertStatsTabContent();
-      await ml.trainedModelsTable.assertPipelinesTabContent(false);
-    });
-
-    it('displays the built-in model and no actions are enabled', async () => {
-      await ml.testExecution.logTestStep('should display the model in the table');
-      await ml.trainedModelsTable.filterWithSearchString(builtInModelData.modelId, 1);
-
-      await ml.testExecution.logTestStep('displays expected row values for the model in the table');
-      await ml.trainedModelsTable.assertModelsRowFields(builtInModelData.modelId, {
-        id: builtInModelData.modelId,
-        description: builtInModelData.description,
-        modelTypes: builtInModelData.modelTypes,
+    describe('for ML power user', () => {
+      before(async () => {
+        await ml.securityUI.loginAsMlPowerUser();
+        await ml.navigation.navigateToTrainedModels();
       });
 
-      await ml.testExecution.logTestStep(
-        'should not show collapsed actions menu for the model in the table'
-      );
-      await ml.trainedModelsTable.assertModelCollapsedActionsButtonExists(
-        builtInModelData.modelId,
-        false
-      );
-
-      await ml.testExecution.logTestStep(
-        'should not show delete action for the model in the table'
-      );
-      await ml.trainedModelsTable.assertModelDeleteActionButtonExists(
-        builtInModelData.modelId,
-        false
-      );
-    });
-
-    it('displays a model with an ingest pipeline and delete action is disabled', async () => {
-      await ml.testExecution.logTestStep('should display the model in the table');
-      await ml.trainedModelsTable.filterWithSearchString(modelWithPipelineData.modelId, 1);
-
-      await ml.testExecution.logTestStep('displays expected row values for the model in the table');
-      await ml.trainedModelsTable.assertModelsRowFields(modelWithPipelineData.modelId, {
-        id: modelWithPipelineData.modelId,
-        description: modelWithPipelineData.description,
-        modelTypes: modelWithPipelineData.modelTypes,
+      after(async () => {
+        await ml.securityUI.logout();
       });
 
-      await ml.testExecution.logTestStep(
-        'should show disabled delete action for the model in the table'
-      );
+      it('renders trained models list', async () => {
+        await ml.testExecution.logTestStep(
+          'should display the stats bar with the total number of models'
+        );
+        // +1 because of the built-in model
+        await ml.trainedModels.assertStats(31);
 
-      await ml.trainedModelsTable.assertModelDeleteActionButtonEnabled(
-        modelWithPipelineData.modelId,
-        false
-      );
-    });
-
-    it('displays a model without an ingest pipeline and model can be deleted', async () => {
-      await ml.testExecution.logTestStep('should display the model in the table');
-      await ml.trainedModelsTable.filterWithSearchString(modelWithoutPipelineData.modelId, 1);
-
-      await ml.testExecution.logTestStep('displays expected row values for the model in the table');
-      await ml.trainedModelsTable.assertModelsRowFields(modelWithoutPipelineData.modelId, {
-        id: modelWithoutPipelineData.modelId,
-        description: modelWithoutPipelineData.description,
-        modelTypes: modelWithoutPipelineData.modelTypes,
+        await ml.testExecution.logTestStep('should display the table');
+        await ml.trainedModels.assertTableExists();
+        await ml.trainedModels.assertRowsNumberPerPage(10);
       });
 
-      await ml.testExecution.logTestStep(
-        'should show enabled delete action for the model in the table'
-      );
+      it('renders expanded row content correctly for model with pipelines', async () => {
+        await ml.trainedModelsTable.ensureRowIsExpanded(modelWithPipelineData.modelId);
+        await ml.trainedModelsTable.assertDetailsTabContent();
+        await ml.trainedModelsTable.assertInferenceConfigTabContent();
+        await ml.trainedModelsTable.assertStatsTabContent();
+        await ml.trainedModelsTable.assertPipelinesTabContent();
+      });
 
-      await ml.trainedModelsTable.assertModelDeleteActionButtonEnabled(
-        modelWithoutPipelineData.modelId,
-        true
-      );
+      it('renders expanded row content correctly for model without pipelines', async () => {
+        await ml.trainedModelsTable.ensureRowIsExpanded(modelWithoutPipelineData.modelId);
+        await ml.trainedModelsTable.assertDetailsTabContent();
+        await ml.trainedModelsTable.assertInferenceConfigTabContent();
+        await ml.trainedModelsTable.assertStatsTabContent();
+        await ml.trainedModelsTable.assertPipelinesTabContent(false);
+      });
 
-      await ml.testExecution.logTestStep('should show the delete modal');
-      await ml.trainedModelsTable.clickDeleteAction(modelWithoutPipelineData.modelId);
+      it('displays the built-in model and no actions are enabled', async () => {
+        await ml.testExecution.logTestStep('should display the model in the table');
+        await ml.trainedModelsTable.filterWithSearchString(builtInModelData.modelId, 1);
 
-      await ml.testExecution.logTestStep('should delete the model');
-      await ml.trainedModelsTable.confirmDeleteModel();
-      await ml.trainedModelsTable.assertModelDisplayedInTable(
-        modelWithoutPipelineData.modelId,
-        false
-      );
+        await ml.testExecution.logTestStep(
+          'displays expected row values for the model in the table'
+        );
+        await ml.trainedModelsTable.assertModelsRowFields(builtInModelData.modelId, {
+          id: builtInModelData.modelId,
+          description: builtInModelData.description,
+          modelTypes: builtInModelData.modelTypes,
+        });
+
+        await ml.testExecution.logTestStep(
+          'should not show collapsed actions menu for the model in the table'
+        );
+        await ml.trainedModelsTable.assertModelCollapsedActionsButtonExists(
+          builtInModelData.modelId,
+          false
+        );
+
+        await ml.testExecution.logTestStep(
+          'should not show delete action for the model in the table'
+        );
+        await ml.trainedModelsTable.assertModelDeleteActionButtonExists(
+          builtInModelData.modelId,
+          false
+        );
+      });
+
+      it('displays a model with an ingest pipeline and delete action is disabled', async () => {
+        await ml.testExecution.logTestStep('should display the model in the table');
+        await ml.trainedModelsTable.filterWithSearchString(modelWithPipelineData.modelId, 1);
+
+        await ml.testExecution.logTestStep(
+          'displays expected row values for the model in the table'
+        );
+        await ml.trainedModelsTable.assertModelsRowFields(modelWithPipelineData.modelId, {
+          id: modelWithPipelineData.modelId,
+          description: modelWithPipelineData.description,
+          modelTypes: modelWithPipelineData.modelTypes,
+        });
+
+        await ml.testExecution.logTestStep(
+          'should show disabled delete action for the model in the table'
+        );
+
+        await ml.trainedModelsTable.assertModelDeleteActionButtonEnabled(
+          modelWithPipelineData.modelId,
+          false
+        );
+      });
+
+      it('displays a model without an ingest pipeline and model can be deleted', async () => {
+        await ml.testExecution.logTestStep('should display the model in the table');
+        await ml.trainedModelsTable.filterWithSearchString(modelWithoutPipelineData.modelId, 1);
+
+        await ml.testExecution.logTestStep(
+          'displays expected row values for the model in the table'
+        );
+        await ml.trainedModelsTable.assertModelsRowFields(modelWithoutPipelineData.modelId, {
+          id: modelWithoutPipelineData.modelId,
+          description: modelWithoutPipelineData.description,
+          modelTypes: modelWithoutPipelineData.modelTypes,
+        });
+
+        await ml.testExecution.logTestStep(
+          'should show enabled delete action for the model in the table'
+        );
+
+        await ml.trainedModelsTable.assertModelDeleteActionButtonEnabled(
+          modelWithoutPipelineData.modelId,
+          true
+        );
+
+        await ml.testExecution.logTestStep('should show the delete modal');
+        await ml.trainedModelsTable.clickDeleteAction(modelWithoutPipelineData.modelId);
+
+        await ml.testExecution.logTestStep('should delete the model');
+        await ml.trainedModelsTable.confirmDeleteModel();
+        await ml.trainedModelsTable.assertModelDisplayedInTable(
+          modelWithoutPipelineData.modelId,
+          false
+        );
+      });
+    });
+
+    describe('for ML user with read-only access', () => {
+      before(async () => {
+        await ml.securityUI.loginAsMlViewer();
+        await ml.navigation.navigateToTrainedModels();
+      });
+
+      after(async () => {
+        await ml.securityUI.logout();
+      });
+
+      it('renders expanded row content correctly for model with pipelines', async () => {
+        await ml.trainedModelsTable.ensureRowIsExpanded(modelWithPipelineData.modelId);
+        await ml.trainedModelsTable.assertDetailsTabContent();
+        await ml.trainedModelsTable.assertInferenceConfigTabContent();
+        await ml.trainedModelsTable.assertStatsTabContent();
+        await ml.trainedModelsTable.assertPipelinesTabContent(false);
+      });
     });
   });
 }

--- a/x-pack/test/functional/services/ml/trained_models_table.ts
+++ b/x-pack/test/functional/services/ml/trained_models_table.ts
@@ -249,8 +249,23 @@ export function TrainedModelsTableProvider({ getService }: FtrProviderContext) {
       await this.assertTabContent('stats', expectVisible);
     }
 
-    public async assertPipelinesTabContent(expectVisible = true) {
+    public async assertPipelinesTabContent(
+      expectVisible = true,
+      pipelinesExpectOptions?: Array<{ pipelineName: string; expectDefinition: boolean }>
+    ) {
       await this.assertTabContent('pipelines', expectVisible);
+
+      if (Array.isArray(pipelinesExpectOptions)) {
+        for (const p of pipelinesExpectOptions) {
+          if (p.expectDefinition) {
+            await testSubjects.existOrFail(`mlTrainedModelPipelineEditButton_${p.pipelineName}`);
+            await testSubjects.existOrFail(`mlTrainedModelPipelineDefinition_${p.pipelineName}`);
+          } else {
+            await testSubjects.missingOrFail(`mlTrainedModelPipelineEditButton_${p.pipelineName}`);
+            await testSubjects.missingOrFail(`mlTrainedModelPipelineDefinition_${p.pipelineName}`);
+          }
+        }
+      }
     }
   })();
 }

--- a/x-pack/test/functional/services/ml/trained_models_table.ts
+++ b/x-pack/test/functional/services/ml/trained_models_table.ts
@@ -250,7 +250,7 @@ export function TrainedModelsTableProvider({ getService }: FtrProviderContext) {
     }
 
     public async assertPipelinesTabContent(expectVisible = true) {
-      await this.assertTabContent('stats', expectVisible);
+      await this.assertTabContent('pipelines', expectVisible);
     }
   })();
 }

--- a/x-pack/test/functional/services/ml/trained_models_table.ts
+++ b/x-pack/test/functional/services/ml/trained_models_table.ts
@@ -7,6 +7,7 @@
 
 import expect from '@kbn/expect';
 import { ProvidedType } from '@kbn/test';
+import { upperFirst } from 'lodash';
 
 import { WebElementWrapper } from 'test/functional/services/lib/web_element_wrapper';
 import { FtrProviderContext } from '../../ftr_provider_context';
@@ -219,24 +220,37 @@ export function TrainedModelsTableProvider({ getService }: FtrProviderContext) {
       });
     }
 
-    public async assertDetailsTabVisible() {
-      await testSubjects.existOrFail('mlTrainedModelDetails');
-    }
+    public async assertTabContent(
+      type: 'details' | 'stats' | 'inferenceConfig' | 'pipelines',
+      expectVisible = true
+    ) {
+      const tabTestSubj = `mlTrainedModel${upperFirst(type)}`;
+      const tabContentTestSubj = `mlTrainedModel${upperFirst(type)}Content`;
 
-    public async assertInferenceConfigTabVisible() {
-      await testSubjects.existOrFail('mlTrainedModelInferenceConfig');
-    }
-
-    public async assertStatsTabVisible() {
-      await testSubjects.existOrFail('mlTrainedModelStats');
-    }
-
-    public async assertPipelinesTabVisible(expectVisible: boolean = true) {
-      if (expectVisible) {
-        await testSubjects.existOrFail('mlTrainedModelPipelines');
-      } else {
-        await testSubjects.missingOrFail('mlTrainedModelPipelines');
+      if (!expectVisible) {
+        await testSubjects.missingOrFail(tabTestSubj);
+        return;
       }
+
+      await testSubjects.existOrFail(tabTestSubj);
+      await testSubjects.click(tabTestSubj);
+      await testSubjects.existOrFail(tabContentTestSubj);
+    }
+
+    public async assertDetailsTabContent(expectVisible = true) {
+      await this.assertTabContent('details', expectVisible);
+    }
+
+    public async assertInferenceConfigTabContent(expectVisible = true) {
+      await this.assertTabContent('inferenceConfig', expectVisible);
+    }
+
+    public async assertStatsTabContent(expectVisible = true) {
+      await this.assertTabContent('stats', expectVisible);
+    }
+
+    public async assertPipelinesTabContent(expectVisible = true) {
+      await this.assertTabContent('stats', expectVisible);
     }
   })();
 }

--- a/x-pack/test/functional/services/ml/trained_models_table.ts
+++ b/x-pack/test/functional/services/ml/trained_models_table.ts
@@ -208,5 +208,35 @@ export function TrainedModelsTableProvider({ getService }: FtrProviderContext) {
       await testSubjects.click(this.rowSelector(modelId, 'mlModelsTableRowDeleteAction'));
       await this.assertDeleteModalExists();
     }
+
+    public async ensureRowIsExpanded(modelId: string) {
+      await this.filterWithSearchString(modelId);
+      await retry.tryForTime(10 * 1000, async () => {
+        if (!(await testSubjects.exists('mlTrainedModelRowDetails'))) {
+          await testSubjects.click(`${this.rowSelector(modelId)} > mlModelsTableRowDetailsToggle`);
+          await testSubjects.existOrFail('mlTrainedModelRowDetails', { timeout: 1000 });
+        }
+      });
+    }
+
+    public async assertDetailsTabVisible() {
+      await testSubjects.existOrFail('mlTrainedModelDetails');
+    }
+
+    public async assertInferenceConfigTabVisible() {
+      await testSubjects.existOrFail('mlTrainedModelInferenceConfig');
+    }
+
+    public async assertStatsTabVisible() {
+      await testSubjects.existOrFail('mlTrainedModelStats');
+    }
+
+    public async assertPipelinesTabVisible(expectVisible: boolean = true) {
+      if (expectVisible) {
+        await testSubjects.existOrFail('mlTrainedModelPipelines');
+      } else {
+        await testSubjects.missingOrFail('mlTrainedModelPipelines');
+      }
+    }
   })();
 }


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/117501

- Fixes the Stats tab content 
- Fixes the Pipelines tab for ML viewer 
- Adds functional tests for Trained Models rows expansion 

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
