### PR TITLE
[APM] Bug: Service maps popover detail metrics are aggregates over all transaction types

### DIFF
--- a/x-pack/plugins/apm/server/lib/transaction_groups/get_failed_transaction_rate.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/get_failed_transaction_rate.ts
@@ -46,7 +46,7 @@ export async function getFailedTransactionRate({
   environment: string;
   kuery: string;
   serviceName: string;
-  transactionType?: string;
+  transactionType?: string | string[];
   transactionName?: string;
   setup: Setup;
   searchAggregatedTransactions: boolean;
@@ -67,7 +67,9 @@ export async function getFailedTransactionRate({
       },
     },
     ...termQuery(TRANSACTION_NAME, transactionName),
-    ...termQuery(TRANSACTION_TYPE, transactionType),
+    ...(Array.isArray(transactionType)
+      ? [{ terms: { [TRANSACTION_TYPE]: transactionType } }]
+      : termQuery(TRANSACTION_TYPE, transactionType)),
     ...getDocumentTypeFilterForTransactions(searchAggregatedTransactions),
     ...rangeQuery(start, end),
     ...environmentQuery(environment),

--- a/x-pack/plugins/apm/server/lib/transaction_groups/get_failed_transaction_rate.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/get_failed_transaction_rate.ts
@@ -35,7 +35,7 @@ export async function getFailedTransactionRate({
   environment,
   kuery,
   serviceName,
-  transactionType,
+  transactionTypes,
   transactionName,
   setup,
   searchAggregatedTransactions,
@@ -46,7 +46,7 @@ export async function getFailedTransactionRate({
   environment: string;
   kuery: string;
   serviceName: string;
-  transactionType?: string | string[];
+  transactionTypes: string[];
   transactionName?: string;
   setup: Setup;
   searchAggregatedTransactions: boolean;
@@ -66,10 +66,8 @@ export async function getFailedTransactionRate({
         [EVENT_OUTCOME]: [EventOutcome.failure, EventOutcome.success],
       },
     },
+    { terms: { [TRANSACTION_TYPE]: transactionTypes } },
     ...termQuery(TRANSACTION_NAME, transactionName),
-    ...(Array.isArray(transactionType)
-      ? [{ terms: { [TRANSACTION_TYPE]: transactionType } }]
-      : termQuery(TRANSACTION_TYPE, transactionType)),
     ...getDocumentTypeFilterForTransactions(searchAggregatedTransactions),
     ...rangeQuery(start, end),
     ...environmentQuery(environment),

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_service_node_info.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_service_node_info.ts
@@ -144,7 +144,7 @@ async function getFailedTransactionsRateStats({
       end,
       kuery: '',
       numBuckets,
-      transactionType: [TRANSACTION_REQUEST, TRANSACTION_PAGE_LOAD],
+      transactionTypes: [TRANSACTION_REQUEST, TRANSACTION_PAGE_LOAD],
     });
     return {
       value: average,

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_service_node_info.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_service_node_info.ts
@@ -144,6 +144,7 @@ async function getFailedTransactionsRateStats({
       end,
       kuery: '',
       numBuckets,
+      transactionType: [TRANSACTION_REQUEST, TRANSACTION_PAGE_LOAD],
     });
     return {
       value: average,

--- a/x-pack/plugins/apm/server/routes/transactions/get_failed_transaction_rate_periods.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/get_failed_transaction_rate_periods.ts
@@ -24,7 +24,7 @@ export async function getFailedTransactionRatePeriods({
   environment: string;
   kuery: string;
   serviceName: string;
-  transactionType?: string;
+  transactionType: string;
   transactionName?: string;
   setup: Setup;
   searchAggregatedTransactions: boolean;
@@ -37,7 +37,7 @@ export async function getFailedTransactionRatePeriods({
     environment,
     kuery,
     serviceName,
-    transactionType,
+    transactionTypes: [transactionType],
     transactionName,
     setup,
     searchAggregatedTransactions,

--- a/x-pack/test/apm_api_integration/tests/error_rate/service_maps.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/error_rate/service_maps.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { apm, timerange } from '@elastic/apm-synthtrace';
+import expect from '@kbn/expect';
+import { meanBy } from 'lodash';
+import { FtrProviderContext } from '../../common/ftr_provider_context';
+
+export default function ApiTest({ getService }: FtrProviderContext) {
+  const registry = getService('registry');
+  const apmApiClient = getService('apmApiClient');
+  const synthtraceEsClient = getService('synthtraceEsClient');
+
+  const serviceName = 'synth-go';
+  const start = new Date('2021-01-01T00:00:00.000Z').getTime();
+  const end = new Date('2021-01-01T00:15:00.000Z').getTime() - 1;
+
+  async function getErrorRateValues(processorEvent: 'transaction' | 'metric') {
+    const commonQuery = {
+      start: new Date(start).toISOString(),
+      end: new Date(end).toISOString(),
+      environment: 'ENVIRONMENT_ALL',
+    };
+    const [serviceInventoryAPIResponse, serviceMapsNodeDetails] = await Promise.all([
+      apmApiClient.readUser({
+        endpoint: 'GET /internal/apm/services',
+        params: {
+          query: {
+            ...commonQuery,
+            kuery: `service.name : "${serviceName}" and processor.event : "${processorEvent}"`,
+          },
+        },
+      }),
+      apmApiClient.readUser({
+        endpoint: `GET /internal/apm/service-map/service/{serviceName}`,
+        params: {
+          path: { serviceName },
+          query: commonQuery,
+        },
+      }),
+    ]);
+
+    const serviceInventoryErrorRate =
+      serviceInventoryAPIResponse.body.items[0].transactionErrorRate;
+
+    const serviceMapsNodeDetailsErrorRate = meanBy(
+      serviceMapsNodeDetails.body.currentPeriod.failedTransactionsRate?.timeseries,
+      'y'
+    );
+
+    return {
+      serviceInventoryErrorRate,
+      serviceMapsNodeDetailsErrorRate,
+    };
+  }
+
+  let errorRateMetricValues: Awaited<ReturnType<typeof getErrorRateValues>>;
+  let errorTransactionValues: Awaited<ReturnType<typeof getErrorRateValues>>;
+  registry.when(
+    'Service maps APIs',
+    { config: 'trial', archives: ['apm_mappings_only_8.0.0'] },
+    () => {
+      describe('when data is loaded ', () => {
+        const GO_PROD_LIST_RATE = 75;
+        const GO_PROD_LIST_ERROR_RATE = 25;
+        const GO_PROD_ID_RATE = 50;
+        const GO_PROD_ID_ERROR_RATE = 50;
+        before(async () => {
+          const serviceGoProdInstance = apm
+            .service(serviceName, 'production', 'go')
+            .instance('instance-a');
+
+          const transactionNameProductList = 'GET /api/product/list';
+          const transactionNameProductId = 'GET /api/product/:id';
+
+          await synthtraceEsClient.index([
+            ...timerange(start, end)
+              .interval('1m')
+              .rate(GO_PROD_LIST_RATE)
+              .flatMap((timestamp) =>
+                serviceGoProdInstance
+                  .transaction(transactionNameProductList, 'Worker')
+                  .timestamp(timestamp)
+                  .duration(1000)
+                  .success()
+                  .serialize()
+              ),
+            ...timerange(start, end)
+              .interval('1m')
+              .rate(GO_PROD_LIST_ERROR_RATE)
+              .flatMap((timestamp) =>
+                serviceGoProdInstance
+                  .transaction(transactionNameProductList, 'Worker')
+                  .duration(1000)
+                  .timestamp(timestamp)
+                  .failure()
+                  .serialize()
+              ),
+            ...timerange(start, end)
+              .interval('1m')
+              .rate(GO_PROD_ID_RATE)
+              .flatMap((timestamp) =>
+                serviceGoProdInstance
+                  .transaction(transactionNameProductId)
+                  .timestamp(timestamp)
+                  .duration(1000)
+                  .success()
+                  .serialize()
+              ),
+            ...timerange(start, end)
+              .interval('1m')
+              .rate(GO_PROD_ID_ERROR_RATE)
+              .flatMap((timestamp) =>
+                serviceGoProdInstance
+                  .transaction(transactionNameProductId)
+                  .duration(1000)
+                  .timestamp(timestamp)
+                  .failure()
+                  .serialize()
+              ),
+          ]);
+        });
+
+        after(() => synthtraceEsClient.clean());
+
+        describe('compare latency value between service inventory and service maps', () => {
+          before(async () => {
+            [errorTransactionValues, errorRateMetricValues] = await Promise.all([
+              getErrorRateValues('transaction'),
+              getErrorRateValues('metric'),
+            ]);
+          });
+
+          it('returns same avg error rate value for Transaction-based and Metric-based data', () => {
+            [
+              errorTransactionValues.serviceInventoryErrorRate,
+              errorTransactionValues.serviceMapsNodeDetailsErrorRate,
+              errorRateMetricValues.serviceInventoryErrorRate,
+              errorRateMetricValues.serviceMapsNodeDetailsErrorRate,
+            ].forEach((value) => expect(value).to.be.equal(GO_PROD_ID_ERROR_RATE / 100));
+          });
+        });
+      });
+    }
+  );
+}

--- a/x-pack/test/apm_api_integration/tests/latency/service_maps.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/latency/service_maps.spec.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { apm, timerange } from '@elastic/apm-synthtrace';
+import expect from '@kbn/expect';
+import { meanBy } from 'lodash';
+import { FtrProviderContext } from '../../common/ftr_provider_context';
+
+export default function ApiTest({ getService }: FtrProviderContext) {
+  const registry = getService('registry');
+  const apmApiClient = getService('apmApiClient');
+  const synthtraceEsClient = getService('synthtraceEsClient');
+
+  const serviceName = 'synth-go';
+  const start = new Date('2021-01-01T00:00:00.000Z').getTime();
+  const end = new Date('2021-01-01T00:15:00.000Z').getTime() - 1;
+
+  async function getLatencyValues(processorEvent: 'transaction' | 'metric') {
+    const commonQuery = {
+      start: new Date(start).toISOString(),
+      end: new Date(end).toISOString(),
+      environment: 'ENVIRONMENT_ALL',
+    };
+    const [serviceInventoryAPIResponse, serviceMapsNodeDetails] = await Promise.all([
+      apmApiClient.readUser({
+        endpoint: 'GET /internal/apm/services',
+        params: {
+          query: {
+            ...commonQuery,
+            kuery: `service.name : "${serviceName}" and processor.event : "${processorEvent}"`,
+          },
+        },
+      }),
+      apmApiClient.readUser({
+        endpoint: `GET /internal/apm/service-map/service/{serviceName}`,
+        params: {
+          path: { serviceName },
+          query: commonQuery,
+        },
+      }),
+    ]);
+
+    const serviceInventoryLatency = serviceInventoryAPIResponse.body.items[0].latency;
+
+    const serviceMapsNodeDetailsLatency = meanBy(
+      serviceMapsNodeDetails.body.currentPeriod.transactionStats?.latency?.timeseries,
+      'y'
+    );
+
+    return {
+      serviceInventoryLatency,
+      serviceMapsNodeDetailsLatency,
+    };
+  }
+
+  let latencyMetricValues: Awaited<ReturnType<typeof getLatencyValues>>;
+  let latencyTransactionValues: Awaited<ReturnType<typeof getLatencyValues>>;
+  registry.when(
+    'Service maps APIs',
+    { config: 'trial', archives: ['apm_mappings_only_8.0.0'] },
+    () => {
+      describe('when data is loaded ', () => {
+        const GO_PROD_RATE = 80;
+        const GO_DEV_RATE = 20;
+        const GO_PROD_DURATION = 1000;
+        const GO_DEV_DURATION = 500;
+        before(async () => {
+          const serviceGoProdInstance = apm
+            .service(serviceName, 'production', 'go')
+            .instance('instance-a');
+          const serviceGoDevInstance = apm
+            .service(serviceName, 'development', 'go')
+            .instance('instance-b');
+
+          await synthtraceEsClient.index([
+            ...timerange(start, end)
+              .interval('1m')
+              .rate(GO_PROD_RATE)
+              .flatMap((timestamp) =>
+                serviceGoProdInstance
+                  .transaction('GET /api/product/list', 'Worker')
+                  .duration(GO_PROD_DURATION)
+                  .timestamp(timestamp)
+                  .serialize()
+              ),
+            ...timerange(start, end)
+              .interval('1m')
+              .rate(GO_DEV_RATE)
+              .flatMap((timestamp) =>
+                serviceGoDevInstance
+                  .transaction('GET /api/product/:id')
+                  .duration(GO_DEV_DURATION)
+                  .timestamp(timestamp)
+                  .serialize()
+              ),
+          ]);
+        });
+
+        after(() => synthtraceEsClient.clean());
+
+        describe('compare latency value between service inventory and service maps', () => {
+          before(async () => {
+            [latencyTransactionValues, latencyMetricValues] = await Promise.all([
+              getLatencyValues('transaction'),
+              getLatencyValues('metric'),
+            ]);
+          });
+
+          it('returns same avg latency value for Transaction-based and Metric-based data', () => {
+            const expectedLatencyAvgValueMs =
+              ((GO_DEV_RATE * GO_DEV_DURATION) / GO_DEV_RATE) * 1000;
+
+            [
+              latencyTransactionValues.serviceMapsNodeDetailsLatency,
+              latencyTransactionValues.serviceInventoryLatency,
+              latencyMetricValues.serviceMapsNodeDetailsLatency,
+              latencyMetricValues.serviceInventoryLatency,
+            ].forEach((value) => expect(value).to.be.equal(expectedLatencyAvgValueMs));
+          });
+        });
+      });
+    }
+  );
+}

--- a/x-pack/test/apm_api_integration/tests/throughput/service_maps.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/throughput/service_maps.spec.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { apm, timerange } from '@elastic/apm-synthtrace';
+import expect from '@kbn/expect';
+import { meanBy } from 'lodash';
+import { FtrProviderContext } from '../../common/ftr_provider_context';
+import { roundNumber } from '../../utils';
+
+export default function ApiTest({ getService }: FtrProviderContext) {
+  const registry = getService('registry');
+  const apmApiClient = getService('apmApiClient');
+  const synthtraceEsClient = getService('synthtraceEsClient');
+
+  const serviceName = 'synth-go';
+  const start = new Date('2021-01-01T00:00:00.000Z').getTime();
+  const end = new Date('2021-01-01T00:15:00.000Z').getTime() - 1;
+
+  async function getThroughputValues(processorEvent: 'transaction' | 'metric') {
+    const commonQuery = {
+      start: new Date(start).toISOString(),
+      end: new Date(end).toISOString(),
+      environment: 'ENVIRONMENT_ALL',
+    };
+    const [serviceInventoryAPIResponse, serviceMapsNodeDetails] = await Promise.all([
+      apmApiClient.readUser({
+        endpoint: 'GET /internal/apm/services',
+        params: {
+          query: {
+            ...commonQuery,
+            kuery: `service.name : "${serviceName}" and processor.event : "${processorEvent}"`,
+          },
+        },
+      }),
+      apmApiClient.readUser({
+        endpoint: `GET /internal/apm/service-map/service/{serviceName}`,
+        params: {
+          path: { serviceName },
+          query: commonQuery,
+        },
+      }),
+    ]);
+
+    const serviceInventoryThroughput = serviceInventoryAPIResponse.body.items[0].throughput;
+
+    const serviceMapsNodeDetailsThroughput = meanBy(
+      serviceMapsNodeDetails.body.currentPeriod.transactionStats?.throughput?.timeseries,
+      'y'
+    );
+
+    return {
+      serviceInventoryThroughput,
+      serviceMapsNodeDetailsThroughput,
+    };
+  }
+
+  let throughputMetricValues: Awaited<ReturnType<typeof getThroughputValues>>;
+  let throughputTransactionValues: Awaited<ReturnType<typeof getThroughputValues>>;
+
+  registry.when(
+    'Service maps APIs',
+    { config: 'trial', archives: ['apm_mappings_only_8.0.0'] },
+    () => {
+      describe('when data is loaded ', () => {
+        const GO_PROD_RATE = 80;
+        const GO_DEV_RATE = 20;
+        before(async () => {
+          const serviceGoProdInstance = apm
+            .service(serviceName, 'production', 'go')
+            .instance('instance-a');
+          const serviceGoDevInstance = apm
+            .service(serviceName, 'development', 'go')
+            .instance('instance-b');
+
+          await synthtraceEsClient.index([
+            ...timerange(start, end)
+              .interval('1m')
+              .rate(GO_PROD_RATE)
+              .flatMap((timestamp) =>
+                serviceGoProdInstance
+                  .transaction('GET /api/product/list', 'Worker')
+                  .duration(1000)
+                  .timestamp(timestamp)
+                  .serialize()
+              ),
+            ...timerange(start, end)
+              .interval('1m')
+              .rate(GO_DEV_RATE)
+              .flatMap((timestamp) =>
+                serviceGoDevInstance
+                  .transaction('GET /api/product/:id')
+                  .duration(1000)
+                  .timestamp(timestamp)
+                  .serialize()
+              ),
+          ]);
+        });
+
+        after(() => synthtraceEsClient.clean());
+
+        describe('compare throughput value between service inventory and service maps', () => {
+          before(async () => {
+            [throughputTransactionValues, throughputMetricValues] = await Promise.all([
+              getThroughputValues('transaction'),
+              getThroughputValues('metric'),
+            ]);
+          });
+
+          it('returns same throughput value for Transaction-based and Metric-based data', () => {
+            [
+              ...Object.values(throughputTransactionValues),
+              ...Object.values(throughputMetricValues),
+            ].forEach((value) => expect(roundNumber(value)).to.be.equal(roundNumber(GO_DEV_RATE)));
+          });
+        });
+      });
+    }
+  );
+}


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/125429

Before:
<img width="2636" alt="Screen Shot 2022-02-14 at 3 48 50 PM" src="https://user-images.githubusercontent.com/55978943/153944452-ea33a704-d449-4e23-93e6-a734d41a5319.png">

After:
<img width="2680" alt="Screen Shot 2022-02-14 at 3 49 22 PM" src="https://user-images.githubusercontent.com/55978943/153944461-c891ac3f-e94b-4bef-83b2-9dd51c5bf07d.png">
