### PR TITLE
[8.1] [Fleet] Do not mutate package policy update object  (#125622)

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -363,11 +363,11 @@ class PackagePolicyService {
     soClient: SavedObjectsClientContract,
     esClient: ElasticsearchClient,
     id: string,
-    packagePolicy: UpdatePackagePolicy,
+    packagePolicyUpdate: UpdatePackagePolicy,
     options?: { user?: AuthenticatedUser },
     currentVersion?: string
   ): Promise<PackagePolicy> {
-    packagePolicy.name = packagePolicy.name.trim();
+    const packagePolicy = { ...packagePolicyUpdate, name: packagePolicyUpdate.name.trim() };
     const oldPackagePolicy = await this.get(soClient, id);
     const { version, ...restOfPackagePolicy } = packagePolicy;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Fleet] Do not mutate package policy update object  (#125622)](https://github.com/elastic/kibana/pull/125622)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)