### PR TITLE
[Visualize] Extract and inject references for by value

### DIFF
--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.test.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.test.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { EmbeddableStateWithType } from 'src/plugins/embeddable/common';
+import { VisualizeEmbeddableFactory, VisualizeInput } from '.';
+import { VisualizeEmbeddableFactoryDeps } from './visualize_embeddable_factory';
+
+describe('visualize_embeddable_factory', () => {
+  const factory = new VisualizeEmbeddableFactory({} as VisualizeEmbeddableFactoryDeps);
+  test('extract saved search references for search source state and not store them in state', () => {
+    const { state, references } = factory.extract({
+      savedVis: {
+        type: 'area',
+        params: {},
+        uiState: {},
+        data: {
+          aggs: [
+            {
+              id: '1',
+              enabled: true,
+              type: 'count',
+              params: {},
+              schema: 'metric',
+            },
+          ],
+          searchSource: {
+            query: {
+              query: '',
+              language: 'kuery',
+            },
+            filter: [],
+          },
+          savedSearchId: '123',
+        },
+      },
+      enhancements: {},
+      type: 'visualization',
+    } as unknown as EmbeddableStateWithType);
+    expect(references).toEqual([
+      {
+        type: 'search',
+        name: 'search_0',
+        id: '123',
+      },
+    ]);
+    expect((state as unknown as VisualizeInput).savedVis?.data.savedSearchId).toBeUndefined();
+  });
+
+  test('extract data view references for search source state and not store them in state', () => {
+    const { state, references } = factory.extract({
+      savedVis: {
+        type: 'area',
+        params: {},
+        uiState: {},
+        data: {
+          aggs: [
+            {
+              id: '1',
+              enabled: true,
+              type: 'count',
+              params: {},
+              schema: 'metric',
+            },
+          ],
+          searchSource: {
+            query: {
+              query: '',
+              language: 'kuery',
+            },
+            index: '123',
+            filter: [],
+          },
+        },
+      },
+      enhancements: {},
+      type: 'visualization',
+    } as unknown as EmbeddableStateWithType);
+    expect(references).toEqual([
+      {
+        type: 'index-pattern',
+        name: (
+          (state as unknown as VisualizeInput).savedVis?.data.searchSource as {
+            indexRefName: string;
+          }
+        ).indexRefName,
+        id: '123',
+      },
+    ]);
+    expect((state as unknown as VisualizeInput).savedVis?.data.searchSource.index).toBeUndefined();
+  });
+
+  test('inject data view references into search source state', () => {
+    const embeddedState = factory.inject(
+      {
+        savedVis: {
+          type: 'area',
+          params: {},
+          uiState: {},
+          data: {
+            aggs: [
+              {
+                id: '1',
+                enabled: true,
+                type: 'count',
+                params: {},
+                schema: 'metric',
+              },
+            ],
+            searchSource: {
+              query: {
+                query: '',
+                language: 'kuery',
+              },
+              indexRefName: 'x',
+              filter: [],
+            },
+          },
+        },
+        enhancements: {},
+        type: 'visualization',
+      } as unknown as EmbeddableStateWithType,
+      [{ name: 'x', id: '123', type: 'index-pattern' }]
+    ) as VisualizeInput;
+    expect(embeddedState.savedVis!.data.searchSource.index).toBe('123');
+    expect(
+      (embeddedState.savedVis!.data.searchSource as { indexRefName: string }).indexRefName
+    ).toBe(undefined);
+  });
+
+  test('inject data view reference into search source state even if it is in injected state already', () => {
+    const embeddedState = factory.inject(
+      {
+        savedVis: {
+          type: 'area',
+          params: {},
+          uiState: {},
+          data: {
+            aggs: [
+              {
+                id: '1',
+                enabled: true,
+                type: 'count',
+                params: {},
+                schema: 'metric',
+              },
+            ],
+            searchSource: {
+              query: {
+                query: '',
+                language: 'kuery',
+              },
+              index: '456',
+              filter: [],
+            },
+          },
+        },
+        enhancements: {},
+        type: 'visualization',
+      } as unknown as EmbeddableStateWithType,
+      [{ name: 'kibanaSavedObjectMeta.searchSourceJSON.index', id: '123', type: 'index-pattern' }]
+    ) as VisualizeInput;
+    expect(embeddedState.savedVis!.data.searchSource.index).toBe('123');
+    expect(
+      (embeddedState.savedVis!.data.searchSource as { indexRefName: string }).indexRefName
+    ).toBe(undefined);
+  });
+
+  test('inject search reference into search source state', () => {
+    const embeddedState = factory.inject(
+      {
+        savedVis: {
+          type: 'area',
+          params: {},
+          uiState: {},
+          data: {
+            aggs: [
+              {
+                id: '1',
+                enabled: true,
+                type: 'count',
+                params: {},
+                schema: 'metric',
+              },
+            ],
+            searchSource: {
+              query: {
+                query: '',
+                language: 'kuery',
+              },
+              filter: [],
+            },
+          },
+        },
+        enhancements: {},
+        type: 'visualization',
+      } as unknown as EmbeddableStateWithType,
+      [{ name: 'search_0', id: '123', type: 'search' }]
+    );
+    expect((embeddedState as VisualizeInput).savedVis!.data.savedSearchId).toBe('123');
+  });
+
+  test('inject search reference into search source state even if it is injected already', () => {
+    const embeddedState = factory.inject(
+      {
+        savedVis: {
+          type: 'area',
+          params: {},
+          uiState: {},
+          data: {
+            aggs: [
+              {
+                id: '1',
+                enabled: true,
+                type: 'count',
+                params: {},
+                schema: 'metric',
+              },
+            ],
+            searchSource: {
+              query: {
+                query: '',
+                language: 'kuery',
+              },
+              filter: [],
+            },
+            savedSearchId: '789',
+          },
+        },
+        enhancements: {},
+        type: 'visualization',
+      } as unknown as EmbeddableStateWithType,
+      [{ name: 'search_0', id: '123', type: 'search' }]
+    );
+    expect((embeddedState as VisualizeInput).savedVis!.data.savedSearchId).toBe('123');
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/126461

The Visualize embeddable currently extracts references to saved search or data view correctly on save, but it doesn't update its internal state to actually remove the ids from the internal panel state, nor does it inject new upstream references into its panel state on load.

This PR fixes this by 
* returning the extracted search source state in the `extract` method of the factory class and removing the saved search id
* on `inject`, actually injecting references into the search source calling the appropriate function exposed by the data plugin as well as putting the saved search id into the right spot if available
* To fix visualizations which are broken already because people upgraded to 8.0 and copied/imported saved objects with conflicts, it's checking as part of `inject` whether the state object is in injected state already - if that's the case, it's running the extract routine, then inject with the new upstream references to effectively update them. This is possible because all reference names are constructed deterministically.

To test:
* Create a dashboard with an agg based by value vis
* Export the dashboard with referenced SOs (should include data views / saved searches)
* Import it in another space
* Without this PR, the vis will fail to render
* With this PR, it will load fine

Test matrix:
* Direct data view
* Saved search
* Local filters in the vis
* Dashboards that got created without the fix start to load fine (with all of the above) if imported/copied into multiple spaces
* Dashboards that got created after the fix continue to load fine even if imported/copied into multiple spaces

----

**Release note:** Fixes some dashboard visualizations that could show "Could not located index pattern" errors when copied from one space to another.