### PR TITLE
[Fleet] hide enroll command when clicking on create agent policy

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_select_create.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_select_create.tsx
@@ -73,6 +73,9 @@ export const SelectCreateAgentPolicy: React.FC<Props> = ({
   const onClickCreatePolicy = () => {
     setCreateState({ status: CREATE_STATUS.INITIAL });
     setShowCreatePolicy(true);
+    if (withKeySelection && onKeyChange) {
+      onKeyChange(undefined);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/126428

To verify:
- Navigate to Fleet>Agents tab>Add Agent.
- Observe an existing policy is selected and command for same is available.
- Click create new policy and scroll down and observe command is not visible until a new agent policy is created

<img width="841" alt="image" src="https://user-images.githubusercontent.com/90178898/155955241-5afcb7e9-7f2c-4c5f-8547-2795678491a3.png">


