### PR TITLE
[data views / data] Remove unused deprecated references, use field formats plugin directly

### DIFF
--- a/src/plugins/data/common/es_query/index.ts
+++ b/src/plugins/data/common/es_query/index.ts
@@ -54,7 +54,6 @@ import {
   KueryNode as oldKueryNode,
   FilterMeta as oldFilterMeta,
   FILTERS as oldFILTERS,
-  IFieldSubType as oldIFieldSubType,
   EsQueryConfig as oldEsQueryConfig,
   compareFilters as oldCompareFilters,
   COMPARE_ALL_OPTIONS as OLD_COMPARE_ALL_OPTIONS,
@@ -360,12 +359,6 @@ type FilterMeta = oldFilterMeta;
  * @deprecated Import from the "@kbn/es-query" package directly instead.
  * @removeBy 8.1
  */
-type IFieldSubType = oldIFieldSubType;
-
-/**
- * @deprecated Import from the "@kbn/es-query" package directly instead.
- * @removeBy 8.1
- */
 type EsQueryConfig = oldEsQueryConfig;
 
 /**
@@ -385,7 +378,6 @@ export type {
   RangeFilter,
   KueryNode,
   FilterMeta,
-  IFieldSubType,
   EsQueryConfig,
 };
 export {

--- a/src/plugins/data/common/kbn_field_types/index.ts
+++ b/src/plugins/data/common/kbn_field_types/index.ts
@@ -7,29 +7,6 @@
  */
 
 // NOTE: trick to mark exports as deprecated (only for constants and types, but not for interfaces, classes or enums)
-import {
-  getFilterableKbnTypeNames as oldGetFilterableKbnTypeNames,
-  getKbnFieldType as oldGetKbnFieldType,
-  getKbnTypeNames as oldGetKbnTypeNames,
-  KbnFieldType,
-} from '@kbn/field-types';
+import { KbnFieldType } from '@kbn/field-types';
 
-/**
- * @deprecated Import from the "@kbn/field-types" package directly instead.
- * @removeBy 8.1
- */
-const getFilterableKbnTypeNames = oldGetFilterableKbnTypeNames;
-
-/**
- * @deprecated Import from the "@kbn/field-types" package directly instead.
- * @removeBy 8.1
- */
-const getKbnFieldType = oldGetKbnFieldType;
-
-/**
- * @deprecated Import from the "@kbn/field-types" package directly instead.
- * @removeBy 8.1
- */
-const getKbnTypeNames = oldGetKbnTypeNames;
-
-export { getKbnFieldType, getKbnTypeNames, getFilterableKbnTypeNames, KbnFieldType };
+export { KbnFieldType };

--- a/src/plugins/data/public/deprecated.ts
+++ b/src/plugins/data/public/deprecated.ts
@@ -47,7 +47,6 @@ import {
   PhraseFilter,
   CustomFilter,
   MatchAllFilter,
-  IFieldSubType,
   EsQueryConfig,
   FilterStateStore,
   compareFilters,
@@ -147,7 +146,6 @@ export type {
   PhraseFilter,
   CustomFilter,
   MatchAllFilter,
-  IFieldSubType,
   EsQueryConfig,
 };
 export { isFilter, isFilters };

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -292,7 +292,7 @@ export type {
 
 export type { AggsStart } from './search/aggs';
 
-export { getTime, getKbnTypeNames } from '../common';
+export { getTime } from '../common';
 
 export { isTimeRange, isQuery } from '../common';
 

--- a/src/plugins/data/server/deprecated.ts
+++ b/src/plugins/data/server/deprecated.ts
@@ -67,4 +67,4 @@ export const esQuery = {
   buildEsQuery,
 };
 
-export type { Filter, Query, EsQueryConfig, KueryNode, IFieldSubType } from '../common';
+export type { Filter, Query, EsQueryConfig, KueryNode } from '../common';

--- a/src/plugins/data_view_field_editor/public/components/field_editor_context.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_editor_context.tsx
@@ -8,6 +8,7 @@
 
 import React, { createContext, useContext, FunctionComponent, useMemo } from 'react';
 import { NotificationsStart, CoreStart } from 'src/core/public';
+import { FieldFormatsStart } from '../shared_imports';
 import type { DataView, DataPublicPluginStart } from '../shared_imports';
 import { ApiService } from '../lib/api';
 import type { InternalFieldType, PluginStart } from '../types';
@@ -25,7 +26,7 @@ export interface Context {
     notifications: NotificationsStart;
   };
   fieldFormatEditors: PluginStart['fieldFormatEditors'];
-  fieldFormats: DataPublicPluginStart['fieldFormats'];
+  fieldFormats: FieldFormatsStart;
   /**
    * An array of field names not allowed.
    * e.g we probably don't want a user to give a name of an existing

--- a/src/plugins/data_view_field_editor/public/components/field_editor_flyout_content_container.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_editor_flyout_content_container.tsx
@@ -11,6 +11,7 @@ import { DocLinksStart, NotificationsStart, CoreStart } from 'src/core/public';
 import { i18n } from '@kbn/i18n';
 import { METRIC_TYPE } from '@kbn/analytics';
 
+import { FieldFormatsStart } from 'src/plugins/field_formats/public';
 import {
   DataViewField,
   DataView,
@@ -51,7 +52,7 @@ export interface Props {
   apiService: ApiService;
   /** Field format */
   fieldFormatEditors: PluginStart['fieldFormatEditors'];
-  fieldFormats: DataPublicPluginStart['fieldFormats'];
+  fieldFormats: FieldFormatsStart;
   uiSettings: CoreStart['uiSettings'];
 }
 

--- a/src/plugins/data_view_field_editor/public/components/field_format_editor/field_format_editor.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_format_editor/field_format_editor.tsx
@@ -11,24 +11,21 @@ import { EuiCode, EuiFormRow, EuiSelect } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import {
-  IndexPattern,
-  KBN_FIELD_TYPES,
-  ES_FIELD_TYPES,
-  DataPublicPluginStart,
-} from 'src/plugins/data/public';
+import { KBN_FIELD_TYPES, ES_FIELD_TYPES } from 'src/plugins/data/public';
 import type { FieldFormatInstanceType } from 'src/plugins/field_formats/common';
 import { CoreStart } from 'src/core/public';
 import { castEsToKbnFieldTypeName } from '@kbn/field-types';
+import { FieldFormatsStart } from 'src/plugins/field_formats/public';
+import { DataView } from 'src/plugins/data_views/public';
 import { FormatEditor } from './format_editor';
 import { FormatEditorServiceStart } from '../../service';
 import { FieldFormatConfig } from '../../types';
 
 export interface FormatSelectEditorProps {
   esTypes: ES_FIELD_TYPES[];
-  indexPattern: IndexPattern;
+  indexPattern: DataView;
   fieldFormatEditors: FormatEditorServiceStart['fieldFormatEditors'];
-  fieldFormats: DataPublicPluginStart['fieldFormats'];
+  fieldFormats: FieldFormatsStart;
   uiSettings: CoreStart['uiSettings'];
   onChange: (change?: FieldFormatConfig) => void;
   onError: (error?: string) => void;
@@ -54,7 +51,7 @@ interface InitialFieldTypeFormat extends FieldTypeFormat {
 const getFieldTypeFormatsList = (
   fieldType: KBN_FIELD_TYPES,
   defaultFieldFormat: FieldFormatInstanceType,
-  fieldFormats: DataPublicPluginStart['fieldFormats']
+  fieldFormats: FieldFormatsStart
 ) => {
   const formatsByType = fieldFormats.getByFieldType(fieldType).map(({ id, title }) => ({
     id,

--- a/src/plugins/data_view_field_editor/public/plugin.test.tsx
+++ b/src/plugins/data_view_field_editor/public/plugin.test.tsx
@@ -20,6 +20,7 @@ jest.mock('../../kibana_react/public', () => {
 import { CoreStart } from 'src/core/public';
 import { coreMock } from 'src/core/public/mocks';
 import { dataPluginMock } from '../../data/public/mocks';
+import { fieldFormatsServiceMock } from '../../field_formats/public/mocks';
 import { usageCollectionPluginMock } from '../../usage_collection/public/mocks';
 
 import { FieldEditorLoader } from './components/field_editor_loader';
@@ -35,7 +36,7 @@ describe('DataViewFieldEditorPlugin', () => {
     data: dataPluginMock.createStartContract(),
     usageCollection: usageCollectionPluginMock.createSetupContract(),
     dataViews: dataPluginMock.createStartContract().dataViews,
-    fieldFormats: dataPluginMock.createStartContract().fieldFormats,
+    fieldFormats: fieldFormatsServiceMock.createStartContract(),
   };
 
   let plugin: IndexPatternFieldEditorPlugin;


### PR DESCRIPTION
Remove some unused deprecated references, data view field editor uses field formats plugin directly instead of through data plugin