### PR TITLE
[ML] Docs screenshots - fix weblogs anomaly explorer screenshot

### DIFF
--- a/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/geographic_data.ts
+++ b/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/geographic_data.ts
@@ -266,7 +266,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('select swim lane tile');
       const cells = await ml.swimLane.getCells(overallSwimLaneTestSubj);
       const sampleCell1 = cells[11];
-      const sampleCell2 = cells[12];
+      const sampleCell2 = cells[cells.length - 1];
       await ml.swimLane.selectCells(overallSwimLaneTestSubj, {
         x1: sampleCell1.x + cellSize,
         y1: sampleCell1.y + cellSize,
@@ -281,6 +281,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       // clickFitToData only works with displayed legend
       await maps.openLegend();
       await maps.clickFitToData();
+      await ml.anomalyExplorer.scrollChartsContainerIntoView();
       await maps.closeLegend();
 
       await mlScreenshots.takeScreenshot(


### PR DESCRIPTION
## Summary

This PR fixes the weblogs anomaly explorer docs screenshot by expanding the cell selection to the last element of the array and using another scrollIntoView.
