### PR TITLE
[Security Solutions] Reduces timeouts from 10 minutes per test down to 2 minutes and changes log.error to log.debug to avoid spamming

### DIFF
--- a/x-pack/test/detection_engine_api_integration/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/utils.ts
@@ -874,7 +874,7 @@ export const waitFor = async (
   functionToTest: () => Promise<boolean>,
   functionName: string,
   log: ToolingLog,
-  maxTimeout: number = 800000,
+  maxTimeout: number = 100000,
   timeoutWait: number = 250
 ): Promise<void> => {
   let found = false;
@@ -1324,7 +1324,7 @@ export const waitForAlertToComplete = async (
     async () => {
       const response = await supertest.get(`/api/alerts/alert/${id}/state`).set('kbn-xsrf', 'true');
       if (response.status !== 200) {
-        log.error(
+        log.debug(
           `Did not get an expected 200 "ok" when waiting for an alert to complete (waitForAlertToComplete). CI issues could happen. Suspect this line if you are seeing CI issues. body: ${JSON.stringify(
             response.body
           )}, status: ${JSON.stringify(response.status)}`
@@ -1357,7 +1357,7 @@ export const waitForRuleSuccessOrStatus = async (
           .set('kbn-xsrf', 'true')
           .query({ id });
         if (response.status !== 200) {
-          log.error(
+          log.debug(
             `Did not get an expected 200 "ok" when waiting for a rule success or status (waitForRuleSuccessOrStatus). CI issues could happen. Suspect this line if you are seeing CI issues. body: ${JSON.stringify(
               response.body
             )}, status: ${JSON.stringify(response.status)}`
@@ -1411,9 +1411,7 @@ export const waitForSignalsToBePresent = async (
       return signalsOpen.hits.hits.length >= numberOfSignals;
     },
     'waitForSignalsToBePresent',
-    log,
-    20000,
-    250 // Wait 250ms between tries
+    log
   );
 };
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/125319

Reduces timeouts from 10 minutes per test down to 2 minutes and changes log.error to log.debug to avoid spamming

I test this by making a failing test here:
```
x-pack/test/detection_engine_api_integration/security_and_spaces/tests/aliases.ts
```

By increasing `await waitForSignalsToBePresent(supertest, log, 4, [id]);` from `4` to `5`....Then I watched the logs and timed it to ensure it doesn't take 2 minutes.

I did this by running the server:
```sh
 node scripts/functional_tests_server.js --config test/detection_engine_api_integration/security_and_spaces/config.ts
```

And then running the client:
```sh
 node scripts/functional_test_runner.js --config test/detection_engine_api_integration/security_and_spaces/config.ts --include test/detection_engine_api_integration/security_and_spaces/tests/aliases.ts
```

If we start to see flake again on the regular build servers we might have to slightly increase this number again. If this doesn't allow failing servers to fully complete we might need to also decrease this number further or we might need to make this more configurable.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
