### PR TITLE
[DOCS] Reformats the Monitoring settings tables into definition lists

### DIFF
--- a/docs/settings/monitoring-settings.asciidoc
+++ b/docs/settings/monitoring-settings.asciidoc
@@ -29,50 +29,47 @@ For more information, see
 [[monitoring-general-settings]]
 ==== General monitoring settings
 
-[cols="2*<"]
-|===
-| `monitoring.ui.ccs.enabled`
-  | Set to `true` (default) to enable {ref}/modules-cross-cluster-search.html[cross-cluster search] of your monitoring data. The {ref}/modules-remote-clusters.html#remote-cluster-settings[`remote_cluster_client`] role must exist on each node.
+`monitoring.ui.ccs.enabled`::
+Set to `true` (default) to enable {ref}/modules-cross-cluster-search.html[cross-cluster search] of your monitoring data. The {ref}/modules-remote-clusters.html#remote-cluster-settings[`remote_cluster_client`] role must exist on each node.
 
 
-| `monitoring.ui.elasticsearch.hosts`
-  | Specifies the location of the {es} cluster where your monitoring data is stored.
-  By default, this is the same as <<elasticsearch-hosts, `elasticsearch.hosts`>>. This setting enables
-  you to use a single {kib} instance to search and visualize data in your
-  production cluster as well as monitor data sent to a dedicated monitoring
-  cluster.
+`monitoring.ui.elasticsearch.hosts`::
+Specifies the location of the {es} cluster where your monitoring data is stored.
++
+By default, this is the same as <<elasticsearch-hosts, `elasticsearch.hosts`>>. This setting enables
+you to use a single {kib} instance to search and visualize data in your
+production cluster as well as monitor data sent to a dedicated monitoring
+cluster.
 
-| `monitoring.ui.elasticsearch.username`
-  | Specifies the username used by {kib} monitoring to establish a persistent connection
-  in {kib}  to the {es} monitoring cluster and to verify licensing status on the {es}
-  monitoring cluster. +
-  +
-  Every other request performed by *{stack-monitor-app}* to the monitoring {es}
-  cluster uses the authenticated user's credentials, which must be the same on
-  both the {es} monitoring cluster and the {es} production cluster. +
-  +
-  If not set, {kib} uses the value of the <<elasticsearch-user-passwd, `elasticsearch.username`>> setting.
+`monitoring.ui.elasticsearch.username`::
+Specifies the username used by {kib} monitoring to establish a persistent connection
+in {kib}  to the {es} monitoring cluster and to verify licensing status on the {es}
+monitoring cluster.
++
+Every other request performed by *{stack-monitor-app}* to the monitoring {es}
+cluster uses the authenticated user's credentials, which must be the same on
+both the {es} monitoring cluster and the {es} production cluster.
++
+If not set, {kib} uses the value of the <<elasticsearch-user-passwd, `elasticsearch.username`>> setting.
 
-| `monitoring.ui.elasticsearch.password`
-  | Specifies the password used by {kib} monitoring to establish a persistent connection
-  in {kib}  to the {es} monitoring cluster and to verify licensing status on the {es}
-  monitoring cluster. +
-  +
-  Every other request performed by *{stack-monitor-app}* to the monitoring {es}
-  cluster uses the authenticated user's credentials, which must be the same on
-  both the {es} monitoring cluster and the {es} production cluster. +
-  +
-  If not set, {kib} uses the value of the <<elasticsearch-user-passwd, `elasticsearch.password`>> setting.
+`monitoring.ui.elasticsearch.password`::
+Specifies the password used by {kib} monitoring to establish a persistent connection
+in {kib}  to the {es} monitoring cluster and to verify licensing status on the {es}
+monitoring cluster.
++
+Every other request performed by *{stack-monitor-app}* to the monitoring {es}
+cluster uses the authenticated user's credentials, which must be the same on
+both the {es} monitoring cluster and the {es} production cluster.
++
+If not set, {kib} uses the value of the <<elasticsearch-user-passwd, `elasticsearch.password`>> setting.
 
-| `monitoring.ui.elasticsearch.pingTimeout`
-  | Specifies the time in milliseconds to wait for {es} to respond to internal
-  health checks. By default, it matches the <<elasticsearch-pingTimeout, `elasticsearch.pingTimeout`>> setting,
-  which has a default value of `30000`.
+`monitoring.ui.elasticsearch.pingTimeout`::
+Specifies the time in milliseconds to wait for {es} to respond to internal
+health checks. By default, it matches the <<elasticsearch-pingTimeout, `elasticsearch.pingTimeout`>> setting,
+which has a default value of `30000`.
 
-| `monitoring.ui.elasticsearch.ssl`
-  | Shares the same configuration as <<elasticsearch-ssl-cert-key, `elasticsearch.ssl`>>. These settings configure encrypted communication between {kib} and the monitoring cluster.
-
-|===
+`monitoring.ui.elasticsearch.ssl`::
+Shares the same configuration as <<elasticsearch-ssl-cert-key, `elasticsearch.ssl`>>. These settings configure encrypted communication between {kib} and the monitoring cluster.
 
 [float]
 [[monitoring-collection-settings]]
@@ -80,18 +77,14 @@ For more information, see
 
 These settings control how data is collected from {kib}.
 
-[cols="2*<"]
-|===
-| `monitoring.kibana.collection.enabled`
-  | Set to `true` (default) to enable data collection from the {kib} NodeJS server
-  for {kib} dashboards to be featured in *{stack-monitor-app}*.
+`monitoring.kibana.collection.enabled`::
+Set to `true` (default) to enable data collection from the {kib} NodeJS server
+for {kib} dashboards to be featured in *{stack-monitor-app}*.
 
