### PR TITLE
[Fleet] readded missing packages to keep up to date list

### DIFF
--- a/x-pack/plugins/fleet/common/constants/preconfiguration.ts
+++ b/x-pack/plugins/fleet/common/constants/preconfiguration.ts
@@ -30,7 +30,7 @@ export const AUTO_UPGRADE_POLICIES_PACKAGES = autoUpgradePoliciesPackages.map((n
   version: PRECONFIGURATION_LATEST_KEYWORD,
 }));
 
-export const DEFAULT_PACKAGES = [
+export const FLEET_PACKAGES = [
   FLEET_SYSTEM_PACKAGE,
   FLEET_ELASTIC_AGENT_PACKAGE,
   FLEET_SERVER_PACKAGE,
@@ -41,7 +41,7 @@ export const DEFAULT_PACKAGES = [
 
 // Controls whether the `Keep Policies up to date` setting is exposed to the user
 export const KEEP_POLICIES_UP_TO_DATE_PACKAGES = uniqBy(
-  [...AUTO_UPGRADE_POLICIES_PACKAGES, ...DEFAULT_PACKAGES, ...AUTO_UPDATE_PACKAGES],
+  [...AUTO_UPGRADE_POLICIES_PACKAGES, ...FLEET_PACKAGES, ...AUTO_UPDATE_PACKAGES],
   ({ name }) => name
 );
 

--- a/x-pack/plugins/fleet/common/constants/preconfiguration.ts
+++ b/x-pack/plugins/fleet/common/constants/preconfiguration.ts
@@ -7,6 +7,8 @@
 
 import { uniqBy } from 'lodash';
 
+import { FLEET_ELASTIC_AGENT_PACKAGE, FLEET_SERVER_PACKAGE, FLEET_SYSTEM_PACKAGE } from '.';
+
 import { autoUpdatePackages, autoUpgradePoliciesPackages } from './epm';
 
 // UUID v5 values require a namespace. We use UUID v5 for some of our preconfigured ID values.
@@ -28,9 +30,18 @@ export const AUTO_UPGRADE_POLICIES_PACKAGES = autoUpgradePoliciesPackages.map((n
   version: PRECONFIGURATION_LATEST_KEYWORD,
 }));
 
+export const DEFAULT_PACKAGES = [
+  FLEET_SYSTEM_PACKAGE,
+  FLEET_ELASTIC_AGENT_PACKAGE,
+  FLEET_SERVER_PACKAGE,
+].map((name) => ({
+  name,
+  version: PRECONFIGURATION_LATEST_KEYWORD,
+}));
+
 // Controls whether the `Keep Policies up to date` setting is exposed to the user
 export const KEEP_POLICIES_UP_TO_DATE_PACKAGES = uniqBy(
-  [...AUTO_UPGRADE_POLICIES_PACKAGES, ...AUTO_UPDATE_PACKAGES],
+  [...AUTO_UPGRADE_POLICIES_PACKAGES, ...DEFAULT_PACKAGES, ...AUTO_UPDATE_PACKAGES],
   ({ name }) => name
 );
 


### PR DESCRIPTION
## Summary

Fixed bug introduced in https://github.com/elastic/kibana/pull/121628/files#diff-906d1d4c2213a91b312c0572a63424c4a08638157ebb500c1d08c8f6695c61fa
Packages system, elastic_agent, fleet_server were removed from the list of keep policies up to date, meaning that the UI doesn't show the keep up to date switch on these.
This pr adds them back.

Bug: switch not visible on e.g. elastic agent integration settings

<img width="981" alt="image" src="https://user-images.githubusercontent.com/90178898/154275145-9f56d194-0ff8-476f-84b1-50b929f8b273.png">

After the fix: 
<img width="966" alt="image" src="https://user-images.githubusercontent.com/90178898/154275645-41cea760-2a66-4a54-8eb9-0b8d0c2036d6.png">
