### PR TITLE
[Uptime] synthetics e2e - use custom location when defined

### DIFF
--- a/x-pack/plugins/uptime/e2e/journeys/monitor_management.journey.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/monitor_management.journey.ts
@@ -10,8 +10,10 @@ import { monitorManagementPageProvider } from '../page_objects/monitor_managemen
 import { DataStream } from '../../common/runtime_types/monitor_management';
 import { byTestId } from './utils';
 
+const customLocation = process.env.SYNTHETICS_TEST_LOCATION;
+
 const basicMonitorDetails = {
-  location: 'US Central',
+  location: customLocation || 'US Central',
   schedule: '@every 3m',
 };
 const httpName = 'http monitor';


### PR DESCRIPTION
## Summary

Allows defining a custom location for Monitor Management journeys.

This is important because prod locations are different than dev, qa, and staging locations. 