### PR TITLE
[7.17] [DOCS] Fixes legacy viz breaking changes (#125970)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -303,6 +303,8 @@ Use the following supported browsers:
 The legacy aggregation-based data table and `vis_type_table.legacyVisEnabled` setting are no longer supported. For more information, refer to {kibana-pull}111339[#111339].
 
 *Impact* +
+When you upgrade to 7.16.0, {kib} automatically uses the new data table. 
+
 To auto-fit the table row height, create an {kibana-ref}/add-aggregation-based-visualization-panels.html#create-aggregation-based-panel[aggregation-based data table], click *Options*, then select *Auto fit rows to content*.
 ====
       
@@ -315,7 +317,7 @@ To auto-fit the table row height, create an {kibana-ref}/add-aggregation-based-v
 The legacy aggregation-based area, bar, and line charts are no longer supported. For more information, refer to {kibana-pull}110786[#110786].
 
 *Impact* +
-When you upgrade to 7.16.0, you are only able to create area, bar, and line charts using the new implementation.
+When you upgrade to 7.16.0, {kib} automatically uses the new area, bar, and line charts.
 ====
       
 [discrete]


### PR DESCRIPTION
# Backport

This will backport the following commits from `7.16` to `7.17`:
 - [[DOCS] Fixes legacy viz breaking changes #125970](https://github.com/elastic/kibana/pull/125970)

<!--- Backport version: 7.17.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)