### PR TITLE
[bazel/ts] stop building sourcemaps since they're ignored

### DIFF
--- a/packages/elastic-apm-synthtrace/BUILD.bazel
+++ b/packages/elastic-apm-synthtrace/BUILD.bazel
@@ -67,11 +67,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
   validate = False,
 )

--- a/packages/elastic-apm-synthtrace/tsconfig.json
+++ b/packages/elastic-apm-synthtrace/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/elastic-apm-synthtrace/src",
     "types": ["node", "jest"]
   },
   "include": ["./src/**/*.ts"]

--- a/packages/elastic-datemath/BUILD.bazel
+++ b/packages/elastic-datemath/BUILD.bazel
@@ -50,10 +50,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig"
 )

--- a/packages/elastic-datemath/tsconfig.json
+++ b/packages/elastic-datemath/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/elastic-datemath/src",
     "types": [
       "node"
     ]

--- a/packages/kbn-ace/BUILD.bazel
+++ b/packages/kbn-ace/BUILD.bazel
@@ -68,10 +68,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-ace/tsconfig.json
+++ b/packages/kbn-ace/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ace/src",
     "stripInternal": true,
     "types": ["node"]
   },

--- a/packages/kbn-alerts/BUILD.bazel
+++ b/packages/kbn-alerts/BUILD.bazel
@@ -74,11 +74,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-alerts/tsconfig.json
+++ b/packages/kbn-alerts/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-alerts/src",
     "types": ["jest", "node"]
   },
   "include": ["src/**/*"],

--- a/packages/kbn-analytics/BUILD.bazel
+++ b/packages/kbn-analytics/BUILD.bazel
@@ -71,11 +71,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-analytics/tsconfig.json
+++ b/packages/kbn-analytics/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-analytics/src",
     "stripInternal": true,
     "types": [
       "node"

--- a/packages/kbn-apm-config-loader/BUILD.bazel
+++ b/packages/kbn-apm-config-loader/BUILD.bazel
@@ -66,10 +66,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-apm-config-loader/tsconfig.json
+++ b/packages/kbn-apm-config-loader/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-apm-config-loader/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-apm-utils/BUILD.bazel
+++ b/packages/kbn-apm-utils/BUILD.bazel
@@ -51,10 +51,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-apm-utils/tsconfig.json
+++ b/packages/kbn-apm-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-apm-utils/src",
     "types": [
       "node"
     ]

--- a/packages/kbn-cli-dev-mode/BUILD.bazel
+++ b/packages/kbn-cli-dev-mode/BUILD.bazel
@@ -93,11 +93,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-cli-dev-mode/tsconfig.json
+++ b/packages/kbn-cli-dev-mode/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-cli-dev-mode/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-config-schema/BUILD.bazel
+++ b/packages/kbn-config-schema/BUILD.bazel
@@ -62,10 +62,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-config-schema/tsconfig.json
+++ b/packages/kbn-config-schema/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-config-schema/src",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-config/BUILD.bazel
+++ b/packages/kbn-config/BUILD.bazel
@@ -83,10 +83,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-config/tsconfig.json
+++ b/packages/kbn-config/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-config/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-crypto/BUILD.bazel
+++ b/packages/kbn-crypto/BUILD.bazel
@@ -62,10 +62,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-crypto/tsconfig.json
+++ b/packages/kbn-crypto/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-crypto/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-dev-utils/BUILD.bazel
+++ b/packages/kbn-dev-utils/BUILD.bazel
@@ -114,10 +114,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-dev-utils/tsconfig.json
+++ b/packages/kbn-dev-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-dev-utils/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-doc-links/BUILD.bazel
+++ b/packages/kbn-doc-links/BUILD.bazel
@@ -61,10 +61,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-doc-links/tsconfig.json
+++ b/packages/kbn-doc-links/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-doc-links/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-docs-utils/BUILD.bazel
+++ b/packages/kbn-docs-utils/BUILD.bazel
@@ -67,10 +67,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-docs-utils/tsconfig.json
+++ b/packages/kbn-docs-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-docs-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es-archiver/BUILD.bazel
+++ b/packages/kbn-es-archiver/BUILD.bazel
@@ -80,10 +80,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-es-archiver/tsconfig.json
+++ b/packages/kbn-es-archiver/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-es-archiver/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es-query/BUILD.bazel
+++ b/packages/kbn-es-query/BUILD.bazel
@@ -94,10 +94,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-es-query/tsconfig.json
+++ b/packages/kbn-es-query/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-es-query/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-field-types/BUILD.bazel
+++ b/packages/kbn-field-types/BUILD.bazel
@@ -64,10 +64,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-field-types/tsconfig.json
+++ b/packages/kbn-field-types/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "outDir": "./target_types",
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-field-types/src"
   },
   "include": ["src/**/*"]
 }

