### PR TITLE
[Cases] Add telemetry for deprecated API

### DIFF
--- a/x-pack/plugins/cases/server/routes/api/comments/get_all_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/get_all_comment.ts
@@ -7,7 +7,6 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { getWarningHeader, logDeprecatedEndpoint } from '../utils';
 import { CASE_COMMENTS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
@@ -23,20 +22,12 @@ export const getAllCommentsRoute = createCasesRoute({
       case_id: schema.string(),
     }),
   },
+  options: { deprecated: true },
   handler: async ({ context, request, response, logger, kibanaVersion }) => {
     try {
-      logDeprecatedEndpoint(
-        logger,
-        request.headers,
-        `The get all cases comments API '${CASE_COMMENTS_URL}' is deprecated.`
-      );
-
       const client = await context.cases.getCasesClient();
 
       return response.ok({
-        headers: {
-          ...getWarningHeader(kibanaVersion),
-        },
         body: await client.attachments.getAll({
           caseID: request.params.case_id,
         }),

--- a/x-pack/plugins/cases/server/routes/api/register_routes.ts
+++ b/x-pack/plugins/cases/server/routes/api/register_routes.ts
@@ -6,10 +6,18 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { RouteRegistrar } from 'kibana/server';
+import { Headers, RouteRegistrar } from 'kibana/server';
 import { CasesRequestHandlerContext } from '../../types';
 import { CaseRoute, RegisterRoutesDeps } from './types';
-import { escapeHatch, getIsKibanaRequest, wrapError } from './utils';
+import {
+  escapeHatch,
+  getIsKibanaRequest,
+  getWarningHeader,
+  logDeprecatedEndpoint,
+  wrapError,
+} from './utils';
+
+const getEndpoint = (method: string, path: string): string => `${method.toUpperCase()} ${path}`;
 
 const increaseTelemetryCounters = ({
   telemetryUsageCounter,
@@ -24,7 +32,7 @@ const increaseTelemetryCounters = ({
   isKibanaRequest: boolean;
   isError?: boolean;
 }) => {
-  const counterName = `${method.toUpperCase()} ${path}`;
+  const counterName = getEndpoint(method, path);
 
   telemetryUsageCounter.incrementCounter({
     counterName,
@@ -37,11 +45,36 @@ const increaseTelemetryCounters = ({
   });
 };
 
+const logAndIncreaseDeprecationTelemetryCounters = ({
+  logger,
+  headers,
+  method,
+  path,
+  telemetryUsageCounter,
+}: {
+  logger: RegisterRoutesDeps['logger'];
+  headers: Headers;
+  method: string;
+  path: string;
+  telemetryUsageCounter?: Exclude<RegisterRoutesDeps['telemetryUsageCounter'], undefined>;
+}) => {
+  const endpoint = getEndpoint(method, path);
+
+  logDeprecatedEndpoint(logger, headers, `The endpoint ${endpoint} is deprecated.`);
+
+  if (telemetryUsageCounter) {
+    telemetryUsageCounter.incrementCounter({
+      counterName: endpoint,
+      counterType: 'deprecated',
+    });
+  }
+};
+
 export const registerRoutes = (deps: RegisterRoutesDeps) => {
   const { router, routes, logger, kibanaVersion, telemetryUsageCounter } = deps;
 
   routes.forEach((route) => {
-    const { method, path, params, handler } = route as CaseRoute;
+    const { method, path, params, options, handler } = route;
 
     (router[method] as RouteRegistrar<typeof method, CasesRequestHandlerContext>)(
       {
@@ -53,6 +86,7 @@ export const registerRoutes = (deps: RegisterRoutesDeps) => {
         },
       },
       async (context, request, response) => {
+        let responseHeaders = {};
         const isKibanaRequest = getIsKibanaRequest(request.headers);
 
         if (!context.cases) {
@@ -60,11 +94,30 @@ export const registerRoutes = (deps: RegisterRoutesDeps) => {
         }
 
         try {
+          if (options?.deprecated) {
+            logAndIncreaseDeprecationTelemetryCounters({
+              telemetryUsageCounter,
+              logger,
+              path,
+              method,
+              headers: request.headers,
+            });
+
+            responseHeaders = {
+              ...responseHeaders,
+              ...getWarningHeader(kibanaVersion),
+            };
+          }
+
           const res = await handler({ logger, context, request, response, kibanaVersion });
 
           if (telemetryUsageCounter) {
             increaseTelemetryCounters({ telemetryUsageCounter, method, path, isKibanaRequest });
           }
+
+          res.options.headers = {
+            ...responseHeaders,
+          };
 
           return res;
         } catch (error) {

--- a/x-pack/plugins/cases/server/routes/api/register_routes.ts
+++ b/x-pack/plugins/cases/server/routes/api/register_routes.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import { Headers, RouteRegistrar } from 'kibana/server';
 import { CasesRequestHandlerContext } from '../../types';
-import { CaseRoute, RegisterRoutesDeps } from './types';
+import { RegisterRoutesDeps } from './types';
 import {
   escapeHatch,
   getIsKibanaRequest,

--- a/x-pack/plugins/cases/server/routes/api/register_routes.ts
+++ b/x-pack/plugins/cases/server/routes/api/register_routes.ts
@@ -116,6 +116,7 @@ export const registerRoutes = (deps: RegisterRoutesDeps) => {
           }
 
           res.options.headers = {
+            ...res.options.headers,
             ...responseHeaders,
           };
 

--- a/x-pack/plugins/cases/server/routes/api/stats/get_status.ts
+++ b/x-pack/plugins/cases/server/routes/api/stats/get_status.ts
@@ -6,7 +6,6 @@
  */
 
 import { CaseRoute } from '../types';
-import { getWarningHeader, logDeprecatedEndpoint } from '../utils';
 
 import { CasesStatusRequest } from '../../../../common/api';
 import { CASE_STATUS_URL } from '../../../../common/constants';
@@ -19,19 +18,11 @@ import { createCasesRoute } from '../create_cases_route';
 export const getStatusRoute: CaseRoute = createCasesRoute({
   method: 'get',
   path: CASE_STATUS_URL,
+  options: { deprecated: true },
   handler: async ({ context, request, response, logger, kibanaVersion }) => {
     try {
-      logDeprecatedEndpoint(
-        logger,
-        request.headers,
-        `The get cases status API '${CASE_STATUS_URL}' is deprecated.`
-      );
-
       const client = await context.cases.getCasesClient();
       return response.ok({
-        headers: {
-          ...getWarningHeader(kibanaVersion),
-        },
         body: await client.metrics.getStatusTotalsByType(request.query as CasesStatusRequest),
       });
     } catch (error) {

--- a/x-pack/plugins/cases/server/routes/api/types.ts
+++ b/x-pack/plugins/cases/server/routes/api/types.ts
@@ -44,5 +44,6 @@ export interface CaseRoute<P = unknown, Q = unknown, B = unknown> {
   method: 'get' | 'post' | 'put' | 'delete' | 'patch';
   path: string;
   params?: RouteValidatorConfig<P, Q, B>;
+  options?: { deprecated?: boolean };
   handler: (args: CaseRouteHandlerArguments<P, Q, B>) => Promise<IKibanaResponse>;
 }

--- a/x-pack/plugins/cases/server/routes/api/user_actions/get_all_user_actions.ts
+++ b/x-pack/plugins/cases/server/routes/api/user_actions/get_all_user_actions.ts
@@ -7,7 +7,6 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { getWarningHeader, logDeprecatedEndpoint } from '../utils';
 import { CASE_USER_ACTIONS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
@@ -23,21 +22,13 @@ export const getUserActionsRoute = createCasesRoute({
       case_id: schema.string(),
     }),
   },
+  options: { deprecated: true },
   handler: async ({ context, request, response, logger, kibanaVersion }) => {
     try {
-      logDeprecatedEndpoint(
-        logger,
-        request.headers,
-        `The get all cases user actions API '${CASE_USER_ACTIONS_URL}' is deprecated.`
-      );
-
       const casesClient = await context.cases.getCasesClient();
       const caseId = request.params.case_id;
 
       return response.ok({
-        headers: {
-          ...getWarningHeader(kibanaVersion),
-        },
         body: await casesClient.userActions.getAll({ caseId }),
       });
     } catch (error) {

--- a/x-pack/plugins/cases/server/routes/api/utils.test.ts
+++ b/x-pack/plugins/cases/server/routes/api/utils.test.ts
@@ -8,7 +8,7 @@
 import { isBoom, boomify } from '@hapi/boom';
 import { loggingSystemMock } from '../../../../../../src/core/server/mocks';
 import { HTTPError } from '../../common/error';
-import { logDeprecatedEndpoint, wrapError } from './utils';
+import { extractWarningValueFromWarningHeader, logDeprecatedEndpoint, wrapError } from './utils';
 
 describe('Utils', () => {
   describe('wrapError', () => {
@@ -73,6 +73,14 @@ describe('Utils', () => {
     it('does log when the request is NOT from the kibana client', () => {
       logDeprecatedEndpoint(logger, {}, 'test');
       expect(logger.warn).toHaveBeenCalledWith('test');
+    });
+  });
+
+  describe('extractWarningValueFromWarningHeader', () => {
+    it('extracts the warning value from a warning header correctly', () => {
+      expect(extractWarningValueFromWarningHeader(`299 Kibana-8.1.0 "Deprecation endpoint"`)).toBe(
+        'Deprecation endpoint'
+      );
     });
   });
 });

--- a/x-pack/plugins/cases/server/routes/api/utils.ts
+++ b/x-pack/plugins/cases/server/routes/api/utils.ts
@@ -63,3 +63,15 @@ export const logDeprecatedEndpoint = (logger: Logger, headers: Headers, msg: str
     logger.warn(msg);
   }
 };
+
+/**
+ * Extracts the warning value a warning header that is formatted according to RFC 7234.
+ * For example for the string 299 Kibana-8.1.0 "Deprecation endpoint", the return value is Deprecation endpoint.
+ *
+ */
+export const extractWarningValueFromWarningHeader = (warningHeader: string) => {
+  const firstQuote = warningHeader.indexOf('"');
+  const lastQuote = warningHeader.length - 1;
+  const warningValue = warningHeader.substring(firstQuote + 1, lastQuote);
+  return warningValue;
+};


### PR DESCRIPTION
## Summary

This PR is a continuation of https://github.com/elastic/kibana/pull/125928. It adds telemetry to the deprecated endpoints.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
