### PR TITLE
Use response-ops GitHub team everywhere, no more alerting services

### DIFF
--- a/api_docs/actions.mdx
+++ b/api_docs/actions.mdx
@@ -12,7 +12,7 @@ import actionsObj from './actions.devdocs.json';
 
 
 
-Contact [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) for questions regarding this plugin.
+Contact [Response Ops](https://github.com/orgs/elastic/teams/response-ops) for questions regarding this plugin.
 
 **Code health stats**
 

--- a/api_docs/alerting.mdx
+++ b/api_docs/alerting.mdx
@@ -12,7 +12,7 @@ import alertingObj from './alerting.devdocs.json';
 
 
 
-Contact [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) for questions regarding this plugin.
+Contact [Response Ops](https://github.com/orgs/elastic/teams/response-ops) for questions regarding this plugin.
 
 **Code health stats**
 

--- a/api_docs/event_log.mdx
+++ b/api_docs/event_log.mdx
@@ -12,7 +12,7 @@ import eventLogObj from './event_log.devdocs.json';
 
 
 
-Contact [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) for questions regarding this plugin.
+Contact [Response Ops](https://github.com/orgs/elastic/teams/response-ops) for questions regarding this plugin.
 
 **Code health stats**
 

--- a/api_docs/plugin_directory.mdx
+++ b/api_docs/plugin_directory.mdx
@@ -24,14 +24,14 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
 
 | Plugin name &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;  | Maintaining team | Description | API Cnt | Any Cnt | Missing<br />comments | Missing<br />exports | 
 |--------------|----------------|-----------|--------------|----------|---------------|--------|
-| <DocLink id="kibActionsPluginApi" text="actions"/> | [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) | - | 125 | 0 | 125 | 11 |
+| <DocLink id="kibActionsPluginApi" text="actions"/> | [Response Ops](https://github.com/orgs/elastic/teams/response-ops) | - | 125 | 0 | 125 | 11 |
 | <DocLink id="kibAdvancedSettingsPluginApi" text="advancedSettings"/> | [Vis Editors](https://github.com/orgs/elastic/teams/kibana-vis-editors) | - | 23 | 0 | 19 | 1 |
-| <DocLink id="kibAlertingPluginApi" text="alerting"/> | [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) | - | 299 | 0 | 291 | 19 |
+| <DocLink id="kibAlertingPluginApi" text="alerting"/> | [Response Ops](https://github.com/orgs/elastic/teams/response-ops) | - | 299 | 0 | 291 | 19 |
 | <DocLink id="kibApmPluginApi" text="apm"/> | [APM UI](https://github.com/orgs/elastic/teams/apm-ui) | The user interface for Elastic APM | 40 | 0 | 40 | 49 |
 | <DocLink id="kibBannersPluginApi" text="banners"/> | [Kibana Core](https://github.com/orgs/elastic/teams/kibana-core) | - | 9 | 0 | 9 | 0 |
 | <DocLink id="kibBfetchPluginApi" text="bfetch"/> | [App Services](https://github.com/orgs/elastic/teams/kibana-app-services) | Considering using bfetch capabilities when fetching large amounts of data. This services supports batching HTTP requests and streaming responses back. | 78 | 1 | 69 | 2 |
 | <DocLink id="kibCanvasPluginApi" text="canvas"/> | [Kibana Presentation](https://github.com/orgs/elastic/teams/kibana-presentation) | Adds Canvas application to Kibana | 9 | 0 | 8 | 3 |
-| <DocLink id="kibCasesPluginApi" text="cases"/> | [ResponseOps](https://github.com/orgs/elastic/teams/response-ops) | The Case management system in Kibana | 82 | 0 | 59 | 20 |
+| <DocLink id="kibCasesPluginApi" text="cases"/> | [Response Ops](https://github.com/orgs/elastic/teams/response-ops) | The Case management system in Kibana | 82 | 0 | 59 | 20 |
 | <DocLink id="kibChartsPluginApi" text="charts"/> | [Vis Editors](https://github.com/orgs/elastic/teams/kibana-vis-editors) | - | 321 | 2 | 288 | 4 |
 | <DocLink id="kibCloudPluginApi" text="cloud"/> | [Kibana Core](https://github.com/orgs/elastic/teams/kibana-core) | - | 28 | 0 | 23 | 0 |
 | <DocLink id="kibConsolePluginApi" text="console"/> | [Stack Management](https://github.com/orgs/elastic/teams/kibana-stack-management) | - | 13 | 0 | 13 | 1 |
@@ -56,7 +56,7 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
 | <DocLink id="kibEncryptedSavedObjectsPluginApi" text="encryptedSavedObjects"/> | [Platform Security](https://github.com/orgs/elastic/teams/kibana-security) | This plugin provides encryption and decryption utilities for saved objects containing sensitive information. | 48 | 0 | 44 | 0 |
 | <DocLink id="kibEnterpriseSearchPluginApi" text="enterpriseSearch"/> | [Enterprise Search](https://github.com/orgs/elastic/teams/enterprise-search-frontend) | Adds dashboards for discovering and managing Enterprise Search products. | 2 | 0 | 2 | 0 |
 | <DocLink id="kibEsUiSharedPluginApi" text="esUiShared"/> | [Stack Management](https://github.com/orgs/elastic/teams/kibana-stack-management) | - | 110 | 3 | 106 | 3 |
-| <DocLink id="kibEventLogPluginApi" text="eventLog"/> | [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) | - | 82 | 0 | 82 | 6 |
+| <DocLink id="kibEventLogPluginApi" text="eventLog"/> | [Response Ops](https://github.com/orgs/elastic/teams/response-ops) | - | 82 | 0 | 82 | 6 |
 | <DocLink id="kibExpressionErrorPluginApi" text="expressionError"/> | [Kibana Presentation](https://github.com/orgs/elastic/teams/kibana-presentation) | Adds 'error' renderer to expressions | 17 | 0 | 15 | 2 |
 | <DocLink id="kibExpressionGaugePluginApi" text="expressionGauge"/> | [Vis Editors](https://github.com/orgs/elastic/teams/kibana-vis-editors) | Expression Gauge plugin adds a `gauge` renderer and function to the expression plugin. The renderer will display the `gauge` chart. | 68 | 0 | 68 | 3 |
 | <DocLink id="kibExpressionHeatmapPluginApi" text="expressionHeatmap"/> | [Vis Editors](https://github.com/orgs/elastic/teams/kibana-vis-editors) | Expression Heatmap plugin adds a `heatmap` renderer and function to the expression plugin. The renderer will display the `heatmap` chart. | 114 | 0 | 110 | 3 |
@@ -126,8 +126,8 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
 | <DocLink id="kibSharedUXPluginApi" text="sharedUX"/> | [Shared UX](https://github.com/orgs/elastic/teams/shared-ux) | A plugin providing components and services for shared user experiences in Kibana. | 14 | 0 | 0 | 1 |
 | <DocLink id="kibSnapshotRestorePluginApi" text="snapshotRestore"/> | [Stack Management](https://github.com/orgs/elastic/teams/kibana-stack-management) | - | 21 | 1 | 21 | 1 |
 | <DocLink id="kibSpacesPluginApi" text="spaces"/> | [Platform Security](https://github.com/orgs/elastic/teams/kibana-security) | This plugin provides the Spaces feature, which allows saved objects to be organized into meaningful categories. | 250 | 0 | 61 | 0 |
-| <DocLink id="kibStackAlertsPluginApi" text="stackAlerts"/> | [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) | - | 4 | 0 | 4 | 0 |
-| <DocLink id="kibTaskManagerPluginApi" text="taskManager"/> | [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) | - | 71 | 0 | 33 | 7 |
+| <DocLink id="kibStackAlertsPluginApi" text="stackAlerts"/> | [Response Ops](https://github.com/orgs/elastic/teams/response-ops) | - | 4 | 0 | 4 | 0 |
+| <DocLink id="kibTaskManagerPluginApi" text="taskManager"/> | [Response Ops](https://github.com/orgs/elastic/teams/response-ops) | - | 71 | 0 | 33 | 7 |
 | <DocLink id="kibTelemetryPluginApi" text="telemetry"/> | [Kibana Telemetry](https://github.com/orgs/elastic/teams/kibana-telemetry) | - | 41 | 0 | 0 | 0 |
 | <DocLink id="kibTelemetryCollectionManagerPluginApi" text="telemetryCollectionManager"/> | [Kibana Telemetry](https://github.com/orgs/elastic/teams/kibana-telemetry) | - | 33 | 0 | 33 | 6 |
 | <DocLink id="kibTelemetryCollectionXpackPluginApi" text="telemetryCollectionXpack"/> | [Kibana Telemetry](https://github.com/orgs/elastic/teams/kibana-telemetry) | - | 1 | 0 | 1 | 0 |
@@ -135,7 +135,7 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
 | <DocLink id="kibTimelinesPluginApi" text="timelines"/> | [Security solution](https://github.com/orgs/elastic/teams/security-solution) | - | 444 | 1 | 338 | 34 |
 | <DocLink id="kibTransformPluginApi" text="transform"/> | [Machine Learning UI](https://github.com/orgs/elastic/teams/ml-ui) | This plugin provides access to the transforms features provided by Elastic. Transforms enable you to convert existing Elasticsearch indices into summarized indices, which provide opportunities for new insights and analytics. | 4 | 0 | 4 | 1 |
 | translations | [Kibana Localization](https://github.com/orgs/elastic/teams/kibana-localization) | - | 0 | 0 | 0 | 0 |
-| <DocLink id="kibTriggersActionsUiPluginApi" text="triggersActionsUi"/> | [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) | - | 246 | 0 | 234 | 20 |
+| <DocLink id="kibTriggersActionsUiPluginApi" text="triggersActionsUi"/> | [Response Ops](https://github.com/orgs/elastic/teams/response-ops) | - | 246 | 0 | 234 | 20 |
 | <DocLink id="kibUiActionsPluginApi" text="uiActions"/> | [App Services](https://github.com/orgs/elastic/teams/kibana-app-services) | Adds UI Actions service to Kibana | 130 | 0 | 91 | 11 |
 | <DocLink id="kibUiActionsEnhancedPluginApi" text="uiActionsEnhanced"/> | [App Services](https://github.com/orgs/elastic/teams/kibana-app-services) | Extends UI Actions plugin with more functionality | 203 | 0 | 141 | 9 |
 | upgradeAssistant | [Stack Management](https://github.com/orgs/elastic/teams/kibana-stack-management) | - | 0 | 0 | 0 | 0 |

--- a/api_docs/stack_alerts.mdx
+++ b/api_docs/stack_alerts.mdx
@@ -12,7 +12,7 @@ import stackAlertsObj from './stack_alerts.devdocs.json';
 
 
 
-Contact [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) for questions regarding this plugin.
+Contact [Response Ops](https://github.com/orgs/elastic/teams/response-ops) for questions regarding this plugin.
 
 **Code health stats**
 

--- a/api_docs/task_manager.mdx
+++ b/api_docs/task_manager.mdx
@@ -12,7 +12,7 @@ import taskManagerObj from './task_manager.devdocs.json';
 
 
 
-Contact [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) for questions regarding this plugin.
+Contact [Response Ops](https://github.com/orgs/elastic/teams/response-ops) for questions regarding this plugin.
 
 **Code health stats**
 

--- a/api_docs/triggers_actions_ui.mdx
+++ b/api_docs/triggers_actions_ui.mdx
@@ -12,7 +12,7 @@ import triggersActionsUiObj from './triggers_actions_ui.devdocs.json';
 
 
 
-Contact [Kibana Alerting](https://github.com/orgs/elastic/teams/kibana-alerting-services) for questions regarding this plugin.
+Contact [Response Ops](https://github.com/orgs/elastic/teams/response-ops) for questions regarding this plugin.
 
 **Code health stats**
 

--- a/x-pack/examples/alerting_example/kibana.json
+++ b/x-pack/examples/alerting_example/kibana.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "kibanaVersion": "kibana",
   "owner": {
-    "name": "Kibana Alerting",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "server": true,
   "ui": true,

--- a/x-pack/plugins/actions/kibana.json
+++ b/x-pack/plugins/actions/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "actions",
   "owner": {
-    "name": "Kibana Alerting",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "server": true,
   "version": "8.0.0",

--- a/x-pack/plugins/alerting/kibana.json
+++ b/x-pack/plugins/alerting/kibana.json
@@ -3,8 +3,8 @@
   "server": true,
   "ui": true,
   "owner": {
-    "name": "Kibana Alerting",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "version": "8.0.0",
   "kibanaVersion": "kibana",

--- a/x-pack/plugins/event_log/kibana.json
+++ b/x-pack/plugins/event_log/kibana.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "kibanaVersion": "kibana",
   "owner": {
-    "name": "Kibana Alerting",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "configPath": ["xpack", "eventLog"],
   "optionalPlugins": ["spaces"],

--- a/x-pack/plugins/stack_alerts/kibana.json
+++ b/x-pack/plugins/stack_alerts/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "stackAlerts",
   "owner": {
-    "name": "Kibana Alerting",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "server": true,
   "version": "8.2.0",

--- a/x-pack/plugins/task_manager/kibana.json
+++ b/x-pack/plugins/task_manager/kibana.json
@@ -3,8 +3,8 @@
   "server": true,
   "version": "8.2.0",
   "owner": {
-    "name": "Kibana Alerting",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "kibanaVersion": "kibana",
   "configPath": ["xpack", "task_manager"],

--- a/x-pack/plugins/triggers_actions_ui/kibana.json
+++ b/x-pack/plugins/triggers_actions_ui/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "triggersActionsUi",
   "owner": {
-    "name": "Kibana Alerting",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "version": "kibana",
   "server": true,

--- a/x-pack/test/alerting_api_integration/common/fixtures/plugins/aad/kibana.json
+++ b/x-pack/test/alerting_api_integration/common/fixtures/plugins/aad/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "aadFixtures",
   "owner": {
-    "name": "Alerting Services",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "version": "1.0.0",
   "kibanaVersion": "kibana",

--- a/x-pack/test/alerting_api_integration/common/fixtures/plugins/actions_simulators/kibana.json
+++ b/x-pack/test/alerting_api_integration/common/fixtures/plugins/actions_simulators/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "actionsSimulators",
   "owner": {
-    "name": "Alerting Services",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "version": "1.0.0",
   "kibanaVersion": "kibana",

--- a/x-pack/test/alerting_api_integration/common/fixtures/plugins/alerts/kibana.json
+++ b/x-pack/test/alerting_api_integration/common/fixtures/plugins/alerts/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "alertsFixtures",
   "owner": {
-    "name": "Alerting Services",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "version": "1.0.0",
   "kibanaVersion": "kibana",

--- a/x-pack/test/alerting_api_integration/common/fixtures/plugins/alerts_restricted/kibana.json
+++ b/x-pack/test/alerting_api_integration/common/fixtures/plugins/alerts_restricted/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "alertsRestrictedFixtures",
   "owner": {
-    "name": "Alerting Services",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "version": "1.0.0",
   "kibanaVersion": "kibana",

--- a/x-pack/test/alerting_api_integration/common/fixtures/plugins/task_manager_fixture/kibana.json
+++ b/x-pack/test/alerting_api_integration/common/fixtures/plugins/task_manager_fixture/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "taskManagerFixture",
   "owner": {
-    "name": "Alerting Services",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "version": "1.0.0",
   "kibanaVersion": "kibana",

--- a/x-pack/test/functional_with_es_ssl/fixtures/plugins/alerts/kibana.json
+++ b/x-pack/test/functional_with_es_ssl/fixtures/plugins/alerts/kibana.json
@@ -1,6 +1,6 @@
 {
   "id": "alertingFixture",
-  "owner": { "name": "Alerting Services", "githubTeam": "kibana-alerting-services" },
+  "owner": { "name": "Response Ops", "githubTeam": "response-ops" },
   "version": "1.0.0",
   "kibanaVersion": "kibana",
   "requiredPlugins": ["alerting", "triggersActionsUi", "features"],

--- a/x-pack/test/plugin_api_integration/plugins/event_log/kibana.json
+++ b/x-pack/test/plugin_api_integration/plugins/event_log/kibana.json
@@ -2,7 +2,7 @@
   "id": "eventLogFixture",
   "owner": {
     "name": "Kibana Alerting",
-    "githubTeam": "kibana-alerting-services"
+    "githubTeam": "response-ops"
   },
   "version": "1.0.0",
   "kibanaVersion": "kibana",

--- a/x-pack/test/plugin_api_integration/plugins/event_log/kibana.json
+++ b/x-pack/test/plugin_api_integration/plugins/event_log/kibana.json
@@ -1,7 +1,7 @@
 {
   "id": "eventLogFixture",
   "owner": {
-    "name": "Kibana Alerting",
+    "name": "Response Ops",
     "githubTeam": "response-ops"
   },
   "version": "1.0.0",

--- a/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/kibana.json
+++ b/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/kibana.json
@@ -1,8 +1,8 @@
 {
   "id": "sampleTaskPlugin",
   "owner": {
-    "name": "Alerting Services",
-    "githubTeam": "kibana-alerting-services"
+    "name": "Response Ops",
+    "githubTeam": "response-ops"
   },
   "version": "1.0.0",
   "kibanaVersion": "kibana",

--- a/x-pack/test/plugin_api_perf/plugins/task_manager_performance/kibana.json
+++ b/x-pack/test/plugin_api_perf/plugins/task_manager_performance/kibana.json
@@ -1,6 +1,6 @@
 {
   "id": "taskManagerPerformance",
-  "owner": { "name": "Alerting Services", "githubTeam": "kibana-alerting-services" },
+  "owner": { "name": "Response Ops", "githubTeam": "response-ops" },
   "version": "1.0.0",
   "kibanaVersion": "kibana",
   "requiredPlugins": ["taskManager"],


### PR DESCRIPTION
There were a few places in docs and in `kibana.json`s that were using the old `kibana-alerting-services` GitHub team. This changes all references to `response-ops`.

Resolves https://github.com/elastic/kibana/issues/126505