### PR TITLE
[8.0] CCS Fail Test Mode (#125997)

### DIFF
--- a/packages/kbn-es/src/cluster.js
+++ b/packages/kbn-es/src/cluster.js
@@ -260,6 +260,7 @@ exports.Cluster = class Cluster {
     const esArgs = [
       'action.destructive_requires_name=true',
       'ingest.geoip.downloader.enabled=false',
+      'search.check_ccs_compatibility=true',
     ].concat(options.esArgs || []);
 
     // Add to esArgs if ssl is enabled
@@ -282,7 +283,7 @@ exports.Cluster = class Cluster {
       []
     );
 
-    this._log.debug('%s %s', ES_BIN, args.join(' '));
+    this._log.info('%s %s', ES_BIN, args.join(' '));
 
     let esJavaOpts = `${options.esJavaOpts || ''} ${process.env.ES_JAVA_OPTS || ''}`;
 
@@ -295,7 +296,7 @@ exports.Cluster = class Cluster {
       esJavaOpts += ' -Xms1536m -Xmx1536m';
     }
 
-    this._log.debug('ES_JAVA_OPTS: %s', esJavaOpts.trim());
+    this._log.info('ES_JAVA_OPTS: %s', esJavaOpts.trim());
 
     this._process = execa(ES_BIN, args, {
       cwd: installPath,

--- a/packages/kbn-es/src/integration_tests/cluster.test.js
+++ b/packages/kbn-es/src/integration_tests/cluster.test.js
@@ -309,6 +309,7 @@ describe('#start(installPath)', () => {
           Array [
             "action.destructive_requires_name=true",
             "ingest.geoip.downloader.enabled=false",
+            "search.check_ccs_compatibility=true",
           ],
           undefined,
           Object {
@@ -387,6 +388,7 @@ describe('#run()', () => {
           Array [
             "action.destructive_requires_name=true",
             "ingest.geoip.downloader.enabled=false",
+            "search.check_ccs_compatibility=true",
           ],
           undefined,
           Object {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [CCS Fail Test Mode (#125997)](https://github.com/elastic/kibana/pull/125997)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)