### PR TITLE
[8.1] Resolve latest package version from bundled packages if possible (#126492)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -8,6 +8,7 @@
 import { URL } from 'url';
 
 import mime from 'mime-types';
+import semverGte from 'semver/functions/gte';
 
 import type { Response } from 'node-fetch';
 
@@ -74,7 +75,10 @@ async function _fetchFindLatestPackage(
   packageName: string,
   options?: FetchFindLatestPackageOptions
 ) {
+  const logger = appContextService.getLogger();
   const { ignoreConstraints = false } = options ?? {};
+
+  const bundledPackage = await getBundledPackageByName(packageName);
 
   const registryUrl = getRegistryUrl();
   const url = new URL(`${registryUrl}/search?package=${packageName}&experimental=true`);
@@ -83,55 +87,61 @@ async function _fetchFindLatestPackage(
     setKibanaVersion(url);
   }
 
-  const res = await fetchUrl(url.toString(), 1);
-  const searchResults: RegistryPackage[] = JSON.parse(res);
+  try {
+    const res = await fetchUrl(url.toString(), 1);
+    const searchResults: RegistryPackage[] = JSON.parse(res);
 
-  return searchResults;
+    const latestPackageFromRegistry = searchResults[0] ?? null;
+
+    if (bundledPackage && semverGte(bundledPackage.version, latestPackageFromRegistry.version)) {
+      return bundledPackage;
+    }
+
+    return latestPackageFromRegistry;
+  } catch (error) {
+    logger.error(
+      `Failed to fetch latest version of ${packageName} from registry: ${error.message}`
+    );
+
+    // Fall back to the bundled version of the package if it exists
+    if (bundledPackage) {
+      return bundledPackage;
+    }
+
+    // Otherwise, return null and allow callers to determine whether they'll consider this an error or not
+    return null;
+  }
 }
 
 export async function fetchFindLatestPackageOrThrow(
   packageName: string,
   options?: FetchFindLatestPackageOptions
 ) {
-  try {
-    const searchResults = await _fetchFindLatestPackage(packageName, options);
+  const latestPackage = await _fetchFindLatestPackage(packageName, options);
 
-    if (!searchResults.length) {
-      throw new PackageNotFoundError(`[${packageName}] package not found in registry`);
-    }
-
-    return searchResults[0];
-  } catch (error) {
-    const bundledPackage = await getBundledPackageByName(packageName);
-
-    if (!bundledPackage) {
-      throw error;
-    }
-
-    return bundledPackage;
+  if (!latestPackage) {
+    throw new PackageNotFoundError(`[${packageName}] package not found in registry`);
   }
+
+  return latestPackage;
 }
 
 export async function fetchFindLatestPackageOrUndefined(
   packageName: string,
   options?: FetchFindLatestPackageOptions
 ) {
+  const logger = appContextService.getLogger();
+
   try {
-    const searchResults = await _fetchFindLatestPackage(packageName, options);
+    const latestPackage = await _fetchFindLatestPackage(packageName, options);
 
-    if (!searchResults.length) {
+    if (!latestPackage) {
       return undefined;
     }
-
-    return searchResults[0];
+    return latestPackage;
   } catch (error) {
-    const bundledPackage = await getBundledPackageByName(packageName);
-
-    if (!bundledPackage) {
-      return undefined;
-    }
-
-    return bundledPackage;
+    logger.warn(`Error fetching latest package for ${packageName}: ${error.message}`);
+    return undefined;
   }
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [Resolve latest package version from bundled packages if possible (#126492)](https://github.com/elastic/kibana/pull/126492)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)