### PR TITLE
[ML] Maps integration: adds influencers to tooltip in anomalies layer

### DIFF
--- a/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_field.ts
@@ -98,6 +98,12 @@ export const ANOMALY_SOURCE_FIELDS: Record<string, Record<string, string>> = {
     }),
     type: 'string',
   },
+  influencers: {
+    label: i18n.translate('xpack.ml.maps.anomalyLayerInfluencersLabel', {
+      defaultMessage: 'Influencers',
+    }),
+    type: 'string',
+  },
 };
 
 export class AnomalySourceTooltipProperty implements ITooltipProperty {

--- a/x-pack/plugins/ml/public/maps/maps_util.test.js
+++ b/x-pack/plugins/ml/public/maps/maps_util.test.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getInfluencersHtmlString } from './util';
+
+describe('getInfluencersHtmlString', () => {
+  const splitField = 'split_field_influencer';
+  const valueFour = 'value_four';
+  const influencerFour = 'influencer_four';
+  const influencers = [
+    {
+      influencer_field_name: 'influencer_one',
+      influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
+    },
+    {
+      influencer_field_name: 'influencer_two',
+      influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
+    },
+    {
+      influencer_field_name: splitField,
+      influencer_field_values: ['value_one', 'value_two'],
+    },
+    {
+      influencer_field_name: 'influencer_three',
+      influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
+    },
+    {
+      influencer_field_name: influencerFour,
+      influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
+    },
+  ];
+
+  test('should create the html string when given an array of influencers', () => {
+    const expected =
+      '<ul><li>influencer_one: value_one, value_two, value_three</li><li>influencer_two: value_one, value_two, value_three</li><li>influencer_three: value_one, value_two, value_three</li></ul>';
+    const actual = getInfluencersHtmlString(influencers, splitField);
+    expect(actual).toBe(expected);
+    // Should not include split field
+    expect(actual.includes(splitField)).toBe(false);
+    // should limit to the first three influencer values
+    expect(actual.includes(valueFour)).toBe(false);
+    // should limit to the first three influencer names
+    expect(actual.includes(influencerFour)).toBe(false);
+  });
+});

--- a/x-pack/plugins/ml/public/maps/maps_util.test.js
+++ b/x-pack/plugins/ml/public/maps/maps_util.test.js
@@ -5,45 +5,86 @@
  * 2.0.
  */
 
-import { getInfluencersHtmlString } from './util';
+import { getInfluencersHtmlString, getResultsForJobId } from './util';
+import {
+  mlResultsServiceMock,
+  typicalExpected,
+  actualExpected,
+  typicalToActualExpected,
+} from './results.test.mock';
 
