### PR TITLE
[7.17] [Maps] Reverts backport

### DIFF
--- a/x-pack/plugins/maps/public/classes/layers/new_vector_layer_wizard/config.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/new_vector_layer_wizard/config.tsx
@@ -22,7 +22,7 @@ export const newVectorLayerWizardConfig: LayerWizard = {
   }),
   disabledReason: i18n.translate('xpack.maps.newVectorLayerWizard.disabledDesc', {
     defaultMessage:
-      'Unable to create index, you are missing the Kibana privilege "Data View Management".',
+      'Unable to create index, you are missing the Kibana privilege "Index Pattern Management".',
   }),
   getIsDisabled: async () => {
     const hasImportPermission = await getFileUpload().hasImportPermission({


### PR DESCRIPTION
Reverts #125220  at #125344 for 7.17 since `Data View` term is only used from 8.0.