### PR TITLE
[Fleet] added loading spinner to add agent flyout

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.tsx
@@ -118,6 +118,25 @@ describe('<AgentEnrollmentFlyout />', () => {
     jest.clearAllMocks();
   });
 
+  it('should show loading when agent policies are loading', async () => {
+    (useAgentEnrollmentFlyoutData as jest.Mock).mockReturnValue?.({
+      agentPolicies: [],
+      refreshAgentPolicies: jest.fn(),
+      isLoadingAgentPolicies: true,
+    });
+
+    await act(async () => {
+      testBed = await setup({
+        onClose: jest.fn(),
+      });
+      testBed.component.update();
+    });
+
+    const { exists } = testBed;
+    expect(exists('agentEnrollmentFlyout')).toBe(true);
+    expect(exists('loadingSpinner')).toBe(true);
+  });
+
   describe('managed instructions', () => {
     it('uses the agent policy selection step', async () => {
       const { exists } = testBed;

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.tsx
@@ -122,7 +122,7 @@ describe('<AgentEnrollmentFlyout />', () => {
     (useAgentEnrollmentFlyoutData as jest.Mock).mockReturnValue?.({
       agentPolicies: [],
       refreshAgentPolicies: jest.fn(),
-      isLoadingAgentPolicies: true,
+      isLoadingInitialAgentPolicies: true,
     });
 
     await act(async () => {

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -66,8 +66,12 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
   const [policyId, setSelectedPolicyId] = useState(agentPolicy?.id);
   const [isFleetServerPolicySelected, setIsFleetServerPolicySelected] = useState<boolean>(false);
 
-  const { agentPolicies, isLoadingAgentPolicies, refreshAgentPolicies } =
-    useAgentEnrollmentFlyoutData();
+  const {
+    agentPolicies,
+    isLoadingInitialAgentPolicies,
+    isLoadingAgentPolicies,
+    refreshAgentPolicies,
+  } = useAgentEnrollmentFlyoutData();
 
   useEffect(() => {
     async function checkPolicyIsFleetServer() {
@@ -144,7 +148,7 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
           ) : undefined
         }
       >
-        {isLoadingAgentPolicies ? (
+        {isLoadingInitialAgentPolicies ? (
           <Loading />
         ) : mode === 'managed' ? (
           <ManagedInstructions
@@ -155,6 +159,7 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
             viewDataStep={viewDataStep}
             isFleetServerPolicySelected={isFleetServerPolicySelected}
             refreshAgentPolicies={refreshAgentPolicies}
+            isLoadingAgentPolicies={isLoadingAgentPolicies}
           />
         ) : (
           <StandaloneInstructions

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -31,6 +31,8 @@ import {
 import { FLEET_SERVER_PACKAGE } from '../../constants';
 import type { PackagePolicy } from '../../types';
 
+import { Loading } from '..';
+
 import { ManagedInstructions } from './managed_instructions';
 import { StandaloneInstructions } from './standalone_instructions';
 import { MissingFleetServerHostCallout } from './missing_fleet_server_host_callout';
@@ -64,7 +66,8 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
   const [policyId, setSelectedPolicyId] = useState(agentPolicy?.id);
   const [isFleetServerPolicySelected, setIsFleetServerPolicySelected] = useState<boolean>(false);
 
-  const { agentPolicies, refreshAgentPolicies } = useAgentEnrollmentFlyoutData();
+  const { agentPolicies, isLoadingAgentPolicies, refreshAgentPolicies } =
+    useAgentEnrollmentFlyoutData();
 
   useEffect(() => {
     async function checkPolicyIsFleetServer() {
@@ -141,7 +144,9 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
           ) : undefined
         }
       >
-        {mode === 'managed' ? (
+        {isLoadingAgentPolicies ? (
+          <Loading />
+        ) : mode === 'managed' ? (
           <ManagedInstructions
             settings={settings.data?.item}
             setSelectedPolicyId={setSelectedPolicyId}

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
@@ -66,6 +66,7 @@ export const ManagedInstructions = React.memo<InstructionProps>(
     isFleetServerPolicySelected,
     settings,
     refreshAgentPolicies,
+    isLoadingAgentPolicies,
   }) => {
     const fleetStatus = useFleetStatus();
 
@@ -161,7 +162,10 @@ export const ManagedInstructions = React.memo<InstructionProps>(
       return null;
     }
 
-    if (fleetStatus.isReady && (isLoadingAgents || fleetServers.length > 0)) {
+    if (
+      fleetStatus.isReady &&
+      (isLoadingAgents || isLoadingAgentPolicies || fleetServers.length > 0)
+    ) {
       return (
         <>
           <EuiText>

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/types.ts
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/types.ts
@@ -31,4 +31,5 @@ export interface BaseProps {
 export interface InstructionProps extends BaseProps {
   agentPolicies: AgentPolicy[];
   refreshAgentPolicies: () => void;
+  isLoadingAgentPolicies?: boolean;
 }

--- a/x-pack/plugins/fleet/public/components/loading.tsx
+++ b/x-pack/plugins/fleet/public/components/loading.tsx
@@ -12,7 +12,7 @@ import type { EuiLoadingSpinnerSize } from '@elastic/eui/src/components/loading/
 export const Loading: React.FunctionComponent<{ size?: EuiLoadingSpinnerSize }> = ({ size }) => (
   <EuiFlexGroup justifyContent="spaceAround">
     <EuiFlexItem grow={false}>
-      <EuiLoadingSpinner size={size || 'xl'} />
+      <EuiLoadingSpinner size={size || 'xl'} data-test-subj="loadingSpinner" />
     </EuiFlexItem>
   </EuiFlexGroup>
 );

--- a/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout.data.test.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout.data.test.ts
@@ -23,6 +23,7 @@ describe('useAgentEnrollmentFlyoutData', () => {
     (useGetAgentPolicies as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
     const { result } = testRenderer.renderHook(() => useAgentEnrollmentFlyoutData());
     expect(result.current.agentPolicies).toEqual([]);
+    expect(result.current.isLoadingAgentPolicies).toBe(true);
   });
 
   it('should return empty agentPolicies when http not loading and no data', () => {

--- a/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
@@ -14,6 +14,7 @@ import { useGetAgentPolicies } from './use_request';
 interface AgentEnrollmentFlyoutData {
   agentPolicies: AgentPolicy[];
   refreshAgentPolicies: () => void;
+  isLoadingAgentPolicies: boolean;
 }
 
 export function useAgentEnrollmentFlyoutData(): AgentEnrollmentFlyoutData {
@@ -34,5 +35,5 @@ export function useAgentEnrollmentFlyoutData(): AgentEnrollmentFlyoutData {
     return [];
   }, [isLoadingAgentPolicies, agentPoliciesData?.items]);
 
-  return { agentPolicies, refreshAgentPolicies };
+  return { agentPolicies, refreshAgentPolicies, isLoadingAgentPolicies };
 }

--- a/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
@@ -14,12 +14,14 @@ import { useGetAgentPolicies } from './use_request';
 interface AgentEnrollmentFlyoutData {
   agentPolicies: AgentPolicy[];
   refreshAgentPolicies: () => void;
+  isLoadingInitialAgentPolicies: boolean;
   isLoadingAgentPolicies: boolean;
 }
 
 export function useAgentEnrollmentFlyoutData(): AgentEnrollmentFlyoutData {
   const {
     data: agentPoliciesData,
+    isInitialRequest,
     isLoading: isLoadingAgentPolicies,
     resendRequest: refreshAgentPolicies,
   } = useGetAgentPolicies({
@@ -35,5 +37,10 @@ export function useAgentEnrollmentFlyoutData(): AgentEnrollmentFlyoutData {
     return [];
   }, [isLoadingAgentPolicies, agentPoliciesData?.items]);
 
-  return { agentPolicies, refreshAgentPolicies, isLoadingAgentPolicies };
+  return {
+    agentPolicies,
+    refreshAgentPolicies,
+    isLoadingInitialAgentPolicies: isInitialRequest && isLoadingAgentPolicies,
+    isLoadingAgentPolicies,
+  };
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/125757

Added loading spinner while agent policies are loading in Add agent flyout. This solves the issue of flickering Fleet Server instructions.

Can be tested by using throttling in Chrome dev tools.

https://user-images.githubusercontent.com/90178898/154230728-22924f43-b0e5-467f-a6fa-d82e07df97e0.mov

Create new agent policy should keep showing the newly created policy in dropdown
<img width="484" alt="image" src="https://user-images.githubusercontent.com/90178898/154254176-a9879ae3-80cb-4a57-a7be-8ff8f4722752.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
