### PR TITLE
Update token used for Fleet QA labeling action

### DIFF
--- a/.github/workflows/label-qa-fixed-in.yml
+++ b/.github/workflows/label-qa-fixed-in.yml
@@ -37,7 +37,7 @@ jobs:
               }
             }
           prnumber: ${{ github.event.number }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FLEET_TECH_KIBANA_USER_TOKEN }}
       - uses: sergeysova/jq-action@v2
         id: issues_to_label
         with:
@@ -75,4 +75,4 @@ jobs:
             }
           issueid: ${{ matrix.issueNodeId }}
           labelids: ${{ needs.fetch_issues_to_label.outputs.label_ids }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FLEET_TECH_KIBANA_USER_TOKEN }}


### PR DESCRIPTION
## Summary

This updates the token used for adding labels to Kibana issues to use an access token that has the required level of access rather than using the PR author's token which may not have required access level