### PR TITLE
[Fleet] Remove unused api_key property from the output model

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -4226,9 +4226,6 @@
           "ca_trusted_fingerprint": {
             "type": "string"
           },
-          "api_key": {
-            "type": "string"
-          },
           "config": {
             "type": "object"
           },

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2664,8 +2664,6 @@ components:
           type: string
         ca_trusted_fingerprint:
           type: string
-        api_key:
-          type: string
         config:
           type: object
         config_yaml:

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/output.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/output.yaml
@@ -20,8 +20,6 @@ properties:
     type: string
   ca_trusted_fingerprint:
     type: string
-  api_key:
-    type: string
   config:
     type: object
   config_yaml:

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -75,7 +75,7 @@ export interface FullAgentPolicyOutputPermissions {
   };
 }
 
-export type FullAgentPolicyOutput = Pick<Output, 'type' | 'hosts' | 'ca_sha256' | 'api_key'> & {
+export type FullAgentPolicyOutput = Pick<Output, 'type' | 'hosts' | 'ca_sha256'> & {
   [key: string]: any;
 };
 

--- a/x-pack/plugins/fleet/common/types/models/output.ts
+++ b/x-pack/plugins/fleet/common/types/models/output.ts
@@ -18,7 +18,6 @@ export interface NewOutput {
   hosts?: string[];
   ca_sha256?: string;
   ca_trusted_fingerprint?: string;
-  api_key?: string;
   config_yaml?: string;
   is_preconfigured?: boolean;
 }

--- a/x-pack/plugins/fleet/server/services/agent_policies/__snapshots__/full_agent_policy.test.ts.snap
+++ b/x-pack/plugins/fleet/server/services/agent_policies/__snapshots__/full_agent_policy.test.ts.snap
@@ -46,7 +46,6 @@ Object {
   },
   "outputs": Object {
     "data-output-id": Object {
-      "api_key": undefined,
       "ca_sha256": undefined,
       "hosts": Array [
         "http://es-data.co:9201",
@@ -54,7 +53,6 @@ Object {
       "type": "elasticsearch",
     },
     "default": Object {
-      "api_key": undefined,
       "ca_sha256": undefined,
       "hosts": Array [
         "http://127.0.0.1:9201",
@@ -112,7 +110,6 @@ Object {
   },
   "outputs": Object {
     "default": Object {
-      "api_key": undefined,
       "ca_sha256": undefined,
       "hosts": Array [
         "http://127.0.0.1:9201",
@@ -120,7 +117,6 @@ Object {
       "type": "elasticsearch",
     },
     "monitoring-output-id": Object {
-      "api_key": undefined,
       "ca_sha256": undefined,
       "hosts": Array [
         "http://es-monitoring.co:9201",
@@ -178,7 +174,6 @@ Object {
   },
   "outputs": Object {
     "data-output-id": Object {
-      "api_key": undefined,
       "ca_sha256": undefined,
       "hosts": Array [
         "http://es-data.co:9201",
@@ -186,7 +181,6 @@ Object {
       "type": "elasticsearch",
     },
     "monitoring-output-id": Object {
-      "api_key": undefined,
       "ca_sha256": undefined,
       "hosts": Array [
         "http://es-monitoring.co:9201",

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -145,7 +145,6 @@ describe('getFullAgentPolicy', () => {
           type: 'elasticsearch',
           hosts: ['http://127.0.0.1:9201'],
           ca_sha256: undefined,
-          api_key: undefined,
         },
       },
       inputs: [],
@@ -178,7 +177,6 @@ describe('getFullAgentPolicy', () => {
           type: 'elasticsearch',
           hosts: ['http://127.0.0.1:9201'],
           ca_sha256: undefined,
-          api_key: undefined,
         },
       },
       inputs: [],
@@ -213,7 +211,6 @@ describe('getFullAgentPolicy', () => {
           type: 'elasticsearch',
           hosts: ['http://127.0.0.1:9201'],
           ca_sha256: undefined,
-          api_key: undefined,
         },
       },
       inputs: [],
@@ -315,12 +312,10 @@ describe('transformOutputToFullPolicyOutput', () => {
       is_default_monitoring: false,
       name: 'test output',
       type: 'elasticsearch',
-      api_key: 'apikey123',
     });
 
     expect(policyOutput).toMatchInlineSnapshot(`
       Object {
-        "api_key": "apikey123",
         "ca_sha256": undefined,
         "hosts": Array [
           "http://host.fr",
@@ -337,7 +332,6 @@ describe('transformOutputToFullPolicyOutput', () => {
       is_default_monitoring: false,
       name: 'test output',
       type: 'elasticsearch',
-      api_key: 'apikey123',
       ca_trusted_fingerprint: 'fingerprint123',
       config_yaml: `
 test: 1234      
@@ -347,7 +341,6 @@ ssl.test: 123
 
     expect(policyOutput).toMatchInlineSnapshot(`
       Object {
-        "api_key": "apikey123",
         "ca_sha256": undefined,
         "hosts": Array [
           "http://host.fr",

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -171,19 +171,17 @@ export function transformOutputToFullPolicyOutput(
   standalone = false
 ): FullAgentPolicyOutput {
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { config_yaml, type, hosts, ca_sha256, ca_trusted_fingerprint, api_key } = output;
+  const { config_yaml, type, hosts, ca_sha256, ca_trusted_fingerprint } = output;
   const configJs = config_yaml ? safeLoad(config_yaml) : {};
   const newOutput: FullAgentPolicyOutput = {
     ...configJs,
     type,
     hosts,
     ca_sha256,
-    api_key,
     ...(ca_trusted_fingerprint ? { 'ssl.ca_trusted_fingerprint': ca_trusted_fingerprint } : {}),
   };
 
   if (standalone) {
-    delete newOutput.api_key;
     newOutput.username = '{ES_USERNAME}';
     newOutput.password = '{ES_PASSWORD}';
   }

--- a/x-pack/plugins/fleet/server/types/models/output.ts
+++ b/x-pack/plugins/fleet/server/types/models/output.ts
@@ -13,7 +13,6 @@ const OutputBaseSchema = {
   name: schema.string(),
   type: schema.oneOf([schema.literal(outputType.Elasticsearch)]),
   hosts: schema.maybe(schema.arrayOf(schema.string())),
-  api_key: schema.maybe(schema.string()),
   config: schema.maybe(schema.recordOf(schema.string(), schema.any())),
   config_yaml: schema.maybe(schema.string()),
 };


### PR DESCRIPTION
## Summary

While working on the logstash output I found we have an unused property `api_key` on the output model, that PR remove it.

The field was already removed from the saved object and was never used, so no current user should use it.