### PR TITLE
Revert "[build] Include x-pack example plugins when using example-plu…

### DIFF
--- a/src/dev/build/tasks/build_kibana_example_plugins.ts
+++ b/src/dev/build/tasks/build_kibana_example_plugins.ts
@@ -13,23 +13,17 @@ import { exec, mkdirp, copyAll, Task } from '../lib';
 
 export const BuildKibanaExamplePlugins: Task = {
   description: 'Building distributable versions of Kibana example plugins',
-  async run(config, log) {
+  async run(config, log, build) {
+    const examplesDir = Path.resolve(REPO_ROOT, 'examples');
     const args = [
-      Path.resolve(REPO_ROOT, 'scripts/plugin_helpers'),
+      '../../scripts/plugin_helpers',
       'build',
       `--kibana-version=${config.getBuildVersion()}`,
     ];
 
-    const getExampleFolders = (dir: string) => {
-      return Fs.readdirSync(dir, { withFileTypes: true })
-        .filter((f) => f.isDirectory())
-        .map((f) => Path.resolve(dir, f.name));
-    };
-
-    const folders = [
-      ...getExampleFolders(Path.resolve(REPO_ROOT, 'examples')),
-      ...getExampleFolders(Path.resolve(REPO_ROOT, 'x-pack/examples')),
-    ];
+    const folders = Fs.readdirSync(examplesDir, { withFileTypes: true })
+      .filter((f) => f.isDirectory())
+      .map((f) => Path.resolve(REPO_ROOT, 'examples', f.name));
 
     for (const examplePlugin of folders) {
       try {
@@ -46,8 +40,8 @@ export const BuildKibanaExamplePlugins: Task = {
 
     const pluginsDir = config.resolveFromTarget('example_plugins');
     await mkdirp(pluginsDir);
-    await copyAll(REPO_ROOT, pluginsDir, {
-      select: ['examples/*/build/*.zip', 'x-pack/examples/*/build/*.zip'],
+    await copyAll(examplesDir, pluginsDir, {
+      select: ['*/build/*.zip'],
     });
   },
 };


### PR DESCRIPTION
…gins flag (#120697)"

This reverts commit 3a4c6030b901241eb8e9fbef337c5d36f6fd2fb5.

This is causing errors in the demo environment.  We can look into un-reverting after debugging the error.

```
[2022-02-15T21:10:17.889+00:00][FATAL][root] Error: Cannot find module '../../../../src/core/utils/default_app_categories'
Require stack:
- /usr/share/kibana/plugins/alertingExample/server/plugin.js
```