### PR TITLE
[ResponseOps] Adds `uiSettingsClient` to alerting framework services

### DIFF
--- a/x-pack/plugins/alerting/server/mocks.ts
+++ b/x-pack/plugins/alerting/server/mocks.ts
@@ -11,6 +11,7 @@ import { Alert, AlertFactoryDoneUtils } from './alert';
 import {
   elasticsearchServiceMock,
   savedObjectsClientMock,
+  uiSettingsServiceMock,
 } from '../../../../src/core/server/mocks';
 import { AlertInstanceContext, AlertInstanceState } from './types';
 
@@ -105,6 +106,7 @@ const createAlertServicesMock = <
       done: jest.fn().mockReturnValue(alertFactoryMockDone),
     },
     savedObjectsClient: savedObjectsClientMock.create(),
+    uiSettingsClient: uiSettingsServiceMock.createClient(),
     scopedClusterClient: elasticsearchServiceMock.createScopedClusterClient(),
     shouldWriteAlerts: () => true,
     shouldStopExecution: () => true,

--- a/x-pack/plugins/alerting/server/plugin.ts
+++ b/x-pack/plugins/alerting/server/plugin.ts
@@ -384,6 +384,7 @@ export class AlertingPlugin {
     taskRunnerFactory.initialize({
       logger,
       savedObjects: core.savedObjects,
+      uiSettings: core.uiSettings,
       elasticsearch: core.elasticsearch,
       getRulesClientWithRequest,
       spaceIdToNamespace,

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
@@ -30,6 +30,7 @@ import {
   executionContextServiceMock,
   savedObjectsServiceMock,
   elasticsearchServiceMock,
+  uiSettingsServiceMock,
 } from '../../../../../src/core/server/mocks';
 import { PluginStartContract as ActionsPluginStart } from '../../../actions/server';
 import { actionsMock, actionsClientMock } from '../../../actions/server/mocks';
@@ -95,6 +96,7 @@ describe('Task Runner', () => {
   const ruleTypeRegistry = ruleTypeRegistryMock.create();
   const savedObjectsService = savedObjectsServiceMock.createInternalStartContract();
   const elasticsearchService = elasticsearchServiceMock.createInternalStart();
+  const uiSettingsService = uiSettingsServiceMock.createStartContract();
 
   type TaskRunnerFactoryInitializerParamsType = jest.Mocked<TaskRunnerContext> & {
     actionsPlugin: jest.Mocked<ActionsPluginStart>;
@@ -106,6 +108,7 @@ describe('Task Runner', () => {
 
   const taskRunnerFactoryInitializerParams: TaskRunnerFactoryInitializerParamsType = {
     savedObjects: savedObjectsService,
+    uiSettings: uiSettingsService,
     elasticsearch: elasticsearchService,
     actionsPlugin: actionsMock.createStart(),
     getRulesClientWithRequest: jest.fn().mockReturnValue(rulesClient),

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -352,14 +352,17 @@ export class TaskRunner<
         }] namespace`,
       };
 
+      const savedObjectsClient = this.context.savedObjects.getScopedClient(fakeRequest, {
+        includedHiddenTypes: ['alert', 'action'],
+      });
+
       updatedRuleTypeState = await this.context.executionContext.withContext(ctx, () =>
         this.ruleType.executor({
           alertId: ruleId,
           executionId: this.executionId,
           services: {
-            savedObjectsClient: this.context.savedObjects.getScopedClient(fakeRequest, {
-              includedHiddenTypes: ['alert', 'action'],
-            }),
+            savedObjectsClient,
+            uiSettingsClient: this.context.uiSettings.asScopedToClient(savedObjectsClient),
             scopedClusterClient: wrappedScopedClusterClient.client(),
             alertFactory: createAlertFactory<
               InstanceState,

--- a/x-pack/plugins/alerting/server/task_runner/task_runner_cancel.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner_cancel.test.ts
@@ -25,6 +25,7 @@ import {
   executionContextServiceMock,
   savedObjectsServiceMock,
   elasticsearchServiceMock,
+  uiSettingsServiceMock,
 } from '../../../../../src/core/server/mocks';
 import { PluginStartContract as ActionsPluginStart } from '../../../actions/server';
 import { actionsMock, actionsClientMock } from '../../../actions/server/mocks';
@@ -94,6 +95,7 @@ describe('Task Runner Cancel', () => {
   const ruleTypeRegistry = ruleTypeRegistryMock.create();
   const savedObjectsService = savedObjectsServiceMock.createInternalStartContract();
   const elasticsearchService = elasticsearchServiceMock.createInternalStart();
+  const uiSettingsService = uiSettingsServiceMock.createStartContract();
 
   type TaskRunnerFactoryInitializerParamsType = jest.Mocked<TaskRunnerContext> & {
     actionsPlugin: jest.Mocked<ActionsPluginStart>;
@@ -103,6 +105,7 @@ describe('Task Runner Cancel', () => {
 
   const taskRunnerFactoryInitializerParams: TaskRunnerFactoryInitializerParamsType = {
     savedObjects: savedObjectsService,
+    uiSettings: uiSettingsService,
     elasticsearch: elasticsearchService,
     actionsPlugin: actionsMock.createStart(),
     getRulesClientWithRequest: jest.fn().mockReturnValue(rulesClient),

--- a/x-pack/plugins/alerting/server/task_runner/task_runner_factory.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner_factory.test.ts
@@ -16,6 +16,7 @@ import {
   httpServiceMock,
   savedObjectsServiceMock,
   elasticsearchServiceMock,
+  uiSettingsServiceMock,
 } from '../../../../../src/core/server/mocks';
 import { actionsMock } from '../../../actions/server/mocks';
 import { rulesClientMock } from '../mocks';
@@ -28,6 +29,7 @@ const executionContext = executionContextServiceMock.createSetupContract();
 const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
 const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
 const savedObjectsService = savedObjectsServiceMock.createInternalStartContract();
+const uiSettingsService = uiSettingsServiceMock.createStartContract();
 const elasticsearchService = elasticsearchServiceMock.createInternalStart();
 const ruleType: UntypedNormalizedRuleType = {
   id: 'test',
@@ -77,6 +79,7 @@ describe('Task Runner Factory', () => {
 
   const taskRunnerFactoryInitializerParams: jest.Mocked<TaskRunnerContext> = {
     savedObjects: savedObjectsService,
+    uiSettings: uiSettingsService,
     elasticsearch: elasticsearchService,
     getRulesClientWithRequest: jest.fn().mockReturnValue(rulesClient),
     actionsPlugin: actionsMock.createStart(),

--- a/x-pack/plugins/alerting/server/task_runner/task_runner_factory.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner_factory.ts
@@ -15,6 +15,7 @@ import type {
   ExecutionContextStart,
   SavedObjectsServiceStart,
   ElasticsearchServiceStart,
+  UiSettingsServiceStart,
 } from '../../../../../src/core/server';
 import { RunContext } from '../../../task_manager/server';
 import { EncryptedSavedObjectsClient } from '../../../encrypted_saved_objects/server';
@@ -35,6 +36,7 @@ import { NormalizedRuleType } from '../rule_type_registry';
 export interface TaskRunnerContext {
   logger: Logger;
   savedObjects: SavedObjectsServiceStart;
+  uiSettings: UiSettingsServiceStart;
   elasticsearch: ElasticsearchServiceStart;
   getRulesClientWithRequest(request: KibanaRequest): PublicMethodsOf<RulesClient>;
   actionsPlugin: ActionsPluginStartContract;

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -11,6 +11,7 @@ import type {
   RequestHandlerContext,
   SavedObjectReference,
   ElasticsearchClient,
+  IUiSettingsClient,
 } from 'src/core/server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import { AlertFactoryDoneUtils, PublicAlert } from './alert';
@@ -78,6 +79,7 @@ export interface AlertServices<
   ActionGroupIds extends string = never
 > {
   savedObjectsClient: SavedObjectsClientContract;
+  uiSettingsClient: IUiSettingsClient;
   scopedClusterClient: IScopedClusterClient;
   alertFactory: {
     create: (id: string) => PublicAlert<InstanceState, InstanceContext, ActionGroupIds>;

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
@@ -112,6 +112,7 @@ function createRule(shouldWriteAlerts: boolean = true) {
         services: {
           alertFactory,
           savedObjectsClient: {} as any,
+          uiSettingsClient: {} as any,
           scopedClusterClient: {} as any,
           shouldWriteAlerts: () => shouldWriteAlerts,
           shouldStopExecution: () => false,

--- a/x-pack/plugins/rule_registry/server/utils/rule_executor_test_utils.ts
+++ b/x-pack/plugins/rule_registry/server/utils/rule_executor_test_utils.ts
@@ -7,6 +7,7 @@
 import {
   elasticsearchServiceMock,
   savedObjectsClientMock,
+  uiSettingsServiceMock,
 } from '../../../../../src/core/server/mocks';
 import {
   AlertExecutorOptions,
@@ -69,6 +70,7 @@ export const createDefaultAlertExecutorOptions = <
   services: {
     alertFactory: alertsMock.createAlertServices<InstanceState, InstanceContext>().alertFactory,
     savedObjectsClient: savedObjectsClientMock.create(),
+    uiSettingsClient: uiSettingsServiceMock.createClient(),
     scopedClusterClient: elasticsearchServiceMock.createScopedClusterClient(),
     shouldWriteAlerts: () => shouldWriteAlerts,
     shouldStopExecution: () => false,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
@@ -195,6 +195,7 @@ export const previewRulesRoute = async (
                 }),
                 savedObjectsClient: context.core.savedObjects.client,
                 scopedClusterClient: context.core.elasticsearch.client,
+                uiSettingsClient: context.core.uiSettings.client,
               },
               spaceId,
               startedAt: startedAt.toDate(),


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/64588 and brought up in this (much more recent) [PR comment](https://github.com/elastic/kibana/pull/124459#discussion_r803364097)

Some of the plugins that use the alerting framework plugin (such as the security solution) require access to kibana's ui advanced settings on the backend. Previously this had been achieved by using the uiSettings config off the `savedObjectsClient` directly but as stated in the [above comment](https://github.com/elastic/kibana/pull/124459#discussion_r803364097), this is not a best practice approach as the location/format of the config is subject to change.

This PR adds the `uiSettingsClient` from the kibana `core` start service and passes it down through to the alerting framework services which then allows it to be consumed and utilized by dependent features such as the security solution rule executors.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
