### PR TITLE
[7.17] Update x-pack readme to fix broken link (#124874)

### DIFF
--- a/x-pack/README.md
+++ b/x-pack/README.md
@@ -16,7 +16,7 @@ By default, this will also set the password for native realm accounts to the pas
 
 # Testing
 
-For information on testing, see [the Elastic functional test development guide](https://www.elastic.co/guide/en/kibana/current/development-functional-tests.html).
+For information on testing, see [the Elastic functional test development guide](https://www.elastic.co/guide/en/kibana/current/development-tests.html).
 
 #### Running functional tests
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Update x-pack readme to fix broken link (#124874)](https://github.com/elastic/kibana/pull/124874)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)