### PR TITLE
[8.0] [DOCS] Add license expiration for searchable snapshot (#126865)

### DIFF
--- a/docs/management/managing-licenses.asciidoc
+++ b/docs/management/managing-licenses.asciidoc
@@ -79,6 +79,7 @@ cluster.
 * The deprecation API is disabled.
 * SQL support is disabled.
 * Aggregations provided by the analytics plugin are no longer usable.
+* All searchable snapshots indices are unassigned and cannot be searched.
 
 [discrete]
 [[expiration-watcher]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[DOCS] Add license expiration for searchable snapshot (#126865)](https://github.com/elastic/kibana/pull/126865)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)