### PR TITLE
[Maps] Safety check for field meta categories

### DIFF
--- a/x-pack/plugins/maps/public/classes/styles/vector/style_meta.ts
+++ b/x-pack/plugins/maps/public/classes/styles/vector/style_meta.ts
@@ -14,14 +14,14 @@ export class StyleMeta {
   }
 
   getRangeFieldMetaDescriptor(fieldName: string): RangeFieldMeta | null {
-    return this._descriptor.fieldMeta[fieldName] && this._descriptor.fieldMeta[fieldName].range
+    return this._descriptor.fieldMeta[fieldName]
       ? this._descriptor.fieldMeta[fieldName].range!
       : null;
   }
 
   getCategoryFieldMetaDescriptor(fieldName: string): Category[] {
-    return this._descriptor.fieldMeta[fieldName] && this._descriptor.fieldMeta[fieldName].categories
-      ? this._descriptor.fieldMeta[fieldName].categories!
+    return this._descriptor.fieldMeta[fieldName]
+      ? this._descriptor.fieldMeta[fieldName].categories
       : [];
   }
 

--- a/x-pack/plugins/maps/public/classes/styles/vector/style_meta.ts
+++ b/x-pack/plugins/maps/public/classes/styles/vector/style_meta.ts
@@ -14,7 +14,7 @@ export class StyleMeta {
   }
 
   getRangeFieldMetaDescriptor(fieldName: string): RangeFieldMeta | null {
-    return this._descriptor.fieldMeta[fieldName]
+    return this._descriptor.fieldMeta[fieldName] && this._descriptor.fieldMeta[fieldName].range
       ? this._descriptor.fieldMeta[fieldName].range!
       : null;
   }

--- a/x-pack/plugins/maps/public/classes/styles/vector/style_meta.ts
+++ b/x-pack/plugins/maps/public/classes/styles/vector/style_meta.ts
@@ -20,7 +20,9 @@ export class StyleMeta {
   }
 
   getCategoryFieldMetaDescriptor(fieldName: string): Category[] {
-    return this._descriptor.fieldMeta[fieldName].categories;
+    return this._descriptor.fieldMeta[fieldName] && this._descriptor.fieldMeta[fieldName].categories
+      ? this._descriptor.fieldMeta[fieldName].categories!
+      : [];
   }
 
   isPointsOnly(): boolean {

--- a/x-pack/plugins/maps/public/classes/styles/vector/vector_style.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/vector_style.tsx
@@ -521,9 +521,11 @@ export class VectorStyle implements IVectorStyle {
       if (!styleMeta.fieldMeta[name]) {
         styleMeta.fieldMeta[name] = { categories: [] };
       }
-      styleMeta.fieldMeta[name].categories =
+      const categories =
         dynamicProperty.pluckCategoricalStyleMetaFromTileMetaFeatures(metaFeatures);
-
+      if (categories.length) {
+        styleMeta.fieldMeta[name].categories = categories;
+      }
       const ordinalStyleMeta =
         dynamicProperty.pluckOrdinalStyleMetaFromTileMetaFeatures(metaFeatures);
       if (ordinalStyleMeta) {
@@ -601,8 +603,10 @@ export class VectorStyle implements IVectorStyle {
         if (!styleMeta.fieldMeta[name]) {
           styleMeta.fieldMeta[name] = { categories: [] };
         }
-        styleMeta.fieldMeta[name].categories =
-          dynamicProperty.pluckCategoricalStyleMetaFromFeatures(features);
+        const categories = dynamicProperty.pluckCategoricalStyleMetaFromFeatures(features);
+        if (categories.length) {
+          styleMeta.fieldMeta[name].categories = categories;
+        }
         const ordinalStyleMeta = dynamicProperty.pluckOrdinalStyleMetaFromFeatures(features);
         if (ordinalStyleMeta) {
           styleMeta.fieldMeta[name].range = ordinalStyleMeta;


### PR DESCRIPTION
## Summary
Fixes #126008 

We can't guarantee that the style descriptor `fieldMeta` will have the `fieldName` property with all calls to `getCategoryFieldMetaDescriptor`. So this adds a safety check to ensure we don't crash the application.




