### PR TITLE
[Fleet] Do not mutate package policy update object 

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -363,11 +363,11 @@ class PackagePolicyService {
     soClient: SavedObjectsClientContract,
     esClient: ElasticsearchClient,
     id: string,
-    packagePolicy: UpdatePackagePolicy,
+    packagePolicyUpdate: UpdatePackagePolicy,
     options?: { user?: AuthenticatedUser },
     currentVersion?: string
   ): Promise<PackagePolicy> {
-    packagePolicy.name = packagePolicy.name.trim();
+    const packagePolicy = { ...packagePolicyUpdate, name: packagePolicyUpdate.name.trim() };
     const oldPackagePolicy = await this.get(soClient, id);
     const { version, ...restOfPackagePolicy } = packagePolicy;
 


### PR DESCRIPTION
## Summary

@patrykkopycinski pointed out an error when OSQuery call the package policy update method: 

![image](https://user-images.githubusercontent.com/3315046/154046135-4c90a4db-b9f1-4110-8124-1553036521af.png)

this was due to us mutating the packagePolicy parameter to trim whitespace from the name. I have added a unit test for this scenario.