-| `monitoring.kibana.collection.interval` {ess-icon}
-  | Specifies the number of milliseconds to wait in between data sampling on the
-  {kib} NodeJS server for the metrics that are displayed in the {kib} dashboards.
-  Defaults to `10000` (10 seconds).
-
-|===
+`monitoring.kibana.collection.interval` {ess-icon}::
+Specifies the number of milliseconds to wait in between data sampling on the
+{kib} NodeJS server for the metrics that are displayed in the {kib} dashboards.
+Defaults to `10000` (10 seconds).
 
 [float]
 [[monitoring-ui-settings]]
@@ -102,36 +95,32 @@ However, the defaults work best in most circumstances. For more information
 about configuring {kib}, see
 {kibana-ref}/settings.html[Setting {kib} server properties].
 
-[cols="2*<"]
-|===
-| `monitoring.ui.elasticsearch.logFetchCount`
-  | Specifies the number of log entries to display in *{stack-monitor-app}*.
-  Defaults to `10`. The maximum value is `50`.
+`monitoring.ui.elasticsearch.logFetchCount`::
+Specifies the number of log entries to display in *{stack-monitor-app}*.
+Defaults to `10`. The maximum value is `50`.
 
-|[[monitoring-ui-enabled]] `monitoring.ui.enabled`
-  | Set to `false` to hide *{stack-monitor-app}*. The monitoring back-end
-    continues to run as an agent for sending {kib} stats to the monitoring
-    cluster. Defaults to `true`.
+[[monitoring-ui-enabled]] `monitoring.ui.enabled`::
+Set to `false` to hide *{stack-monitor-app}*. The monitoring back-end
+continues to run as an agent for sending {kib} stats to the monitoring
+cluster. Defaults to `true`.
 
-| `monitoring.ui.logs.index`
-  | Specifies the name of the indices that are shown on the
-  <<logs-monitor-page,*Logs*>> page in *{stack-monitor-app}*. The default value
-  is `filebeat-*`.
+`monitoring.ui.logs.index`::
+Specifies the name of the indices that are shown on the
+<<logs-monitor-page,*Logs*>> page in *{stack-monitor-app}*. The default value
+is `filebeat-*`.
 
-| `monitoring.ui.max_bucket_size`
-  | Specifies the number of term buckets to return out of the overall terms list when
-  performing terms aggregations to retrieve index and node metrics. For more
-  information about the `size` parameter, see
-  {ref}/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-size[Terms Aggregation].
-  Defaults to `10000`.
+`monitoring.ui.max_bucket_size`::
+Specifies the number of term buckets to return out of the overall terms list when
+performing terms aggregations to retrieve index and node metrics. For more
+information about the `size` parameter, see
+{ref}/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-size[Terms Aggregation].
+Defaults to `10000`.
 
-| `monitoring.ui.min_interval_seconds` {ess-icon}
-  | Specifies the minimum number of seconds that a time bucket in a chart can
-  represent. Defaults to 10. If you modify the
-  `monitoring.ui.collection.interval` in `elasticsearch.yml`, use the same
-  value in this setting.
-
-|===
+`monitoring.ui.min_interval_seconds` {ess-icon}::
+Specifies the minimum number of seconds that a time bucket in a chart can
+represent. Defaults to 10. If you modify the
+`monitoring.ui.collection.interval` in `elasticsearch.yml`, use the same
+value in this setting.
 
 [float]
 [[monitoring-ui-cgroup-settings]]
@@ -142,20 +131,16 @@ better decisions about your container performance, rather than guessing based on
 the overall machine performance. If you are not running your applications in a
 container, then Cgroup statistics are not useful.
 
-[cols="2*<"]
-|===
-| `monitoring.ui.container.elasticsearch.enabled` {ess-icon}
-  | For {es} clusters that are running in containers, this setting changes the
-  *Node Listing* to display the CPU utilization based on the reported Cgroup
-  statistics. It also adds the calculated Cgroup CPU utilization to the
-  *Node Overview* page instead of the overall operating system's CPU
-  utilization. Defaults to `false`.
+`monitoring.ui.container.elasticsearch.enabled` {ess-icon}::
+For {es} clusters that are running in containers, this setting changes the
+*Node Listing* to display the CPU utilization based on the reported Cgroup
+statistics. It also adds the calculated Cgroup CPU utilization to the
+*Node Overview* page instead of the overall operating system's CPU
+utilization. Defaults to `false`.
 
-| `monitoring.ui.container.logstash.enabled`
-  | For {ls} nodes that are running in containers, this setting
-  changes the {ls} *Node Listing* to display the CPU utilization
-  based on the reported Cgroup statistics. It also adds the
-  calculated Cgroup CPU utilization to the {ls} node detail
-  pages instead of the overall operating system’s CPU utilization. Defaults to `false`.
-
-|===
+`monitoring.ui.container.logstash.enabled`::
+For {ls} nodes that are running in containers, this setting
+changes the {ls} *Node Listing* to display the CPU utilization
+based on the reported Cgroup statistics. It also adds the
+calculated Cgroup CPU utilization to the {ls} node detail
+pages instead of the overall operating system’s CPU utilization. Defaults to `false`.


### PR DESCRIPTION
## Summary

Closes part of https://github.com/elastic/kibana/issues/104482.

Docs preview link: https://kibana_126489.docs-preview.app.elstc.co/diff