### PR TITLE
[Upgrade Assistant] Update status API response

### DIFF
--- a/x-pack/plugins/upgrade_assistant/server/routes/status.test.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/status.test.ts
@@ -121,8 +121,7 @@ describe('Status API', () => {
       expect(resp.payload).toEqual({
         readyForUpgrade: false,
         details:
-          'You have 0 system indices that must be migrated and ' +
-          '1 Elasticsearch deprecation issue and 1 Kibana deprecation issue that must be resolved before upgrading.',
+          'The following issues must be resolved before upgrading: 1 Elasticsearch deprecation issue, 1 Kibana deprecation issue.',
       });
     });
 
@@ -144,8 +143,7 @@ describe('Status API', () => {
       expect(resp.payload).toEqual({
         readyForUpgrade: false,
         details:
-          'You have 1 system index that must be migrated and ' +
-          '1 Elasticsearch deprecation issue and 1 Kibana deprecation issue that must be resolved before upgrading.',
+          'The following issues must be resolved before upgrading: 1 unmigrated system index, 1 Elasticsearch deprecation issue, 1 Kibana deprecation issue.',
       });
     });
 
@@ -167,8 +165,7 @@ describe('Status API', () => {
       expect(resp.payload).toEqual({
         readyForUpgrade: false,
         details:
-          'You have 1 system index that must be migrated and ' +
-          '0 Elasticsearch deprecation issues and 0 Kibana deprecation issues that must be resolved before upgrading.',
+          'The following issues must be resolved before upgrading: 1 unmigrated system index.',
       });
     });
 

--- a/x-pack/plugins/upgrade_assistant/server/routes/status.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/status.ts
@@ -87,7 +87,7 @@ export function registerUpgradeStatusRoute({ router, lib: { handleEsError } }: R
 
             if (kibanaTotalCriticalDeps) {
               upgradeIssues.push(
-                i18n.translate('xpack.upgradeAssistant.status.esTotalCriticalDepsMessage', {
+                i18n.translate('xpack.upgradeAssistant.status.kibanaTotalCriticalDepsMessage', {
                   defaultMessage:
                     '{kibanaTotalCriticalDeps} Kibana deprecation {kibanaTotalCriticalDeps, plural, one {issue} other {issues}}',
                   values: { kibanaTotalCriticalDeps },

--- a/x-pack/plugins/upgrade_assistant/server/routes/status.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/status.ts
@@ -63,12 +63,44 @@ export function registerUpgradeStatusRoute({ router, lib: { handleEsError } }: R
               );
             }
 
+            const upgradeIssues: string[] = [];
+
+            if (notMigratedSystemIndices) {
+              upgradeIssues.push(
+                i18n.translate('xpack.upgradeAssistant.status.systemIndicesMessage', {
+                  defaultMessage:
+                    '{notMigratedSystemIndices} unmigrated system {notMigratedSystemIndices, plural, one {index} other {indices}}',
+                  values: { notMigratedSystemIndices },
+                })
+              );
+            }
+
+            if (esTotalCriticalDeps) {
+              upgradeIssues.push(
+                i18n.translate('xpack.upgradeAssistant.status.esTotalCriticalDepsMessage', {
+                  defaultMessage:
+                    '{esTotalCriticalDeps} Elasticsearch deprecation {esTotalCriticalDeps, plural, one {issue} other {issues}}',
+                  values: { esTotalCriticalDeps },
+                })
+              );
+            }
+
+            if (kibanaTotalCriticalDeps) {
+              upgradeIssues.push(
+                i18n.translate('xpack.upgradeAssistant.status.esTotalCriticalDepsMessage', {
+                  defaultMessage:
+                    '{kibanaTotalCriticalDeps} Kibana deprecation {kibanaTotalCriticalDeps, plural, one {issue} other {issues}}',
+                  values: { kibanaTotalCriticalDeps },
+                })
+              );
+            }
+
             return i18n.translate('xpack.upgradeAssistant.status.deprecationsUnresolvedMessage', {
               defaultMessage:
-                'You have {notMigratedSystemIndices} system {notMigratedSystemIndices, plural, one {index} other {indices}} that must be migrated ' +
-                'and {esTotalCriticalDeps} Elasticsearch deprecation {esTotalCriticalDeps, plural, one {issue} other {issues}} ' +
-                'and {kibanaTotalCriticalDeps} Kibana deprecation {kibanaTotalCriticalDeps, plural, one {issue} other {issues}} that must be resolved before upgrading.',
-              values: { esTotalCriticalDeps, kibanaTotalCriticalDeps, notMigratedSystemIndices },
+                'The following issues must be resolved before upgrading: {upgradeIssues}.',
+              values: {
+                upgradeIssues: upgradeIssues.join(', '),
+              },
             });
           };
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/121773

This PR updates the `details` property in the status API response to only include the relevant deprecation information.

Example responses:

```
The following issues must be resolved before upgrading: 2 unmigrated system indices, 7 Elasticsearch deprecation issues, 2 Kibana deprecation issues.
```

```
The following issues must be resolved before upgrading: 2 unmigrated system indices, 7 Elasticsearch deprecation issues.
```

```
The following issues must be resolved before upgrading: 11 Elasticsearch deprecation issues.
```