### PR TITLE
[Uptime] synthetics - add cluster name to telemetry headers

### DIFF
--- a/x-pack/plugins/uptime/server/lib/telemetry/sender.test.ts
+++ b/x-pack/plugins/uptime/server/lib/telemetry/sender.test.ts
@@ -130,6 +130,7 @@ describe('TelemetryEventsSender', () => {
         headers: {
           'Content-Type': 'application/x-ndjson',
           'X-Elastic-Cluster-ID': '1',
+          'X-Elastic-Cluster-Name': 'name',
           'X-Elastic-Stack-Version': '8.0.0',
         },
       };

--- a/x-pack/plugins/uptime/server/lib/telemetry/sender.ts
+++ b/x-pack/plugins/uptime/server/lib/telemetry/sender.ts
@@ -134,7 +134,8 @@ export class TelemetryEventsSender {
         events,
         telemetryUrl,
         clusterInfo?.cluster_uuid,
-        clusterInfo?.version?.number
+        clusterInfo?.version?.number,
+        clusterInfo?.cluster_name
       );
     } catch (err) {
       this.logger.debug(`Error sending telemetry events data: ${err}`);
@@ -162,7 +163,8 @@ export class TelemetryEventsSender {
     events: unknown[],
     telemetryUrl: string,
     clusterUuid: string | undefined,
-    clusterVersionNumber: string | undefined
+    clusterVersionNumber: string | undefined,
+    clusterName: string | undefined
   ) {
     // using ndjson so that each line will be wrapped in json envelope on server side
     // see https://github.com/elastic/infra/blob/master/docs/telemetry/telemetry-next-dataflow.md#json-envelope
@@ -173,6 +175,7 @@ export class TelemetryEventsSender {
         headers: {
           'Content-Type': 'application/x-ndjson',
           'X-Elastic-Cluster-ID': clusterUuid,
+          'X-Elastic-Cluster-Name': clusterName,
           'X-Elastic-Stack-Version': clusterVersionNumber ? clusterVersionNumber : '8.2.0',
         },
       });


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/125933

Adds cluster name to the headers for telemetry events. 

The cluster name can be found under `x-elastic-cluster-name`

### Testing
Navigate to https://infra-staging.elastic.dev/telemetry/workbench/synthetics-monitor-update/events/9aeadcd4-fcd8-4139-bec1-0e77cf032b4d/edit. Click `fetch latest event`. Verify that you can find the `x-elastic-cluster-name` header in the payload.
