### PR TITLE
[ESAdd typescript-eslint/no-unused-vars rule to eslint-config-kibana

### DIFF
--- a/packages/elastic-eslint-config-kibana/typescript.js
+++ b/packages/elastic-eslint-config-kibana/typescript.js
@@ -230,6 +230,7 @@ module.exports = {
           'no-unused-expressions': 'off',
           '@typescript-eslint/no-unused-expressions': 'error',
           'no-unused-labels': 'error',
+          '@typescript-eslint/no-unused-vars':'error',
           'no-var': 'error',
           'object-shorthand': 'error',
           'one-var': [ 'error', 'never' ],


### PR DESCRIPTION
## Summary

This adds the `@typescript-eslint/no-unused-vars` rule to `eslint-config-kibana`. The Kibana TypeScript configuration already breaks compilation on unused variables and imports, so this should not break any existing code. It will help avoid unnecessary CI cycles and dev waiting times, as the pre-commit hook and linting currently does not detect these unused vars. That should change with this PR.

