### PR TITLE
[8.0] [Snapshot & Restore] Fix date parsing in the search bar (#125234)

### DIFF
--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/snapshot_list.test.tsx
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/snapshot_list.test.tsx
@@ -155,6 +155,17 @@ describe('<SnapshotList />', () => {
           });
         });
 
+        test('term search with a date is parsed', async () => {
+          await setSearchText('2022.02.10');
+          expect(useLoadSnapshots).lastCalledWith({
+            ...DEFAULT_SNAPSHOT_LIST_PARAMS,
+            searchField: 'snapshot',
+            searchValue: '2022.02.10',
+            searchMatch: 'must',
+            searchOperator: 'eq',
+          });
+        });
+
         test('excluding term search is converted to partial excluding snapshot search', async () => {
           await setSearchText('-test_snapshot');
           expect(useLoadSnapshots).lastCalledWith({

--- a/x-pack/plugins/snapshot_restore/public/application/lib/snapshot_list_params.ts
+++ b/x-pack/plugins/snapshot_restore/public/application/lib/snapshot_list_params.ts
@@ -6,6 +6,7 @@
  */
 
 import { Direction, Query } from '@elastic/eui';
+import { SchemaType } from '@elastic/eui/src/components/search_bar/search_box';
 
 export type SortField =
   | 'snapshot'
@@ -49,12 +50,15 @@ const resetSearchOptions = (listParams: SnapshotListParams): SnapshotListParams 
 });
 
 // to init the query for repository and policyName search passed via url
-export const getQueryFromListParams = (listParams: SnapshotListParams): Query => {
+export const getQueryFromListParams = (
+  listParams: SnapshotListParams,
+  schema: SchemaType
+): Query => {
   const { searchField, searchValue } = listParams;
   if (!searchField || !searchValue) {
     return Query.MATCH_ALL;
   }
-  return Query.parse(`${searchField}=${searchValue}`);
+  return Query.parse(`${searchField}=${searchValue}`, { schema });
 };
 
 export const getListParams = (listParams: SnapshotListParams, query: Query): SnapshotListParams => {

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/components/snapshot_search_bar.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/components/snapshot_search_bar.tsx
@@ -126,7 +126,7 @@ export const SnapshotSearchBar: React.FunctionComponent<Props> = ({
     </EuiButton>
   );
 
-  const [query, setQuery] = useState<Query>(getQueryFromListParams(listParams));
+  const [query, setQuery] = useState<Query>(getQueryFromListParams(listParams, searchSchema));
   const [error, setError] = useState<Error | null>(null);
 
   const onSearchBarChange = (args: EuiSearchBarOnChangeArgs) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[Snapshot & Restore] Fix date parsing in the search bar (#125234)](https://github.com/elastic/kibana/pull/125234)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)