### PR TITLE
[Fleet] Improve error message for duplicate package policies

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -115,7 +115,7 @@ class PackagePolicyService {
       // Check that the name does not exist already
       if (existingPoliciesWithName.items.length > 0) {
         throw new IngestManagerError(
-          `There is already an integration policy with the same name: ${packagePolicy.name}`
+          `An integration policy with the name ${packagePolicy.name} already exists. Please rename it or choose a different name.`
         );
       }
     }
@@ -389,7 +389,9 @@ class PackagePolicyService {
     const filtered = (existingPoliciesWithName?.items || []).filter((p) => p.id !== id);
 
     if (filtered.length > 0) {
-      throw new IngestManagerError('There is already an integration policy with the same name');
+      throw new IngestManagerError(
+        `An integration policy with the name ${packagePolicy.name} already exists. Please rename it or choose a different name.`
+      );
     }
 
     let inputs = restOfPackagePolicy.inputs.map((input) =>


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/126164

Ensures the package policy name is always included in the error message when a duplicate is detected, and add a "call to action" message to the error output.

## To test

1. Attempt to create an integration policy with a name that already exists on another policy. 
2. Note the new error message in the toast and in the Kibana logs

![image](https://user-images.githubusercontent.com/6766512/155177830-61d6136f-6cbd-42bc-aaf8-8a174e9d5d8a.png)

