### PR TITLE
[Fleet] added support for dimension field

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -689,6 +689,31 @@ describe('EPM template', () => {
     expect(JSON.stringify(mappings)).toEqual(JSON.stringify(constantKeywordMapping));
   });
 
+  it('tests processing dimension field', () => {
+    const literalYml = `
+- name: example.id
+  type: keyword
+  dimension: true
+  `;
+    const expectedMapping = {
+      properties: {
+        example: {
+          properties: {
+            id: {
+              ignore_above: 1024,
+              time_series_dimension: true,
+              type: 'keyword',
+            },
+          },
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(literalYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(expectedMapping);
+  });
+
   it('processes meta fields', () => {
     const metaFieldLiteralYaml = `
 - name: fieldWithMetas

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -264,6 +264,9 @@ function generateKeywordMapping(field: Field): IndexTemplateMapping {
   if (field.normalizer) {
     mapping.normalizer = field.normalizer;
   }
+  if (field.dimension) {
+    mapping.time_series_dimension = field.dimension;
+  }
   return mapping;
 }
 

--- a/x-pack/plugins/fleet/server/services/epm/fields/field.ts
+++ b/x-pack/plugins/fleet/server/services/epm/fields/field.ts
@@ -35,6 +35,7 @@ export interface Field {
   include_in_parent?: boolean;
   include_in_root?: boolean;
   null_value?: string;
+  dimension?: boolean;
 
   // Meta fields
   metric_type?: string;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/115620

Added support for dimension field.

In packages field definitions, a dimension is defined as a boolean value in a fields definition, for example:
```
- name: example.id
  type: keyword
  dimension: true
```

This should be translated into a mapping including the `time_series_dimension` parameter (added in https://github.com/elastic/elasticsearch/issues/74014) set to `true`, something like this:
```
...
  "mappings": {
    "properties":
      "example":
        "properties":
          "id": {
            "type": "keyword",
            "time_series_dimension": true
          }
       }
    }
...
```


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
