### PR TITLE
Fix multi terms performance bottleneck

### DIFF
--- a/src/plugins/data/common/search/aggs/utils/get_aggs_formats.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/get_aggs_formats.test.ts
@@ -126,7 +126,7 @@ describe('getAggsFormats', () => {
     const mapping = {
       id: 'multi_terms',
       params: {
-        paramsPerField: Array(terms.length).fill({ id: 'terms' }),
+        paramsPerField: [{ id: 'terms' }, { id: 'terms' }, { id: 'terms' }],
       },
     };
 
@@ -141,7 +141,7 @@ describe('getAggsFormats', () => {
     const mapping = {
       id: 'multi_terms',
       params: {
-        paramsPerField: Array(terms.length).fill({ id: 'terms' }),
+        paramsPerField: [{ id: 'terms' }, { id: 'terms' }, { id: 'terms' }],
         separator: ' - ',
       },
     };

--- a/src/plugins/data/common/search/aggs/utils/get_aggs_formats.ts
+++ b/src/plugins/data/common/search/aggs/utils/get_aggs_formats.ts
@@ -12,6 +12,7 @@ import { i18n } from '@kbn/i18n';
 import {
   FieldFormat,
   FieldFormatInstanceType,
+  FieldFormatParams,
   FieldFormatsContentType,
   IFieldFormat,
   SerializedFieldFormat,
@@ -133,11 +134,20 @@ export function getAggsFormats(getFieldFormat: GetFieldFormat): FieldFormatInsta
       static id = 'multi_terms';
       static hidden = true;
 
+      private formatCache: Map<SerializedFieldFormat<FieldFormatParams>, FieldFormat> = new Map();
+
       convert = (val: unknown, type: FieldFormatsContentType) => {
         const params = this._params;
-        const formats = (params.paramsPerField as SerializedFieldFormat[]).map((fieldParams) =>
-          getFieldFormat({ id: fieldParams.id, params: fieldParams })
-        );
+        const formats = (params.paramsPerField as SerializedFieldFormat[]).map((fieldParams) => {
+          const isCached = this.formatCache.has(fieldParams);
+          const cachedFormat =
+            this.formatCache.get(fieldParams) ||
+            getFieldFormat({ id: fieldParams.id, params: fieldParams });
+          if (!isCached) {
+            this.formatCache.set(fieldParams, cachedFormat);
+          }
+          return cachedFormat;
+        });
 
         if (String(val) === '__other__') {
           return params.otherBucketLabel;

--- a/x-pack/plugins/lens/public/xy_visualization/color_assignment.ts
+++ b/x-pack/plugins/lens/public/xy_visualization/color_assignment.ts
@@ -67,7 +67,7 @@ export function getColorAssignments(
               data.tables[layer.layerId].rows.map((row) => {
                 let value = row[splitAccessor];
                 if (value && !isPrimitive(value)) {
-                  value = columnFormatter?.convert(value) || value;
+                  value = columnFormatter?.convert(value) ?? value;
                 } else {
                   value = String(value);
                 }

--- a/x-pack/plugins/lens/public/xy_visualization/color_assignment.ts
+++ b/x-pack/plugins/lens/public/xy_visualization/color_assignment.ts
@@ -59,6 +59,7 @@ export function getColorAssignments(
       }
       const splitAccessor = layer.splitAccessor;
       const column = data.tables[layer.layerId]?.columns.find(({ id }) => id === splitAccessor);
+      const columnFormatter = column && formatFactory(column.meta.params);
       const splits =
         !column || !data.tables[layer.layerId]
           ? []
@@ -66,7 +67,7 @@ export function getColorAssignments(
               data.tables[layer.layerId].rows.map((row) => {
                 let value = row[splitAccessor];
                 if (value && !isPrimitive(value)) {
-                  value = formatFactory(column.meta.params).convert(value);
+                  value = columnFormatter?.convert(value) || value;
                 } else {
                   value = String(value);
                 }


### PR DESCRIPTION
This PR drastically reduces the number of times new formatter instances as constructed, speeding up rendering of chart with lots of data points especially if they are using multi terms (because it would instantiate new formatter instances for each part of the key from scratch on each formatting).

Before:
<img width="1358" alt="Screenshot 2022-03-01 at 12 58 01" src="https://user-images.githubusercontent.com/1508364/156168539-e1f28e4a-aa5c-46fe-a1b1-63538bb3df6f.png">

After:
<img width="1361" alt="Screenshot 2022-03-01 at 13 20 20" src="https://user-images.githubusercontent.com/1508364/156168542-ba220067-6a58-43ef-a8e8-06320c93bcc5.png">

There are a few other things to improve but those are to most relevant ones.