### PR TITLE
[APM] Remove readOnly from secret token field

### DIFF
--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/agent_authorization_settings.test.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/agent_authorization_settings.test.ts
@@ -22,7 +22,6 @@ describe('apm-fleet-apm-integration', () => {
       expect(secretToken).toEqual({
         type: 'text',
         key: 'secret_token',
-        readOnly: true,
         labelAppend: 'Optional',
         label: 'Secret token',
       });
@@ -34,7 +33,6 @@ describe('apm-fleet-apm-integration', () => {
       expect(secretToken).toEqual({
         type: 'text',
         key: 'secret_token',
-        readOnly: false,
         labelAppend: 'Optional',
         label: 'Secret token',
       });

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/agent_authorization_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/agent_authorization_settings.ts
@@ -65,7 +65,6 @@ export function getAgentAuthorizationSettings({
     {
       type: 'text',
       key: 'secret_token',
-      readOnly: isCloudPolicy,
       labelAppend: OPTIONAL_LABEL,
       label: i18n.translate(
         'xpack.apm.fleet_integration.settings.agentAuthorization.secretTokenLabel',


### PR DESCRIPTION
This PR makes the `Secret token` field editable on APM integration. We decided to go for the minimum change for 8.1.0.

<img width="903" alt="Screen Shot 2022-02-28 at 4 42 06 PM" src="https://user-images.githubusercontent.com/55978943/156063796-9d2aa0ea-3e23-48eb-8a41-95716bf8b2ce.png">
