### PR TITLE
[APM] Migrate service overview api test to apmApiClient

### DIFF
--- a/x-pack/test/apm_api_integration/tests/service_overview/get_service_node_ids.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/get_service_node_ids.ts
@@ -9,19 +9,19 @@ import { LatencyAggregationType } from '../../../../plugins/apm/common/latency_a
 import { ApmApiSupertest } from '../../common/apm_api_supertest';
 
 export async function getServiceNodeIds({
-  apmApiSupertest,
+  apmApiClient,
   start,
   end,
   serviceName = 'opbeans-java',
   count = 1,
 }: {
-  apmApiSupertest: ApmApiSupertest;
+  apmApiClient: ApmApiSupertest;
   start: string;
   end: string;
   serviceName?: string;
   count?: number;
 }) {
-  const { body } = await apmApiSupertest({
+  const { body } = await apmApiClient.readUser({
     endpoint: `GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics`,
     params: {
       path: { serviceName },

--- a/x-pack/test/apm_api_integration/tests/service_overview/get_service_node_ids.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/get_service_node_ids.ts
@@ -6,7 +6,7 @@
  */
 import { take } from 'lodash';
 import { LatencyAggregationType } from '../../../../plugins/apm/common/latency_aggregation_types';
-import { ApmApiSupertest } from '../../common/apm_api_supertest';
+import { ApmServices } from '../../common/config';
 
 export async function getServiceNodeIds({
   apmApiClient,
@@ -15,7 +15,7 @@ export async function getServiceNodeIds({
   serviceName = 'opbeans-java',
   count = 1,
 }: {
-  apmApiClient: ApmApiSupertest;
+  apmApiClient: Awaited<ReturnType<ApmServices['apmApiClient']>>;
   start: string;
   end: string;
   serviceName?: string;

--- a/x-pack/test/apm_api_integration/tests/service_overview/instance_details.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/instance_details.spec.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import url from 'url';
 import expect from '@kbn/expect';
 import { omit } from 'lodash';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
@@ -30,8 +29,9 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         it('handles empty state', async () => {
           const response = await apmApiClient.readUser({
             endpoint:
-              'GET /internal/apm/services/opbeans-java/service_overview_instances/details/foo',
+              'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}',
             params: {
+              path: { serviceName: 'opbeans-java', serviceNodeName: 'foo' },
               query: {
                 start,
                 end,
@@ -68,9 +68,9 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
           response = await apmApiClient.readUser({
             endpoint:
-              'GET /internal/apm/services/opbeans-node/service_overview_instances/details/{serviceId}',
+              'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}',
             params: {
-              path: { serviceId: serviceNodeIds[0] },
+              path: { serviceName: 'opbeans-node', serviceNodeName: serviceNodeIds[0] },
               query: {
                 start,
                 end,
@@ -96,8 +96,10 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('handles empty state when instance id not found', async () => {
         const response = await apmApiClient.readUser({
-          endpoint: `GET /internal/apm/services/opbeans-java/service_overview_instances/details/foo`,
+          endpoint:
+            'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}',
           params: {
+            path: { serviceName: 'opbeans-java', serviceNodeName: 'foo' },
             query: {
               start,
               end,

--- a/x-pack/test/apm_api_integration/tests/service_overview/instance_details.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/instance_details.spec.ts
@@ -11,15 +11,13 @@ import { FtrProviderContext } from '../../common/ftr_provider_context';
 import archives from '../../common/fixtures/es_archiver/archives_metadata';
 import { APIReturnType } from '../../../../plugins/apm/public/services/rest/create_call_apm_api';
 import { getServiceNodeIds } from './get_service_node_ids';
-import { createApmApiClient } from '../../common/apm_api_supertest';
 
 type ServiceOverviewInstanceDetails =
   APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}'>;
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
-  const supertest = getService('legacySupertestAsApmReadUser');
-  const apmApiSupertest = createApmApiClient(supertest);
+  const apmApiClient = getService('apmApiClient');
 
   const archiveName = 'apm_8.0.0';
   const { start, end } = archives[archiveName];
@@ -30,16 +28,16 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       describe('when data is not loaded', () => {
         it('handles empty state', async () => {
-          const response = await supertest.get(
-            url.format({
-              pathname:
-                '/internal/apm/services/opbeans-java/service_overview_instances/details/foo',
+          const response = await apmApiClient.readUser({
+            endpoint:
+              'GET /internal/apm/services/opbeans-java/service_overview_instances/details/foo',
+            params: {
               query: {
                 start,
                 end,
               },
-            })
-          );
+            },
+          });
 
           expect(response.status).to.be(200);
           expect(response.body).to.eql({});
@@ -62,16 +60,23 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         let serviceNodeIds: string[];
 
         before(async () => {
-          serviceNodeIds = await getServiceNodeIds({ apmApiSupertest, start, end });
-          response = await supertest.get(
-            url.format({
-              pathname: `/internal/apm/services/opbeans-java/service_overview_instances/details/${serviceNodeIds[0]}`,
+          serviceNodeIds = await getServiceNodeIds({
+            apmApiClient,
+            start,
+            end,
+          });
+
+          response = await apmApiClient.readUser({
+            endpoint:
+              'GET /internal/apm/services/opbeans-node/service_overview_instances/details/{serviceId}',
+            params: {
+              path: { serviceId: serviceNodeIds[0] },
               query: {
                 start,
                 end,
               },
-            })
-          );
+            },
+          });
         });
 
         it('returns the instance details', () => {
@@ -90,15 +95,15 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     { config: 'basic', archives: [archiveName] },
     () => {
       it('handles empty state when instance id not found', async () => {
-        const response = await supertest.get(
-          url.format({
-            pathname: '/internal/apm/services/opbeans-java/service_overview_instances/details/foo',
+        const response = await apmApiClient.readUser({
+          endpoint: `GET /internal/apm/services/opbeans-java/service_overview_instances/details/foo`,
+          params: {
             query: {
               start,
               end,
             },
-          })
-        );
+          },
+        });
         expect(response.status).to.be(200);
         expect(response.body).to.eql({});
       });

--- a/x-pack/test/apm_api_integration/tests/service_overview/instances_detailed_statistics.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/instances_detailed_statistics.spec.ts
@@ -6,9 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import url from 'url';
 import moment from 'moment';
 import { Coordinate } from '../../../../plugins/apm/typings/timeseries';
+import { LatencyAggregationType } from '../../../../plugins/apm/common/latency_aggregation_types';
 import { isFiniteNumber } from '../../../../plugins/apm/common/utils/is_finite_number';
 import { APIReturnType } from '../../../../plugins/apm/public/services/rest/create_call_apm_api';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
@@ -19,6 +19,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
   const apmApiClient = getService('apmApiClient');
 
+  const serviceName = 'opbeans-java';
   const archiveName = 'apm_8.0.0';
   const { start, end } = archives[archiveName];
 
@@ -35,10 +36,11 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         it('handles the empty state', async () => {
           const response = await apmApiClient.readUser({
             endpoint:
-              'GET /internal/apm/services/opbeans-java/service_overview_instances/detailed_statistics',
+              'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
             params: {
+              path: { serviceName },
               query: {
-                latencyAggregationType: 'avg',
+                latencyAggregationType: LatencyAggregationType.avg,
                 start,
                 end,
                 numBuckets: 20,
@@ -78,10 +80,11 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         beforeEach(async () => {
           response = await apmApiClient.readUser({
             endpoint:
-              'GET /internal/apm/services/opbeans-java/service_overview_instances/detailed_statistics',
+              'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
             params: {
+              path: { serviceName },
               query: {
-                latencyAggregationType: 'avg',
+                latencyAggregationType: LatencyAggregationType.avg,
                 start,
                 end,
                 numBuckets: 20,
@@ -137,10 +140,11 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         beforeEach(async () => {
           response = await apmApiClient.readUser({
             endpoint:
-              'GET /internal/apm/services/opbeans-java/service_overview_instances/detailed_statistics',
+              'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
             params: {
+              path: { serviceName },
               query: {
-                latencyAggregationType: 'avg',
+                latencyAggregationType: LatencyAggregationType.avg,
                 numBuckets: 20,
                 transactionType: 'request',
                 serviceNodeIds: JSON.stringify(serviceNodeIds),


### PR DESCRIPTION
## Summary

An attempt to refactor api tests and migrate to `apmApiClient`. 
