### PR TITLE
[bazel] avoid a little boilerplate in packages

### DIFF
--- a/packages/elastic-apm-synthtrace/BUILD.bazel
+++ b/packages/elastic-apm-synthtrace/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "elastic-apm-synthtrace"
 PKG_REQUIRE_NAME = "@elastic/apm-synthtrace"
-TYPES_PKG_REQUIRE_NAME = "@types/elastic__apm-synthtrace"
 
 SOURCE_FILES = glob(
   [
@@ -103,7 +102,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/elastic-apm-synthtrace/BUILD.bazel
+++ b/packages/elastic-apm-synthtrace/BUILD.bazel
@@ -66,11 +66,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
   validate = False,
 )

--- a/packages/elastic-apm-synthtrace/tsconfig.json
+++ b/packages/elastic-apm-synthtrace/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/elastic-apm-synthtrace/src",
     "types": ["node", "jest"]
   },
   "include": ["./src/**/*.ts"]

--- a/packages/elastic-datemath/BUILD.bazel
+++ b/packages/elastic-datemath/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "ts_project", "pkg_npm", "p
 
 PKG_BASE_NAME = "elastic-datemath"
 PKG_REQUIRE_NAME = "@elastic/datemath"
-TYPES_PKG_REQUIRE_NAME = "@types/elastic__datemath"
 
 SOURCE_FILES = glob([
   "src/index.ts",
@@ -85,7 +84,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/elastic-datemath/BUILD.bazel
+++ b/packages/elastic-datemath/BUILD.bazel
@@ -49,10 +49,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig"
 )

--- a/packages/elastic-datemath/tsconfig.json
+++ b/packages/elastic-datemath/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/elastic-datemath/src",
     "types": [
       "node"
     ]

--- a/packages/kbn-ace/BUILD.bazel
+++ b/packages/kbn-ace/BUILD.bazel
@@ -67,10 +67,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-ace/BUILD.bazel
+++ b/packages/kbn-ace/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-ace"
 PKG_REQUIRE_NAME = "@kbn/ace"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__ace"
 
 SOURCE_FILES = glob(
   [
@@ -103,7 +102,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-ace/tsconfig.json
+++ b/packages/kbn-ace/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ace/src",
     "stripInternal": true,
     "types": ["node"]
   },

--- a/packages/kbn-alerts/BUILD.bazel
+++ b/packages/kbn-alerts/BUILD.bazel
@@ -73,11 +73,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-alerts/BUILD.bazel
+++ b/packages/kbn-alerts/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-alerts"
 PKG_REQUIRE_NAME = "@kbn/alerts"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__alerts"
 
 SOURCE_FILES = glob(
   [
@@ -109,7 +108,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-alerts/tsconfig.json
+++ b/packages/kbn-alerts/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-alerts/src",
     "types": ["jest", "node"]
   },
   "include": ["src/**/*"],

--- a/packages/kbn-analytics/BUILD.bazel
+++ b/packages/kbn-analytics/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-analytics"
 PKG_REQUIRE_NAME = "@kbn/analytics"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__analytics"
 
 SOURCE_FILES = glob(
   [
@@ -106,7 +105,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-analytics/BUILD.bazel
+++ b/packages/kbn-analytics/BUILD.bazel
@@ -70,11 +70,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-analytics/tsconfig.json
+++ b/packages/kbn-analytics/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-analytics/src",
     "stripInternal": true,
     "types": [
       "node"

--- a/packages/kbn-apm-config-loader/BUILD.bazel
+++ b/packages/kbn-apm-config-loader/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-apm-config-loader"
 PKG_REQUIRE_NAME = "@kbn/apm-config-loader"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__apm-config-loader"
 
 SOURCE_FILES = glob(
   [
@@ -101,7 +100,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-apm-config-loader/BUILD.bazel
+++ b/packages/kbn-apm-config-loader/BUILD.bazel
@@ -65,10 +65,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-apm-config-loader/tsconfig.json
+++ b/packages/kbn-apm-config-loader/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-apm-config-loader/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-apm-utils/BUILD.bazel
+++ b/packages/kbn-apm-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-apm-utils"
 PKG_REQUIRE_NAME = "@kbn/apm-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__apm-utils"
 
 SOURCE_FILES = glob([
   "src/index.ts",
@@ -86,7 +85,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-apm-utils/BUILD.bazel
+++ b/packages/kbn-apm-utils/BUILD.bazel
@@ -50,10 +50,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-apm-utils/tsconfig.json
+++ b/packages/kbn-apm-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-apm-utils/src",
     "types": [
       "node"
     ]

--- a/packages/kbn-cli-dev-mode/BUILD.bazel
+++ b/packages/kbn-cli-dev-mode/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-cli-dev-mode"
 PKG_REQUIRE_NAME = "@kbn/cli-dev-mode"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__cli-dev-mode"
 
 SOURCE_FILES = glob(
   [
@@ -128,7 +127,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-cli-dev-mode/BUILD.bazel
+++ b/packages/kbn-cli-dev-mode/BUILD.bazel
@@ -92,11 +92,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-cli-dev-mode/tsconfig.json
+++ b/packages/kbn-cli-dev-mode/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-cli-dev-mode/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-config-schema/BUILD.bazel
+++ b/packages/kbn-config-schema/BUILD.bazel
@@ -61,10 +61,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-config-schema/BUILD.bazel
+++ b/packages/kbn-config-schema/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-config-schema"
 PKG_REQUIRE_NAME = "@kbn/config-schema"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__config-schema"
 
 SOURCE_FILES = glob([
   "src/**/*.ts",
@@ -97,7 +96,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-config-schema/tsconfig.json
+++ b/packages/kbn-config-schema/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-config-schema/src",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-config/BUILD.bazel
+++ b/packages/kbn-config/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-config"
 PKG_REQUIRE_NAME = "@kbn/config"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__config"
 
 SOURCE_FILES = glob(
   [
@@ -118,7 +117,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-config/BUILD.bazel
+++ b/packages/kbn-config/BUILD.bazel
@@ -82,10 +82,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-config/tsconfig.json
+++ b/packages/kbn-config/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-config/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-crypto/BUILD.bazel
+++ b/packages/kbn-crypto/BUILD.bazel
@@ -61,10 +61,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-crypto/BUILD.bazel
+++ b/packages/kbn-crypto/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-crypto"
 PKG_REQUIRE_NAME = "@kbn/crypto"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__crypto"
 
 SOURCE_FILES = glob(
   [
@@ -29,7 +28,7 @@ NPM_MODULE_EXTRA_FILES = [
 ]
 
 RUNTIME_DEPS = [
-  "//packages/kbn-dev-utils",
+  "//packages/kbn-dev-utils:build",
   "@npm//node-forge",
 ]
 
@@ -97,7 +96,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-crypto/tsconfig.json
+++ b/packages/kbn-crypto/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-crypto/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-dev-utils/BUILD.bazel
+++ b/packages/kbn-dev-utils/BUILD.bazel
@@ -113,10 +113,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-dev-utils/BUILD.bazel
+++ b/packages/kbn-dev-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-dev-utils"
 PKG_REQUIRE_NAME = "@kbn/dev-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__dev-utils"
 
 SOURCE_FILES = glob(
   [
@@ -149,7 +148,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-dev-utils/tsconfig.json
+++ b/packages/kbn-dev-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-dev-utils/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-doc-links/BUILD.bazel
+++ b/packages/kbn-doc-links/BUILD.bazel
@@ -60,10 +60,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-doc-links/BUILD.bazel
+++ b/packages/kbn-doc-links/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-doc-links"
 PKG_REQUIRE_NAME = "@kbn/doc-links"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__doc-links"
 
 SOURCE_FILES = glob(
   [
@@ -96,7 +95,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-doc-links/tsconfig.json
+++ b/packages/kbn-doc-links/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-doc-links/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-docs-utils/BUILD.bazel
+++ b/packages/kbn-docs-utils/BUILD.bazel
@@ -66,10 +66,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-docs-utils/BUILD.bazel
+++ b/packages/kbn-docs-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-docs-utils"
 PKG_REQUIRE_NAME = "@kbn/docs-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__docs-utils"
 
 SOURCE_FILES = glob(
   [
@@ -102,7 +101,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-docs-utils/tsconfig.json
+++ b/packages/kbn-docs-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-docs-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es-archiver/BUILD.bazel
+++ b/packages/kbn-es-archiver/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-es-archiver"
 PKG_REQUIRE_NAME = "@kbn/es-archiver"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__es-archiver"
 
 SOURCE_FILES = glob(
   [
@@ -115,7 +114,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-es-archiver/BUILD.bazel
+++ b/packages/kbn-es-archiver/BUILD.bazel
@@ -79,10 +79,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-es-archiver/tsconfig.json
+++ b/packages/kbn-es-archiver/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-es-archiver/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es-query/BUILD.bazel
+++ b/packages/kbn-es-query/BUILD.bazel
@@ -93,10 +93,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-es-query/BUILD.bazel
+++ b/packages/kbn-es-query/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-es-query"
 PKG_REQUIRE_NAME = "@kbn/es-query"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__es-query"
 
 SOURCE_FILES = glob(
   [
@@ -129,7 +128,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-es-query/tsconfig.json
+++ b/packages/kbn-es-query/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-es-query/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-field-types/BUILD.bazel
+++ b/packages/kbn-field-types/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-field-types"
 PKG_REQUIRE_NAME = "@kbn/field-types"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__field-types"
 
 SOURCE_FILES = glob(
   [
@@ -99,7 +98,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-field-types/BUILD.bazel
+++ b/packages/kbn-field-types/BUILD.bazel
@@ -63,10 +63,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-field-types/tsconfig.json
+++ b/packages/kbn-field-types/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "outDir": "./target_types",
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-field-types/src"
   },
   "include": ["src/**/*"]
 }

--- a/packages/kbn-i18n-react/BUILD.bazel
+++ b/packages/kbn-i18n-react/BUILD.bazel
@@ -73,10 +73,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-i18n-react/BUILD.bazel
+++ b/packages/kbn-i18n-react/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-i18n-react"
 PKG_REQUIRE_NAME = "@kbn/i18n-react"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__i18n-react"
 
 SOURCE_FILES = glob(
   [
@@ -109,7 +108,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-i18n-react/tsconfig.json
+++ b/packages/kbn-i18n-react/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-i18n-react/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-i18n/BUILD.bazel
+++ b/packages/kbn-i18n/BUILD.bazel
@@ -74,10 +74,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-i18n/BUILD.bazel
+++ b/packages/kbn-i18n/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-i18n"
 PKG_REQUIRE_NAME = "@kbn/i18n"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__i18n"
 
 SOURCE_FILES = glob(
   [
@@ -110,7 +109,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-i18n/tsconfig.json
+++ b/packages/kbn-i18n/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-i18n/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-interpreter/BUILD.bazel
+++ b/packages/kbn-interpreter/BUILD.bazel
@@ -73,10 +73,8 @@ ts_project(
   deps = TYPES_DEPS,
   allow_js = True,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-interpreter/BUILD.bazel
+++ b/packages/kbn-interpreter/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-interpreter"
 PKG_REQUIRE_NAME = "@kbn/interpreter"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__interpreter"
 
 SOURCE_FILES = glob(
   [
@@ -109,7 +108,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-interpreter/tsconfig.json
+++ b/packages/kbn-interpreter/tsconfig.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-interpreter/src",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-io-ts-utils/BUILD.bazel
+++ b/packages/kbn-io-ts-utils/BUILD.bazel
@@ -64,10 +64,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-io-ts-utils/BUILD.bazel
+++ b/packages/kbn-io-ts-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-io-ts-utils"
 PKG_REQUIRE_NAME = "@kbn/io-ts-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__io-ts-utils"
 
 SOURCE_FILES = glob(
   [
@@ -100,7 +99,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-io-ts-utils/tsconfig.json
+++ b/packages/kbn-io-ts-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-io-ts-utils/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-logging-mocks/BUILD.bazel
+++ b/packages/kbn-logging-mocks/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-logging-mocks"
 PKG_REQUIRE_NAME = "@kbn/logging-mocks"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__logging-mocks"
 
 SOURCE_FILES = glob(
   [
@@ -92,7 +91,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-logging-mocks/BUILD.bazel
+++ b/packages/kbn-logging-mocks/BUILD.bazel
@@ -56,10 +56,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-logging-mocks/tsconfig.json
+++ b/packages/kbn-logging-mocks/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-logging-mocks/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-logging/BUILD.bazel
+++ b/packages/kbn-logging/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-logging"
 PKG_REQUIRE_NAME = "@kbn/logging"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__logging"
 
 SOURCE_FILES = glob(
   [
@@ -93,7 +92,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-logging/BUILD.bazel
+++ b/packages/kbn-logging/BUILD.bazel
@@ -57,10 +57,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-logging/tsconfig.json
+++ b/packages/kbn-logging/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-logging/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-mapbox-gl/BUILD.bazel
+++ b/packages/kbn-mapbox-gl/BUILD.bazel
@@ -60,10 +60,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-mapbox-gl/BUILD.bazel
+++ b/packages/kbn-mapbox-gl/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-mapbox-gl"
 PKG_REQUIRE_NAME = "@kbn/mapbox-gl"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__mapbox-gl"
 
 SOURCE_FILES = glob(
   [
@@ -96,7 +95,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-mapbox-gl/tsconfig.json
+++ b/packages/kbn-mapbox-gl/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-mapbox-gl/src",
     "types": []
   },
   "include": [

--- a/packages/kbn-monaco/BUILD.bazel
+++ b/packages/kbn-monaco/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-monaco"
 PKG_REQUIRE_NAME = "@kbn/monaco"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__monaco"
 
 SOURCE_FILES = glob(
   [
@@ -131,7 +130,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-monaco/BUILD.bazel
+++ b/packages/kbn-monaco/BUILD.bazel
@@ -95,10 +95,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-monaco/tsconfig.json
+++ b/packages/kbn-monaco/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-monaco/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-optimizer/BUILD.bazel
+++ b/packages/kbn-optimizer/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-optimizer"
 PKG_REQUIRE_NAME = "@kbn/optimizer"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__optimizer"
 
 SOURCE_FILES = glob(
   [
@@ -154,7 +153,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-optimizer/BUILD.bazel
+++ b/packages/kbn-optimizer/BUILD.bazel
@@ -118,10 +118,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-optimizer/tsconfig.json
+++ b/packages/kbn-optimizer/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-optimizer/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-plugin-generator/BUILD.bazel
+++ b/packages/kbn-plugin-generator/BUILD.bazel
@@ -85,10 +85,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-plugin-generator/BUILD.bazel
+++ b/packages/kbn-plugin-generator/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-plugin-generator"
 PKG_REQUIRE_NAME = "@kbn/plugin-generator"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__plugin-generator"
 
 SOURCE_FILES = glob(
   [
@@ -121,7 +120,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-plugin-generator/tsconfig.json
+++ b/packages/kbn-plugin-generator/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-plugin-generator/src",
     "target": "ES2019",
     "types": [
       "jest",

--- a/packages/kbn-plugin-helpers/BUILD.bazel
+++ b/packages/kbn-plugin-helpers/BUILD.bazel
@@ -78,10 +78,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-plugin-helpers/BUILD.bazel
+++ b/packages/kbn-plugin-helpers/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-plugin-helpers"
 PKG_REQUIRE_NAME = "@kbn/plugin-helpers"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__plugin-helpers"
 
 SOURCE_FILES = glob(
   [
@@ -114,7 +113,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-plugin-helpers/tsconfig.json
+++ b/packages/kbn-plugin-helpers/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-plugin-helpers/src",
     "target": "ES2018",
     "types": [
       "jest",

--- a/packages/kbn-react-field/BUILD.bazel
+++ b/packages/kbn-react-field/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-react-field"
 PKG_REQUIRE_NAME = "@kbn/react-field"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__react-field"
 
 SOURCE_FILES = glob(
   [
@@ -119,7 +118,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-react-field/BUILD.bazel
+++ b/packages/kbn-react-field/BUILD.bazel
@@ -83,10 +83,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-react-field/tsconfig.json
+++ b/packages/kbn-react-field/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-react-field/src",
     "types": [
       "jest",
       "node",

--- a/packages/kbn-rule-data-utils/BUILD.bazel
+++ b/packages/kbn-rule-data-utils/BUILD.bazel
@@ -59,11 +59,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   incremental = False,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-rule-data-utils/BUILD.bazel
+++ b/packages/kbn-rule-data-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-rule-data-utils"
 PKG_REQUIRE_NAME = "@kbn/rule-data-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__rule-data-utils"
 
 SOURCE_FILES = glob(
   [
@@ -96,7 +95,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-rule-data-utils/tsconfig.json
+++ b/packages/kbn-rule-data-utils/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "incremental": false,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-rule-data-utils/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-securitysolution-autocomplete/BUILD.bazel
+++ b/packages/kbn-securitysolution-autocomplete/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-autocomplete"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-autocomplete"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-autocomplete"
 
 SOURCE_FILES = glob(
   [
@@ -128,7 +127,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-autocomplete/BUILD.bazel
+++ b/packages/kbn-securitysolution-autocomplete/BUILD.bazel
@@ -92,11 +92,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-autocomplete/tsconfig.json
+++ b/packages/kbn-securitysolution-autocomplete/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-autocomplete/src",
     "rootDir": "src",
     "types": ["jest", "node"]
   },

--- a/packages/kbn-securitysolution-es-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-es-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-es-utils"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-es-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-es-utils"
 
 SOURCE_FILES = glob(
   [
@@ -100,7 +99,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-es-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-es-utils/BUILD.bazel
@@ -64,11 +64,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-es-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-es-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-es-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-hook-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-hook-utils/BUILD.bazel
@@ -71,11 +71,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-hook-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-hook-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-hook-utils"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-hook-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-hook-utils"
 
 SOURCE_FILES = glob(
   [
@@ -107,7 +106,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-hook-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-hook-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-hook-utils/src",
     "types": ["jest", "node"]
   },
   "include": ["src/**/*"]

--- a/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-io-ts-alerting-types"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-io-ts-alerting-types"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-io-ts-alerting-types"
 
 SOURCE_FILES = glob(
   [
@@ -110,7 +109,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
@@ -74,11 +74,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-alerting-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-alerting-types/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-io-ts-list-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-list-types/BUILD.bazel
@@ -74,11 +74,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-list-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-list-types/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-io-ts-list-types"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-io-ts-list-types"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-io-ts-list-types"
 
 SOURCE_FILES = glob(
   [
@@ -110,7 +109,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-io-ts-list-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-list-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-list-types/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-io-ts-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-types/BUILD.bazel
@@ -72,11 +72,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-types/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-io-ts-types"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-io-ts-types"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-io-ts-types"
 
 SOURCE_FILES = glob(
   [
@@ -108,7 +107,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-io-ts-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-types/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-io-ts-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-utils/BUILD.bazel
@@ -75,11 +75,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-io-ts-utils"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-io-ts-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-io-ts-utils"
 
 SOURCE_FILES = glob(
   [
@@ -111,7 +110,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-io-ts-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-api/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-api/BUILD.bazel
@@ -74,11 +74,9 @@ ts_project(
   deps = TYPES_DEPS,
   args = ["--pretty"],
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-api/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-api/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-list-api"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-list-api"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-list-api"
 
 SOURCE_FILES = glob(
   [
@@ -110,7 +109,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-list-api/tsconfig.json
+++ b/packages/kbn-securitysolution-list-api/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-api/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-constants/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-constants/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-list-constants"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-list-constants"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-list-constants"
 
 SOURCE_FILES = glob(
   [
@@ -98,7 +97,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-list-constants/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-constants/BUILD.bazel
@@ -62,11 +62,9 @@ ts_project(
   deps = TYPES_DEPS,
   args = ["--pretty"],
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-constants/tsconfig.json
+++ b/packages/kbn-securitysolution-list-constants/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-constants/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-hooks/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-hooks/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-list-hooks"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-list-hooks"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-list-hooks"
 
 SOURCE_FILES = glob(
   [
@@ -118,7 +117,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-list-hooks/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-hooks/BUILD.bazel
@@ -82,11 +82,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-hooks/tsconfig.json
+++ b/packages/kbn-securitysolution-list-hooks/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-hooks/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-utils/BUILD.bazel
@@ -81,11 +81,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-list-utils"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-list-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-list-utils"
 
 SOURCE_FILES = glob(
   [
@@ -118,7 +117,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-list-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-list-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-rules/BUILD.bazel
+++ b/packages/kbn-securitysolution-rules/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-rules"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-rules"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-rules"
 
 SOURCE_FILES = glob(
   [
@@ -98,7 +97,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-rules/BUILD.bazel
+++ b/packages/kbn-securitysolution-rules/BUILD.bazel
@@ -62,11 +62,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-rules/tsconfig.json
+++ b/packages/kbn-securitysolution-rules/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-rules/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-t-grid/BUILD.bazel
+++ b/packages/kbn-securitysolution-t-grid/BUILD.bazel
@@ -71,11 +71,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-t-grid/BUILD.bazel
+++ b/packages/kbn-securitysolution-t-grid/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-t-grid"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-t-grid"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-t-grid"
 
 SOURCE_FILES = glob(
   [
@@ -107,7 +106,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-t-grid/tsconfig.json
+++ b/packages/kbn-securitysolution-t-grid/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-t-grid/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-securitysolution-utils"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__securitysolution-utils"
 
 SOURCE_FILES = glob(
   [
@@ -96,7 +95,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-utils/BUILD.bazel
@@ -60,11 +60,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-server-http-tools/BUILD.bazel
+++ b/packages/kbn-server-http-tools/BUILD.bazel
@@ -71,10 +71,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-server-http-tools/BUILD.bazel
+++ b/packages/kbn-server-http-tools/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-server-http-tools"
 PKG_REQUIRE_NAME = "@kbn/server-http-tools"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__server-http-tools"
 
 SOURCE_FILES = glob(
   [
@@ -107,7 +106,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-server-http-tools/tsconfig.json
+++ b/packages/kbn-server-http-tools/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target/types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-server-http-tools/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-server-route-repository/BUILD.bazel
+++ b/packages/kbn-server-route-repository/BUILD.bazel
@@ -67,10 +67,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-server-route-repository/BUILD.bazel
+++ b/packages/kbn-server-route-repository/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-server-route-repository"
 PKG_REQUIRE_NAME = "@kbn/server-route-repository"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__server-route-repository"
 
 SOURCE_FILES = glob(
   [
@@ -103,7 +102,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-server-route-repository/tsconfig.json
+++ b/packages/kbn-server-route-repository/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-server-route-repository/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-std/BUILD.bazel
+++ b/packages/kbn-std/BUILD.bazel
@@ -66,10 +66,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-std/BUILD.bazel
+++ b/packages/kbn-std/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-std"
 PKG_REQUIRE_NAME = "@kbn/std"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__std"
 
 SOURCE_FILES = glob(
   [
@@ -102,7 +101,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-std/tsconfig.json
+++ b/packages/kbn-std/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-std/src",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-storybook/BUILD.bazel
+++ b/packages/kbn-storybook/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-storybook"
 PKG_REQUIRE_NAME = "@kbn/storybook"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__storybook"
 
 SOURCE_FILES = glob(
   [
@@ -128,7 +127,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-storybook/BUILD.bazel
+++ b/packages/kbn-storybook/BUILD.bazel
@@ -92,11 +92,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-storybook/tsconfig.json
+++ b/packages/kbn-storybook/tsconfig.json
@@ -2,14 +2,11 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "incremental": false,
     "outDir": "target_types",
     "rootDir": "src",
     "skipLibCheck": true,
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-storybook",
     "target": "es2015",
     "types": ["node"]
   },

--- a/packages/kbn-telemetry-tools/BUILD.bazel
+++ b/packages/kbn-telemetry-tools/BUILD.bazel
@@ -70,10 +70,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-telemetry-tools/BUILD.bazel
+++ b/packages/kbn-telemetry-tools/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-telemetry-tools"
 PKG_REQUIRE_NAME = "@kbn/telemetry-tools"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__telemetry-tools"
 
 SOURCE_FILES = glob(
   [
@@ -106,7 +105,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-telemetry-tools/tsconfig.json
+++ b/packages/kbn-telemetry-tools/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-telemetry-tools/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-test-jest-helpers/BUILD.bazel
+++ b/packages/kbn-test-jest-helpers/BUILD.bazel
@@ -132,10 +132,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-test-jest-helpers/BUILD.bazel
+++ b/packages/kbn-test-jest-helpers/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-test-jest-helpers"
 PKG_REQUIRE_NAME = "@kbn/test-jest-helpers"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__test-jest-helpers"
 
 SOURCE_FILES = glob(
   [
@@ -168,7 +167,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-test-jest-helpers/tsconfig.json
+++ b/packages/kbn-test-jest-helpers/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "stripInternal": true,
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../../packages/kbn-test-jest-helpers/src",
     "types": ["jest", "node"]
   },
   "include": ["src/**/*"],

--- a/packages/kbn-test/BUILD.bazel
+++ b/packages/kbn-test/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-test"
 PKG_REQUIRE_NAME = "@kbn/test"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__test"
 
 SOURCE_FILES = glob(
   [
@@ -174,7 +173,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-test/BUILD.bazel
+++ b/packages/kbn-test/BUILD.bazel
@@ -138,10 +138,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-test/tsconfig.json
+++ b/packages/kbn-test/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "stripInternal": true,
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../../packages/kbn-test/src",
     "types": ["jest", "node"]
   },
   "include": ["src/**/*", "index.d.ts"],

--- a/packages/kbn-typed-react-router-config/BUILD.bazel
+++ b/packages/kbn-typed-react-router-config/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-typed-react-router-config"
 PKG_REQUIRE_NAME = "@kbn/typed-react-router-config"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__typed-react-router-config"
 
 SOURCE_FILES = glob(
   [
@@ -118,7 +117,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-typed-react-router-config/BUILD.bazel
+++ b/packages/kbn-typed-react-router-config/BUILD.bazel
@@ -82,10 +82,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-typed-react-router-config/tsconfig.json
+++ b/packages/kbn-typed-react-router-config/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-typed-react-router-config/src",
     "stripInternal": true,
     "types": [
       "node",

--- a/packages/kbn-ui-shared-deps-npm/BUILD.bazel
+++ b/packages/kbn-ui-shared-deps-npm/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-ui-shared-deps-npm"
 PKG_REQUIRE_NAME = "@kbn/ui-shared-deps-npm"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__ui-shared-deps-npm"
 
 SOURCE_FILES = glob(
   [
@@ -174,7 +173,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-ui-shared-deps-npm/BUILD.bazel
+++ b/packages/kbn-ui-shared-deps-npm/BUILD.bazel
@@ -120,11 +120,9 @@ ts_project(
   deps = TYPES_DEPS,
   allow_js = True,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-ui-shared-deps-npm/tsconfig.json
+++ b/packages/kbn-ui-shared-deps-npm/tsconfig.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ui-shared-deps-npm/src",
     "types": [
       "node",
     ]

--- a/packages/kbn-ui-shared-deps-src/BUILD.bazel
+++ b/packages/kbn-ui-shared-deps-src/BUILD.bazel
@@ -76,11 +76,9 @@ ts_project(
   deps = TYPES_DEPS,
   allow_js = True,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-ui-shared-deps-src/BUILD.bazel
+++ b/packages/kbn-ui-shared-deps-src/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-ui-shared-deps-src"
 PKG_REQUIRE_NAME = "@kbn/ui-shared-deps-src"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__ui-shared-deps-src"
 
 SOURCE_FILES = glob(
   [
@@ -130,7 +129,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-ui-shared-deps-src/tsconfig.json
+++ b/packages/kbn-ui-shared-deps-src/tsconfig.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ui-shared-deps-src/src",
     "types": [
       "node",
     ]

--- a/packages/kbn-ui-theme/BUILD.bazel
+++ b/packages/kbn-ui-theme/BUILD.bazel
@@ -60,10 +60,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-ui-theme/BUILD.bazel
+++ b/packages/kbn-ui-theme/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-ui-theme"
 PKG_REQUIRE_NAME = "@kbn/ui-theme"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__ui-theme"
 
 SOURCE_FILES = glob(
   [
@@ -96,7 +95,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-ui-theme/tsconfig.json
+++ b/packages/kbn-ui-theme/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ui-theme/src",
     "stripInternal": true,
     "types": ["node"]
   },

--- a/packages/kbn-utility-types/BUILD.bazel
+++ b/packages/kbn-utility-types/BUILD.bazel
@@ -55,10 +55,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-utility-types/BUILD.bazel
+++ b/packages/kbn-utility-types/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-utility-types"
 PKG_REQUIRE_NAME = "@kbn/utility-types"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__utility-types"
 
 SOURCE_FILES = glob([
   "src/jest/index.ts",
@@ -91,7 +90,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-utility-types/tsconfig.json
+++ b/packages/kbn-utility-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-utility-types",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-utils/BUILD.bazel
+++ b/packages/kbn-utils/BUILD.bazel
@@ -59,10 +59,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-utils/BUILD.bazel
+++ b/packages/kbn-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-utils"
 PKG_REQUIRE_NAME = "@kbn/utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__utils"
 
 SOURCE_FILES = glob(
   [
@@ -95,7 +94,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-utils/tsconfig.json
+++ b/packages/kbn-utils/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-utils/src",
     "types": [
       "jest",
       "node"

--- a/src/dev/bazel/pkg_npm_types/pkg_npm_types.bzl
+++ b/src/dev/bazel/pkg_npm_types/pkg_npm_types.bzl
@@ -33,6 +33,9 @@ def _collect_inputs_deps_and_transitive_types_deps(ctx):
   deps_files = depset(transitive = deps_files_depsets).to_list()
   return [deps_files, transitive_types_deps]
 
+def _get_type_package_name(actualName):
+  return "@types/" + actualName.replace("@", "").replace("/", "__")
+
 def _calculate_entrypoint_path(ctx):
   return _join(ctx.bin_dir.path, ctx.label.package, _get_types_outdir_name(ctx), ctx.attr.entrypoint_name)
 
@@ -78,7 +81,7 @@ def _pkg_npm_types_impl(ctx):
 
   # gathering template args
   template_args = [
-    "NAME", ctx.attr.package_name
+    "NAME", _get_type_package_name(ctx.attr.package_name)
   ]
 
   # layout api extractor arguments
@@ -119,7 +122,7 @@ def _pkg_npm_types_impl(ctx):
       deps = transitive_types_deps,
     ),
     LinkablePackageInfo(
-      package_name = ctx.attr.package_name,
+      package_name = _get_type_package_name(ctx.attr.package_name),
       package_path = "",
       path = package_dir.path,
       files = package_dir_depset,


### PR DESCRIPTION
1. Removes the `TYPES_PKG_REQUIRE_NAME` variable from all `BUILD.bazel` files and instead derives it from the `PKG_REQUIRE_NAME` variable so that they are all consistent and so we don't need to pass both values or reverse the conversion in order to know the package we're generating a types packages for.
2. Removes sourceMap related configs from tsconfig.json files as they're not used, and incorrect in some cases (`sourceRoot`). I'm working on re-enabling sourceMaps for our `@types/*` packages, starting with `@kbn/crypto` in https://github.com/elastic/kibana/pull/126287