### PR TITLE
[8.1] [DOCS] Fix copy for `Allow string indices in TSVB` setting (#126374)

### DIFF
--- a/src/plugins/vis_types/timeseries/server/ui_settings.ts
+++ b/src/plugins/vis_types/timeseries/server/ui_settings.ts
@@ -32,7 +32,7 @@ export const getUiSettings: () => Record<string, UiSettingsParams> = () => ({
     requiresPageReload: true,
     description: i18n.translate('visTypeTimeseries.advancedSettings.allowStringIndicesText', {
       defaultMessage:
-        'Enables you to use index patterns and Elasticsearch indices in <strong>TSVB</strong> visualizations.',
+        'Enables you to query Elasticsearch indices in <strong>TSVB</strong> visualizations.',
     }),
     schema: schema.boolean(),
   },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[DOCS] Fix copy for `Allow string indices in TSVB` setting (#126374)](https://github.com/elastic/kibana/pull/126374)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)