### PR TITLE
[Fleet] Enable per policy outputs

### DIFF
--- a/x-pack/plugins/fleet/common/constants/output.ts
+++ b/x-pack/plugins/fleet/common/constants/output.ts
@@ -23,3 +23,5 @@ export const DEFAULT_OUTPUT: NewOutput = {
   type: outputType.Elasticsearch,
   hosts: [''],
 };
+
+export const LICENCE_FOR_PER_POLICY_OUTPUT = 'platinum';

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3825,6 +3825,14 @@
                 "logs"
               ]
             }
+          },
+          "data_output_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "monitoring_output_id": {
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [
@@ -3979,6 +3987,12 @@
                 "format": "date-time"
               },
               "updated_by": {
+                "type": "string"
+              },
+              "data_output_id": {
+                "type": "string"
+              },
+              "monitoring_output_id": {
                 "type": "string"
               },
               "revision": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2402,6 +2402,12 @@ components:
             enum:
               - metrics
               - logs
+        data_output_id:
+          type: string
+          nullable: true
+        monitoring_output_id:
+          type: string
+          nullable: true
       required:
         - name
         - namespace
@@ -2500,6 +2506,10 @@ components:
               type: string
               format: date-time
             updated_by:
+              type: string
+            data_output_id:
+              type: string
+            monitoring_output_id:
               type: string
             revision:
               type: number

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
@@ -22,6 +22,10 @@ allOf:
         format: date-time
       updated_by:
         type: string
+      data_output_id:
+        type: string
+      monitoring_output_id:
+        type: string
       revision:
         type: number
       agents:

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/new_agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/new_agent_policy.yaml
@@ -16,6 +16,12 @@ properties:
       enum:
         - metrics
         - logs
+  data_output_id:
+    type: string
+    nullable: true
+  monitoring_output_id:
+    type: string
+    nullable: true
 required:
   - name
   - namespace

