### PR TITLE
[8.1] Improve error message for duplicate package policies (#126170)

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -115,7 +115,7 @@ class PackagePolicyService {
       // Check that the name does not exist already
       if (existingPoliciesWithName.items.length > 0) {
         throw new IngestManagerError(
-          `There is already an integration policy with the same name: ${packagePolicy.name}`
+          `An integration policy with the name ${packagePolicy.name} already exists. Please rename it or choose a different name.`
         );
       }
     }
@@ -384,7 +384,9 @@ class PackagePolicyService {
     const filtered = (existingPoliciesWithName?.items || []).filter((p) => p.id !== id);
 
     if (filtered.length > 0) {
-      throw new IngestManagerError('There is already an integration policy with the same name');
+      throw new IngestManagerError(
+        `An integration policy with the name ${packagePolicy.name} already exists. Please rename it or choose a different name.`
+      );
     }
 
     let inputs = restOfPackagePolicy.inputs.map((input) =>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [Improve error message for duplicate package policies (#126170)](https://github.com/elastic/kibana/pull/126170)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)