### PR TITLE
[Lens] Do not allow rarity in some cases

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/droppable/droppable.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/droppable/droppable.test.ts
@@ -771,6 +771,41 @@ describe('IndexPatternDimensionEditorPanel', () => {
         });
       });
 
+      it('returns no combine_compatible drop type if the target column uses rarity ordering', () => {
+        state = getStateWithMultiFieldColumn();
+        state.layers.first = {
+          indexPatternId: 'foo',
+          columnOrder: ['col1', 'col2'],
+          columns: {
+            col1: state.layers.first.columns.col1,
+
+            col2: {
+              ...state.layers.first.columns.col1,
+              sourceField: 'bytes',
+              params: {
+                ...(state.layers.first.columns.col1 as TermsIndexPatternColumn).params,
+                orderBy: { type: 'rare' },
+              },
+            } as TermsIndexPatternColumn,
+          },
+        };
+
+        expect(
+          getDropProps({
+            ...defaultProps,
+            state,
+            groupId,
+            dragging: {
+              ...draggingCol1,
+              groupId: 'c',
+            },
+            columnId: 'col2',
+          })
+        ).toEqual({
+          dropTypes: ['replace_compatible', 'replace_duplicate_compatible'],
+        });
+      });
+
       it('returns no combine drop type if the dragged column is compatible, the target one supports multiple fields but there are too many fields', () => {
         state = getStateWithMultiFieldColumn();
         state.layers.first = {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/mocks.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/mocks.ts
@@ -50,6 +50,7 @@ export const createMockedIndexPattern = (): IndexPattern => {
       type: 'number',
       aggregatable: true,
       searchable: true,
+      esTypes: ['float'],
     },
     {
       name: 'source',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -40,6 +40,13 @@ import {
   isSortableByColumn,
 } from './helpers';
 
+export function supportsRarityRanking(field?: IndexPatternField) {
+  // these es field types can't be sorted by rarity
+  return !field?.esTypes?.some((esType) =>
+    ['double', 'float', 'half_float', 'scaled_float'].includes(esType)
+  );
+}
+
 export type { TermsIndexPatternColumn } from './types';
 
 const missingFieldLabel = i18n.translate('xpack.lens.indexPattern.missingFieldLabel', {
@@ -144,7 +151,10 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
     return ret;
   },
   canAddNewField: ({ targetColumn, sourceColumn, field, indexPattern }) => {
-    // first step: collect the fields from the targetColumn
+    if (targetColumn.params.orderBy.type === 'rare') {
+      return false;
+    }
+    // collect the fields from the targetColumn
     const originalTerms = new Set([
       targetColumn.sourceField,
       ...(targetColumn.params?.secondaryFields ?? []),
@@ -306,6 +316,9 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
       delete newParams.format;
     }
     newParams.parentFormat = getParentFormatter(newParams);
+    if (!supportsRarityRanking(field) && newParams.orderBy.type === 'rare') {
+      newParams.orderBy = { type: 'alphabetical' };
+    }
     return {
       ...oldColumn,
       dataType: field.type as DataType,
@@ -375,6 +388,10 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
         };
         if ('format' in newParams && newDataType !== 'number') {
           delete newParams.format;
+        }
+        const mainField = indexPattern.getFieldByName(fields[0]);
+        if (!supportsRarityRanking(mainField) && newParams.orderBy.type === 'rare') {
+          newParams.orderBy = { type: 'alphabetical' };
         }
         updateLayer({
           ...layer,
@@ -494,7 +511,10 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
         defaultMessage: 'Alphabetical',
       }),
     });
-    if (!currentColumn.params.secondaryFields?.length) {
+    if (
+      !currentColumn.params.secondaryFields?.length &&
+      supportsRarityRanking(indexPattern.getFieldByName(currentColumn.sourceField))
+    ) {
       orderOptions.push({
         value: toValue({ type: 'rare', maxDocCount: DEFAULT_MAX_DOC_COUNT }),
         text: i18n.translate('xpack.lens.indexPattern.terms.orderRare', {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -404,7 +404,7 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
               label: ofName(
                 indexPattern.getFieldByName(fields[0])?.displayName,
                 fields.length - 1,
-                column.params.orderBy.type === 'rare'
+                newParams.orderBy.type === 'rare'
               ),
               params: {
                 ...newParams,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
@@ -1713,6 +1713,30 @@ describe('terms', () => {
       ]);
     });
 
+    it('should disable rare ordering for floating point types', () => {
+      const updateLayerSpy = jest.fn();
+      const instance = shallow(
+        <InlineOptions
+          {...defaultProps}
+          layer={layer}
+          updateLayer={updateLayerSpy}
+          columnId="col1"
+          currentColumn={
+            { ...layer.columns.col1, sourceField: 'memory' } as TermsIndexPatternColumn
+          }
+        />
+      );
+
+      const select = instance.find('[data-test-subj="indexPattern-terms-orderBy"]').find(EuiSelect);
+
+      expect(select.prop('value')).toEqual('alphabetical');
+
+      expect(select.prop('options')!.map(({ value }) => value)).toEqual([
+        'column$$$col2',
+        'alphabetical',
+      ]);
+    });
+
     it('should update state with the order by value', () => {
       const updateLayerSpy = jest.fn();
       const instance = shallow(


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/124789

Actually there were a few cases beyond the one described in the issue to get into an invalid state regarding rarity-sorting. I hope I caught them all:
* Dragging a floating point field into a rarity-sorted top values will switch to alphabetical sorting
* Combine-action is disabled as long as rarity-sorting is active
* Rarity sorting option not shown as long as floating point field is selected
* Switching to floating point field via field select in dropdown for a rarity-sorted top values will switch to alphabetical sorting
* No "Rank by rarity" call-to-action in the warning for floating point fields