### PR TITLE
[DOCS] Add settings for Enterprise Search

### DIFF
--- a/docs/settings/enterprise-search-settings.asciidoc
+++ b/docs/settings/enterprise-search-settings.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Enterprise Search settings</titleabbrev>
 ++++
 
-You do not need to configure any settings to use Enterprise Search in {kib}. It is enabled by default.
+On Elastic Cloud, you do not need to configure any settings to use Enterprise Search in {kib}. It is enabled by default. On self-managed installations, you must configure `enterpriseSearch.host`.
 
 `enterpriseSearch.host`::
 The http(s) URL of your Enterprise Search instance. For example, in a local self-managed setup,

--- a/docs/settings/enterprise-search-settings.asciidoc
+++ b/docs/settings/enterprise-search-settings.asciidoc
@@ -1,0 +1,26 @@
+[role="xpack"]
+[[enterprise-search-settings-kb]]
+=== Enterprise Search settings in {kib}
+++++
+<titleabbrev>Enterprise Search settings</titleabbrev>
+++++
+
+You do not need to configure any settings to use Enterprise Search in {kib}. It is enabled by default.
+
+`enterpriseSearch.host`::
+The http(s) URL of your Enterprise Search instance. For example, in a local self-managed setup,
+set this to `http://localhost:3002`. Authentication between {kib} and the Enterprise Search host URL,
+such as via OAuth, is not supported. You can also
+{enterprise-search-ref}/configure-ssl-tls.html#configure-ssl-tls-in-kibana[configure {kib} to trust
+your Enterprise Search TLS certificate authority].
+
+
+`enterpriseSearch.accessCheckTimeout`::
+When launching the Enterprise Search UI, the maximum number of milliseconds for {kib} to wait
+for a response from Enterprise Search
+before considering the attempt failed and logging a warning.
+Default: 5000.
+
+`enterpriseSearch.accessCheckTimeoutWarning`::
+When launching the Enterprise Search UI, the maximum number of milliseconds for {kib} to wait for a response from
+Enterprise Search before logging a warning. Default: 300.

--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -282,9 +282,6 @@ on the {kib} index at startup. {kib} users still need to authenticate with
 that the {kib} server uses to perform maintenance on the {kib} index at startup. This setting
 is an alternative to `elasticsearch.username` and `elasticsearch.password`.
 
-| `enterpriseSearch.host`
-  | The http(s) URL of your Enterprise Search instance. For example, in a local self-managed setup, set this to `http://localhost:3002`. Authentication between Kibana and the Enterprise Search host URL, such as via OAuth, is not supported. You can also {enterprise-search-ref}/configure-ssl-tls.html#configure-ssl-tls-in-kibana[configure Kibana to trust your Enterprise Search TLS certificate authority].
-
 | `interpreter.enableInVisualize`
   | Enables use of interpreter in Visualize. *Default: `true`*
 
@@ -719,6 +716,7 @@ Valid locales are: `en`, `zh-CN`, `ja-JP`. *Default: `en`*
 include::{kib-repo-dir}/settings/alert-action-settings.asciidoc[]
 include::{kib-repo-dir}/settings/apm-settings.asciidoc[]
 include::{kib-repo-dir}/settings/banners-settings.asciidoc[]
+include::{kib-repo-dir}/settings/enterprise-search-settings.asciidoc[]
 include::{kib-repo-dir}/settings/fleet-settings.asciidoc[]
 include::{kib-repo-dir}/settings/i18n-settings.asciidoc[]
 include::{kib-repo-dir}/settings/logging-settings.asciidoc[]
@@ -726,8 +724,8 @@ include::{kib-repo-dir}/settings/logs-ui-settings.asciidoc[]
 include::{kib-repo-dir}/settings/infrastructure-ui-settings.asciidoc[]
 include::{kib-repo-dir}/settings/monitoring-settings.asciidoc[]
 include::{kib-repo-dir}/settings/reporting-settings.asciidoc[]
-include::secure-settings.asciidoc[]
 include::{kib-repo-dir}/settings/search-sessions-settings.asciidoc[]
+include::secure-settings.asciidoc[]
 include::{kib-repo-dir}/settings/security-settings.asciidoc[]
 include::{kib-repo-dir}/settings/spaces-settings.asciidoc[]
 include::{kib-repo-dir}/settings/task-manager-settings.asciidoc[]


### PR DESCRIPTION
## Summary

This PR:
- Adds a page for Enterprise Search settings.
- Documents `enterpriseSearch.accessCheckTimeout` and `enterpriseSearch.accessCheckTimeoutWarning`
- Moves `enterpriseSearch.host` from the general settings page to the new page.

Closes #126536