### PR TITLE
[Fleet] Remove automation for old project board

### DIFF
--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -20,7 +20,6 @@ jobs:
               {"label": "Feature:Drilldowns", "projectNumber": 68, "columnName": "Inbox"},
               {"label": "Feature:Input Controls", "projectNumber": 72, "columnName": "Inbox"},
               {"label": "Team:Security", "projectNumber": 320, "columnName": "Awaiting triage", "projectScope": "org"},
-              {"label": "Team:Operations", "projectNumber": 314, "columnName": "Triage", "projectScope": "org"},
-              {"label": "Team:Fleet", "projectNumber": 490, "columnName": "Inbox", "projectScope": "org"}
+              {"label": "Team:Operations", "projectNumber": 314, "columnName": "Triage", "projectScope": "org"}
             ]
           ghToken: ${{ secrets.PROJECT_ASSIGNER_TOKEN }}


### PR DESCRIPTION
## Summary

We're no longer using this board and can remove it from the GH action