### PR TITLE
[Lens] Retry opening context menu in flaky test

### DIFF
--- a/test/functional/services/inspector.ts
+++ b/test/functional/services/inspector.ts
@@ -195,8 +195,12 @@ export class InspectorService extends FtrService {
    */
   public async openInspectorView(viewId: string): Promise<void> {
     this.log.debug(`Open Inspector view ${viewId}`);
-    await this.testSubjects.click('inspectorViewChooser');
-    await this.testSubjects.click(viewId);
+    await this.retry.try(async () => {
+      await this.testSubjects.click('inspectorViewChooser');
+      // check whether popover menu opens, if not, fail and retry opening
+      await this.testSubjects.existOrFail(viewId, { timeout: 2000 });
+      await this.testSubjects.click(viewId);
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/125650 by retrying to open the context menu in inspector