### PR TITLE
[8.0] [DOCS] Removes technical preview flag from DFA ML page. (#125497)

### DIFF
--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -26,7 +26,8 @@ If {stack-security-features} are enabled, users must have the necessary
 privileges to use {ml-features}. Refer to
 {ml-docs}/setup.html#setup-privileges[Set up {ml-features}].
 
-NOTE: There are limitations in {ml-features} that affect {kib}. For more information, refer to {ml-docs}/ml-limitations.html[Machine learning].
+NOTE: There are limitations in {ml-features} that affect {kib}. For more 
+information, refer to {ml-docs}/ml-limitations.html[{ml-cap}].
 
 --
 
@@ -83,8 +84,6 @@ and {ml-docs}/ml-ad-overview.html[{ml-cap} {anomaly-detect}].
 
 [[xpack-ml-dfanalytics]]
 == {dfanalytics-cap}
-
-experimental[]
 
 The Elastic {ml} {dfanalytics} feature enables you to analyze your data using
 {classification}, {oldetection}, and {regression} algorithms and generate new


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Removes technical preview flag from DFA ML page. (#125497)