### PR TITLE
fix(NA): APM translations for xpack.apm.ux.overview.agent.title

### DIFF
--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -7808,7 +7808,6 @@
     "xpack.apm.tutorial.windowsServerInstructions.textPre": "1.[ダウンロードページ]（{downloadPageLink}）から APM Server Windows zip ファイルをダウンロードします。\n2.zip ファイルの内容を {zipFileExtractFolder} に抽出します。\n3.「{apmServerDirectory} ディレクトリの名前を「APM-Server」に変更します。\n4.管理者としてPowerShellプロンプトを開きます（PowerShellアイコンを右クリックして「管理者として実行」を選択します）。Windows XPをご使用の場合、PowerShellのダウンロードとインストールが必要な場合があります。\n5.PowerShell プロンプトで次のコマンドを実行し、APM Server を Windows サービスとしてインストールします。",
     "xpack.apm.unitLabel": "単位を選択",
     "xpack.apm.ux.overview.agent.description": "APMエージェントを使用して、APMデータを収集します。多数の一般的な言語では、エージェントを使用することで処理が簡単になっています。",
-    "xpack.apm.ux.overview.agent.title": "APM統合を追加",
     "xpack.apm.views.dependencies.title": "依存関係",
     "xpack.apm.views.dependenciesInventory.title": "依存関係",
     "xpack.apm.views.errors.title": "エラー",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -7881,7 +7881,6 @@
     "xpack.apm.unitLabel": "选择单位",
     "xpack.apm.unsavedChanges": "{unsavedChangesCount, plural, =0{0 个未保存更改} one {1 个未保存更改} other {# 个未保存更改}} ",
     "xpack.apm.ux.overview.agent.description": "使用 APM 代理来收集 APM 数据。我们的代理支持许多流行语言，可以轻松使用。",
-    "xpack.apm.ux.overview.agent.title": "添加 APM 集成",
     "xpack.apm.views.dependencies.title": "依赖项",
     "xpack.apm.views.dependenciesInventory.title": "依赖项",
     "xpack.apm.views.errors.title": "错误",


### PR DESCRIPTION
This PR removes an unused translation `xpack.apm.ux.overview.agent.title` that was removed at https://github.com/elastic/kibana/pull/126146 so we can fix the CI.