### PR TITLE
[8.0] [Snapshot & Restore] Fix repository types on Cloud (#125656)

### DIFF
--- a/x-pack/plugins/snapshot_restore/common/constants.ts
+++ b/x-pack/plugins/snapshot_restore/common/constants.ts
@@ -35,12 +35,15 @@ export enum REPOSITORY_TYPES {
 }
 
 // Deliberately do not include `source` as a default repository since we treat it as a flag
-export const DEFAULT_REPOSITORY_TYPES: RepositoryType[] = [
+export const ON_PREM_REPOSITORY_TYPES: RepositoryType[] = [
+  REPOSITORY_TYPES.fs,
+  REPOSITORY_TYPES.url,
+];
+
+export const MODULE_REPOSITORY_TYPES: RepositoryType[] = [
   REPOSITORY_TYPES.azure,
   REPOSITORY_TYPES.gcs,
   REPOSITORY_TYPES.s3,
-  REPOSITORY_TYPES.fs,
-  REPOSITORY_TYPES.url,
 ];
 
 export const PLUGIN_REPOSITORY_TYPES: RepositoryType[] = [REPOSITORY_TYPES.hdfs];

--- a/x-pack/plugins/snapshot_restore/server/routes/api/repositories.test.ts
+++ b/x-pack/plugins/snapshot_restore/server/routes/api/repositories.test.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { DEFAULT_REPOSITORY_TYPES, REPOSITORY_PLUGINS_MAP } from '../../../common/constants';
+import {
+  ON_PREM_REPOSITORY_TYPES,
+  MODULE_REPOSITORY_TYPES,
+  REPOSITORY_PLUGINS_MAP,
+} from '../../../common';
 import { addBasePath } from '../helpers';
 import { registerRepositoriesRoutes } from './repositories';
 import { RouterMock, routeDependencies, RequestMock } from '../../test/helpers';
@@ -253,32 +257,40 @@ describe('[Snapshot and Restore API Routes] Repositories', () => {
       path: addBasePath('repository_types'),
     };
 
-    it('should return default types if no repository plugins returned from ES', async () => {
-      catPluginsFn.mockResolvedValue({ body: {} });
+    // TODO add Cloud specific tests for repo types
+    describe('on prem', () => {
+      it('returns module types and on-prem types if no repository plugins returned from ES', async () => {
+        catPluginsFn.mockResolvedValue({ body: {} });
 
-      const expectedResponse = [...DEFAULT_REPOSITORY_TYPES];
-      await expect(router.runRequest(mockRequest)).resolves.toEqual({ body: expectedResponse });
-    });
+        const expectedResponse = [...MODULE_REPOSITORY_TYPES, ...ON_PREM_REPOSITORY_TYPES];
+        await expect(router.runRequest(mockRequest)).resolves.toEqual({ body: expectedResponse });
+      });
 
-    it('should return default types with any repository plugins returned from ES', async () => {
-      const pluginNames = Object.keys(REPOSITORY_PLUGINS_MAP);
-      const pluginTypes = Object.entries(REPOSITORY_PLUGINS_MAP).map(([key, value]) => value);
+      it('returns module types and on-prem types with any repository plugins returned from ES', async () => {
+        const pluginNames = Object.keys(REPOSITORY_PLUGINS_MAP);
+        const pluginTypes = Object.entries(REPOSITORY_PLUGINS_MAP).map(([key, value]) => value);
 
-      const mockEsResponse = [...pluginNames.map((key) => ({ component: key }))];
-      catPluginsFn.mockResolvedValue({ body: mockEsResponse });
+        const mockEsResponse = [...pluginNames.map((key) => ({ component: key }))];
+        catPluginsFn.mockResolvedValue({ body: mockEsResponse });
 
-      const expectedResponse = [...DEFAULT_REPOSITORY_TYPES, ...pluginTypes];
-      await expect(router.runRequest(mockRequest)).resolves.toEqual({ body: expectedResponse });
-    });
 
-    it('should not return non-repository plugins returned from ES', async () => {
-      const pluginNames = ['foo-plugin', 'bar-plugin'];
-      const mockEsResponse = [...pluginNames.map((key) => ({ component: key }))];
-      catPluginsFn.mockResolvedValue({ body: mockEsResponse });
+        const expectedResponse = [
+          ...MODULE_REPOSITORY_TYPES,
+          ...ON_PREM_REPOSITORY_TYPES,
+          ...pluginTypes,
+        ];
+        await expect(router.runRequest(mockRequest)).resolves.toEqual({ body: expectedResponse });
+      });
 
-      const expectedResponse = [...DEFAULT_REPOSITORY_TYPES];
+      it(`doesn't return non-repository plugins returned from ES`, async () => {
+        const pluginNames = ['foo-plugin', 'bar-plugin'];
+        const mockEsResponse = [...pluginNames.map((key) => ({ component: key }))];
+        catPluginsFn.mockResolvedValue({ body: mockEsResponse });
 
-      await expect(router.runRequest(mockRequest)).resolves.toEqual({ body: expectedResponse });
+        const expectedResponse = [...MODULE_REPOSITORY_TYPES, ...ON_PREM_REPOSITORY_TYPES];
+
+        await expect(router.runRequest(mockRequest)).resolves.toEqual({ body: expectedResponse });
+      });
     });
 
     it('should throw if ES error', async () => {

--- a/x-pack/plugins/snapshot_restore/server/routes/api/repositories.test.ts
+++ b/x-pack/plugins/snapshot_restore/server/routes/api/repositories.test.ts
@@ -273,7 +273,6 @@ describe('[Snapshot and Restore API Routes] Repositories', () => {
         const mockEsResponse = [...pluginNames.map((key) => ({ component: key }))];
         catPluginsFn.mockResolvedValue({ body: mockEsResponse });
 
-
         const expectedResponse = [
           ...MODULE_REPOSITORY_TYPES,
           ...ON_PREM_REPOSITORY_TYPES,

--- a/x-pack/plugins/snapshot_restore/server/routes/api/repositories.ts
+++ b/x-pack/plugins/snapshot_restore/server/routes/api/repositories.ts
@@ -11,7 +11,11 @@ import type {
   SnapshotRepositorySettings,
 } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
-import { DEFAULT_REPOSITORY_TYPES, REPOSITORY_PLUGINS_MAP } from '../../../common/constants';
+import {
+  ON_PREM_REPOSITORY_TYPES,
+  REPOSITORY_PLUGINS_MAP,
+  MODULE_REPOSITORY_TYPES,
+} from '../../../common';
 import { Repository, RepositoryType } from '../../../common/types';
 import { RouteDependencies } from '../../types';
 import { addBasePath } from '../helpers';
@@ -158,8 +162,11 @@ export function registerRepositoriesRoutes({
     { path: addBasePath('repository_types'), validate: false },
     license.guardApiRoute(async (ctx, req, res) => {
       const { client: clusterClient } = ctx.core.elasticsearch;
-      // In ECE/ESS, do not enable the default types
-      const types: RepositoryType[] = isCloudEnabled ? [] : [...DEFAULT_REPOSITORY_TYPES];
+      // module repo types are available everywhere out of the box
+      // on-prem repo types are not available on Cloud
+      const types: RepositoryType[] = isCloudEnabled
+        ? [...MODULE_REPOSITORY_TYPES]
+        : [...MODULE_REPOSITORY_TYPES, ...ON_PREM_REPOSITORY_TYPES];
 
       try {
         // Call with internal user so that the requesting user does not need `monitoring` cluster

--- a/x-pack/test/api_integration/apis/management/snapshot_restore/index.ts
+++ b/x-pack/test/api_integration/apis/management/snapshot_restore/index.ts
@@ -11,5 +11,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Snapshot and Restore', () => {
     loadTestFile(require.resolve('./policies'));
     loadTestFile(require.resolve('./snapshots'));
+    loadTestFile(require.resolve('./repositories'));
   });
 }

--- a/x-pack/test/api_integration/apis/management/snapshot_restore/repositories.ts
+++ b/x-pack/test/api_integration/apis/management/snapshot_restore/repositories.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+const API_BASE_PATH = '/api/snapshot_restore';
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const deployment = getService('deployment');
+
+  describe('snapshot repositories', function () {
+    describe('repository types', () => {
+      it('returns a list of default repository types', async () => {
+        const { body } = await supertest.get(`${API_BASE_PATH}/repository_types`).expect(200);
+
+        const isCloud = await deployment.isCloud();
+        if (isCloud) {
+          // on Cloud there are only module repo types
+          expect(body).to.eql(['azure', 'gcs', 's3']);
+        } else {
+          // on prem there are module repo types and file system and url repo types
+          expect(body).to.eql(['azure', 'gcs', 's3', 'fs', 'url']);
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[Snapshot & Restore] Fix repository types on Cloud (#125656)](https://github.com/elastic/kibana/pull/125656)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)