### PR TITLE
[Reporting] Fix reference to job output metrics for logging

### DIFF
--- a/x-pack/plugins/reporting/server/lib/tasks/execute_report.ts
+++ b/x-pack/plugins/reporting/server/lib/tasks/execute_report.ts
@@ -369,7 +369,7 @@ export class ExecuteReportTask implements ReportingTask {
             report._primary_term = stream.getPrimaryTerm()!;
 
             eventLog.logExecutionComplete({
-              ...(report.metrics ?? {}),
+              ...(output.metrics ?? {}),
               byteSize: stream.bytesWritten,
             });
 


### PR DESCRIPTION
## Summary

Follows https://github.com/elastic/kibana/pull/125450

This PR fixes the event logging system to reference the correct object that contains metric stats we want to log.

The highlighted fields now show up correctly in the logged data:
![image](https://user-images.githubusercontent.com/908371/155433305-3e5fdd0a-d6e2-4ae5-8a56-f73139b9c7da.png)

Seeing logs in this format requires kibana.yml to have debug logging enabled for the reporting plugin, and the format of logging to be json:
```
logging:
  appenders:
    my_json:
      type: console
      layout.type: json
  root:
    appenders: [my_json]
  loggers:
    - name: plugins.reporting
      level: debug
```