### PR TITLE
[APM] Revert maxNumServices to 500

### DIFF
--- a/x-pack/plugins/apm/server/routes/services/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/services/__snapshots__/queries.test.ts.snap
@@ -124,7 +124,7 @@ Array [
           },
           "terms": Object {
             "field": "service.name",
-            "size": 50,
+            "size": 500,
           },
         },
       },
@@ -177,7 +177,7 @@ Array [
           },
           "terms": Object {
             "field": "service.name",
-            "size": 50,
+            "size": 500,
           },
         },
       },

--- a/x-pack/plugins/apm/server/routes/services/get_services/get_services_items.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_services_items.ts
@@ -15,7 +15,7 @@ import { mergeServiceStats } from './merge_service_stats';
 
 export type ServicesItemsSetup = Setup;
 
-const MAX_NUMBER_OF_SERVICES = 50;
+const MAX_NUMBER_OF_SERVICES = 500;
 
 export async function getServicesItems({
   environment,


### PR DESCRIPTION
## Summary

Reverting the change made in https://github.com/elastic/kibana/pull/125646 