### PR TITLE
[Security Solution] [Endpoint] Remove meta field before create/update event filter item

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/service/service_actions.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/service/service_actions.ts
@@ -76,6 +76,8 @@ export async function addEventFilters(
   exception: ExceptionListItemSchema | CreateExceptionListItemSchema
 ) {
   await ensureEventFiltersListExists(http);
+  // Clean meta data before create event flter as the API throws an error with it
+  delete exception.meta;
   return http.post<ExceptionListItemSchema>(EXCEPTION_LIST_ITEM_URL, {
     body: JSON.stringify(exception),
   });
@@ -136,12 +138,11 @@ export function cleanEventFilterToUpdate(
   [
     'created_at',
     'created_by',
-    'created_at',
-    'created_by',
     'list_id',
     'tie_breaker_id',
     'updated_at',
     'updated_by',
+    'meta',
   ].forEach((field) => {
     delete exceptionToUpdateCleaned[field as keyof UpdateExceptionListItemSchema];
   });


### PR DESCRIPTION
## Summary

- Removes `meta` field from ExceptionListItem before create/update it as it's not supported by the API.
- This was causing an error when creating event filter from hosts tab without modifying the ExceptionsBuilder.
- If an update was done, then the ExceptionsBuilder clean the meta field and it works as expected. 

![create event filter from hosts tab](https://user-images.githubusercontent.com/15727784/154047479-7b3351f5-9f3b-4a62-93bb-8b2c1cb84343.gif)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
