### PR TITLE
[SecuritySolution] Skip flaky suricata test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/timelines/row_renderers.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/timelines/row_renderers.spec.ts
@@ -87,7 +87,9 @@ describe('Row renderers', () => {
   });
 
   describe('Suricata', () => {
-    it('Signature tooltips do not overlap', () => {
+    // This test has become very flaky over time and was blocking a lot of PRs.
+    // A follw-up ticket to tackle this issue has been created.
+    it.skip('Signature tooltips do not overlap', () => {
       // Hover the signature to show the tooltips
       cy.get(TIMELINE_ROW_RENDERERS_SURICATA_SIGNATURE)
         .parents('.euiPopover__anchor')


### PR DESCRIPTION
## Summary

The Suricata test has become very flaky and is causing a lot of test re-runs at the moment. Therefore we'll temporarily skip the test until we made the test more stable.

Related issue: https://github.com/elastic/kibana/issues/126894
