### PR TITLE
[8.1] [Uptime Monitor management] Update test configs (#125358)

### DIFF
--- a/x-pack/plugins/uptime/e2e/tasks/read_kibana_config.ts
+++ b/x-pack/plugins/uptime/e2e/tasks/read_kibana_config.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+export type KibanaConfig = ReturnType<typeof readKibanaConfig>;
+
+export const readKibanaConfig = () => {
+  const kibanaConfigDir = path.join(__filename, '../../../../../../config');
+  const kibanaDevConfig = path.join(kibanaConfigDir, 'kibana.dev.yml');
+  const kibanaConfig = path.join(kibanaConfigDir, 'kibana.yml');
+
+  return (yaml.safeLoad(
+    fs.readFileSync(fs.existsSync(kibanaDevConfig) ? kibanaDevConfig : kibanaConfig, 'utf8')
+  ) || {}) as Record<string, string>;
+};

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.ts
@@ -16,7 +16,7 @@ import { UptimeServerSetup } from '../adapters/framework';
 export async function getServiceLocations(server: UptimeServerSetup) {
   const locations: ServiceLocations = [];
 
-  if (!server.config.service!.manifestUrl!) {
+  if (!server.config.service?.manifestUrl) {
     return { locations };
   }
 

--- a/x-pack/test/api_integration/config.ts
+++ b/x-pack/test/api_integration/config.ts
@@ -37,7 +37,6 @@ export async function getApiIntegrationConfig({ readConfigFile }: FtrConfigProvi
         '--xpack.ruleRegistry.write.cache.enabled=false',
         '--xpack.uptime.service.enabled=true',
         '--xpack.uptime.service.password=test',
-        '--xpack.uptime.service.manifestUrl=http://test.com',
         '--xpack.uptime.service.username=localKibanaIntegrationTestsUser',
         `--xpack.securitySolution.enableExperimental=${JSON.stringify(['ruleRegistryEnabled'])}`,
       ],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Uptime Monitor management] Update test configs (#125358)](https://github.com/elastic/kibana/pull/125358)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)