### PR TITLE
[APM] Update APM local setup doc

### DIFF
--- a/x-pack/plugins/apm/dev_docs/local_setup.md
+++ b/x-pack/plugins/apm/dev_docs/local_setup.md
@@ -21,7 +21,7 @@ yarn es snapshot
 **Create APM mappings**
 
 ```
-node ./scripts/es_archiver load "x-pack/plugins/apm/ftr_e2e/cypress/fixtures/es_archiver/apm_mappings_only_8.0.0" --es-url=http://elastic:changeme@localhost:9200 --kibana-url=http://elastic:changeme@localhost:5601 --config=./test/functional/config.js
+node ./scripts/es_archiver load "x-pack/plugins/apm/ftr_e2e/cypress/fixtures/es_archiver/apm_mappings_only_8.0.0" --es-url=http://system_indices_superuser:changeme@localhost:9200 --kibana-url=http://elastic:changeme@localhost:5601 --config=./test/functional/config.js
 ```
 
 *Note: Elasticsearch must be available before running the above command*


### PR DESCRIPTION
## Summary
Update the command that creates APM mappings to use `system_indices_superuser` (introduced by https://github.com/elastic/kibana/pull/123337) as `superuser` role does not have write access to indices.