### PR TITLE
filter for transaction name in the apm latency threshold rule type

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/fields.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/fields.tsx
@@ -12,6 +12,7 @@ import {
   SERVICE_ENVIRONMENT,
   SERVICE_NAME,
   TRANSACTION_TYPE,
+  TRANSACTION_NAME,
 } from '../../../common/elasticsearch_fieldnames';
 import {
   ENVIRONMENT_ALL,
@@ -95,6 +96,40 @@ export function EnvironmentField({
         placeholder={i18n.translate('xpack.apm.environmentsSelectPlaceholder', {
           defaultMessage: 'Select environment',
         })}
+      />
+    </PopoverExpression>
+  );
+}
+
+export function TransactionNameField({
+  currentValue,
+  onChange,
+}: {
+  currentValue: string;
+  onChange: (value?: string) => void;
+}) {
+  const label = i18n.translate('xpack.apm.alerting.fields.transactionName', {
+    defaultMessage: 'Transaction',
+  });
+  return (
+    <PopoverExpression value={currentValue || allOption.value} title={label}>
+      <SuggestionsSelect
+        allOption={allOption}
+        field={TRANSACTION_NAME}
+        defaultValue={currentValue}
+        customOptionText={i18n.translate(
+          'xpack.apm.transactionNameSelectCustomOptionText',
+          {
+            defaultMessage: 'Add \\{searchValue\\} as a new transaction name',
+          }
+        )}
+        onChange={onChange}
+        placeholder={i18n.translate(
+          'xpack.apm.transactionNameSelectPlaceholder',
+          {
+            defaultMessage: 'Select transaction name',
+          }
+        )}
       />
     </PopoverExpression>
   );

--- a/x-pack/plugins/apm/public/components/alerting/transaction_duration_alert_trigger/index.stories.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/transaction_duration_alert_trigger/index.stories.tsx
@@ -38,6 +38,7 @@ export const Example: Story = () => {
     serviceName: 'testServiceName',
     threshold: 1500,
     transactionType: 'testTransactionType',
+    transactionName: 'testTransactionName',
     windowSize: 5,
     windowUnit: 'm',
   });

--- a/x-pack/plugins/apm/public/components/alerting/transaction_duration_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/transaction_duration_alert_trigger/index.tsx
@@ -26,6 +26,7 @@ import {
   IsAboveField,
   ServiceField,
   TransactionTypeField,
+  TransactionNameField,
 } from '../fields';
 import { AlertMetadata, getIntervalAndTimeRange, TimeUnit } from '../helper';
 import { ServiceAlertTrigger } from '../service_alert_trigger';
@@ -37,6 +38,7 @@ export interface RuleParams {
   serviceName: string;
   threshold: number;
   transactionType: string;
+  transactionName: string;
   windowSize: number;
   windowUnit: string;
 }
@@ -125,7 +127,6 @@ export function TransactionDurationAlertTrigger(props: Props) {
       params.windowUnit,
     ]
   );
-
   const latencyChartPreview = data?.latencyChartPreview ?? [];
 
   const maxY = getMaxY([{ data: latencyChartPreview }]);
@@ -153,6 +154,10 @@ export function TransactionDurationAlertTrigger(props: Props) {
     <TransactionTypeField
       currentValue={params.transactionType}
       onChange={(value) => setRuleParams('transactionType', value)}
+    />,
+    <TransactionNameField
+      currentValue={params.transactionName}
+      onChange={(value) => setRuleParams('transactionName', value)}
     />,
     <EnvironmentField
       currentValue={params.environment}

--- a/x-pack/plugins/apm/server/routes/alerts/register_transaction_duration_alert_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/register_transaction_duration_alert_type.ts
@@ -46,6 +46,7 @@ import { RegisterRuleDependencies } from './register_apm_alerts';
 const paramsSchema = schema.object({
   serviceName: schema.string(),
   transactionType: schema.string(),
+  transactionName: schema.string(),
   windowSize: schema.number(),
   windowUnit: schema.string(),
   threshold: schema.number(),


### PR DESCRIPTION
In the existing Latency threshold rule type that can be found under `Stack Management > Rules and Connectors`
user can already specify the average transaction duration threshold above which they want to be notified. This PR adds a new filter for `transaction.name` in the existing`APM - Latency threshold` and fixes https://github.com/elastic/sdh-kibana/issues/2575

<img src="https://user-images.githubusercontent.com/2852703/154360664-a508ecac-77b0-4a8f-bfbf-d366670cf725.png" width="400"> <img src="https://user-images.githubusercontent.com/2852703/154360529-7b94b3a2-c71f-46ab-a9c5-9ae17745974c.png" width="400">





