### PR TITLE
[Fleet] added time_series_metric mapping for metric_type package field

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -714,42 +714,54 @@ describe('EPM template', () => {
     expect(mappings).toEqual(expectedMapping);
   });
 
+  it('tests processing metric_type field', () => {
+    const literalYml = `
+- name: total.norm.pct
+  type: scaled_float
+  metric_type: gauge
+  unit: percent
+  format: percent
+`;
+    const expectedMapping = {
+      properties: {
+        total: {
+          properties: {
+            norm: {
+              properties: {
+                pct: {
+                  scaling_factor: 1000,
+                  type: 'scaled_float',
+                  meta: {
+                    unit: 'percent',
+                  },
+                  time_series_metric: {
+                    type: 'gauge',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(literalYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(expectedMapping);
+  });
+
   it('processes meta fields', () => {
     const metaFieldLiteralYaml = `
 - name: fieldWithMetas
   type: integer
   unit: byte
-  metric_type: gauge
   `;
     const metaFieldMapping = {
       properties: {
         fieldWithMetas: {
           type: 'long',
           meta: {
-            metric_type: 'gauge',
             unit: 'byte',
-          },
-        },
-      },
-    };
-    const fields: Field[] = safeLoad(metaFieldLiteralYaml);
-    const processedFields = processFields(fields);
-    const mappings = generateMappings(processedFields);
-    expect(JSON.stringify(mappings)).toEqual(JSON.stringify(metaFieldMapping));
-  });
-
-  it('processes meta fields with only one meta value', () => {
-    const metaFieldLiteralYaml = `
-- name: fieldWithMetas
-  type: integer
-  metric_type: gauge
-  `;
-    const metaFieldMapping = {
-      properties: {
-        fieldWithMetas: {
-          type: 'long',
-          meta: {
-            metric_type: 'gauge',
           },
         },
       },
@@ -765,16 +777,13 @@ describe('EPM template', () => {
 - name: groupWithMetas
   type: group
   unit: byte
-  metric_type: gauge
   fields:
     - name: fieldA
       type: integer
       unit: byte
-      metric_type: gauge
     - name: fieldB
       type: integer
       unit: byte
-      metric_type: gauge
   `;
     const metaFieldMapping = {
       properties: {
@@ -783,14 +792,12 @@ describe('EPM template', () => {
             fieldA: {
               type: 'long',
               meta: {
-                metric_type: 'gauge',
                 unit: 'byte',
               },
             },
             fieldB: {
               type: 'long',
               meta: {
-                metric_type: 'gauge',
                 unit: 'byte',
               },
             },

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -732,11 +732,10 @@ describe('EPM template', () => {
                   scaling_factor: 1000,
                   type: 'scaled_float',
                   meta: {
+                    metric_type: 'gauge',
                     unit: 'percent',
                   },
-                  time_series_metric: {
-                    type: 'gauge',
-                  },
+                  time_series_metric: 'gauge',
                 },
               },
             },

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -133,7 +133,7 @@ export function generateMappings(fields: Field[]): IndexTemplateMappings {
           fieldProps.type = 'scaled_float';
           fieldProps.scaling_factor = field.scaling_factor || DEFAULT_SCALING_FACTOR;
           if (field.metric_type) {
-            fieldProps.time_series_metric = { type: field.metric_type };
+            fieldProps.time_series_metric = field.metric_type;
           }
           break;
         case 'text':
@@ -196,6 +196,7 @@ export function generateMappings(fields: Field[]): IndexTemplateMappings {
             break;
           default: {
             const meta = {};
+            if ('metric_type' in field) Reflect.set(meta, 'metric_type', field.metric_type);
             if ('unit' in field) Reflect.set(meta, 'unit', field.unit);
             fieldProps.meta = meta;
           }

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -132,6 +132,9 @@ export function generateMappings(fields: Field[]): IndexTemplateMappings {
         case 'scaled_float':
           fieldProps.type = 'scaled_float';
           fieldProps.scaling_factor = field.scaling_factor || DEFAULT_SCALING_FACTOR;
+          if (field.metric_type) {
+            fieldProps.time_series_metric = { type: field.metric_type };
+          }
           break;
         case 'text':
           const textMapping = generateTextMapping(field);
@@ -193,7 +196,6 @@ export function generateMappings(fields: Field[]): IndexTemplateMappings {
             break;
           default: {
             const meta = {};
-            if ('metric_type' in field) Reflect.set(meta, 'metric_type', field.metric_type);
             if ('unit' in field) Reflect.set(meta, 'unit', field.unit);
             fieldProps.meta = meta;
           }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/115621

Moved `metric_type` to `time_series_metric` mapping, removed from `meta`.

Example:
```
- name: total.norm.pct
  type: scaled_float
  metric_type: gauge
  unit: percent
  format: percent
```
Resulting mapping:
```
  "properties": {
    "total": {
      "properties": {
        "norm": {
          "properties": {
            "pct": {
              "scaling_factor": 1000,
              "type": "scaled_float",
              "meta": {
                "unit": "percent"
              },
              "time_series_metric": {
                "type": "gauge"
              }
            }
          }
        }
      }
    }
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
