### PR TITLE
Tweak Canvas plot renderer

### DIFF
--- a/packages/kbn-flot-charts/lib/jquery_flot.js
+++ b/packages/kbn-flot-charts/lib/jquery_flot.js
@@ -351,7 +351,7 @@ Licensed under the MIT license.
 
 		if (info == null) {
 
-			var element = $("<div></div>").html(text)
+			var element = $("<div></div>").text(text)
 				.css({
 					position: "absolute",
 					'max-width': width,


### PR DESCRIPTION
The Canvas plot renderer includes a call to `$.html`, which can be used by consumers to render arbitrary HTML from Elasticsearch documents. This doesn't appear to be intended or necessary, and this could be abused except for the fact that Kibana uses a Content-Security-Policy that forbids inline Javascript.

### Testing

1. Start Kibana
2. Navigate to **Dev Tools**, then add this data:
   ```
   PUT test/_doc/123
   { "foo": true, "bar": "<script>alert('hi!')</script>", "@timestamp": "2022-01-25T13:01:19.233-05:00" }
   ```
4. Navigate to **Stack Management** -> **Saved Objects**, then import this test workpad: [export.ndjson.zip](https://github.com/elastic/kibana/files/8181619/export.ndjson.zip)
5. Navigate to the test workpad and observe how it is displayed

### Before changes:

The HTML is rendered to the page, and the developer console contains this error because the Javascript was blocked by CSP: `Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'unsafe-eval' 'self'". ...`

![image](https://user-images.githubusercontent.com/5295965/156662947-483b4ee4-a4d5-44b3-b127-41dc79350d9f.png)

### After changes:

![image](https://user-images.githubusercontent.com/5295965/156663613-3dd48f72-e2fa-42a2-9592-1a5c592bfeda.png)
