### PR TITLE
[Fleet] fix showing fleet server policies in enroll selection

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
@@ -120,7 +120,6 @@ export const ManagedInstructions = React.memo<InstructionProps>(
               selectedApiKeyId,
               setSelectedAPIKeyId,
               setSelectedPolicyId,
-              excludeFleetServer: true,
               refreshAgentPolicies,
             })
           : AgentEnrollmentKeySelectionStep({ agentPolicy, selectedApiKeyId, setSelectedAPIKeyId }),

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
@@ -16,8 +16,6 @@ import semverPatch from 'semver/functions/patch';
 import type { AgentPolicy } from '../../types';
 import { useKibanaVersion } from '../../hooks';
 
-import { policyHasFleetServer } from '../../applications/fleet/sections/agents/services/has_fleet_server';
-
 import { AdvancedAgentAuthenticationSettings } from './advanced_agent_authentication_settings';
 import { SelectCreateAgentPolicy } from './agent_policy_select_create';
 
@@ -95,7 +93,7 @@ export const AgentPolicySelectionStep = ({
   const regularAgentPolicies = useMemo(() => {
     return agentPolicies.filter(
       (policy) =>
-        policy && !policy.is_managed && (!excludeFleetServer || !policyHasFleetServer(policy))
+        policy && !policy.is_managed && (!excludeFleetServer || !policy.is_default_fleet_server)
     );
   }, [agentPolicies, excludeFleetServer]);
 


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/kibana/issues/126449

showing fleet server policies in Enroll Agent policy selection

to verify:
- Navigate to Fleet>Agents tab>Add Agent.
- Agent policy with Fleet Server integration should be available under Add Agent flyout.

<img width="538" alt="image" src="https://user-images.githubusercontent.com/90178898/155990239-48b1a7ff-cf8d-4751-bec0-cd3c50393509.png">


