### PR TITLE
Embeddable Lens - retry on fetch dataview failure

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/use_load_index_pattern.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/use_load_index_pattern.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import { AppDataType } from '../types';
+import { IndexPatternState } from '../hooks/use_app_index_pattern';
+import { ObservabilityDataViews } from '../../../../utils/observability_data_views';
+import { DataViewsPublicPluginStart } from '../../../../../../../../src/plugins/data_views/public';
+
+export const useLoadIndexPattern = ({
+  dataType,
+  dataTypesIndexPatterns,
+  dataViewsPlugin,
+  retryOnFetchDataViewFailure,
+}: {
+  dataType: AppDataType;
+  dataTypesIndexPatterns?: Partial<Record<AppDataType, string>>;
+  dataViewsPlugin: DataViewsPublicPluginStart;
+  retryOnFetchDataViewFailure?: boolean;
+}) => {
+  const [indexPatterns, setIndexPatterns] = useState<IndexPatternState>({} as IndexPatternState);
+  const [loading, setLoading] = useState(false);
+  const loadIndexPattern = useCallback(async () => {
+    setLoading(true);
+    try {
+      const obsvIndexP = new ObservabilityDataViews(dataViewsPlugin);
+      const indPattern = await obsvIndexP.getDataView(
+        dataType,
+        dataTypesIndexPatterns?.[dataType],
+        retryOnFetchDataViewFailure
+      );
+      setIndexPatterns((prevState) => ({ ...(prevState ?? {}), [dataType]: indPattern }));
+
+      setLoading(false);
+    } catch (e) {
+      setLoading(false);
+    }
+  }, [dataType, dataTypesIndexPatterns, dataViewsPlugin, retryOnFetchDataViewFailure]);
+
+  useEffect(() => {
+    if (dataType) {
+      loadIndexPattern();
+    }
+  }, [dataType, loadIndexPattern]);
+
+  return { indexPatterns, loading };
+};

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/utils.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/utils.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { TypedLensByValueInput } from '../../../../../../lens/public';
+
+export const addDataViewToLensAttributes = ({
+  lensAttributes,
+  dataViewId,
+}: {
+  lensAttributes: TypedLensByValueInput['attributes'];
+  dataViewId: string;
+}): TypedLensByValueInput['attributes'] => ({
+  ...lensAttributes,
+  references: lensAttributes.references.map((ref: { id: string; type: string; name: string }) => ({
+    ...ref,
+    id: dataViewId,
+  })),
+});

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -270,6 +270,12 @@ export class Plugin
       },
       createExploratoryViewUrl,
       ExploratoryViewEmbeddable: getExploratoryViewEmbeddable(coreStart, pluginsStart),
+      // useLoadIndexPattern: ({ dataType, dataTypesIndexPatterns }) =>
+      //   useLoadIndexPattern.bind(null, {
+      //     dataType,
+      //     dataTypesIndexPatterns,
+      //     dataViewsPlugin: pluginsStart.dataViews,
+      //   }),
     };
   }
 }


### PR DESCRIPTION
## Summary

When had a problem when rendering charts without existing dataView id, 
1. We have to inject customLensAttr with the newly created dataView id in order to get the right index patterns.
2. There were lots of response error when creating dataView (video 1 - 0'38). Guess it's because we render multiple embeddables on the page, and each embeddable sent the same request, added a retry flag to make sure all the charts load the dataView id.


https://user-images.githubusercontent.com/6295984/155551291-ff824f95-37ee-4c93-993f-44cfb63038f8.mp4

https://user-images.githubusercontent.com/6295984/155552193-2bcfd1d6-5bb5-416b-98c8-d4b84309d223.mp4


after fixed:

https://user-images.githubusercontent.com/6295984/155552139-2b22e808-c593-4c5f-abea-637316af847b.mp4



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
