### PR TITLE
ExecutionContext: encode all context fields when converting to header

### DIFF
--- a/src/core/server/execution_context/execution_context_container.test.ts
+++ b/src/core/server/execution_context/execution_context_container.test.ts
@@ -91,16 +91,40 @@ describe('KibanaExecutionContext', () => {
       expect(value).toBe('type:name:41;child-test-type:child-test-name:42');
     });
 
-    it('returns an escaped string representation of provided execution contextStringified', () => {
+    it('returns an escaped string representation of provided execution context', () => {
       const context: KibanaExecutionContext = {
         id: 'Visualization☺漢字',
+        type: 'test☺type',
+        name: 'test漢name',
+        description: 'test字description',
+      };
+
+      const value = new ExecutionContextContainer(context).toString();
+      expect(value).toBe(
+        'test%E2%98%BAtype:test%E6%BC%A2name:Visualization%E2%98%BA%E6%BC%A2%E5%AD%97'
+      );
+    });
+
+    it('returns an escaped string representation of provided execution context parent', () => {
+      const parentContext: KibanaExecutionContext = {
+        id: 'Dashboard☺漢字',
+        type: 'test☺type',
+        name: 'test漢name',
+        description: 'parent-descripton',
+      };
+      const parentContainer = new ExecutionContextContainer(parentContext);
+
+      const context: KibanaExecutionContext = {
+        id: 'Visualization',
         type: 'test-type',
         name: 'test-name',
         description: 'test-description',
       };
 
-      const value = new ExecutionContextContainer(context).toString();
-      expect(value).toBe('test-type:test-name:Visualization%E2%98%BA%E6%BC%A2%E5%AD%97');
+      const value = new ExecutionContextContainer(context, parentContainer).toString();
+      expect(value).toBe(
+        'test%E2%98%BAtype:test%E6%BC%A2name:Dashboard%E2%98%BA%E6%BC%A2%E5%AD%97;test-type:test-name:Visualization'
+      );
     });
 
     it('trims a string representation of provided execution context if it is bigger max allowed size', () => {

--- a/src/core/server/execution_context/execution_context_container.ts
+++ b/src/core/server/execution_context/execution_context_container.ts
@@ -50,18 +50,23 @@ export interface IExecutionContextContainer {
 }
 
 function stringify(ctx: KibanaExecutionContext): string {
-  const stringifiedCtx = `${ctx.type}:${ctx.name}:${encodeURIComponent(ctx.id!)}`;
+  const stringifiedCtx = `${encodeURIComponent(ctx.type)}:${encodeURIComponent(
+    ctx.name
+  )}:${encodeURIComponent(ctx.id!)}`;
   return ctx.child ? `${stringifiedCtx};${stringify(ctx.child)}` : stringifiedCtx;
 }
 
 export class ExecutionContextContainer implements IExecutionContextContainer {
   readonly #context: Readonly<KibanaExecutionContext>;
+
   constructor(context: KibanaExecutionContext, parent?: IExecutionContextContainer) {
     this.#context = parent ? { ...parent.toJSON(), child: context } : context;
   }
+
   toString(): string {
     return enforceMaxLength(stringify(this.#context));
   }
+
   toJSON() {
     return this.#context;
   }

--- a/src/core/server/execution_context/integration_tests/tracing.test.ts
+++ b/src/core/server/execution_context/integration_tests/tracing.test.ts
@@ -18,6 +18,13 @@ const parentContext = {
   description: 'test-description',
 };
 
+const withUtf8CharsContext = {
+  type: 'test字type',
+  name: 'test漢字name',
+  id: '9000☺',
+  description: 'test-description',
+};
+
 describe('trace', () => {
   let esServer: kbnTestServer.TestElasticsearchUtils;
   let root: ReturnType<typeof kbnTestServer.createRoot>;
@@ -382,6 +389,35 @@ describe('trace', () => {
         .expect(200);
 
       expect(response.body).toEqual(parentContext);
+    });
+
+    it('supports UTF-8 characters', async () => {
+      const { http } = await root.setup();
+      const { createRouter } = http;
+
+      const router = createRouter('');
+      router.get({ path: '/execution-context', validate: false }, async (context, req, res) => {
+        const { headers } = await context.core.elasticsearch.client.asCurrentUser.ping(
+          {},
+          { meta: true }
+        );
+        return res.ok({ body: headers || {} });
+      });
+
+      await root.start();
+      const response = await kbnTestServer.request
+        .get(root, '/execution-context')
+        .set('x-opaque-id', 'utf-test')
+        .set(new ExecutionContextContainer(withUtf8CharsContext).toHeader())
+        .expect(200);
+
+      const rawOpaqueId = response.body['x-opaque-id'];
+      expect(rawOpaqueId).toEqual(
+        'utf-test;kibana:test%E5%AD%97type:test%E6%BC%A2%E5%AD%97name:9000%E2%98%BA'
+      );
+      expect(decodeURIComponent(rawOpaqueId)).toEqual(
+        'utf-test;kibana:test字type:test漢字name:9000☺'
+      );
     });
 
     it('execution context is the same for all the lifecycle events', async () => {

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -401,7 +401,7 @@ export class VisualizeEmbeddable
     const parentContext = this.parent?.getInput().executionContext;
     const child: KibanaExecutionContext = {
       type: 'visualization',
-      name: this.vis.type.title,
+      name: this.vis.type.name,
       id: this.vis.id ?? 'an_unsaved_vis',
       description: this.vis.title || this.input.title || this.vis.type.name,
       url: this.output.editUrl,

--- a/x-pack/test/functional_execution_context/tests/browser.ts
+++ b/x-pack/test/functional_execution_context/tests/browser.ts
@@ -251,7 +251,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           predicate: (record) =>
             Boolean(
               record.http?.request?.id?.includes(
-                'kibana:application:dashboard:7adfa750-4c81-11e8-b3d7-01146121b73d;visualization:TSVB:bcb63b50-4c89-11e8-b3d7-01146121b73d'
+                'kibana:application:dashboard:7adfa750-4c81-11e8-b3d7-01146121b73d;visualization:metrics:bcb63b50-4c89-11e8-b3d7-01146121b73d'
               )
             ),
           retry,
@@ -268,7 +268,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
               url: '/view/7adfa750-4c81-11e8-b3d7-01146121b73d',
               child: {
                 type: 'visualization',
-                name: 'TSVB',
+                name: 'metrics',
                 id: 'bcb63b50-4c89-11e8-b3d7-01146121b73d',
                 description: '[Flights] Delays & Cancellations',
                 url: '/app/visualize#/edit/bcb63b50-4c89-11e8-b3d7-01146121b73d',
@@ -278,13 +278,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
       });
 
+      // application:dashboard:7adfa750-4c81-11e8-b3d7-01146121b73d;visualization:vega:ed78a660-53a0-11e8-acbd-0be0ad9d822b
       it('propagates context for Vega visualizations', async () => {
         await assertLogContains({
           description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
           predicate: (record) =>
             Boolean(
               record.http?.request?.id?.includes(
-                'kibana:application:dashboard:7adfa750-4c81-11e8-b3d7-01146121b73d;visualization:Vega:ed78a660-53a0-11e8-acbd-0be0ad9d822b'
+                'kibana:application:dashboard:7adfa750-4c81-11e8-b3d7-01146121b73d;visualization:vega:ed78a660-53a0-11e8-acbd-0be0ad9d822b'
               )
             ),
           retry,
@@ -301,7 +302,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
               url: '/view/7adfa750-4c81-11e8-b3d7-01146121b73d',
               child: {
                 type: 'visualization',
-                name: 'Vega',
+                name: 'vega',
                 id: 'ed78a660-53a0-11e8-acbd-0be0ad9d822b',
                 description: '[Flights] Airport Connections (Hover Over Airport)',
                 url: '/app/visualize#/edit/ed78a660-53a0-11e8-acbd-0be0ad9d822b',
@@ -317,7 +318,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           predicate: (record) =>
             Boolean(
               record.http?.request?.id?.includes(
-                'kibana:application:dashboard:7adfa750-4c81-11e8-b3d7-01146121b73d;visualization:Tag cloud:293b5a30-4c8f-11e8-b3d7-01146121b73d'
+                'kibana:application:dashboard:7adfa750-4c81-11e8-b3d7-01146121b73d;visualization:tagcloud:293b5a30-4c8f-11e8-b3d7-01146121b73d'
               )
             ),
           retry,
@@ -334,7 +335,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
               url: '/view/7adfa750-4c81-11e8-b3d7-01146121b73d',
               child: {
                 type: 'visualization',
-                name: 'Tag cloud',
+                name: 'tagcloud',
                 id: '293b5a30-4c8f-11e8-b3d7-01146121b73d',
                 description: '[Flights] Destination Weather',
                 url: '/app/visualize#/edit/293b5a30-4c8f-11e8-b3d7-01146121b73d',
@@ -350,7 +351,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           predicate: (record) =>
             Boolean(
               record.http?.request?.id?.includes(
-                'kibana:application:dashboard:7adfa750-4c81-11e8-b3d7-01146121b73d;visualization:Vertical bar:9886b410-4c8b-11e8-b3d7-01146121b73d'
+                'kibana:application:dashboard:7adfa750-4c81-11e8-b3d7-01146121b73d;visualization:histogram:9886b410-4c8b-11e8-b3d7-01146121b73d'
               )
             ),
           retry,
@@ -367,7 +368,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
               url: '/view/7adfa750-4c81-11e8-b3d7-01146121b73d',
               child: {
                 type: 'visualization',
-                name: 'Vertical bar',
+                name: 'histogram',
                 id: '9886b410-4c8b-11e8-b3d7-01146121b73d',
                 description: '[Flights] Delay Buckets',
                 url: '/app/visualize#/edit/9886b410-4c8b-11e8-b3d7-01146121b73d',

--- a/x-pack/test/functional_execution_context/tests/server.ts
+++ b/x-pack/test/functional_execution_context/tests/server.ts
@@ -73,7 +73,7 @@ export default function ({ getService }: FtrProviderContext) {
           Boolean(
             // exclude part with taskId
             record.http?.request?.id?.includes(
-              `kibana:task manager:run alerting:test.executionContext:`
+              `kibana:task%20manager:run%20alerting%3Atest.executionContext:`
             )
           ),
         retry,
@@ -84,7 +84,7 @@ export default function ({ getService }: FtrProviderContext) {
           'alerting execution context propagates to Elasticsearch via "x-opaque-id" header',
         predicate: (record) =>
           Boolean(
-            record.http?.request?.id?.includes(`alert:execute test.executionContext:${alertId}`)
+            record.http?.request?.id?.includes(`alert:execute%20test.executionContext:${alertId}`)
           ),
         retry,
       });


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/125700

- Encode all of the context's fields when converting to its `x-opaque-id` value
- Get back to using the `name` of the vis when creating context instead of `title`

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
