### PR TITLE
Stop using `aborted` event for `KibanaRequest.events.aborted$`

### DIFF
--- a/src/core/server/http/integration_tests/request.test.ts
+++ b/src/core/server/http/integration_tests/request.test.ts
@@ -198,6 +198,42 @@ describe('KibanaRequest', () => {
         expect(nextSpy).toHaveBeenCalledTimes(1);
       });
 
+      it('emits once and completes when request aborted after the payload has been consumed', async () => {
+        expect.assertions(1);
+        const { server: innerServer, createRouter } = await server.setup(setupDeps);
+        const router = createRouter('/');
+
+        const nextSpy = jest.fn();
+
+        const done = new Promise<void>((resolve) => {
+          router.post(
+            { path: '/', validate: { body: schema.any() } },
+            async (context, request, res) => {
+              request.events.aborted$.subscribe({
+                next: nextSpy,
+                complete: resolve,
+              });
+
+              // prevents the server to respond
+              await delay(30000);
+              return res.ok({ body: 'ok' });
+            }
+          );
+        });
+
+        await server.start();
+
+        const incomingRequest = supertest(innerServer.listener)
+          .post('/')
+          .send({ hello: 'dolly' })
+          // end required to send request
+          .end();
+
+        setTimeout(() => incomingRequest.abort(), 50);
+        await done;
+        expect(nextSpy).toHaveBeenCalledTimes(1);
+      });
+
       it('completes & does not emit when request handled', async () => {
         const { server: innerServer, createRouter } = await server.setup(setupDeps);
         const router = createRouter('/');

--- a/src/core/server/http/integration_tests/request.test.ts
+++ b/src/core/server/http/integration_tests/request.test.ts
@@ -372,6 +372,41 @@ describe('KibanaRequest', () => {
         await done;
         expect(nextSpy).toHaveBeenCalledTimes(1);
       });
+
+      it('emits once and completes when response is aborted after the payload has been consumed', async () => {
+        expect.assertions(2);
+        const { server: innerServer, createRouter } = await server.setup(setupDeps);
+        const router = createRouter('/');
+
+        const nextSpy = jest.fn();
+
+        const done = new Promise<void>((resolve) => {
+          router.post(
+            { path: '/', validate: { body: schema.any() } },
+            async (context, req, res) => {
+              req.events.completed$.subscribe({
+                next: nextSpy,
+                complete: resolve,
+              });
+
+              expect(nextSpy).not.toHaveBeenCalled();
+              await delay(30000);
+              return res.ok({ body: 'ok' });
+            }
+          );
+        });
+
+        await server.start();
+
+        const incomingRequest = supertest(innerServer.listener)
+          .post('/')
+          .send({ foo: 'bar' })
+          // end required to send request
+          .end();
+        setTimeout(() => incomingRequest.abort(), 50);
+        await done;
+        expect(nextSpy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -227,6 +227,7 @@ export class KibanaRequest<
     // the response's underlying connection was terminated prematurely
     const aborted$ = closed$.pipe(
       filter(() => !isCompleted(request)),
+      shareReplay(1),
       first(),
       takeUntil(finished$)
     );

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -10,7 +10,7 @@ import { URL } from 'url';
 import uuid from 'uuid';
 import { Request, RouteOptionsApp, RequestApplicationState, RouteOptions } from '@hapi/hapi';
 import { Observable, fromEvent, merge } from 'rxjs';
-import { shareReplay, first, takeUntil } from 'rxjs/operators';
+import { shareReplay, first, takeUntil, filter } from 'rxjs/operators';
 import { RecursiveReadonly } from '@kbn/utility-types';
 import { deepFreeze } from '@kbn/std';
 
@@ -127,6 +127,7 @@ export class KibanaRequest<
     const body = routeValidator.getBody(req.payload, 'request body');
     return { query, params, body };
   }
+
   /**
    * A identifier to identify this request.
    *
@@ -215,11 +216,24 @@ export class KibanaRequest<
   }
 
   private getEvents(request: Request): KibanaRequestEvents {
-    // the response is completed, or its underlying connection was terminated prematurely
-    const finish$ = fromEvent(request.raw.res, 'close').pipe(shareReplay(1), first());
+    // the response is completed
+    const finished$ = fromEvent<void>(request.raw.res, 'close').pipe(
+      filter(() => {
+        return isCompleted(request);
+      }),
+      first()
+    );
 
-    const aborted$ = fromEvent<void>(request.raw.req, 'aborted').pipe(first(), takeUntil(finish$));
-    const completed$ = merge<void, void>(finish$, aborted$).pipe(shareReplay(1), first());
+    // the response's underlying connection was terminated prematurely
+    const aborted$ = fromEvent<void>(request.raw.res, 'close').pipe(
+      filter(() => {
+        return !isCompleted(request);
+      }),
+      first(),
+      takeUntil(finished$)
+    );
+
+    const completed$ = merge<void, void>(finished$, aborted$).pipe(shareReplay(1), first());
 
     return {
       aborted$,
@@ -330,4 +344,8 @@ function isRequest(request: any): request is Request {
  */
 export function isRealRequest(request: unknown): request is KibanaRequest | Request {
   return isKibanaRequest(request) || isRequest(request);
+}
+
+function isCompleted(request: Request) {
+  return request.raw.res.writableFinished;
 }

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -9,7 +9,7 @@
 import { URL } from 'url';
 import uuid from 'uuid';
 import { Request, RouteOptionsApp, RequestApplicationState, RouteOptions } from '@hapi/hapi';
-import { Observable, fromEvent, merge } from 'rxjs';
+import { Observable, fromEvent } from 'rxjs';
 import { shareReplay, first, filter } from 'rxjs/operators';
 import { RecursiveReadonly } from '@kbn/utility-types';
 import { deepFreeze } from '@kbn/std';
@@ -216,14 +216,9 @@ export class KibanaRequest<
   }
 
   private getEvents(request: Request): KibanaRequestEvents {
-    const closed$ = fromEvent<void>(request.raw.res, 'close').pipe(shareReplay(1), first());
-
-    // the response is completed
-    const finished$ = closed$.pipe(filter(() => isCompleted(request)));
+    const completed$ = fromEvent<void>(request.raw.res, 'close').pipe(shareReplay(1), first());
     // the response's underlying connection was terminated prematurely
-    const aborted$ = closed$.pipe(filter(() => !isCompleted(request)));
-    // the response was either finished or aborted
-    const completed$ = merge<void, void>(finished$, aborted$);
+    const aborted$ = completed$.pipe(filter(() => !isCompleted(request)));
 
     return {
       aborted$,

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -223,7 +223,7 @@ export class KibanaRequest<
     // the response's underlying connection was terminated prematurely
     const aborted$ = closed$.pipe(filter(() => !isCompleted(request)));
     // the response was either finished or aborted
-    const completed$ = merge<void, void>(finished$, aborted$).pipe(shareReplay(1));
+    const completed$ = merge<void, void>(finished$, aborted$);
 
     return {
       aborted$,


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/125240

Fix a problem causing `KibanaRequest.events.aborted$` to not emit in scenarios where it should, when used within endpoints consuming the payload (basically most of our `POST` or `PUT` endpoints).

This was caused by a ~~regression~~ deliberate (and undocumented) change in the way node's `IncomingMessage` internally works. See https://github.com/nodejs/node/issues/40775 for more context.

Also has the upside to stop using that `aborted` event which is flagged as deprecated since node `v16.12.0` (https://nodejs.org/docs/latest-v16.x/api/http.html#event-abort)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



