### PR TITLE
[Reporting] New _stats API endpoint for monitoring the instance

### DIFF
--- a/x-pack/plugins/reporting/common/constants/index.ts
+++ b/x-pack/plugins/reporting/common/constants/index.ts
@@ -89,6 +89,9 @@ export const REPORTING_MANAGEMENT_HOME = '/app/management/insightsAndAlerting/re
 
 export const REPORTING_REDIRECT_LOCATOR_STORE_KEY = '__REPORTING_REDIRECT_LOCATOR_STORE_KEY__';
 
+export const INTERNAL_BASE_URL = '/internal/reporting';
+export const API_STATS_URL = `${INTERNAL_BASE_URL}/_stats`;
+
 /**
  * A way to get the client side route for the reporting redirect app.
  *

--- a/x-pack/plugins/reporting/common/constants/index.ts
+++ b/x-pack/plugins/reporting/common/constants/index.ts
@@ -73,13 +73,13 @@ export const LICENSE_TYPE_PLATINUM = 'platinum';
 export const LICENSE_TYPE_ENTERPRISE = 'enterprise';
 
 // Routes
-export const API_BASE_URL = '/api/reporting'; // "Generation URL" from share menu
-export const API_BASE_GENERATE = `${API_BASE_URL}/generate`;
-export const API_LIST_URL = `${API_BASE_URL}/jobs`;
-export const API_DIAGNOSE_URL = `${API_BASE_URL}/diagnose`;
+export const PUBLIC_BASE_URL = '/api/reporting'; // "Generation URL" from share menu
+export const API_BASE_GENERATE = `${PUBLIC_BASE_URL}/generate`;
+export const API_LIST_URL = `${PUBLIC_BASE_URL}/jobs`;
+export const API_DIAGNOSE_URL = `${PUBLIC_BASE_URL}/diagnose`;
 
-export const API_GET_ILM_POLICY_STATUS = `${API_BASE_URL}/ilm_policy_status`;
-export const API_MIGRATE_ILM_POLICY_URL = `${API_BASE_URL}/deprecations/migrate_ilm_policy`;
+export const API_GET_ILM_POLICY_STATUS = `${PUBLIC_BASE_URL}/ilm_policy_status`;
+export const API_MIGRATE_ILM_POLICY_URL = `${PUBLIC_BASE_URL}/deprecations/migrate_ilm_policy`;
 export const API_BASE_URL_V1 = '/api/reporting/v1'; //
 
 export const ILM_POLICY_NAME = 'kibana-reporting';

--- a/x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts
+++ b/x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts
@@ -13,7 +13,7 @@ import { HttpSetup, IUiSettingsClient } from '@kbn/core/public';
 import { buildKibanaPath } from '../../../common/build_kibana_path';
 import {
   API_BASE_GENERATE,
-  API_BASE_URL,
+  PUBLIC_BASE_URL,
   API_GENERATE_IMMEDIATE,
   API_LIST_URL,
   API_MIGRATE_ILM_POLICY_URL,
@@ -222,13 +222,13 @@ export class ReportingAPIClient implements IReportingAPI {
   public getServerBasePath = () => this.http.basePath.serverBasePath;
 
   public verifyBrowser() {
-    return this.http.post<DiagnoseResponse>(`${API_BASE_URL}/diagnose/browser`, {
+    return this.http.post<DiagnoseResponse>(`${PUBLIC_BASE_URL}/diagnose/browser`, {
       asSystemRequest: true,
     });
   }
 
   public verifyScreenCapture() {
-    return this.http.post<DiagnoseResponse>(`${API_BASE_URL}/diagnose/screenshot`, {
+    return this.http.post<DiagnoseResponse>(`${PUBLIC_BASE_URL}/diagnose/screenshot`, {
       asSystemRequest: true,
     });
   }

--- a/x-pack/plugins/reporting/server/core.ts
+++ b/x-pack/plugins/reporting/server/core.ts
@@ -392,8 +392,15 @@ export class ReportingCore {
     return this.executing.size;
   }
 
+  /**
+   * Provides an internal service that logs system events
+   *
+   * @param {IReport} report - definition of a report
+   * @param [task] - definition of a TM task
+   * @returns internal service
+   */
   public getEventLogger(report: IReport, task?: { id: string }) {
-    const ReportingEventLogger = reportingEventLoggerFactory(this.logger);
+    const ReportingEventLogger = reportingEventLoggerFactory(this, this.logger);
     return new ReportingEventLogger(report, task);
   }
 }

