### PR TITLE
[Cloud Posture] add filterting for benchmark

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
@@ -76,15 +76,15 @@ describe('benchmarks API', () => {
       });
     });
 
-    it('expect to find benchmark_filter', async () => {
+    it('expect to find benchmark_name', async () => {
       const validatedQuery = benchmarksInputSchema.validate({
-        benchmark_filter: 'my_cis_benchmark',
+        benchmark_name: 'my_cis_benchmark',
       });
 
       expect(validatedQuery).toMatchObject({
         page: 1,
         per_page: DEFAULT_BENCHMARKS_PER_PAGE,
-        benchmark_filter: 'my_cis_benchmark',
+        benchmark_name: 'my_cis_benchmark',
       });
     });
 
@@ -137,13 +137,13 @@ describe('benchmarks API', () => {
       });
     });
 
-    it('should format request by benchmark_filter', async () => {
+    it('should format request by benchmark_name', async () => {
       const mockAgentPolicyService = createPackagePolicyServiceMock();
 
       await getPackagePolicies(mockSoClient, mockAgentPolicyService, 'myPackage', {
         page: 1,
         per_page: 100,
-        benchmark_filter: 'my_cis_benchmark',
+        benchmark_name: 'my_cis_benchmark',
       });
 
       expect(mockAgentPolicyService.list.mock.calls[0][1]).toMatchObject(

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
@@ -76,6 +76,18 @@ describe('benchmarks API', () => {
       });
     });
 
+    it('expect to find benchmark_filter', async () => {
+      const validatedQuery = benchmarksInputSchema.validate({
+        benchmark_filter: 'my_cis_benchmark',
+      });
+
+      expect(validatedQuery).toMatchObject({
+        page: 1,
+        per_page: DEFAULT_BENCHMARKS_PER_PAGE,
+        benchmark_filter: 'my_cis_benchmark',
+      });
+    });
+
     it('should throw when page field is not a positive integer', async () => {
       expect(() => {
         benchmarksInputSchema.validate({ page: -2 });
@@ -123,6 +135,24 @@ describe('benchmarks API', () => {
           })
         );
       });
+    });
+
+    it('should format request by benchmark_filter', async () => {
+      const mockAgentPolicyService = createPackagePolicyServiceMock();
+
+      await getPackagePolicies(mockSoClient, mockAgentPolicyService, 'myPackage', {
+        page: 1,
+        per_page: 100,
+        benchmark_filter: 'my_cis_benchmark',
+      });
+
+      expect(mockAgentPolicyService.list.mock.calls[0][1]).toMatchObject(
+        expect.objectContaining({
+          kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:myPackage AND ${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.name: *my_cis_benchmark*`,
+          page: 1,
+          perPage: 100,
+        })
+      );
     });
 
     describe('test getAgentPolicies', () => {

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
@@ -43,8 +43,13 @@ export interface Benchmark {
 export const DEFAULT_BENCHMARKS_PER_PAGE = 20;
 export const PACKAGE_POLICY_SAVED_OBJECT_TYPE = 'ingest-package-policies';
 
-const getPackageNameQuery = (packageName: string): string => {
-  return `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${packageName}`;
+const getPackageNameQuery = (packageName: string, benchmarkFilter: string | undefined): string => {
+  const integrationNameQuery = `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${packageName}`;
+  const kquery = benchmarkFilter
+    ? `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${packageName} AND ${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.name: *${benchmarkFilter}*`
+    : integrationNameQuery;
+
+  return kquery;
 };
 
 export const getPackagePolicies = async (
@@ -57,7 +62,7 @@ export const getPackagePolicies = async (
     throw new Error('packagePolicyService is undefined');
   }
 
-  const packageNameQuery = getPackageNameQuery(packageName);
+  const packageNameQuery = getPackageNameQuery(packageName, queryParams.benchmark_filter);
 
   const { items: packagePolicies } = (await packagePolicyService?.list(soClient, {
     kuery: packageNameQuery,
@@ -193,4 +198,8 @@ export const benchmarksInputSchema = rt.object({
    * The number of objects to include in each page
    */
   per_page: rt.number({ defaultValue: DEFAULT_BENCHMARKS_PER_PAGE, min: 0 }),
+  /**
+   * Benchmark filter
+   */
+  benchmark_filter: rt.maybe(rt.string()),
 });

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
@@ -43,7 +43,7 @@ export interface Benchmark {
 export const DEFAULT_BENCHMARKS_PER_PAGE = 20;
 export const PACKAGE_POLICY_SAVED_OBJECT_TYPE = 'ingest-package-policies';
 
-const getPackageNameQuery = (packageName: string, benchmarkFilter: string | undefined): string => {
+const getPackageNameQuery = (packageName: string, benchmarkFilter?: string): string => {
   const integrationNameQuery = `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${packageName}`;
   const kquery = benchmarkFilter
     ? `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${packageName} AND ${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.name: *${benchmarkFilter}*`
@@ -62,7 +62,7 @@ export const getPackagePolicies = async (
     throw new Error('packagePolicyService is undefined');
   }
 
-  const packageNameQuery = getPackageNameQuery(packageName, queryParams.benchmark_filter);
+  const packageNameQuery = getPackageNameQuery(packageName, queryParams.benchmark_name);
 
   const { items: packagePolicies } = (await packagePolicyService?.list(soClient, {
     kuery: packageNameQuery,
@@ -201,5 +201,5 @@ export const benchmarksInputSchema = rt.object({
   /**
    * Benchmark filter
    */
-  benchmark_filter: rt.maybe(rt.string()),
+  benchmark_name: rt.maybe(rt.string()),
 });


### PR DESCRIPTION
Resolves: #126981 
Add support for filtering benchmarks in cloud security posture plugin 
Adding support for filter by integration name.
To test it create different agent policies, in each one of them add cis_kubernetes_benchmark package and give it a different name.
then use the next curl commands:

```
curl --location --request GET 'http://localhost:5601/api/csp/benchmarks?benchmark_filter=my_cis_package' \
--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
--header 'kbn-xsrf;'
```
