### PR TITLE
[Fleet] hide policy created message on clicking create policy link

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_select_create.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_select_create.tsx
@@ -70,6 +70,11 @@ export const SelectCreateAgentPolicy: React.FC<Props> = ({
     [onAgentPolicyChange]
   );
 
+  const onClickCreatePolicy = () => {
+    setCreateState({ status: CREATE_STATUS.INITIAL });
+    setShowCreatePolicy(true);
+  };
+
   return (
     <>
       {showCreatePolicy ? (
@@ -86,7 +91,7 @@ export const SelectCreateAgentPolicy: React.FC<Props> = ({
           onKeyChange={onKeyChange}
           onAgentPolicyChange={onAgentPolicyChange}
           excludeFleetServer={excludeFleetServer}
-          onClickCreatePolicy={() => setShowCreatePolicy(true)}
+          onClickCreatePolicy={onClickCreatePolicy}
           selectedAgentPolicy={selectedAgentPolicy}
           isFleetServerPolicy={isFleetServerPolicy}
         />


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/126310

To verify:
- Navigate to Agents tab click Add Agent button, create a policy with name Agent Policy 1
- Observe Agent Policy 1 is selected and Agent policy created message is displayed.
- Navigate back to Create new policy from the same flyout.
Expected Result:
- On navigating to Create new policy twice after creating once, Policy created message should get removed under Add Agent flyout.