--- a/x-pack/plugins/reporting/server/lib/event_logger/adapter.ts
+++ b/x-pack/plugins/reporting/server/lib/event_logger/adapter.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import deepMerge from 'deepmerge';
 import type { Logger, LogMeta } from '@kbn/core/server';
+import deepMerge from 'deepmerge';
+import type { ReportingCore } from '../..';
 import type { IReportingEventLogger } from './logger';
 
 /** @internal */
@@ -23,7 +24,7 @@ export class EcsLogAdapter implements IReportingEventLogger {
    * @param {Logger} logger - Reporting's wrapper of the core logger
    * @param {Partial<LogMeta>} properties - initial ECS data with template for Reporting metrics
    */
-  constructor(logger: Logger, private properties: Partial<LogMeta>) {
+  constructor(_reporting: ReportingCore, logger: Logger, private properties: Partial<LogMeta>) {
     this.logger = logger.get('events');
   }
 

--- a/x-pack/plugins/reporting/server/lib/event_logger/logger.test.ts
+++ b/x-pack/plugins/reporting/server/lib/event_logger/logger.test.ts
@@ -7,11 +7,14 @@
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
+import { ReportingCore } from '../..';
+import { createMockConfigSchema, createMockReportingCore } from '../../test_helpers';
 import { BasePayload } from '../../types';
 import { Report } from '../store';
 import { ReportingEventLogger, reportingEventLoggerFactory } from './logger';
 
 describe('Event Logger', () => {
+  let mockCore: ReportingCore;
   const mockReport = new Report({
     _id: '12348',
     payload: { browserTimezone: 'UTC' } as BasePayload,
@@ -20,8 +23,12 @@ describe('Event Logger', () => {
 
   let factory: ReportingEventLogger;
 
+  beforeAll(async () => {
+    mockCore = await createMockReportingCore(createMockConfigSchema({}));
+  });
+
   beforeEach(() => {
-    factory = reportingEventLoggerFactory(loggingSystemMock.createLogger());
+    factory = reportingEventLoggerFactory(mockCore, loggingSystemMock.createLogger());
   });
 
   it(`should construct with an internal seed object`, () => {

--- a/x-pack/plugins/reporting/server/lib/event_logger/logger.ts
+++ b/x-pack/plugins/reporting/server/lib/event_logger/logger.ts
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import deepMerge from 'deepmerge';
 import type { Logger, LogMeta } from '@kbn/core/server';
+import deepMerge from 'deepmerge';
+import { ActionType } from '.';
+import type { ReportingCore } from '../..';
 import { PLUGIN_ID } from '../../../common/constants';
 import type { TaskRunMetrics } from '../../../common/types';
 import { IReport } from '../store';
-import { ActionType } from '.';
 import { EcsLogAdapter } from './adapter';
 import {
   ClaimedTask,
@@ -47,8 +48,8 @@ export interface BaseEvent {
   user?: { name: string };
 }
 
-export function reportingEventLoggerFactory(logger: Logger) {
-  const genericLogger = new EcsLogAdapter(logger, { event: { provider: PLUGIN_ID } });
+export function reportingEventLoggerFactory(reporting: ReportingCore, logger: Logger) {
+  const genericLogger = new EcsLogAdapter(reporting, logger, { event: { provider: PLUGIN_ID } });
 
   return class ReportingEventLogger {
     readonly eventObj: BaseEvent;
@@ -71,7 +72,9 @@ export function reportingEventLoggerFactory(logger: Logger) {
       };
 
       // create a "complete" logger that will use EventLog helpers to calculate timings
-      this.completionLogger = new EcsLogAdapter(logger, { event: { provider: PLUGIN_ID } });
+      this.completionLogger = new EcsLogAdapter(reporting, logger, {
+        event: { provider: PLUGIN_ID },
+      });
     }
 
     logScheduleTask(): ScheduledTask {

--- a/x-pack/plugins/reporting/server/lib/event_logger/types.ts
+++ b/x-pack/plugins/reporting/server/lib/event_logger/types.ts
@@ -9,7 +9,7 @@ import { LogMeta } from '@kbn/core/server';
 import type { TaskRunMetrics } from '../../../common/types';
 import { ActionType } from '.';
 
-export interface ReportingAction<A extends ActionType> extends LogMeta {
+export interface ReportingAction<A extends ActionType = ActionType> extends LogMeta {
   event: {
     timezone: string;
     // Within ReportingEventLogger, duration is auto-calculated for "completion" event, manually calculated for

--- a/x-pack/plugins/reporting/server/lib/stats/index.ts
+++ b/x-pack/plugins/reporting/server/lib/stats/index.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import { ReportingConfig } from '../..';
+import { durationToNumber } from '../../../common/schema_utils';
+import { ReportingStatsPayload } from '../../types';
+import { ActionType } from '../event_logger';
+import { ReportingAction } from '../event_logger/types';
+
+export interface IReportingStats {
+  durations: {
+    scheduling: number;
+    waiting: number;
+    executing: number;
+    saving: number;
+  };
+  queue: {
+    scheduled: number;
+    claimed: number;
+    started: number;
+    completed: number;
+    retried: number;
+    saved: number;
+    failed: number;
+    errors: number;
+  };
+  state: {
+    status: 'idle' | 'processing';
+    processing?: string;
+  };
+  jobTypes: { [jobType: string]: number };
+  // TODO error codes
+}
+
+/**
+ * A service to accumulate ReportingAction events directly from ReportingEventLogger
+ * and summarize them into system stats
+ */
+export class ReportingStats {
+  private events: ReportingAction[] = [];
+  private state: IReportingStats = {
+    durations: { scheduling: 0, waiting: 0, executing: 0, saving: 0 },
+    jobTypes: {},
+    queue: {
+      scheduled: 0,
+      claimed: 0,
+      started: 0,
+      completed: 0,
+      retried: 0,
+      saved: 0,
+      failed: 0,
+      errors: 0,
+    },
+    state: { status: 'idle' },
+  };
+  private readonly stats$: BehaviorSubject<IReportingStats> = new BehaviorSubject<IReportingStats>(
+    this.state
+  );
+
+  constructor(private config: () => ReportingConfig, jobTypes: string[], private version: string) {
+    // initialize the state's jobType keys
+    jobTypes.forEach((jobType) => {
+      this.state.jobTypes[jobType] = 0;
+    });
+  }
+
+  private clearEvents() {
+    this.events.length = 0;
+  }
+
+  private compileStats() {
+    // make a copy of the cached events
+    const events = [...this.events];
+
+    // clear out the cache of events
+    this.clearEvents();
+
+    // TODO The more events exist, the more this will block the event loop. Partition the long synchronous into async
+    this.state = events.reduce((compiled, event) => {
+      const reportJobId = event.kibana.reporting.id;
+
+      const { state, jobTypes, queue, durations } = compiled;
+      const durationMs = event.event?.duration && event.event?.duration / 1000000;
+
+      // state.status, state.processing
+      switch (event.kibana.reporting.actionType) {
+        case ActionType.EXECUTE_START:
+          state.status = 'processing';
+          state.processing = reportJobId;
+          break;
+        case ActionType.SAVE_REPORT:
+        case ActionType.FAIL_REPORT:
+          state.status = 'idle';
+          state.processing = undefined;
+      }
+
+      // durations.*, queue.*
+      switch (event.kibana.reporting.actionType) {
+        case ActionType.SCHEDULE_TASK:
+          if (durationMs) {
+            durations.scheduling += durationMs;
+          }
+          queue.scheduled += 1;
+          break;
+        case ActionType.CLAIM_TASK: {
+          if (durationMs) {
+            durations.waiting += durationMs;
+          }
+          queue.claimed += 1;
+          break;
+        }
+        case ActionType.EXECUTE_START:
+          queue.started += 1;
+          break;
+        case ActionType.EXECUTE_COMPLETE:
+          if (durationMs) {
+            durations.executing += durationMs;
+          }
+          queue.completed += 1;
+          break;
+        case ActionType.RETRY:
+          if (durationMs) {
+            durations.scheduling += durationMs;
+          }
+          queue.retried += 1;
+          break;
+        case ActionType.SAVE_REPORT:
+          if (durationMs) {
+            durations.saving += durationMs;
+          }
+          queue.saved += 1;
+          break;
+        case ActionType.FAIL_REPORT:
+          if (durationMs) {
+            durations.saving += durationMs;
+          }
+          queue.failed += 1;
+          break;
+        case ActionType.EXECUTE_ERROR:
+        default:
+          queue.errors += 1;
+      }
+
+      // jobCount.*
+      const jobCount = jobTypes[event.kibana.reporting.jobType] || 0;
+      jobTypes[event.kibana.reporting.jobType] = jobCount + 1;
+      return { ...compiled };
+    }, this.state);
+
+    return this.state;
+  }
+
+  public addEvent(event: ReportingAction) {
+    this.events.push(event);
+    this.stats$.next(this.compileStats());
+  }
+
+  public toApiJSON(): ReportingStatsPayload {
+    const config = this.config();
+
+    const pollEnabled = config.get('queue', 'pollEnabled');
+    const timeout = durationToNumber(config.get('queue', 'timeout'));
+    const maxAttempts = config.get('capture', 'maxAttempts');
+    const legacyRolesEnabled = config.get('roles', 'enabled');
+
+    return {
+      config: {
+        roles: { enabled: legacyRolesEnabled },
+        queue: { pollEnabled, timeout },
+        capture: { maxAttempts },
+      },
+      kibana: {
+        uuid: config.kbnConfig.get('server', 'uuid'),
+        host: config.kbnConfig.get('server', 'host'),
+        name: config.kbnConfig.get('server', 'name'),
+        basePath: config.kbnConfig.get('server', 'basePath'),
+        version: this.version,
+      },
+      reports: this.stats$.getValue(),
+    };
+  }
+}

--- a/x-pack/plugins/reporting/server/routes/generate/generate_from_jobparams.ts
+++ b/x-pack/plugins/reporting/server/routes/generate/generate_from_jobparams.ts
@@ -9,12 +9,12 @@ import { schema } from '@kbn/config-schema';
 import rison from 'rison-node';
 import type { Logger } from '@kbn/core/server';
 import type { ReportingCore } from '../..';
-import { API_BASE_URL } from '../../../common/constants';
+import { PUBLIC_BASE_URL } from '../../../common/constants';
 import type { BaseParams } from '../../types';
 import { authorizedUserPreRouting } from '../lib/authorized_user_pre_routing';
 import { RequestHandler } from '../lib/request_handler';
 
-const BASE_GENERATE = `${API_BASE_URL}/generate`;
+const BASE_GENERATE = `${PUBLIC_BASE_URL}/generate`;
 
 export function registerJobGenerationRoutes(reporting: ReportingCore, logger: Logger) {
   const setupDeps = reporting.getPluginSetupDeps();

--- a/x-pack/plugins/reporting/server/routes/index.ts
+++ b/x-pack/plugins/reporting/server/routes/index.ts
@@ -9,6 +9,7 @@ import type { Logger } from '@kbn/core/server';
 import { ReportingCore } from '..';
 import { registerDeprecationsRoutes } from './deprecations/deprecations';
 import { registerDiagnosticRoutes } from './diagnostic';
+import { registerStatsRoutes } from './stats';
 import {
   registerGenerateCsvFromSavedObjectImmediate,
   registerJobGenerationRoutes,
@@ -21,4 +22,5 @@ export function registerRoutes(reporting: ReportingCore, logger: Logger) {
   registerGenerateCsvFromSavedObjectImmediate(reporting, logger);
   registerJobGenerationRoutes(reporting, logger);
   registerJobInfoRoutes(reporting);
+  registerStatsRoutes(reporting);
 }

--- a/x-pack/plugins/reporting/server/routes/lib/request_handler.ts
+++ b/x-pack/plugins/reporting/server/routes/lib/request_handler.ts
@@ -9,7 +9,7 @@ import Boom from '@hapi/boom';
 import { i18n } from '@kbn/i18n';
 import type { KibanaRequest, KibanaResponseFactory, Logger } from '@kbn/core/server';
 import type { ReportingCore } from '../..';
-import { API_BASE_URL } from '../../../common/constants';
+import { PUBLIC_BASE_URL } from '../../../common/constants';
 import { checkParamsVersion, cryptoFactory } from '../../lib';
 import { Report } from '../../lib/store';
 import type { BaseParams, ReportingRequestHandlerContext, ReportingUser } from '../../types';
@@ -20,7 +20,7 @@ export const handleUnavailable = (res: KibanaResponseFactory) => {
 
 const getDownloadBaseUrl = (reporting: ReportingCore) => {
   const config = reporting.getConfig();
-  return config.kbnConfig.get('server', 'basePath') + `${API_BASE_URL}/jobs/download`;
+  return config.kbnConfig.get('server', 'basePath') + `${PUBLIC_BASE_URL}/jobs/download`;
 };
 
 export class RequestHandler {

--- a/x-pack/plugins/reporting/server/routes/management/jobs.ts
+++ b/x-pack/plugins/reporting/server/routes/management/jobs.ts
@@ -9,13 +9,13 @@ import { schema } from '@kbn/config-schema';
 import { i18n } from '@kbn/i18n';
 import { ROUTE_TAG_CAN_REDIRECT } from '@kbn/security-plugin/server';
 import { ReportingCore } from '../..';
-import { API_BASE_URL } from '../../../common/constants';
+import { PUBLIC_BASE_URL } from '../../../common/constants';
 import { authorizedUserPreRouting } from '../lib/authorized_user_pre_routing';
 import { jobsQueryFactory } from '../lib/jobs_query';
 import { deleteJobResponseHandler, downloadJobResponseHandler } from '../lib/job_response_handler';
 import { handleUnavailable } from '../lib/request_handler';
 
-const MAIN_ENTRY = `${API_BASE_URL}/jobs`;
+const MAIN_ENTRY = `${PUBLIC_BASE_URL}/jobs`;
 
 export function registerJobInfoRoutes(reporting: ReportingCore) {
   const setupDeps = reporting.getPluginSetupDeps();

--- a/x-pack/plugins/reporting/server/routes/stats/index.ts
+++ b/x-pack/plugins/reporting/server/routes/stats/index.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { ReportingCore } from '../..';
+import { API_STATS_URL } from '../../../common/constants';
+
+export const registerStatsRoutes = (reporting: ReportingCore) => {
+  const { router } = reporting.getPluginSetupDeps();
+  const stats = reporting.getStats();
+
+  router.get(
+    {
+      // internal API: starts with /internal/{pluginname}/{...}.
+      path: API_STATS_URL,
+      options: { authRequired: true, tags: ['api'] },
+      validate: {
+        params: schema.maybe(schema.any()),
+        query: schema.maybe(schema.any()),
+      },
+    },
+    (_context, _request, response) => {
+      return response.ok({
+        body: stats.toApiJSON(),
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+  );
+};

--- a/x-pack/plugins/reporting/server/types.ts
+++ b/x-pack/plugins/reporting/server/types.ts
@@ -33,6 +33,7 @@ import type { CancellationToken } from '../common/cancellation_token';
 import type { BaseParams, BasePayload, TaskRunResult, UrlOrUrlLocatorTuple } from '../common/types';
 import type { ReportingConfigType } from './config';
 import type { ReportingCore } from './core';
+import { IReportingStats } from './lib/stats';
 import type { ReportTaskParams } from './lib/tasks';
 
 /**
@@ -128,3 +129,26 @@ export interface PngScreenshotOptions extends Omit<BasePngScreenshotOptions, 'ti
 }
 
 export type { BaseParams, BasePayload };
+
+export interface ReportingStatsPayload {
+  reports: IReportingStats;
+  config: {
+    capture: {
+      maxAttempts: number;
+    };
+    queue: {
+      pollEnabled: boolean;
+      timeout: number;
+    };
+    roles: {
+      enabled: boolean;
+    };
+  };
+  kibana: {
+    uuid: string;
+    host: string;
+    name: string;
+    basePath: string;
+    version: string;
+  };
+}

--- a/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
@@ -26,6 +26,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./network_policy'));
     loadTestFile(require.resolve('./spaces'));
     loadTestFile(require.resolve('./usage'));
+    loadTestFile(require.resolve('./stats'));
     loadTestFile(require.resolve('./ilm_migration_apis'));
     loadTestFile(require.resolve('./error_codes'));
     loadTestFile(require.resolve('./validation'));

--- a/x-pack/test/reporting_api_integration/reporting_and_security/stats.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/stats.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { API_STATS_URL as REPORTING_STATS_URL } from '@kbn/reporting-plugin/common/constants';
+import { ReportingStatsPayload } from '@kbn/reporting-plugin/server/types';
+import { FtrProviderContext } from '../ftr_provider_context';
+
+// eslint-disable-next-line import/no-default-export
+export default function ({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  describe('Health stats', function () {
+    it('requires authentication', async () => {
+      await supertestWithoutAuth.get(REPORTING_STATS_URL).expect(401);
+    });
+
+    describe('API response', () => {
+      let stats: ReportingStatsPayload;
+
+      before(async () => {
+        const { text } = await supertest.get(REPORTING_STATS_URL).expect(200);
+        stats = JSON.parse(text);
+      });
+
+      it('includes config values', () => {
+        expect(stats.config.queue.pollEnabled).eql(true);
+        expect(stats.config.queue.timeout).eql(120000);
+        expect(stats.config.capture.maxAttempts).eql(1);
+        expect(stats.config.roles.enabled).eql(false);
+      });
+
+      it('includes kibana stats', () => {
+        expect(Object.keys(stats.kibana).length).eql(4);
+        expect(stats.kibana.host).a('string');
+        expect(stats.kibana.name).a('string');
+        expect(stats.kibana.uuid).a('string');
+        expect(stats.kibana.version).match(/8\.2\.0/);
+      });
+
+      it('includes reports stats', () => {
+        expect(Object.keys(stats.reports.queue).length).eql(7);
+        expect(stats.reports.queue.claimed).a('number');
+        expect(stats.reports.queue.completed).a('number');
+        expect(stats.reports.queue.failed).a('number');
+        expect(stats.reports.queue.retried).a('number');
+        expect(stats.reports.queue.saved).a('number');
+        expect(stats.reports.queue.scheduled).a('number');
+        expect(stats.reports.queue.started).a('number');
+        expect(stats.reports.state.status).eql('idle');
+
+        expect(Object.keys(stats.reports.jobTypes).length).eql(6);
+        expect(stats.reports.jobTypes.PNG).a('number');
+        expect(stats.reports.jobTypes.PNGV2).a('number');
+        expect(stats.reports.jobTypes.csv_searchsource).a('number');
+        expect(stats.reports.jobTypes.csv_searchsource_immediate).a('number');
+        expect(stats.reports.jobTypes.printable_pdf).a('number');
+        expect(stats.reports.jobTypes.printable_pdf_v2).a('number');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Draft: investigate creating an API endpoint in Reporting that can be used to monitor the instance with Metricbeat.