### PR TITLE
[Fleet] refresh policies on create and flyout open

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_select_create.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_select_create.tsx
@@ -25,6 +25,7 @@ interface Props {
   selectedApiKeyId?: string;
   onKeyChange?: (key?: string) => void;
   isFleetServerPolicy?: boolean;
+  policyId?: string;
 }
 
 export const SelectCreateAgentPolicy: React.FC<Props> = ({
@@ -35,6 +36,7 @@ export const SelectCreateAgentPolicy: React.FC<Props> = ({
   selectedApiKeyId,
   onKeyChange,
   isFleetServerPolicy,
+  policyId,
 }) => {
   const [showCreatePolicy, setShowCreatePolicy] = useState(agentPolicies.length === 0);
 
@@ -42,7 +44,7 @@ export const SelectCreateAgentPolicy: React.FC<Props> = ({
 
   const [newName, setNewName] = useState(incrementPolicyName(agentPolicies, isFleetServerPolicy));
 
-  const [selectedAgentPolicy, setSelectedAgentPolicy] = useState<string | undefined>(undefined);
+  const [selectedAgentPolicy, setSelectedAgentPolicy] = useState<string | undefined>(policyId);
 
   useEffect(() => {
     setShowCreatePolicy(agentPolicies.length === 0);

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_selection.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_selection.tsx
@@ -154,7 +154,7 @@ export const EnrollmentStepAgentPolicy: React.FC<Props> = (props) => {
             value: agentPolicy.id,
             text: agentPolicy.name,
           }))}
-          value={selectedAgentPolicyId || undefined}
+          value={selectedAgentPolicyId}
           onChange={(e) => setSelectedAgentPolicyId(e.target.value)}
           aria-label={i18n.translate(
             'xpack.fleet.enrollmentStepAgentPolicy.policySelectAriaLabel',

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
@@ -11,13 +11,7 @@ import type { EuiContainedStepProps } from '@elastic/eui/src/components/steps/st
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import {
-  useGetOneEnrollmentAPIKey,
-  useLink,
-  useFleetStatus,
-  useGetAgents,
-  useGetAgentPolicies,
-} from '../../hooks';
+import { useGetOneEnrollmentAPIKey, useLink, useFleetStatus, useGetAgents } from '../../hooks';
 
 import { ManualInstructions } from '../../components/enrollment_instructions';
 import {
@@ -34,9 +28,7 @@ import { policyHasFleetServer } from '../../applications/fleet/sections/agents/s
 import { FLEET_SERVER_PACKAGE } from '../../constants';
 
 import { DownloadStep, AgentPolicySelectionStep, AgentEnrollmentKeySelectionStep } from './steps';
-import type { BaseProps } from './types';
-
-type Props = BaseProps;
+import type { InstructionProps } from './types';
 
 const DefaultMissingRequirements = () => {
   const { getHref } = useLink();
@@ -65,7 +57,7 @@ const FleetServerMissingRequirements = () => {
   return <FleetServerRequirementPage />;
 };
 
-export const ManagedInstructions = React.memo<Props>(
+export const ManagedInstructions = React.memo<InstructionProps>(
   ({
     agentPolicy,
     agentPolicies,
@@ -73,6 +65,7 @@ export const ManagedInstructions = React.memo<Props>(
     setSelectedPolicyId,
     isFleetServerPolicySelected,
     settings,
+    refreshAgentPolicies,
   }) => {
     const fleetStatus = useFleetStatus();
 
@@ -87,24 +80,15 @@ export const ManagedInstructions = React.memo<Props>(
       showInactive: false,
     });
 
-    const { data: agentPoliciesData, isLoading: isLoadingAgentPolicies } = useGetAgentPolicies({
-      page: 1,
-      perPage: 1000,
-      full: true,
-    });
-
     const fleetServers = useMemo(() => {
-      let policies = agentPolicies;
-      if (!agentPolicies && !isLoadingAgentPolicies) {
-        policies = agentPoliciesData?.items;
-      }
+      const policies = agentPolicies;
       const fleetServerAgentPolicies: string[] = (policies ?? [])
         .filter((pol) => policyHasFleetServer(pol))
         .map((pol) => pol.id);
       return (agents?.items ?? []).filter((agent) =>
         fleetServerAgentPolicies.includes(agent.policy_id ?? '')
       );
-    }, [agents, agentPolicies, agentPoliciesData, isLoadingAgentPolicies]);
+    }, [agents, agentPolicies]);
 
     const fleetServerSteps = useMemo(() => {
       const {
@@ -137,6 +121,7 @@ export const ManagedInstructions = React.memo<Props>(
               setSelectedAPIKeyId,
               setSelectedPolicyId,
               excludeFleetServer: true,
+              refreshAgentPolicies,
             })
           : AgentEnrollmentKeySelectionStep({ agentPolicy, selectedApiKeyId, setSelectedAPIKeyId }),
         DownloadStep(isFleetServerPolicySelected || false),
@@ -165,6 +150,7 @@ export const ManagedInstructions = React.memo<Props>(
       setSelectedPolicyId,
       setSelectedAPIKeyId,
       agentPolicies,
+      refreshAgentPolicies,
       apiKey.data,
       fleetServerSteps,
       isFleetServerPolicySelected,

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
@@ -43,233 +43,240 @@ import {
 import { PlatformSelector } from '../enrollment_instructions/manual/platform_selector';
 
 import { DownloadStep, AgentPolicySelectionStep } from './steps';
-import type { BaseProps } from './types';
+import type { InstructionProps } from './types';
 
-type Props = BaseProps;
+export const StandaloneInstructions = React.memo<InstructionProps>(
+  ({ agentPolicy, agentPolicies, refreshAgentPolicies }) => {
+    const { getHref } = useLink();
+    const core = useStartServices();
+    const { notifications } = core;
 
-export const StandaloneInstructions = React.memo<Props>(({ agentPolicy, agentPolicies }) => {
-  const { getHref } = useLink();
-  const core = useStartServices();
-  const { notifications } = core;
+    const [selectedPolicyId, setSelectedPolicyId] = useState<string | undefined>(agentPolicy?.id);
+    const [fullAgentPolicy, setFullAgentPolicy] = useState<any | undefined>();
+    const [isK8s, setIsK8s] = useState<'IS_LOADING' | 'IS_KUBERNETES' | 'IS_NOT_KUBERNETES'>(
+      'IS_LOADING'
+    );
+    const [yaml, setYaml] = useState<string | string>('');
+    const linuxMacCommand =
+      isK8s === 'IS_KUBERNETES'
+        ? KUBERNETES_RUN_INSTRUCTIONS
+        : STANDALONE_RUN_INSTRUCTIONS_LINUXMAC;
+    const windowsCommand =
+      isK8s === 'IS_KUBERNETES' ? KUBERNETES_RUN_INSTRUCTIONS : STANDALONE_RUN_INSTRUCTIONS_WINDOWS;
+    const { docLinks } = useStartServices();
 
-  const [selectedPolicyId, setSelectedPolicyId] = useState<string | undefined>(agentPolicy?.id);
-  const [fullAgentPolicy, setFullAgentPolicy] = useState<any | undefined>();
-  const [isK8s, setIsK8s] = useState<'IS_LOADING' | 'IS_KUBERNETES' | 'IS_NOT_KUBERNETES'>(
-    'IS_LOADING'
-  );
-  const [yaml, setYaml] = useState<string | string>('');
-  const linuxMacCommand =
-    isK8s === 'IS_KUBERNETES' ? KUBERNETES_RUN_INSTRUCTIONS : STANDALONE_RUN_INSTRUCTIONS_LINUXMAC;
-  const windowsCommand =
-    isK8s === 'IS_KUBERNETES' ? KUBERNETES_RUN_INSTRUCTIONS : STANDALONE_RUN_INSTRUCTIONS_WINDOWS;
-  const { docLinks } = useStartServices();
-
-  useEffect(() => {
-    async function checkifK8s() {
-      if (!selectedPolicyId) {
-        return;
-      }
-      const agentPolicyRequest = await sendGetOneAgentPolicy(selectedPolicyId);
-      const agentPol = agentPolicyRequest.data ? agentPolicyRequest.data.item : null;
-
-      if (!agentPol) {
-        setIsK8s('IS_NOT_KUBERNETES');
-        return;
-      }
-      const k8s = (pkg: PackagePolicy) => pkg.package?.name === FLEET_KUBERNETES_PACKAGE;
-      setIsK8s(
-        (agentPol.package_policies as PackagePolicy[]).some(k8s)
-          ? 'IS_KUBERNETES'
-          : 'IS_NOT_KUBERNETES'
-      );
-    }
-    checkifK8s();
-  }, [selectedPolicyId, notifications.toasts]);
-
-  useEffect(() => {
-    async function fetchFullPolicy() {
-      try {
+    useEffect(() => {
+      async function checkifK8s() {
         if (!selectedPolicyId) {
           return;
         }
-        let query = { standalone: true, kubernetes: false };
-        if (isK8s === 'IS_KUBERNETES') {
-          query = { standalone: true, kubernetes: true };
+        const agentPolicyRequest = await sendGetOneAgentPolicy(selectedPolicyId);
+        const agentPol = agentPolicyRequest.data ? agentPolicyRequest.data.item : null;
+
+        if (!agentPol) {
+          setIsK8s('IS_NOT_KUBERNETES');
+          return;
         }
-        const res = await sendGetOneAgentPolicyFull(selectedPolicyId, query);
-        if (res.error) {
-          throw res.error;
+        const k8s = (pkg: PackagePolicy) => pkg.package?.name === FLEET_KUBERNETES_PACKAGE;
+        setIsK8s(
+          (agentPol.package_policies as PackagePolicy[]).some(k8s)
+            ? 'IS_KUBERNETES'
+            : 'IS_NOT_KUBERNETES'
+        );
+      }
+      checkifK8s();
+    }, [selectedPolicyId, notifications.toasts]);
+
+    useEffect(() => {
+      async function fetchFullPolicy() {
+        try {
+          if (!selectedPolicyId) {
+            return;
+          }
+          let query = { standalone: true, kubernetes: false };
+          if (isK8s === 'IS_KUBERNETES') {
+            query = { standalone: true, kubernetes: true };
+          }
+          const res = await sendGetOneAgentPolicyFull(selectedPolicyId, query);
+          if (res.error) {
+            throw res.error;
+          }
+
+          if (!res.data) {
+            throw new Error('No data while fetching full agent policy');
+          }
+          setFullAgentPolicy(res.data.item);
+        } catch (error) {
+          notifications.toasts.addError(error, {
+            title: 'Error',
+          });
         }
+      }
+      if (isK8s !== 'IS_LOADING') {
+        fetchFullPolicy();
+      }
+    }, [selectedPolicyId, notifications.toasts, isK8s, core.http.basePath]);
 
-        if (!res.data) {
-          throw new Error('No data while fetching full agent policy');
+    useEffect(() => {
+      if (isK8s === 'IS_KUBERNETES') {
+        if (typeof fullAgentPolicy === 'object') {
+          return;
         }
-        setFullAgentPolicy(res.data.item);
-      } catch (error) {
-        notifications.toasts.addError(error, {
-          title: 'Error',
-        });
+        setYaml(fullAgentPolicy);
+      } else {
+        if (typeof fullAgentPolicy === 'string') {
+          return;
+        }
+        setYaml(fullAgentPolicyToYaml(fullAgentPolicy, safeDump));
       }
-    }
-    if (isK8s !== 'IS_LOADING') {
-      fetchFullPolicy();
-    }
-  }, [selectedPolicyId, notifications.toasts, isK8s, core.http.basePath]);
+    }, [fullAgentPolicy, isK8s]);
 
-  useEffect(() => {
-    if (isK8s === 'IS_KUBERNETES') {
-      if (typeof fullAgentPolicy === 'object') {
-        return;
-      }
-      setYaml(fullAgentPolicy);
-    } else {
-      if (typeof fullAgentPolicy === 'string') {
-        return;
-      }
-      setYaml(fullAgentPolicyToYaml(fullAgentPolicy, safeDump));
-    }
-  }, [fullAgentPolicy, isK8s]);
-
-  const policyMsg =
-    isK8s === 'IS_KUBERNETES' ? (
-      <FormattedMessage
-        id="xpack.fleet.agentEnrollment.stepConfigureAgentDescriptionk8s"
-        defaultMessage="Copy or download the Kubernetes manifest inside the Kubernetes cluster. Modify {ESUsernameVariable} and {ESPasswordVariable} in the Daemonset environment variables and apply the manifest."
-        values={{
-          ESUsernameVariable: <EuiCode>ES_USERNAME</EuiCode>,
-          ESPasswordVariable: <EuiCode>ES_PASSWORD</EuiCode>,
-        }}
-      />
-    ) : (
-      <FormattedMessage
-        id="xpack.fleet.agentEnrollment.stepConfigureAgentDescription"
-        defaultMessage="Copy this policy to the {fileName} on the host where the Elastic Agent is installed. Modify {ESUsernameVariable} and {ESPasswordVariable} in the {outputSection} section of {fileName} to use your Elasticsearch credentials."
-        values={{
-          fileName: <EuiCode>elastic-agent.yml</EuiCode>,
-          ESUsernameVariable: <EuiCode>ES_USERNAME</EuiCode>,
-          ESPasswordVariable: <EuiCode>ES_PASSWORD</EuiCode>,
-          outputSection: <EuiCode>outputs</EuiCode>,
-        }}
-      />
-    );
-
-  let downloadLink = '';
-  if (selectedPolicyId) {
-    downloadLink =
-      isK8s === 'IS_KUBERNETES'
-        ? core.http.basePath.prepend(
-            `${agentPolicyRouteService.getInfoFullDownloadPath(selectedPolicyId)}?kubernetes=true`
-          )
-        : core.http.basePath.prepend(
-            `${agentPolicyRouteService.getInfoFullDownloadPath(selectedPolicyId)}?standalone=true`
-          );
-  }
-
-  const downloadMsg =
-    isK8s === 'IS_KUBERNETES' ? (
-      <FormattedMessage
-        id="xpack.fleet.agentEnrollment.downloadPolicyButtonk8s"
-        defaultMessage="Download Manifest"
-      />
-    ) : (
-      <FormattedMessage
-        id="xpack.fleet.agentEnrollment.downloadPolicyButton"
-        defaultMessage="Download Policy"
-      />
-    );
-
-  const steps = [
-    !agentPolicy
-      ? AgentPolicySelectionStep({ agentPolicies, setSelectedPolicyId, excludeFleetServer: true })
-      : undefined,
-    DownloadStep(false),
-    {
-      title: i18n.translate('xpack.fleet.agentEnrollment.stepConfigureAgentTitle', {
-        defaultMessage: 'Configure the agent',
-      }),
-      children: (
-        <>
-          <EuiText>
-            <>{policyMsg}</>
-            <EuiSpacer size="m" />
-            <EuiFlexGroup gutterSize="m">
-              <EuiFlexItem grow={false}>
-                <EuiCopy textToCopy={yaml}>
-                  {(copy) => (
-                    <EuiButton onClick={copy} iconType="copyClipboard">
-                      <FormattedMessage
-                        id="xpack.fleet.agentEnrollment.copyPolicyButton"
-                        defaultMessage="Copy to clipboard"
-                      />
-                    </EuiButton>
-                  )}
-                </EuiCopy>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton iconType="download" href={downloadLink} isDisabled={!downloadLink}>
-                  <>{downloadMsg}</>
-                </EuiButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-            <EuiSpacer size="m" />
-            <EuiCodeBlock language="yaml" style={{ maxHeight: 300 }} fontSize="m">
-              {yaml}
-            </EuiCodeBlock>
-          </EuiText>
-        </>
-      ),
-    },
-    {
-      title: i18n.translate('xpack.fleet.agentEnrollment.stepRunAgentTitle', {
-        defaultMessage: 'Start the agent',
-      }),
-      children: (
-        <PlatformSelector
-          linuxMacCommand={linuxMacCommand}
-          windowsCommand={windowsCommand}
-          installAgentLink={docLinks.links.fleet.installElasticAgentStandalone}
-          troubleshootLink={docLinks.links.fleet.troubleshooting}
-          isK8s={isK8s === 'IS_KUBERNETES'}
-        />
-      ),
-    },
-    {
-      title: i18n.translate('xpack.fleet.agentEnrollment.stepCheckForDataTitle', {
-        defaultMessage: 'Check for data',
-      }),
-      children: (
-        <>
-          <EuiText>
-            <FormattedMessage
-              id="xpack.fleet.agentEnrollment.stepCheckForDataDescription"
-              defaultMessage="The agent should begin sending data. Go to {link} to view your data."
-              values={{
-                link: (
-                  <EuiLink href={getHref('data_streams')}>
-                    <FormattedMessage
-                      id="xpack.fleet.agentEnrollment.goToDataStreamsLink"
-                      defaultMessage="data streams"
-                    />
-                  </EuiLink>
-                ),
-              }}
-            />
-          </EuiText>
-        </>
-      ),
-    },
-  ].filter(Boolean) as EuiContainedStepProps[];
-
-  return (
-    <>
-      <EuiText>
+    const policyMsg =
+      isK8s === 'IS_KUBERNETES' ? (
         <FormattedMessage
-          id="xpack.fleet.agentEnrollment.standaloneDescription"
-          defaultMessage="Run an Elastic Agent standalone to configure and update the agent manually on the host where the agent is installed."
+          id="xpack.fleet.agentEnrollment.stepConfigureAgentDescriptionk8s"
+          defaultMessage="Copy or download the Kubernetes manifest inside the Kubernetes cluster. Modify {ESUsernameVariable} and {ESPasswordVariable} in the Daemonset environment variables and apply the manifest."
+          values={{
+            ESUsernameVariable: <EuiCode>ES_USERNAME</EuiCode>,
+            ESPasswordVariable: <EuiCode>ES_PASSWORD</EuiCode>,
+          }}
         />
-      </EuiText>
-      <EuiSpacer size="l" />
-      <EuiSteps steps={steps} />
-    </>
-  );
-});
+      ) : (
+        <FormattedMessage
+          id="xpack.fleet.agentEnrollment.stepConfigureAgentDescription"
+          defaultMessage="Copy this policy to the {fileName} on the host where the Elastic Agent is installed. Modify {ESUsernameVariable} and {ESPasswordVariable} in the {outputSection} section of {fileName} to use your Elasticsearch credentials."
+          values={{
+            fileName: <EuiCode>elastic-agent.yml</EuiCode>,
+            ESUsernameVariable: <EuiCode>ES_USERNAME</EuiCode>,
+            ESPasswordVariable: <EuiCode>ES_PASSWORD</EuiCode>,
+            outputSection: <EuiCode>outputs</EuiCode>,
+          }}
+        />
+      );
+
+    let downloadLink = '';
+    if (selectedPolicyId) {
+      downloadLink =
+        isK8s === 'IS_KUBERNETES'
+          ? core.http.basePath.prepend(
+              `${agentPolicyRouteService.getInfoFullDownloadPath(selectedPolicyId)}?kubernetes=true`
+            )
+          : core.http.basePath.prepend(
+              `${agentPolicyRouteService.getInfoFullDownloadPath(selectedPolicyId)}?standalone=true`
+            );
+    }
+
+    const downloadMsg =
+      isK8s === 'IS_KUBERNETES' ? (
+        <FormattedMessage
+          id="xpack.fleet.agentEnrollment.downloadPolicyButtonk8s"
+          defaultMessage="Download Manifest"
+        />
+      ) : (
+        <FormattedMessage
+          id="xpack.fleet.agentEnrollment.downloadPolicyButton"
+          defaultMessage="Download Policy"
+        />
+      );
+
+    const steps = [
+      !agentPolicy
+        ? AgentPolicySelectionStep({
+            agentPolicies,
+            setSelectedPolicyId,
+            excludeFleetServer: true,
+            refreshAgentPolicies,
+          })
+        : undefined,
+      DownloadStep(false),
+      {
+        title: i18n.translate('xpack.fleet.agentEnrollment.stepConfigureAgentTitle', {
+          defaultMessage: 'Configure the agent',
+        }),
+        children: (
+          <>
+            <EuiText>
+              <>{policyMsg}</>
+              <EuiSpacer size="m" />
+              <EuiFlexGroup gutterSize="m">
+                <EuiFlexItem grow={false}>
+                  <EuiCopy textToCopy={yaml}>
+                    {(copy) => (
+                      <EuiButton onClick={copy} iconType="copyClipboard">
+                        <FormattedMessage
+                          id="xpack.fleet.agentEnrollment.copyPolicyButton"
+                          defaultMessage="Copy to clipboard"
+                        />
+                      </EuiButton>
+                    )}
+                  </EuiCopy>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButton iconType="download" href={downloadLink} isDisabled={!downloadLink}>
+                    <>{downloadMsg}</>
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+              <EuiSpacer size="m" />
+              <EuiCodeBlock language="yaml" style={{ maxHeight: 300 }} fontSize="m">
+                {yaml}
+              </EuiCodeBlock>
+            </EuiText>
+          </>
+        ),
+      },
+      {
+        title: i18n.translate('xpack.fleet.agentEnrollment.stepRunAgentTitle', {
+          defaultMessage: 'Start the agent',
+        }),
+        children: (
+          <PlatformSelector
+            linuxMacCommand={linuxMacCommand}
+            windowsCommand={windowsCommand}
+            installAgentLink={docLinks.links.fleet.installElasticAgentStandalone}
+            troubleshootLink={docLinks.links.fleet.troubleshooting}
+            isK8s={isK8s === 'IS_KUBERNETES'}
+          />
+        ),
+      },
+      {
+        title: i18n.translate('xpack.fleet.agentEnrollment.stepCheckForDataTitle', {
+          defaultMessage: 'Check for data',
+        }),
+        children: (
+          <>
+            <EuiText>
+              <FormattedMessage
+                id="xpack.fleet.agentEnrollment.stepCheckForDataDescription"
+                defaultMessage="The agent should begin sending data. Go to {link} to view your data."
+                values={{
+                  link: (
+                    <EuiLink href={getHref('data_streams')}>
+                      <FormattedMessage
+                        id="xpack.fleet.agentEnrollment.goToDataStreamsLink"
+                        defaultMessage="data streams"
+                      />
+                    </EuiLink>
+                  ),
+                }}
+              />
+            </EuiText>
+          </>
+        ),
+      },
+    ].filter(Boolean) as EuiContainedStepProps[];
+
+    return (
+      <>
+        <EuiText>
+          <FormattedMessage
+            id="xpack.fleet.agentEnrollment.standaloneDescription"
+            defaultMessage="Run an Elastic Agent standalone to configure and update the agent manually on the host where the agent is installed."
+          />
+        </EuiText>
+        <EuiSpacer size="l" />
+        <EuiSteps steps={steps} />
+      </>
+    );
+  }
+);

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { EuiText, EuiButton, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -90,6 +90,8 @@ export const AgentPolicySelectionStep = ({
   excludeFleetServer?: boolean;
   refreshAgentPolicies: () => void;
 }) => {
+  // storing the created agent policy id as the child component is being recreated
+  const [policyId, setPolicyId] = useState<string | undefined>(undefined);
   const regularAgentPolicies = useMemo(() => {
     return (agentPolicies ?? []).filter(
       (policy) =>
@@ -104,6 +106,7 @@ export const AgentPolicySelectionStep = ({
       }
       if (setSelectedPolicyId) {
         setSelectedPolicyId(key);
+        setPolicyId(key);
       }
     },
     [setSelectedPolicyId, refreshAgentPolicies]
@@ -122,6 +125,7 @@ export const AgentPolicySelectionStep = ({
           onKeyChange={setSelectedAPIKeyId}
           onAgentPolicyChange={onAgentPolicyChange}
           excludeFleetServer={excludeFleetServer}
+          policyId={policyId}
         />
       </>
     ),

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
@@ -81,32 +81,32 @@ export const AgentPolicySelectionStep = ({
   selectedApiKeyId,
   setSelectedAPIKeyId,
   excludeFleetServer,
+  refreshAgentPolicies,
 }: {
   agentPolicies?: AgentPolicy[];
   setSelectedPolicyId?: (policyId?: string) => void;
   selectedApiKeyId?: string;
   setSelectedAPIKeyId?: (key?: string) => void;
   excludeFleetServer?: boolean;
+  refreshAgentPolicies: () => void;
 }) => {
-  const [agentPolicyList, setAgentPolicyList] = useState<AgentPolicy[]>(agentPolicies || []);
-
   const regularAgentPolicies = useMemo(() => {
-    return agentPolicyList.filter(
+    return (agentPolicies ?? []).filter(
       (policy) =>
         policy && !policy.is_managed && (!excludeFleetServer || !policyHasFleetServer(policy))
     );
-  }, [agentPolicyList, excludeFleetServer]);
+  }, [agentPolicies, excludeFleetServer]);
 
   const onAgentPolicyChange = useCallback(
     async (key?: string, policy?: AgentPolicy) => {
       if (policy) {
-        setAgentPolicyList([...agentPolicyList, policy]);
+        refreshAgentPolicies();
       }
       if (setSelectedPolicyId) {
         setSelectedPolicyId(key);
       }
     },
-    [setSelectedPolicyId, setAgentPolicyList, agentPolicyList]
+    [setSelectedPolicyId, refreshAgentPolicies]
   );
 
   return {

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { EuiText, EuiButton, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/types.ts
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/types.ts
@@ -34,3 +34,7 @@ export interface BaseProps {
 
   isFleetServerPolicySelected?: boolean;
 }
+
+export interface InstructionProps extends BaseProps {
+  refreshAgentPolicies: () => void;
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/125481

Steps to reproduce:

1. Navigate to Fleet>Agents tab (without any agent policies created, only one Fleet Server policy should be there with Fleet Server enrolled)
2. Click Add Agent flyout and click Create policy with default name- Agent Policy 1 (both Enroll in Agent and Standalone tab)
3. Navigate to Agent policies and observe Agent Policy 1 is created.
4. Navigate back to Agents tab and click Add Agent flyout.
5. Dropdown should be visible with Agent Policy 1
