### PR TITLE
[8.0] [ML] Fix flaky Trained Models tests  (#125484)

### DIFF
--- a/x-pack/plugins/ml/public/application/services/ml_api_service/trained_models.ts
+++ b/x-pack/plugins/ml/public/application/services/ml_api_service/trained_models.ts
@@ -81,10 +81,7 @@ export function trainedModelsApiProvider(httpService: HttpService) {
      * @param params - Optional query params
      */
     getTrainedModelStats(modelId?: string | string[], params?: InferenceStatsQueryParams) {
-      let model = modelId ?? '_all';
-      if (Array.isArray(modelId)) {
-        model = modelId.join(',');
-      }
+      const model = (Array.isArray(modelId) ? modelId.join(',') : modelId) || '_all';
 
       return httpService.http<InferenceStatsResponse>({
         path: `${apiBasePath}/trained_models/${model}/_stats`,

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/models_list.tsx
@@ -190,6 +190,7 @@ export const ModelsList: FC = () => {
 
   useEffect(
     function updateOnTimerRefresh() {
+      if (!refresh) return;
       fetchModelsData();
     },
     [refresh]

--- a/x-pack/test/functional/apps/ml/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/model_management/model_list.ts
@@ -14,8 +14,6 @@ export default function ({ getService }: FtrProviderContext) {
     before(async () => {
       await ml.trainedModels.createTestTrainedModels('classification', 15, true);
       await ml.trainedModels.createTestTrainedModels('regression', 15);
-      await ml.securityUI.loginAsMlPowerUser();
-      await ml.navigation.navigateToTrainedModels();
     });
 
     after(async () => {
@@ -46,6 +44,7 @@ export default function ({ getService }: FtrProviderContext) {
       before(async () => {
         await ml.securityUI.loginAsMlPowerUser();
         await ml.navigation.navigateToTrainedModels();
+        await ml.commonUI.waitForRefreshButtonEnabled();
       });
 
       after(async () => {
@@ -173,6 +172,7 @@ export default function ({ getService }: FtrProviderContext) {
       before(async () => {
         await ml.securityUI.loginAsMlViewer();
         await ml.navigation.navigateToTrainedModels();
+        await ml.commonUI.waitForRefreshButtonEnabled();
       });
 
       after(async () => {

--- a/x-pack/test/functional/apps/ml/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/model_management/model_list.ts
@@ -44,7 +44,7 @@ export default function ({ getService }: FtrProviderContext) {
       before(async () => {
         await ml.securityUI.loginAsMlPowerUser();
         await ml.navigation.navigateToTrainedModels();
-        await ml.commonUI.waitForRefreshButtonEnabled();
+        await ml.trainedModelsTable.waitForRefreshButtonLoaded();
       });
 
       after(async () => {
@@ -172,7 +172,7 @@ export default function ({ getService }: FtrProviderContext) {
       before(async () => {
         await ml.securityUI.loginAsMlViewer();
         await ml.navigation.navigateToTrainedModels();
-        await ml.commonUI.waitForRefreshButtonEnabled();
+        await ml.trainedModelsTable.waitForRefreshButtonLoaded();
       });
 
       after(async () => {

--- a/x-pack/test/functional/services/ml/common_ui.ts
+++ b/x-pack/test/functional/services/ml/common_ui.ts
@@ -313,9 +313,5 @@ export function MachineLearningCommonUIProvider({
     async waitForDatePickerIndicatorLoaded() {
       await testSubjects.waitForEnabled('superDatePickerApplyTimeButton');
     },
-
-    async waitForRefreshButtonEnabled() {
-      await testSubjects.waitForEnabled('~mlRefreshPageButton');
-    },
   };
 }

--- a/x-pack/test/functional/services/ml/common_ui.ts
+++ b/x-pack/test/functional/services/ml/common_ui.ts
@@ -309,5 +309,13 @@ export function MachineLearningCommonUIProvider({
       await PageObjects.spaceSelector.goToSpecificSpace(spaceId);
       await PageObjects.spaceSelector.expectHomePage(spaceId);
     },
+
+    async waitForDatePickerIndicatorLoaded() {
+      await testSubjects.waitForEnabled('superDatePickerApplyTimeButton');
+    },
+
+    async waitForRefreshButtonEnabled() {
+      await testSubjects.waitForEnabled('~mlRefreshPageButton');
+    },
   };
 }

--- a/x-pack/test/functional/services/ml/index.ts
+++ b/x-pack/test/functional/services/ml/index.ts
@@ -54,6 +54,7 @@ import { MachineLearningDashboardEmbeddablesProvider } from './dashboard_embedda
 import { TrainedModelsProvider } from './trained_models';
 import { TrainedModelsTableProvider } from './trained_models_table';
 import { MachineLearningJobAnnotationsProvider } from './job_annotations_table';
+import { MlNodesPanelProvider } from './ml_nodes_list';
 
 export function MachineLearningProvider(context: FtrProviderContext) {
   const commonAPI = MachineLearningCommonAPIProvider(context);
@@ -123,7 +124,8 @@ export function MachineLearningProvider(context: FtrProviderContext) {
   const alerting = MachineLearningAlertingProvider(context, commonUI);
   const swimLane = SwimLaneProvider(context);
   const trainedModels = TrainedModelsProvider(context, api, commonUI);
-  const trainedModelsTable = TrainedModelsTableProvider(context);
+  const trainedModelsTable = TrainedModelsTableProvider(context, commonUI);
+  const mlNodesPanel = MlNodesPanelProvider(context);
 
   return {
     anomaliesTable,
@@ -173,5 +175,6 @@ export function MachineLearningProvider(context: FtrProviderContext) {
     testResources,
     trainedModels,
     trainedModelsTable,
+    mlNodesPanel,
   };
 }

--- a/x-pack/test/functional/services/ml/index.ts
+++ b/x-pack/test/functional/services/ml/index.ts
@@ -54,7 +54,6 @@ import { MachineLearningDashboardEmbeddablesProvider } from './dashboard_embedda
 import { TrainedModelsProvider } from './trained_models';
 import { TrainedModelsTableProvider } from './trained_models_table';
 import { MachineLearningJobAnnotationsProvider } from './job_annotations_table';
-import { MlNodesPanelProvider } from './ml_nodes_list';
 
 export function MachineLearningProvider(context: FtrProviderContext) {
   const commonAPI = MachineLearningCommonAPIProvider(context);
@@ -125,7 +124,6 @@ export function MachineLearningProvider(context: FtrProviderContext) {
   const swimLane = SwimLaneProvider(context);
   const trainedModels = TrainedModelsProvider(context, api, commonUI);
   const trainedModelsTable = TrainedModelsTableProvider(context, commonUI);
-  const mlNodesPanel = MlNodesPanelProvider(context);
 
   return {
     anomaliesTable,
@@ -175,6 +173,5 @@ export function MachineLearningProvider(context: FtrProviderContext) {
     testResources,
     trainedModels,
     trainedModelsTable,
-    mlNodesPanel,
   };
 }

--- a/x-pack/test/functional/services/ml/trained_models_table.ts
+++ b/x-pack/test/functional/services/ml/trained_models_table.ts
@@ -10,7 +10,8 @@ import { ProvidedType } from '@kbn/test';
 import { upperFirst } from 'lodash';
 
 import { WebElementWrapper } from 'test/functional/services/lib/web_element_wrapper';
-import { FtrProviderContext } from '../../ftr_provider_context';
+import type { FtrProviderContext } from '../../ftr_provider_context';
+import type { MlCommonUI } from './common_ui';
 
 export interface TrainedModelRowData {
   id: string;
@@ -20,7 +21,10 @@ export interface TrainedModelRowData {
 
 export type MlTrainedModelsTable = ProvidedType<typeof TrainedModelsTableProvider>;
 
-export function TrainedModelsTableProvider({ getService }: FtrProviderContext) {
+export function TrainedModelsTableProvider(
+  { getService }: FtrProviderContext,
+  mlCommonUI: MlCommonUI
+) {
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
 
@@ -218,6 +222,7 @@ export function TrainedModelsTableProvider({ getService }: FtrProviderContext) {
           await testSubjects.existOrFail('mlTrainedModelRowDetails', { timeout: 1000 });
         }
       });
+      await mlCommonUI.waitForRefreshButtonEnabled();
     }
 
     public async assertTabContent(

--- a/x-pack/test/functional/services/ml/trained_models_table.ts
+++ b/x-pack/test/functional/services/ml/trained_models_table.ts
@@ -222,7 +222,7 @@ export function TrainedModelsTableProvider(
           await testSubjects.existOrFail('mlTrainedModelRowDetails', { timeout: 1000 });
         }
       });
-      await mlCommonUI.waitForRefreshButtonEnabled();
+      await this.waitForRefreshButtonLoaded();
     }
 
     public async assertTabContent(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[ML] Fix flaky Trained Models tests  (#125484)](https://github.com/elastic/kibana/pull/125484)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)