### PR TITLE
Make embeddable example plugin not fail for read-only user

### DIFF
--- a/examples/embeddable_explorer/public/plugin.tsx
+++ b/examples/embeddable_explorer/public/plugin.tsx
@@ -37,7 +37,7 @@ export class EmbeddableExplorerPlugin implements Plugin<void, void, {}, StartDep
         try {
           await depsStart.embeddableExamples.createSampleData();
         } catch (error) {
-          //eslint-disable-next-line no-console
+          // eslint-disable-next-line no-console
           console.error('Failed to create sample data', error);
         }
         return renderApp(

--- a/examples/embeddable_explorer/public/plugin.tsx
+++ b/examples/embeddable_explorer/public/plugin.tsx
@@ -34,7 +34,12 @@ export class EmbeddableExplorerPlugin implements Plugin<void, void, {}, StartDep
       async mount(params: AppMountParameters) {
         const [coreStart, depsStart] = await core.getStartServices();
         const { renderApp } = await import('./app');
-        await depsStart.embeddableExamples.createSampleData();
+        try {
+          await depsStart.embeddableExamples.createSampleData();
+        } catch (error) {
+          //eslint-disable-next-line no-console
+          console.error('Failed to create sample data', error);
+        }
         return renderApp(
           {
             notifications: coreStart.notifications,


### PR DESCRIPTION
## Summary

Embeddable sample plugin crashes if it does not have write permissions, because it tries to write sample data to ES. This *TryCatchBlock* makes sure the plugin does not crash if the write request fails.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
