### PR TITLE
[8.1] [ML] Data Frame Analytics audit messages api test (#125325)

### DIFF
--- a/x-pack/plugins/ml/public/application/services/ml_api_service/data_frame_analytics.ts
+++ b/x-pack/plugins/ml/public/application/services/ml_api_service/data_frame_analytics.ts
@@ -16,6 +16,7 @@ import {
 } from '../../data_frame_analytics/common';
 import { DeepPartial } from '../../../../common/types/common';
 import { NewJobCapsResponse } from '../../../../common/types/fields';
+import { JobMessage } from '../../../../common/types/audit_message';
 import {
   DeleteDataFrameAnalyticsWithIndexStatus,
   AnalyticsMapReturnType,
@@ -161,7 +162,7 @@ export const dataFrameAnalytics = {
     });
   },
   getAnalyticsAuditMessages(analyticsId: string) {
-    return http<any>({
+    return http<JobMessage[]>({
       path: `${basePath()}/data_frame/analytics/${analyticsId}/messages`,
       method: 'GET',
     });


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.1` of:
 - #125325

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
