### PR TITLE
Use Discover locator in Observability plugin

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_discover_link.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_discover_link.tsx
@@ -6,13 +6,13 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
+import { Filter } from '@kbn/es-query';
 import { useKibana } from '../../../../utils/kibana_react';
 import { SeriesConfig, SeriesUrl } from '../types';
 import { useAppIndexPatternContext } from './use_app_index_pattern';
 import { buildExistsFilter, urlFilterToPersistedFilter } from '../configurations/utils';
 import { getFiltersFromDefs } from './use_lens_attributes';
 import { RECORDS_FIELD, RECORDS_PERCENTAGE_FIELD } from '../configurations/constants';
-import { Filter } from '@kbn/es-query';
 
 interface UseDiscoverLink {
   seriesConfig?: SeriesConfig;

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_discover_link.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_discover_link.tsx
@@ -12,6 +12,7 @@ import { useAppIndexPatternContext } from './use_app_index_pattern';
 import { buildExistsFilter, urlFilterToPersistedFilter } from '../configurations/utils';
 import { getFiltersFromDefs } from './use_lens_attributes';
 import { RECORDS_FIELD, RECORDS_PERCENTAGE_FIELD } from '../configurations/constants';
+import { Filter } from '@kbn/es-query';
 
 interface UseDiscoverLink {
   seriesConfig?: SeriesConfig;
@@ -26,7 +27,7 @@ export const useDiscoverLink = ({ series, seriesConfig }: UseDiscoverLink) => {
 
   const { indexPatterns } = useAppIndexPatternContext();
 
-  const urlGenerator = kServices.discover?.urlGenerator;
+  const locator = kServices.discover?.locator;
   const [discoverUrl, setDiscoverUrl] = useState<string>('');
 
   useEffect(() => {
@@ -41,7 +42,7 @@ export const useDiscoverLink = ({ series, seriesConfig }: UseDiscoverLink) => {
         indexPattern,
         urlFilters,
         initFilters: seriesConfig?.baseFilters,
-      });
+      }) as Filter[];
 
       const selectedMetricField = series.selectedMetricField;
 
@@ -54,9 +55,9 @@ export const useDiscoverLink = ({ series, seriesConfig }: UseDiscoverLink) => {
       }
 
       const getDiscoverUrl = async () => {
-        if (!urlGenerator?.createUrl) return;
+        if (!locator) return;
 
-        const newUrl = await urlGenerator.createUrl({
+        const newUrl = await locator.getUrl({
           filters,
           indexPatternId: indexPattern?.id,
         });
@@ -71,7 +72,7 @@ export const useDiscoverLink = ({ series, seriesConfig }: UseDiscoverLink) => {
     series.reportDefinitions,
     series.selectedMetricField,
     seriesConfig?.baseFilters,
-    urlGenerator,
+    locator,
   ]);
 
   const onClick = useCallback(


### PR DESCRIPTION
## Summary

Switches to Discover locator instead of deprecated URL generator.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
