### PR TITLE
[Fleet] extracted hook, clean up unused prop

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -103,10 +103,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
     <>
       {isEnrollmentFlyoutOpen ? (
         <EuiPortal>
-          <AgentEnrollmentFlyout
-            agentPolicies={agentPolicies}
-            onClose={() => setIsEnrollmentFlyoutOpen(false)}
-          />
+          <AgentEnrollmentFlyout onClose={() => setIsEnrollmentFlyoutOpen(false)} />
         </EuiPortal>
       ) : null}
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -525,7 +525,6 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
       {enrollmentFlyout.isOpen ? (
         <EuiPortal>
           <AgentEnrollmentFlyout
-            agentPolicies={agentPolicies}
             agentPolicy={agentPolicies.find((p) => p.id === enrollmentFlyout.selectedPolicyId)}
             onClose={() => setEnrollmentFlyoutState({ isOpen: false })}
           />

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/index.tsx
@@ -5,21 +5,14 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { Router, Route, Switch, useHistory } from 'react-router-dom';
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiPortal } from '@elastic/eui';
 
 import { FLEET_ROUTING_PATHS } from '../../constants';
 import { Loading, Error, AgentEnrollmentFlyout } from '../../components';
-import {
-  useConfig,
-  useFleetStatus,
-  useBreadcrumbs,
-  useAuthz,
-  useGetSettings,
-  useGetAgentPolicies,
-} from '../../hooks';
+import { useConfig, useFleetStatus, useBreadcrumbs, useAuthz, useGetSettings } from '../../hooks';
 import { DefaultLayout, WithoutHeaderLayout } from '../../layouts';
 
 import { AgentListPage } from './agent_list_page';
@@ -33,18 +26,6 @@ export const AgentsApp: React.FunctionComponent = () => {
   const history = useHistory();
   const { agents } = useConfig();
   const hasFleetAllPrivileges = useAuthz().fleet.all;
-
-  const agentPoliciesRequest = useGetAgentPolicies({
-    page: 1,
-    perPage: 1000,
-    full: true,
-  });
-
-  const agentPolicies = useMemo(
-    () => agentPoliciesRequest.data?.items || [],
-    [agentPoliciesRequest.data]
-  );
-
   const fleetStatus = useFleetStatus();
 
   const settings = useGetSettings();
@@ -104,7 +85,6 @@ export const AgentsApp: React.FunctionComponent = () => {
         <EuiPortal>
           <AgentEnrollmentFlyout
             defaultMode="standalone"
-            agentPolicies={agentPolicies}
             onClose={() => setIsEnrollmentFlyoutOpen(false)}
           />
         </EuiPortal>

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.mocks.ts
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.mocks.ts
@@ -5,6 +5,13 @@
  * 2.0.
  */
 
+jest.mock('../../hooks', () => {
+  return {
+    ...jest.requireActual('../../hooks'),
+    useAgentEnrollmentFlyoutData: jest.fn(),
+  };
+});
+
 jest.mock('../../hooks/use_request', () => {
   const module = jest.requireActual('../../hooks/use_request');
   return {

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.tsx
@@ -21,9 +21,8 @@ import {
   sendGetFleetStatus,
   sendGetOneAgentPolicy,
   useGetAgents,
-  useGetAgentPolicies,
 } from '../../hooks/use_request';
-import { FleetStatusProvider, ConfigContext } from '../../hooks';
+import { FleetStatusProvider, ConfigContext, useAgentEnrollmentFlyoutData } from '../../hooks';
 
 import { useFleetServerInstructions } from '../../applications/fleet/sections/agents/agent_requirements_page/components';
 
@@ -102,13 +101,13 @@ describe('<AgentEnrollmentFlyout />', () => {
       data: { items: [{ policy_id: 'fleet-server-policy' }] },
     });
 
-    (useGetAgentPolicies as jest.Mock).mockReturnValue?.({
-      data: { items: [{ id: 'fleet-server-policy' }] },
+    (useAgentEnrollmentFlyoutData as jest.Mock).mockReturnValue?.({
+      agentPolicies: [{ id: 'fleet-server-policy' } as AgentPolicy],
+      refreshAgentPolicies: jest.fn(),
     });
 
     await act(async () => {
       testBed = await setup({
-        agentPolicies: [{ id: 'fleet-server-policy' } as AgentPolicy],
         onClose: jest.fn(),
       });
       testBed.component.update();
@@ -132,7 +131,6 @@ describe('<AgentEnrollmentFlyout />', () => {
         jest.clearAllMocks();
         await act(async () => {
           testBed = await setup({
-            agentPolicies: [{ id: 'fleet-server-policy' } as AgentPolicy],
             agentPolicy: testAgentPolicy,
             onClose: jest.fn(),
           });
@@ -173,7 +171,6 @@ describe('<AgentEnrollmentFlyout />', () => {
         jest.clearAllMocks();
         await act(async () => {
           testBed = await setup({
-            agentPolicies: [{ id: 'fleet-server-policy' } as AgentPolicy],
             onClose: jest.fn(),
             viewDataStep: { title: 'View Data', children: <div /> },
           });
@@ -193,7 +190,6 @@ describe('<AgentEnrollmentFlyout />', () => {
         jest.clearAllMocks();
         await act(async () => {
           testBed = await setup({
-            agentPolicies: [{ id: 'fleet-server-policy' } as AgentPolicy],
             onClose: jest.fn(),
             viewDataStep: undefined,
           });
@@ -224,7 +220,6 @@ describe('<AgentEnrollmentFlyout />', () => {
         jest.clearAllMocks();
         await act(async () => {
           testBed = await setup({
-            agentPolicies: [{ id: 'fleet-server-policy' } as AgentPolicy],
             agentPolicy: testAgentPolicy,
             onClose: jest.fn(),
           });

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_selection.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_selection.tsx
@@ -51,10 +51,10 @@ type Props = {
 );
 
 const resolveAgentId = (
-  agentPolicies?: AgentPolicy[],
+  agentPolicies: AgentPolicy[],
   selectedAgentPolicyId?: string
 ): undefined | string => {
-  if (agentPolicies && agentPolicies.length && !selectedAgentPolicyId) {
+  if (agentPolicies.length && !selectedAgentPolicyId) {
     if (agentPolicies.length === 1) {
       return agentPolicies[0].id;
     }

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -26,7 +26,7 @@ import {
   useGetSettings,
   sendGetOneAgentPolicy,
   useFleetStatus,
-  useGetAgentPolicies,
+  useAgentEnrollmentFlyoutData,
 } from '../../hooks';
 import { FLEET_SERVER_PACKAGE } from '../../constants';
 import type { PackagePolicy } from '../../types';
@@ -64,23 +64,7 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
   const [policyId, setSelectedPolicyId] = useState(agentPolicy?.id);
   const [isFleetServerPolicySelected, setIsFleetServerPolicySelected] = useState<boolean>(false);
 
-  // loading the latest agentPolicies for add agent flyout
-  const {
-    data: agentPoliciesData,
-    isLoading: isLoadingAgentPolicies,
-    resendRequest: refreshAgentPolicies,
-  } = useGetAgentPolicies({
-    page: 1,
-    perPage: 1000,
-    full: true,
-  });
-
-  const agentPolicies = useMemo(() => {
-    if (!isLoadingAgentPolicies) {
-      return agentPoliciesData?.items;
-    }
-    return [];
-  }, [isLoadingAgentPolicies, agentPoliciesData?.items]);
+  const { agentPolicies, refreshAgentPolicies } = useAgentEnrollmentFlyoutData();
 
   useEffect(() => {
     async function checkPolicyIsFleetServer() {

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   EuiFlyout,
   EuiFlyoutBody,

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
@@ -81,8 +81,7 @@ export const ManagedInstructions = React.memo<InstructionProps>(
     });
 
     const fleetServers = useMemo(() => {
-      const policies = agentPolicies;
-      const fleetServerAgentPolicies: string[] = (policies ?? [])
+      const fleetServerAgentPolicies: string[] = agentPolicies
         .filter((pol) => policyHasFleetServer(pol))
         .map((pol) => pol.id);
       return (agents?.items ?? []).filter((agent) =>

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
@@ -83,7 +83,7 @@ export const AgentPolicySelectionStep = ({
   excludeFleetServer,
   refreshAgentPolicies,
 }: {
-  agentPolicies?: AgentPolicy[];
+  agentPolicies: AgentPolicy[];
   setSelectedPolicyId?: (policyId?: string) => void;
   selectedApiKeyId?: string;
   setSelectedAPIKeyId?: (key?: string) => void;
@@ -93,7 +93,7 @@ export const AgentPolicySelectionStep = ({
   // storing the created agent policy id as the child component is being recreated
   const [policyId, setPolicyId] = useState<string | undefined>(undefined);
   const regularAgentPolicies = useMemo(() => {
-    return (agentPolicies ?? []).filter(
+    return agentPolicies.filter(
       (policy) =>
         policy && !policy.is_managed && (!excludeFleetServer || !policyHasFleetServer(policy))
     );

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/types.ts
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/types.ts
@@ -16,13 +16,6 @@ export interface BaseProps {
   agentPolicy?: AgentPolicy;
 
   /**
-   * A selection of policies for the user to choose from, will be ignored if `agentPolicy` has been provided.
-   *
-   * If this value is `undefined` a value must be provided for `agentPolicy`.
-   */
-  agentPolicies?: AgentPolicy[];
-
-  /**
    * There is a step in the agent enrollment process that allows users to see the data from an integration represented in the UI
    * in some way. This is an area for consumers to render a button and text explaining how data can be viewed.
    */
@@ -36,5 +29,6 @@ export interface BaseProps {
 }
 
 export interface InstructionProps extends BaseProps {
+  agentPolicies: AgentPolicy[];
   refreshAgentPolicies: () => void;
 }

--- a/x-pack/plugins/fleet/public/hooks/index.ts
+++ b/x-pack/plugins/fleet/public/hooks/index.ts
@@ -5,20 +5,18 @@
  * 2.0.
  */
 
-export { useAuthz } from './use_authz';
-export { useStartServices } from './use_core';
-export { useConfig, ConfigContext } from './use_config';
-export { useKibanaVersion, KibanaVersionContext } from './use_kibana_version';
-export { licenseService, useLicense } from './use_license';
-export { useLink } from './use_link';
-export { useKibanaLink, getHrefToObjectInKibanaApp } from './use_kibana_link';
-export type { UsePackageIconType } from './use_package_icon_type';
-export { usePackageIconType } from './use_package_icon_type';
-export type { Pagination } from './use_pagination';
-export { usePagination, PAGE_SIZE_OPTIONS } from './use_pagination';
-export { useUrlPagination } from './use_url_pagination';
-export { useSorting } from './use_sorting';
-export { useDebounce } from './use_debounce';
+export * from './use_authz';
+export * from './use_core';
+export * from './use_config';
+export * from './use_kibana_version';
+export * from './use_license';
+export * from './use_link';
+export * from './use_kibana_link';
+export * from './use_package_icon_type';
+export * from './use_pagination';
+export * from './use_url_pagination';
+export * from './use_sorting';
+export * from './use_debounce';
 export * from './use_request';
 export * from './use_input';
 export * from './use_url_params';

--- a/x-pack/plugins/fleet/public/hooks/index.ts
+++ b/x-pack/plugins/fleet/public/hooks/index.ts
@@ -28,3 +28,4 @@ export * from './use_intra_app_state';
 export * from './use_platform';
 export * from './use_agent_policy_refresh';
 export * from './use_package_installations';
+export * from './use_agent_enrollment_flyout_data';

--- a/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout.data.test.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout.data.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createFleetTestRendererMock } from '../mock';
+
+import { useGetAgentPolicies, useAgentEnrollmentFlyoutData } from '.';
+
+jest.mock('./use_request', () => {
+  return {
+    ...jest.requireActual('./use_request'),
+    useGetAgentPolicies: jest.fn(),
+  };
+});
+
+describe('useAgentEnrollmentFlyoutData', () => {
+  const testRenderer = createFleetTestRendererMock();
+
+  it('should return empty agentPolicies when http loading', () => {
+    (useGetAgentPolicies as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+    const { result } = testRenderer.renderHook(() => useAgentEnrollmentFlyoutData());
+    expect(result.current.agentPolicies).toEqual([]);
+  });
+
+  it('should return empty agentPolicies when http not loading and no data', () => {
+    (useGetAgentPolicies as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = testRenderer.renderHook(() => useAgentEnrollmentFlyoutData());
+    expect(result.current.agentPolicies).toEqual([]);
+  });
+
+  it('should return empty agentPolicies when http not loading and no items', () => {
+    (useGetAgentPolicies as jest.Mock).mockReturnValue({ data: { items: undefined } });
+    const { result } = testRenderer.renderHook(() => useAgentEnrollmentFlyoutData());
+    expect(result.current.agentPolicies).toEqual([]);
+  });
+
+  it('should return agentPolicies when http not loading', () => {
+    (useGetAgentPolicies as jest.Mock).mockReturnValue({ data: { items: [{ id: 'policy1' }] } });
+    const { result } = testRenderer.renderHook(() => useAgentEnrollmentFlyoutData());
+    expect(result.current.agentPolicies).toEqual([{ id: 'policy1' }]);
+  });
+
+  it('should resend request when refresh agent policies called', () => {
+    const resendRequestMock = jest.fn();
+    (useGetAgentPolicies as jest.Mock).mockReturnValue({
+      data: { items: [{ id: 'policy1' }] },
+      isLoading: false,
+      resendRequest: resendRequestMock,
+    });
+    const { result } = testRenderer.renderHook(() => useAgentEnrollmentFlyoutData());
+    result.current.refreshAgentPolicies();
+    expect(resendRequestMock).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
@@ -9,7 +9,7 @@ import { useMemo } from 'react';
 
 import type { AgentPolicy } from '../types';
 
-import { useGetAgentPolicies } from '.';
+import { useGetAgentPolicies } from './use_request';
 
 interface AgentEnrollmentFlyoutData {
   agentPolicies: AgentPolicy[];

--- a/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+
+import type { AgentPolicy } from '../types';
+
+import { useGetAgentPolicies } from '.';
+
+interface AgentEnrollmentFlyoutData {
+  agentPolicies: AgentPolicy[];
+  refreshAgentPolicies: () => void;
+}
+
+export function useAgentEnrollmentFlyoutData(): AgentEnrollmentFlyoutData {
+  const {
+    data: agentPoliciesData,
+    isLoading: isLoadingAgentPolicies,
+    resendRequest: refreshAgentPolicies,
+  } = useGetAgentPolicies({
+    page: 1,
+    perPage: 1000,
+    full: true,
+  });
+
+  const agentPolicies = useMemo(() => {
+    if (!isLoadingAgentPolicies) {
+      return agentPoliciesData?.items ?? [];
+    }
+    return [];
+  }, [isLoadingAgentPolicies, agentPoliciesData?.items]);
+
+  return { agentPolicies, refreshAgentPolicies };
+}


### PR DESCRIPTION
## Summary

Cleanup after https://github.com/elastic/kibana/pull/125499

Removed unused `agentPolicies` prop from `AgentEnrollmentFlyout`.
Extracted `useAgentEnrollmentFlyoutData` hook to contain logic of loading `agentPolicies` and `refreshAgentPolicies` function.
To verify: same as linked issue:
- try creating agent policies in Add Agent Flyout
- verify that the dropdown is being updated right after
- dropdown is updated after closing and reopening flyout