### PR TITLE
fix get_alerts_index failing tests

### DIFF
--- a/x-pack/test/rule_registry/common/lib/authentication/roles.ts
+++ b/x-pack/test/rule_registry/common/lib/authentication/roles.ts
@@ -69,7 +69,18 @@ export const securitySolutionOnlyRead: Role = {
   name: 'sec_only_read_spaces_space1',
   privileges: {
     elasticsearch: {
-      indices: [],
+      indices: [
+        {
+          names: [
+            '.alerts-security.alerts-space1',
+            '.internal.alerts-security.alerts-space1',
+            '.lists-space1',
+            '.items-space1',
+            '.siem-signals-space1',
+          ],
+          privileges: ['write', 'read', 'view_index_metadata', 'maintenance'],
+        },
+      ],
     },
     kibana: [
       {

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alerts_index.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alerts_index.ts
@@ -15,12 +15,13 @@ import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext) => {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
   const TEST_URL = '/internal/rac/alerts';
   const ALERTS_INDEX_URL = `${TEST_URL}/index`;
   const SPACE1 = 'space1';
-  const APM_ALERT_INDEX = '.alerts-observability-apm';
+  const APM_ALERT_INDEX = '.alerts-observability.apm.alerts';
   const SECURITY_SOLUTION_ALERT_INDEX = '.alerts-security.alerts';
 
   const getAPMIndexName = async (user: User, space: string, expected: number = 200) => {
@@ -38,12 +39,11 @@ export default ({ getService }: FtrProviderContext) => {
     space: string,
     expectedStatusCode: number = 200
   ) => {
-    const { body: indexNames }: { body: { index_name: string[] | undefined } } =
-      await supertestWithoutAuth
-        .get(`${getSpaceUrlPrefix(space)}${ALERTS_INDEX_URL}?features=siem`)
-        .auth(user.username, user.password)
-        .set('kbn-xsrf', 'true')
-        .expect(expectedStatusCode);
+    const { body: indexNames }: { body: { index_name: string[] | undefined } } = await supertest
+      .get(`${getSpaceUrlPrefix(space)}${ALERTS_INDEX_URL}?features=siem`)
+      .auth(user.username, user.password)
+      .set('kbn-xsrf', 'true')
+      .expect(expectedStatusCode);
     return indexNames;
   };
 

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/index.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/index.ts
@@ -28,7 +28,7 @@ export default ({ loadTestFile, getService }: FtrProviderContext): void => {
     // loadTestFile(require.resolve('./update_alert'));
     // loadTestFile(require.resolve('./bulk_update_alerts'));
     // loadTestFile(require.resolve('./find_alerts'));
-    // loadTestFile(require.resolve('./get_alerts_index'));
     loadTestFile(require.resolve('./search_strategy'));
+    loadTestFile(require.resolve('./get_alerts_index'));
   });
 };


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/124370

In Observability Overview page we would like to make use of existing `AlertsClient` in order to be able to retrieve number of active and recovered alerts. With a discussion I had with @XavierM, he informed me that these [rule_registry tests](https://github.com/elastic/kibana/blob/main/x-pack/test/rule_registry/security_and_spaces/tests/basic/index.ts) have been disabled due to not working properly.

This PR tries to fix `./get_alerts_index` test suite. There were 2 issues with these tests:
- the apm index name was wrong and it is fixed as part of this PR
- the test for a user with read only permissions to security feature for space1 was failing when using `supertestWithoutAuth`. When I switched to `supertest`, test was green.

I am not sure if changing supertestWithoutAuth to supertest is the proper solution, that's why I would like security's input on how to proceed with these tests. I did a little bit of debugging and I noticed that privileges returned from [checkPrivileges](https://github.com/elastic/kibana/blob/main/x-pack/plugins/alerting/server/authorization/alerting_authorization.ts#L371) in the `augmentRuleTypesWithAuthorization` function are all authorized: false. 

I tracked down the problem to [indexPrivileges being empty](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security/server/authorization/check_privileges.ts#L97), although I have specified in my tests following elastic search indices (I could be in a wrong direction though):

```
 elasticsearch: {
      indices: [
        {
          names: [
            '.alerts-security.alerts-space1',
            '.internal.alerts-security.alerts-space1',
            '.lists-space1',
            '.items-space1',
            '.siem-signals-space1',
          ],
          privileges: ['write', 'read', 'view_index_metadata', 'maintenance'],
        },
      ],
    },
```

For proper indices names and privileges I followed what I found in the official documentation for `Kibana space Read privileges for the Security feature` https://www.elastic.co/guide/en/security/master/detections-permissions-section.html.

In order to verify that it is not a problem in the setup of the test itself (for example by not specifying correct privileges and index names) but a problem in the AlertsClient code I made a quick experiment. I manually created a new role with read only access to security feature for space1 specifying the index names and privileges I mentioned above and I made following request to the alerts api in the [events_viewer](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx) of the security solution:

```
async function getIndex() {
  try {
    const res = await KibanaServices.get().http.fetch(`${BASE_RAC_ALERTS_API_PATH}/index`, {
      method: 'GET',
    });
    console.log(res, '!!index result')
  } catch (e) {
    console.log(e, '!!error');
  }
}
```

But I got back an empty index_name array `index_name: []`, similar to what the test was returning when using supertestWithoutAuth. So my conclusion is that there's an issue with the privileges returned from [checkPrivileges](https://github.com/elastic/kibana/blob/main/x-pack/plugins/alerting/server/authorization/alerting_authorization.ts#L371), where elasticsearch indices are empty. I would assume that user specified indices and privileges under Stack Management role would be stored in a saved object and be part of the Kibana request, which doesn't seem to be the case? I might be in a wrong direction though, so any input would be much appreciated.

cc @estermv 