### PR TITLE
Switch back to name for context id to prevent character encoding issue

### DIFF
--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -401,7 +401,7 @@ export class VisualizeEmbeddable
     const parentContext = this.parent?.getInput().executionContext;
     const child: KibanaExecutionContext = {
       type: 'visualization',
-      name: this.vis.type.title,
+      name: this.vis.type.name,
       id: this.vis.id ?? 'an_unsaved_vis',
       description: this.vis.title || this.input.title || this.vis.type.name,
       url: this.output.editUrl,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/125700

Bu using the name of the vis type instead of the i18n-ified title for the request context to avoid encoding issues in http headers