### PR TITLE
FTR simulate mocha dry run

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/fake_mocha_types.ts
+++ b/packages/kbn-test/src/functional_test_runner/fake_mocha_types.ts
@@ -31,6 +31,7 @@ export interface Test {
   file?: string;
   parent?: Suite;
   isPassed: () => boolean;
+  pending?: boolean;
 }
 
 export interface Runner extends EventEmitter {

--- a/packages/kbn-test/src/functional_test_runner/functional_test_runner.ts
+++ b/packages/kbn-test/src/functional_test_runner/functional_test_runner.ts
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
-import Path from 'path';
+import { writeFileSync, mkdirSync } from 'fs';
+import Path, { dirname } from 'path';
 import { ToolingLog } from '@kbn/dev-utils';
 import { REPO_ROOT } from '@kbn/utils';
 
@@ -97,6 +98,15 @@ export class FunctionalTestRunner {
         reporter,
         reporterOptions
       );
+
+      // there's a bug in mocha's dry run, see https://github.com/mochajs/mocha/issues/4838
+      // until we can update to a mocha version where this is fixed, we won't actually
+      // execute the mocha dry run but simulate it by reading the suites and tests of
+      // the mocha object and writing a report file with similar structure to the json report
+      // (just leave out some execution details like timing, retry and erros)
+      if (config.get('mochaOpts.dryRun')) {
+        return this.simulateMochaDryRun(mocha);
+      }
 
       await this.lifecycle.beforeTests.trigger(mocha.suite);
       this.log.info('Starting tests');
@@ -243,5 +253,63 @@ export class FunctionalTestRunner {
 
     this.closed = true;
     await this.lifecycle.cleanup.trigger();
+  }
+
+  simulateMochaDryRun(mocha: any) {
+    interface TestEntry {
+      file: string;
+      title: string;
+      fullTitle: string;
+    }
+
+    const getFullTitle = (node: Test | Suite): string => {
+      const parentTitle = node.parent && getFullTitle(node.parent);
+      return parentTitle ? `${parentTitle} ${node.title}` : node.title;
+    };
+
+    let suiteCount = 0;
+    const passes: TestEntry[] = [];
+    const pending: TestEntry[] = [];
+
+    const collectTests = (suite: Suite) => {
+      for (const subSuite of suite.suites) {
+        suiteCount++;
+        for (const test of subSuite.tests) {
+          const testEntry = {
+            title: test.title,
+            fullTitle: getFullTitle(test),
+            file: test.file || '',
+          };
+          if (test.pending) {
+            pending.push(testEntry);
+          } else {
+            passes.push(testEntry);
+          }
+        }
+        collectTests(subSuite);
+      }
+    };
+
+    collectTests(mocha.suite);
+
+    const reportData = {
+      stats: {
+        suites: suiteCount,
+        tests: passes.length + pending.length,
+        passes: passes.length,
+        pending: pending.length,
+        failures: 0,
+      },
+      tests: [...passes, ...pending],
+      passes,
+      pending,
+      failures: [],
+    };
+
+    const reportPath = mocha.options.reporterOptions.output;
+    mkdirSync(dirname(reportPath), { recursive: true });
+    writeFileSync(reportPath, JSON.stringify(reportData, null, 2), 'utf8');
+
+    return 0;
   }
 }


### PR DESCRIPTION
## Summary

This PR works around a bug in mocha's dry run execution by collecting the tests without actually running mocha.

### Details

- This is a follow-up on #125915
- It still uses the same output file
- The created report structure is close to the json reporter output, just left away some execution specific fields:
  ![image](https://user-images.githubusercontent.com/1945390/156412038-a292d5f3-2298-46af-986b-fede87bb35ca.png)
  ![image](https://user-images.githubusercontent.com/1945390/156412172-74920a4a-22fe-4c20-837f-0d3a6a0be452.png)
- Tested locally with the whole `api_integration` suite and with the whole `functional` suite to make sure it works for many entries


