### PR TITLE
Use locator in osquery plugin

### DIFF
--- a/x-pack/plugins/osquery/public/common/hooks/use_discover_link.tsx
+++ b/x-pack/plugins/osquery/public/common/hooks/use_discover_link.tsx
@@ -18,14 +18,14 @@ export const useDiscoverLink = ({ filters }: UseDiscoverLink) => {
   const {
     application: { navigateToUrl },
   } = useKibana().services;
-  const urlGenerator = useKibana().services.discover?.urlGenerator;
+  const locator = useKibana().services.discover?.locator;
   const [discoverUrl, setDiscoverUrl] = useState<string>('');
 
   useEffect(() => {
     const getDiscoverUrl = async () => {
-      if (!urlGenerator?.createUrl) return;
+      if (!locator) return;
 
-      const newUrl = await urlGenerator.createUrl({
+      const newUrl = await locator.getUrl({
         indexPatternId: 'logs-*',
         filters: filters.map((filter) => ({
           meta: {
@@ -44,7 +44,7 @@ export const useDiscoverLink = ({ filters }: UseDiscoverLink) => {
       setDiscoverUrl(newUrl);
     };
     getDiscoverUrl();
-  }, [filters, urlGenerator]);
+  }, [filters, locator]);
 
   const onClick = useCallback(
     (event: React.MouseEvent) => {

--- a/x-pack/plugins/osquery/public/packs/pack_queries_status_table.tsx
+++ b/x-pack/plugins/osquery/public/packs/pack_queries_status_table.tsx
@@ -264,12 +264,12 @@ const ViewResultsInDiscoverActionComponent: React.FC<ViewResultsInDiscoverAction
   endDate,
   startDate,
 }) => {
-  const urlGenerator = useKibana().services.discover?.urlGenerator;
+  const locator = useKibana().services.discover?.locator;
   const [discoverUrl, setDiscoverUrl] = useState<string>('');
 
   useEffect(() => {
     const getDiscoverUrl = async () => {
-      if (!urlGenerator?.createUrl) return;
+      if (!locator) return;
 
       const agentIdsQuery = agentIds?.length
         ? {
@@ -280,7 +280,7 @@ const ViewResultsInDiscoverActionComponent: React.FC<ViewResultsInDiscoverAction
           }
         : null;
 
-      const newUrl = await urlGenerator.createUrl({
+      const newUrl = await locator.getUrl({
         indexPatternId: 'logs-*',
         filters: [
           {
@@ -334,7 +334,7 @@ const ViewResultsInDiscoverActionComponent: React.FC<ViewResultsInDiscoverAction
       setDiscoverUrl(newUrl);
     };
     getDiscoverUrl();
-  }, [actionId, agentIds, endDate, startDate, urlGenerator]);
+  }, [actionId, agentIds, endDate, startDate, locator]);
 
   if (buttonType === ViewResultsActionButtonType.button) {
     return (


### PR DESCRIPTION
## Summary

Uses Discover locator instead of deprecated URL generator in `osquery` plugin.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
