### PR TITLE
[7.17] [ML] Anomaly Detection: Update annotation directly using the index it is stored in. (#126573)

### DIFF
--- a/x-pack/plugins/ml/common/types/annotations.ts
+++ b/x-pack/plugins/ml/common/types/annotations.ts
@@ -6,10 +6,10 @@
  */
 
 // The Annotation interface is based on annotation documents stored in the
-// `.ml-annotations-6` index, accessed via the `.ml-annotations-[read|write]` aliases.
+// `.ml-annotations-*` index, accessed via the `.ml-annotations-[read|write]` aliases.
 
 // Annotation document mapping:
-// PUT .ml-annotations-6
+// PUT .ml-annotations-000001
 // {
 //   "mappings": {
 //     "annotation": {
@@ -54,8 +54,8 @@
 // POST /_aliases
 // {
 //     "actions" : [
-//         { "add" : { "index" : ".ml-annotations-6", "alias" : ".ml-annotations-read" } },
-//         { "add" : { "index" : ".ml-annotations-6", "alias" : ".ml-annotations-write" } }
+//         { "add" : { "index" : ".ml-annotations-000001", "alias" : ".ml-annotations-read" } },
+//         { "add" : { "index" : ".ml-annotations-000001", "alias" : ".ml-annotations-write" } }
 //     ]
 // }
 

--- a/x-pack/plugins/ml/server/models/annotation_service/__mocks__/get_annotations_response.json
+++ b/x-pack/plugins/ml/server/models/annotation_service/__mocks__/get_annotations_response.json
@@ -15,8 +15,7 @@
     "max_score": 0,
     "hits": [
       {
-        "_index": ".ml-annotations-6",
-        "_type": "doc",
+        "_index": ".ml-annotations-000001",
         "_id": "T-CNvmgBQUJYQVn7TCPA",
         "_score": 0,
         "_source": {
@@ -32,8 +31,7 @@
         }
       },
       {
-        "_index": ".ml-annotations-6",
-        "_type": "doc",
+        "_index": ".ml-annotations-000001",
         "_id": "3lVpvmgB5xYzd3PM-MSe",
         "_score": 0,
         "_source": {

--- a/x-pack/plugins/ml/server/models/annotation_service/annotation.test.ts
+++ b/x-pack/plugins/ml/server/models/annotation_service/annotation.test.ts
@@ -41,7 +41,7 @@ describe('annotation_service', () => {
 
       const annotationMockId = 'mockId';
       const deleteParamsMock: DeleteParams = {
-        index: '.ml-annotations-6',
+        index: '.ml-annotations-000001',
         id: annotationMockId,
         refresh: 'wait_for',
       };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ML] Anomaly Detection: Update annotation directly using the index it is stored in. (#126573)](https://github.com/elastic/kibana/pull/126573)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)