### PR TITLE
[Discover] Re-introduce saved_searches test

### DIFF
--- a/x-pack/test/functional/apps/discover/saved_searches.ts
+++ b/x-pack/test/functional/apps/discover/saved_searches.ts
@@ -30,9 +30,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     await PageObjects.timePicker.setAbsoluteRange(fromTime, toTime);
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/104578
-  // FLAKY: https://github.com/elastic/kibana/issues/114002
-  describe.skip('Discover Saved Searches', () => {
+  describe('Discover Saved Searches', () => {
     before('initialize tests', async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/ecommerce');
       await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/discover');


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/114002

This PR re-introduces the saved_searches test, as the [root cause](https://github.com/elastic/kibana/issues/116557) has been fixed.
Flaky spec runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/175


### Checklist

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
