### PR TITLE
[Security Solution][Detections]Fixes helper text for tags combobox in rules bulk edit

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -400,7 +400,7 @@ export const BULK_EDIT_FLYOUT_FORM_ADD_TAGS_HELP_TEXT = i18n.translate(
   'xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.addTagsComboboxHelpText',
   {
     defaultMessage:
-      'Add one or more custom identifying tags for selected rules. Press enter after each tag to begin a new one.',
+      'Add one or more tags for selected rules from the dropdown. You can also enter custom identifying tags and press Enter to begin a new one.',
   }
 );
 
@@ -408,7 +408,7 @@ export const BULK_EDIT_FLYOUT_FORM_DELETE_TAGS_HELP_TEXT = i18n.translate(
   'xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.deleteTagsComboboxHelpText',
   {
     defaultMessage:
-      'Delete one or more custom identifying tags for selected rules. Press enter after each tag to begin a new one.',
+      'Delete one or more tags for selected rules from the dropdown. You can also enter custom identifying tags and press Enter to begin a new one.',
   }
 );
 


### PR DESCRIPTION
Fixes helper text for tags combobox in rules bulk edit from:

## Before
<img width="1290" alt="Screenshot 2022-02-14 at 10 42 43" src="https://user-images.githubusercontent.com/92328789/153849260-dfd7d90c-e6ec-46cf-ab99-57396c12e20d.png">



## After
<img width="1281" alt="Screenshot 2022-02-14 at 10 42 08" src="https://user-images.githubusercontent.com/92328789/153849147-fb069a32-f0bb-4801-9191-77bcc9bc64dc.png">

