### PR TITLE
[Fleet] Add component to show agents enrolment

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1094,6 +1094,22 @@
             "name": "policyId",
             "in": "query",
             "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "name": "kuery",
+            "in": "query",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "name": "enrolledAt",
+            "in": "query",
+            "required": false
           }
         ]
       }

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1102,14 +1102,6 @@
             "name": "kuery",
             "in": "query",
             "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "name": "enrolledAt",
-            "in": "query",
-            "required": false
           }
         ]
       }

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -677,11 +677,6 @@ paths:
           name: kuery
           in: query
           required: false
-        - schema:
-            type: string
-          name: enrolledAt
-          in: query
-          required: false
   /agents:
     get:
       summary: Agents - List

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -672,6 +672,16 @@ paths:
           name: policyId
           in: query
           required: false
+        - schema:
+            type: string
+          name: kuery
+          in: query
+          required: false
+        - schema:
+            type: string
+          name: enrolledAt
+          in: query
+          required: false
   /agents:
     get:
       summary: Agents - List

--- a/x-pack/plugins/fleet/common/openapi/paths/agent_status.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agent_status.yaml
@@ -46,8 +46,3 @@ get:
       name: kuery
       in: query
       required: false
-    - schema:
-        type: string
-      name: enrolledAt
-      in: query
-      required: false

--- a/x-pack/plugins/fleet/common/openapi/paths/agent_status.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agent_status.yaml
@@ -41,3 +41,13 @@ get:
       name: policyId
       in: query
       required: false
