### PR TITLE
Add mlr-docs to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -344,8 +344,8 @@
 /x-pack/plugins/triggers_actions_ui/ @elastic/response-ops
 /x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/ @elastic/response-ops
 /x-pack/test/functional_with_es_ssl/fixtures/plugins/alerts/ @elastic/response-ops
-/docs/user/alerting/ @elastic/response-ops
-/docs/management/connectors/ @elastic/response-ops
+/docs/user/alerting/ @elastic/response-ops @elastic/mlr-docs
+/docs/management/connectors/ @elastic/response-ops @elastic/mlr-docs
 #CC# /x-pack/plugins/stack_alerts @elastic/response-ops
 /x-pack/plugins/cases/ @elastic/response-ops
 /x-pack/test/cases_api_integration/ @elastic/response-ops


### PR DESCRIPTION
This PR adds the mlr-docs team to the code owner list for the alerting and connectors documentation in the Kibana Guide.

