### PR TITLE
[8.0] [bazel] avoid a little boilerplate in packages (#126309)

### DIFF
--- a/packages/elastic-apm-synthtrace/BUILD.bazel
+++ b/packages/elastic-apm-synthtrace/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "elastic-apm-synthtrace"
 PKG_REQUIRE_NAME = "@elastic/apm-synthtrace"
-TYPES_PKG_REQUIRE_NAME = "@types/elastic__apm-synthtrace"
 
 SOURCE_FILES = glob(
   [
@@ -67,11 +66,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
   validate = False,
 )
@@ -103,7 +100,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/elastic-apm-synthtrace/tsconfig.json
+++ b/packages/elastic-apm-synthtrace/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/elastic-apm-synthtrace/src",
     "types": ["node", "jest"]
   },
   "include": ["./src/**/*.ts"]

--- a/packages/elastic-datemath/BUILD.bazel
+++ b/packages/elastic-datemath/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "ts_project", "pkg_npm", "p
 
 PKG_BASE_NAME = "elastic-datemath"
 PKG_REQUIRE_NAME = "@elastic/datemath"
-TYPES_PKG_REQUIRE_NAME = "@types/elastic__datemath"
 
 SOURCE_FILES = glob([
   "src/index.ts",
@@ -50,10 +49,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig"
 )
@@ -85,7 +82,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/elastic-datemath/tsconfig.json
+++ b/packages/elastic-datemath/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/elastic-datemath/src",
     "types": [
       "node"
     ]

--- a/packages/kbn-ace/BUILD.bazel
+++ b/packages/kbn-ace/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-ace"
 PKG_REQUIRE_NAME = "@kbn/ace"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__ace"
 
 SOURCE_FILES = glob(
   [
@@ -68,10 +67,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -103,7 +100,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-ace/tsconfig.json
+++ b/packages/kbn-ace/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ace/src",
     "stripInternal": true,
     "types": ["node"]
   },

--- a/packages/kbn-alerts/BUILD.bazel
+++ b/packages/kbn-alerts/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-alerts"
 PKG_REQUIRE_NAME = "@kbn/alerts"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__alerts"
 
 SOURCE_FILES = glob(
   [
@@ -76,11 +75,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 
@@ -111,7 +108,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-alerts/tsconfig.json
+++ b/packages/kbn-alerts/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-alerts/src",
     "types": ["jest", "node", "resize-observer-polyfill"]
   },
   "include": ["src/**/*"],

--- a/packages/kbn-analytics/BUILD.bazel
+++ b/packages/kbn-analytics/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-analytics"
 PKG_REQUIRE_NAME = "@kbn/analytics"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__analytics"
 
 SOURCE_FILES = glob(
   [
@@ -71,11 +70,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 
@@ -106,7 +103,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-analytics/tsconfig.json
+++ b/packages/kbn-analytics/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-analytics/src",
     "stripInternal": true,
     "types": [
       "node"

--- a/packages/kbn-apm-config-loader/BUILD.bazel
+++ b/packages/kbn-apm-config-loader/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-apm-config-loader"
 PKG_REQUIRE_NAME = "@kbn/apm-config-loader"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__apm-config-loader"
 
 SOURCE_FILES = glob(
   [
@@ -66,10 +65,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -101,7 +98,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-apm-config-loader/tsconfig.json
+++ b/packages/kbn-apm-config-loader/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-apm-config-loader/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-apm-utils/BUILD.bazel
+++ b/packages/kbn-apm-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-apm-utils"
 PKG_REQUIRE_NAME = "@kbn/apm-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__apm-utils"
 
 SOURCE_FILES = glob([
   "src/index.ts",
@@ -51,10 +50,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -86,7 +83,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-apm-utils/tsconfig.json
+++ b/packages/kbn-apm-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-apm-utils/src",
     "types": [
       "node"
     ]

--- a/packages/kbn-cli-dev-mode/BUILD.bazel
+++ b/packages/kbn-cli-dev-mode/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-cli-dev-mode"
 PKG_REQUIRE_NAME = "@kbn/cli-dev-mode"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__cli-dev-mode"
 
 SOURCE_FILES = glob(
   [
@@ -93,11 +92,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 
@@ -128,7 +125,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-cli-dev-mode/tsconfig.json
+++ b/packages/kbn-cli-dev-mode/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-cli-dev-mode/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-config-schema/BUILD.bazel
+++ b/packages/kbn-config-schema/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-config-schema"
 PKG_REQUIRE_NAME = "@kbn/config-schema"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__config-schema"
 
 SOURCE_FILES = glob([
   "src/**/*.ts",
@@ -62,10 +61,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -97,7 +94,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-config-schema/tsconfig.json
+++ b/packages/kbn-config-schema/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-config-schema/src",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-config/BUILD.bazel
+++ b/packages/kbn-config/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-config"
 PKG_REQUIRE_NAME = "@kbn/config"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__config"
 
 SOURCE_FILES = glob(
   [
@@ -81,10 +80,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -116,7 +113,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-config/tsconfig.json
+++ b/packages/kbn-config/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-config/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-crypto/BUILD.bazel
+++ b/packages/kbn-crypto/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-crypto"
 PKG_REQUIRE_NAME = "@kbn/crypto"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__crypto"
 
 SOURCE_FILES = glob(
   [
@@ -29,7 +28,7 @@ NPM_MODULE_EXTRA_FILES = [
 ]
 
 RUNTIME_DEPS = [
-  "//packages/kbn-dev-utils",
+  "//packages/kbn-dev-utils:build",
   "@npm//node-forge",
 ]
 
@@ -62,10 +61,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -97,7 +94,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-crypto/tsconfig.json
+++ b/packages/kbn-crypto/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-crypto/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-dev-utils/BUILD.bazel
+++ b/packages/kbn-dev-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-dev-utils"
 PKG_REQUIRE_NAME = "@kbn/dev-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__dev-utils"
 
 SOURCE_FILES = glob(
   [
@@ -114,10 +113,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -149,7 +146,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-dev-utils/tsconfig.json
+++ b/packages/kbn-dev-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-dev-utils/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-docs-utils/BUILD.bazel
+++ b/packages/kbn-docs-utils/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-docs-utils"
 PKG_REQUIRE_NAME = "@kbn/docs-utils"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__docs-utils"
 
 SOURCE_FILES = glob(
   [
@@ -67,10 +66,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -102,7 +99,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-docs-utils/tsconfig.json
+++ b/packages/kbn-docs-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-docs-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es-archiver/BUILD.bazel
+++ b/packages/kbn-es-archiver/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-es-archiver"
 PKG_REQUIRE_NAME = "@kbn/es-archiver"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__es-archiver"
 
 SOURCE_FILES = glob(
   [
@@ -82,10 +81,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -117,7 +114,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-es-archiver/tsconfig.json
+++ b/packages/kbn-es-archiver/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-es-archiver/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es-query/BUILD.bazel
+++ b/packages/kbn-es-query/BUILD.bazel
@@ -5,7 +5,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-es-query"
 PKG_REQUIRE_NAME = "@kbn/es-query"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__es-query"
 
 SOURCE_FILES = glob(
   [
@@ -94,10 +93,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -129,7 +126,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-es-query/tsconfig.json
+++ b/packages/kbn-es-query/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-es-query/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-field-types/BUILD.bazel
+++ b/packages/kbn-field-types/BUILD.bazel
@@ -64,10 +64,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-field-types/tsconfig.json
+++ b/packages/kbn-field-types/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "outDir": "./target_types",
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-field-types/src"
   },
   "include": ["src/**/*"]
 }

--- a/packages/kbn-i18n-react/BUILD.bazel
+++ b/packages/kbn-i18n-react/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-i18n-react"
 PKG_REQUIRE_NAME = "@kbn/i18n-react"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__i18n-react"
 
 SOURCE_FILES = glob(
   [
@@ -74,10 +73,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -109,7 +106,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-i18n-react/tsconfig.json
+++ b/packages/kbn-i18n-react/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-i18n-react/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-i18n/BUILD.bazel
+++ b/packages/kbn-i18n/BUILD.bazel
@@ -4,7 +4,6 @@ load("//src/dev/bazel:index.bzl", "jsts_transpiler", "pkg_npm", "pkg_npm_types",
 
 PKG_BASE_NAME = "kbn-i18n"
 PKG_REQUIRE_NAME = "@kbn/i18n"
-TYPES_PKG_REQUIRE_NAME = "@types/kbn__i18n"
 
 SOURCE_FILES = glob(
   [
@@ -75,10 +74,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )
@@ -110,7 +107,7 @@ pkg_npm_types(
   name = "npm_module_types",
   srcs = SRCS,
   deps = [":tsc_types"],
-  package_name = TYPES_PKG_REQUIRE_NAME,
+  package_name = PKG_REQUIRE_NAME,
   tsconfig = ":tsconfig",
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-i18n/tsconfig.json
+++ b/packages/kbn-i18n/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-i18n/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-interpreter/BUILD.bazel
+++ b/packages/kbn-interpreter/BUILD.bazel
@@ -73,10 +73,8 @@ ts_project(
   deps = TYPES_DEPS,
   allow_js = True,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-interpreter/tsconfig.json
+++ b/packages/kbn-interpreter/tsconfig.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-interpreter/src",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-io-ts-utils/BUILD.bazel
+++ b/packages/kbn-io-ts-utils/BUILD.bazel
@@ -75,10 +75,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-io-ts-utils/tsconfig.json
+++ b/packages/kbn-io-ts-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-io-ts-utils/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-logging/BUILD.bazel
+++ b/packages/kbn-logging/BUILD.bazel
@@ -58,10 +58,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-logging/tsconfig.json
+++ b/packages/kbn-logging/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-logging/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-mapbox-gl/BUILD.bazel
+++ b/packages/kbn-mapbox-gl/BUILD.bazel
@@ -60,10 +60,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-mapbox-gl/tsconfig.json
+++ b/packages/kbn-mapbox-gl/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-mapbox-gl/src",
     "types": []
   },
   "include": [

--- a/packages/kbn-monaco/BUILD.bazel
+++ b/packages/kbn-monaco/BUILD.bazel
@@ -93,10 +93,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-monaco/tsconfig.json
+++ b/packages/kbn-monaco/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-monaco/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-optimizer/BUILD.bazel
+++ b/packages/kbn-optimizer/BUILD.bazel
@@ -120,10 +120,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-optimizer/tsconfig.json
+++ b/packages/kbn-optimizer/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-optimizer/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-plugin-generator/BUILD.bazel
+++ b/packages/kbn-plugin-generator/BUILD.bazel
@@ -85,10 +85,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-plugin-generator/tsconfig.json
+++ b/packages/kbn-plugin-generator/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-plugin-generator/src",
     "target": "ES2019",
     "types": [
       "jest",

--- a/packages/kbn-plugin-helpers/BUILD.bazel
+++ b/packages/kbn-plugin-helpers/BUILD.bazel
@@ -78,10 +78,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-plugin-helpers/tsconfig.json
+++ b/packages/kbn-plugin-helpers/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-plugin-helpers/src",
     "target": "ES2018",
     "types": [
       "jest",

--- a/packages/kbn-rule-data-utils/BUILD.bazel
+++ b/packages/kbn-rule-data-utils/BUILD.bazel
@@ -63,11 +63,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   incremental = False,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-rule-data-utils/tsconfig.json
+++ b/packages/kbn-rule-data-utils/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "incremental": false,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-rule-data-utils/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-securitysolution-autocomplete/BUILD.bazel
+++ b/packages/kbn-securitysolution-autocomplete/BUILD.bazel
@@ -90,11 +90,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-autocomplete/tsconfig.json
+++ b/packages/kbn-securitysolution-autocomplete/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-autocomplete/src",
     "rootDir": "src",
     "types": ["jest", "node", "resize-observer-polyfill"]
   },

--- a/packages/kbn-securitysolution-es-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-es-utils/BUILD.bazel
@@ -65,11 +65,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-es-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-es-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-es-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-hook-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-hook-utils/BUILD.bazel
@@ -72,11 +72,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-hook-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-hook-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-hook-utils/src",
     "types": ["jest", "node"]
   },
   "include": ["src/**/*"]

--- a/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
@@ -73,11 +73,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-alerting-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-alerting-types/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-io-ts-list-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-list-types/BUILD.bazel
@@ -71,11 +71,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-list-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-list-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-list-types/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-io-ts-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-types/BUILD.bazel
@@ -71,11 +71,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-types/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-io-ts-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-utils/BUILD.bazel
@@ -75,11 +75,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-io-ts-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-api/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-api/BUILD.bazel
@@ -74,11 +74,9 @@ ts_project(
   deps = TYPES_DEPS,
   args = ["--pretty"],
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-api/tsconfig.json
+++ b/packages/kbn-securitysolution-list-api/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-api/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-constants/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-constants/BUILD.bazel
@@ -63,11 +63,9 @@ ts_project(
   deps = TYPES_DEPS,
   args = ["--pretty"],
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-constants/tsconfig.json
+++ b/packages/kbn-securitysolution-list-constants/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-constants/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-hooks/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-hooks/BUILD.bazel
@@ -80,11 +80,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-hooks/tsconfig.json
+++ b/packages/kbn-securitysolution-list-hooks/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-hooks/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-list-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-utils/BUILD.bazel
@@ -77,11 +77,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-list-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-list-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-list-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-rules/BUILD.bazel
+++ b/packages/kbn-securitysolution-rules/BUILD.bazel
@@ -63,11 +63,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-rules/tsconfig.json
+++ b/packages/kbn-securitysolution-rules/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-rules/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-t-grid/BUILD.bazel
+++ b/packages/kbn-securitysolution-t-grid/BUILD.bazel
@@ -72,11 +72,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-t-grid/tsconfig.json
+++ b/packages/kbn-securitysolution-t-grid/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-t-grid/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-utils/BUILD.bazel
@@ -61,11 +61,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-securitysolution-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-utils/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-securitysolution-utils/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-server-http-tools/BUILD.bazel
+++ b/packages/kbn-server-http-tools/BUILD.bazel
@@ -71,10 +71,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-server-http-tools/tsconfig.json
+++ b/packages/kbn-server-http-tools/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target/types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-server-http-tools/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-server-route-repository/BUILD.bazel
+++ b/packages/kbn-server-route-repository/BUILD.bazel
@@ -67,10 +67,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-server-route-repository/tsconfig.json
+++ b/packages/kbn-server-route-repository/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-server-route-repository/src",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-std/BUILD.bazel
+++ b/packages/kbn-std/BUILD.bazel
@@ -66,10 +66,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-std/tsconfig.json
+++ b/packages/kbn-std/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-std/src",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-storybook/BUILD.bazel
+++ b/packages/kbn-storybook/BUILD.bazel
@@ -89,11 +89,9 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-storybook/tsconfig.json
+++ b/packages/kbn-storybook/tsconfig.json
@@ -2,14 +2,11 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "incremental": false,
     "outDir": "target_types",
     "rootDir": "src",
     "skipLibCheck": true,
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-storybook",
     "target": "es2015",
     "types": ["node"]
   },

--- a/packages/kbn-telemetry-tools/BUILD.bazel
+++ b/packages/kbn-telemetry-tools/BUILD.bazel
@@ -70,10 +70,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-telemetry-tools/tsconfig.json
+++ b/packages/kbn-telemetry-tools/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-telemetry-tools/src",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-test/BUILD.bazel
+++ b/packages/kbn-test/BUILD.bazel
@@ -139,10 +139,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-test/tsconfig.json
+++ b/packages/kbn-test/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "stripInternal": true,
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../../packages/kbn-test/src",
     "types": ["jest", "node"]
   },
   "include": ["src/**/*", "index.d.ts"],

--- a/packages/kbn-typed-react-router-config/BUILD.bazel
+++ b/packages/kbn-typed-react-router-config/BUILD.bazel
@@ -75,10 +75,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-typed-react-router-config/tsconfig.json
+++ b/packages/kbn-typed-react-router-config/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "./target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../../packages/kbn-typed-react-router-config/src",
     "stripInternal": true,
     "types": [
       "node",

--- a/packages/kbn-ui-shared-deps-npm/BUILD.bazel
+++ b/packages/kbn-ui-shared-deps-npm/BUILD.bazel
@@ -124,11 +124,9 @@ ts_project(
   deps = TYPES_DEPS,
   allow_js = True,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-ui-shared-deps-npm/tsconfig.json
+++ b/packages/kbn-ui-shared-deps-npm/tsconfig.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ui-shared-deps-npm/src",
     "types": [
       "node",
       "resize-observer-polyfill"

--- a/packages/kbn-ui-shared-deps-src/BUILD.bazel
+++ b/packages/kbn-ui-shared-deps-src/BUILD.bazel
@@ -76,11 +76,9 @@ ts_project(
   deps = TYPES_DEPS,
   allow_js = True,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",
-  source_map = True,
   tsconfig = ":tsconfig",
 )
 

--- a/packages/kbn-ui-shared-deps-src/tsconfig.json
+++ b/packages/kbn-ui-shared-deps-src/tsconfig.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-ui-shared-deps-src/src",
     "types": [
       "node",
       "resize-observer-polyfill"

--- a/packages/kbn-utility-types/BUILD.bazel
+++ b/packages/kbn-utility-types/BUILD.bazel
@@ -55,10 +55,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-utility-types/tsconfig.json
+++ b/packages/kbn-utility-types/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-utility-types",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-utils/BUILD.bazel
+++ b/packages/kbn-utils/BUILD.bazel
@@ -59,10 +59,8 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
-  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
-  source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
 )

--- a/packages/kbn-utils/tsconfig.json
+++ b/packages/kbn-utils/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "sourceMap": true,
-    "sourceRoot": "../../../../packages/kbn-utils/src",
     "types": [
       "jest",
       "node"

--- a/src/dev/bazel/pkg_npm_types/pkg_npm_types.bzl
+++ b/src/dev/bazel/pkg_npm_types/pkg_npm_types.bzl
@@ -33,6 +33,9 @@ def _collect_inputs_deps_and_transitive_types_deps(ctx):
   deps_files = depset(transitive = deps_files_depsets).to_list()
   return [deps_files, transitive_types_deps]
 
+def _get_type_package_name(actualName):
+  return "@types/" + actualName.replace("@", "").replace("/", "__")
+
 def _calculate_entrypoint_path(ctx):
   return _join(ctx.bin_dir.path, ctx.label.package, _get_types_outdir_name(ctx), ctx.attr.entrypoint_name)
 
@@ -78,7 +81,7 @@ def _pkg_npm_types_impl(ctx):
 
   # gathering template args
   template_args = [
-    "NAME", ctx.attr.package_name
+    "NAME", _get_type_package_name(ctx.attr.package_name)
   ]
 
   # layout api extractor arguments
@@ -119,7 +122,7 @@ def _pkg_npm_types_impl(ctx):
       deps = transitive_types_deps,
     ),
     LinkablePackageInfo(
-      package_name = ctx.attr.package_name,
+      package_name = _get_type_package_name(ctx.attr.package_name),
       package_path = "",
       path = package_dir.path,
       files = package_dir_depset,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[bazel] avoid a little boilerplate in packages (#126309)](https://github.com/elastic/kibana/pull/126309)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)