--- a/x-pack/plugins/fleet/common/services/license.ts
+++ b/x-pack/plugins/fleet/common/services/license.ts
@@ -40,25 +40,10 @@ export class LicenseService {
   }
 
   public isGoldPlus() {
-    return (
-      this.licenseInformation?.isAvailable &&
-      this.licenseInformation?.isActive &&
-      this.licenseInformation?.hasAtLeast('gold')
-    );
+    return this.hasAtLeast('gold');
   }
   public isEnterprise() {
-    return (
-      this.licenseInformation?.isAvailable &&
-      this.licenseInformation?.isActive &&
-      this.licenseInformation?.hasAtLeast('enterprise')
-    );
-  }
-  public isPlatinium() {
-    return (
-      this.licenseInformation?.isAvailable &&
-      this.licenseInformation?.isActive &&
-      this.licenseInformation?.hasAtLeast('platinum')
-    );
+    return this.hasAtLeast('enterprise');
   }
   public hasAtLeast(licenseType: LicenseType) {
     return (

--- a/x-pack/plugins/fleet/common/services/license.ts
+++ b/x-pack/plugins/fleet/common/services/license.ts
@@ -53,6 +53,13 @@ export class LicenseService {
       this.licenseInformation?.hasAtLeast('enterprise')
     );
   }
+  public isPlatinium() {
+    return (
+      this.licenseInformation?.isAvailable &&
+      this.licenseInformation?.isActive &&
+      this.licenseInformation?.hasAtLeast('platinum')
+    );
+  }
   public hasAtLeast(licenseType: LicenseType) {
     return (
       this.licenseInformation?.isAvailable &&

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -25,6 +25,7 @@ export interface NewAgentPolicy {
   monitoring_enabled?: MonitoringType;
   unenroll_timeout?: number;
   is_preconfigured?: boolean;
+  // Nullable to allow user to reset to default outputs
   data_output_id?: string | null;
   monitoring_output_id?: string | null;
 }

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -25,8 +25,8 @@ export interface NewAgentPolicy {
   monitoring_enabled?: MonitoringType;
   unenroll_timeout?: number;
   is_preconfigured?: boolean;
-  data_output_id?: string;
-  monitoring_output_id?: string;
+  data_output_id?: string | null;
+  monitoring_output_id?: string | null;
 }
 
 export interface AgentPolicy extends Omit<NewAgentPolicy, 'id'> {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.test.tsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createFleetTestRendererMock } from '../../../../../../mock';
+import type { MockedFleetStartServices } from '../../../../../../mock';
+import { useLicense } from '../../../../../../hooks/use_license';
+import type { LicenseService } from '../../../../services';
+
+import { useOutputOptions } from './hooks';
+
+jest.mock('../../../../../../hooks/use_license');
+
+const mockedUseLicence = useLicense as jest.MockedFunction<typeof useLicense>;
+
+function defaultHttpClientGetImplementation(path: any) {
+  if (typeof path !== 'string') {
+    throw new Error('Invalid request');
+  }
+  const err = new Error(`API [GET ${path}] is not MOCKED!`);
+  // eslint-disable-next-line no-console
+  console.log(err);
+  throw err;
+}
+
+const mockApiCallsWithOutputs = (http: MockedFleetStartServices['http']) => {
+  http.get.mockImplementation(async (path) => {
+    if (typeof path !== 'string') {
+      throw new Error('Invalid request');
+    }
+    if (path === '/api/fleet/outputs') {
+      return {
+        data: {
+          items: [
+            {
+              id: 'output1',
+              name: 'Output 1',
+              is_default: true,
+              is_default_monitoring: true,
+            },
+            {
+              id: 'output2',
+              name: 'Output 2',
+              is_default: true,
+              is_default_monitoring: true,
+            },
+            {
+              id: 'output3',
+              name: 'Output 3',
+              is_default: true,
+              is_default_monitoring: true,
+            },
+          ],
+        },
+      };
+    }
+
+    return defaultHttpClientGetImplementation(path);
+  });
+};
+
+describe('useOutputOptions', () => {
+  it('should generate enabled options if the licence is platinium', async () => {
+    const testRenderer = createFleetTestRendererMock();
+    mockedUseLicence.mockReturnValue({
+      isPlatinium: () => true,
+    } as unknown as LicenseService);
+    mockApiCallsWithOutputs(testRenderer.startServices.http);
+    const { result, waitForNextUpdate } = testRenderer.renderHook(() => useOutputOptions());
+    expect(result.current.isLoading).toBeTruthy();
+
+    await waitForNextUpdate();
+    expect(result.current.dataOutputOptions).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "inputDisplay": "Default (currently Output 1)",
+          "value": "@@##DEFAULT_OUTPUT_VALUE##@@",
+        },
+        Object {
+          "disabled": false,
+          "inputDisplay": "Output 1",
+          "value": "output1",
+        },
+        Object {
+          "disabled": false,
+          "inputDisplay": "Output 2",
+          "value": "output2",
+        },
+        Object {
+          "disabled": false,
+          "inputDisplay": "Output 3",
+          "value": "output3",
+        },
+      ]
+    `);
+    expect(result.current.monitoringOutputOptions).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "inputDisplay": "Default (currently Output 1)",
+          "value": "@@##DEFAULT_OUTPUT_VALUE##@@",
+        },
+        Object {
+          "disabled": false,
+          "inputDisplay": "Output 1",
+          "value": "output1",
+        },
+        Object {
+          "disabled": false,
+          "inputDisplay": "Output 2",
+          "value": "output2",
+        },
+        Object {
+          "disabled": false,
+          "inputDisplay": "Output 3",
+          "value": "output3",
+        },
+      ]
+    `);
+  });
+
+  it('should only enable the default options if the licence is not platinium', async () => {
+    const testRenderer = createFleetTestRendererMock();
+    mockedUseLicence.mockReturnValue({
+      isPlatinium: () => false,
+    } as unknown as LicenseService);
+    mockApiCallsWithOutputs(testRenderer.startServices.http);
+    const { result, waitForNextUpdate } = testRenderer.renderHook(() => useOutputOptions());
+    expect(result.current.isLoading).toBeTruthy();
+
+    await waitForNextUpdate();
+    expect(result.current.dataOutputOptions).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "inputDisplay": "Default (currently Output 1)",
+          "value": "@@##DEFAULT_OUTPUT_VALUE##@@",
+        },
+        Object {
+          "disabled": true,
+          "inputDisplay": "Output 1",
+          "value": "output1",
+        },
+        Object {
+          "disabled": true,
+          "inputDisplay": "Output 2",
+          "value": "output2",
+        },
+        Object {
+          "disabled": true,
+          "inputDisplay": "Output 3",
+          "value": "output3",
+        },
+      ]
+    `);
+    expect(result.current.monitoringOutputOptions).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "inputDisplay": "Default (currently Output 1)",
+          "value": "@@##DEFAULT_OUTPUT_VALUE##@@",
+        },
+        Object {
+          "disabled": true,
+          "inputDisplay": "Output 1",
+          "value": "output1",
+        },
+        Object {
+          "disabled": true,
+          "inputDisplay": "Output 2",
+          "value": "output2",
+        },
+        Object {
+          "disabled": true,
+          "inputDisplay": "Output 3",
+          "value": "output3",
+        },
+      ]
+    `);
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.test.tsx
@@ -66,7 +66,7 @@ describe('useOutputOptions', () => {
   it('should generate enabled options if the licence is platinium', async () => {
     const testRenderer = createFleetTestRendererMock();
     mockedUseLicence.mockReturnValue({
-      isPlatinium: () => true,
+      hasAtLeast: () => true,
     } as unknown as LicenseService);
     mockApiCallsWithOutputs(testRenderer.startServices.http);
     const { result, waitForNextUpdate } = testRenderer.renderHook(() => useOutputOptions());
@@ -124,7 +124,7 @@ describe('useOutputOptions', () => {
   it('should only enable the default options if the licence is not platinium', async () => {
     const testRenderer = createFleetTestRendererMock();
     mockedUseLicence.mockReturnValue({
-      isPlatinium: () => false,
+      hasAtLeast: () => false,
     } as unknown as LicenseService);
     mockApiCallsWithOutputs(testRenderer.startServices.http);
     const { result, waitForNextUpdate } = testRenderer.renderHook(() => useOutputOptions());

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { EuiSuperSelectOption } from '@elastic/eui';
+
+import { useGetOutputs, useLicense } from '../../../../hooks';
+
+export const DEFAULT_OUTPUT_VALUE = '@@##DEFAULT_OUTPUT_VALUE##@@';
+
+export function useOutputOptions() {
+  const outputsRequest = useGetOutputs();
+  const { isPlatinium: isPlatiniumFn } = useLicense();
+
+  const isPlatinium = useMemo(() => isPlatiniumFn(), [isPlatiniumFn]);
+
+  const outputOptions: Array<EuiSuperSelectOption<string>> = useMemo(() => {
+    if (outputsRequest.isLoading || !outputsRequest.data) {
+      return [];
+    }
+
+    return outputsRequest.data.items.map((item) => ({
+      value: item.id,
+      inputDisplay: item.name,
+      disabled: !isPlatinium,
+    }));
+  }, [outputsRequest, isPlatinium]);
+
+  const dataOutputOptions = useMemo(() => {
+    if (outputsRequest.isLoading || !outputsRequest.data) {
+      return [];
+    }
+
+    const defaultOutputName = outputsRequest.data.items.find((item) => item.is_default)?.name;
+    return [
+      { inputDisplay: `Default (currently ${defaultOutputName})`, value: DEFAULT_OUTPUT_VALUE },
+      ...outputOptions,
+    ]; // TODO translations
+  }, [outputsRequest, outputOptions]);
+
+  const monitoringOutputOptions = useMemo(() => {
+    if (outputsRequest.isLoading || !outputsRequest.data) {
+      return [];
+    }
+
+    const defaultOutputName = outputsRequest.data.items.find(
+      (item) => item.is_default_monitoring
+    )?.name;
+    return [
+      { inputDisplay: `Default (currently ${defaultOutputName})`, value: DEFAULT_OUTPUT_VALUE },
+      ...outputOptions,
+    ]; // TODO translations
+  }, [outputsRequest, outputOptions]);
+
+  return useMemo(
+    () => ({
+      dataOutputOptions,
+      monitoringOutputOptions,
+      isLoading: outputsRequest.isLoading,
+    }),
+    [dataOutputOptions, monitoringOutputOptions, outputsRequest.isLoading]
+  );
+}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
@@ -6,11 +6,23 @@
  */
 
 import { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
 import type { EuiSuperSelectOption } from '@elastic/eui';
 
 import { useGetOutputs, useLicense } from '../../../../hooks';
 
+// The super select component do not support null or '' as a value
 export const DEFAULT_OUTPUT_VALUE = '@@##DEFAULT_OUTPUT_VALUE##@@';
+
+function getDefaultOutput(defaultOutputName?: string) {
+  return {
+    inputDisplay: i18n.translate('xpack.fleet.agentPolicy.outputOptions.defaultOutputText', {
+      defaultMessage: 'Default (currently {defaultOutputName})',
+      values: { defaultOutputName },
+    }),
+    value: DEFAULT_OUTPUT_VALUE,
+  };
+}
 
 export function useOutputOptions() {
   const outputsRequest = useGetOutputs();
@@ -36,10 +48,7 @@ export function useOutputOptions() {
     }
 
     const defaultOutputName = outputsRequest.data.items.find((item) => item.is_default)?.name;
-    return [
-      { inputDisplay: `Default (currently ${defaultOutputName})`, value: DEFAULT_OUTPUT_VALUE },
-      ...outputOptions,
-    ]; // TODO translations
+    return [getDefaultOutput(defaultOutputName), ...outputOptions];
   }, [outputsRequest, outputOptions]);
 
   const monitoringOutputOptions = useMemo(() => {
@@ -50,10 +59,7 @@ export function useOutputOptions() {
     const defaultOutputName = outputsRequest.data.items.find(
       (item) => item.is_default_monitoring
     )?.name;
-    return [
-      { inputDisplay: `Default (currently ${defaultOutputName})`, value: DEFAULT_OUTPUT_VALUE },
-      ...outputOptions,
-    ]; // TODO translations
+    return [getDefaultOutput(defaultOutputName), , ...outputOptions]; // TODO translations
   }, [outputsRequest, outputOptions]);
 
   return useMemo(

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import type { EuiSuperSelectOption } from '@elastic/eui';
 
 import { useGetOutputs, useLicense } from '../../../../hooks';
+import { LICENCE_FOR_PER_POLICY_OUTPUT } from '../../../../../../../common';
 
 // The super select component do not support null or '' as a value
 export const DEFAULT_OUTPUT_VALUE = '@@##DEFAULT_OUTPUT_VALUE##@@';
@@ -28,7 +29,7 @@ export function useOutputOptions() {
   const outputsRequest = useGetOutputs();
   const licenseService = useLicense();
 
-  const isPlatinium = useMemo(() => licenseService.isPlatinium(), [licenseService]);
+  const isLicenceAllowingPolicyPerOutput = licenseService.hasAtLeast(LICENCE_FOR_PER_POLICY_OUTPUT);
 
   const outputOptions: Array<EuiSuperSelectOption<string>> = useMemo(() => {
     if (outputsRequest.isLoading || !outputsRequest.data) {
@@ -38,9 +39,9 @@ export function useOutputOptions() {
     return outputsRequest.data.items.map((item) => ({
       value: item.id,
       inputDisplay: item.name,
-      disabled: !isPlatinium,
+      disabled: !isLicenceAllowingPolicyPerOutput,
     }));
-  }, [outputsRequest, isPlatinium]);
+  }, [outputsRequest, isLicenceAllowingPolicyPerOutput]);
 
   const dataOutputOptions = useMemo(() => {
     if (outputsRequest.isLoading || !outputsRequest.data) {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
@@ -59,7 +59,7 @@ export function useOutputOptions() {
     const defaultOutputName = outputsRequest.data.items.find(
       (item) => item.is_default_monitoring
     )?.name;
-    return [getDefaultOutput(defaultOutputName), , ...outputOptions]; // TODO translations
+    return [getDefaultOutput(defaultOutputName), ...outputOptions];
   }, [outputsRequest, outputOptions]);
 
   return useMemo(

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
@@ -26,9 +26,9 @@ function getDefaultOutput(defaultOutputName?: string) {
 
 export function useOutputOptions() {
   const outputsRequest = useGetOutputs();
-  const { isPlatinium: isPlatiniumFn } = useLicense();
+  const licenseService = useLicense();
 
-  const isPlatinium = useMemo(() => isPlatiniumFn(), [isPlatiniumFn]);
+  const isPlatinium = useMemo(() => licenseService.isPlatinium(), [licenseService]);
 
   const outputOptions: Array<EuiSuperSelectOption<string>> = useMemo(() => {
     if (outputsRequest.isLoading || !outputsRequest.data) {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -17,20 +17,23 @@ import {
   EuiLink,
   EuiFieldNumber,
   EuiFieldText,
+  EuiSuperSelect,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 
-import { dataTypes } from '../../../../../../common';
-import type { NewAgentPolicy, AgentPolicy } from '../../../types';
-import { useStartServices } from '../../../hooks';
+import { dataTypes } from '../../../../../../../common';
+import type { NewAgentPolicy, AgentPolicy } from '../../../../types';
+import { useStartServices } from '../../../../hooks';
 
-import { AgentPolicyPackageBadge } from '../../../components';
+import { AgentPolicyPackageBadge } from '../../../../components';
 
-import { policyHasFleetServer } from '../../agents/services/has_fleet_server';
+import { policyHasFleetServer } from '../../../agents/services/has_fleet_server';
 
-import { AgentPolicyDeleteProvider } from './agent_policy_delete_provider';
-import type { ValidationResults } from './agent_policy_validation';
+import { AgentPolicyDeleteProvider } from '../agent_policy_delete_provider';
+import type { ValidationResults } from '../agent_policy_validation';
+
+import { useOutputOptions, DEFAULT_OUTPUT_VALUE } from './hooks';
 
 interface Props {
   agentPolicy: Partial<NewAgentPolicy | AgentPolicy>;
@@ -49,6 +52,11 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
 }) => {
   const { docLinks } = useStartServices();
   const [touchedFields, setTouchedFields] = useState<{ [key: string]: boolean }>({});
+  const {
+    dataOutputOptions,
+    monitoringOutputOptions,
+    isLoading: isLoadingOptions,
+  } = useOutputOptions();
 
   // agent monitoring checkbox group can appear multiple times in the DOM, ids have to be unique to work correctly
   const monitoringCheckboxIdSuffix = Date.now();
@@ -272,6 +280,82 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
             }}
             isInvalid={Boolean(touchedFields.unenroll_timeout && validation.unenroll_timeout)}
             onBlur={() => setTouchedFields({ ...touchedFields, unenroll_timeout: true })}
+          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+      <EuiDescribedFormGroup
+        title={
+          <h4>
+            <FormattedMessage
+              id="xpack.fleet.agentPolicyForm.dataOutputLabel"
+              defaultMessage="Output for integrations"
+            />
+          </h4>
+        }
+        description={
+          <FormattedMessage
+            id="xpack.fleet.agentPolicyForm.dataOutputDescription"
+            defaultMessage="Select which output to use for data from integrations."
+          />
+        }
+      >
+        <EuiFormRow
+          fullWidth
+          error={
+            touchedFields.data_output_id && validation.data_output_id
+              ? validation.data_output_id
+              : null
+          }
+          isInvalid={Boolean(touchedFields.data_output_id && validation.data_output_id)}
+        >
+          <EuiSuperSelect
+            valueOfSelected={agentPolicy.data_output_id || DEFAULT_OUTPUT_VALUE}
+            fullWidth
+            isLoading={isLoadingOptions}
+            onChange={(e) => {
+              updateAgentPolicy({
+                data_output_id: e !== DEFAULT_OUTPUT_VALUE ? e : null,
+              });
+            }}
+            options={dataOutputOptions}
+          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+      <EuiDescribedFormGroup
+        title={
+          <h4>
+            <FormattedMessage
+              id="xpack.fleet.agentPolicyForm.monitoringOutputLabel"
+              defaultMessage="Output for agent monitoring"
+            />
+          </h4>
+        }
+        description={
+          <FormattedMessage
+            id="xpack.fleet.agentPolicyForm.monitoringOutputDescription"
+            defaultMessage="Select which output to use for the agents own monitoring data."
+          />
+        }
+      >
+        <EuiFormRow
+          fullWidth
+          error={
+            touchedFields.monitoring_output_id && validation.monitoring_output_id
+              ? validation.monitoring_output_id
+              : null
+          }
+          isInvalid={Boolean(touchedFields.monitoring_output_id && validation.monitoring_output_id)}
+        >
+          <EuiSuperSelect
+            valueOfSelected={agentPolicy.monitoring_output_id || DEFAULT_OUTPUT_VALUE}
+            fullWidth
+            isLoading={isLoadingOptions}
+            onChange={(e) => {
+              updateAgentPolicy({
+                monitoring_output_id: e !== DEFAULT_OUTPUT_VALUE ? e : null,
+              });
+            }}
+            options={monitoringOutputOptions}
           />
         </EuiFormRow>
       </EuiDescribedFormGroup>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
@@ -73,14 +73,27 @@ export const SettingsView = memo<{ agentPolicy: AgentPolicy }>(
     const submitUpdateAgentPolicy = async () => {
       setIsLoading(true);
       try {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        const { name, description, namespace, monitoring_enabled, unenroll_timeout } = agentPolicy;
+        const {
+          name,
+          description,
+          namespace,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          monitoring_enabled,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          unenroll_timeout,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          data_output_id,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          monitoring_output_id,
+        } = agentPolicy;
         const { data, error } = await sendUpdateAgentPolicy(agentPolicy.id, {
           name,
           description,
           namespace,
           monitoring_enabled,
           unenroll_timeout,
+          data_output_id,
+          monitoring_output_id,
         });
         if (data) {
           notifications.toasts.addSuccess(

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/settings_page/output_section.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/settings_page/output_section.tsx
@@ -12,7 +12,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { useLink } from '../../../../hooks';
 import type { Output } from '../../../../types';
 import { OutputsTable } from '../outputs_table';
-import { FEATURE_ADD_OUTPUT_ENABLED } from '../../constants';
 
 export interface OutputSectionProps {
   outputs: Output[];
@@ -42,14 +41,12 @@ export const OutputSection: React.FunctionComponent<OutputSectionProps> = ({
       <EuiSpacer size="m" />
       <OutputsTable outputs={outputs} deleteOutput={deleteOutput} />
       <EuiSpacer size="s" />
-      {FEATURE_ADD_OUTPUT_ENABLED && (
-        <EuiButtonEmpty iconType="plusInCircle" href={getHref('settings_create_outputs')}>
-          <FormattedMessage
-            id="xpack.fleet.settings.outputCreateButtonLabel"
-            defaultMessage="Add output"
-          />
-        </EuiButtonEmpty>
-      )}
+      <EuiButtonEmpty iconType="plusInCircle" href={getHref('settings_create_outputs')}>
+        <FormattedMessage
+          id="xpack.fleet.settings.outputCreateButtonLabel"
+          defaultMessage="Add output"
+        />
+      </EuiButtonEmpty>
     </>
   );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/constants/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/constants/index.tsx
@@ -6,5 +6,3 @@
  */
 
 export const FLYOUT_MAX_WIDTH = 670;
-
-export const FEATURE_ADD_OUTPUT_ENABLED = false;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/index.tsx
@@ -19,7 +19,6 @@ import { withConfirmModalProvider } from './hooks/use_confirm_modal';
 import { FleetServerHostsFlyout } from './components/fleet_server_hosts_flyout';
 import { EditOutputFlyout } from './components/edit_output_flyout';
 import { useDeleteOutput } from './hooks/use_delete_output';
-import { FEATURE_ADD_OUTPUT_ENABLED } from './constants';
 
 export const SettingsApp = withConfirmModalProvider(() => {
   useBreadcrumbs('settings');
@@ -64,13 +63,11 @@ export const SettingsApp = withConfirmModalProvider(() => {
               />
             </EuiPortal>
           </Route>
-          {FEATURE_ADD_OUTPUT_ENABLED && (
-            <Route path={FLEET_ROUTING_PATHS.settings_create_outputs}>
-              <EuiPortal>
-                <EditOutputFlyout onClose={onCloseCallback} />
-              </EuiPortal>
-            </Route>
-          )}
+          <Route path={FLEET_ROUTING_PATHS.settings_create_outputs}>
+            <EuiPortal>
+              <EditOutputFlyout onClose={onCloseCallback} />
+            </EuiPortal>
+          </Route>
           <Route path={FLEET_ROUTING_PATHS.settings_edit_outputs}>
             {(route: { match: { params: { outputId: string } } }) => {
               const output = outputs.data?.items.find((o) => route.match.params.outputId === o.id);

--- a/x-pack/plugins/fleet/server/services/agent_policies/index.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { getFullAgentPolicy } from './full_agent_policy';
+export { validateOutputForPolicy } from './validate_outputs_for_policy';

--- a/x-pack/plugins/fleet/server/services/agent_policies/validate_outputs_for_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/validate_outputs_for_policy.test.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { appContextService } from '..';
+
+import { validateOutputForPolicy } from '.';
+
+jest.mock('../app_context');
+
+const mockedAppContextService = appContextService as jest.Mocked<typeof appContextService>;
+
+function mockHasLicence(res: boolean) {
+  mockedAppContextService.getSecurityLicense.mockReturnValue({
+    hasAtLeast: () => res,
+  } as any);
+}
+
+describe('validateOutputForPolicy', () => {
+  describe('Without oldData (create)', () => {
+    it('should allow default outputs without platinum licence', async () => {
+      mockHasLicence(false);
+      await validateOutputForPolicy({
+        data_output_id: null,
+        monitoring_output_id: null,
+      });
+    });
+
+    it('should allow default outputs with platinum licence', async () => {
+      mockHasLicence(false);
+      await validateOutputForPolicy({
+        data_output_id: null,
+        monitoring_output_id: null,
+      });
+    });
+
+    it('should not allow custom data outputs without platinum licence', async () => {
+      mockHasLicence(false);
+      const res = validateOutputForPolicy({
+        data_output_id: 'test1',
+        monitoring_output_id: null,
+      });
+      await expect(res).rejects.toThrow(
+        'Invalid licence to set per policy output, you need platinum licence'
+      );
+    });
+
+    it('should not allow custom monitoring outputs without platinum licence', async () => {
+      mockHasLicence(false);
+      const res = validateOutputForPolicy({
+        data_output_id: null,
+        monitoring_output_id: 'test1',
+      });
+      await expect(res).rejects.toThrow(
+        'Invalid licence to set per policy output, you need platinum licence'
+      );
+    });
+
+    it('should allow custom data output with platinum licence', async () => {
+      mockHasLicence(true);
+      await validateOutputForPolicy({
+        data_output_id: 'test1',
+        monitoring_output_id: null,
+      });
+    });
+
+    it('should allow custom monitoring output with platinum licence', async () => {
+      mockHasLicence(true);
+      await validateOutputForPolicy({
+        data_output_id: null,
+        monitoring_output_id: 'test1',
+      });
+    });
+
+    it('should allow custom outputs for managed preconfigured policy without licence', async () => {
+      mockHasLicence(false);
+      await validateOutputForPolicy({
+        is_managed: true,
+        is_preconfigured: true,
+        data_output_id: 'test1',
+        monitoring_output_id: 'test1',
+      });
+    });
+  });
+
+  describe('With oldData (update)', () => {
+    it('should allow default outputs without platinum licence', async () => {
+      mockHasLicence(false);
+      await validateOutputForPolicy(
+        {
+          data_output_id: null,
+          monitoring_output_id: null,
+        },
+        {
+          data_output_id: 'test1',
+          monitoring_output_id: 'test1',
+        }
+      );
+    });
+
+    it('should not allow custom data outputs without platinum licence', async () => {
+      mockHasLicence(false);
+      const res = validateOutputForPolicy(
+        {
+          data_output_id: 'test1',
+          monitoring_output_id: null,
+        },
+        {
+          data_output_id: null,
+          monitoring_output_id: null,
+        }
+      );
+      await expect(res).rejects.toThrow(
+        'Invalid licence to set per policy output, you need platinum licence'
+      );
+    });
+
+    it('should not allow custom monitoring outputs without platinum licence', async () => {
+      mockHasLicence(false);
+      const res = validateOutputForPolicy(
+        {
+          data_output_id: null,
+          monitoring_output_id: 'test1',
+        },
+        {
+          data_output_id: null,
+          monitoring_output_id: null,
+        }
+      );
+      await expect(res).rejects.toThrow(
+        'Invalid licence to set per policy output, you need platinum licence'
+      );
+    });
+
+    it('should allow custom data output with platinum licence', async () => {
+      mockHasLicence(true);
+      await validateOutputForPolicy(
+        {
+          data_output_id: 'test1',
+          monitoring_output_id: null,
+        },
+        {
+          data_output_id: 'test1',
+          monitoring_output_id: null,
+        }
+      );
+    });
+
+    it('should allow custom monitoring output with platinum licence', async () => {
+      mockHasLicence(true);
+      await validateOutputForPolicy({
+        data_output_id: null,
+        monitoring_output_id: 'test1',
+      });
+    });
+
+    it('should allow custom outputs for managed preconfigured policy without licence', async () => {
+      mockHasLicence(false);
+      await validateOutputForPolicy(
+        {
+          data_output_id: 'test1',
+          monitoring_output_id: 'test1',
+        },
+        { is_managed: true, is_preconfigured: true }
+      );
+    });
+
+    it('should allow custom outputs if they did not change without licence', async () => {
+      mockHasLicence(false);
+      await validateOutputForPolicy(
+        {
+          data_output_id: 'test1',
+          monitoring_output_id: 'test1',
+        },
+        { data_output_id: 'test1', monitoring_output_id: 'test1' }
+      );
+    });
+  });
+});

--- a/x-pack/plugins/fleet/server/services/agent_policies/validate_outputs_for_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/validate_outputs_for_policy.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentPolicySOAttributes } from '../../types';
+import { LICENCE_FOR_PER_POLICY_OUTPUT } from '../../../common';
+import { appContextService } from '..';
+
+/**
+ * Validate outputs are valid for a policy using the current kibana licence or throw.
+ * @param data
+ * @returns
+ */
+export async function validateOutputForPolicy(
+  newData: Partial<AgentPolicySOAttributes>,
+  oldData: Partial<AgentPolicySOAttributes> = {}
+) {
+  if (
+    newData.data_output_id === oldData.data_output_id &&
+    newData.monitoring_output_id === oldData.monitoring_output_id
+  ) {
+    return;
+  }
+
+  const data = { ...oldData, ...newData };
+
+  if (!data.data_output_id && !data.monitoring_output_id) {
+    return;
+  }
+
+  // Do not validate licence output for managed and preconfigured policy
+  if (data.is_managed && data.is_preconfigured) {
+    return;
+  }
+
+  const hasLicence = appContextService
+    .getSecurityLicense()
+    .hasAtLeast(LICENCE_FOR_PER_POLICY_OUTPUT);
+
+  if (!hasLicence) {
+    throw new Error(
+      `Invalid licence to set per policy output, you need ${LICENCE_FOR_PER_POLICY_OUTPUT} licence`
+    );
+  }
+}

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -63,6 +63,7 @@ import { agentPolicyUpdateEventHandler } from './agent_policy_update';
 import { normalizeKuery, escapeSearchQueryPhrase } from './saved_object';
 import { appContextService } from './app_context';
 import { getFullAgentPolicy } from './agent_policies';
+import { validateOutputForPolicy } from './agent_policies';
 
 const SAVED_OBJECT_TYPE = AGENT_POLICY_SAVED_OBJECT_TYPE;
 
@@ -98,6 +99,8 @@ class AgentPolicyService {
         `Agent policy ${id} cannot be updated because it is ${oldAgentPolicy.status}`
       );
     }
+
+    await validateOutputForPolicy(agentPolicy);
 
     await soClient.update<AgentPolicySOAttributes>(SAVED_OBJECT_TYPE, id, {
       ...agentPolicy,
@@ -168,6 +171,8 @@ class AgentPolicyService {
     options?: { id?: string; user?: AuthenticatedUser }
   ): Promise<AgentPolicy> {
     await this.requireUniqueName(soClient, agentPolicy);
+
+    await validateOutputForPolicy(agentPolicy);
 
     const newSo = await soClient.create<AgentPolicySOAttributes>(
       SAVED_OBJECT_TYPE,

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -32,6 +32,8 @@ export const AgentPolicyBaseSchema = {
       schema.oneOf([schema.literal(dataTypes.Logs), schema.literal(dataTypes.Metrics)])
     )
   ),
+  data_output_id: schema.maybe(schema.nullable(schema.string())),
+  monitoring_output_id: schema.maybe(schema.nullable(schema.string())),
 };
 
 export const NewAgentPolicySchema = schema.object({


### PR DESCRIPTION
## Summary

Resolve #104985

Allow user to set per policy outputs (that feature is only accessible for user with platinum licence)

## UI Changes

#### With Platinum licence
<img width="995" alt="Screen Shot 2022-03-02 at 10 41 51 AM" src="https://user-images.githubusercontent.com/1336873/156397505-7a085148-3462-406c-8fb0-fdb71400ff72.png">
<img width="1014" alt="Screen Shot 2022-03-02 at 10 41 57 AM" src="https://user-images.githubusercontent.com/1336873/156398314-200cfe73-b72a-43a0-890a-6b6521f5402b.png">


#### With an expired platinum licence and previously configured per policy output

<img width="906" alt="Screen Shot 2022-03-02 at 10 49 28 AM" src="https://user-images.githubusercontent.com/1336873/156397513-ce52e1c4-b6e5-4297-afca-2a44801635d6.png">


#### Without platinum licence
<img width="924" alt="Screen Shot 2022-03-02 at 10 49 35 AM" src="https://user-images.githubusercontent.com/1336873/156397515-91520a7c-b733-4cd1-bb41-4cf00bbdf56d.png">


## How to test 

you can use this in your kibana.dev.yml to quickly get some outputs to test

```
xpack.fleet.outputs:
  - id: test1
    name: Elasticsearch 1
    hosts: [https://es1:9200]
    type: "elasticsearch"
    is_default: true
    is_default_monitoring: true
  - id: test2
    name: Elasticsearch 2
    hosts: [https://es2:9200]
    type: "elasticsearch"
    is_default: false
    is_default_monitoring: false
  - id: test3
    name: Elasticsearch 3
    hosts: [https://es3:9200]
    type: "elasticsearch"
    is_default: false
    is_default_monitoring: false
```

## tests

Cover with unit tests:
- the policy generation with different output(previously done)
- the output option  generation client side.
- the agent policy output validation server side.
- 