### PR TITLE
[Fleet] Use registry version check on main

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -116,10 +116,8 @@ function setKibanaVersion(url: URL) {
   }
 
   const kibanaVersion = appContextService.getKibanaVersion().split('-')[0]; // may be x.y.z-SNAPSHOT
-  const kibanaBranch = appContextService.getKibanaBranch();
 
-  // on main, request all packages regardless of version
-  if (kibanaVersion && kibanaBranch !== 'main') {
+  if (kibanaVersion) {
     url.searchParams.set('kibana.version', kibanaVersion);
   }
 }


### PR DESCRIPTION
## Summary

Related to #125409

We currently have special logic in place that removes the `kibana.version` parameter from requests to EPR when running on the `main` branch. This makes testing logic around compatibility inflexible and leads to developers running different logic than we use in production.

This removes this logic in preference of the `xpack.fleet.developer.disableRegistryVersionCheck` config that was added previously. I did consider making this default to `true` in when running Kibana in development, but decided against it in order to facilitate using the production behavior by default and making the other logic more explicit.

This does not affect production behavior at all.