### PR TITLE
Synthetics functional tests - Query for experimental packages

### DIFF
--- a/x-pack/test/functional_synthetics/services/uptime/synthetics_package.ts
+++ b/x-pack/test/functional_synthetics/services/uptime/synthetics_package.ts
@@ -50,6 +50,7 @@ export function SyntheticsPackageProvider({ getService }: FtrProviderContext) {
         apiRequest = retry.try(() => {
           return supertest
             .get(INGEST_API_EPM_PACKAGES)
+            .query({ experimental: true })
             .set('kbn-xsrf', 'xxx')
             .expect(200)
             .catch((error) => {


### PR DESCRIPTION
## Summary
Relates to https://github.com/elastic/kibana/issues/116522

Following support for [prerelease semver tags in package registry](https://github.com/elastic/package-registry/commit/4a270e45cb76e4482f3d214512679c073abe10ed), beta packages are now considered experimental at the API level. The user experience in Kibana remains the same, including the `Beta` label on the package, but we now must query for experimental packages in our tests. 