### PR TITLE
[ML] Maps integration: add empty state prompt when no supported jobs exist

### DIFF
--- a/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
@@ -81,6 +81,11 @@ export class AnomalyJobSelector extends Component<Props, State> {
           }
         />
       </EuiFormRow>
-    ) : < AnomalyJobSelectorEmptyState jobsManagementPath={this.props.jobsManagementPath} canGetJobs={this.props.canGetJobs} />;
+    ) : (
+      <AnomalyJobSelectorEmptyState
+        jobsManagementPath={this.props.jobsManagementPath}
+        canGetJobs={this.props.canGetJobs}
+      />
+    );
   }
 }

--- a/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
@@ -11,10 +11,13 @@ import { EuiComboBox, EuiFormRow, EuiComboBoxOptionOption } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isEqual } from 'lodash';
 import type { MlApiServices } from '../application/services/ml_api_service';
+import { AnomalyJobSelectorEmptyState } from './anomaly_job_selector_empty_state';
 
 interface Props {
   onJobChange: (jobId: string) => void;
   mlJobsService: MlApiServices['jobs'];
+  jobsManagementPath: string;
+  canGetJobs: boolean;
 }
 
 interface State {
@@ -61,11 +64,8 @@ export class AnomalyJobSelector extends Component<Props, State> {
   };
 
   render() {
-    if (!this.state.jobIdList) {
-      return null;
-    }
-
-    return (
+    const supportedJobsExist = this.state.jobIdList?.length && this.state.jobIdList?.length > 0;
+    return supportedJobsExist ? (
       <EuiFormRow
         label={i18n.translate('xpack.ml.maps.jobIdLabel', {
           defaultMessage: 'Job ID',
@@ -81,6 +81,6 @@ export class AnomalyJobSelector extends Component<Props, State> {
           }
         />
       </EuiFormRow>
-    );
+    ) : < AnomalyJobSelectorEmptyState jobsManagementPath={this.props.jobsManagementPath} canGetJobs={this.props.canGetJobs} />;
   }
 }

--- a/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_job_selector.tsx
@@ -16,8 +16,8 @@ import { AnomalyJobSelectorEmptyState } from './anomaly_job_selector_empty_state
 interface Props {
   onJobChange: (jobId: string) => void;
   mlJobsService: MlApiServices['jobs'];
-  jobsManagementPath: string;
-  canGetJobs: boolean;
+  jobsManagementPath?: string;
+  canCreateJobs: boolean;
 }
 
 interface State {
@@ -65,7 +65,7 @@ export class AnomalyJobSelector extends Component<Props, State> {
 
   render() {
     const supportedJobsExist = this.state.jobIdList?.length && this.state.jobIdList?.length > 0;
-    return supportedJobsExist ? (
+    return supportedJobsExist || !this.props.jobsManagementPath ? (
       <EuiFormRow
         label={i18n.translate('xpack.ml.maps.jobIdLabel', {
           defaultMessage: 'Job ID',
@@ -84,7 +84,7 @@ export class AnomalyJobSelector extends Component<Props, State> {
     ) : (
       <AnomalyJobSelectorEmptyState
         jobsManagementPath={this.props.jobsManagementPath}
-        canGetJobs={this.props.canGetJobs}
+        canCreateJobs={this.props.canCreateJobs}
       />
     );
   }

--- a/x-pack/plugins/ml/public/maps/anomaly_job_selector_empty_state.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_job_selector_empty_state.tsx
@@ -11,10 +11,10 @@ import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
 
 interface Props {
   jobsManagementPath: string;
-  canGetJobs: boolean;
+  canCreateJobs: boolean;
 }
 
-export const AnomalyJobSelectorEmptyState: FC<Props> = ({ jobsManagementPath, canGetJobs }) => (
+export const AnomalyJobSelectorEmptyState: FC<Props> = ({ jobsManagementPath, canCreateJobs }) => (
   <EuiEmptyPrompt
     layout="vertical"
     hasBorder={false}
@@ -44,7 +44,7 @@ export const AnomalyJobSelectorEmptyState: FC<Props> = ({ jobsManagementPath, ca
         href={jobsManagementPath}
         fill
         iconType="plusInCircle"
-        isDisabled={!canGetJobs}
+        isDisabled={!canCreateJobs}
         data-test-subj="mlMapsCreateNewJobButton"
       >
         <FormattedMessage

--- a/x-pack/plugins/ml/public/maps/anomaly_job_selector_empty_state.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_job_selector_empty_state.tsx
@@ -7,10 +7,7 @@
 
 import React, { FC } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import {
-  EuiButton,
-  EuiEmptyPrompt,
-} from '@elastic/eui';
+import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
 
 interface Props {
   jobsManagementPath: string;

--- a/x-pack/plugins/ml/public/maps/anomaly_job_selector_empty_state.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_job_selector_empty_state.tsx
@@ -29,14 +29,12 @@ export const AnomalyJobSelectorEmptyState: FC<Props> = ({ jobsManagementPath, ca
       </h2>
     }
     body={
-      <>
-        <p>
-          <FormattedMessage
-            id="xpack.ml.mapsAnomaliesLayerEmptyPrompt.emptyPromptText"
-            defaultMessage="Anomaly detection enables you to find unusual behaviour in your geographic data. Create a job that uses the lat_long function, which is necessary for the maps anomaly layer."
-          />
-        </p>
-      </>
+      <p>
+        <FormattedMessage
+          id="xpack.ml.mapsAnomaliesLayerEmptyPrompt.emptyPromptText"
+          defaultMessage="Anomaly detection enables you to find unusual behaviour in your geographic data. Create a job that uses the lat_long function, which is necessary for the maps anomaly layer."
+        />
+      </p>
     }
     actions={
       <EuiButton

--- a/x-pack/plugins/ml/public/maps/anomaly_job_selector_empty_state.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_job_selector_empty_state.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  EuiButton,
+  EuiEmptyPrompt,
+} from '@elastic/eui';
+
+interface Props {
+  jobsManagementPath: string;
+  canGetJobs: boolean;
+}
+
+export const AnomalyJobSelectorEmptyState: FC<Props> = ({ jobsManagementPath, canGetJobs }) => (
+  <EuiEmptyPrompt
+    layout="vertical"
+    hasBorder={false}
+    hasShadow={false}
+    color="subdued"
+    title={
+      <h2>
+        <FormattedMessage
+          id="xpack.ml.mapsAnomaliesLayerEmptyPrompt.createJobMessage"
+          defaultMessage="Create an anomaly detection job"
+        />
+      </h2>
+    }
+    body={
+      <>
+        <p>
+          <FormattedMessage
+            id="xpack.ml.mapsAnomaliesLayerEmptyPrompt.emptyPromptText"
+            defaultMessage="Anomaly detection enables you to find unusual behaviour in your geographic data. Create a job that uses the lat_long function, which is necessary for the maps anomaly layer."
+          />
+        </p>
+      </>
+    }
+    actions={
+      <EuiButton
+        color="primary"
+        href={jobsManagementPath}
+        fill
+        iconType="plusInCircle"
+        isDisabled={!canGetJobs}
+        data-test-subj="mlMapsCreateNewJobButton"
+      >
+        <FormattedMessage
+          id="xpack.ml.mapsAnomaliesLayerEmptyPrompt.createJobButtonText"
+          defaultMessage="Create job"
+        />
+      </EuiButton>
+    }
+    data-test-subj="mlMapsAnomalyDetectionEmptyState"
+  />
+);

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
@@ -46,7 +46,7 @@ export class AnomalyLayerWizardFactory {
     this.canGetJobs = canGetJobs;
   }
 
-  private async getServices(): Promise<{ mlJobsService: MlApiServices['jobs'], mlLocator: any }> {
+  private async getServices(): Promise<{ mlJobsService: MlApiServices['jobs']; mlLocator: any }> {
     const [coreStart, pluginStart] = await this.getStartServices();
     const { jobsApiProvider } = await import('../application/services/ml_api_service/jobs');
 
@@ -61,7 +61,7 @@ export class AnomalyLayerWizardFactory {
     const { mlJobsService, mlLocator } = await this.getServices();
     const jobsManagementPath = await mlLocator.getUrl({
       page: ML_PAGES.ANOMALY_DETECTION_JOBS_MANAGE,
-    })
+    });
 
     const { anomalyLayerWizard } = await import('./anomaly_layer_wizard');
 

--- a/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
@@ -17,6 +17,8 @@ import type { MlApiServices } from '../application/services/ml_api_service';
 interface Props {
   onSourceConfigChange: (sourceConfig: Partial<AnomalySourceDescriptor> | null) => void;
   mlJobsService: MlApiServices['jobs'];
+  jobsManagementPath: string;
+  canGetJobs: boolean;
 }
 
 interface State {
@@ -81,6 +83,8 @@ export class CreateAnomalySourceEditor extends Component<Props, State> {
         <AnomalyJobSelector
           onJobChange={this.previewLayer}
           mlJobsService={this.props.mlJobsService}
+          jobsManagementPath={this.props.jobsManagementPath}
+          canGetJobs={this.props.canGetJobs}
         />
         {selector}
       </EuiPanel>

--- a/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
+++ b/x-pack/plugins/ml/public/maps/create_anomaly_source_editor.tsx
@@ -17,8 +17,8 @@ import type { MlApiServices } from '../application/services/ml_api_service';
 interface Props {
   onSourceConfigChange: (sourceConfig: Partial<AnomalySourceDescriptor> | null) => void;
   mlJobsService: MlApiServices['jobs'];
-  jobsManagementPath: string;
-  canGetJobs: boolean;
+  jobsManagementPath?: string;
+  canCreateJobs: boolean;
 }
 
 interface State {
@@ -84,7 +84,7 @@ export class CreateAnomalySourceEditor extends Component<Props, State> {
           onJobChange={this.previewLayer}
           mlJobsService={this.props.mlJobsService}
           jobsManagementPath={this.props.jobsManagementPath}
-          canGetJobs={this.props.canGetJobs}
+          canCreateJobs={this.props.canCreateJobs}
         />
         {selector}
       </EuiPanel>

--- a/x-pack/plugins/ml/public/maps/register_map_extension.ts
+++ b/x-pack/plugins/ml/public/maps/register_map_extension.ts
@@ -13,12 +13,13 @@ import { AnomalyLayerWizardFactory } from './anomaly_layer_wizard_factory';
 export async function registerMapExtension(
   mapsSetupApi: MapsSetupApi,
   core: MlCoreSetup,
-  canGetJobs: boolean
+  { canGetJobs, canCreateJobs }: { canGetJobs: boolean; canCreateJobs: boolean }
 ) {
   const anomalySourceFactory = new AnomalySourceFactory(core.getStartServices, canGetJobs);
   const anomalyLayerWizardFactory = new AnomalyLayerWizardFactory(
     core.getStartServices,
-    canGetJobs
+    canGetJobs,
+    canCreateJobs
   );
   const anomalylayerWizard = await anomalyLayerWizardFactory.create();
 

--- a/x-pack/plugins/ml/public/plugin.ts
+++ b/x-pack/plugins/ml/public/plugin.ts
@@ -176,8 +176,8 @@ export class MlPlugin implements Plugin<MlPluginSetup, MlPluginStart> {
 
       if (pluginsSetup.maps) {
         // Pass capabilites.ml.canGetJobs as minimum permission to show anomalies card in maps layers
-        const canGetJobs = capabilities.ml?.canGetJobs === true || false;
-        const canCreateJobs = capabilities.ml?.canCreateJob === true || false;
+        const canGetJobs = capabilities.ml?.canGetJobs === true;
+        const canCreateJobs = capabilities.ml?.canCreateJob === true;
         await registerMapExtension(pluginsSetup.maps, core, { canGetJobs, canCreateJobs });
       }
 

--- a/x-pack/plugins/ml/public/plugin.ts
+++ b/x-pack/plugins/ml/public/plugin.ts
@@ -177,7 +177,8 @@ export class MlPlugin implements Plugin<MlPluginSetup, MlPluginStart> {
       if (pluginsSetup.maps) {
         // Pass capabilites.ml.canGetJobs as minimum permission to show anomalies card in maps layers
         const canGetJobs = capabilities.ml?.canGetJobs === true || false;
-        await registerMapExtension(pluginsSetup.maps, core, canGetJobs);
+        const canCreateJobs = capabilities.ml?.canCreateJob === true || false;
+        await registerMapExtension(pluginsSetup.maps, core, { canGetJobs, canCreateJobs });
       }
 
       if (mlEnabled) {


### PR DESCRIPTION
## Summary

Related meta issue: https://github.com/elastic/kibana/issues/123492

When there are no ML jobs available for selection in the wizard shows a prompt with a link to ML job management page. 

<img width="788" alt="image" src="https://user-images.githubusercontent.com/6446462/154364602-0efc7c21-bb06-441f-999c-ba713695216d.png">



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

