### PR TITLE
Update title on the APM empty state prompt

### DIFF
--- a/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
@@ -61,7 +61,7 @@ export function ApmMainTemplate({
   const { data: fleetApmIntegrations } = useFetcher(
     (callApmApi) => {
       if (!data?.hasData && !shouldBypassNoDataScreen) {
-        return callApmApi('GET /internal/apm/fleet/has_data');
+        return callApmApi('GET /internal/apm/fleet/has_apm_policies');
       }
     },
     [shouldBypassNoDataScreen, data?.hasData]
@@ -70,8 +70,9 @@ export function ApmMainTemplate({
   const noDataConfig = getNoDataConfig({
     basePath,
     docsLink: docLinks!.links.observability.guide,
-    hasData: data?.hasData,
-    hasApmIntegrations: fleetApmIntegrations?.hasData,
+    hasApmData: data?.hasData,
+    hasApmIntegrations: fleetApmIntegrations?.hasApmPolicies,
+    shouldBypassNoDataScreen,
   });
 
   const rightSideItems = environmentFilter ? [<ApmEnvironmentFilter />] : [];

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
@@ -54,15 +54,25 @@ export function ApmMainTemplate({
     return callApmApi('GET /internal/apm/has_data');
   }, []);
 
+  const shouldBypassNoDataScreen = bypassNoDataScreenPaths.some((path) =>
+    location.pathname.includes(path)
+  );
+
+  const { data: fleetApmIntegrations } = useFetcher(
+    (callApmApi) => {
+      if (!data?.hasData && !shouldBypassNoDataScreen) {
+        return callApmApi('GET /internal/apm/fleet/has_data');
+      }
+    },
+    [shouldBypassNoDataScreen, data?.hasData]
+  );
+
   const noDataConfig = getNoDataConfig({
     basePath,
     docsLink: docLinks!.links.observability.guide,
     hasData: data?.hasData,
+    hasApmIntegrations: fleetApmIntegrations?.hasData,
   });
-
-  const shouldBypassNoDataScreen = bypassNoDataScreenPaths.some((path) =>
-    location.pathname.includes(path)
-  );
 
   const rightSideItems = environmentFilter ? [<ApmEnvironmentFilter />] : [];
 

--- a/x-pack/plugins/apm/public/components/routing/templates/no_data_config.ts
+++ b/x-pack/plugins/apm/public/components/routing/templates/no_data_config.ts
@@ -11,42 +11,51 @@ import { KibanaPageTemplateProps } from '../../../../../../../src/plugins/kibana
 export function getNoDataConfig({
   docsLink,
   basePath,
-  hasData,
+  hasApmData,
   hasApmIntegrations,
+  shouldBypassNoDataScreen,
 }: {
   docsLink: string;
   basePath?: string;
-  hasData?: boolean;
+  hasApmData?: boolean;
   hasApmIntegrations?: boolean;
+  shouldBypassNoDataScreen: boolean;
 }): KibanaPageTemplateProps['noDataConfig'] {
-  // Returns no data config when there is no historical data
-  if (hasData === false) {
-    const title = hasApmIntegrations
-      ? i18n.translate('xpack.apm.noDataConfig.addDataButtonLabel', {
-          defaultMessage: 'Add data',
-        })
-      : i18n.translate('xpack.apm.noDataConfig.addApmIntegrationButtonLabel', {
-          defaultMessage: 'Add the APM integration',
-        });
-
-    return {
-      solution: i18n.translate('xpack.apm.noDataConfig.solutionName', {
-        defaultMessage: 'Observability',
-      }),
-      actions: {
-        elasticAgent: {
-          title,
-          description: i18n.translate(
-            'xpack.apm.ux.overview.agent.description',
-            {
-              defaultMessage:
-                'Use APM agents to collect APM data. We make it easy with agents for many popular languages.',
-            }
-          ),
-          href: `${basePath}/app/home#/tutorial/apm`,
-        },
-      },
-      docsLink,
-    };
+  // don't show "no data screen" when there is APM data or it should be bypassed
+  if (hasApmData || shouldBypassNoDataScreen) {
+    return;
   }
+  const noDataConfigDetails = hasApmIntegrations
+    ? {
+        title: i18n.translate('xpack.apm.noDataConfig.addDataButtonLabel', {
+          defaultMessage: 'Add data',
+        }),
+        href: `${basePath}/app/home#/tutorial/apm`,
+      }
+    : {
+        title: i18n.translate(
+          'xpack.apm.noDataConfig.addApmIntegrationButtonLabel',
+          {
+            defaultMessage: 'Add the APM integration',
+          }
+        ),
+        href: `${basePath}/app/integrations/detail/apm/overview`,
+      };
+
+  return {
+    solution: i18n.translate('xpack.apm.noDataConfig.solutionName', {
+      defaultMessage: 'Observability',
+    }),
+    actions: {
+      elasticAgent: {
+        title: noDataConfigDetails.title,
+        description: i18n.translate('xpack.apm.ux.overview.agent.description', {
+          defaultMessage:
+            'Use APM agents to collect APM data. We make it easy with agents for many popular languages.',
+        }),
+        href: noDataConfigDetails.href,
+      },
+    },
+    docsLink,
+  };
 }

--- a/x-pack/plugins/apm/public/components/routing/templates/no_data_config.ts
+++ b/x-pack/plugins/apm/public/components/routing/templates/no_data_config.ts
@@ -10,19 +10,21 @@ import { KibanaPageTemplateProps } from '../../../../../../../src/plugins/kibana
 
 export function getNoDataConfig({
   docsLink,
+  shouldBypassNoDataScreen,
+  loading,
   basePath,
   hasApmData,
   hasApmIntegrations,
-  shouldBypassNoDataScreen,
 }: {
   docsLink: string;
+  shouldBypassNoDataScreen: boolean;
+  loading: boolean;
   basePath?: string;
   hasApmData?: boolean;
   hasApmIntegrations?: boolean;
-  shouldBypassNoDataScreen: boolean;
 }): KibanaPageTemplateProps['noDataConfig'] {
   // don't show "no data screen" when there is APM data or it should be bypassed
-  if (hasApmData || shouldBypassNoDataScreen) {
+  if (hasApmData || shouldBypassNoDataScreen || loading) {
     return;
   }
   const noDataConfigDetails = hasApmIntegrations

--- a/x-pack/plugins/apm/public/components/routing/templates/no_data_config.ts
+++ b/x-pack/plugins/apm/public/components/routing/templates/no_data_config.ts
@@ -12,22 +12,30 @@ export function getNoDataConfig({
   docsLink,
   basePath,
   hasData,
+  hasApmIntegrations,
 }: {
   docsLink: string;
   basePath?: string;
   hasData?: boolean;
+  hasApmIntegrations?: boolean;
 }): KibanaPageTemplateProps['noDataConfig'] {
   // Returns no data config when there is no historical data
   if (hasData === false) {
+    const title = hasApmIntegrations
+      ? i18n.translate('xpack.apm.noDataConfig.addDataButtonLabel', {
+          defaultMessage: 'Add data',
+        })
+      : i18n.translate('xpack.apm.noDataConfig.addApmIntegrationButtonLabel', {
+          defaultMessage: 'Add the APM integration',
+        });
+
     return {
       solution: i18n.translate('xpack.apm.noDataConfig.solutionName', {
         defaultMessage: 'Observability',
       }),
       actions: {
         elasticAgent: {
-          title: i18n.translate('xpack.apm.ux.overview.agent.title', {
-            defaultMessage: 'Add the APM integration',
-          }),
+          title,
           description: i18n.translate(
             'xpack.apm.ux.overview.agent.description',
             {

--- a/x-pack/plugins/apm/public/tutorial/tutorial_apm_fleet_check.ts
+++ b/x-pack/plugins/apm/public/tutorial/tutorial_apm_fleet_check.ts
@@ -8,13 +8,13 @@ import { callApmApi } from '../services/rest/create_call_apm_api';
 
 export async function hasFleetApmIntegrations() {
   try {
-    const { hasData = false } = await callApmApi(
-      'GET /internal/apm/fleet/has_data',
+    const { hasApmPolicies = false } = await callApmApi(
+      'GET /internal/apm/fleet/has_apm_policies',
       {
         signal: null,
       }
     );
-    return hasData;
+    return hasApmPolicies;
   } catch (e) {
     console.error('Something went wrong while fetching apm fleet data', e);
     return false;

--- a/x-pack/plugins/apm/server/routes/fleet/route.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/route.ts
@@ -27,18 +27,18 @@ import { setupRequest } from '../../lib/helpers/setup_request';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 
 const hasFleetDataRoute = createApmServerRoute({
-  endpoint: 'GET /internal/apm/fleet/has_data',
+  endpoint: 'GET /internal/apm/fleet/has_apm_policies',
   options: { tags: [] },
-  handler: async ({ core, plugins }): Promise<{ hasData: boolean }> => {
+  handler: async ({ core, plugins }): Promise<{ hasApmPolicies: boolean }> => {
     const fleetPluginStart = await plugins.fleet?.start();
     if (!fleetPluginStart) {
-      return { hasData: false };
+      return { hasApmPolicies: false };
     }
     const packagePolicies = await getApmPackgePolicies({
       core,
       fleetPluginStart,
     });
-    return { hasData: packagePolicies.total > 0 };
+    return { hasApmPolicies: packagePolicies.total > 0 };
   },
 });
 


### PR DESCRIPTION
## Summary
Updates the title on the APM empty state prompt.

If there is an APM integration installed the title is `Add data`, otherwise it's `Add the APM integration`.

<img width="381" alt="image" src="https://user-images.githubusercontent.com/5831975/155129391-babb0fe0-3a7b-48fd-a810-b8d480d5b905.png">

<img width="421" alt="image" src="https://user-images.githubusercontent.com/5831975/155129218-aeeb4301-4d58-4474-b34a-bf4f0efe0509.png">

Closes https://github.com/elastic/kibana/issues/125907