### PR TITLE
[Legacy Input Controls] Remove Deprecated References

### DIFF
--- a/src/plugins/input_control_vis/public/components/editor/control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/control_editor.tsx
@@ -22,7 +22,7 @@ import {
 import { RangeControlEditor } from './range_control_editor';
 import { ListControlEditor } from './list_control_editor';
 import { getTitle, ControlParams, CONTROL_TYPES, ControlParamsOptions } from '../../editor_utils';
-import { IndexPattern } from '../../../../data/public';
+import { DataView } from '../../../../data_views/public';
 import { InputControlVisDependencies } from '../../plugin';
 
 import './control_editor.scss';
@@ -35,7 +35,7 @@ interface ControlEditorUiProps {
   handleRemoveControl: (controlIndex: number) => void;
   handleIndexPatternChange: (controlIndex: number, indexPatternId: string) => void;
   handleFieldNameChange: (controlIndex: number, fieldName: string) => void;
-  getIndexPattern: (indexPatternId: string) => Promise<IndexPattern>;
+  getIndexPattern: (indexPatternId: string) => Promise<DataView>;
   handleOptionsChange: <T extends keyof ControlParamsOptions>(
     controlIndex: number,
     optionName: T,

--- a/src/plugins/input_control_vis/public/components/editor/controls_tab.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/controls_tab.tsx
@@ -20,7 +20,7 @@ import {
 } from '@elastic/eui';
 
 import { VisEditorOptionsProps } from 'src/plugins/visualizations/public';
-import { IndexPattern } from 'src/plugins/data/public';
+import { DataView } from '../../../../data_views/public';
 import { ControlEditor } from './control_editor';
 import {
   addControl,
@@ -49,7 +49,7 @@ class ControlsTab extends PureComponent<ControlsTabProps, ControlsTabUiState> {
     type: CONTROL_TYPES.LIST,
   };
 
-  getIndexPattern = async (indexPatternId: string): Promise<IndexPattern> => {
+  getIndexPattern = async (indexPatternId: string): Promise<DataView> => {
     const [, startDeps] = await this.props.deps.core.getStartServices();
     return await startDeps.data.indexPatterns.get(indexPatternId);
   };

--- a/src/plugins/input_control_vis/public/components/editor/field_select.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/field_select.tsx
@@ -12,7 +12,7 @@ import React, { Component } from 'react';
 import { injectI18n, FormattedMessage, InjectedIntlProps } from '@kbn/i18n-react';
 import { EuiFormRow, EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
 
-import { IndexPattern, IndexPatternField } from '../../../../data/public';
+import { DataView, DataViewField } from '../../../../data_views/public';
 
 interface FieldSelectUiState {
   isLoading: boolean;
@@ -21,11 +21,11 @@ interface FieldSelectUiState {
 }
 
 export type FieldSelectUiProps = InjectedIntlProps & {
-  getIndexPattern: (indexPatternId: string) => Promise<IndexPattern>;
+  getIndexPattern: (indexPatternId: string) => Promise<DataView>;
   indexPatternId: string;
   onChange: (value: any) => void;
   fieldName?: string;
-  filterField?: (field: IndexPatternField) => boolean;
+  filterField?: (field: DataViewField) => boolean;
   controlIndex: number;
 };
 
@@ -74,7 +74,7 @@ class FieldSelectUi extends Component<FieldSelectUiProps, FieldSelectUiState> {
       return;
     }
 
-    let indexPattern: IndexPattern;
+    let indexPattern: DataView;
     try {
       indexPattern = await this.props.getIndexPattern(indexPatternId);
     } catch (err) {
@@ -96,7 +96,7 @@ class FieldSelectUi extends Component<FieldSelectUiProps, FieldSelectUiState> {
     const fields: Array<EuiComboBoxOptionOption<string>> = [];
     indexPattern.fields
       .filter(this.props.filterField ?? (() => true))
-      .forEach((field: IndexPatternField) => {
+      .forEach((field: DataViewField) => {
         const fieldsList = fieldsByTypeMap.get(field.type) ?? [];
         fieldsList.push(field.name);
         fieldsByTypeMap.set(field.type, fieldsList);

--- a/src/plugins/input_control_vis/public/components/editor/list_control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/list_control_editor.tsx
@@ -14,7 +14,8 @@ import { EuiFormRow, EuiFieldNumber, EuiSwitch, EuiSelect } from '@elastic/eui';
 import { IndexPatternSelectFormRow } from './index_pattern_select_form_row';
 import { FieldSelect } from './field_select';
 import { ControlParams, ControlParamsOptions } from '../../editor_utils';
-import { IndexPattern, IndexPatternField, IndexPatternSelectProps } from '../../../../data/public';
+import { IndexPatternSelectProps } from '../../../../data/public';
+import { DataView, DataViewField } from '../../../../data_views/public';
 import { InputControlVisDependencies } from '../../plugin';
 
 interface ListControlEditorState {
@@ -25,7 +26,7 @@ interface ListControlEditorState {
 }
 
 interface ListControlEditorProps {
-  getIndexPattern: (indexPatternId: string) => Promise<IndexPattern>;
+  getIndexPattern: (indexPatternId: string) => Promise<DataView>;
   controlIndex: number;
   controlParams: ControlParams;
   handleFieldNameChange: (fieldName: string) => void;
@@ -40,7 +41,7 @@ interface ListControlEditorProps {
   deps: InputControlVisDependencies;
 }
 
-function filterField(field: IndexPatternField) {
+function filterField(field: DataViewField) {
   return (
     Boolean(field.aggregatable) &&
     ['number', 'boolean', 'date', 'ip', 'string'].includes(field.type)
@@ -104,7 +105,7 @@ export class ListControlEditor extends PureComponent<
       return;
     }
 
-    let indexPattern: IndexPattern;
+    let indexPattern: DataView;
     try {
       indexPattern = await this.props.getIndexPattern(this.props.controlParams.indexPattern);
     } catch (err) {
@@ -116,7 +117,7 @@ export class ListControlEditor extends PureComponent<
       return;
     }
 
-    const field = (indexPattern.fields as IndexPatternField[]).find(
+    const field = (indexPattern.fields as DataViewField[]).find(
       ({ name }) => name === this.props.controlParams.fieldName
     );
     if (!field) {

--- a/src/plugins/input_control_vis/public/components/editor/range_control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/range_control_editor.tsx
@@ -14,13 +14,14 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { IndexPatternSelectFormRow } from './index_pattern_select_form_row';
 import { FieldSelect } from './field_select';
 import { ControlParams, ControlParamsOptions } from '../../editor_utils';
-import { IndexPattern, IndexPatternField, IndexPatternSelectProps } from '../../../../data/public';
+import { IndexPatternSelectProps } from '../../../../data/public';
+import { DataView, DataViewField } from '../../../../data_views/public';
 import { InputControlVisDependencies } from '../../plugin';
 
 interface RangeControlEditorProps {
   controlIndex: number;
   controlParams: ControlParams;
-  getIndexPattern: (indexPatternId: string) => Promise<IndexPattern>;
+  getIndexPattern: (indexPatternId: string) => Promise<DataView>;
   handleFieldNameChange: (fieldName: string) => void;
   handleIndexPatternChange: (indexPatternId: string) => void;
   handleOptionsChange: <T extends keyof ControlParamsOptions>(
@@ -35,7 +36,7 @@ interface RangeControlEditorState {
   IndexPatternSelect: ComponentType<IndexPatternSelectProps> | null;
 }
 
-function filterField(field: IndexPatternField) {
+function filterField(field: DataViewField) {
   return field.type === 'number';
 }
 

--- a/src/plugins/input_control_vis/public/control/control.ts
+++ b/src/plugins/input_control_vis/public/control/control.ts
@@ -9,7 +9,7 @@
 import _ from 'lodash';
 import { i18n } from '@kbn/i18n';
 
-import { Filter } from 'src/plugins/data/public';
+import { Filter } from '@kbn/es-query';
 import { ControlParams, ControlParamsOptions, CONTROL_TYPES } from '../editor_utils';
 import { RangeFilterManager } from './filter_manager/range_filter_manager';
 import { PhraseFilterManager } from './filter_manager/phrase_filter_manager';

--- a/src/plugins/input_control_vis/public/control/create_search_source.ts
+++ b/src/plugins/input_control_vis/public/control/create_search_source.ts
@@ -9,15 +9,16 @@
 import { Filter } from '@kbn/es-query';
 import {
   SerializedSearchSourceFields,
-  IndexPattern,
   TimefilterContract,
   DataPublicPluginStart,
 } from 'src/plugins/data/public';
 
+import { DataView } from '../../../data_views/public';
+
 export async function createSearchSource(
   { create }: DataPublicPluginStart['search']['searchSource'],
   initialState: SerializedSearchSourceFields | null,
-  indexPattern: IndexPattern,
+  indexPattern: DataView,
   aggs: any,
   useTimeFilter: boolean,
   filters: Filter[] = [],

--- a/src/plugins/input_control_vis/public/control/filter_manager/filter_manager.test.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/filter_manager.test.ts
@@ -10,11 +10,8 @@ import expect from '@kbn/expect';
 
 import { FilterManager } from './filter_manager';
 import { coreMock } from '../../../../../core/public/mocks';
-import {
-  Filter,
-  FilterManager as QueryFilterManager,
-  IndexPatternsContract,
-} from '../../../../data/public';
+import { FilterManager as QueryFilterManager, DataViewsContract } from '../../../../data/public';
+import { Filter } from '@kbn/es-query';
 
 const setupMock = coreMock.createSetup();
 
@@ -44,7 +41,7 @@ describe('FilterManager', function () {
         controlId,
         'field1',
         '1',
-        {} as IndexPatternsContract,
+        {} as DataViewsContract,
         queryFilterMock
       );
     });

--- a/src/plugins/input_control_vis/public/control/filter_manager/filter_manager.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/filter_manager.ts
@@ -6,23 +6,20 @@
  * Side Public License, v 1.
  */
 
+import { Filter } from '@kbn/es-query';
 import _ from 'lodash';
 
-import {
-  FilterManager as QueryFilterManager,
-  IndexPattern,
-  Filter,
-  IndexPatternsContract,
-} from '../../../../data/public';
+import { FilterManager as QueryFilterManager, DataViewsContract } from '../../../../data/public';
+import { DataView } from '../../../../data_views/public';
 
 export abstract class FilterManager {
-  protected indexPattern: IndexPattern | undefined;
+  protected indexPattern: DataView | undefined;
 
   constructor(
     public controlId: string,
     public fieldName: string,
     private indexPatternId: string,
-    private indexPatternsService: IndexPatternsContract,
+    private indexPatternsService: DataViewsContract,
     protected queryFilter: QueryFilterManager
   ) {}
 
@@ -48,7 +45,7 @@ export abstract class FilterManager {
     }
   }
 
-  getIndexPattern(): IndexPattern | undefined {
+  getIndexPattern(): DataView | undefined {
     return this.indexPattern;
   }
 

--- a/src/plugins/input_control_vis/public/control/filter_manager/phrase_filter_manager.test.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/phrase_filter_manager.test.ts
@@ -9,11 +9,8 @@
 import { Filter } from '@kbn/es-query';
 import expect from '@kbn/expect';
 
-import {
-  IndexPattern,
-  FilterManager as QueryFilterManager,
-  IndexPatternsContract,
-} from '../../../../data/public';
+import { FilterManager as QueryFilterManager, DataViewsContract } from '../../../../data/public';
+import { DataView } from '../../../../data_views/public';
 import { PhraseFilterManager } from './phrase_filter_manager';
 
 describe('PhraseFilterManager', function () {
@@ -27,7 +24,7 @@ describe('PhraseFilterManager', function () {
         convert: (value: any) => value,
       },
     };
-    const indexPatternMock: IndexPattern = {
+    const indexPatternMock: DataView = {
       id: indexPatternId,
       fields: {
         getByName: (name: string) => {
@@ -35,10 +32,10 @@ describe('PhraseFilterManager', function () {
           return fields[name];
         },
       },
-    } as IndexPattern;
+    } as DataView;
     const indexPatternsServiceMock = {
       get: jest.fn().mockReturnValue(Promise.resolve(indexPatternMock)),
-    } as unknown as jest.Mocked<IndexPatternsContract>;
+    } as unknown as jest.Mocked<DataViewsContract>;
     const queryFilterMock: QueryFilterManager = {} as QueryFilterManager;
     let filterManager: PhraseFilterManager;
     beforeEach(async () => {
@@ -89,7 +86,7 @@ describe('PhraseFilterManager', function () {
         id: string,
         fieldName: string,
         indexPatternId: string,
-        indexPatternsService: IndexPatternsContract,
+        indexPatternsService: DataViewsContract,
         queryFilter: QueryFilterManager
       ) {
         super(id, fieldName, indexPatternId, indexPatternsService, queryFilter);
@@ -105,7 +102,7 @@ describe('PhraseFilterManager', function () {
       }
     }
 
-    const indexPatternsServiceMock = {} as IndexPatternsContract;
+    const indexPatternsServiceMock = {} as DataViewsContract;
     const queryFilterMock: QueryFilterManager = {} as QueryFilterManager;
     let filterManager: MockFindFiltersPhraseFilterManager;
     beforeEach(() => {

--- a/src/plugins/input_control_vis/public/control/filter_manager/phrase_filter_manager.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/phrase_filter_manager.ts
@@ -18,17 +18,14 @@ import {
   PhraseFilter,
 } from '@kbn/es-query';
 import { FilterManager } from './filter_manager';
-import {
-  IndexPatternsContract,
-  FilterManager as QueryFilterManager,
-} from '../../../../data/public';
+import { DataViewsContract, FilterManager as QueryFilterManager } from '../../../../data/public';
 
 export class PhraseFilterManager extends FilterManager {
   constructor(
     controlId: string,
     fieldName: string,
     indexPatternId: string,
-    indexPatternsService: IndexPatternsContract,
+    indexPatternsService: DataViewsContract,
     queryFilter: QueryFilterManager
   ) {
     super(controlId, fieldName, indexPatternId, indexPatternsService, queryFilter);

--- a/src/plugins/input_control_vis/public/control/filter_manager/range_filter_manager.test.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/range_filter_manager.test.ts
@@ -9,11 +9,8 @@
 import expect from '@kbn/expect';
 
 import { RangeFilterManager } from './range_filter_manager';
-import {
-  IndexPattern,
-  FilterManager as QueryFilterManager,
-  IndexPatternsContract,
-} from '../../../../data/public';
+import { FilterManager as QueryFilterManager, DataViewsContract } from '../../../../data/public';
+import { DataView } from '../../../../data_views/public';
 import { RangeFilter, RangeFilterMeta } from '@kbn/es-query';
 
 describe('RangeFilterManager', function () {
@@ -24,7 +21,7 @@ describe('RangeFilterManager', function () {
     const fieldMock = {
       name: 'field1',
     };
-    const indexPatternMock: IndexPattern = {
+    const indexPatternMock: DataView = {
       id: indexPatternId,
       fields: {
         getByName: (name: any) => {
@@ -34,10 +31,10 @@ describe('RangeFilterManager', function () {
           return fields[name];
         },
       },
-    } as IndexPattern;
+    } as DataView;
     const indexPatternsServiceMock = {
       get: jest.fn().mockReturnValue(Promise.resolve(indexPatternMock)),
-    } as unknown as jest.Mocked<IndexPatternsContract>;
+    } as unknown as jest.Mocked<DataViewsContract>;
     const queryFilterMock: QueryFilterManager = {} as QueryFilterManager;
     let filterManager: RangeFilterManager;
     beforeEach(async () => {
@@ -70,7 +67,7 @@ describe('RangeFilterManager', function () {
         id: string,
         fieldName: string,
         indexPatternId: string,
-        indexPatternsService: IndexPatternsContract,
+        indexPatternsService: DataViewsContract,
         queryFilter: QueryFilterManager
       ) {
         super(id, fieldName, indexPatternId, indexPatternsService, queryFilter);
@@ -86,7 +83,7 @@ describe('RangeFilterManager', function () {
       }
     }
 
-    const indexPatternsServiceMock = {} as IndexPatternsContract;
+    const indexPatternsServiceMock = {} as DataViewsContract;
     const queryFilterMock: QueryFilterManager = {} as QueryFilterManager;
     let filterManager: MockFindFiltersRangeFilterManager;
     beforeEach(() => {

--- a/src/plugins/input_control_vis/public/control/list_control_factory.ts
+++ b/src/plugins/input_control_vis/public/control/list_control_factory.ts
@@ -9,11 +9,11 @@
 import _ from 'lodash';
 import { i18n } from '@kbn/i18n';
 import {
-  IndexPatternField,
   TimefilterContract,
   SerializedSearchSourceFields,
   DataPublicPluginStart,
 } from 'src/plugins/data/public';
+import { DataViewField } from '../../../data_views/public';
 import { Control, noValuesDisableMsg, noIndexPatternMsg } from './control';
 import { PhraseFilterManager } from './filter_manager/phrase_filter_manager';
 import { createSearchSource } from './create_search_source';
@@ -26,7 +26,7 @@ function getEscapedQuery(query = '') {
 }
 
 interface TermsAggArgs {
-  field?: IndexPatternField;
+  field?: DataViewField;
   size: number | null;
   direction: string;
   query?: string;

--- a/src/plugins/input_control_vis/public/control/range_control_factory.ts
+++ b/src/plugins/input_control_vis/public/control/range_control_factory.ts
@@ -9,18 +9,15 @@
 import _ from 'lodash';
 import { i18n } from '@kbn/i18n';
 
-import {
-  IndexPatternField,
-  TimefilterContract,
-  DataPublicPluginStart,
-} from 'src/plugins/data/public';
+import { TimefilterContract, DataPublicPluginStart } from 'src/plugins/data/public';
+import { DataViewField } from '../../../data_views/public';
 import { Control, noValuesDisableMsg, noIndexPatternMsg } from './control';
 import { RangeFilterManager } from './filter_manager/range_filter_manager';
 import { createSearchSource } from './create_search_source';
 import { ControlParams } from '../editor_utils';
 import { InputControlVisDependencies } from '../plugin';
 
-const minMaxAgg = (field?: IndexPatternField) => {
+const minMaxAgg = (field?: DataViewField) => {
   const aggBody: any = {};
   if (field) {
     if (field.scripted) {

--- a/src/plugins/input_control_vis/public/test_utils/get_index_pattern_mock.ts
+++ b/src/plugins/input_control_vis/public/test_utils/get_index_pattern_mock.ts
@@ -6,12 +6,12 @@
  * Side Public License, v 1.
  */
 
-import { IndexPattern } from 'src/plugins/data/public';
+import { DataView } from 'src/plugins/data_views/public';
 
 /**
  * Returns forced **Partial** IndexPattern for use in tests
  */
-export const getIndexPatternMock = (): Promise<IndexPattern> => {
+export const getIndexPatternMock = (): Promise<DataView> => {
   return Promise.resolve({
     id: 'mockIndexPattern',
     title: 'mockIndexPattern',
@@ -20,5 +20,5 @@ export const getIndexPatternMock = (): Promise<IndexPattern> => {
       { name: 'textField', type: 'string', aggregatable: false },
       { name: 'numberField', type: 'number', aggregatable: true },
     ],
-  } as IndexPattern);
+  } as DataView);
 };

--- a/src/plugins/input_control_vis/public/vis_controller.tsx
+++ b/src/plugins/input_control_vis/public/vis_controller.tsx
@@ -13,8 +13,9 @@ import { Subscription } from 'rxjs';
 
 import { I18nStart } from 'kibana/public';
 import { IInterpreterRenderHandlers } from 'src/plugins/expressions';
+import { Filter } from '@kbn/es-query';
 import { VisualizationContainer } from '../../visualizations/public';
-import { FilterManager, Filter } from '../../data/public';
+import { FilterManager } from '../../data/public';
 
 import { InputControlVis } from './components/vis/input_control_vis';
 import { getControlFactory } from './control/control_factory';

--- a/src/plugins/input_control_vis/tsconfig.json
+++ b/src/plugins/input_control_vis/tsconfig.json
@@ -13,6 +13,7 @@
   "references": [
     { "path": "../kibana_react/tsconfig.json" },
     { "path": "../data/tsconfig.json"},
+    { "path": "../data_views/tsconfig.json"},
     { "path": "../expressions/tsconfig.json" },
     { "path": "../visualizations/tsconfig.json" },
     { "path": "../vis_default_editor/tsconfig.json" },


### PR DESCRIPTION
## Summary
Removes deprecated references from the input_controls_vis plugin as part of https://github.com/elastic/kibana/issues/126509


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
