### PR TITLE
[8.0] Hide timeline bar if user does not have security solution crud capability (#123775)

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { TestProviders } from '../../../common/mock';
+import { SecuritySolutionTemplateWrapper } from './';
+
+jest.mock('./bottom_bar', () => ({
+  ...jest.requireActual('./bottom_bar'),
+  SecuritySolutionBottomBar: () => <div>{'Bottom Bar'}</div>,
+}));
+
+const mockSiemUserCanCrud = jest.fn();
+jest.mock('../../../common/lib/kibana', () => {
+  const original = jest.requireActual('../../../common/lib/kibana');
+
+  return {
+    ...original,
+    useKibana: () => ({
+      services: {
+        ...original.useKibana().services,
+        application: {
+          capabilities: {
+            siem: mockSiemUserCanCrud(),
+          },
+        },
+      },
+    }),
+  };
+});
+
+jest.mock('../../../common/components/navigation/use_security_solution_navigation', () => {
+  return {
+    useSecuritySolutionNavigation: () => ({
+      icon: 'logoSecurity',
+      items: [
+        {
+          id: 'investigate',
+          name: 'Investigate',
+          items: [
+            {
+              'data-href': 'some-data-href',
+              'data-test-subj': 'navigation-cases',
+              disabled: false,
+              href: 'some-href',
+              id: 'cases',
+              isSelected: true,
+              name: 'Cases',
+            },
+          ],
+          tabIndex: undefined,
+        },
+      ],
+      name: 'Security',
+    }),
+  };
+});
+
+const renderComponent = () => {
+  return render(
+    <TestProviders>
+      <SecuritySolutionTemplateWrapper onAppLeave={() => null}>
+        <div>{'child of wrapper'}</div>
+      </SecuritySolutionTemplateWrapper>
+    </TestProviders>
+  );
+};
+
+describe('SecuritySolutionTemplateWrapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSiemUserCanCrud.mockReturnValue({ show: true });
+  });
+
+  it('Should render to the page with bottom bar if user has SIEM show', async () => {
+    const { getByText } = renderComponent();
+    expect(getByText('child of wrapper')).toBeInTheDocument();
+    expect(getByText('Bottom Bar')).toBeInTheDocument();
+  });
+
+  it('Should not show bottom bar if user does not have SIEM show', async () => {
+    mockSiemUserCanCrud.mockReturnValue({ show: false });
+
+    const { getByText } = renderComponent();
+    expect(getByText('child of wrapper')).toBeInTheDocument();
+    expect(() => getByText('Bottom Bar')).toThrow();
+  });
+});

--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
@@ -26,6 +26,7 @@ import {
 } from './bottom_bar';
 import { useShowTimeline } from '../../../common/utils/timeline/use_show_timeline';
 import { gutterTimeline } from '../../../common/lib/helpers';
+import { useKibana } from '../../../common/lib/kibana';
 import { useShowPagesWithEmptyView } from '../../../common/utils/empty_view/use_show_pages_with_empty_view';
 
 /**
@@ -75,6 +76,8 @@ export const SecuritySolutionTemplateWrapper: React.FC<SecuritySolutionPageWrapp
     const { show: isShowingTimelineOverlay } = useDeepEqualSelector((state) =>
       getTimelineShowStatus(state, TimelineId.active)
     );
+
+    const userHasSecuritySolutionVisible = useKibana().services.application.capabilities.siem.show;
     const showEmptyState = useShowPagesWithEmptyView();
     const emptyStateProps = showEmptyState ? NO_DATA_PAGE_TEMPLATE_PROPS : {};
 
@@ -89,7 +92,9 @@ export const SecuritySolutionTemplateWrapper: React.FC<SecuritySolutionPageWrapp
         $isTimelineBottomBarVisible={isTimelineBottomBarVisible}
         $isShowingTimelineOverlay={isShowingTimelineOverlay}
         bottomBarProps={SecuritySolutionBottomBarProps}
-        bottomBar={<SecuritySolutionBottomBar onAppLeave={onAppLeave} />}
+        bottomBar={
+          userHasSecuritySolutionVisible && <SecuritySolutionBottomBar onAppLeave={onAppLeave} />
+        }
         paddingSize="none"
         solutionNav={solutionNav}
         restrictWidth={false}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [Hide timeline bar if user does not have security solution crud capability (#123775)](https://github.com/elastic/kibana/pull/123775)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)