### PR TITLE
Remove ts refs build from bootstrap

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -26,6 +26,8 @@ fi
 ### upload ts-refs-cache artifacts as quickly as possible so they are available for download
 ###
 if [[ "${BUILD_TS_REFS_CACHE_CAPTURE:-}" == "true" ]]; then
+  echo "--- Build ts-refs-cache"
+  node scripts/build_ts_refs.js --ignore-type-failures
   echo "--- Upload ts-refs-cache"
   cd "$KIBANA_DIR/target/ts_refs_cache"
   gsutil cp "*.zip" 'gs://kibana-ci-ts-refs-cache/'

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -8987,13 +8987,6 @@ const BootstrapCommand = {
     }, {
       prefix: '[vscode]',
       debug: false
-    });
-    await Object(_utils_child_process__WEBPACK_IMPORTED_MODULE_3__["spawnStreaming"])(process.execPath, ['scripts/build_ts_refs', '--ignore-type-failures'], {
-      cwd: kbn.getAbsolute(),
-      env: process.env
-    }, {
-      prefix: '[ts refs]',
-      debug: false
     }); // send timings
 
     await reporter.timings({

--- a/packages/kbn-pm/src/commands/bootstrap.ts
+++ b/packages/kbn-pm/src/commands/bootstrap.ts
@@ -137,16 +137,6 @@ export const BootstrapCommand: ICommand = {
       { prefix: '[vscode]', debug: false }
     );
 
-    await spawnStreaming(
-      process.execPath,
-      ['scripts/build_ts_refs', '--ignore-type-failures'],
-      {
-        cwd: kbn.getAbsolute(),
-        env: process.env,
-      },
-      { prefix: '[ts refs]', debug: false }
-    );
-
     // send timings
     await reporter.timings({
       upstreamBranch: kbn.kibanaProject.json.branch,


### PR DESCRIPTION
This re-implements the changes in https://github.com/elastic/kibana/pull/125314 that were reverted.  [Previously](https://buildkite.com/elastic/kibana-on-merge/builds/12400#ee5ac4aa-8771-4441-b551-3251c561e6e3), the CI on merge job was no longer building references on bootstrap and then  attempting to upload a non existent references cache 

Instead of relying on bootstrap to build the ts references cache, this will build references if `BUILD_TS_REFS_CACHE_CAPTURE` is set.