### PR TITLE
[Fleet] Hide advanced tab in Integrations when role is Fleet All Integrations Read

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -514,7 +514,7 @@ export function Detail() {
       });
     }
 
-    if (showCustomTab) {
+    if (canReadPackageSettings && showCustomTab) {
       tabs.push({
         id: 'custom',
         name: (


### PR DESCRIPTION
## Summary
Follow up of https://github.com/elastic/kibana/pull/122347

While testing we discovered that one of the requirements from the superuser removal work was missing:
For users with Fleet "All", Integration "Read", the advanced tab in the integrations details view should be hidden.

Note that this tab is only visible for Endpoint security integration.

### Testing 

- Go to Stack management -> Roles and create a new role with Fleet "All", Integration "Read"
![Screenshot 2022-02-16 at 15 39 23](https://user-images.githubusercontent.com/16084106/154309625-5c7017bb-fd6e-45b3-9178-a7e488f4403c.png)

- Go to Stack management -> Users and create a new user that has this newly minted role
![Screenshot 2022-02-16 at 15 49 57](https://user-images.githubusercontent.com/16084106/154309780-389acf1e-6fcc-4480-9aab-342c6154bf5f.png)

- Log in with the new user and navigate to Integrations. Choose Endpoint security. The tabs shouldn't have "Advanced"
![Screenshot 2022-02-16 at 17 25 30](https://user-images.githubusercontent.com/16084106/154310276-64018d2f-b85d-4849-a842-7d1f549690cc.png)

- Log in with the admin user and repeat the steps, now the tabs should have "Advanced"
![Screenshot 2022-02-16 at 17 26 04](https://user-images.githubusercontent.com/16084106/154310393-8655880f-5d0c-4280-bcc2-ebdafaf7ecd7.png)


