### PR TITLE
[8.0] [RAM] Fix bulk action for o11y for 7.17 (#126686)

### DIFF
--- a/x-pack/plugins/timelines/public/components/t_grid/standalone/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/standalone/index.tsx
@@ -48,7 +48,7 @@ import { AddToCaseAction } from '../../actions/timeline/cases/add_to_case_action
 import { TGridLoading, TGridEmpty, TimelineContext } from '../shared';
 
 export const EVENTS_VIEWER_HEADER_HEIGHT = 90; // px
-const STANDALONE_ID = 'standalone-t-grid';
+export const STANDALONE_ID = 'standalone-t-grid';
 const EMPTY_DATA_PROVIDERS: DataProvider[] = [];
 
 const TitleText = styled.span`

--- a/x-pack/plugins/timelines/public/container/use_update_alerts.ts
+++ b/x-pack/plugins/timelines/public/container/use_update_alerts.ts
@@ -45,11 +45,11 @@ export const useUpdateAlertsStatus = (
           body: JSON.stringify({ status, query }),
         });
       } else {
-        const { body } = await http.post<{ body: estypes.UpdateByQueryResponse }>(
+        const response = await http.post<estypes.UpdateByQueryResponse>(
           RAC_ALERTS_BULK_UPDATE_URL,
           { body: JSON.stringify({ index, status, query }) }
         );
-        return body;
+        return response;
       }
     },
   };

--- a/x-pack/plugins/timelines/public/container/use_update_alerts.ts
+++ b/x-pack/plugins/timelines/public/container/use_update_alerts.ts
@@ -45,11 +45,11 @@ export const useUpdateAlertsStatus = (
           body: JSON.stringify({ status, query }),
         });
       } else {
-        const response = await http.post<estypes.UpdateByQueryResponse>(
+        const { body } = await http.post<{ body: estypes.UpdateByQueryResponse }>(
           RAC_ALERTS_BULK_UPDATE_URL,
           { body: JSON.stringify({ index, status, query }) }
         );
-        return response;
+        return body;
       }
     },
   };

--- a/x-pack/plugins/timelines/public/hooks/use_status_bulk_action_items.tsx
+++ b/x-pack/plugins/timelines/public/hooks/use_status_bulk_action_items.tsx
@@ -12,6 +12,7 @@ import * as i18n from '../components/t_grid/translations';
 import type { AlertStatus, StatusBulkActionsProps } from '../../common/types/timeline';
 import { useUpdateAlertsStatus } from '../container/use_update_alerts';
 import { useAppToasts } from './use_app_toasts';
+import { STANDALONE_ID } from '../components/t_grid/standalone';
 
 export const getUpdateAlertsQuery = (eventIds: Readonly<string[]>) => {
   return { bool: { filter: { terms: { _id: eventIds } } } };
@@ -28,7 +29,7 @@ export const useStatusBulkActionItems = ({
   onUpdateFailure,
   timelineId,
 }: StatusBulkActionsProps) => {
-  const { updateAlertStatus } = useUpdateAlertsStatus(timelineId != null);
+  const { updateAlertStatus } = useUpdateAlertsStatus(timelineId !== STANDALONE_ID);
   const { addSuccess, addError, addWarning } = useAppToasts();
 
   const onAlertStatusUpdateSuccess = useCallback(

--- a/x-pack/test/functional/config.js
+++ b/x-pack/test/functional/config.js
@@ -602,6 +602,27 @@ export default async function ({ readConfigFile }) {
             cluster: ['manage'],
           },
         },
+
+        global_alerts_logs_all_else_read: {
+          kibana: [
+            {
+              feature: {
+                apm: ['read'],
+                logs: ['all'],
+                infrastructure: ['read'],
+              },
+              spaces: ['*'],
+            },
+          ],
+          elasticsearch: {
+            indices: [
+              {
+                names: ['*'],
+                privileges: ['all'],
+              },
+            ],
+          },
+        },
       },
       defaultRoles: ['superuser'],
     },

--- a/x-pack/test/functional/services/observability/alerts/common.ts
+++ b/x-pack/test/functional/services/observability/alerts/common.ts
@@ -78,6 +78,14 @@ export function ObservabilityAlertsCommonProvider({
     return await testSubjects.findAll('dataGridRowCell');
   };
 
+  const getAllDisabledCheckBoxInTable = async () => {
+    return await find.allByCssSelector('.euiDataGridRowCell input[type="checkbox"]:disabled');
+  };
+
+  const getAllEnabledCheckBoxInTable = async () => {
+    return await find.allByCssSelector('.euiDataGridRowCell input[type="checkbox"]:enabled');
+  };
+
   const getExperimentalDisclaimer = async () => {
     return testSubjects.existOrFail('o11yExperimentalDisclaimer');
   };
@@ -281,6 +289,8 @@ export function ObservabilityAlertsCommonProvider({
     getAlertsFlyoutOrFail,
     getAlertsFlyoutTitle,
     getAlertsFlyoutViewInAppButtonOrFail,
+    getAllDisabledCheckBoxInTable,
+    getAllEnabledCheckBoxInTable,
     getFilterForValueButton,
     getNoDataPageOrFail,
     getNoDataStateOrFail,

--- a/x-pack/test/observability_functional/apps/observability/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/alerts/index.ts
@@ -243,7 +243,7 @@ export default ({ getService }: FtrProviderContext) => {
        */
       describe.skip('Bulk Actions', () => {
         before(async () => {
-          await security.testUser.setRoles(['global_alerts_logs_all_else_read'], true);
+          await security.testUser.setRoles(['global_alerts_logs_all_else_read']);
           await observability.alerts.common.submitQuery('kibana.alert.status: "active"');
         });
         after(async () => {

--- a/x-pack/test/observability_functional/apps/observability/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/alerts/index.ts
@@ -18,6 +18,9 @@ const ACTIVE_ALERTS_CELL_COUNT = 78;
 const RECOVERED_ALERTS_CELL_COUNT = 150;
 const TOTAL_ALERTS_CELL_COUNT = 200;
 
+const DISABLED_ALERTS_CHECKBOX = 6;
+const ENABLED_ALERTS_CHECKBOX = 4;
+
 export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const find = getService('find');
@@ -28,6 +31,7 @@ export default ({ getService }: FtrProviderContext) => {
     const testSubjects = getService('testSubjects');
     const retry = getService('retry');
     const observability = getService('observability');
+    const security = getService('security');
 
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/observability/alerts');
@@ -220,20 +224,71 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       describe('Actions Button', () => {
-        before(async () => {
-          await esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs');
-          await observability.alerts.common.navigateToTimeWithData();
-        });
-
-        after(async () => {
-          await esArchiver.unload('x-pack/test/functional/es_archives/infra/metrics_and_logs');
-        });
-
         it('Opens rule details page when click on "View Rule Details"', async () => {
           const actionsButton = await observability.alerts.common.getActionsButtonByIndex(0);
           await actionsButton.click();
           await observability.alerts.common.viewRuleDetailsButtonClick();
           expect(await find.existsByCssSelector('[title="Rules and Connectors"]')).to.eql(true);
+        });
+      });
+
+      /*
+       * ATTENTION FUTURE DEVELOPER
+       *
+       * These tests should only be valid for 7.17.x
+       * You can run this test if you go to this file:
+       * x-pack/plugins/observability/public/pages/alerts/containers/alerts_table_t_grid/alerts_table_t_grid.tsx
+       * and at line 397 and change showCheckboxes to true
+       *
+       */
+      describe.skip('Bulk Actions', () => {
+        before(async () => {
+          await security.testUser.setRoles(['global_alerts_logs_all_else_read'], true);
+          await observability.alerts.common.submitQuery('kibana.alert.status: "active"');
+        });
+        after(async () => {
+          await observability.alerts.common.submitQuery('');
+          await security.testUser.restoreDefaults();
+        });
+
+        it('Only logs alert should be enable for bulk actions', async () => {
+          const disabledCheckBoxes =
+            await observability.alerts.common.getAllDisabledCheckBoxInTable();
+          const enabledCheckBoxes =
+            await observability.alerts.common.getAllEnabledCheckBoxInTable();
+
+          expect(disabledCheckBoxes.length).to.eql(DISABLED_ALERTS_CHECKBOX);
+          expect(enabledCheckBoxes.length).to.eql(ENABLED_ALERTS_CHECKBOX);
+        });
+
+        it('validate formatting of the bulk actions button', async () => {
+          const selectAll = await testSubjects.find('select-all-events');
+          await selectAll.click();
+          const bulkActionsButton = await testSubjects.find('selectedShowBulkActionsButton');
+          expect(await bulkActionsButton.getVisibleText()).to.be('Selected 4 alerts');
+          await selectAll.click();
+        });
+
+        it('validate functionality of the bulk actions button', async () => {
+          const selectAll = await testSubjects.find('select-all-events');
+          await selectAll.click();
+
+          const bulkActionsButton = await testSubjects.find('selectedShowBulkActionsButton');
+          await bulkActionsButton.click();
+
+          const bulkActionsAcknowledgedAlertStatusButton = await testSubjects.find(
+            'acknowledged-alert-status'
+          );
+          await bulkActionsAcknowledgedAlertStatusButton.click();
+          await observability.alerts.common.submitQuery(
+            'kibana.alert.workflow_status : "acknowledged"'
+          );
+
+          await retry.try(async () => {
+            const enabledCheckBoxes =
+              await observability.alerts.common.getAllEnabledCheckBoxInTable();
+            expect(enabledCheckBoxes.length).to.eql(1);
+          });
         });
       });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[RAM] Fix bulk action for o11y for 7.17 (#126686)](https://github.com/elastic/kibana/pull/126686)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)