### PR TITLE
[Fleet] Automatically quote vars that start with asterisks or ampersands

### DIFF
--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -260,29 +260,6 @@ export const validatePackagePolicyConfig = (
         })
       );
     }
-    if (varDef.type === 'text' && parsedValue && Array.isArray(parsedValue)) {
-      const invalidStrings = parsedValue.filter((cand) => /^[*&]/.test(cand));
-      // only show one error if multiple strings in array are invalid
-      if (invalidStrings.length > 0) {
-        errors.push(
-          i18n.translate('xpack.fleet.packagePolicyValidation.quoteStringErrorMessage', {
-            defaultMessage:
-              'Strings starting with special YAML characters like * or & need to be enclosed in double quotes.',
-          })
-        );
-      }
-    }
-  }
-
-  if (varDef.type === 'text' && parsedValue && !Array.isArray(parsedValue)) {
-    if (/^[*&]/.test(parsedValue)) {
-      errors.push(
-        i18n.translate('xpack.fleet.packagePolicyValidation.quoteStringErrorMessage', {
-          defaultMessage:
-            'Strings starting with special YAML characters like * or & need to be enclosed in double quotes.',
-        })
-      );
-    }
   }
 
   if (

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -330,7 +330,7 @@ export interface RegistryDataStreamPrivileges {
   indices?: string[];
 }
 
-export type RegistryVarType = 'integer' | 'bool' | 'password' | 'text' | 'yaml' | 'string';
+export type RegistryVarType = 'integer' | 'bool' | 'password' | 'text' | 'yaml';
 export enum RegistryVarsEntryKeys {
   name = 'name',
   title = 'title',

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
@@ -273,4 +273,48 @@ paths:
       'Error while compiling agent template: options.inverse is not a function'
     );
   });
+
+  it('should escape string values when necessary', () => {
+    const stringTemplate = `
+my-package:
+    asterisk: {{asterisk}}
+    leadingasterisk: {{leadingasterisk}}
+    middleasterisk: {{middleasterisk}}
+    trailingasterisk: {{trailingasterisk}}
+    ampersand: {{ampersand}}
+    leadingampersand: {{leadingampersand}}
+    middleampersand: {{middleampersand}}
+    trailingampersand: {{trailingampersand}}`;
+
+    // List of special chars that may lead to YAML parsing errors when not quoted.
+    // See YAML specification section 5.3 Indicator characters
+    // https://yaml.org/spec/1.2/spec.html#id2772075
+    // Currently only escaping leading * and &
+    const vars = {
+      asterisk: { value: '*', type: 'text' },
+      leadingasterisk: { value: '*blah', type: 'text' },
+      middleasterisk: { value: 'blah*blah', type: 'text' },
+      trailingasterisk: { value: 'blah*', type: 'text' },
+      ampersand: { value: '&', type: 'text' },
+      leadingampersand: { value: '&blah', type: 'text' },
+      middleampersand: { value: 'blah&blah', type: 'text' },
+      trailingampersand: { value: 'blah&', type: 'text' },
+    };
+
+    const targetOutput = {
+      'my-package': {
+        asterisk: '*',
+        leadingasterisk: '*blah',
+        middleasterisk: 'blah*blah',
+        trailingasterisk: 'blah*',
+        ampersand: '&',
+        leadingampersand: '&blah',
+        middleampersand: 'blah&blah',
+        trailingampersand: 'blah&',
+      },
+    };
+
+    const output = compileTemplate(vars, stringTemplate);
+    expect(output).toEqual(targetOutput);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #121934

We ran into this problem about a year ago in #91401. Initially that was fixed by escaping _all_ special YAML characters in https://github.com/elastic/kibana/pull/91418. However, this created another issue and this was then reverted and replaced with a validation error in https://github.com/elastic/kibana/pull/93585.

While https://github.com/elastic/kibana/pull/93585 has a good explanation of why this problem presents itself when converting between YAML to JSON back to YAML, I don't agree with the conclusion that putting the onus on package developers and users makes sense. We should be able to handle at least the most common scenarios (like a string that starts with a `*`).

It appears the initial implementation of this in #91418 was too heavy handed and could be re-implemented in a safer way. Instead of quoting any strings that contain any special characters at any position, this PR will only quote strings that start with `*` or `&`.

### How to test

Start Kibana with this configuration (needs to be the Cloud policy w/o the APM policy added):
```yaml
xpack.apm.agent.migrations.enabled: true

# Cloud Agent policy
xpack.fleet.packages:
  - name: fleet_server
    version: latest
xpack.fleet.outputs:
  - name: 'Elastic Cloud internal output'
    type: 'elasticsearch'
    id: 'es-containerhost'
    hosts: ["http://localhost:9200"]
xpack.fleet.agentPolicies:
  # Cloud Agent policy
  - name: Elastic Cloud agent policy
    description: Default agent policy for agents hosted on Elastic Cloud
    id: policy-elastic-agent-on-cloud

    # set the internal containerhost URL to ES
    data_output_id: es-containerhost
    monitoring_output_id: es-containerhost

    is_default: false
    is_managed: true
    is_default_fleet_server: false

    namespace: default
    monitoring_enabled: []
    # If a user scales up / down the Elastic Agent in Cloud, the old
    # instances will still be shown as offline for 24h
    # The reason for having a value such high is to prevent fleet-servers to self unenroll to soon
    # in case checkin cannot happen for a longer time period.
    unenroll_timeout: 86400 # 1 day TTL

    package_policies:
      - name: Fleet Server
        id: elastic-cloud-fleet-server
        package:
          name: fleet_server
        inputs:
          - type: fleet-server
            keep_enabled: true

            vars:
              - name: host
                value: 0.0.0.0
                frozen: true
              - name: port
                value: 8220
                frozen: true
              - name: custom
                value: |
                  server.runtime:
                    gc_percent: 20          # Force the GC to execute more frequently: see https://golang.org/pkg/runtime/debug/#SetGCPercent

```

Run this curl command to setup the correct APM state:
```
curl --request POST \
  --url http://localhost:5601/api/apm/fleet/apm_server_schema \
  --user elastic:changeme \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: true' \
  --data '{
	"schema": {
		"apm-server.host": "0.0.0.0:8200",
		"apm-server.secret_token": "asdfkjhasdf",
		"apm-server.api_key.enabled": true,
		"apm-server.read_timeout": 3600,
		"apm-server.register.ingest.pipeline.enabled": true,
		"apm-server.rum.enabled": true,
		"apm-server.rum.allow_origins": [
			"*"
		],
		"apm-server.rum.rate_limit": 10,
		"apm-server.shutdown_timeout": "30s",
		"logging.level": "error",
		"logging.metrics.enabled": false,
		"queue.mem.events": 2000,
		"queue.mem.flush.min_events": 267,
		"queue.mem.flush.timeout": "1s",
		"setup.template.settings.index.auto_expand_replicas": "0-1",
		"setup.template.settings.index.number_of_replicas": 1,
		"setup.template.settings.index.number_of_shards": 1
	}
}'
```

- Go to APM/Settings/Schema/Switch to Elastic Agent
- After doing the switch (without any errors) go to the Elastic APM integration policy that was created and verify that RUM allowed origins has a single `*` setting.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios