### PR TITLE
Fix types for graphql actions

### DIFF
--- a/.github/workflows/add-to-fleet-project.yml
+++ b/.github/workflows/add-to-fleet-project.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           headers: '{"GraphQL-Features": "projects_next_graphql"}'
           query: |
-            mutation add_to_project($projectid:String!,$contentid:String!) {
+            mutation add_to_project($projectid: ID!, $contentid: ID!) {
               addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
                 projectNextItem {
                   id

--- a/.github/workflows/label-qa-fixed-in.yml
+++ b/.github/workflows/label-qa-fixed-in.yml
@@ -76,12 +76,12 @@ jobs:
         id: add_labels_to_closed_issue
         with:
           query: |
-            mutation add_label($issueid:String!, $labelids:[String!]!) {
+            mutation add_label($issueid: ID!, $labelids:[ID!]!) {
               addLabelsToLabelable(input: {labelableId: $issueid, labelIds: $labelids}) {
                 clientMutationId
               }
             }
           issueid: ${{ matrix.issueNodeId }}
-          labelids: ${{ needs.fetch_issues_to_label.outputs.label_ids }}
+          labelids: ${{ fromJSON(needs.fetch_issues_to_label.outputs.label_ids) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Getting lots of `Type mismatch on variable $projectid and argument projectId (String! / ID!)` errors on these actions, [beginning yesterday](https://github.com/elastic/kibana/actions/workflows/add-to-fleet-project.yml?query=is%3Afailure). There was a deployment yesterday to the GraphQL API that may have impacted this, but the [changelog](https://docs.github.com/en/graphql/overview/changelog#schema-changes-for-2022-02-28) doesn't show any relevant changes. 🤔 

I verified this fixed the issue by running these queries manually.