### PR TITLE
[Security Solution][Detections] Remove the bulk editing feature switch

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -22,7 +22,6 @@ export const allowedExperimentalValues = Object.freeze({
   riskyHostsEnabled: false,
   securityRulesCancelEnabled: false,
   pendingActionResponsesWithAck: true,
-  rulesBulkEditEnabled: true,
   policyListEnabled: false,
 
   /**

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/use_bulk_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/use_bulk_actions.tsx
@@ -42,7 +42,6 @@ import { useHasActionsPrivileges } from '../use_has_actions_privileges';
 import { useHasMlPermissions } from '../use_has_ml_permissions';
 import { getCustomRulesCountFromCache } from './use_custom_rules_count';
 import { useAppToasts } from '../../../../../../common/hooks/use_app_toasts';
-import { useIsExperimentalFeatureEnabled } from '../../../../../../common/hooks/use_experimental_features';
 import { convertRulesFilterToKQL } from '../../../../../containers/detection_engine/rules/utils';
 
 import type { FilterOptions } from '../../../../../containers/detection_engine/rules/types';
@@ -74,7 +73,6 @@ export const useBulkActions = ({
   const [, dispatchToaster] = useStateToaster();
   const hasActionsPrivileges = useHasActionsPrivileges();
   const toasts = useAppToasts();
-  const isRulesBulkEditEnabled = useIsExperimentalFeatureEnabled('rulesBulkEditEnabled');
   const getIsMounted = useIsMounted();
   const filterQuery = convertRulesFilterToKQL(filterOptions);
 
@@ -340,7 +338,7 @@ export const useBulkActions = ({
       return [
         {
           id: 0,
-          title: isRulesBulkEditEnabled ? i18n.BULK_ACTION_MENU_TITLE : undefined,
+          title: i18n.BULK_ACTION_MENU_TITLE,
           items: [
             {
               key: i18n.BULK_ACTION_ENABLE,
@@ -351,7 +349,7 @@ export const useBulkActions = ({
               onClick: handleActivateAction,
               toolTipContent: missingActionPrivileges ? i18n.EDIT_RULE_SETTINGS_TOOLTIP : undefined,
               toolTipPosition: 'right',
-              icon: isRulesBulkEditEnabled ? undefined : 'checkInCircleFilled',
+              icon: undefined,
             },
             {
               key: i18n.BULK_ACTION_DUPLICATE,
@@ -361,26 +359,22 @@ export const useBulkActions = ({
               onClick: handleDuplicateAction,
               toolTipContent: missingActionPrivileges ? i18n.EDIT_RULE_SETTINGS_TOOLTIP : undefined,
               toolTipPosition: 'right',
-              icon: isRulesBulkEditEnabled ? undefined : 'crossInACircleFilled',
+              icon: undefined,
             },
-            ...(isRulesBulkEditEnabled
-              ? [
-                  {
-                    key: i18n.BULK_ACTION_INDEX_PATTERNS,
-                    name: i18n.BULK_ACTION_INDEX_PATTERNS,
-                    'data-test-subj': 'indexPatternsBulkEditRule',
-                    disabled: isEditDisabled,
-                    panel: 2,
-                  },
-                  {
-                    key: i18n.BULK_ACTION_TAGS,
-                    name: i18n.BULK_ACTION_TAGS,
-                    'data-test-subj': 'tagsBulkEditRule',
-                    disabled: isEditDisabled,
-                    panel: 1,
-                  },
-                ]
-              : []),
+            {
+              key: i18n.BULK_ACTION_INDEX_PATTERNS,
+              name: i18n.BULK_ACTION_INDEX_PATTERNS,
+              'data-test-subj': 'indexPatternsBulkEditRule',
+              disabled: isEditDisabled,
+              panel: 2,
+            },
+            {
+              key: i18n.BULK_ACTION_TAGS,
+              name: i18n.BULK_ACTION_TAGS,
+              'data-test-subj': 'tagsBulkEditRule',
+              disabled: isEditDisabled,
+              panel: 1,
+            },
             {
               key: i18n.BULK_ACTION_EXPORT,
               name: i18n.BULK_ACTION_EXPORT,
@@ -390,7 +384,7 @@ export const useBulkActions = ({
                 containsLoading ||
                 selectedRuleIds.length === 0,
               onClick: handleExportAction,
-              icon: isRulesBulkEditEnabled ? undefined : 'exportAction',
+              icon: undefined,
             },
             {
               key: i18n.BULK_ACTION_DISABLE,
@@ -401,7 +395,7 @@ export const useBulkActions = ({
               onClick: handleDeactivateActions,
               toolTipContent: missingActionPrivileges ? i18n.EDIT_RULE_SETTINGS_TOOLTIP : undefined,
               toolTipPosition: 'right',
-              icon: isRulesBulkEditEnabled ? undefined : 'copy',
+              icon: undefined,
             },
             {
               key: i18n.BULK_ACTION_DELETE,
@@ -419,7 +413,7 @@ export const useBulkActions = ({
                 ? i18n.BATCH_ACTION_DELETE_SELECTED_IMMUTABLE
                 : undefined,
               toolTipPosition: 'right',
-              icon: isRulesBulkEditEnabled ? undefined : 'trash',
+              icon: undefined,
             },
           ],
         },
@@ -477,7 +471,6 @@ export const useBulkActions = ({
       rules,
       selectedRuleIds,
       hasActionsPrivileges,
-      isRulesBulkEditEnabled,
       isAllSelected,
       loadingRuleIds,
       hasMlPermissions,


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/125502

## Summary

Removed the `rulesBulkEditEnabled` experimental flag from the config and its usage from the client-side code.