### PR TITLE
[Stack Monitoring] api_integration - Ignore `logs` section of index detail api

### DIFF
--- a/x-pack/test/api_integration/apis/monitoring/elasticsearch/index_detail.js
+++ b/x-pack/test/api_integration/apis/monitoring/elasticsearch/index_detail.js
@@ -41,6 +41,9 @@ export default function ({ getService }) {
         })
         .expect(200);
 
+      // Work around ESTF failure outlined in https://github.com/elastic/kibana/issues/124594
+      indexDetailFixture.logs = body.logs;
+
       expect(body).to.eql(indexDetailFixture);
     });
 


### PR DESCRIPTION
## Summary

The full assertion works fine in typical FTR testing, but fails in ESTF where `reason: { correctIndexName: true }`.

It's unclear what difference in the ES setup is causing the API to respond differently, but this should get the test passing.

Rel: https://github.com/elastic/kibana/issues/124594

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
