### PR TITLE
[Security Solution] Fix timeline newsfeed css

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/recent_timelines/recent_timelines.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/recent_timelines/recent_timelines.tsx
@@ -15,6 +15,7 @@ import {
 } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 
+import styled from 'styled-components';
 import { RecentTimelineHeader } from './header';
 import {
   OnOpenTimeline,
@@ -31,6 +32,15 @@ interface RecentTimelinesItemProps {
   onOpenTimeline: OnOpenTimeline;
   isLastItem: boolean;
 }
+
+const ClampText = styled.div`
+  /* Clamp text content to 3 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+`;
 
 const RecentTimelinesItem = React.memo<RecentTimelinesItemProps>(
   ({ timeline, onOpenTimeline, isLastItem }) => {
@@ -55,7 +65,7 @@ const RecentTimelinesItem = React.memo<RecentTimelinesItemProps>(
             <RecentTimelineCounts timeline={timeline} />
             {timeline.description && timeline.description.length && (
               <EuiText color="subdued" size="xs">
-                {timeline.description}
+                <ClampText>{timeline.description}</ClampText>
               </EuiText>
             )}
           </EuiFlexItem>


### PR DESCRIPTION
## Summary

Fixes a [bug](https://github.com/elastic/kibana/issues/126145) where the overview page layout breaks because of text overflow of timeline descriptions in the sidebar. Adds some CSS to prevent that.

Before:
![bad](https://user-images.githubusercontent.com/6935300/156230368-ebb08a6c-63eb-46ad-b079-568205749f59.png)

After:
![good](https://user-images.githubusercontent.com/6935300/156230371-57f9d649-c714-4f16-99b1-d7a13a8672fe.png)

