### PR TITLE
[Lens][Terms] Preserve custom label when changing with multi-terms settings

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -322,11 +322,13 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
     return {
       ...oldColumn,
       dataType: field.type as DataType,
-      label: ofName(
-        field.displayName,
-        newParams.secondaryFields?.length,
-        newParams.orderBy.type === 'rare'
-      ),
+      label: oldColumn.customLabel
+        ? oldColumn.label
+        : ofName(
+            field.displayName,
+            newParams.secondaryFields?.length,
+            newParams.orderBy.type === 'rare'
+          ),
       sourceField: field.name,
       params: newParams,
     };
@@ -401,11 +403,13 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
               ...column,
               dataType: newDataType,
               sourceField: fields[0],
-              label: ofName(
-                indexPattern.getFieldByName(fields[0])?.displayName,
-                fields.length - 1,
-                newParams.orderBy.type === 'rare'
-              ),
+              label: column.customLabel
+                ? column.label
+                : ofName(
+                    indexPattern.getFieldByName(fields[0])?.displayName,
+                    fields.length - 1,
+                    newParams.orderBy.type === 'rare'
+                  ),
               params: {
                 ...newParams,
                 secondaryFields,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
@@ -1481,6 +1481,59 @@ describe('terms', () => {
         })
       );
     });
+
+    it('should preserve custom label when set by the user', () => {
+      const updateLayerSpy = jest.fn();
+      const existingFields = getExistingFields();
+      const operationSupportMatrix = getDefaultOperationSupportMatrix('col1', existingFields);
+
+      layer.columns.col1 = {
+        label: 'MyCustomLabel',
+        customLabel: true,
+        dataType: 'string',
+        isBucketed: true,
+        operationType: 'terms',
+        params: {
+          orderBy: { type: 'alphabetical' },
+          size: 3,
+          orderDirection: 'asc',
+          secondaryFields: ['geo.src'],
+        },
+        sourceField: 'source',
+      } as TermsIndexPatternColumn;
+      let instance = mount(
+        <InlineFieldInput
+          {...defaultFieldInputProps}
+          layer={layer}
+          updateLayer={updateLayerSpy}
+          columnId="col1"
+          existingFields={existingFields}
+          operationSupportMatrix={operationSupportMatrix}
+          selectedColumn={layer.columns.col1 as TermsIndexPatternColumn}
+        />
+      );
+      // add a new field
+      act(() => {
+        instance.find('[data-test-subj="indexPattern-terms-add-field"]').first().simulate('click');
+      });
+      instance = instance.update();
+
+      act(() => {
+        instance.find(EuiComboBox).last().prop('onChange')!([
+          { value: { type: 'field', field: 'bytes' }, label: 'bytes' },
+        ]);
+      });
+
+      expect(updateLayerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          columns: expect.objectContaining({
+            col1: expect.objectContaining({
+              label: 'MyCustomLabel',
+            }),
+          }),
+        })
+      );
+    });
   });
 
   describe('param editor', () => {


### PR DESCRIPTION
## Summary

Fixes #126344 

![multi_terms_label](https://user-images.githubusercontent.com/924948/156575628-d4bcfa05-017c-461d-9971-16177d003c6c.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
