### PR TITLE
[ci] Retry failed steps in on-merge pipeline

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -13,12 +13,20 @@ steps:
     agents:
       queue: c2-8
     timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
 
   - command: .buildkite/scripts/steps/on_merge_ts_refs_api_docs.sh
     label: Build TS Refs and Check Public API Docs
     agents:
       queue: c2-4
     timeout_in_minutes: 80
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
The failures in this pipeline are almost always transient, so let's retry these steps one time before failing the build.