-describe('getInfluencersHtmlString', () => {
-  const splitField = 'split_field_influencer';
-  const valueFour = 'value_four';
-  const influencerFour = 'influencer_four';
-  const influencers = [
-    {
-      influencer_field_name: 'influencer_one',
-      influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
-    },
-    {
-      influencer_field_name: 'influencer_two',
-      influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
-    },
-    {
-      influencer_field_name: splitField,
-      influencer_field_values: ['value_one', 'value_two'],
-    },
-    {
-      influencer_field_name: 'influencer_three',
-      influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
-    },
-    {
-      influencer_field_name: influencerFour,
-      influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
-    },
-  ];
+describe('Maps util', () => {
+  describe('getInfluencersHtmlString', () => {
+    const splitField = 'split_field_influencer';
+    const valueFour = 'value_four';
+    const influencerFour = 'influencer_four';
+    const influencers = [
+      {
+        influencer_field_name: 'influencer_one',
+        influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
+      },
+      {
+        influencer_field_name: 'influencer_two',
+        influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
+      },
+      {
+        influencer_field_name: splitField,
+        influencer_field_values: ['value_one', 'value_two'],
+      },
+      {
+        influencer_field_name: 'influencer_three',
+        influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
+      },
+      {
+        influencer_field_name: influencerFour,
+        influencer_field_values: ['value_one', 'value_two', 'value_three', valueFour],
+      },
+    ];
 
-  test('should create the html string when given an array of influencers', () => {
-    const expected =
-      '<ul><li>influencer_one: value_one, value_two, value_three</li><li>influencer_two: value_one, value_two, value_three</li><li>influencer_three: value_one, value_two, value_three</li></ul>';
-    const actual = getInfluencersHtmlString(influencers, splitField);
-    expect(actual).toBe(expected);
-    // Should not include split field
-    expect(actual.includes(splitField)).toBe(false);
-    // should limit to the first three influencer values
-    expect(actual.includes(valueFour)).toBe(false);
-    // should limit to the first three influencer names
-    expect(actual.includes(influencerFour)).toBe(false);
+    test('should create the html string when given an array of influencers', () => {
+      const expected =
+        '<ul><li>influencer_one: value_one, value_two, value_three</li><li>influencer_two: value_one, value_two, value_three</li><li>influencer_three: value_one, value_two, value_three</li></ul>';
+      const actual = getInfluencersHtmlString(influencers, splitField);
+      expect(actual).toBe(expected);
+      // Should not include split field
+      expect(actual.includes(splitField)).toBe(false);
+      // should limit to the first three influencer values
+      expect(actual.includes(valueFour)).toBe(false);
+      // should limit to the first three influencer names
+      expect(actual.includes(influencerFour)).toBe(false);
+    });
+  });
+
+  describe('getResultsForJobId', () => {
+    const jobId = 'jobId';
+    const searchFilters = {
+      timeFilters: { from: 'now-2y', to: 'now' },
+      query: { language: 'kuery', query: '' },
+    };
+
+    test('should get map features from job anomalies results for typical layer', async () => {
+      const actual = await getResultsForJobId(
+        mlResultsServiceMock,
+        jobId,
+        'typical',
+        searchFilters
+      );
+      expect(actual).toEqual(typicalExpected);
+    });
+
+    test('should get map features from job anomalies results for actual layer', async () => {
+      const actual = await getResultsForJobId(mlResultsServiceMock, jobId, 'actual', searchFilters);
+      expect(actual).toEqual(actualExpected);
+    });
+
+    test('should get map features from job anomalies results for "typical to actual" layer', async () => {
+      const actual = await getResultsForJobId(
+        mlResultsServiceMock,
+        jobId,
+        'typical to actual',
+        searchFilters
+      );
+      expect(actual).toEqual(typicalToActualExpected);
+    });
   });
 });

--- a/x-pack/plugins/ml/public/maps/results.test.mock.ts
+++ b/x-pack/plugins/ml/public/maps/results.test.mock.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const results = {
+  took: 9,
+  timed_out: false,
+  _shards: {
+    total: 1,
+    successful: 1,
+    skipped: 0,
+    failed: 0,
+  },
+  hits: {
+    total: {
+      value: 19,
+      relation: 'eq',
+    },
+    max_score: 4.4813457,
+    hits: [
+      {
+        _index: '.ml-anomalies-shared',
+        _id: 'test-tooltip-one_record_1645974000000_900_0_0_0',
+        _score: 4.4813457,
+        _source: {
+          job_id: 'test-tooltip-one',
+          result_type: 'record',
+          probability: 0.00042878057629659614,
+          multi_bucket_impact: -5,
+          record_score: 77.74620142126848,
+          initial_record_score: 77.74620142126848,
+          bucket_span: 900,
+          detector_index: 0,
+          is_interim: false,
+          timestamp: 1645974000000,
+          function: 'lat_long',
+          function_description: 'lat_long',
+          typical: [39.9864616394043, -97.862548828125],
+          actual: [29.261693651787937, -121.93940273718908],
+          field_name: 'geo.coordinates',
+          influencers: [
+            {
+              influencer_field_name: 'geo.dest',
+              influencer_field_values: ['CN', 'DO', 'RU', 'US'],
+            },
+            {
+              influencer_field_name: 'clientip',
+              influencer_field_values: [
+                '108.131.25.207',
+                '192.41.143.247',
+                '194.12.201.131',
+                '41.91.106.242',
+              ],
+            },
+            {
+              influencer_field_name: 'agent.keyword',
+              influencer_field_values: [
+                'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)',
+                'Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24',
+                'Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1',
+              ],
+            },
+          ],
+          geo_results: {
+            typical_point: '39.986461639404,-97.862548828125',
+            actual_point: '29.261693651788,-121.939402737189',
+          },
+          'geo.dest': ['CN', 'DO', 'RU', 'US'],
+          'agent.keyword': [
+            'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)',
+            'Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24',
+            'Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1',
+          ],
+          clientip: ['108.131.25.207', '192.41.143.247', '194.12.201.131', '41.91.106.242'],
+        },
+      },
+    ],
+  },
+};
+
+export const typicalExpected = {
+  features: [
+    {
+      geometry: { coordinates: [-97.862548828125, 39.986461639404], type: 'Point' },
+      properties: {
+        actual: [-121.939402737189, 29.261693651788],
+        actualDisplay: [-121.94, 29.26],
+        fieldName: 'geo.coordinates',
+        functionDescription: 'lat_long',
+        influencers:
+          '<ul><li>geo.dest: CN, DO, RU</li><li>clientip: 108.131.25.207, 192.41.143.247, 194.12.201.131</li><li>agent.keyword: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322), Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24, Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1</li></ul>',
+        record_score: 77,
+        timestamp: 'February 27th 2022, 10:00:00',
+        typical: [-97.862548828125, 39.986461639404],
+        typicalDisplay: [-97.86, 39.99],
+      },
+      type: 'Feature',
+    },
+  ],
+  type: 'FeatureCollection',
+};
+
+export const actualExpected = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [-121.939402737189, 29.261693651788],
+      },
+      properties: {
+        actual: [-121.939402737189, 29.261693651788],
+        actualDisplay: [-121.94, 29.26],
+        typical: [-97.862548828125, 39.986461639404],
+        typicalDisplay: [-97.86, 39.99],
+        fieldName: 'geo.coordinates',
+        functionDescription: 'lat_long',
+        timestamp: 'February 27th 2022, 10:00:00',
+        record_score: 77,
+        influencers:
+          '<ul><li>geo.dest: CN, DO, RU</li><li>clientip: 108.131.25.207, 192.41.143.247, 194.12.201.131</li><li>agent.keyword: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322), Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24, Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1</li></ul>',
+      },
+    },
+  ],
+};
+export const typicalToActualExpected = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [-97.862548828125, 39.986461639404],
+          [-121.939402737189, 29.261693651788],
+        ],
+      },
+      properties: {
+        actual: [-121.939402737189, 29.261693651788],
+        actualDisplay: [-121.94, 29.26],
+        typical: [-97.862548828125, 39.986461639404],
+        typicalDisplay: [-97.86, 39.99],
+        fieldName: 'geo.coordinates',
+        functionDescription: 'lat_long',
+        timestamp: 'February 27th 2022, 10:00:00',
+        record_score: 77,
+        influencers:
+          '<ul><li>geo.dest: CN, DO, RU</li><li>clientip: 108.131.25.207, 192.41.143.247, 194.12.201.131</li><li>agent.keyword: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322), Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24, Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1</li></ul>',
+      },
+    },
+  ],
+};
+
+export const mlResultsServiceMock = {
+  anomalySearch: () => results,
+};

