### PR TITLE
Bump prismjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "**/pdfkit/crypto-js": "4.0.0",
     "**/react-syntax-highlighter": "^15.3.1",
     "**/react-syntax-highlighter/**/highlight.js": "^10.4.1",
+    "**/refractor/prismjs": "~1.27.0",
     "**/trim": "1.0.1",
     "**/typescript": "4.5.3",
     "**/underscore": "^1.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23717,10 +23717,10 @@ printj@~1.1.0:
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
   integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
-prismjs@^1.22.0, prismjs@~1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.25.0.tgz#6f822df1bdad965734b310b315a23315cf999756"
-  integrity sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==
+prismjs@^1.22.0, prismjs@~1.25.0, prismjs@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 private@^0.1.8, private@~0.1.5:
   version "0.1.8"


### PR DESCRIPTION
Changes:

* 1a8258a0fad632aed5e14afc7ef8ffac7118571f: prismjs 1.25.0 -> 1.27.0 ([changes](https://github.com/PrismJS/prism/blob/master/CHANGELOG.md#1270-2022-02-17))

Notes:

* We originally added a yarn dependency resolution here: #113388
* We removed that dependency resolution here: #114654
* We needed to add the yarn dependency resolution again because prismjs is a transitive dependency of refractor, and we would have to upgrade to a new major version of refractor which we're not ready to do yet
* This resolution is also being added to EUI for the time being: elastic/eui#5654