### PR TITLE
Skip apm overview tests on cloud

### DIFF
--- a/x-pack/test/api_integration/apis/monitoring/apm/overview.js
+++ b/x-pack/test/api_integration/apis/monitoring/apm/overview.js
@@ -12,7 +12,10 @@ export default function ({ getService }) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  describe('overview', () => {
+  describe('overview', function () {
+    // Archive contains non-cgroup data which collides with the in-cgroup APM server present by default on cloud deployments
+    this.tags(['skipCloud']);
+
     const archive = 'x-pack/test/functional/es_archives/monitoring/apm';
     const timeRange = {
       min: '2018-08-31T12:59:49.104Z',

--- a/x-pack/test/api_integration/apis/monitoring/apm/overview_mb.js
+++ b/x-pack/test/api_integration/apis/monitoring/apm/overview_mb.js
@@ -12,7 +12,10 @@ export default function ({ getService }) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  describe('overview mb', () => {
+  describe('overview mb', function () {
+    // Archive contains non-cgroup data which collides with the in-cgroup APM server present by default on cloud deployments
+    this.tags(['skipCloud']);
+
     const archive = 'x-pack/test/functional/es_archives/monitoring/apm_mb';
     const timeRange = {
       min: '2018-08-31T12:59:49.104Z',


### PR DESCRIPTION
## Summary

These tests contain an archive of non-cgroup apm server data. Cloud runs an in-cgroup apm server by default, so the API rightly switches to reflect the cgroup state.

Since we lack a good way to vary fixture data based on cgroup status, I've marked these tests out of the on-cloud suite.

Fixes https://github.com/elastic/kibana/issues/98418
Fixes https://github.com/elastic/kibana/issues/105354
