### PR TITLE
[Fleet] Empty fleet_package.json on main

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -12,25 +12,4 @@
   in order to verify package integrity.
 */
 
-[
-  {
-    "name": "apm",
-    "version": "8.1.0"
-  },
-  {
-    "name": "elastic_agent",
-    "version": "1.3.0"
-  },
-  {
-    "name": "endpoint",
-    "version": "1.5.0"
-  },
-  {
-    "name": "fleet_server",
-    "version": "1.1.0"
-  },
-  {
-    "name": "synthetics",
-    "version": "0.9.2"
-  }
-]
+[]


### PR DESCRIPTION
## Summary

Ref https://github.com/elastic/kibana/issues/126695

Removes bundled packages from `main` due to issues around installation of Elasticsearch assets from bundled/uploaded package archives.
