### PR TITLE
[Fleet] Fix GITHUB_TOKEN for Fleet QA labeling action

### DIFF
--- a/.github/workflows/label-qa-fixed-in.yml
+++ b/.github/workflows/label-qa-fixed-in.yml
@@ -37,7 +37,8 @@ jobs:
               }
             }
           prnumber: ${{ github.event.number }}
-          token: ${{ secrets.FLEET_TECH_KIBANA_USER_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.FLEET_TECH_KIBANA_USER_TOKEN }}
       - uses: sergeysova/jq-action@v2
         id: issues_to_label
         with:
@@ -75,4 +76,5 @@ jobs:
             }
           issueid: ${{ matrix.issueNodeId }}
           labelids: ${{ needs.fetch_issues_to_label.outputs.label_ids }}
-          token: ${{ secrets.FLEET_TECH_KIBANA_USER_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.FLEET_TECH_KIBANA_USER_TOKEN }}


### PR DESCRIPTION
## Summary

Seems to be the `with.token` option isn't working with a custom secret [despite the docs saying it should work](https://github.com/octokit/auth-action.js#createactionauth), this switches it to use `env.GITHUB_TOKEN` similar to other actions we have.