### PR TITLE
[8.1] [Uptime] handle null duration on ping list (#125438)

### DIFF
--- a/x-pack/plugins/uptime/common/runtime_types/ping/ping.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/ping/ping.ts
@@ -90,14 +90,14 @@ export type Tls = t.TypeOf<typeof TlsType>;
 
 export const MonitorType = t.intersection([
   t.type({
-    duration: t.type({
-      us: t.number,
-    }),
     id: t.string,
     status: t.string,
     type: t.string,
   }),
   t.partial({
+    duration: t.type({
+      us: t.number,
+    }),
     check_group: t.string,
     ip: t.string,
     name: t.string,

--- a/x-pack/plugins/uptime/public/components/monitor/ping_list/ping_list.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor/ping_list/ping_list.test.tsx
@@ -42,7 +42,6 @@ describe('PingList component', () => {
         type: 'io',
       },
       monitor: {
-        duration: { us: 1370 },
         id: 'auto-tcp-0X81440A68E839814D',
         ip: '255.255.255.0',
         name: '',
@@ -161,9 +160,6 @@ describe('PingList component', () => {
                 "type": "io",
               },
               "monitor": Object {
-                "duration": Object {
-                  "us": 1370,
-                },
                 "id": "auto-tcp-0X81440A68E839814D",
                 "ip": "255.255.255.0",
                 "name": "",
@@ -183,6 +179,13 @@ describe('PingList component', () => {
         const ping = pings[0];
         ping.monitor.type = 'browser';
         expect(rowShouldExpand(ping)).toBe(true);
+      });
+    });
+
+    describe('duration column', () => {
+      it('shows -- when duration is null', () => {
+        const { getByTestId } = render(<PingList />);
+        expect(getByTestId('ping-list-duration-unavailable-tool-tip')).toBeInTheDocument();
       });
     });
 

--- a/x-pack/plugins/uptime/public/components/monitor/ping_list/ping_list_table.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor/ping_list/ping_list_table.tsx
@@ -140,7 +140,12 @@ export function PingListTable({ loading, error, pings, pagination, onChange, fai
       name: i18n.translate('xpack.uptime.pingList.durationMsColumnLabel', {
         defaultMessage: 'Duration',
       }),
-      render: (duration: number) => formatDuration(duration),
+      render: (duration: number | null) =>
+        duration ? (
+          formatDuration(duration)
+        ) : (
+          <span data-test-subj="ping-list-duration-unavailable-tool-tip">{'--'}</span>
+        ),
     },
     ...(hasError
       ? [

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
@@ -244,6 +244,7 @@ export class SyntheticsService {
     const findResult = await savedObjectsClient.find<SyntheticsMonitor>({
       type: syntheticsMonitorType,
       namespaces: ['*'],
+      perPage: 10000,
     });
 
     return (findResult.saved_objects ?? []).map(({ attributes, id }) => ({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Uptime] handle null duration on ping list (#125438)](https://github.com/elastic/kibana/pull/125438)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)