### PR TITLE
[kibana_react] Deprecate `ExitFullScreenButton` in favor of new Shared UX component

### DIFF
--- a/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.tsx
+++ b/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.tsx
@@ -101,4 +101,5 @@ class ExitFullScreenButtonUi extends PureComponent<ExitFullScreenButtonProps> {
   }
 }
 
+/** @deprecated Use `ExitFullScreenButton` from `src/plugins/shared_ux/public`. */
 export const ExitFullScreenButton = ExitFullScreenButtonUi;

--- a/src/plugins/shared_ux/public/components/exit_full_screen_button/exit_full_screen_button.tsx
+++ b/src/plugins/shared_ux/public/components/exit_full_screen_button/exit_full_screen_button.tsx
@@ -25,8 +25,10 @@ export interface Props {
 
 /**
  * A service-enabled component that provides Kibana-specific functionality to the `ExitFullScreenButton`
- * component.  Use of this component requires both the `EuiTheme` context as well as the Shared UX
- * `ServicesProvider`.
+ * component.
+ *
+ * Use of this component requires both the `EuiTheme` context as well as either a configured Shared UX
+ * `ServicesProvider` or the `ServicesContext` provided by the Shared UX public plugin contract.
  *
  * See shared-ux/public/services for information.
  */

--- a/src/plugins/shared_ux/public/components/exit_full_screen_button/index.ts
+++ b/src/plugins/shared_ux/public/components/exit_full_screen_button/index.ts
@@ -5,13 +5,5 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-/* eslint-disable import/no-default-export */
 
-import { ExitFullScreenButton } from './exit_full_screen_button';
 export { ExitFullScreenButton } from './exit_full_screen_button';
-
-/**
- * Exporting the ExitFullScreenButton component as a default export so it can be
- * loaded by React.lazy.
- */
-export default ExitFullScreenButton;

--- a/src/plugins/shared_ux/public/components/index.ts
+++ b/src/plugins/shared_ux/public/components/index.ts
@@ -13,7 +13,11 @@ import { withSuspense } from './utility';
  * The Lazily-loaded `ExitFullScreenButton` component.  Consumers should use `React.Suspennse` or the
  * `withSuspense` HOC to load this component.
  */
-export const LazyExitFullScreenButton = React.lazy(() => import('./exit_full_screen_button'));
+export const LazyExitFullScreenButton = React.lazy(() =>
+  import('./exit_full_screen_button').then(({ ExitFullScreenButton }) => ({
+    default: ExitFullScreenButton,
+  }))
+);
 
 /**
  * A `ExitFullScreenButton` component that is wrapped by the `withSuspense` HOC.  This component can

--- a/src/plugins/shared_ux/public/services/index.tsx
+++ b/src/plugins/shared_ux/public/services/index.tsx
@@ -27,8 +27,11 @@ const ServicesContext = createContext<SharedUXServices>(servicesFactory());
 
 /**
  * The `React.Context` Provider component for the `SharedUXServices` context.  Any
- * plugin or environemnt that consumes SharedUX components needs to wrap their React
+ * plugin or environment that consumes SharedUX components needs to wrap their React
  * tree with this provider.
+ *
+ * Within a plugin, you can use the `ServicesContext` provided by the SharedUX plugin start
+ * lifeycle method.
  */
 export const ServicesProvider: FC<SharedUXServices> = ({ children, ...services }) => (
   <ServicesContext.Provider value={services}>{children}</ServicesContext.Provider>


### PR DESCRIPTION
## Summary

> Related: #122556, #122499
> Addresses: #114990

Since a revised `ExitFullScreenButton` was added to Shared UX, we can deprecate the existing component and notify consuming teams to migrate.  Once complete, we can delete the existing component.

This PR deprecates the component, (and fixes a few minor issues and docs).
