### PR TITLE
[Maps] Fix race condition that caused Maps and Vega Maps zoom levels limited to 10

### DIFF
--- a/x-pack/plugins/maps/public/util.ts
+++ b/x-pack/plugins/maps/public/util.ts
@@ -36,9 +36,13 @@ let emsClientPromise: Promise<EMSClient> | null = null;
 let latestLicenseId: string | undefined;
 async function getEMSClient(): Promise<EMSClient> {
   if (!emsClientPromise) {
-    emsClientPromise = new Promise(async (resolve) => {
-      const emsClient = await getMapsEmsStart().createEMSClient();
-      resolve(emsClient);
+    emsClientPromise = new Promise(async (resolve, reject) => {
+      try {
+        const emsClient = await getMapsEmsStart().createEMSClient();
+        resolve(emsClient);
+      } catch (error) {
+        reject(error);
+      }
     });
   }
   const emsClient = await emsClientPromise;

--- a/x-pack/plugins/maps/public/util.ts
+++ b/x-pack/plugins/maps/public/util.ts
@@ -32,12 +32,16 @@ export async function getEmsTmsServices(): Promise<TMSService[]> {
   return (await getEMSClient()).getTMSServices();
 }
 
-let emsClient: EMSClient | null = null;
+let emsClientPromise: Promise<EMSClient> | null = null;
 let latestLicenseId: string | undefined;
 async function getEMSClient(): Promise<EMSClient> {
-  if (!emsClient) {
-    emsClient = await getMapsEmsStart().createEMSClient();
+  if (!emsClientPromise) {
+    emsClientPromise = new Promise(async (resolve) => {
+      const emsClient = await getMapsEmsStart().createEMSClient();
+      resolve(emsClient);
+    });
   }
+  const emsClient = await emsClientPromise;
   const licenseId = getLicenseId();
   if (latestLicenseId !== licenseId) {
     latestLicenseId = licenseId;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/125072, a regression introduced in https://github.com/elastic/kibana/pull/104422.

Fixes a race condition with the `getEmsClient` function that did not add the `license` query parameter for requests for the EMS manifest, effectively limiting the max zoom for Maps and Vega maps to level 10. 