### PR TITLE
[Screenshotting] [POC] API key-based authorization

### DIFF
--- a/x-pack/plugins/screenshotting/kibana.json
+++ b/x-pack/plugins/screenshotting/kibana.json
@@ -8,6 +8,7 @@
   },
   "description": "Kibana Screenshotting Plugin",
   "requiredPlugins": ["screenshotMode"],
+  "optionalPlugins": ["security"],
   "configPath": ["xpack", "screenshotting"],
   "server": true
 }

--- a/x-pack/plugins/screenshotting/server/plugin.ts
+++ b/x-pack/plugins/screenshotting/server/plugin.ts
@@ -15,6 +15,7 @@ import type {
   PluginInitializerContext,
 } from 'src/core/server';
 import type { ScreenshotModePluginSetup } from 'src/plugins/screenshot_mode/server';
+import type { SecurityPluginStart } from '../../security/server';
 import { ChromiumArchivePaths, HeadlessChromiumDriverFactory, install } from './browsers';
 import { ConfigType, createConfig } from './config';
 import { Screenshots } from './screenshots';
@@ -22,6 +23,10 @@ import { getChromiumPackage } from './utils';
 
 interface SetupDeps {
   screenshotMode: ScreenshotModePluginSetup;
+}
+
+interface StartDeps {
+  security: SecurityPluginStart;
 }
 
 /**
@@ -42,7 +47,9 @@ export interface ScreenshottingStart {
   getScreenshots: Screenshots['getScreenshots'];
 }
 
-export class ScreenshottingPlugin implements Plugin<void, ScreenshottingStart, SetupDeps> {
+export class ScreenshottingPlugin
+  implements Plugin<void, ScreenshottingStart, SetupDeps, StartDeps>
+{
   private config: ConfigType;
   private logger: Logger;
   private screenshotMode!: ScreenshotModePluginSetup;
@@ -90,13 +97,13 @@ export class ScreenshottingPlugin implements Plugin<void, ScreenshottingStart, S
     return {};
   }
 
-  start({}: CoreStart): ScreenshottingStart {
+  start({}: CoreStart, { security }: StartDeps): ScreenshottingStart {
     return {
       diagnose: () =>
         from(this.browserDriverFactory).pipe(switchMap((factory) => factory.diagnose())),
       getScreenshots: (options) =>
         from(this.screenshots).pipe(
-          switchMap((screenshots) => screenshots.getScreenshots(options))
+          switchMap((screenshots) => screenshots.getScreenshots(options, security))
         ),
     };
   }

--- a/x-pack/plugins/screenshotting/tsconfig.json
+++ b/x-pack/plugins/screenshotting/tsconfig.json
@@ -14,5 +14,6 @@
   "references": [
     { "path": "../../../src/core/tsconfig.json" },
     { "path": "../../../src/plugins/screenshot_mode/tsconfig.json" },
+    { "path": "../security/tsconfig.json" },
   ]
 }


### PR DESCRIPTION
## Summary

This PR demonstrates the possibility of authenticating using the API keys generated by the security plugin.
There are some things we should take into account before moving forward:
- Current implementation issues and invalidates API keys on every screenshot batch.
- Current implementation requires the `KibanaRequest` instance, which makes using API keys redundant in a way.
- It makes more sense to put this logic into reporting and reuse one API key in multiple jobs.
- We can store the API key in the reporting jobs instead of headers.
- That should enable us towards scheduled reports since we are in control of the API key expiration.

### Testing
This feature can be tested using reporting diagnostic tool in stack management.
