### PR TITLE
[7.17] [Reporting/Screenshotting] Add libnss3 to the list of package dependencies (#126384)

### DIFF
--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -30,6 +30,7 @@ If you are using Ubuntu/Debian systems, install the following packages:
 
 * `fonts-liberation`
 * `libfontconfig1`
+* `libnss3`
 
 If the system is missing dependencies, *Reporting* fails in a non-deterministic way. {kib} runs a self-test at server startup, and
 if it encounters errors, logs them in the Console. The error message does not include


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Reporting/Screenshotting] Add libnss3 to the list of package dependencies (#126384)](https://github.com/elastic/kibana/pull/126384)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)