### PR TITLE
[Cloud Posture]add support for search findings by kql

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.test.tsx
@@ -46,7 +46,7 @@ const getFakeFindings = (): CspFinding & { id: string } => ({
     uid: chance.string(),
     mode: chance.string(),
   },
-  run_id: chance.string(),
+  cycle_id: chance.string(),
   host: {} as any,
   ecs: {} as any,
   '@timestamp': new Date().toISOString(),

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
@@ -8,7 +8,7 @@
 // TODO: this needs to be defined in a versioned schema
 export interface CspFinding {
   '@timestamp': string;
-  run_id: string;
+  cycle_id: string;
   result: CspFindingResult;
   resource: CspFindingResource;
   rule: CspRule;

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.test.ts
@@ -183,7 +183,7 @@ describe('findings API', () => {
       expect(handlerArgs).toMatchObject({
         query: {
           bool: {
-            filter: [{ terms: { 'cycle_id.keyword': 'randomId1' } }],
+            filter: [{ terms: { 'cycle_id.keyword': ['randomId1'] } }],
           },
         },
       });

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.test.ts
@@ -162,7 +162,7 @@ describe('findings API', () => {
                 {
                   group_docs: {
                     hits: {
-                      hits: [{ fields: { 'run_id.keyword': ['randomId1'] } }],
+                      hits: [{ fields: { 'cycle_id.keyword': ['randomId1'] } }],
                     },
                   },
                 },
@@ -183,7 +183,7 @@ describe('findings API', () => {
       expect(handlerArgs).toMatchObject({
         query: {
           bool: {
-            filter: [{ term: { 'run_id.keyword': 'randomId1' } }],
+            filter: [{ terms: { 'cycle_id.keyword': 'randomId1' } }],
           },
         },
       });
@@ -347,6 +347,110 @@ describe('findings API', () => {
       expect(handlerArgs).toMatchObject({
         _source: ['field1', 'field2', 'field3'],
       });
+    });
+  });
+
+  it('takes dslQuery and validate the conversion to esQuery filter', async () => {
+    const mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;
+    const router = httpServiceMock.createRouter();
+    const cspAppContextService = new CspAppService();
+    const cspContext: CspAppContext = {
+      logger,
+      service: cspAppContextService,
+    };
+
+    defineFindingsIndexRoute(router, cspContext);
+
+    const [_, handler] = router.get.mock.calls[0];
+    const mockContext = getMockCspContext(mockEsClient);
+    const mockResponse = httpServerMock.createResponseFactory();
+    const mockRequest = httpServerMock.createKibanaRequest({
+      query: {
+        kquery: 'result.evaluation.keyword:failed',
+      },
+    });
+
+    const [context, req, res] = [mockContext, mockRequest, mockResponse];
+
+    await handler(context, req, res);
+    const handlerArgs = mockEsClient.search.mock.calls[0][0];
+
+    expect(handlerArgs).toMatchObject({
+      query: {
+        bool: {
+          filter: [
+            {
+              bool: {
+                minimum_should_match: 1,
+                should: [{ match: { 'result.evaluation.keyword': 'failed' } }],
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('takes dslQuery and latest_cycle filter validate the conversion to esQuery filter', async () => {
+    const mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;
+    const router = httpServiceMock.createRouter();
+    const cspAppContextService = new CspAppService();
+    const cspContext: CspAppContext = {
+      logger,
+      service: cspAppContextService,
+    };
+
+    defineFindingsIndexRoute(router, cspContext);
+    const [_, handler] = router.get.mock.calls[0];
+
+    const mockContext = getMockCspContext(mockEsClient);
+    const mockResponse = httpServerMock.createResponseFactory();
+    const mockRequest = httpServerMock.createKibanaRequest({
+      query: {
+        kquery: 'result.evaluation.keyword:failed',
+        latest_cycle: true,
+      },
+    });
+
+    mockEsClient.search.mockResolvedValueOnce(
+      // @ts-expect-error @elastic/elasticsearch Aggregate only allows unknown values
+      elasticsearchClientMock.createSuccessTransportRequestPromise({
+        aggregations: {
+          group: {
+            buckets: [
+              {
+                group_docs: {
+                  hits: {
+                    hits: [{ fields: { 'cycle_id.keyword': ['randomId1'] } }],
+                  },
+                },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const [context, req, res] = [mockContext, mockRequest, mockResponse];
+
+    await handler(context, req, res);
+
+    const handlerArgs = mockEsClient.search.mock.calls[1][0];
+    // console.log(handlerArgs.query.bool);
+    expect(handlerArgs).toMatchObject({
+      query: {
+        bool: {
+          filter: [
+            {
+              bool: {
+                should: [{ match: { 'result.evaluation.keyword': 'failed' } }],
+                minimum_should_match: 1,
+              },
+            },
+            { terms: { 'cycle_id.keyword': ['randomId1'] } },
+          ],
+        },
+      },
     });
   });
 });

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import type { IRouter } from 'src/core/server';
+import type { IRouter, Logger } from 'src/core/server';
 import { SearchRequest, QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
+import { QueryDslBoolQuery } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { schema as rt, TypeOf } from '@kbn/config-schema';
 import type { SortOrder } from '@elastic/elasticsearch/lib/api/types';
 import { transformError } from '@kbn/securitysolution-es-utils';
@@ -50,18 +52,48 @@ const getFindingsEsQuery = (
   };
 };
 
-const buildQueryRequest = (latestCycleIds?: string[]): QueryDslQueryContainer => {
-  let filterPart: QueryDslQueryContainer = { match_all: {} };
+const buildLatestCycleFilter = (
+  filter: QueryDslQueryContainer[],
+  latestCycleIds?: string[]
+): QueryDslQueryContainer[] => {
   if (!!latestCycleIds) {
-    const filter = latestCycleIds.map((latestCycleId) => ({
-      term: { 'run_id.keyword': latestCycleId },
-    }));
-    filterPart = { bool: { filter } };
+    filter.push({
+      terms: { 'cycle_id.keyword': latestCycleIds },
+    });
   }
+  return filter;
+};
 
-  return {
-    ...filterPart,
+const convertKqueryToElasticsearchQuery = (
+  kquery: string | undefined,
+  logger: Logger
+): QueryDslQueryContainer[] => {
+  let dslFilterQuery: QueryDslBoolQuery['filter'];
+  try {
+    dslFilterQuery = kquery ? toElasticsearchQuery(fromKueryExpression(kquery)) : [];
+    if (!Array.isArray(dslFilterQuery)) {
+      dslFilterQuery = [dslFilterQuery];
+    }
+  } catch (err) {
+    logger.warn(`Invalid kuery syntax for the filter (${kquery}) error: ${err.message}`);
+    throw err;
+  }
+  return dslFilterQuery;
+};
+
+const buildQueryRequest = (
+  kquery: string | undefined,
+  latestCycleIds: string[] | undefined,
+  logger: Logger
+): QueryDslQueryContainer => {
+  const kqueryFilter = convertKqueryToElasticsearchQuery(kquery, logger);
+  const filter = buildLatestCycleFilter(kqueryFilter, latestCycleIds);
+  const query = {
+    bool: {
+      filter,
+    },
   };
+  return query;
 };
 
 const buildOptionsRequest = (queryParams: FindingsQuerySchema): FindingsOptions => ({
@@ -87,15 +119,20 @@ export const defineFindingsIndexRoute = (router: IRouter, cspContext: CspAppCont
             ? await getLatestCycleIds(esClient, cspContext.logger)
             : undefined;
 
-        const query = buildQueryRequest(latestCycleIds);
+        if (request.query.latest_cycle === true && latestCycleIds === undefined) {
+          return response.ok({ body: [] });
+        }
+
+        const query = buildQueryRequest(request.query.kquery, latestCycleIds, cspContext.logger);
         const esQuery = getFindingsEsQuery(query, options);
 
-        const findings = await esClient.search(esQuery, { meta: true });
+        const findings = await esClient.search(esQuery);
         const hits = findings.body.hits.hits;
 
         return response.ok({ body: hits });
       } catch (err) {
         const error = transformError(err);
+        cspContext.logger.error(`Failed to fetch Findings ${error.message}`);
         return response.customError({
           body: { message: error.message },
           statusCode: error.statusCode,
@@ -129,4 +166,8 @@ export const findingsInputSchema = rt.object({
    * The fields in the entity to return in the response
    */
   fields: rt.maybe(rt.string()),
+  /**
+   * kql query
+   */
+  kquery: rt.maybe(rt.string()),
 });

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/get_latest_cycle.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/get_latest_cycle.test.ts
@@ -47,7 +47,7 @@ describe('get latest cycle ids', () => {
               {
                 group_docs: {
                   hits: {
-                    hits: [{ fields: { 'run_id.keyword': ['randomId1'] } }],
+                    hits: [{ fields: { 'cycle_id.keyword': ['randomId1'] } }],
                   },
                 },
               },
@@ -70,21 +70,21 @@ describe('get latest cycle ids', () => {
               {
                 group_docs: {
                   hits: {
-                    hits: [{ fields: { 'run_id.keyword': ['randomId1'] } }],
+                    hits: [{ fields: { 'cycle_id.keyword': ['randomId1'] } }],
                   },
                 },
               },
               {
                 group_docs: {
                   hits: {
-                    hits: [{ fields: { 'run_id.keyword': ['randomId2'] } }],
+                    hits: [{ fields: { 'cycle_id.keyword': ['randomId2'] } }],
                   },
                 },
               },
               {
                 group_docs: {
                   hits: {
-                    hits: [{ fields: { 'run_id.keyword': ['randomId3'] } }],
+                    hits: [{ fields: { 'cycle_id.keyword': ['randomId3'] } }],
                   },
                 },
               },

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/get_latest_cycle_ids.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/get_latest_cycle_ids.ts
@@ -30,18 +30,18 @@ const getAgentLogsEsQuery = (): SearchRequest => ({
       },
     },
   },
-  fields: ['run_id.keyword', 'agent.id.keyword'],
+  fields: ['cycle_id.keyword', 'agent.id.keyword'],
   _source: false,
 });
 
-const getCycleId = (v: any): string => v.group_docs.hits.hits?.[0]?.fields['run_id.keyword'][0];
+const getCycleId = (v: any): string => v.group_docs.hits.hits?.[0]?.fields['cycle_id.keyword'][0];
 
 export const getLatestCycleIds = async (
   esClient: ElasticsearchClient,
   logger: Logger
 ): Promise<string[] | undefined> => {
   try {
-    const agentLogs = await esClient.search(getAgentLogsEsQuery(), { meta: true });
+    const agentLogs = await esClient.search(getAgentLogsEsQuery());
     const aggregations = agentLogs.body.aggregations;
     if (!aggregations) {
       return;
@@ -50,9 +50,10 @@ export const getLatestCycleIds = async (
     if (!Array.isArray(buckets)) {
       return;
     }
+
     return buckets.map(getCycleId);
   } catch (err) {
     logger.error('Failed to fetch cycle_ids');
-    return;
+    throw new Error('Failed to fetch cycle_ids');
   }
 };


### PR DESCRIPTION
Resolves: #126984 
Adding support for search by kql query via the Findings API

```
curl --location --request GET 'http://localhost:5601/api/csp/findings?kquery=result.evaluation.keyword:failed' \
--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
--header 'kbn-xsrf;'
```