### PR TITLE
[Archive Migration] split kbn_archiver out of es_archiver for unmapped_fields

### DIFF
--- a/test/functional/apps/discover/_indexpattern_with_unmapped_fields.ts
+++ b/test/functional/apps/discover/_indexpattern_with_unmapped_fields.ts
@@ -19,6 +19,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('index pattern with unmapped fields', () => {
     before(async () => {
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/unmapped_fields');
+      await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
+      await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/unmapped_fields');
       await security.testUser.setRoles(['kibana_admin', 'test-index-unmapped-fields']);
       const fromTime = 'Jan 20, 2021 @ 00:00:00.000';
       const toTime = 'Jan 25, 2021 @ 00:00:00.000';
@@ -35,6 +37,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await esArchiver.unload('test/functional/fixtures/es_archiver/unmapped_fields');
+      await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
       await kibanaServer.uiSettings.unset('defaultIndex');
       await kibanaServer.uiSettings.unset('discover:searchFieldsFromSource');
       await kibanaServer.uiSettings.unset('timepicker:timeDefaults');

--- a/test/functional/fixtures/es_archiver/unmapped_fields/data.json
+++ b/test/functional/fixtures/es_archiver/unmapped_fields/data.json
@@ -1,51 +1,6 @@
 {
   "type": "doc",
   "value": {
-    "id": "search:cd43f5c2-h761-13f6-9486-733b1ac9221a",
-    "index": ".kibana",
-    "source": {
-      "search": {
-        "columns": [
-          "_source"
-        ],
-        "description": "Existing Saved Search",
-        "hits": 4,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n \"index\": \"test-index-unmapped-fields\",\n \"highlightAll\": true,\n \"filter\": [],\n \"query\": {\n \"query_string\": {\n \"query\": \"*\",\n \"analyze_wildcard\": true\n }\n }\n}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Existing Saved Search",
-        "version": 1
-      },
-      "type": "search"
-    }
-  }
-}
-
-{
-  "type": "doc",
-  "value": {
-    "id": "index-pattern:test-index-unmapped-fields",
-    "index": ".kibana",
-    "source": {
-      "index-pattern": {
-        "fields": "[{\"name\":\"_id\",\"type\":\"string\",\"esTypes\":[\"_id\"],\"count\":1,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_index\",\"type\":\"string\",\"esTypes\":[\"_index\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_score\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_source\",\"type\":\"_source\",\"esTypes\":[\"_source\"],\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_type\",\"type\":\"string\",\"esTypes\":[\"_type\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"timestamp\",\"type\":\"date\",\"esTypes\":[\"date\"],\"count\":4,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true}]",
-        "timeFieldName": "timestamp",
-        "title": "test-index-unmapped-fields",
-        "fieldFormatMap": "{\"timestamp\":{\"id\":\"date\"}}"
-      },
-      "type": "index-pattern"
-    },
-    "type": "_doc"
-  }
-}
-
-{
-  "type": "doc",
-  "value": {
     "id": "1",
     "index": "test-index-unmapped-fields",
     "source": {

--- a/test/functional/fixtures/kbn_archiver/unmapped_fields.json
+++ b/test/functional/fixtures/kbn_archiver/unmapped_fields.json
@@ -1,0 +1,51 @@
+{
+  "attributes": {
+    "fieldFormatMap": "{\"timestamp\":{\"id\":\"date\"}}",
+    "fields": "[{\"name\":\"_id\",\"type\":\"string\",\"esTypes\":[\"_id\"],\"count\":1,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_index\",\"type\":\"string\",\"esTypes\":[\"_index\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_score\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_source\",\"type\":\"_source\",\"esTypes\":[\"_source\"],\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_type\",\"type\":\"string\",\"esTypes\":[\"_type\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"timestamp\",\"type\":\"date\",\"esTypes\":[\"date\"],\"count\":4,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true}]",
+    "timeFieldName": "timestamp",
+    "title": "test-index-unmapped-fields"
+  },
+  "coreMigrationVersion": "7.17.1",
+  "id": "test-index-unmapped-fields",
+  "migrationVersion": {
+    "index-pattern": "7.11.0"
+  },
+  "references": [],
+  "type": "index-pattern",
+  "version": "WzEzLDJd"
+}
+
+{
+  "attributes": {
+    "columns": [
+      "_source"
+    ],
+    "description": "Existing Saved Search",
+    "hits": 4,
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": "{\"highlightAll\":true,\"filter\":[],\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+    },
+    "sort": [
+      [
+        "@timestamp",
+        "desc"
+      ]
+    ],
+    "title": "Existing Saved Search",
+    "version": 1
+  },
+  "coreMigrationVersion": "7.17.1",
+  "id": "cd43f5c2-h761-13f6-9486-733b1ac9221a",
+  "migrationVersion": {
+    "search": "7.9.3"
+  },
+  "references": [
+    {
+      "id": "test-index-unmapped-fields",
+      "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "search",
+  "version": "WzEyLDJd"
+}


### PR DESCRIPTION
## Summary

Another es_archive that contained both data and Kibana saved objects.

Part of: https://github.com/elastic/kibana/issues/102552