### PR TITLE
[DOCS] Updated link to Embed code doc

### DIFF
--- a/docs/user/security/authentication/index.asciidoc
+++ b/docs/user/security/authentication/index.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Authentication</titleabbrev>
 ++++
 :keywords: administrator, concept, security, authentication
-:description: A list of the supported authentication mechanisms in {kib}. 
+:description: A list of the supported authentication mechanisms in {kib}.
 
 {kib} supports the following authentication mechanisms:
 
@@ -483,4 +483,4 @@ To make this iframe leverage anonymous access automatically, you will need to mo
 
 NOTE: `auth_provider_hint` query string parameter goes *before* the hash URL fragment.
 
-For more information on how to embed, refer to <<embedding, Embed {kib} content in a web page>>.
+For more information, refer to <<embed-code, Embed {kib} content in a web page>>.

--- a/docs/user/security/authentication/index.asciidoc
+++ b/docs/user/security/authentication/index.asciidoc
@@ -483,4 +483,4 @@ To make this iframe leverage anonymous access automatically, you will need to mo
 
 NOTE: `auth_provider_hint` query string parameter goes *before* the hash URL fragment.
 
-For more information, refer to <<embed-code, Embed {kib} content in a web page>>.
+For more information, refer to <<embed-code, Embed code>>.


### PR DESCRIPTION
## Summary

This PR updates the link at the bottom of [https://www.elastic.co/guide/en/kibana/8.0/kibana-authentication.html#embedded-content-authentication](https://www.elastic.co/guide/en/kibana/8.0/kibana-authentication.html#embedded-content-authentication) to point back to [https://www.elastic.co/guide/en/kibana/8.0/reporting-getting-started.html#embed-code](https://www.elastic.co/guide/en/kibana/8.0/reporting-getting-started.html#embed-code).

[Preview the change](https://kibana_126734.docs-preview.app.elstc.co/guide/en/kibana/master/kibana-authentication.html)