### PR TITLE
[Fleet] Fix preconfiguration allow to enable disabled by default inputs

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.test.ts
@@ -1704,8 +1704,8 @@ describe('Package policy service', () => {
       });
     });
 
-    describe('when an input or stream is disabled on the original policy object', () => {
-      it('remains disabled on the resulting policy object', () => {
+    describe('when an input or stream is disabled by default in the package', () => {
+      it('allow preconfiguration to enable it', () => {
         const basePackagePolicy: NewPackagePolicy = {
           name: 'base-package-policy',
           description: 'Base Package Policy',
@@ -1914,13 +1914,13 @@ describe('Package policy service', () => {
         expect(template2Inputs).toHaveLength(1);
 
         const logsInput = template1Inputs?.find((input) => input.type === 'logs');
-        expect(logsInput?.enabled).toBe(false);
+        expect(logsInput?.enabled).toBe(true);
 
         const logfileStream = logsInput?.streams.find(
           (stream) => stream.data_stream.type === 'logfile'
         );
 
-        expect(logfileStream?.enabled).toBe(false);
+        expect(logfileStream?.enabled).toBe(true);
       });
     });
 

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -1323,14 +1323,11 @@ export function preconfigurePackageInputs(
       continue;
     }
 
-    // For flags like this, we only want to override the original value if it was set
-    // as `undefined` in the original object. An explicit true/false value should be
-    // persisted from the original object to the result after the override process is complete.
-    if (originalInput.enabled === undefined && preconfiguredInput.enabled !== undefined) {
+    if (preconfiguredInput.enabled !== undefined) {
       originalInput.enabled = preconfiguredInput.enabled;
     }
 
-    if (originalInput.keep_enabled === undefined && preconfiguredInput.keep_enabled !== undefined) {
+    if (preconfiguredInput.keep_enabled !== undefined) {
       originalInput.keep_enabled = preconfiguredInput.keep_enabled;
     }
 
@@ -1353,7 +1350,7 @@ export function preconfigurePackageInputs(
           continue;
         }
 
-        if (originalStream?.enabled === undefined) {
+        if (stream.enabled !== undefined) {
           originalStream.enabled = stream.enabled;
         }
 


### PR DESCRIPTION
## Summary

Resolve #125730

The preconfiguration code was not allowing to enabled/disable inputs (only using default inputs/streams) that PR fix that.


### How to test

You can try to add an input that is not enabled by default like the tcp one of synthetics
```
xpack.fleet.packages:
- name: system
  version: latest
- name: elastic_agent
  version: latest
- name: fleet_server
  version: latest
- name: synthetics
  version: latest
xpack.fleet.agentPolicies:
- name: My agent policy 2
  id: my-agent-policy-2
  namespace: default
  monitoring_enabled:
  - logs
  - metrics
  unenroll_timeout: 900
  is_default: true
  package_policies:
    - package:
        name: synthetics
      name: My monitor
      id: my-monitor-123
      inputs:
        - type: synthetics/tcp
          enabled: true
          streams:
            - data_stream:
                type: synthetics
                dataset: tcp
              enabled: true
              vars:
                - name: type
                  value: tcp
                - name: hosts
                  value: localhost:9200
                
                ```