### PR TITLE
[APM] Remove beta badge for AWS lambda

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/service_icons/cloud_details.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/cloud_details.tsx
@@ -5,13 +5,7 @@
  * 2.0.
  */
 
-import {
-  EuiBadge,
-  EuiDescriptionList,
-  EuiBetaBadge,
-  EuiFlexGroup,
-  EuiFlexItem,
-} from '@elastic/eui';
+import { EuiBadge, EuiDescriptionList } from '@elastic/eui';
 import { EuiDescriptionListProps } from '@elastic/eui/src/components/description_list/description_list';
 import { i18n } from '@kbn/i18n';
 import React from 'react';

--- a/x-pack/plugins/apm/public/components/shared/service_icons/cloud_details.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/cloud_details.tsx
@@ -51,32 +51,7 @@ export function CloudDetails({ cloud, isServerless }: Props) {
           defaultMessage: 'Cloud service',
         }
       ),
-      description: (
-        <EuiFlexGroup alignItems="center" gutterSize="xs">
-          <EuiFlexItem grow={false}>{cloud.serviceName}</EuiFlexItem>
-          {isServerless && (
-            <EuiFlexItem grow={false}>
-              <EuiBetaBadge
-                label={i18n.translate(
-                  'xpack.apm.serviceIcons.serviceDetails.cloud.betaLabel',
-                  {
-                    defaultMessage: 'Beta',
-                  }
-                )}
-                tooltipContent={i18n.translate(
-                  'xpack.apm.serviceIcons.serviceDetails.cloud.betaTooltip',
-                  {
-                    defaultMessage:
-                      'AWS Lambda support is not GA. Please help us by reporting bugs.',
-                  }
-                )}
-                size="s"
-                iconType="beaker"
-              />
-            </EuiFlexItem>
-          )}
-        </EuiFlexGroup>
-      ),
+      description: cloud.serviceName,
     });
   }
 

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -7295,8 +7295,6 @@
     "xpack.apm.serviceIcons.serverless": "サーバーレス",
     "xpack.apm.serviceIcons.service": "サービス",
     "xpack.apm.serviceIcons.serviceDetails.cloud.availabilityZoneLabel": "{zones, plural, other {可用性ゾーン}} ",
-    "xpack.apm.serviceIcons.serviceDetails.cloud.betaLabel": "ベータ",
-    "xpack.apm.serviceIcons.serviceDetails.cloud.betaTooltip": "AWS Lambdaサポートは一般公開されていません。不具合を報告して支援してください。",
     "xpack.apm.serviceIcons.serviceDetails.cloud.faasTriggerTypeLabel": "{triggerTypes, plural, other  {トリガータイプ}} ",
     "xpack.apm.serviceIcons.serviceDetails.cloud.functionNameLabel": "{functionNames, plural, other  {関数名}} ",
     "xpack.apm.serviceIcons.serviceDetails.cloud.machineTypesLabel": "{machineTypes, plural, other {コンピュータータイプ} }\n ",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -7312,8 +7312,6 @@
     "xpack.apm.serviceIcons.serverless": "无服务器",
     "xpack.apm.serviceIcons.service": "服务",
     "xpack.apm.serviceIcons.serviceDetails.cloud.availabilityZoneLabel": "{zones, plural, other {可用性区域}} ",
-    "xpack.apm.serviceIcons.serviceDetails.cloud.betaLabel": "公测版",
-    "xpack.apm.serviceIcons.serviceDetails.cloud.betaTooltip": "AWS Lambda 支持不是 GA 版。请通过报告错误来帮助我们。",
     "xpack.apm.serviceIcons.serviceDetails.cloud.faasTriggerTypeLabel": "{triggerTypes, plural, other {触发类型}} ",
     "xpack.apm.serviceIcons.serviceDetails.cloud.functionNameLabel": "{functionNames, plural, other {功能名称}} ",
     "xpack.apm.serviceIcons.serviceDetails.cloud.machineTypesLabel": "{machineTypes, plural, other {机器类型}} ",


### PR DESCRIPTION
## Summary
Removes beta badge for AWS lambda in cloud service details popover. 

### Before
<img width="708" alt="Screenshot 2022-03-01 at 14 14 19" src="https://user-images.githubusercontent.com/5831975/156185605-38010635-f4af-4b52-a0ac-9bda592b6fbe.png">

### After
<img width="775" alt="Screenshot 2022-03-01 at 14 13 34" src="https://user-images.githubusercontent.com/5831975/156185613-bd0cc289-01ef-4ce0-a964-81217827d8db.png">

Closes https://github.com/elastic/kibana/issues/126440