### PR TITLE
[ci] Configure hourly pipeline for a small spot instance trial

### DIFF
--- a/.buildkite/pipelines/hourly.yml
+++ b/.buildkite/pipelines/hourly.yml
@@ -56,7 +56,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/oss_accessibility.sh
     label: 'OSS Accessibility Tests'
     agents:
-      queue: ci-group-4d
+      queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 120
     retry:
@@ -67,7 +67,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/xpack_accessibility.sh
     label: 'Default Accessibility Tests'
     agents:
-      queue: n2-4
+      queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 120
     retry:
@@ -89,7 +89,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/xpack_firefox.sh
     label: 'Default Firefox Tests'
     agents:
-      queue: n2-4
+      queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 120
     retry:
@@ -111,7 +111,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/xpack_saved_object_field_metrics.sh
     label: 'Saved Object Field Metrics'
     agents:
-      queue: n2-4
+      queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 120
     retry:
@@ -138,7 +138,7 @@ steps:
   - command: .buildkite/scripts/steps/test/api_integration.sh
     label: 'API Integration Tests'
     agents:
-      queue: n2-2
+      queue: n2-4-spot
     timeout_in_minutes: 120
     key: api-integration
 

--- a/.buildkite/pipelines/hourly.yml
+++ b/.buildkite/pipelines/hourly.yml
@@ -61,8 +61,18 @@ steps:
     timeout_in_minutes: 120
     retry:
       automatic:
-        - exit_status: '*'
+        - exit_status: '1'
           limit: 1
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '130'
+          limit: 3
+        - exit_status: '137'
+          limit: 3
+        - exit_status: '143'
+          limit: 3
+        - exit_status: '255'
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/xpack_accessibility.sh
     label: 'Default Accessibility Tests'
@@ -72,8 +82,18 @@ steps:
     timeout_in_minutes: 120
     retry:
       automatic:
-        - exit_status: '*'
+        - exit_status: '1'
           limit: 1
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '130'
+          limit: 3
+        - exit_status: '137'
+          limit: 3
+        - exit_status: '143'
+          limit: 3
+        - exit_status: '255'
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/oss_firefox.sh
     label: 'OSS Firefox Tests'
@@ -94,8 +114,18 @@ steps:
     timeout_in_minutes: 120
     retry:
       automatic:
-        - exit_status: '*'
+        - exit_status: '1'
           limit: 1
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '130'
+          limit: 3
+        - exit_status: '137'
+          limit: 3
+        - exit_status: '143'
+          limit: 3
+        - exit_status: '255'
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/oss_misc.sh
     label: 'OSS Misc Functional Tests'
@@ -116,8 +146,18 @@ steps:
     timeout_in_minutes: 120
     retry:
       automatic:
-        - exit_status: '*'
+        - exit_status: '1'
           limit: 1
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '130'
+          limit: 3
+        - exit_status: '137'
+          limit: 3
+        - exit_status: '143'
+          limit: 3
+        - exit_status: '255'
+          limit: 3
 
   - command: .buildkite/scripts/steps/test/jest.sh
     label: 'Jest Tests'
@@ -141,6 +181,20 @@ steps:
       queue: n2-4-spot
     timeout_in_minutes: 120
     key: api-integration
+    retry:
+      automatic:
+        - exit_status: '1'
+          limit: 1
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '130'
+          limit: 3
+        - exit_status: '137'
+          limit: 3
+        - exit_status: '143'
+          limit: 3
+        - exit_status: '255'
+          limit: 3
 
   - command: .buildkite/scripts/steps/lint.sh
     label: 'Linting'


### PR DESCRIPTION
Configures a small number of fairly short steps to use spot instances, as a small trial. I'm only configuring the hourly pipeline so that PRs will be unaffected if the trial doesn't go well.

Note that if we do a larger scale rollout of spot instances, I think that we would move the retry logic to our build bot, as the syntax is pretty unwieldy.