+    - schema:
+        type: string
+      name: kuery
+      in: query
+      required: false
+    - schema:
+        type: string
+      name: enrolledAt
+      in: query
+      required: false

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -146,6 +146,7 @@ export interface UpdateAgentRequest {
 export interface GetAgentStatusRequest {
   query: {
     kuery?: string;
+    enrolledAt?: string;
     policyId?: string;
   };
 }

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -146,8 +146,8 @@ export interface UpdateAgentRequest {
 export interface GetAgentStatusRequest {
   query: {
     kuery?: string;
-    enrolledAt?: string;
     policyId?: string;
+    enrolledAt?: string;
   };
 }
 

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -147,7 +147,6 @@ export interface GetAgentStatusRequest {
   query: {
     kuery?: string;
     policyId?: string;
-    enrolledAt?: string;
   };
 }
 

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/confirm_agent_enrollment.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/confirm_agent_enrollment.tsx
@@ -10,24 +10,29 @@ import { EuiCallOut, EuiButton } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { useGetAgentStatus } from '../../hooks';
-
+import { AGENTS_PREFIX } from '../../constants';
 interface Props {
   policyId: string;
-  onButtonClick: () => void;
+  onClickViewAgents: () => void;
 }
 
 export const ConfirmAgentEnrollment: React.FunctionComponent<Props> = ({
   policyId,
-  onButtonClick,
+  onClickViewAgents,
 }) => {
   // Check the agents enrolled in the last 10 minutes
   const enrolledAt = 'now-10m';
-
-  const agentStatusRequest = useGetAgentStatus({ policyId, enrolledAt });
+  const kuery = `${AGENTS_PREFIX}.enrolled_at >= "${enrolledAt}"`;
+  const agentStatusRequest = useGetAgentStatus({ kuery, policyId });
   const agentsCount = agentStatusRequest.data?.results?.total;
-  return agentsCount ? (
+
+  if (!agentsCount) {
+    return null;
+  }
+
+  return (
     <EuiCallOut
-      data-test-subj="ConfirmAgentEnrollment"
+      data-test-subj="ConfirmAgentEnrollmentCallOut"
       title={i18n.translate('xpack.fleet.agentEnrollment.confirmation.title', {
         defaultMessage:
           '{agentsCount} {agentsCount, plural, one {agent has} other {agents have}} been enrolled.',
@@ -38,11 +43,15 @@ export const ConfirmAgentEnrollment: React.FunctionComponent<Props> = ({
       color="success"
       iconType="check"
     >
-      <EuiButton onClick={onButtonClick} color="success">
+      <EuiButton
+        onClick={onClickViewAgents}
+        color="success"
+        data-test-subj="ConfirmAgentEnrollmentButton"
+      >
         {i18n.translate('xpack.fleet.agentEnrollment.confirmation.button', {
           defaultMessage: 'View enrolled agents',
         })}
       </EuiButton>
     </EuiCallOut>
-  ) : null;
+  );
 };

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/confirm_agent_enrollment.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/confirm_agent_enrollment.tsx
@@ -25,7 +25,7 @@ export const ConfirmAgentEnrollment: React.FunctionComponent<Props> = ({
 
   const agentStatusRequest = useGetAgentStatus({ policyId, enrolledAt });
   const agentsCount = agentStatusRequest.data?.results?.total;
-  return (
+  return agentsCount ? (
     <EuiCallOut
       data-test-subj="ConfirmAgentEnrollment"
       title={i18n.translate('xpack.fleet.agentEnrollment.confirmation.title', {
@@ -44,5 +44,5 @@ export const ConfirmAgentEnrollment: React.FunctionComponent<Props> = ({
         })}
       </EuiButton>
     </EuiCallOut>
-  );
+  ) : null;
 };

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/confirm_agent_enrollment.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/confirm_agent_enrollment.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiCallOut, EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { useGetAgentStatus } from '../../hooks';
+
+interface Props {
+  policyId: string;
+  onButtonClick: () => void;
+}
+
+export const ConfirmAgentEnrollment: React.FunctionComponent<Props> = ({
+  policyId,
+  onButtonClick,
+}) => {
+  // Check the agents enrolled in the last 10 minutes
+  const enrolledAt = 'now-10m';
+
+  const agentStatusRequest = useGetAgentStatus({ policyId, enrolledAt });
+  const agentsCount = agentStatusRequest.data?.results?.total;
+  return (
+    <EuiCallOut
+      data-test-subj="ConfirmAgentEnrollment"
+      title={i18n.translate('xpack.fleet.agentEnrollment.confirmation.title', {
+        defaultMessage:
+          '{agentsCount} {agentsCount, plural, one {agent has} other {agents have}} been enrolled.',
+        values: {
+          agentsCount,
+        },
+      })}
+      color="success"
+      iconType="check"
+    >
+      <EuiButton onClick={onButtonClick} color="success">
+        {i18n.translate('xpack.fleet.agentEnrollment.confirmation.button', {
+          defaultMessage: 'View enrolled agents',
+        })}
+      </EuiButton>
+    </EuiCallOut>
+  );
+};

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -36,7 +36,6 @@ import { Loading } from '..';
 import { ManagedInstructions } from './managed_instructions';
 import { StandaloneInstructions } from './standalone_instructions';
 import { MissingFleetServerHostCallout } from './missing_fleet_server_host_callout';
-import { ConfirmAgentEnrollment } from './confirm_agent_enrollment';
 import type { BaseProps } from './types';
 
 type FlyoutMode = 'managed' | 'standalone';

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -36,6 +36,7 @@ import { Loading } from '..';
 import { ManagedInstructions } from './managed_instructions';
 import { StandaloneInstructions } from './standalone_instructions';
 import { MissingFleetServerHostCallout } from './missing_fleet_server_host_callout';
+import { ConfirmAgentEnrollment } from './confirm_agent_enrollment';
 import type { BaseProps } from './types';
 
 type FlyoutMode = 'managed' | 'standalone';
@@ -98,6 +99,8 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
   return (
     <EuiFlyout data-test-subj="agentEnrollmentFlyout" onClose={onClose} size="m">
       <EuiFlyoutHeader hasBorder aria-labelledby="FleetAgentEnrollmentFlyoutTitle">
+        {/* TODO: component here for testing */}
+        <ConfirmAgentEnrollment policyId={policyId} onButtonClick={onClose} />
         <EuiTitle size="m">
           <h2 id="FleetAgentEnrollmentFlyoutTitle">
             <FormattedMessage

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -99,8 +99,6 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
   return (
     <EuiFlyout data-test-subj="agentEnrollmentFlyout" onClose={onClose} size="m">
       <EuiFlyoutHeader hasBorder aria-labelledby="FleetAgentEnrollmentFlyoutTitle">
-        {/* TODO: component here for testing */}
-        <ConfirmAgentEnrollment policyId={policyId} onButtonClick={onClose} />
         <EuiTitle size="m">
           <h2 id="FleetAgentEnrollmentFlyoutTitle">
             <FormattedMessage

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -205,12 +205,10 @@ export const getAgentStatusForAgentPolicyHandler: RequestHandler<
 > = async (context, request, response) => {
   const esClient = context.core.elasticsearch.client.asInternalUser;
   try {
-    // TODO change path
     const results = await AgentService.getAgentStatusForAgentPolicy(
       esClient,
       request.query.policyId,
-      request.query.kuery,
-      request.query.enrolledAt
+      request.query.kuery
     );
 
     const body: GetAgentStatusResponse = { results };

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -204,12 +204,12 @@ export const getAgentStatusForAgentPolicyHandler: RequestHandler<
   TypeOf<typeof GetAgentStatusRequestSchema.query>
 > = async (context, request, response) => {
   const esClient = context.core.elasticsearch.client.asInternalUser;
-
   try {
     // TODO change path
     const results = await AgentService.getAgentStatusForAgentPolicy(
       esClient,
       request.query.policyId,
+      request.query.enrolledAt,
       request.query.kuery
     );
 

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -209,8 +209,8 @@ export const getAgentStatusForAgentPolicyHandler: RequestHandler<
     const results = await AgentService.getAgentStatusForAgentPolicy(
       esClient,
       request.query.policyId,
-      request.query.enrolledAt,
-      request.query.kuery
+      request.query.kuery,
+      request.query.enrolledAt
     );
 
     const body: GetAgentStatusResponse = { results };

--- a/x-pack/plugins/fleet/server/services/agents/status.ts
+++ b/x-pack/plugins/fleet/server/services/agents/status.ts
@@ -50,6 +50,7 @@ function joinKuerys(...kuerys: Array<string | undefined>) {
 export async function getAgentStatusForAgentPolicy(
   esClient: ElasticsearchClient,
   agentPolicyId?: string,
+  enrolledAt?: string,
   filterKuery?: string
 ) {
   const [all, allActive, online, error, offline, updating] = await pMap(
@@ -72,6 +73,7 @@ export async function getAgentStatusForAgentPolicy(
             filterKuery,
             `${AGENTS_PREFIX}.attributes.active:true`,
             agentPolicyId ? `${AGENTS_PREFIX}.policy_id:"${agentPolicyId}"` : undefined,
+            enrolledAt ? `${AGENTS_PREFIX}.enrolled_at >= "${enrolledAt}"` : undefined,
           ]
         ),
       }),

--- a/x-pack/plugins/fleet/server/services/agents/status.ts
+++ b/x-pack/plugins/fleet/server/services/agents/status.ts
@@ -50,8 +50,7 @@ function joinKuerys(...kuerys: Array<string | undefined>) {
 export async function getAgentStatusForAgentPolicy(
   esClient: ElasticsearchClient,
   agentPolicyId?: string,
-  filterKuery?: string,
-  enrolledAt?: string
+  filterKuery?: string
 ) {
   const [all, allActive, online, error, offline, updating] = await pMap(
     [
@@ -73,7 +72,6 @@ export async function getAgentStatusForAgentPolicy(
             filterKuery,
             `${AGENTS_PREFIX}.attributes.active:true`,
             agentPolicyId ? `${AGENTS_PREFIX}.policy_id:"${agentPolicyId}"` : undefined,
-            enrolledAt ? `${AGENTS_PREFIX}.enrolled_at >= "${enrolledAt}"` : undefined,
           ]
         ),
       }),

--- a/x-pack/plugins/fleet/server/services/agents/status.ts
+++ b/x-pack/plugins/fleet/server/services/agents/status.ts
@@ -50,8 +50,8 @@ function joinKuerys(...kuerys: Array<string | undefined>) {
 export async function getAgentStatusForAgentPolicy(
   esClient: ElasticsearchClient,
   agentPolicyId?: string,
-  enrolledAt?: string,
-  filterKuery?: string
+  filterKuery?: string,
+  enrolledAt?: string
 ) {
   const [all, allActive, online, error, offline, updating] = await pMap(
     [

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -108,6 +108,7 @@ export const UpdateAgentRequestSchema = {
 export const GetAgentStatusRequestSchema = {
   query: schema.object({
     policyId: schema.maybe(schema.string()),
+    enrolledAt: schema.maybe(schema.string()),
     kuery: schema.maybe(schema.string()),
   }),
 };

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -109,6 +109,5 @@ export const GetAgentStatusRequestSchema = {
   query: schema.object({
     policyId: schema.maybe(schema.string()),
     kuery: schema.maybe(schema.string()),
-    enrolledAt: schema.maybe(schema.string()),
   }),
 };

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -108,7 +108,7 @@ export const UpdateAgentRequestSchema = {
 export const GetAgentStatusRequestSchema = {
   query: schema.object({
     policyId: schema.maybe(schema.string()),
-    enrolledAt: schema.maybe(schema.string()),
     kuery: schema.maybe(schema.string()),
+    enrolledAt: schema.maybe(schema.string()),
   }),
 };


### PR DESCRIPTION
## Summary
Part of https://github.com/elastic/kibana/issues/125534

Creating "Confirm agent enrolment" component. It will be used as a step in the redesigned agent flyout.

- Uses the existing `agent_status` endpoint with an optional `kuery` that gets how many agents were enrolled in the last 10 minutes (using `now-10m`)
- Creates a small component that queries the endpoint with this new parameter. The callout has also a button that triggers the `onClose` function from the flyout to show the active agents.

![Screenshot 2022-02-28 at 12 29 27](https://user-images.githubusercontent.com/16084106/155976141-29ee885e-8737-46e6-a167-f8d6ddd63271.png)

- Updates the openApi document with `kuery` parameter as it was missing

#### Testing steps

For now the component isn't being shown anywhere since the whole flyout needs to be updated. To test it, I added the following code [here](https://github.com/elastic/kibana/blob/9ddb3e8756e9294c857e58b3ab0deedfb9375cbe/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx#L102)
` <ConfirmAgentEnrollment policyId={policyId} onClickViewAgents ={onClose} />`


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
