### PR TITLE
[8.0] Alert doesn't fire action if it's muted or throttled (#124775)

### DIFF
--- a/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
@@ -40,6 +40,7 @@ import { omit } from 'lodash';
 import { UntypedNormalizedAlertType } from '../rule_type_registry';
 import { ruleTypeRegistryMock } from '../rule_type_registry.mock';
 import { ExecuteOptions } from '../../../actions/server/create_execute_function';
+import moment from 'moment';
 
 const alertType: jest.Mocked<UntypedNormalizedAlertType> = {
   id: 'test',
@@ -54,6 +55,10 @@ const alertType: jest.Mocked<UntypedNormalizedAlertType> = {
 };
 
 let fakeTimer: sinon.SinonFakeTimers;
+
+export const mockRunNowResponse = {
+  id: 1,
+} as jest.ResolvedValue<unknown>;
 
 describe('Task Runner', () => {
   let mockedTaskInstance: ConcreteTaskInstance;
@@ -865,7 +870,136 @@ describe('Task Runner', () => {
       }
   );
 
-  test('actionsPlugin.execute is not called when notifyWhen=onActionGroupChange and alert instance state does not change', async () => {
+  testAgainstEphemeralSupport(
+    'skips firing actions for active alert if alert is throttled %s',
+    (
+        customTaskRunnerFactoryInitializerParams: TaskRunnerFactoryInitializerParamsType,
+        enqueueFunction: (options: ExecuteOptions) => Promise<void | RunNowResult>
+      ) =>
+      async () => {
+        (
+          customTaskRunnerFactoryInitializerParams as TaskRunnerFactoryInitializerParamsType
+        ).actionsPlugin.isActionTypeEnabled.mockReturnValue(true);
+        customTaskRunnerFactoryInitializerParams.actionsPlugin.isActionExecutable.mockReturnValue(
+          true
+        );
+        actionsClient.ephemeralEnqueuedExecution.mockResolvedValue(mockRunNowResponse);
+        alertType.executor.mockImplementation(
+          async ({
+            services: executorServices,
+          }: AlertExecutorOptions<
+            AlertTypeParams,
+            AlertTypeState,
+            AlertInstanceState,
+            AlertInstanceContext,
+            string
+          >) => {
+            executorServices.alertInstanceFactory('1').scheduleActions('default');
+            executorServices.alertInstanceFactory('2').scheduleActions('default');
+          }
+        );
+        const taskRunner = new TaskRunner(
+          alertType,
+          {
+            ...mockedTaskInstance,
+            state: {
+              ...mockedTaskInstance.state,
+              alertInstances: {
+                '2': {
+                  meta: {
+                    lastScheduledActions: { date: moment().toISOString(), group: 'default' },
+                  },
+                  state: {
+                    bar: false,
+                    start: '1969-12-31T00:00:00.000Z',
+                    duration: 86400000000000,
+                  },
+                },
+              },
+            },
+          },
+          taskRunnerFactoryInitializerParams
+        );
+        rulesClient.get.mockResolvedValue({
+          ...mockedAlertTypeSavedObject,
+          throttle: '1d',
+        });
+        encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue({
+          id: '1',
+          type: 'alert',
+          attributes: {
+            apiKey: Buffer.from('123:abc').toString('base64'),
+            enabled: true,
+          },
+          references: [],
+        });
+        await taskRunner.run();
+        // expect(enqueueFunction).toHaveBeenCalledTimes(1);
+
+        const logger = customTaskRunnerFactoryInitializerParams.logger;
+        expect(logger.debug).toHaveBeenCalledTimes(4);
+        expect(logger.debug).nthCalledWith(
+          3,
+          `skipping scheduling of actions for '2' in alert test:1: 'alert-name': instance is throttled`
+        );
+      }
+  );
+
+  testAgainstEphemeralSupport(
+    'skips firing actions for active alert when alert is muted even if notifyWhen === onActionGroupChange %s',
+    (
+        customTaskRunnerFactoryInitializerParams: TaskRunnerFactoryInitializerParamsType,
+        enqueueFunction: (options: ExecuteOptions) => Promise<void | RunNowResult>
+      ) =>
+      async () => {
+        customTaskRunnerFactoryInitializerParams.actionsPlugin.isActionExecutable.mockReturnValue(
+          true
+        );
+        alertType.executor.mockImplementation(
+          async ({
+            services: executorServices,
+          }: AlertExecutorOptions<
+            AlertTypeParams,
+            AlertTypeState,
+            AlertInstanceState,
+            AlertInstanceContext,
+            string
+          >) => {
+            executorServices.alertInstanceFactory('1').scheduleActions('default');
+            executorServices.alertInstanceFactory('2').scheduleActions('default');
+          }
+        );
+        const taskRunner = new TaskRunner(
+          alertType,
+          mockedTaskInstance,
+          customTaskRunnerFactoryInitializerParams
+        );
+        rulesClient.get.mockResolvedValue({
+          ...mockedAlertTypeSavedObject,
+          mutedInstanceIds: ['2'],
+          notifyWhen: 'onActionGroupChange',
+        });
+        encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue({
+          id: '1',
+          type: 'alert',
+          attributes: {
+            apiKey: Buffer.from('123:abc').toString('base64'),
+            enabled: true,
+          },
+          references: [],
+        });
+        await taskRunner.run();
+        expect(enqueueFunction).toHaveBeenCalledTimes(1);
+        const logger = customTaskRunnerFactoryInitializerParams.logger;
+        expect(logger.debug).toHaveBeenCalledTimes(4);
+        expect(logger.debug).nthCalledWith(
+          3,
+          `skipping scheduling of actions for '2' in alert test:1: 'alert-name': instance is muted`
+        );
+      }
+  );
+
+  test('actionsPlugin.execute is not called when notifyWhen=onActionGroupChange and alert state does not change', async () => {
     taskRunnerFactoryInitializerParams.actionsPlugin.isActionTypeEnabled.mockReturnValue(true);
     taskRunnerFactoryInitializerParams.actionsPlugin.isActionExecutable.mockReturnValue(true);
     alertType.executor.mockImplementation(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [Alert doesn't fire action if it's muted or throttled (#124775)](https://github.com/elastic/kibana/pull/124775)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)