### PR TITLE
[SecuritySolution][Threat Hunting] Add `rule type` to global fields for the alert flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/__mocks__/index.ts
@@ -36,6 +36,12 @@ export const mockAlertDetailsData = [
   },
   { category: 'agent', field: 'agent.version', values: ['7.10.0'], originalValue: '7.10.0' },
   {
+    category: 'agent',
+    field: 'agent.status',
+    values: ['inactive'],
+    originalValue: ['inactive'],
+  },
+  {
     category: 'winlog',
     field: 'winlog.computer_name',
     values: ['windows-native'],

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
@@ -61,6 +61,18 @@ describe('AlertSummaryView', () => {
     expect(getAllByTestId('hover-actions-filter-for').length).toBeGreaterThan(0);
   });
 
+  test('Renders the correct global fields', () => {
+    const { getByText } = render(
+      <TestProviders>
+        <AlertSummaryView {...props} />
+      </TestProviders>
+    );
+
+    ['host.name', 'user.name', 'Rule type', 'query'].forEach((fieldId) => {
+      expect(getByText(fieldId));
+    });
+  });
+
   test('it does NOT render the action cell for the active timeline', () => {
     const { queryAllByTestId } = render(
       <TestProviders>

--- a/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
@@ -41,6 +41,7 @@ const alwaysDisplayedFields: EventSummaryField[] = [
   { id: 'host.name' },
   { id: 'agent.id', overrideField: AGENT_STATUS_FIELD_NAME, label: i18n.AGENT_STATUS },
   { id: 'user.name' },
+  { id: ALERT_RULE_TYPE, label: i18n.RULE_TYPE },
 ];
 
 /**

--- a/x-pack/plugins/security_solution/public/common/components/event_details/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/translations.ts
@@ -84,6 +84,10 @@ export const AGENT_STATUS = i18n.translate('xpack.securitySolution.detections.al
   defaultMessage: 'Agent status',
 });
 
+export const RULE_TYPE = i18n.translate('xpack.securitySolution.detections.alerts.ruleType', {
+  defaultMessage: 'Rule type',
+});
+
 export const MULTI_FIELD_TOOLTIP = i18n.translate(
   'xpack.securitySolution.eventDetails.multiFieldTooltipContent',
   {


### PR DESCRIPTION
Related issue: https://github.com/elastic/kibana/issues/125474

## Summary

This PR introduces the `rule type` as a new global field that is shown on the alert flyout (for all alerts where it is available). This field was missed in the original implementation, hence this PR being marked as a `bug`

<img width="750" alt="Screenshot 2022-02-15 at 16 28 04" src="https://user-images.githubusercontent.com/68591/154094193-0167a542-cf74-4876-a08e-7b5c858f3b33.png">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios