### PR TITLE
[8.1] update es client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "yarn": "^1.21.1"
   },
   "resolutions": {
-    "**/@elastic/transport": "^8.0.2",
     "**/@babel/runtime": "^7.17.2",
+    "**/@elastic/transport": "^8.0.2",
     "**/@types/node": "16.10.2",
     "**/chokidar": "^3.4.3",
     "**/deepmerge": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "yarn": "^1.21.1"
   },
   "resolutions": {
+    "**/@elastic/transport": "^8.0.2",
     "**/@babel/runtime": "^7.17.2",
     "**/@types/node": "16.10.2",
     "**/chokidar": "^3.4.3",
@@ -106,7 +107,7 @@
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
     "@elastic/charts": "43.1.1",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
-    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.1.0-canary.3",
+    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.1.0-canary.2",
     "@elastic/ems-client": "8.0.0",
     "@elastic/eui": "46.1.1",
     "@elastic/filesaver": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
     "@elastic/charts": "43.1.1",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
-    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.1.0-canary.2",
+    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.1.0-canary.3",
     "@elastic/ems-client": "8.0.0",
     "@elastic/eui": "46.1.1",
     "@elastic/filesaver": "1.1.2",

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/ml_model/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/ml_model/install.ts
@@ -74,13 +74,20 @@ async function handleMlModelInstall({
   try {
     await retryTransientEsErrors(
       () =>
-        esClient.ml.putTrainedModel({
-          model_id: mlModel.installationName,
-          defer_definition_decompression: true,
-          timeout: '45s',
-          // @ts-expect-error expects an object not a string
-          body: mlModel.content,
-        }),
+        esClient.ml.putTrainedModel(
+          {
+            model_id: mlModel.installationName,
+            defer_definition_decompression: true,
+            timeout: '45s',
+            // @ts-expect-error expects an object not a string
+            body: mlModel.content,
+          },
+          {
+            headers: {
+              'content-type': 'application/json',
+            },
+          }
+        ),
       { logger }
     );
   } catch (err) {

--- a/x-pack/plugins/painless_lab/server/routes/api/execute.ts
+++ b/x-pack/plugins/painless_lab/server/routes/api/execute.ts
@@ -26,10 +26,17 @@ export function registerExecuteRoute({ router, license }: RouteDependencies) {
 
       try {
         const client = ctx.core.elasticsearch.client.asCurrentUser;
-        const response = await client.scriptsPainlessExecute({
-          // @ts-expect-error `ExecutePainlessScriptRequest.body` does not allow `string`
-          body,
-        });
+        const response = await client.scriptsPainlessExecute(
+          {
+            // @ts-expect-error `ExecutePainlessScriptRequest.body` does not allow `string`
+            body,
+          },
+          {
+            headers: {
+              'content-type': 'application/json',
+            },
+          }
+        );
 
         return res.ok({
           body: response.body,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,12 +2371,12 @@
   dependencies:
     "@elastic/ecs-helpers" "^1.1.0"
 
-"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@8.1.0-canary.2":
-  version "8.1.0-canary.2"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.1.0-canary.2.tgz#7676b3bdad79a37be4b4ada38f97751314a33a52"
-  integrity sha512-nmr7yZbvlTqA5SHu/IJZFsU6v14+Y2nx0btMKB9Hjd0vardaibCAdovO9Bp1RPxda2g6XayEkKEzwq5s79xR1g==
+"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@8.1.0-canary.3":
+  version "8.1.0-canary.3"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.1.0-canary.3.tgz#a84669ad45ea465e533d860bf99aa55aed781cb3"
+  integrity sha512-rpsMiJX5sAAlPjfWzZhijQgpu7ZlPwjcJQHCT3wNz03DTDnokLCqkhc8gsU+uqesbQ/GqYUlSL9erCk4GqjOLg==
   dependencies:
-    "@elastic/transport" "^8.1.0-beta.1"
+    "@elastic/transport" "^8.0.2"
     tslib "^2.3.0"
 
 "@elastic/ems-client@8.0.0":
@@ -2558,17 +2558,17 @@
     ts-node "^10.2.1"
     typescript "^4.3.5"
 
-"@elastic/transport@^8.1.0-beta.1":
-  version "8.1.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.1.0-beta.1.tgz#37fde777cf83226f1ea46bf0a22e51a3e43efb85"
-  integrity sha512-aqncMX86d3r6tNGlve6HEy+NF8XZXetMxDXpplrOAcShL20mHXkMFTJyUyML01tgfkbbgwXnN714YEjin1u1Xg==
+"@elastic/transport@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.0.2.tgz#715f06c7739516867508108df30c33973ca8e81c"
+  integrity sha512-OlDz3WO3pKE9vSxW4wV/mn7rYCtBmSsDwxr64h/S1Uc/zrIBXb0iUsRMSkiybXugXhjwyjqG2n1Wc7jjFxrskQ==
   dependencies:
     debug "^4.3.2"
     hpagent "^0.1.2"
     ms "^2.1.3"
     secure-json-parse "^2.4.0"
     tslib "^2.3.0"
-    undici "^4.7.0"
+    undici "^4.14.1"
 
 "@emotion/babel-plugin-jsx-pragmatic@^0.1.5":
   version "0.1.5"
@@ -29117,10 +29117,10 @@ undertaker@^1.2.1:
     object.reduce "^1.0.0"
     undertaker-registry "^1.0.0"
 
-undici@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-4.7.0.tgz#3bda286d67bf45d0ab1b94ca6c84e546dcb3b0d4"
-  integrity sha512-O1q+/EIs4g0HnVMH8colei3qODGiYBLpavWYv3kI+JazBBsBIndnZfUqZ2MEfPJ12H9d56yVdwZG1/nV/xcoSQ==
+undici@^4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-4.14.1.tgz#7633b143a8a10d6d63335e00511d071e8d52a1d9"
+  integrity sha512-WJ+g+XqiZcATcBaUeluCajqy4pEDcQfK1vy+Fo+bC4/mqXI9IIQD/XWHLS70fkGUT6P52Drm7IFslO651OdLPQ==
 
 unfetch@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,12 +2371,12 @@
   dependencies:
     "@elastic/ecs-helpers" "^1.1.0"
 
-"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@8.1.0-canary.3":
-  version "8.1.0-canary.3"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.1.0-canary.3.tgz#a84669ad45ea465e533d860bf99aa55aed781cb3"
-  integrity sha512-rpsMiJX5sAAlPjfWzZhijQgpu7ZlPwjcJQHCT3wNz03DTDnokLCqkhc8gsU+uqesbQ/GqYUlSL9erCk4GqjOLg==
+"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@8.1.0-canary.2":
+  version "8.1.0-canary.2"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.1.0-canary.2.tgz#7676b3bdad79a37be4b4ada38f97751314a33a52"
+  integrity sha512-nmr7yZbvlTqA5SHu/IJZFsU6v14+Y2nx0btMKB9Hjd0vardaibCAdovO9Bp1RPxda2g6XayEkKEzwq5s79xR1g==
   dependencies:
-    "@elastic/transport" "^8.0.2"
+    "@elastic/transport" "^8.1.0-beta.1"
     tslib "^2.3.0"
 
 "@elastic/ems-client@8.0.0":
@@ -2558,7 +2558,7 @@
     ts-node "^10.2.1"
     typescript "^4.3.5"
 
-"@elastic/transport@^8.0.2":
+"@elastic/transport@^8.0.2", "@elastic/transport@^8.1.0-beta.1":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.0.2.tgz#715f06c7739516867508108df30c33973ca8e81c"
   integrity sha512-OlDz3WO3pKE9vSxW4wV/mn7rYCtBmSsDwxr64h/S1Uc/zrIBXb0iUsRMSkiybXugXhjwyjqG2n1Wc7jjFxrskQ==


### PR DESCRIPTION
## Summary

Update the ES client version to `8.1-canary.3`.
The main purpose of the update is to fix a nodejs warning when too many listeners are attached to an event handler.
cc @gmmorris @mikecote @kobelb 
