### PR TITLE
[Security Solution] Update hover actions css selector to re-hide default cell actions

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/page/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/page/index.tsx
@@ -41,7 +41,7 @@ export const AppGlobalStyle = createGlobalStyle<{ theme: { eui: { euiColorPrimar
     &:first-child,
     &:nth-child(2),
     &:nth-child(3),
-    &:nth-child(6) {
+    &:last-child {
       display: inline-flex;
     }
 

--- a/x-pack/plugins/security_solution/public/common/components/page/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/page/index.tsx
@@ -35,12 +35,13 @@ export const AppGlobalStyle = createGlobalStyle<{ theme: { eui: { euiColorPrimar
     z-index: 9950 !important;
   }
 
-  .euiDataGridRowCell__expandButton .euiDataGridRowCell__actionButtonIcon {
+  .euiDataGridRowCell .euiDataGridRowCell__expandActions .euiDataGridRowCell__actionButtonIcon {
     display: none;
 
     &:first-child,
     &:nth-child(2),
-    &:nth-child(3) {
+    &:nth-child(3),
+    &:nth-child(6) {
       display: inline-flex;
     }
 


### PR DESCRIPTION
## Summary

A recent upgrade to eui https://github.com/elastic/kibana/pull/125023 caused the css selector used by security solution to hide built in row cell hover actions https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/common/components/page/index.tsx#L38 to break, this pr updates the selector so that they are once again hidden. Can probably delete this code once https://github.com/elastic/eui/issues/5132 is implemented.

Before:
![image](https://user-images.githubusercontent.com/56408403/156089631-df2d81a7-88c6-4f8f-85af-c1be1f5d50f9.png)


After:
![image](https://user-images.githubusercontent.com/56408403/156089537-f6097e53-3c90-46b6-91a0-e42962cae533.png)






