### PR TITLE
[Cases] Disable isolated host metric on security solution

### DIFF
--- a/x-pack/plugins/security_solution/public/cases/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/pages/index.tsx
@@ -102,14 +102,7 @@ const CaseContainerComponent: React.FC = () => {
           basePath: CASES_PATH,
           owner: [APP_ID],
           features: {
-            metrics: [
-              'alerts.count',
-              'alerts.users',
-              'alerts.hosts',
-              'actions.isolateHost',
-              'connectors',
-              'lifespan',
-            ],
+            metrics: ['alerts.count', 'alerts.users', 'alerts.hosts', 'connectors', 'lifespan'],
           },
           refreshRef,
           onComponentInitialized,


### PR DESCRIPTION
## Summary

The metric only counts the hosts isolated only from within the case and maybe it will create confusion for our users. Also if you isolate a host from within the case and the isolation fails, cases will report the isolation host despite the failure.

## Screenshot

<img width="2314" alt="Screenshot 2022-02-17 at 11 32 15 AM" src="https://user-images.githubusercontent.com/7871006/154446905-de8d860d-1c4d-4128-a662-fa7aaa997b02.png">

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
