### PR TITLE
[Fleet ] Fix upgrade integration breadcrumb from Integrations UI

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/hooks/use_breadcrumbs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/hooks/use_breadcrumbs.tsx
@@ -108,7 +108,7 @@ const breadcrumbGetters: {
       text: policyName,
     },
     {
-      text: i18n.translate('xpack.fleet.breadcrumbs.upgradePacagePolicyPageTitle', {
+      text: i18n.translate('xpack.fleet.breadcrumbs.upgradePackagePolicyPageTitle', {
         defaultMessage: 'Upgrade integration ',
       }),
     },

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -714,7 +714,7 @@ const IntegrationsBreadcrumb = memo<{
   policyName: string;
   pkgkey: string;
 }>(({ pkgTitle, policyName, pkgkey }) => {
-  useIntegrationsBreadcrumbs('integration_policy_edit', { policyName, pkgTitle, pkgkey });
+  useIntegrationsBreadcrumbs('integration_policy_upgrade', { policyName, pkgTitle, pkgkey });
   return null;
 });
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -694,13 +694,17 @@ const Breadcrumb = memo<{
 }>(({ agentPolicyName, from, packagePolicyName, pkgkey, pkgTitle, policyId }) => {
   let breadcrumb = <PoliciesBreadcrumb policyName={agentPolicyName} policyId={policyId} />;
 
-  if (
-    from === 'package' ||
-    from === 'package-edit' ||
-    from === 'upgrade-from-integrations-policy-list'
-  ) {
+  if (from === 'package' || from === 'package-edit') {
     breadcrumb = (
       <IntegrationsBreadcrumb pkgkey={pkgkey} pkgTitle={pkgTitle} policyName={packagePolicyName} />
+    );
+  } else if (from === 'upgrade-from-integrations-policy-list') {
+    breadcrumb = (
+      <IntegrationsUpgradeBreadcrumb
+        pkgkey={pkgkey}
+        pkgTitle={pkgTitle}
+        policyName={packagePolicyName}
+      />
     );
   } else if (from === 'upgrade-from-fleet-policy-list') {
     breadcrumb = <UpgradeBreadcrumb policyName={agentPolicyName} policyId={policyId} />;
@@ -714,7 +718,7 @@ const IntegrationsBreadcrumb = memo<{
   policyName: string;
   pkgkey: string;
 }>(({ pkgTitle, policyName, pkgkey }) => {
-  useIntegrationsBreadcrumbs('integration_policy_upgrade', { policyName, pkgTitle, pkgkey });
+  useIntegrationsBreadcrumbs('integration_policy_edit', { policyName, pkgTitle, pkgkey });
   return null;
 });
 
@@ -725,6 +729,15 @@ const PoliciesBreadcrumb: React.FunctionComponent<{
   useBreadcrumbs('edit_integration', { policyName, policyId });
   return null;
 };
+
+const IntegrationsUpgradeBreadcrumb = memo<{
+  pkgTitle: string;
+  policyName: string;
+  pkgkey: string;
+}>(({ pkgTitle, policyName, pkgkey }) => {
+  useIntegrationsBreadcrumbs('integration_policy_upgrade', { policyName, pkgTitle, pkgkey });
+  return null;
+});
 
 const UpgradeBreadcrumb: React.FunctionComponent<{
   policyName: string;

--- a/x-pack/plugins/fleet/public/applications/integrations/hooks/use_breadcrumbs.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/hooks/use_breadcrumbs.tsx
@@ -50,6 +50,19 @@ const breadcrumbGetters: {
     },
     { text: policyName },
   ],
+  integration_policy_upgrade: ({ pkgTitle, pkgkey, policyName }) => [
+    BASE_BREADCRUMB,
+    {
+      href: pagePathGetters.integration_details_policies({ pkgkey })[1],
+      text: pkgTitle,
+    },
+    { text: policyName },
+    {
+      text: i18n.translate('xpack.fleet.breadcrumbs.upgradePackagePolicyPageTitle', {
+        defaultMessage: 'Upgrade integration ',
+      }),
+    },
+  ],
 };
 
 export function useBreadcrumbs(page: Page, values: DynamicPagePathValues = {}) {

--- a/x-pack/plugins/fleet/public/constants/page_paths.ts
+++ b/x-pack/plugins/fleet/public/constants/page_paths.ts
@@ -28,6 +28,7 @@ export type DynamicPage =
   | 'integration_details_settings'
   | 'integration_details_custom'
   | 'integration_policy_edit'
+  | 'integration_policy_upgrade'
   | 'policy_details'
   | 'add_integration_to_policy'
   | 'edit_integration'

--- a/x-pack/plugins/fleet/public/constants/page_paths.ts
+++ b/x-pack/plugins/fleet/public/constants/page_paths.ts
@@ -83,6 +83,7 @@ export const INTEGRATIONS_ROUTING_PATHS = {
   integration_details_settings: '/detail/:pkgkey/settings',
   integration_details_custom: '/detail/:pkgkey/custom',
   integration_policy_edit: '/edit-integration/:packagePolicyId',
+  integration_policy_upgrade: '/edit-integration/:packagePolicyId',
 };
 
 export const pagePathGetters: {
@@ -124,6 +125,12 @@ export const pagePathGetters: {
     `/detail/${pkgkey}/custom${integration ? `?integration=${integration}` : ''}`,
   ],
   integration_policy_edit: ({ packagePolicyId }) => [
+    INTEGRATIONS_BASE_PATH,
+    `/edit-integration/${packagePolicyId}`,
+  ],
+  // Upgrades happen on the same edit form, just with a flag set. Separate page record here
+  // allows us to set different breadcrumbds for upgrades when needed.
+  integration_policy_upgrade: ({ packagePolicyId }) => [
     INTEGRATIONS_BASE_PATH,
     `/edit-integration/${packagePolicyId}`,
   ],

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -11956,7 +11956,6 @@
     "xpack.fleet.breadcrumbs.integrationsAppTitle": "統合",
     "xpack.fleet.breadcrumbs.policiesPageTitle": "エージェントポリシー",
     "xpack.fleet.breadcrumbs.settingsPageTitle": "設定",
-    "xpack.fleet.breadcrumbs.upgradePacagePolicyPageTitle": "統合のアップグレード ",
     "xpack.fleet.config.invalidPackageVersionError": "有効なサーバーまたはキーワード「latest」でなければなりません",
     "xpack.fleet.copyAgentPolicy.confirmModal.cancelButtonLabel": "キャンセル",
     "xpack.fleet.copyAgentPolicy.confirmModal.confirmButtonLabel": "ポリシーの複製",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -11956,6 +11956,7 @@
     "xpack.fleet.breadcrumbs.integrationsAppTitle": "統合",
     "xpack.fleet.breadcrumbs.policiesPageTitle": "エージェントポリシー",
     "xpack.fleet.breadcrumbs.settingsPageTitle": "設定",
+    "xpack.fleet.breadcrumbs.upgradePackagePolicyPageTitle": "統合のアップグレード ",
     "xpack.fleet.config.invalidPackageVersionError": "有効なサーバーまたはキーワード「latest」でなければなりません",
     "xpack.fleet.copyAgentPolicy.confirmModal.cancelButtonLabel": "キャンセル",
     "xpack.fleet.copyAgentPolicy.confirmModal.confirmButtonLabel": "ポリシーの複製",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -11978,7 +11978,6 @@
     "xpack.fleet.breadcrumbs.integrationsAppTitle": "集成",
     "xpack.fleet.breadcrumbs.policiesPageTitle": "代理策略",
     "xpack.fleet.breadcrumbs.settingsPageTitle": "设置",
-    "xpack.fleet.breadcrumbs.upgradePacagePolicyPageTitle": "升级集成 ",
     "xpack.fleet.config.invalidPackageVersionError": "必须是有效的 semver 或关键字 `latest`",
     "xpack.fleet.copyAgentPolicy.confirmModal.cancelButtonLabel": "取消",
     "xpack.fleet.copyAgentPolicy.confirmModal.confirmButtonLabel": "复制策略",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -11978,6 +11978,7 @@
     "xpack.fleet.breadcrumbs.integrationsAppTitle": "集成",
     "xpack.fleet.breadcrumbs.policiesPageTitle": "代理策略",
     "xpack.fleet.breadcrumbs.settingsPageTitle": "设置",
+    "xpack.fleet.breadcrumbs.upgradePackagePolicyPageTitle": "升级集成 ",
     "xpack.fleet.config.invalidPackageVersionError": "必须是有效的 semver 或关键字 `latest`",
     "xpack.fleet.copyAgentPolicy.confirmModal.cancelButtonLabel": "取消",
     "xpack.fleet.copyAgentPolicy.confirmModal.confirmButtonLabel": "复制策略",


### PR DESCRIPTION
## Summary

Add "Upgrade integration" text to integrations UI breadcrumb for upgrade integration page.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
