### PR TITLE
[Fleet] revert package policy validation that caused issue with input groups

### DIFF
--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -607,7 +607,8 @@ describe('Fleet - validatePackagePolicy()', () => {
       });
     });
 
-    it('returns package policy validation error if input var does not exist', () => {
+    // TODO enable when https://github.com/elastic/kibana/issues/125655 is fixed
+    it.skip('returns package policy validation error if input var does not exist', () => {
       expect(
         validatePackagePolicy(
           {

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -210,15 +210,11 @@ export const validatePackagePolicyConfig = (
   }
 
   if (varDef === undefined) {
-    errors.push(
-      i18n.translate('xpack.fleet.packagePolicyValidation.nonExistentVarMessage', {
-        defaultMessage: '{varName} var definition does not exist',
-        values: {
-          varName,
-        },
-      })
-    );
-    return errors;
+    // TODO return validation error here once https://github.com/elastic/kibana/issues/125655 is fixed
+    // eslint-disable-next-line no-console
+    console.debug(`No variable definition for ${varName} found`);
+
+    return null;
   }
 
   if (varDef.required) {


### PR DESCRIPTION
## Summary

Partially revert https://github.com/elastic/kibana/pull/124215 to unblock https://github.com/elastic/kibana/issues/125625

Improvement of validation is raised here https://github.com/elastic/kibana/issues/125655

To summarize:
Aws package policy generated by elastic-package is rejected with validation errors, however it should be accepted.
The reason is that policy vars present in package definition global vars, are listed under inputs/streams.
This should be accepted according to this: https://github.com/elastic/kibana/issues/125625#issuecomment-1040223635

Example package policy that should be valid, see below.

To verify, run this with a valid agent policy id in `policy_id`, and verify that it is successfully created.
```
POST /api/fleet/package_policies
{
  "name": "aws-ec2_metrics",
  "description": "",
  "namespace": "ep",
  "policy_id": "ad5e3840-8e4a-11ec-8b0a-59f6cbd7b323",
  "enabled": true,
  "output_id": "",
  "inputs": [
    {
      "type": "aws/metrics",
      "enabled": true,
      "streams": [
        {
          "id": "aws/metrics-aws.ec2_metrics",
          "enabled": true,
          "data_stream": {
            "type": "metrics",
            "dataset": "aws.ec2_metrics"
          },
          "vars": {
            "latency": {
              "value": "10m",
              "type": "text"
            },
            "period": {
              "value": "5m",
              "type": "text"
            },
            "regions": {
              "value": null,
              "type": "text"
            },
            "tags_filter": {
              "value": "- key: Name\n  value: \"elastic-package-test-33138\"",
              "type": "yaml"
            }
          }
        }
      ],
      "vars": {
         "access_key_id": {
           "value": "access_key_id",
           "type": "text"
         },
         "credential_profile_name": {
           "value": "credential_profile_name",
           "type": "text"
         },
         "endpoint": {
           "value": "amazonaws.com",
           "type": "text"
         },
         "proxy_url": {
           "value": "proxy_url",
           "type": "text"
         },
         "role_arn": {
           "value": "role_arn",
           "type": "text"
         },
         "secret_access_key": {
           "value": "secret_access_key",
           "type": "text"
         },
         "session_token": {
           "value": "session_token",
           "type": "text"
         },
         "shared_credential_file": {
           "value": "shared_credential_file",
           "type": "text"
         }
       }
    }
  ],
  "package": {
    "name": "aws",
    "title": "AWS",
    "version": "1.11.4"
  }
}


```
