### PR TITLE
[Cloud Posture] create latest findings index in plugin setup

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -11,7 +11,7 @@ export const BENCHMARKS_ROUTE_PATH = '/api/csp/benchmarks';
 
 export const CSP_KUBEBEAT_INDEX_PATTERN = 'logs-cis_kubernetes_benchmark.findings*';
 export const AGENT_LOGS_INDEX_PATTERN = '.logs-cis_kubernetes_benchmark.metadata*';
-export const LATEST_FINDINGS_INDEX_PATTERN = '.csp-findings-latest';
+export const LATEST_FINDINGS_INDEX_PATTERN = 'cloud_security_posture-findings_latest';
 
 export const CSP_FINDINGS_INDEX_NAME = 'findings';
 export const CIS_KUBERNETES_PACKAGE_NAME = 'cis_kubernetes_benchmark';

--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -11,6 +11,7 @@ export const BENCHMARKS_ROUTE_PATH = '/api/csp/benchmarks';
 
 export const CSP_KUBEBEAT_INDEX_PATTERN = 'logs-cis_kubernetes_benchmark.findings*';
 export const AGENT_LOGS_INDEX_PATTERN = '.logs-cis_kubernetes_benchmark.metadata*';
+export const LATEST_FINDINGS_INDEX_PATTERN = '.csp-findings-latest';
 
 export const CSP_FINDINGS_INDEX_NAME = 'findings';
 export const CIS_KUBERNETES_PACKAGE_NAME = 'cis_kubernetes_benchmark';

--- a/x-pack/plugins/cloud_security_posture/server/create_latest_index.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_latest_index.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { transformError } from '@kbn/securitysolution-es-utils';
+import type { ElasticsearchClient, Logger } from '../../../../src/core/server';
+import { LATEST_FINDINGS_INDEX_PATTERN } from '../common/constants';
+
+// TODO: Add integration tests
+export const initializeCspLatestFindingsIndex = async (
+  esClient: ElasticsearchClient,
+  logger: Logger
+) => {
+  try {
+    const isExists = await esClient.indices.exists({ index: LATEST_FINDINGS_INDEX_PATTERN });
+
+    if (!isExists) {
+      await esClient.indices.create({
+        index: LATEST_FINDINGS_INDEX_PATTERN,
+        settings: {
+          hidden: true,
+        },
+      });
+    }
+  } catch (err) {
+    const error = transformError(err);
+    logger.error(`Failed to create ${LATEST_FINDINGS_INDEX_PATTERN}`);
+    logger.error(error.message);
+  }
+};

--- a/x-pack/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/server/plugin.ts
@@ -22,7 +22,7 @@ import type {
 import { defineRoutes } from './routes';
 import { cspRuleAssetType } from './saved_objects/cis_1_4_1/csp_rule_type';
 import { initializeCspRules } from './saved_objects/cis_1_4_1/initialize_rules';
-
+import { initializeCspLatestFindingsIndex } from './create_latest_index';
 export interface CspAppContext {
   logger: Logger;
   service: CspAppService;
@@ -68,7 +68,7 @@ export class CspPlugin
     });
 
     initializeCspRules(core.savedObjects.createInternalRepository());
-
+    initializeCspLatestFindingsIndex(core.elasticsearch.client.asInternalUser, this.logger);
     return {};
   }
   public stop() {}

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
@@ -76,6 +76,18 @@ describe('benchmarks API', () => {
       });
     });
 
+    it('expect to find benchmark_filter', async () => {
+      const validatedQuery = benchmarksInputSchema.validate({
+        benchmark_filter: 'my_cis_benchmark',
+      });
+
+      expect(validatedQuery).toMatchObject({
+        page: 1,
+        per_page: DEFAULT_BENCHMARKS_PER_PAGE,
+        benchmark_filter: 'my_cis_benchmark',
+      });
+    });
+
     it('should throw when page field is not a positive integer', async () => {
       expect(() => {
         benchmarksInputSchema.validate({ page: -2 });
@@ -123,6 +135,24 @@ describe('benchmarks API', () => {
           })
         );
       });
+    });
+
+    it('should format request by benchmark_filter', async () => {
+      const mockAgentPolicyService = createPackagePolicyServiceMock();
+
+      await getPackagePolicies(mockSoClient, mockAgentPolicyService, 'myPackage', {
+        page: 1,
+        per_page: 100,
+        benchmark_filter: 'my_cis_benchmark',
+      });
+
+      expect(mockAgentPolicyService.list.mock.calls[0][1]).toMatchObject(
+        expect.objectContaining({
+          kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:myPackage AND ${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.name: *my_cis_benchmark*`,
+          page: 1,
+          perPage: 100,
+        })
+      );
     });
 
     describe('test getAgentPolicies', () => {


### PR DESCRIPTION
Resolves: #126989 
create index for latest findings in. `cloud_security_posture` plugin setup