### PR TITLE
[DOCS] Removes technical preview flag from DFA ML page

### DIFF
--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -26,7 +26,8 @@ If {stack-security-features} are enabled, users must have the necessary
 privileges to use {ml-features}. Refer to
 {ml-docs}/setup.html#setup-privileges[Set up {ml-features}].
 
-NOTE: There are limitations in {ml-features} that affect {kib}. For more information, refer to {ml-docs}/ml-limitations.html[Machine learning].
+NOTE: There are limitations in {ml-features} that affect {kib}. For more 
+information, refer to {ml-docs}/ml-limitations.html[{ml-cap}].
 
 --
 
@@ -83,8 +84,6 @@ and {ml-docs}/ml-ad-overview.html[{ml-cap} {anomaly-detect}].
 
 [[xpack-ml-dfanalytics]]
 == {dfanalytics-cap}
-
-experimental[]
 
 The Elastic {ml} {dfanalytics} feature enables you to analyze your data using
 {classification}, {oldetection}, and {regression} algorithms and generate new


### PR DESCRIPTION
## Summary

This PR removes the "experimental" flag from the DFA ML page as data frame analytics is not an experimental feature (or not a technical preview).

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### Preview

[Data frame analytics](https://kibana_125497.docs-preview.app.elstc.co/guide/en/kibana/master/xpack-ml-dfanalytics.html)