### PR TITLE
Update APM config for load testing

### DIFF
--- a/x-pack/test/load/config.ts
+++ b/x-pack/test/load/config.ts
@@ -47,13 +47,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       env: {
         ELASTIC_APM_ACTIVE: process.env.ELASTIC_APM_ACTIVE,
         ELASTIC_APM_CENTRAL_CONFIG: false,
-        ELASTIC_APM_TRANSACTION_SAMPLE_RATE: '0.1',
+        ELASTIC_APM_TRANSACTION_SAMPLE_RATE: '1',
         ELASTIC_APM_BREAKDOWN_METRICS: false,
         ELASTIC_APM_CAPTURE_SPAN_STACK_TRACES: false,
         ELASTIC_APM_METRICS_INTERVAL: '120s',
         ELASTIC_APM_MAX_QUEUE_SIZE: 20480,
-        ELASTIC_SANITIZE_FIELD_NAMES:
-          'password,passwd,pwd,secret,*key,*token*,*session*,*credit*,*card*,*auth*,set-cookie,pw,pass,connect.sid',
         ELASTIC_APM_ENVIRONMENT: process.env.CI ? 'ci' : 'development',
         ELASTIC_APM_SERVER_URL: APM_SERVER_URL,
         ELASTIC_APM_SECRET_TOKEN: APM_PUBLIC_TOKEN,


### PR DESCRIPTION
## Summary

Tweaking APM config according to @lizozom suggestions.

In order to have all transactions reported, sample rate is changed to 1.

Data is collected at [Kibana-stats](https://kibana-stats.elastic.dev/app/apm/services/kibana/transactions/view?kuery=&rangeFrom=now-3d&rangeTo=now&environment=ENVIRONMENT_ALL&transactionName=POST%20%2Finternal%2Fsecurity%2Flogin&transactionType=request&comparisonEnabled=true&comparisonType=week&latencyAggregationType=avg&sampleRangeFrom=3262262&sampleRangeTo=10357621&transactionId=84308466f6b86e92&traceId=9ce995b563a57afe3736d012f9317aa6) cluster