### PR TITLE
[8.0] [Archive Migration]  index pattern without timefield (#125870)

### DIFF
--- a/test/functional/apps/discover/_indexpattern_without_timefield.ts
+++ b/test/functional/apps/discover/_indexpattern_without_timefield.ts
@@ -23,6 +23,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await esArchiver.loadIfNeeded(
         'test/functional/fixtures/es_archiver/index_pattern_without_timefield'
       );
+      await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
+      await kibanaServer.importExport.load(
+        'test/functional/fixtures/kbn_archiver/index_pattern_without_timefield'
+      );
       await kibanaServer.uiSettings.replace({
         defaultIndex: 'without-timefield',
         'timepicker:timeDefaults': '{  "from": "2019-01-18T19:37:13.000Z",  "to": "now"}',
@@ -37,6 +41,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await esArchiver.unload(
         'test/functional/fixtures/es_archiver/index_pattern_without_timefield'
       );
+      await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
     });
 
     it('should not display a timepicker', async () => {

--- a/test/functional/fixtures/es_archiver/index_pattern_without_timefield/data.json
+++ b/test/functional/fixtures/es_archiver/index_pattern_without_timefield/data.json
@@ -1,21 +1,6 @@
 {
   "type": "doc",
   "value": {
-    "id": "index-pattern:without-timefield",
-    "index": ".kibana",
-    "source": {
-      "index-pattern": {
-        "fields": "[]",
-        "title": "without-timefield"
-      },
-      "type": "index-pattern"
-    }
-  }
-}
-
-{
-  "type": "doc",
-  "value": {
     "id": "AU_x3-TaGFA8no6QjiSJ",
     "index": "without-timefield",
     "source": {

--- a/test/functional/fixtures/kbn_archiver/index_pattern_without_timefield.json
+++ b/test/functional/fixtures/kbn_archiver/index_pattern_without_timefield.json
@@ -1,0 +1,30 @@
+{
+  "attributes": {
+    "fields": "[]",
+    "timeFieldName": "@timestamp",
+    "title": "with-timefield"
+  },
+  "coreMigrationVersion": "7.17.1",
+  "id": "with-timefield",
+  "migrationVersion": {
+    "index-pattern": "7.11.0"
+  },
+  "references": [],
+  "type": "index-pattern",
+  "version": "WzEzLDJd"
+}
+
+{
+  "attributes": {
+    "fields": "[]",
+    "title": "without-timefield"
+  },
+  "coreMigrationVersion": "7.17.1",
+  "id": "without-timefield",
+  "migrationVersion": {
+    "index-pattern": "7.11.0"
+  },
+  "references": [],
+  "type": "index-pattern",
+  "version": "WzEyLDJd"
+}

--- a/x-pack/test/functional/apps/discover/value_suggestions_non_timebased.ts
+++ b/x-pack/test/functional/apps/discover/value_suggestions_non_timebased.ts
@@ -9,6 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
   const queryBar = getService('queryBar');
   const PageObjects = getPageObjects(['common', 'settings', 'context', 'header']);
 
@@ -17,12 +18,23 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await esArchiver.loadIfNeeded(
         'test/functional/fixtures/es_archiver/index_pattern_without_timefield'
       );
+      await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
+      await kibanaServer.importExport.load(
+        'test/functional/fixtures/kbn_archiver/index_pattern_without_timefield'
+      );
+      await kibanaServer.uiSettings.replace({ defaultIndex: 'without-timefield' });
+      await kibanaServer.uiSettings.update({
+        'doc_table:legacy': true,
+      });
     });
 
     after(async () => {
       await esArchiver.unload(
         'test/functional/fixtures/es_archiver/index_pattern_without_timefield'
       );
+      await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
+      await kibanaServer.uiSettings.unset('defaultIndex');
+      await kibanaServer.uiSettings.unset('doc_table:legacy');
     });
 
     it('shows all autosuggest options for a filter in discover context app', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[Archive Migration]  index pattern without timefield (#125870)](https://github.com/elastic/kibana/pull/125870)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)