### PR TITLE
[DOCS] Adds date math to KQL doc

### DIFF
--- a/docs/concepts/kuery.asciidoc
+++ b/docs/concepts/kuery.asciidoc
@@ -144,6 +144,8 @@ but in some cases you might need to search on dates. Include the date range in q
 @timestamp < "2021"
 -------------------
 
+KQL also supports queries such as `now-1h/d`. Check out the
+{ref}/common-options.html#date-math[date math documentation] for details.
 
 [discrete]
 === Exist queries

--- a/docs/concepts/kuery.asciidoc
+++ b/docs/concepts/kuery.asciidoc
@@ -144,8 +144,20 @@ but in some cases you might need to search on dates. Include the date range in q
 @timestamp < "2021"
 -------------------
 
-KQL also supports queries such as `now-1h/d`. Check out the
-{ref}/common-options.html#date-math[date math documentation] for details.
+KQL supports date math expressions.
+
+[source,yaml]
+-------------------
+@timestamp < now-1d
+-------------------
+
+[source,yaml]
+-------------------
+updated_at > 2022-02-17||+1M/d
+-------------------
+
+Check the
+{ref}/common-options.html#date-math[date math documentation] for more examples.
 
 [discrete]
 === Exist queries


### PR DESCRIPTION
## Summary

This PR adds a link to the [date math documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math) to make  it clear that you can enter queries like created_at > now-30d in the KQL query bar.

Closes #115766

Preview: [https://kibana_125880.docs-preview.app.elstc.co/guide/en/kibana/master/kuery-query.html](https://kibana_125880.docs-preview.app.elstc.co/guide/en/kibana/master/kuery-query.html)