### PR TITLE
Use 'label' rather than 'category' in docnav

### DIFF
--- a/nav-kibana-dev.docnav.json
+++ b/nav-kibana-dev.docnav.json
@@ -6,7 +6,7 @@
   "description": "Developer documentation for building custom Kibana plugins and extending Kibana functionality.",
   "items": [
     {
-      "category": "Getting started",
+      "label": "Getting started",
       "items": [
         { "id": "kibDevDocsWelcome" },
         { "id": "kibDevTutorialSetupDevEnv" },
@@ -16,7 +16,7 @@
       ]
     },
     {
-      "category": "Key concepts",
+      "label": "Key concepts",
       "items": [
         { "id": "kibPlatformIntro" },
         { "id": "kibDevAnatomyOfAPlugin" },
@@ -32,7 +32,7 @@
       ]
     },
     {
-      "category": "Tutorials",
+      "label": "Tutorials",
       "items": [
         { "id": "kibDevTutorialTestingPlugins" },
         { "id": "kibDevTutorialSavedObject" },
@@ -53,7 +53,7 @@
       ]
     },
     {
-      "category": "Contributing",
+      "label": "Contributing",
       "items": [
         { "id": "kibRepoStructure" },
         { "id": "kibDevPrinciples" },
@@ -65,7 +65,7 @@
       ]
     },
     {
-      "category": "Contributors Newsletters",
+      "label": "Contributors Newsletters",
       "items": [
         { "id": "kibFebruary2022ContributorNewsletter" },
         { "id": "kibJanuary2022ContributorNewsletter" },
@@ -82,7 +82,7 @@
       ]
     },
     {
-      "category": "API documentation",
+      "label": "API documentation",
       "items": [
         { "id": "kibDevDocsApiWelcome" },
         { "id": "kibDevDocsPluginDirectory" },


### PR DESCRIPTION
## Summary

This fixes a deprecation warning:
"DEPRECATION: `category` is a deprecated key for nav definitions. Please use `label` instead."

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
