### PR TITLE
[8.1] Migrated Snapshot and Restore tests to use test user (#126011)

### DIFF
--- a/x-pack/test/functional/apps/snapshot_restore/home_page.ts
+++ b/x-pack/test/functional/apps/snapshot_restore/home_page.ts
@@ -12,9 +12,11 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const pageObjects = getPageObjects(['common', 'snapshotRestore']);
   const log = getService('log');
   const es = getService('es');
+  const security = getService('security');
 
   describe('Home page', function () {
     before(async () => {
+      await security.testUser.setRoles(['snapshot_restore_user'], false);
       await pageObjects.common.navigateToApp('snapshotRestore');
     });
 
@@ -46,9 +48,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
       it('cleanup repository', async () => {
         await pageObjects.snapshotRestore.viewRepositoryDetails('my-repository');
-        await pageObjects.common.sleep(25000);
         const cleanupResponse = await pageObjects.snapshotRestore.performRepositoryCleanup();
-        await pageObjects.common.sleep(25000);
         expect(cleanupResponse).to.contain('results');
         expect(cleanupResponse).to.contain('deleted_bytes');
         expect(cleanupResponse).to.contain('deleted_blobs');
@@ -57,6 +57,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await es.snapshot.deleteRepository({
           name: 'my-repository',
         });
+        await security.testUser.restoreDefaults();
       });
     });
   });

--- a/x-pack/test/functional/config.js
+++ b/x-pack/test/functional/config.js
@@ -551,6 +551,25 @@ export default async function ({ readConfigFile }) {
             },
           ],
         },
+        // https://www.elastic.co/guide/en/elasticsearch/reference/master/snapshots-register-repository.html#snapshot-repo-prereqs
+        snapshot_restore_user: {
+          elasticsearch: {
+            cluster: [
+              'monitor',
+              'manage_slm',
+              'cluster:admin/snapshot',
+              'cluster:admin/repository',
+            ],
+          },
+          kibana: [
+            {
+              feature: {
+                advancedSettings: ['read'],
+              },
+              spaces: ['*'],
+            },
+          ],
+        },
 
         ingest_pipelines_user: {
           elasticsearch: {

--- a/x-pack/test/functional/page_objects/snapshot_restore_page.ts
+++ b/x-pack/test/functional/page_objects/snapshot_restore_page.ts
@@ -49,12 +49,15 @@ export function SnapshotRestorePageProvider({ getService }: FtrProviderContext) 
         const repoToView = repos.filter((r) => (r.repoName = name))[0];
         await repoToView.repoLink.click();
       }
-      await retry.waitForWithTimeout(`Repo title should be ${name}`, 10000, async () => {
+      await retry.waitForWithTimeout(`Repo title should be ${name}`, 25000, async () => {
         return (await testSubjects.getVisibleText('title')) === name;
       });
     },
     async performRepositoryCleanup() {
       await testSubjects.click('cleanupRepositoryButton');
+      await retry.waitForWithTimeout(`wait for code block to be visible`, 25000, async () => {
+        return await testSubjects.isDisplayed('cleanupCodeBlock');
+      });
       return await testSubjects.getVisibleText('cleanupCodeBlock');
     },
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [Migrated Snapshot and Restore tests to use test user (#126011)](https://github.com/elastic/kibana/pull/126011)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)