### PR TITLE
[8.1] [Fleet] Empty `fleet_packages.json` in 8.1

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -12,25 +12,4 @@
   in order to verify package integrity.
 */
 
-[
-  {
-    "name": "apm",
-    "version": "8.1.0"
-  },
-  {
-    "name": "elastic_agent",
-    "version": "1.3.0"
-  },
-  {
-    "name": "endpoint",
-    "version": "1.5.0"
-  },
-  {
-    "name": "fleet_server",
-    "version": "1.1.0"
-  },
-  {
-    "name": "synthetics",
-    "version": "0.9.2"
-  }
-]
+[]


### PR DESCRIPTION
## Summary

Ref https://github.com/elastic/dev/issues/1917#issuecomment-1057098899
Ref https://github.com/elastic/kibana/issues/126695

Remove bundled packages from `fleet_packages.json` for 8.1 to prevent breakages in APM. This prevents bundled packages from being saved to disk during Kibana's build process, and will ensure 8.1 builds rely on an accessible EPR endpoint for stack-aligned packages.