### PR TITLE
[8.1] Update doc links for Ingest Pipelines UI (#125456)

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -544,6 +544,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       lowercase: `${ELASTICSEARCH_DOCS}lowercase-processor.html`,
       pipeline: `${ELASTICSEARCH_DOCS}pipeline-processor.html`,
       pipelines: `${ELASTICSEARCH_DOCS}ingest.html`,
+      csvPipelines: `${ELASTIC_WEBSITE_URL}guide/en/ecs/${DOC_LINK_VERSION}/ecs-converting.html`,
       pipelineFailure: `${ELASTICSEARCH_DOCS}ingest.html#handling-pipeline-failures`,
       processors: `${ELASTICSEARCH_DOCS}processors.html`,
       remove: `${ELASTICSEARCH_DOCS}remove-processor.html`,

--- a/x-pack/plugins/ingest_pipelines/__jest__/client_integration/ingest_pipelines_create_from_csv.test.tsx
+++ b/x-pack/plugins/ingest_pipelines/__jest__/client_integration/ingest_pipelines_create_from_csv.test.tsx
@@ -66,7 +66,7 @@ describe('<PipelinesCreateFromCsv />', () => {
       expect(find('pageTitle').text()).toEqual('Create pipeline from CSV');
 
       expect(exists('documentationLink')).toBe(true);
-      expect(find('documentationLink').text()).toBe('Create pipeline docs');
+      expect(find('documentationLink').text()).toBe('CSV to pipeline docs');
     });
 
     describe('form validation', () => {

--- a/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_create/pipelines_create.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_create/pipelines_create.tsx
@@ -85,7 +85,7 @@ export const PipelinesCreate: React.FunctionComponent<RouteComponentProps & Prop
           <EuiButtonEmpty
             size="s"
             flush="right"
-            href={services.documentation.getPutPipelineApiUrl()}
+            href={services.documentation.getCreatePipelineUrl()}
             target="_blank"
             iconType="help"
             data-test-subj="documentationLink"

--- a/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_create_from_csv/main.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_create_from_csv/main.tsx
@@ -171,14 +171,14 @@ export const PipelinesCreateFromCsv: React.FunctionComponent<RouteComponentProps
           <EuiButtonEmpty
             size="s"
             flush="right"
-            href={services.documentation.getPutPipelineApiUrl()}
+            href={services.documentation.getCreatePipelineCSVUrl()}
             target="_blank"
             iconType="help"
             data-test-subj="documentationLink"
           >
             <FormattedMessage
-              id="xpack.ingestPipelines.create.docsButtonLabel"
-              defaultMessage="Create pipeline docs"
+              id="xpack.ingestPipelines.createFromCSV.docsButtonLabel"
+              defaultMessage="CSV to pipeline docs"
             />
           </EuiButtonEmpty>,
         ]}

--- a/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_edit/pipelines_edit.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_edit/pipelines_edit.tsx
@@ -134,7 +134,7 @@ export const PipelinesEdit: React.FunctionComponent<RouteComponentProps<MatchPar
           <EuiButtonEmpty
             size="s"
             flush="right"
-            href={services.documentation.getPutPipelineApiUrl()}
+            href={services.documentation.getCreatePipelineUrl()}
             target="_blank"
             iconType="help"
             data-test-subj="documentationLink"

--- a/x-pack/plugins/ingest_pipelines/public/application/services/documentation.ts
+++ b/x-pack/plugins/ingest_pipelines/public/application/services/documentation.ts
@@ -12,7 +12,8 @@ export class DocumentationService {
   private ingestNodeUrl: string = '';
   private processorsUrl: string = '';
   private handlingFailureUrl: string = '';
-  private putPipelineApiUrl: string = '';
+  private createPipelineUrl: string = '';
+  private createPipelineCSVUrl: string = '';
   private simulatePipelineApiUrl: string = '';
   private enrichDataUrl: string = '';
   private geoMatchUrl: string = '';
@@ -29,7 +30,8 @@ export class DocumentationService {
     this.ingestNodeUrl = links.ingest.pipelines;
     this.processorsUrl = links.ingest.processors;
     this.handlingFailureUrl = links.ingest.pipelineFailure;
-    this.putPipelineApiUrl = links.apis.createPipeline;
+    this.createPipelineUrl = links.ingest.pipelines;
+    this.createPipelineCSVUrl = links.ingest.csvPipelines;
     this.simulatePipelineApiUrl = links.apis.simulatePipeline;
     this.enrichDataUrl = links.ingest.enrich;
     this.geoMatchUrl = links.ingest.geoMatch;
@@ -55,8 +57,12 @@ export class DocumentationService {
     return this.handlingFailureUrl;
   }
 
-  public getPutPipelineApiUrl() {
-    return this.putPipelineApiUrl;
+  public getCreatePipelineUrl() {
+    return this.createPipelineUrl;
+  }
+
+  public getCreatePipelineCSVUrl() {
+    return this.createPipelineCSVUrl;
   }
 
   public getSimulatePipelineApiUrl() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [Update doc links for Ingest Pipelines UI (#125456)](https://github.com/elastic/kibana/pull/125456)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)