### PR TITLE
[Github] Remove Security & Ops project assigner

### DIFF
--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -18,8 +18,6 @@ jobs:
               {"label": "Feature:Canvas", "projectNumber": 38, "columnName": "Inbox"},
               {"label": "Feature:Dashboard", "projectNumber": 68, "columnName": "Inbox"},
               {"label": "Feature:Drilldowns", "projectNumber": 68, "columnName": "Inbox"},
-              {"label": "Feature:Input Controls", "projectNumber": 72, "columnName": "Inbox"},
-              {"label": "Team:Security", "projectNumber": 320, "columnName": "Awaiting triage", "projectScope": "org"},
-              {"label": "Team:Operations", "projectNumber": 314, "columnName": "Triage", "projectScope": "org"}
+              {"label": "Feature:Input Controls", "projectNumber": 72, "columnName": "Inbox"}
             ]
           ghToken: ${{ secrets.PROJECT_ASSIGNER_TOKEN }}


### PR DESCRIPTION
Platform teams have moved to Jira and no longer use the org-level project boards.