### PR TITLE
[8.0] [Stack Monitoring] update rules queries to support metricbeat 8.0 [fixed PR]

### DIFF
--- a/x-pack/plugins/monitoring/server/lib/alerts/create_dataset_query_filter.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/create_dataset_query_filter.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * We expect that metricset and dataset will be aligned where dataset
+ * is the full {product}.{metricset}, whereas metricset doesn't include
+ * the product, e.g. dataset is elasticsearch.cluster_stats and metricset is
+ * just cluster_stats.
+ *
+ * Unfortunately, this doesn't *always* seem to be the case, and sometimes
+ * the "metricset" value is different. For this reason, we've left these
+ * two as separate arguments to this function, at least until this is resolved.
+ *
+ * More info: https://github.com/elastic/kibana/pull/119112/files#r772605936
+ *
+ * @param  {string} type matches legacy data
+ * @param  {string} metricset matches standalone beats
+ * @param  {string} dataset matches agent integration data streams
+ */
+export const createDatasetFilter = (type: string, metricset: string, dataset: string) => ({
+  bool: {
+    should: [
+      {
+        term: {
+          type,
+        },
+      },
+      {
+        term: {
+          'metricset.name': metricset,
+        },
+      },
+      {
+        term: {
+          'data_stream.dataset': dataset,
+        },
+      },
+    ],
+    minimum_should_match: 1,
+  },
+});

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.ts
@@ -8,6 +8,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { get } from 'lodash';
 import { CCRReadExceptionsStats } from '../../../common/types/alerts';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 export async function fetchCCRReadExceptions(
   esClient: ElasticsearchClient,
@@ -26,20 +27,35 @@ export async function fetchCCRReadExceptions(
         bool: {
           filter: [
             {
-              nested: {
-                path: 'ccr_stats.read_exceptions',
-                query: {
-                  exists: {
-                    field: 'ccr_stats.read_exceptions.exception',
+              bool: {
+                should: [
+                  {
+                    nested: {
+                      ignore_unmapped: true,
+                      path: 'ccr_stats.read_exceptions',
+                      query: {
+                        exists: {
+                          field: 'ccr_stats.read_exceptions.exception',
+                        },
+                      },
+                    },
                   },
-                },
+                  {
+                    nested: {
+                      ignore_unmapped: true,
+                      path: 'elasticsearch.ccr.read_exceptions',
+                      query: {
+                        exists: {
+                          field: 'elasticsearch.ccr.read_exceptions.exception',
+                        },
+                      },
+                    },
+                  },
+                ],
+                minimum_should_match: 1,
               },
             },
-            {
-              term: {
-                type: 'ccr_stats',
-              },
-            },
+            createDatasetFilter('ccr_stats', 'ccr', 'elasticsearch.ccr'),
             {
               range: {
                 timestamp: {
@@ -78,9 +94,13 @@ export async function fetchCCRReadExceptions(
                     _source: {
                       includes: [
                         'cluster_uuid',
+                        'elasticsearch.cluster.id',
                         'ccr_stats.read_exceptions',
+                        'elasticsearch.ccr.read_exceptions',
                         'ccr_stats.shard_id',
+                        'elasticsearch.ccr.shard_id',
                         'ccr_stats.leader_index',
+                        'elasticsearch.ccr.leader.index',
                       ],
                     },
                     size: 1,
@@ -118,15 +138,19 @@ export async function fetchCCRReadExceptions(
 
     for (const followerIndexBucket of followerIndicesBuckets) {
       const followerIndex = followerIndexBucket.key;
-      const {
-        _index: monitoringIndexName,
-        _source: { ccr_stats: ccrStats, cluster_uuid: clusterUuid },
-      } = get(followerIndexBucket, 'hits.hits.hits[0]');
-      const {
-        read_exceptions: readExceptions,
-        leader_index: leaderIndex,
-        shard_id: shardId,
-      } = ccrStats;
+      const clusterUuid =
+        get(followerIndexBucket, 'hits.hits.hits[0]._source.cluster_uuid') ||
+        get(followerIndexBucket, 'hits.hits.hits[0]_source.elasticsearch.cluster.id');
+
+      const monitoringIndexName = get(followerIndexBucket, 'hits.hits.hits[0]._index');
+      const ccrStats =
+        get(followerIndexBucket, 'hits.hits.hits[0]._source.ccr_stats') ||
+        get(followerIndexBucket, 'hits.hits.hits[0]._source.elasticsearch.ccr');
+
+      const { read_exceptions: readExceptions, shard_id: shardId } = ccrStats;
+
+      const leaderIndex = ccrStats.leaderIndex || ccrStats.leader.index;
+
       const { exception: lastReadException } = readExceptions[readExceptions.length - 1];
 
       stats.push({

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_cluster_health.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_cluster_health.ts
@@ -7,6 +7,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { AlertCluster, AlertClusterHealth } from '../../../common/types/alerts';
 import { ElasticsearchSource, ElasticsearchResponse } from '../../../common/types/es';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 export async function fetchClusterHealth(
   esClient: ElasticsearchClient,
@@ -18,7 +19,9 @@ export async function fetchClusterHealth(
     index,
     filter_path: [
       'hits.hits._source.cluster_state.status',
+      'hits.hits._source.elasticsearch.cluster.stats.status',
       'hits.hits._source.cluster_uuid',
+      'hits.hits._source.elasticsearch.cluster.id',
       'hits.hits._index',
     ],
     body: {
@@ -39,11 +42,7 @@ export async function fetchClusterHealth(
                 cluster_uuid: clusters.map((cluster) => cluster.clusterUuid),
               },
             },
-            {
-              term: {
-                type: 'cluster_stats',
-              },
-            },
+            createDatasetFilter('cluster_stats', 'cluster_stats', 'elasticsearch.cluster_stats'),
             {
               range: {
                 timestamp: {
@@ -73,8 +72,9 @@ export async function fetchClusterHealth(
   const response: ElasticsearchResponse = result.body as ElasticsearchResponse;
   return (response.hits?.hits ?? []).map((hit) => {
     return {
-      health: hit._source!.cluster_state?.status,
-      clusterUuid: hit._source!.cluster_uuid,
+      health:
+        hit._source!.cluster_state?.status || hit._source!.elasticsearch?.cluster?.stats?.status,
+      clusterUuid: hit._source!.cluster_uuid || hit._source!.elasticsearch?.cluster?.id,
       ccs: hit._index.includes(':') ? hit._index.split(':')[0] : undefined,
     } as AlertClusterHealth;
   });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.ts
@@ -8,6 +8,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { get } from 'lodash';
 import { AlertCluster } from '../../../common/types/alerts';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 interface RangeFilter {
   [field: string]: {
@@ -26,18 +27,16 @@ export async function fetchClusters(
     filter_path: [
       'hits.hits._source.cluster_settings.cluster.metadata.display_name',
       'hits.hits._source.cluster_uuid',
+      'hits.hits._source.elasticsearch.cluster.id',
       'hits.hits._source.cluster_name',
+      'hits.hits._source.elasticsearch.cluster.name',
     ],
     body: {
       size: 1000,
       query: {
         bool: {
           filter: [
-            {
-              term: {
-                type: 'cluster_stats',
-              },
-            },
+            createDatasetFilter('cluster_stats', 'cluster_stats', 'elasticsearch.cluster_stats'),
             {
               range: rangeFilter,
             },
@@ -50,60 +49,17 @@ export async function fetchClusters(
     },
   };
 
-  const { body: response } = await esClient.search(params);
-  return get(response, 'hits.hits', []).map((hit: any) => {
-    const clusterName: string =
-      get(hit, '_source.cluster_settings.cluster.metadata.display_name') ||
-      get(hit, '_source.cluster_name') ||
-      get(hit, '_source.cluster_uuid');
-    return {
-      clusterUuid: get(hit, '_source.cluster_uuid'),
-      clusterName,
-    };
-  });
-}
+  const response = await esClient.search(params);
 
-export async function fetchClustersLegacy(
-  callCluster: any,
-  index: string,
-  rangeFilter: RangeFilter = { timestamp: { gte: 'now-2m' } }
-): Promise<AlertCluster[]> {
-  const params = {
-    index,
-    filter_path: [
-      'hits.hits._source.cluster_settings.cluster.metadata.display_name',
-      'hits.hits._source.cluster_uuid',
-      'hits.hits._source.cluster_name',
-    ],
-    body: {
-      size: 1000,
-      query: {
-        bool: {
-          filter: [
-            {
-              term: {
-                type: 'cluster_stats',
-              },
-            },
-            {
-              range: rangeFilter,
-            },
-          ],
-        },
-      },
-      collapse: {
-        field: 'cluster_uuid',
-      },
-    },
-  };
-  const response = await callCluster('search', params);
   return get(response, 'hits.hits', []).map((hit: any) => {
     const clusterName: string =
       get(hit, '_source.cluster_settings.cluster.metadata.display_name') ||
       get(hit, '_source.cluster_name') ||
-      get(hit, '_source.cluster_uuid');
+      get(hit, '_source.elasticsearch.cluster.name') ||
+      get(hit, '_source.cluster_uuid') ||
+      get(hit, '_source.elasticsearch.cluster.id');
     return {
-      clusterUuid: get(hit, '_source.cluster_uuid'),
+      clusterUuid: get(hit, '_source.cluster_uuid') || get(hit, '_source.elasticsearch.cluster.id'),
       clusterName,
     };
   });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_cpu_usage_node_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_cpu_usage_node_stats.test.ts
@@ -213,7 +213,16 @@ describe('fetchCpuUsageNodeStats', () => {
           bool: {
             filter: [
               { terms: { cluster_uuid: ['abc123'] } },
-              { term: { type: 'node_stats' } },
+              {
+                bool: {
+                  should: [
+                    { term: { type: 'node_stats' } },
+                    { term: { 'metricset.name': 'node_stats' } },
+                    { term: { 'data_stream.dataset': 'elasticsearch.node_stats' } },
+                  ],
+                  minimum_should_match: 1,
+                },
+              },
               { range: { timestamp: { format: 'epoch_millis', gte: 0, lte: 0 } } },
               {
                 bool: { should: [{ exists: { field: 'cluster_uuid' } }], minimum_should_match: 1 },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_cpu_usage_node_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_cpu_usage_node_stats.ts
@@ -10,6 +10,7 @@ import { get } from 'lodash';
 import moment from 'moment';
 import { NORMALIZED_DERIVATIVE_UNIT } from '../../../common/constants';
 import { AlertCluster, AlertCpuUsageNodeStats } from '../../../common/types/alerts';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 interface NodeBucketESResponse {
   key: string;
@@ -48,11 +49,7 @@ export async function fetchCpuUsageNodeStats(
                 cluster_uuid: clusters.map((cluster) => cluster.clusterUuid),
               },
             },
-            {
-              term: {
-                type: 'node_stats',
-              },
-            },
+            createDatasetFilter('node_stats', 'node_stats', 'elasticsearch.node_stats'),
             {
               range: {
                 timestamp: {

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_disk_usage_node_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_disk_usage_node_stats.ts
@@ -8,6 +8,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { get } from 'lodash';
 import { AlertCluster, AlertDiskUsageNodeStats } from '../../../common/types/alerts';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 export async function fetchDiskUsageNodeStats(
   esClient: ElasticsearchClient,
@@ -31,11 +32,7 @@ export async function fetchDiskUsageNodeStats(
                 cluster_uuid: clustersIds,
               },
             },
-            {
-              term: {
-                type: 'node_stats',
-              },
-            },
+            createDatasetFilter('node_stats', 'node_stats', 'elasticsearch.node_stats'),
             {
               range: {
                 timestamp: {

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_index_shard_size.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_index_shard_size.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock } from 'src/core/server/mocks';
+import { fetchIndexShardSize } from './fetch_index_shard_size';
+
+jest.mock('../../static_globals', () => ({
+  Globals: {
+    app: {
+      getKeyStoreValue: () => '*',
+      config: {
+        ui: {
+          ccs: { enabled: true },
+        },
+      },
+    },
+  },
+}));
+import { Globals } from '../../static_globals';
+
+describe('fetchIndexShardSize', () => {
+  const esClient = elasticsearchServiceMock.createScopedClusterClient().asCurrentUser;
+
+  const clusters = [
+    {
+      clusterUuid: 'cluster123',
+      clusterName: 'test-cluster',
+    },
+  ];
+  const size = 10;
+  const shardIndexPatterns = '*';
+  const threshold = 0.00000001;
+  const esRes = {
+    aggregations: {
+      clusters: {
+        buckets: [
+          {
+            key: 'NG2d5jHiSBGPE6HLlUN2Bg',
+            doc_count: 60,
+            index: {
+              doc_count_error_upper_bound: 0,
+              sum_other_doc_count: 0,
+              buckets: [
+                {
+                  key: '.monitoring-es-7-2022.01.27',
+                  doc_count: 30,
+                  hits: {
+                    hits: {
+                      total: {
+                        value: 30,
+                        relation: 'eq',
+                      },
+                      max_score: null,
+                      hits: [
+                        {
+                          _index: '.monitoring-es-7-2022.01.27',
+                          _id: 'JVkunX4BfK-FILsH9Wr_',
+                          _score: null,
+                          _source: {
+                            index_stats: {
+                              shards: {
+                                primaries: 1,
+                              },
+                              primaries: {
+                                store: {
+                                  size_in_bytes: 3537949,
+                                },
+                              },
+                            },
+                          },
+                          sort: [1643314607570],
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  key: '.monitoring-kibana-7-2022.01.27',
+                  doc_count: 30,
+                  hits: {
+                    hits: {
+                      total: {
+                        value: 30,
+                        relation: 'eq',
+                      },
+                      max_score: null,
+                      hits: [
+                        {
+                          _index: '.monitoring-es-7-2022.01.27',
+                          _id: 'JFkunX4BfK-FILsH9Wr_',
+                          _score: null,
+                          _source: {
+                            index_stats: {
+                              shards: {
+                                primaries: 1,
+                              },
+                              primaries: {
+                                store: {
+                                  size_in_bytes: 1017426,
+                                },
+                              },
+                            },
+                          },
+                          sort: [1643314607570],
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+  it('fetch as expected', async () => {
+    esClient.search.mockResponse(
+      // @ts-expect-error not full response interface
+      esRes
+    );
+
+    const result = await fetchIndexShardSize(
+      esClient,
+      clusters,
+      threshold,
+      shardIndexPatterns,
+      size
+    );
+    expect(result).toEqual([
+      {
+        ccs: undefined,
+        shardIndex: '.monitoring-es-7-2022.01.27',
+        shardSize: 0,
+        clusterUuid: 'NG2d5jHiSBGPE6HLlUN2Bg',
+      },
+      {
+        ccs: undefined,
+        shardIndex: '.monitoring-kibana-7-2022.01.27',
+        shardSize: 0,
+        clusterUuid: 'NG2d5jHiSBGPE6HLlUN2Bg',
+      },
+    ]);
+  });
+  it('should call ES with correct query', async () => {
+    await fetchIndexShardSize(esClient, clusters, threshold, shardIndexPatterns, size);
+    expect(esClient.search).toHaveBeenCalledWith({
+      index:
+        '*:.monitoring-es-*,.monitoring-es-*,*:metrics-elasticsearch.index-*,metrics-elasticsearch.index-*',
+      filter_path: ['aggregations.clusters.buckets'],
+      body: {
+        size: 0,
+        query: {
+          bool: {
+            filter: [
+              {
+                bool: {
+                  should: [
+                    { term: { type: 'index_stats' } },
+                    { term: { 'metricset.name': 'index' } },
+                    { term: { 'data_stream.dataset': 'elasticsearch.index' } },
+                  ],
+                  minimum_should_match: 1,
+                },
+              },
+              { range: { timestamp: { gte: 'now-5m' } } },
+            ],
+          },
+        },
+        aggs: {
+          clusters: {
+            terms: { include: ['cluster123'], field: 'cluster_uuid', size: 10 },
+            aggs: {
+              index: {
+                terms: { field: 'index_stats.index', size: 10 },
+                aggs: {
+                  hits: {
+                    top_hits: {
+                      sort: [{ timestamp: { order: 'desc', unmapped_type: 'long' } }],
+                      _source: {
+                        includes: [
+                          '_index',
+                          'index_stats.shards.primaries',
+                          'index_stats.primaries.store.size_in_bytes',
+                          'elasticsearch.index.shards.primaries',
+                          'elasticsearch.index.primaries.store.size_in_bytes',
+                        ],
+                      },
+                      size: 1,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+  it('should call ES with correct query when ccs disabled', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = false;
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve(esRes as any);
+    });
+    await fetchIndexShardSize(esClient, clusters, threshold, shardIndexPatterns, size);
+    // @ts-ignore
+    expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.index-*');
+  });
+});

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_kibana_versions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_kibana_versions.ts
@@ -7,6 +7,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { get } from 'lodash';
 import { AlertCluster, AlertVersions } from '../../../common/types/alerts';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 interface ESAggResponse {
   key: string;
@@ -32,11 +33,7 @@ export async function fetchKibanaVersions(
                 cluster_uuid: clusters.map((cluster) => cluster.clusterUuid),
               },
             },
-            {
-              term: {
-                type: 'kibana_stats',
-              },
-            },
+            createDatasetFilter('kibana_stats', 'stats', 'kibana.stats'),
             {
               range: {
                 timestamp: {

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_licenses.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_licenses.ts
@@ -7,6 +7,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { AlertLicense, AlertCluster } from '../../../common/types/alerts';
 import { ElasticsearchSource } from '../../../common/types/es';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 export async function fetchLicenses(
   esClient: ElasticsearchClient,
@@ -18,7 +19,9 @@ export async function fetchLicenses(
     index,
     filter_path: [
       'hits.hits._source.license.*',
+      'hits.hits._source.elasticsearch.cluster.stats.license.*',
       'hits.hits._source.cluster_uuid',
+      'hits.hits._source.elasticsearch.cluster.id',
       'hits.hits._index',
     ],
     body: {
@@ -39,11 +42,7 @@ export async function fetchLicenses(
                 cluster_uuid: clusters.map((cluster) => cluster.clusterUuid),
               },
             },
-            {
-              term: {
-                type: 'cluster_stats',
-              },
-            },
+            createDatasetFilter('cluster_stats', 'cluster_stats', 'elasticsearch.cluster_stats'),
             {
               range: {
                 timestamp: {
@@ -72,12 +71,13 @@ export async function fetchLicenses(
   const { body: response } = await esClient.search<ElasticsearchSource>(params);
   return (
     response?.hits?.hits.map((hit) => {
-      const rawLicense = hit._source!.license ?? {};
+      const rawLicense =
+        hit._source!.license ?? hit._source?.elasticsearch?.cluster?.stats?.license ?? {};
       const license: AlertLicense = {
         status: rawLicense.status ?? '',
         type: rawLicense.type ?? '',
         expiryDateMS: rawLicense.expiry_date_in_millis ?? 0,
-        clusterUuid: hit._source!.cluster_uuid,
+        clusterUuid: hit._source?.elasticsearch?.cluster?.id || hit._source!.cluster_uuid,
         ccs: hit._index,
       };
       return license;

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_logstash_versions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_logstash_versions.ts
@@ -7,6 +7,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { get } from 'lodash';
 import { AlertCluster, AlertVersions } from '../../../common/types/alerts';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 interface ESAggResponse {
   key: string;
@@ -32,11 +33,7 @@ export async function fetchLogstashVersions(
                 cluster_uuid: clusters.map((cluster) => cluster.clusterUuid),
               },
             },
-            {
-              term: {
-                type: 'logstash_stats',
-              },
-            },
+            createDatasetFilter('logstash_stats', 'node_stats', 'logstash.node_stats'),
             {
               range: {
                 timestamp: {

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// eslint-disable-next-line @kbn/eslint/no-restricted-paths
+import { elasticsearchClientMock } from '../../../../../../src/core/server/elasticsearch/client/mocks';
+import { fetchMemoryUsageNodeStats } from './fetch_memory_usage_node_stats';
+
+jest.mock('../../static_globals', () => ({
+  Globals: {
+    app: {
+      config: {
+        ui: {
+          ccs: { enabled: true },
+        },
+      },
+    },
+  },
+}));
+import { Globals } from '../../static_globals';
+
+describe('fetchMemoryUsageNodeStats', () => {
+  const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
+  const clusters = [
+    {
+      clusterUuid: 'abc123',
+      clusterName: 'test',
+    },
+  ];
+  const startMs = 0;
+  const endMs = 0;
+  const size = 10;
+
+  const esRes = {
+    aggregations: {
+      clusters: {
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0,
+        buckets: [
+          {
+            key: 'NG2d5jHiSBGPE6HLlUN2Bg',
+            doc_count: 30,
+            nodes: {
+              doc_count_error_upper_bound: 0,
+              sum_other_doc_count: 0,
+              buckets: [
+                {
+                  key: 'qrLmmSBMSXGSfciYLjL3GA',
+                  doc_count: 30,
+                  cluster_uuid: {
+                    doc_count_error_upper_bound: 0,
+                    sum_other_doc_count: 0,
+                    buckets: [
+                      {
+                        key: 'NG2d5jHiSBGPE6HLlUN2Bg',
+                        doc_count: 30,
+                      },
+                    ],
+                  },
+                  avg_heap: {
+                    value: 46.3,
+                  },
+                  name: {
+                    doc_count_error_upper_bound: 0,
+                    sum_other_doc_count: 0,
+                    buckets: [
+                      {
+                        key: 'desktop-dca-192-168-162-170.endgames.local',
+                        doc_count: 30,
+                      },
+                    ],
+                  },
+                  index: {
+                    doc_count_error_upper_bound: 0,
+                    sum_other_doc_count: 0,
+                    buckets: [
+                      {
+                        key: '.monitoring-es-7-2022.01.27',
+                        doc_count: 30,
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  it('fetch stats', async () => {
+    esClient.search.mockResponse(
+      // @ts-expect-error not full response interface
+      esRes
+    );
+    const result = await fetchMemoryUsageNodeStats(esClient, clusters, startMs, endMs, size);
+    expect(result).toEqual([
+      {
+        memoryUsage: 46,
+        clusterUuid: 'NG2d5jHiSBGPE6HLlUN2Bg',
+        nodeId: 'qrLmmSBMSXGSfciYLjL3GA',
+        nodeName: 'desktop-dca-192-168-162-170.endgames.local',
+        ccs: null,
+      },
+    ]);
+  });
+
+  it('should call ES with correct query', async () => {
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve(esRes as any);
+    });
+    await fetchMemoryUsageNodeStats(esClient, clusters, startMs, endMs, size);
+    expect(params).toStrictEqual({
+      index:
+        '*:.monitoring-es-*,.monitoring-es-*,*:metrics-elasticsearch.node_stats-*,metrics-elasticsearch.node_stats-*',
+      filter_path: ['aggregations'],
+      body: {
+        size: 0,
+        query: {
+          bool: {
+            filter: [
+              { terms: { cluster_uuid: ['abc123'] } },
+              {
+                bool: {
+                  should: [
+                    { term: { type: 'node_stats' } },
+                    { term: { 'metricset.name': 'node_stats' } },
+                    { term: { 'data_stream.dataset': 'elasticsearch.node_stats' } },
+                  ],
+                  minimum_should_match: 1,
+                },
+              },
+              { range: { timestamp: { format: 'epoch_millis', gte: 0, lte: 0 } } },
+            ],
+          },
+        },
+        aggs: {
+          clusters: {
+            terms: { field: 'cluster_uuid', size: 10 },
+            aggs: {
+              nodes: {
+                terms: { field: 'source_node.uuid', size: 10 },
+                aggs: {
+                  index: { terms: { field: '_index', size: 1 } },
+                  avg_heap: { avg: { field: 'node_stats.jvm.mem.heap_used_percent' } },
+                  cluster_uuid: { terms: { field: 'cluster_uuid', size: 1 } },
+                  name: { terms: { field: 'source_node.name', size: 1 } },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+  it('should call ES with correct query  when ccs disabled', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = false;
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve(esRes as any);
+    });
+    await fetchMemoryUsageNodeStats(esClient, clusters, startMs, endMs, size);
+    // @ts-ignore
+    expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.node_stats-*');
+  });
+});

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.ts
@@ -8,6 +8,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { get } from 'lodash';
 import { AlertCluster, AlertMemoryUsageNodeStats } from '../../../common/types/alerts';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 export async function fetchMemoryUsageNodeStats(
   esClient: ElasticsearchClient,
@@ -32,11 +33,7 @@ export async function fetchMemoryUsageNodeStats(
                 cluster_uuid: clustersIds,
               },
             },
-            {
-              term: {
-                type: 'node_stats',
-              },
-            },
+            createDatasetFilter('node_stats', 'node_stats', 'elasticsearch.node_stats'),
             {
               range: {
                 timestamp: {

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_missing_monitoring_data.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_missing_monitoring_data.ts
@@ -8,6 +8,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { get } from 'lodash';
 import { AlertCluster, AlertMissingData } from '../../../common/types/alerts';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 interface ClusterBucketESResponse {
   key: string;
@@ -64,6 +65,7 @@ export async function fetchMissingMonitoringData(
                 cluster_uuid: clusters.map((cluster) => cluster.clusterUuid),
               },
             },
+            createDatasetFilter('node_stats', 'node_stats', 'elasticsearch.node_stats'),
             {
               range: {
                 timestamp: {
@@ -106,7 +108,7 @@ export async function fetchMissingMonitoringData(
                       },
                     ],
                     _source: {
-                      includes: ['_index', 'source_node.name'],
+                      includes: ['source_node.name', 'elasticsearch.node.name'],
                     },
                   },
                 },
@@ -142,7 +144,10 @@ export async function fetchMissingMonitoringData(
       const nodeId = uuidBucket.key;
       const indexName = get(uuidBucket, `document.hits.hits[0]._index`);
       const differenceInMs = nowInMs - uuidBucket.most_recent.value;
-      const nodeName = get(uuidBucket, `document.hits.hits[0]._source.source_node.name`, nodeId);
+      const nodeName =
+        get(uuidBucket, `document.hits.hits[0]._source.source_node.name`) ||
+        get(uuidBucket, `document.hits.hits[0]._source.elasticsearch.node.name`) ||
+        nodeId;
 
       uniqueList[`${clusterUuid}${nodeId}`] = {
         nodeId,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// eslint-disable-next-line @kbn/eslint/no-restricted-paths
+import { elasticsearchClientMock } from '../../../../../../src/core/server/elasticsearch/client/mocks';
+import { fetchNodesFromClusterStats } from './fetch_nodes_from_cluster_stats';
+
+jest.mock('../../static_globals', () => ({
+  Globals: {
+    app: {
+      config: {
+        ui: {
+          ccs: { enabled: true },
+        },
+      },
+    },
+  },
+}));
+import { Globals } from '../../static_globals';
+
+describe('fetchNodesFromClusterStats', () => {
+  const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
+  const clusters = [
+    {
+      clusterUuid: 'NG2d5jHiSBGPE6HLlUN2Bg',
+      clusterName: 'elasticsearch',
+    },
+  ];
+
+  const esRes = {
+    aggregations: {
+      clusters: {
+        buckets: [
+          {
+            key: 'NG2d5jHiSBGPE6HLlUN2Bg',
+            doc_count: 12,
+            top: {
+              hits: {
+                total: { value: 12, relation: 'eq' },
+                max_score: null,
+                hits: [
+                  {
+                    _index: '.monitoring-es-7-2022.01.27',
+                    _id: 'IlmvnX4BfK-FILsH34eS',
+                    _score: null,
+                    _source: {
+                      cluster_state: {
+                        nodes_hash: 858284333,
+                        nodes: {
+                          qrLmmSBMSXGSfciYLjL3GA: {
+                            transport_address: '127.0.0.1:9300',
+                            roles: [
+                              'data',
+                              'data_cold',
+                              'data_content',
+                              'data_frozen',
+                              'data_hot',
+                              'data_warm',
+                              'ingest',
+                              'master',
+                              'ml',
+                              'remote_cluster_client',
+                              'transform',
+                            ],
+                            name: 'desktop-dca-192-168-162-170.endgames.local',
+                            attributes: {
+                              'ml.machine_memory': '34359738368',
+                              'xpack.installed': 'true',
+                              'ml.max_jvm_size': '1610612736',
+                            },
+                            ephemeral_id: 'cCXPWB3nSoKkl_m_q2nPFQ',
+                          },
+                        },
+                      },
+                    },
+                    sort: [1643323056014],
+                  },
+                  {
+                    _index: '.monitoring-es-7-2022.01.27',
+                    _id: 'GVmvnX4BfK-FILsHuIeF',
+                    _score: null,
+                    _source: {
+                      cluster_state: {
+                        nodes_hash: 858284333,
+                        nodes: {
+                          qrLmmSBMSXGSfciYLjL3GA: {
+                            transport_address: '127.0.0.1:9300',
+                            roles: [
+                              'data',
+                              'data_cold',
+                              'data_content',
+                              'data_frozen',
+                              'data_hot',
+                              'data_warm',
+                              'ingest',
+                              'master',
+                              'ml',
+                              'remote_cluster_client',
+                              'transform',
+                            ],
+                            name: 'desktop-dca-192-168-162-170.endgames.local',
+                            attributes: {
+                              'ml.machine_memory': '34359738368',
+                              'xpack.installed': 'true',
+                              'ml.max_jvm_size': '1610612736',
+                            },
+                            ephemeral_id: 'cCXPWB3nSoKkl_m_q2nPFQ',
+                          },
+                        },
+                      },
+                    },
+                    sort: [1643323046019],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  it('fetch stats', async () => {
+    esClient.search.mockResponse(
+      // @ts-expect-error not full response interface
+      esRes
+    );
+    const result = await fetchNodesFromClusterStats(esClient, clusters);
+    expect(result).toEqual([
+      {
+        clusterUuid: 'NG2d5jHiSBGPE6HLlUN2Bg',
+        recentNodes: [
+          {
+            nodeUuid: 'qrLmmSBMSXGSfciYLjL3GA',
+            nodeEphemeralId: 'cCXPWB3nSoKkl_m_q2nPFQ',
+            nodeName: 'desktop-dca-192-168-162-170.endgames.local',
+          },
+        ],
+        priorNodes: [
+          {
+            nodeUuid: 'qrLmmSBMSXGSfciYLjL3GA',
+            nodeEphemeralId: 'cCXPWB3nSoKkl_m_q2nPFQ',
+            nodeName: 'desktop-dca-192-168-162-170.endgames.local',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should call ES with correct query', async () => {
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve(esRes as any);
+    });
+    await fetchNodesFromClusterStats(esClient, clusters);
+    expect(params).toStrictEqual({
+      index:
+        '*:.monitoring-es-*,.monitoring-es-*,*:metrics-elasticsearch.cluster_stats-*,metrics-elasticsearch.cluster_stats-*',
+      filter_path: ['aggregations.clusters.buckets'],
+      body: {
+        size: 0,
+        sort: [{ timestamp: { order: 'desc', unmapped_type: 'long' } }],
+        query: {
+          bool: {
+            filter: [
+              {
+                bool: {
+                  should: [
+                    { term: { type: 'cluster_stats' } },
+                    { term: { 'metricset.name': 'cluster_stats' } },
+                    { term: { 'data_stream.dataset': 'elasticsearch.cluster_stats' } },
+                  ],
+                  minimum_should_match: 1,
+                },
+              },
+              { range: { timestamp: { gte: 'now-2m' } } },
+            ],
+          },
+        },
+        aggs: {
+          clusters: {
+            terms: { include: ['NG2d5jHiSBGPE6HLlUN2Bg'], field: 'cluster_uuid' },
+            aggs: {
+              top: {
+                top_hits: {
+                  sort: [{ timestamp: { order: 'desc', unmapped_type: 'long' } }],
+                  _source: {
+                    includes: ['cluster_state.nodes', 'elasticsearch.cluster.stats.nodes'],
+                  },
+                  size: 2,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+  it('should call ES with correct query  when ccs disabled', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = false;
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve(esRes as any);
+    });
+    await fetchNodesFromClusterStats(esClient, clusters);
+    // @ts-ignore
+    expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.cluster_stats-*');
+  });
+});

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.ts
@@ -7,6 +7,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { AlertCluster, AlertClusterStatsNodes } from '../../../common/types/alerts';
 import { ElasticsearchSource } from '../../../common/types/es';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 function formatNode(
   nodes: NonNullable<NonNullable<ElasticsearchSource['cluster_state']>['nodes']> | undefined
@@ -45,11 +46,7 @@ export async function fetchNodesFromClusterStats(
       query: {
         bool: {
           filter: [
-            {
-              term: {
-                type: 'cluster_stats',
-              },
-            },
+            createDatasetFilter('cluster_stats', 'cluster_stats', 'elasticsearch.cluster_stats'),
             {
               range: {
                 timestamp: {
@@ -78,7 +75,7 @@ export async function fetchNodesFromClusterStats(
                   },
                 ],
                 _source: {
-                  includes: ['cluster_state.nodes_hash', 'cluster_state.nodes'],
+                  includes: ['cluster_state.nodes', 'elasticsearch.cluster.stats.nodes'],
                 },
                 size: 2,
               },
@@ -111,8 +108,12 @@ export async function fetchNodesFromClusterStats(
     const indexName = hits[0]._index;
     nodes.push({
       clusterUuid,
-      recentNodes: formatNode(hits[0]._source.cluster_state?.nodes),
-      priorNodes: formatNode(hits[1]._source.cluster_state?.nodes),
+      recentNodes: formatNode(
+        hits[0]._source.cluster_state?.nodes || hits[0]._source.elasticsearch.cluster.stats.nodes
+      ),
+      priorNodes: formatNode(
+        hits[1]._source.cluster_state?.nodes || hits[1]._source.elasticsearch.cluster.stats.nodes
+      ),
       ccs: indexName.includes(':') ? indexName.split(':')[0] : undefined,
     });
   }

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_thread_pool_rejections_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_thread_pool_rejections_stats.ts
@@ -8,6 +8,7 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { get } from 'lodash';
 import { AlertCluster, AlertThreadPoolRejectionsStats } from '../../../common/types/alerts';
+import { createDatasetFilter } from './create_dataset_query_filter';
 
 const invalidNumberValue = (value: number) => {
   return isNaN(value) || value === undefined || value === null;
@@ -24,7 +25,12 @@ const getTopHits = (threadType: string, order: 'asc' | 'desc') => ({
       },
     ],
     _source: {
-      includes: [`node_stats.thread_pool.${threadType}.rejected`, 'source_node.name'],
+      includes: [
+        `node_stats.thread_pool.${threadType}.rejected`,
+        `elasticsearch.node.stats.thread_pool.${threadType}.rejected.count`,
+        'source_node.name',
+        'elasticsearch.node.name',
+      ],
     },
     size: 1,
   },
@@ -53,11 +59,7 @@ export async function fetchThreadPoolRejectionStats(
                 cluster_uuid: clustersIds,
               },
             },
-            {
-              term: {
-                type: 'node_stats',
-              },
-            },
+            createDatasetFilter('node_stats', 'node_stats', 'elasticsearch.node_stats'),
             {
               range: {
                 timestamp: {
@@ -126,8 +128,11 @@ export async function fetchThreadPoolRejectionStats(
       }
 
       const rejectedPath = `_source.node_stats.thread_pool.${threadType}.rejected`;
-      const newRejectionCount = Number(get(mostRecentDoc, rejectedPath));
-      const oldRejectionCount = Number(get(leastRecentDoc, rejectedPath));
+      const rejectedPathEcs = `_source.elasticsearch.node.stats.thread_pool.${threadType}.rejected.count`;
+      const newRejectionCount =
+        Number(get(mostRecentDoc, rejectedPath)) || Number(get(mostRecentDoc, rejectedPathEcs));
+      const oldRejectionCount =
+        Number(get(leastRecentDoc, rejectedPath)) || Number(get(leastRecentDoc, rejectedPathEcs));
 
       if (invalidNumberValue(newRejectionCount) || invalidNumberValue(oldRejectionCount)) {
         continue;
@@ -138,7 +143,10 @@ export async function fetchThreadPoolRejectionStats(
           ? newRejectionCount
           : newRejectionCount - oldRejectionCount;
       const indexName = mostRecentDoc._index;
-      const nodeName = get(mostRecentDoc, '_source.source_node.name') || node.key;
+      const nodeName =
+        get(mostRecentDoc, '_source.source_node.name') ||
+        get(mostRecentDoc, '_source.elasticsearch.node.name') ||
+        node.key;
       const nodeStat = {
         rejectionCount,
         type: threadType,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[Stack Monitoring] update rules queries to support metricbeat 8.0 [fixed PR] (#125748)](https://github.com/elastic/kibana/pull/125748)

**Note: Backport completed manually after resolving conflicts locally.**

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)