--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -23,18 +23,19 @@ export const ML_ANOMALY_LAYERS = {
 } as const;
 
 export type MlAnomalyLayersType = typeof ML_ANOMALY_LAYERS[keyof typeof ML_ANOMALY_LAYERS];
-const INFLUENCER_LIMIT = 2;
-const INFLUENCER_MAX_VALUES = 5;
+const INFLUENCER_LIMIT = 3;
+const INFLUENCER_MAX_VALUES = 3;
 
 function getInfluencersHtmlString(
-  influencers: Array<{ influencer_field_name: string; influencer_field_values: string[] }>
+  influencers: Array<{ influencer_field_name: string; influencer_field_values: string[] }>,
+  splitFields: string[]
 ) {
   let htmlString = '<ul>';
   for (let i = 0; i < influencers.length; i++) {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const { influencer_field_name, influencer_field_values } = influencers[i];
-    // Skip if there are no values
-    if (!influencer_field_values.length) continue;
+    // Skip if there are no values or it's a partition field
+    if (!influencer_field_values.length || splitFields.includes(influencer_field_name)) continue;
 
     const fieldValuesString = influencer_field_values.slice(0, INFLUENCER_MAX_VALUES).join(', ');
 
@@ -162,6 +163,15 @@ export async function getResultsForJobId(
           coordinates: [typical, actual],
         };
       }
+
+      const splitFields = {
+        ...(_source.partition_field_name
+          ? { [_source.partition_field_name]: _source.partition_field_value }
+          : {}),
+        ...(_source.by_field_name ? { [_source.by_field_name]: _source.by_field_value } : {}),
+        ...(_source.over_field_name ? { [_source.over_field_name]: _source.over_field_value } : {}),
+      };
+
       return {
         type: 'Feature',
         geometry,
@@ -174,15 +184,14 @@ export async function getResultsForJobId(
           functionDescription: _source.function_description,
           timestamp: formatHumanReadableDateTimeSeconds(_source.timestamp),
           record_score: Math.floor(_source.record_score),
-          ...(_source.partition_field_name
-            ? { [_source.partition_field_name]: _source.partition_field_value }
-            : {}),
-          ...(_source.by_field_name ? { [_source.by_field_name]: _source.by_field_value } : {}),
-          ...(_source.over_field_name
-            ? { [_source.over_field_name]: _source.over_field_value }
-            : {}),
+          ...(Object.keys(splitFields).length > 0 ? splitFields : {}),
           ...(_source.influencers
-            ? { influencers: getInfluencersHtmlString(_source.influencers) }
+            ? {
+                influencers: getInfluencersHtmlString(
+                  _source.influencers,
+                  Object.keys(splitFields)
+                ),
+              }
             : {}),
         },
       };

--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -26,11 +26,12 @@ export type MlAnomalyLayersType = typeof ML_ANOMALY_LAYERS[keyof typeof ML_ANOMA
 const INFLUENCER_LIMIT = 3;
 const INFLUENCER_MAX_VALUES = 3;
 
-function getInfluencersHtmlString(
+export function getInfluencersHtmlString(
   influencers: Array<{ influencer_field_name: string; influencer_field_values: string[] }>,
   splitFields: string[]
 ) {
   let htmlString = '<ul>';
+  let influencerCount = 0;
   for (let i = 0; i < influencers.length; i++) {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const { influencer_field_name, influencer_field_values } = influencers[i];
@@ -40,13 +41,13 @@ function getInfluencersHtmlString(
     const fieldValuesString = influencer_field_values.slice(0, INFLUENCER_MAX_VALUES).join(', ');
 
     htmlString += `<li>${influencer_field_name}: ${fieldValuesString}</li>`;
+    influencerCount += 1;
 
-    // Only show top two influencers
-    if (i === INFLUENCER_LIMIT - 1) {
-      htmlString += '</ul>';
+    if (influencerCount === INFLUENCER_LIMIT) {
       break;
     }
   }
+  htmlString += '</ul>';
 
   return htmlString;
 }
@@ -185,7 +186,7 @@ export async function getResultsForJobId(
           timestamp: formatHumanReadableDateTimeSeconds(_source.timestamp),
           record_score: Math.floor(_source.record_score),
           ...(Object.keys(splitFields).length > 0 ? splitFields : {}),
-          ...(_source.influencers
+          ...(_source.influencers?.length
             ? {
                 influencers: getInfluencersHtmlString(
                   _source.influencers,


### PR DESCRIPTION
## Summary

Related meta issue: https://github.com/elastic/kibana/issues/123492

Adds influencers to the tooltip for each point on the map - if influencers are present.
Limits to 3 influencers and 3 influencer values to prevent tooltip from becoming too big.

<img width="519" alt="image" src="https://user-images.githubusercontent.com/6446462/155395223-98878d7e-6072-441d-b73f-6e52d9691c61.png">



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))


