### PR TITLE
[8.0][SecuritySolution] Enrich threshold data from correct fields

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
@@ -128,6 +128,183 @@ describe('AlertSummaryView', () => {
     expect(container.querySelector('div[data-test-subj="summary-view"]')).toMatchSnapshot();
   });
 
+  test('Threshold events have special fields', () => {
+    const enhancedData = [
+      ...mockAlertDetailsData.map((item) => {
+        if (item.category === 'kibana' && item.field === 'kibana.alert.rule.type') {
+          return {
+            ...item,
+            values: ['threshold'],
+            originalValue: ['threshold'],
+          };
+        }
+        return item;
+      }),
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.count',
+        values: [9001],
+        originalValue: [9001],
+      },
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.terms.value',
+        values: ['host-23084y2', '3084hf3n84p8934r8h'],
+        originalValue: ['host-23084y2', '3084hf3n84p8934r8h'],
+      },
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.terms.field',
+        values: ['host.name', 'host.id'],
+        originalValue: ['host.name', 'host.id'],
+      },
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.cardinality.field',
+        values: ['host.name'],
+        originalValue: ['host.name'],
+      },
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.cardinality.value',
+        values: [9001],
+        originalValue: [9001],
+      },
+    ] as TimelineEventsDetailsItem[];
+    const renderProps = {
+      ...props,
+      data: enhancedData,
+    };
+    const { getByText } = render(
+      <TestProvidersComponent>
+        <AlertSummaryView {...renderProps} />
+      </TestProvidersComponent>
+    );
+
+    [
+      'Threshold Count',
+      'host.name [threshold]',
+      'host.id [threshold]',
+      'Threshold Cardinality',
+      'count(host.name) >= 9001',
+    ].forEach((fieldId) => {
+      expect(getByText(fieldId));
+    });
+  });
+
+  test('Threshold fields are not shown when data is malformated', () => {
+    const enhancedData = [
+      ...mockAlertDetailsData.map((item) => {
+        if (item.category === 'kibana' && item.field === 'kibana.alert.rule.type') {
+          return {
+            ...item,
+            values: ['threshold'],
+            originalValue: ['threshold'],
+          };
+        }
+        return item;
+      }),
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.count',
+        values: [9001],
+        originalValue: [9001],
+      },
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.terms.field',
+        // This would be expected to have two entries
+        values: ['host.id'],
+        originalValue: ['host.id'],
+      },
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.terms.value',
+        values: ['host-23084y2', '3084hf3n84p8934r8h'],
+        originalValue: ['host-23084y2', '3084hf3n84p8934r8h'],
+      },
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.cardinality.field',
+        values: ['host.name'],
+        originalValue: ['host.name'],
+      },
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.cardinality.value',
+        // This would be expected to have one entry
+        values: [],
+        originalValue: [],
+      },
+    ] as TimelineEventsDetailsItem[];
+    const renderProps = {
+      ...props,
+      data: enhancedData,
+    };
+    const { getByText } = render(
+      <TestProvidersComponent>
+        <AlertSummaryView {...renderProps} />
+      </TestProvidersComponent>
+    );
+
+    ['Threshold Count'].forEach((fieldId) => {
+      expect(getByText(fieldId));
+    });
+
+    [
+      'host.name [threshold]',
+      'host.id [threshold]',
+      'Threshold Cardinality',
+      'count(host.name) >= 9001',
+    ].forEach((fieldText) => {
+      expect(() => getByText(fieldText)).toThrow();
+    });
+  });
+
+  test('Threshold fields are not shown when data is partially missing', () => {
+    const enhancedData = [
+      ...mockAlertDetailsData.map((item) => {
+        if (item.category === 'kibana' && item.field === 'kibana.alert.rule.type') {
+          return {
+            ...item,
+            values: ['threshold'],
+            originalValue: ['threshold'],
+          };
+        }
+        return item;
+      }),
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.terms.field',
+        // This would be expected to have two entries
+        values: ['host.id'],
+        originalValue: ['host.id'],
+      },
+      {
+        category: 'kibana',
+        field: 'kibana.alert.threshold_result.cardinality.field',
+        values: ['host.name'],
+        originalValue: ['host.name'],
+      },
+    ] as TimelineEventsDetailsItem[];
+    const renderProps = {
+      ...props,
+      data: enhancedData,
+    };
+    const { getByText } = render(
+      <TestProvidersComponent>
+        <AlertSummaryView {...renderProps} />
+      </TestProvidersComponent>
+    );
+
+    //  The `value` fields are missing here, so the enriched field info cannot be calculated correctly
+    ['host.id [threshold]', 'Threshold Cardinality', 'count(host.name) >= 9001'].forEach(
+      (fieldText) => {
+        expect(() => getByText(fieldText)).toThrow();
+      }
+    );
+  });
+
   test("doesn't render empty fields", () => {
     const renderProps = {
       ...props,


### PR DESCRIPTION
Note: This PR introduces changes that can potentially result in inconsistencies of displayed data. The issue is described in more length in https://github.com/elastic/kibana/issues/125519.

This is a manual backport PR of https://github.com/elastic/kibana/pull/125376

## Summary

https://github.com/elastic/kibana/issues/124813 and https://github.com/elastic/kibana/issues/124817 describe issues with threshold-related data not showing up in the alert flyout. The reason for these issues is that from `8.0` onward, the type of `threshold_result` has changed and can no longer rely on the JSON strings we had before in `kibana.alert.threshold_result.terms` and `(...).cardinality`.

As proposed in https://github.com/elastic/kibana/issues/124813#issuecomment-1033969917 the threshold data is now enriched from the correct fields. This makes sure that we can use the new `kibana.*` field ids for the threshold fields for data that has been migrated from `7.x` to `8.x`.

<img width="531" alt="Screenshot 2022-02-10 at 17 42 49" src="https://user-images.githubusercontent.com/68591/153455646-2203c16b-c8ae-4cc3-9887-7ec06889378a.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios