### PR TITLE
[8.1] [DOCS] Adds the 8.0.1 release notes (#125958)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -10,15 +10,73 @@
 
 Review important information about the {kib} 8.0.0 releases.
 
-// * <<release-notes-8.0.0>>
-// * <release-notes-8.0.0-rc2>>
-// * <<release-notes-8.0.0-rc1>>
-// * <<release-notes-8.0.0-beta1>>
-// * <<release-notes-8.0.0-alpha2>>
-// * <<release-notes-8.0.0-alpha1>>
+
+* <<release-notes-8.0.1>>
+* <<release-notes-8.0.0>>
+* <<release-notes-8.0.0-rc2>>
+* <<release-notes-8.0.0-rc1>>
+* <<release-notes-8.0.0-beta1>>
+* <<release-notes-8.0.0-alpha2>>
+* <<release-notes-8.0.0-alpha1>>
 
 --
+
 //// ////
+[[release-notes-8.0.1]]
+== {kib} 8.0.1
+
+coming::[8.0.1]
+
+The 8.0.1 release includes the following enhancement and bug fixes.
+
+[float]
+[[enhancement-v8.0.1]]
+=== Enhancements
+Elastic Security::
+For the Elastic Security 8.0.1 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
+
+[float]
+[[fixes-v8.0.1]]
+=== Bug Fixes
+Alerting::
+Fixes an issue where the *Cases* rule link was displayed as `Unknown rule`, even when the correct rule name was retrieved {kibana-pull}123883[#123883]
+
+Dashboard::
+Transfer state when drilldown is opened in a new tab {kibana-pull}124770[#124770]
+
+Elastic Security::
+For the Elastic Security 8.0.1 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
+
+Fleet::
+* Avoid breaking setup when compatible package is unavailable in registry {kibana-pull}125525[#125525]
+* Tell users when assets are installed in a different space {kibana-pull}125278[#125278]
+
+Machine Learning::
+Only fetch field statistics for available fields {kibana-pull}123003[#123003]
+
+Management::
+Registering a snapshot repository is now possible in Snapshot and Restore {kibana-pull}125656[#125656]
+
+Maps::
+* Fixes an issue where dashboards with by-value maps are broken when copied to new space {kibana-pull}125599[#125599]
+* Fixes an issue where styles were unable to be applied to vector tiles {kibana-pull}124289[#124289]
+
+Metrics::
+Allow single values for ip and mac node metadata {kibana-pull}124384[#124384]
+
+Monitoring::
+Update rules queries to support Metricbeat 8.0.0 {kibana-pull}125748[#125748]
+
+Platform::
+Adds origin conflict checks when resolving import errors {kibana-pull}125241[#125241]
+
+Security::
+Adds 8.0.1 rules updates {kibana-pull}125316[#125316]
+
+Uptime::
+Update mobile data view to account for metrics events {kibana-pull}125916[#125916]
+
+>>>>>>> c6fad734fe3 ([DOCS] Adds 8.0.1 release notes)
 [[release-notes-8.0.0]]
 == {kib} 8.0.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -40,7 +40,11 @@ The 8.0.1 release includes the following enhancement and bug fixes.
 [[breaking-changes-8.0.1]]
 === Breaking changes
 
+// tag::notable-breaking-changes[]
+
 There are no breaking changes in the 8.0.1 release. 
+
+// end::notable-breaking-changes[]
 
 To review the breaking changes in previous versions, refer to the following: 
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -10,18 +10,17 @@
 
 Review important information about the {kib} 8.0.0 releases.
 
-* <<release-notes-8.0.0>>
-* <<release-notes-8.0.0-rc2>>
-* <<release-notes-8.0.0-rc1>>
-* <<release-notes-8.0.0-beta1>>
-* <<release-notes-8.0.0-alpha2>>
-* <<release-notes-8.0.0-alpha1>>
+// * <<release-notes-8.0.0>>
+// * <release-notes-8.0.0-rc2>>
+// * <<release-notes-8.0.0-rc1>>
+// * <<release-notes-8.0.0-beta1>>
+// * <<release-notes-8.0.0-alpha2>>
+// * <<release-notes-8.0.0-alpha1>>
 
 --
+//// ////
 [[release-notes-8.0.0]]
 == {kib} 8.0.0
-
-coming::[8.0.0]
 
 Review the {kib} 8.0.0 changes, then use the {kibana-ref-all}/7.17/upgrade-assistant.html[Upgrade Assistant] to complete the upgrade.
 
@@ -1443,3 +1442,5 @@ The 8.0.0-alpha1 release includes the following bug fix.
 
 Operations::
 * Moves systemd service to /usr/lib/systemd/system {kibana-pull}83571[#83571]
+
+//// ////

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,7 +37,7 @@ For the Elastic Security 8.0.1 release information, refer to {security-guide}/re
 
 [float]
 [[fixes-v8.0.1]]
-=== Bug Fixes
+=== Bug fixes
 Alerting::
 Fixes an issue where the *Cases* rule link was displayed as `Unknown rule`, even when the correct rule name was retrieved {kibana-pull}123883[#123883]
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -8,26 +8,44 @@
 :issue: https://github.com/elastic/kibana/issues/
 :pull: https://github.com/elastic/kibana/pull/
 
-Review important information about the {kib} 8.0.0 releases.
+Review important information about the {kib} 8.x releases.
 
-
-* <<release-notes-8.0.1>>
-* <<release-notes-8.0.0>>
-* <<release-notes-8.0.0-rc2>>
-* <<release-notes-8.0.0-rc1>>
-* <<release-notes-8.0.0-beta1>>
-* <<release-notes-8.0.0-alpha2>>
-* <<release-notes-8.0.0-alpha1>>
+* <<release-notes-8.1.0>>
+//* <<release-notes-8.0.1>>
+//* <<release-notes-8.0.0>>
+//* <<release-notes-8.0.0-rc2>>
+//* <<release-notes-8.0.0-rc1>>
+//* <<release-notes-8.0.0-beta1>>
+//* <<release-notes-8.0.0-alpha2>>
+//* <<release-notes-8.0.0-alpha1>>
 
 --
 
-//// ////
+[[release-notes-8.1.0]]
+== {kib} 8.1.0
+
+coming::[8.1.0]
+
+[float]
+[[breaking-changes-8.1.0]]
+=== Breaking changes
+
+/////
 [[release-notes-8.0.1]]
 == {kib} 8.0.1
 
-coming::[8.0.1]
-
 The 8.0.1 release includes the following enhancement and bug fixes.
+
+[float]
+[[breaking-changes-8.0.1]]
+=== Breaking changes
+
+There are no breaking changes in the 8.0.1 release. 
+
+To review the breaking changes in previous versions, refer to the following: 
+
+<<breaking-changes-8.0.0,8.0.0>> | <<breaking-changes-8.0.0-rc2,8.0.0-rc2>> | <<breaking-changes-8.0.0-rc1,8.0.0-rc1>> | <<breaking-changes-8.0.0-beta1,8.0.0-beta1>> | <<breaking-changes-8.0.0-alpha2,8.0.0-alpha2>> | 
+<<breaking-changes-8.0.0-alpha1,8.0.0-alpha1>>
 
 [float]
 [[enhancement-v8.0.1]]
@@ -76,7 +94,6 @@ Adds 8.0.1 rules updates {kibana-pull}125316[#125316]
 Uptime::
 Update mobile data view to account for metrics events {kibana-pull}125916[#125916]
 
->>>>>>> c6fad734fe3 ([DOCS] Adds 8.0.1 release notes)
 [[release-notes-8.0.0]]
 == {kib} 8.0.0
 
@@ -89,8 +106,6 @@ Review the {kib} 8.0.0 changes, then use the {kibana-ref-all}/7.17/upgrade-assis
 Breaking changes can prevent your application from optimal operation and performance.
 Before you upgrade to 8.0.0, review the breaking change, then mitigate the impact to your application.
 
-// tag::notable-breaking-changes[]
-
 [discrete]
 [[breaking-123754]]
 .Removes the `console.ssl` setting
@@ -102,9 +117,6 @@ The `console.ssl` setting has been removed. For more information, refer to {kiba
 *Impact* +
 Before you upgrade to 8.0.0, remove `console.ssl` from kibana.yml.
 ====
-
-// end::notable-breaking-changes[]
-
 
 To review the breaking changes in previous versions, refer to the following: 
 
@@ -1500,5 +1512,4 @@ The 8.0.0-alpha1 release includes the following bug fix.
 
 Operations::
 * Moves systemd service to /usr/lib/systemd/system {kibana-pull}83571[#83571]
-
-//// ////
+/////

--- a/docs/developer/architecture/development-visualize-index.asciidoc
+++ b/docs/developer/architecture/development-visualize-index.asciidoc
@@ -19,7 +19,7 @@ We would recommend waiting until later in `7.x` to upgrade your plugins if possi
 If you would like to keep up with progress on the visualizations plugin in the meantime,
 here are a few resources:
 
-* The <<breaking-changes-8.0.0,breaking changes>> documentation, where we try to capture any changes to the APIs as they occur across minors.
+* The <<breaking-changes-8.1.0,breaking changes>> documentation, where we try to capture any changes to the APIs as they occur across minors.
 * link:https://github.com/elastic/kibana/issues/44121[Meta issue] which is tracking the move of the plugin to the new {kib} platform
 * Our link:https://www.elastic.co/blog/join-our-elastic-stack-workspace-on-slack[Elastic Stack workspace on Slack].
 * The {kib-repo}blob/{branch}/src/plugins/visualizations[source code], which will continue to be

--- a/docs/management/saved-objects/saved-object-ids.asciidoc
+++ b/docs/management/saved-objects/saved-object-ids.asciidoc
@@ -70,7 +70,7 @@ if you import it into the second space again, {kib} will find the second object 
 
 WARNING: When you import a saved object and it is created with a different ID, if 1. it contains weak links to other saved objects (such as
 a dashboard with a Markdown URL to navigate to another dashboard) and 2. the object's ID has changed (step 3 above), those weak links will
-be broken. For more information, refer to <<known-issue-123550,the known issue in the changelog>>.
+be broken. For more information, refer to {kibana-ref-all}/8.0/release-notes-8.0.0.html#known-issue-123550[the known issue in the changelog].
 
 [[saved-object-ids-impact-when-using-apis]]
 ===== Using the saved objects APIs

--- a/docs/setup/upgrade/upgrade-standard.asciidoc
+++ b/docs/setup/upgrade/upgrade-standard.asciidoc
@@ -52,7 +52,7 @@ and becomes a new instance in the monitoring data.
 --
 . Copy the files from the `config` directory from your old installation to your
   new installation. Make sure you remove or update any configurations that are
-  indicated in the <<breaking-changes-8.0.0,breaking changes>> documentation
+  indicated in the <<breaking-changes-8.1.0,breaking changes>> documentation
   otherwise {kib} will fail to start.
 . Copy the files from the `data` directory from your old installation to your
   new installation.

--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -2,7 +2,7 @@
 == What's new in 8.0
 
 This section summarizes the most important changes in each release. For the 
-full list, see <<release-notes>> and <<breaking-changes-8.0.0>>. 
+full list, see <<release-notes>> and <<breaking-changes-8.1.0>>. 
 
 //NOTE: The notable-highlights tagged regions are re-used in the
 //Installation and Upgrade Guide


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.0` to `8.1`:
 - [[DOCS] Adds the 8.0.1 release notes (#125958)](https://github.com/elastic/kibana/pull/125958)

<!--- Backport version: 8.1-->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)