--- a/packages/kbn-i18n-react/BUILD.bazel
+++ b/packages/kbn-i18n-react/BUILD.bazel
@@ -74,10 +74,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-i18n-react/tsconfig.json
+++ b/packages/kbn-i18n-react/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-i18n-react/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-i18n/BUILD.bazel
+++ b/packages/kbn-i18n/BUILD.bazel
@@ -75,10 +75,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-i18n/tsconfig.json
+++ b/packages/kbn-i18n/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-i18n/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-interpreter/BUILD.bazel
+++ b/packages/kbn-interpreter/BUILD.bazel
@@ -74,10 +74,8 @@ ts_project(
   deps = TYPES_DEPS,
   allow_js = True,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-interpreter/tsconfig.json
+++ b/packages/kbn-interpreter/tsconfig.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-interpreter/src",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-io-ts-utils/BUILD.bazel
+++ b/packages/kbn-io-ts-utils/BUILD.bazel
@@ -65,10 +65,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-io-ts-utils/tsconfig.json
+++ b/packages/kbn-io-ts-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-io-ts-utils/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-logging-mocks/BUILD.bazel
+++ b/packages/kbn-logging-mocks/BUILD.bazel
@@ -57,10 +57,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-logging-mocks/tsconfig.json
+++ b/packages/kbn-logging-mocks/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-logging-mocks/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-logging/BUILD.bazel
+++ b/packages/kbn-logging/BUILD.bazel
@@ -58,10 +58,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-logging/tsconfig.json
+++ b/packages/kbn-logging/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-logging/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-mapbox-gl/BUILD.bazel
+++ b/packages/kbn-mapbox-gl/BUILD.bazel
@@ -61,10 +61,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-mapbox-gl/tsconfig.json
+++ b/packages/kbn-mapbox-gl/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-mapbox-gl/src",
     "types": []
   },
   "include": [

--- a/packages/kbn-monaco/BUILD.bazel
+++ b/packages/kbn-monaco/BUILD.bazel
@@ -96,10 +96,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-monaco/tsconfig.json
+++ b/packages/kbn-monaco/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-monaco/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-optimizer/BUILD.bazel
+++ b/packages/kbn-optimizer/BUILD.bazel
@@ -119,10 +119,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-optimizer/tsconfig.json
+++ b/packages/kbn-optimizer/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-optimizer/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-plugin-generator/BUILD.bazel
+++ b/packages/kbn-plugin-generator/BUILD.bazel
@@ -86,10 +86,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-plugin-generator/tsconfig.json
+++ b/packages/kbn-plugin-generator/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-plugin-generator/src",
     "target": "ES2019",
     "types": [
       "jest",

--- a/packages/kbn-plugin-helpers/BUILD.bazel
+++ b/packages/kbn-plugin-helpers/BUILD.bazel
@@ -79,10 +79,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-plugin-helpers/tsconfig.json
+++ b/packages/kbn-plugin-helpers/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-plugin-helpers/src",
     "target": "ES2018",
     "types": [
       "jest",

--- a/packages/kbn-react-field/BUILD.bazel
+++ b/packages/kbn-react-field/BUILD.bazel
@@ -84,10 +84,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-react-field/tsconfig.json
+++ b/packages/kbn-react-field/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-react-field/src",
     "types": [
       "jest",
       "node",

--- a/packages/kbn-rule-data-utils/BUILD.bazel
+++ b/packages/kbn-rule-data-utils/BUILD.bazel
@@ -60,11 +60,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   incremental = False,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-rule-data-utils/tsconfig.json
+++ b/packages/kbn-rule-data-utils/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "incremental": false,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-rule-data-utils/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-securitysolution-autocomplete/BUILD.bazel
+++ b/packages/kbn-securitysolution-autocomplete/BUILD.bazel
@@ -93,11 +93,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-autocomplete/tsconfig.json
+++ b/packages/kbn-securitysolution-autocomplete/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-autocomplete/src",
     "rootDir": "src",
     "types": ["jest", "node"]
   },

--- a/packages/kbn-securitysolution-es-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-es-utils/BUILD.bazel
@@ -65,11 +65,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-es-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-es-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-es-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-hook-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-hook-utils/BUILD.bazel
@@ -72,11 +72,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-hook-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-hook-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-hook-utils/src",
     "types": ["jest", "node"]
   },
   "include": ["src/**/*"]

--- a/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
@@ -75,11 +75,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-alerting-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-alerting-types/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-io-ts-list-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-list-types/BUILD.bazel
@@ -75,11 +75,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-list-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-list-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-list-types/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-io-ts-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-types/BUILD.bazel
@@ -73,11 +73,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-types/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-io-ts-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-utils/BUILD.bazel
@@ -76,11 +76,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-api/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-api/BUILD.bazel
@@ -75,11 +75,9 @@ ts_project(
   deps = TYPES_DEPS,
   args = ["--pretty"],
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-api/tsconfig.json
+++ b/packages/kbn-securitysolution-list-api/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-api/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-constants/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-constants/BUILD.bazel
@@ -63,11 +63,9 @@ ts_project(
   deps = TYPES_DEPS,
   args = ["--pretty"],
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-constants/tsconfig.json
+++ b/packages/kbn-securitysolution-list-constants/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-constants/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-hooks/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-hooks/BUILD.bazel
@@ -83,11 +83,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-hooks/tsconfig.json
+++ b/packages/kbn-securitysolution-list-hooks/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-hooks/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-utils/BUILD.bazel
@@ -82,11 +82,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-list-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-rules/BUILD.bazel
+++ b/packages/kbn-securitysolution-rules/BUILD.bazel
@@ -63,11 +63,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-rules/tsconfig.json
+++ b/packages/kbn-securitysolution-rules/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-rules/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-t-grid/BUILD.bazel
+++ b/packages/kbn-securitysolution-t-grid/BUILD.bazel
@@ -72,11 +72,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-t-grid/tsconfig.json
+++ b/packages/kbn-securitysolution-t-grid/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-t-grid/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-utils/BUILD.bazel
@@ -61,11 +61,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-server-http-tools/BUILD.bazel
+++ b/packages/kbn-server-http-tools/BUILD.bazel
@@ -72,10 +72,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-server-http-tools/tsconfig.json
+++ b/packages/kbn-server-http-tools/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target/types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-server-http-tools/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-server-route-repository/BUILD.bazel
+++ b/packages/kbn-server-route-repository/BUILD.bazel
@@ -68,10 +68,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-server-route-repository/tsconfig.json
+++ b/packages/kbn-server-route-repository/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-server-route-repository/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-std/BUILD.bazel
+++ b/packages/kbn-std/BUILD.bazel
@@ -67,10 +67,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-std/tsconfig.json
+++ b/packages/kbn-std/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-std/src",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-storybook/BUILD.bazel
+++ b/packages/kbn-storybook/BUILD.bazel
@@ -93,11 +93,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-storybook/tsconfig.json
+++ b/packages/kbn-storybook/tsconfig.json
@@ -2,14 +2,11 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "incremental": false,
     "outDir": "target_types",
     "rootDir": "src",
     "skipLibCheck": true,
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-storybook",
     "target": "es2015",
     "types": ["node"]
   },

--- a/packages/kbn-telemetry-tools/BUILD.bazel
+++ b/packages/kbn-telemetry-tools/BUILD.bazel
@@ -71,10 +71,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-telemetry-tools/tsconfig.json
+++ b/packages/kbn-telemetry-tools/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-telemetry-tools/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-test-jest-helpers/BUILD.bazel
+++ b/packages/kbn-test-jest-helpers/BUILD.bazel
@@ -133,10 +133,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-test-jest-helpers/tsconfig.json
+++ b/packages/kbn-test-jest-helpers/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "stripInternal": true,
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../../packages/kbn-test-jest-helpers/src",
     "types": ["jest", "node"]
   },
   "include": ["src/**/*"],

--- a/packages/kbn-test/BUILD.bazel
+++ b/packages/kbn-test/BUILD.bazel
@@ -139,10 +139,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-test/tsconfig.json
+++ b/packages/kbn-test/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "stripInternal": true,
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../../packages/kbn-test/src",
     "types": ["jest", "node"]
   },
   "include": ["src/**/*", "index.d.ts"],

--- a/packages/kbn-typed-react-router-config/BUILD.bazel
+++ b/packages/kbn-typed-react-router-config/BUILD.bazel
@@ -83,10 +83,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-typed-react-router-config/tsconfig.json
+++ b/packages/kbn-typed-react-router-config/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-typed-react-router-config/src",
     "stripInternal": true,
     "types": [
       "node",

--- a/packages/kbn-ui-shared-deps-npm/BUILD.bazel
+++ b/packages/kbn-ui-shared-deps-npm/BUILD.bazel
@@ -121,11 +121,9 @@ ts_project(
   deps = TYPES_DEPS,
   allow_js = True,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-ui-shared-deps-npm/tsconfig.json
+++ b/packages/kbn-ui-shared-deps-npm/tsconfig.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ui-shared-deps-npm/src",
     "types": [
       "node",
     ]

--- a/packages/kbn-ui-shared-deps-src/BUILD.bazel
+++ b/packages/kbn-ui-shared-deps-src/BUILD.bazel
@@ -77,11 +77,9 @@ ts_project(
   deps = TYPES_DEPS,
   allow_js = True,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-ui-shared-deps-src/tsconfig.json
+++ b/packages/kbn-ui-shared-deps-src/tsconfig.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ui-shared-deps-src/src",
     "types": [
       "node",
     ]

--- a/packages/kbn-ui-theme/BUILD.bazel
+++ b/packages/kbn-ui-theme/BUILD.bazel
@@ -61,10 +61,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-ui-theme/tsconfig.json
+++ b/packages/kbn-ui-theme/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ui-theme/src",
     "stripInternal": true,
     "types": ["node"]
   },

--- a/packages/kbn-utility-types/BUILD.bazel
+++ b/packages/kbn-utility-types/BUILD.bazel
@@ -56,10 +56,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-utility-types/tsconfig.json
+++ b/packages/kbn-utility-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-utility-types",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-utils/BUILD.bazel
+++ b/packages/kbn-utils/BUILD.bazel
@@ -60,10 +60,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-utils/tsconfig.json
+++ b/packages/kbn-utils/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-utils/src",
     "types": [
       "jest",
       "node"


### PR DESCRIPTION
When we moved to using api-extractor the source-maps we are generating with Typescript were dropped and not used. I'm working on fixing this, starting with `@kbn/crypto` in #126287, but this requires changes to the tsconfig files being built so it would be great if we could reset the config files and remove the unnecessary steps from the build. This might even make the TS builds a little faster, but I don't have data on that.