### PR TITLE
[data views] Data view runtime field api - fix return of data view

### DIFF
--- a/src/plugins/data_views/server/rest_api_routes/runtime_fields/__snapshots__/response_formatter.test.ts.snap
+++ b/src/plugins/data_views/server/rest_api_routes/runtime_fields/__snapshots__/response_formatter.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`responseFormatter returns correct format 1`] = `
 Object {
   "body": Object {
-    "SERVICE_KEY": Object {
+    "data_view": Object {
       "title": "dataView",
     },
     "fields": Array [
@@ -18,11 +18,11 @@ Object {
 exports[`responseFormatter returns correct format for legacy 1`] = `
 Object {
   "body": Object {
-    "SERVICE_KEY_LEGACY": Object {
-      "title": "dataView",
-    },
     "field": Object {
       "name": "field",
+    },
+    "index_pattern": Object {
+      "title": "dataView",
     },
   },
 }

--- a/src/plugins/data_views/server/rest_api_routes/runtime_fields/response_formatter.ts
+++ b/src/plugins/data_views/server/rest_api_routes/runtime_fields/response_formatter.ts
@@ -7,7 +7,7 @@
  */
 
 import { DataView, DataViewField } from 'src/plugins/data_views/common';
-import { SERVICE_KEY_LEGACY, SERVICE_KEY_TYPE } from '../../constants';
+import { SERVICE_KEY_LEGACY, SERVICE_KEY_TYPE, SERVICE_KEY } from '../../constants';
 
 interface ResponseFormatterArgs {
   serviceKey: SERVICE_KEY_TYPE;
@@ -19,13 +19,13 @@ export const responseFormatter = ({ serviceKey, field, dataView }: ResponseForma
   const response = {
     body: {
       fields: [field.toSpec()],
-      SERVICE_KEY: dataView.toSpec(),
+      [SERVICE_KEY]: dataView.toSpec(),
     },
   };
 
   const legacyResponse = {
     body: {
-      SERVICE_KEY_LEGACY: dataView.toSpec(),
+      [SERVICE_KEY_LEGACY]: dataView.toSpec(),
       field: field.toSpec(),
     },
   };

--- a/test/api_integration/apis/index_patterns/runtime_fields_crud/create_runtime_field/main.ts
+++ b/test/api_integration/apis/index_patterns/runtime_fields_crud/create_runtime_field/main.ts
@@ -47,6 +47,8 @@ export default function ({ getService }: FtrProviderContext) {
           });
 
           expect(response2.status).to.be(200);
+          expect(response2.body[config.serviceKey]).to.not.be.empty();
+
           const field =
             config.serviceKey === 'index_pattern' ? response2.body.field : response2.body.fields[0];
 
@@ -82,6 +84,7 @@ export default function ({ getService }: FtrProviderContext) {
           );
 
           expect(response2.status).to.be(200);
+          expect(response2.body[config.serviceKey]).to.not.be.empty();
 
           const field = response2.body[config.serviceKey].fields.runtimeBar;
 

--- a/test/api_integration/apis/index_patterns/runtime_fields_crud/get_runtime_field/main.ts
+++ b/test/api_integration/apis/index_patterns/runtime_fields_crud/get_runtime_field/main.ts
@@ -60,6 +60,7 @@ export default function ({ getService }: FtrProviderContext) {
             config.serviceKey === 'index_pattern' ? response2.body.field : response2.body.fields[0];
 
           expect(response2.status).to.be(200);
+          expect(response2.body[config.serviceKey]).to.not.be.empty();
           expect(typeof field).to.be('object');
           expect(field.name).to.be('runtimeFoo');
           expect(field.type).to.be('string');

--- a/test/api_integration/apis/index_patterns/runtime_fields_crud/put_runtime_field/main.ts
+++ b/test/api_integration/apis/index_patterns/runtime_fields_crud/put_runtime_field/main.ts
@@ -63,6 +63,7 @@ export default function ({ getService }: FtrProviderContext) {
             });
 
           expect(response2.status).to.be(200);
+          expect(response2.body[config.serviceKey]).to.not.be.empty();
 
           const response3 = await supertest.get(
             `${config.path}/${response1.body[config.serviceKey].id}/runtime_field/runtimeFoo`
@@ -122,6 +123,7 @@ export default function ({ getService }: FtrProviderContext) {
             config.serviceKey === 'index_pattern' ? response2.body.field : response2.body.fields[0];
 
           expect(response2.status).to.be(200);
+          expect(response2.body[config.serviceKey]).to.not.be.empty();
           expect(typeof field.runtimeField).to.be('object');
         });
       });

--- a/test/api_integration/apis/index_patterns/runtime_fields_crud/update_runtime_field/main.ts
+++ b/test/api_integration/apis/index_patterns/runtime_fields_crud/update_runtime_field/main.ts
@@ -70,6 +70,7 @@ export default function ({ getService }: FtrProviderContext) {
             config.serviceKey === 'index_pattern' ? response3.body.field : response3.body.fields[0];
 
           expect(response3.status).to.be(200);
+          expect(response3.body[config.serviceKey]).to.not.be.empty();
           expect(field.type).to.be('string');
           expect(field.runtimeField.type).to.be('keyword');
           expect(field.runtimeField.script.source).to.be("doc['something_new'].value");


### PR DESCRIPTION
## Summary

Fixes legacy index patterns and updated data views api runtime field endpoints - they were return index patterns / data views as `SERVICE_KEY_LEGACY` or `SERVICE_KEY` instead of `index_pattern` or `data_view`.

Closes https://github.com/elastic/kibana/issues/125397

Bug was introduce by https://github.com/elastic/kibana/pull/123107

There's a lot of code overlap between the legacy index patterns api and the updated data views api and a mistake was made in a function that abstracts these differences in the runtime fields endpoints. First, the snapshot plainly showed the problem but I failed to look at it. Second, the runtime fields endpoints did not verify the existence of `data_view` or `index_pattern` content. Now both sets of test should catch the problem should it reoccur.