### PR TITLE
[Fleet] Resolve latest package version from bundled packages if possible

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -8,6 +8,7 @@
 import { URL } from 'url';
 
 import mime from 'mime-types';
+import semverGte from 'semver/functions/gte';
 
 import type { Response } from 'node-fetch';
 
@@ -74,7 +75,10 @@ async function _fetchFindLatestPackage(
   packageName: string,
   options?: FetchFindLatestPackageOptions
 ) {
+  const logger = appContextService.getLogger();
   const { ignoreConstraints = false } = options ?? {};
+
+  const bundledPackage = await getBundledPackageByName(packageName);
 
   const registryUrl = getRegistryUrl();
   const url = new URL(`${registryUrl}/search?package=${packageName}&experimental=true`);
@@ -83,55 +87,61 @@ async function _fetchFindLatestPackage(
     setKibanaVersion(url);
   }
 
-  const res = await fetchUrl(url.toString(), 1);
-  const searchResults: RegistryPackage[] = JSON.parse(res);
+  try {
+    const res = await fetchUrl(url.toString(), 1);
+    const searchResults: RegistryPackage[] = JSON.parse(res);
 
-  return searchResults;
+    const latestPackageFromRegistry = searchResults[0] ?? null;
+
+    if (bundledPackage && semverGte(bundledPackage.version, latestPackageFromRegistry.version)) {
+      return bundledPackage;
+    }
+
+    return latestPackageFromRegistry;
+  } catch (error) {
+    logger.error(
+      `Failed to fetch latest version of ${packageName} from registry: ${error.message}`
+    );
+
+    // Fall back to the bundled version of the package if it exists
+    if (bundledPackage) {
+      return bundledPackage;
+    }
+
+    // Otherwise, return null and allow callers to determine whether they'll consider this an error or not
+    return null;
+  }
 }
 
 export async function fetchFindLatestPackageOrThrow(
   packageName: string,
   options?: FetchFindLatestPackageOptions
 ) {
-  try {
-    const searchResults = await _fetchFindLatestPackage(packageName, options);
+  const latestPackage = await _fetchFindLatestPackage(packageName, options);
 
-    if (!searchResults.length) {
-      throw new PackageNotFoundError(`[${packageName}] package not found in registry`);
-    }
-
-    return searchResults[0];
-  } catch (error) {
-    const bundledPackage = await getBundledPackageByName(packageName);
-
-    if (!bundledPackage) {
-      throw error;
-    }
-
-    return bundledPackage;
+  if (!latestPackage) {
+    throw new PackageNotFoundError(`[${packageName}] package not found in registry`);
   }
+
+  return latestPackage;
 }
 
 export async function fetchFindLatestPackageOrUndefined(
   packageName: string,
   options?: FetchFindLatestPackageOptions
 ) {
+  const logger = appContextService.getLogger();
+
   try {
-    const searchResults = await _fetchFindLatestPackage(packageName, options);
+    const latestPackage = await _fetchFindLatestPackage(packageName, options);
 
-    if (!searchResults.length) {
+    if (!latestPackage) {
       return undefined;
     }
-
-    return searchResults[0];
+    return latestPackage;
   } catch (error) {
-    const bundledPackage = await getBundledPackageByName(packageName);
-
-    if (!bundledPackage) {
-      return undefined;
-    }
-
-    return bundledPackage;
+    logger.warn(`Error fetching latest package for ${packageName}: ${error.message}`);
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/126487

Update "fetch latest package" logic to compare any bundled packages on disk to the version returned from the registry. If the bundled package version is newer, treat that as the latest.

## To test

Create a mimicked cloud policy via `kibana.dev.yml`

```yml
xpack.fleet.packages:
  - name: fleet_server
    version: latest
  - name: apm
    version: latest

xpack.fleet.agentPolicies:
  # Cloud Agent policy
  - name: Elastic Cloud agent policy
    description: Default agent policy for agents hosted on Elastic Cloud
    id: policy-elastic-agent-on-cloud

    is_default: false
    is_managed: true
    is_default_fleet_server: false

    namespace: default
    monitoring_enabled: []
    # If a user scales up / down the Elastic Agent in Cloud, the old
    # instances will still be shown as offline for 24h
    # The reason for having a value such high is to prevent fleet-servers to self unenroll to soon
    # in case checkin cannot happen for a longer time period.
    unenroll_timeout: 86400 # 1 day TTL

    package_policies:
      - name: Fleet Server
        id: elastic-cloud-fleet-server
        package:
          name: fleet_server
        inputs:
          - type: fleet-server
            keep_enabled: true

            vars:
              - name: host
                value: 0.0.0.0
                frozen: true
              - name: port
                value: 8220
                frozen: true
              - name: custom
                value: |
                  server.runtime:
                    gc_percent: 20          # Force the GC to execute more frequently: see https://golang.org/pkg/runtime/debug/#SetGCPercent
      - name: Elastic APM
        id: elastic-cloud-apm
        package:
          name: apm
        inputs:
          - type: apm
            keep_enabled: true
            vars:
              - name: api_key_enabled
                value: true
              - name: host
                value: '0.0.0.0:8200'
                frozen: true
              - name: secret_token
                value: secret
              - name: tls_enabled
                value: true
                frozen: true
              - name: tls_certificate
                value: /app/config/certs/node.crt
                frozen: true
              - name: tls_key
                value: /app/config/certs/node.key
                frozen: true
              - name: url
                value: http://example.com
                frozen: true
```

Then, update your snapshot URL to always resolve to production instead of snapshot/staging by editing this file:

https://github.com/elastic/kibana/blob/4b1bf83bad93b2349581ac7ef70adf230d4dfdb1/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts

Then, run Fleet setup in a fresh ES/Kibana environment. Verify that APM 8.1.0 and Fleet Server 1.1.0 are installed as expected. e.g.

```
[2022-02-28T13:10:55.793-05:00][DEBUG][plugins.fleet] kicking off bulk install of fleet_server, apm
[2022-02-28T13:10:55.799-05:00][DEBUG][plugins.fleet] found bundled package for requested install of apm-8.1.0 - installing from bundled package archive
[2022-02-28T13:10:55.800-05:00][DEBUG][plugins.fleet] found bundled package for requested install of fleet_server-1.1.0 - installing from bundled package archive
```

Note: This does result in a rather broken UI experience on the integration details page, because the installed version does not exist in the configured registry, e.g

![image](https://user-images.githubusercontent.com/6766512/156035934-22c0c25e-c7d7-4d94-b66f-3baccd16e133.png)

However, this is expected for now, and the policy editor for this version of APM is still functional.