### PR TITLE
[Cloud Posture]create rules config based on rules status and update package policy

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -8,6 +8,7 @@
 export const STATS_ROUTE_PATH = '/api/csp/stats';
 export const FINDINGS_ROUTE_PATH = '/api/csp/findings';
 export const BENCHMARKS_ROUTE_PATH = '/api/csp/benchmarks';
+export const UPDATE_RULES_CONFIG_ROUTE_PATH = '/api/csp/update_rules_config';
 
 export const CSP_KUBEBEAT_INDEX_PATTERN = 'logs-cis_kubernetes_benchmark.findings*';
 export const AGENT_LOGS_INDEX_PATTERN = '.logs-cis_kubernetes_benchmark.metadata*';

--- a/x-pack/plugins/cloud_security_posture/common/schemas/csp_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/common/schemas/csp_configuration.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { schema as rt, TypeOf } from '@kbn/config-schema';
+
+export const cspRulesConfigSchema = rt.object({
+  activated_rules: rt.object({
+    cis_k8s: rt.arrayOf(rt.string()),
+  }),
+});
+
+export type CspRulesConfigSchema = TypeOf<typeof cspRulesConfigSchema>;

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
@@ -109,25 +109,15 @@ describe('benchmarks API', () => {
     });
 
     describe('test getPackagePolicies', () => {
-      it('should throw when agentPolicyService is undefined', async () => {
-        const mockAgentPolicyService = undefined;
-        expect(
-          getPackagePolicies(mockSoClient, mockAgentPolicyService, 'myPackage', {
-            page: 1,
-            per_page: 100,
-          })
-        ).rejects.toThrow();
-      });
-
       it('should format request by package name', async () => {
-        const mockAgentPolicyService = createPackagePolicyServiceMock();
+        const mockPackagePolicyService = createPackagePolicyServiceMock();
 
-        await getPackagePolicies(mockSoClient, mockAgentPolicyService, 'myPackage', {
+        await getPackagePolicies(mockSoClient, mockPackagePolicyService, 'myPackage', {
           page: 1,
           per_page: 100,
         });
 
-        expect(mockAgentPolicyService.list.mock.calls[0][1]).toMatchObject(
+        expect(mockPackagePolicyService.list.mock.calls[0][1]).toMatchObject(
           expect.objectContaining({
             kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:myPackage`,
             page: 1,

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
@@ -54,7 +54,7 @@ const getPackageNameQuery = (packageName: string, benchmarkFilter?: string): str
 
 export const getPackagePolicies = async (
   soClient: SavedObjectsClientContract,
-  packagePolicyService: PackagePolicyServiceInterface | undefined,
+  packagePolicyService: PackagePolicyServiceInterface,
   packageName: string,
   queryParams: BenchmarksQuerySchema
 ): Promise<PackagePolicy[]> => {
@@ -159,8 +159,7 @@ export const defineGetBenchmarksRoute = (router: IRouter, cspContext: CspAppCont
         const agentPolicyService = cspContext.service.agentPolicyService;
         const packagePolicyService = cspContext.service.packagePolicyService;
 
-        // TODO: This validate can be remove after #2819 will be merged
-        if (!agentPolicyService || !agentService) {
+        if (!agentPolicyService || !agentService || !packagePolicyService) {
           throw new Error(`Failed to get Fleet services`);
         }
 

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+// eslint-disable-next-line @kbn/eslint/no-restricted-paths
+import { elasticsearchClientMock } from 'src/core/server/elasticsearch/client/mocks';
+import { savedObjectsClientMock, httpServiceMock, loggingSystemMock } from 'src/core/server/mocks';
+import {
+  convertRulesConfigToYaml,
+  createRulesConfig,
+  defineUpdateRulesConfigRoute,
+  getCspRules,
+  setVarToPackagePolicy,
+  updatePackagePolicy,
+} from './update_rules_configuration';
+
+import { CspAppService } from '../../lib/csp_app_services';
+import { CspAppContext } from '../../plugin';
+import { createPackagePolicyMock } from '../../../../fleet/common/mocks';
+import { createPackagePolicyServiceMock } from '../../../../fleet/server/mocks';
+
+import { cspRuleAssetSavedObjectType, CspRuleSchema } from '../../../common/schemas/csp_rule';
+import {
+  ElasticsearchClient,
+  SavedObjectsClientContract,
+  SavedObjectsFindResponse,
+} from 'kibana/server';
+import { Chance } from 'chance';
+
+describe('Update rules configuration API', () => {
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let mockEsClient: jest.Mocked<ElasticsearchClient>;
+  let mockSoClient: jest.Mocked<SavedObjectsClientContract>;
+  const chance = new Chance();
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    jest.clearAllMocks();
+  });
+
+  it('validate the API route path', async () => {
+    const router = httpServiceMock.createRouter();
+    const cspAppContextService = new CspAppService();
+
+    const cspContext: CspAppContext = {
+      logger,
+      service: cspAppContextService,
+    };
+    defineUpdateRulesConfigRoute(router, cspContext);
+
+    const [config, _] = router.post.mock.calls[0];
+
+    expect(config.path).toEqual('/api/csp/update_rules_config');
+  });
+
+  it('validate getCspRules input parameters', async () => {
+    mockSoClient = savedObjectsClientMock.create();
+    mockSoClient.find.mockResolvedValueOnce({} as SavedObjectsFindResponse);
+    await getCspRules(mockSoClient);
+    expect(mockSoClient.find).toBeCalledTimes(1);
+    expect(mockSoClient.find).toHaveBeenCalledWith(
+      expect.objectContaining({ type: cspRuleAssetSavedObjectType })
+    );
+  });
+
+  it('create csp rules config based on activated csp rules', async () => {
+    const cspRules = {
+      page: 1,
+      per_page: 1000,
+      total: 2,
+      saved_objects: [
+        {
+          type: 'csp_rule',
+          id: '1.1.1',
+          attributes: { enabled: true },
+        },
+        {
+          type: 'csp_rule',
+          id: '1.1.2',
+          attributes: { enabled: false },
+        },
+        {
+          type: 'csp_rule',
+          id: '1.1.3',
+          attributes: { enabled: true },
+        },
+      ],
+    } as SavedObjectsFindResponse<CspRuleSchema>;
+    const cspConfig = await createRulesConfig(cspRules);
+    expect(cspConfig).toMatchObject({ activated_rules: { cis_k8s: ['1.1.1', '1.1.3'] } });
+  });
+
+  it('create empty csp rules config when all rules are disabled', async () => {
+    const cspRules = {
+      page: 1,
+      per_page: 1000,
+      total: 2,
+      saved_objects: [
+        {
+          type: 'csp_rule',
+          id: '1.1.1',
+          attributes: { enabled: false },
+        },
+        {
+          type: 'csp_rule',
+          id: '1.1.2',
+          attributes: { enabled: false },
+        },
+      ],
+    } as SavedObjectsFindResponse<CspRuleSchema>;
+    const cspConfig = await createRulesConfig(cspRules);
+    expect(cspConfig).toMatchObject({ activated_rules: { cis_k8s: [] } });
+  });
+
+  it('validate converting rules config object to Yaml', async () => {
+    const cspRuleConfig = { activated_rules: { cis_k8s: ['1.1.1', '1.1.2'] } };
+
+    const dataYaml = convertRulesConfigToYaml(cspRuleConfig);
+
+    expect(dataYaml).toEqual('activated_rules:\n  cis_k8s:\n    - 1.1.1\n    - 1.1.2\n');
+  });
+
+  it('validate adding new data.yaml to package policy instance', async () => {
+    const packagePolicy = createPackagePolicyMock();
+
+    const dataYaml = 'activated_rules:\n  cis_k8s:\n    - 1.1.1\n    - 1.1.2\n';
+    const updatedPackagePolicy = setVarToPackagePolicy(packagePolicy, dataYaml);
+
+    expect(updatedPackagePolicy.vars).toEqual({ dataYaml: { type: 'config', value: dataYaml } });
+  });
+
+  it('validate updatePackagePolicy is called with the right parameters', async () => {
+    mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;
+    mockSoClient = savedObjectsClientMock.create();
+    const mockPackagePolicyService = createPackagePolicyServiceMock();
+
+    const packagePolicyId1 = chance.guid();
+    const packagePolicyId2 = chance.guid();
+    const mockPackagePolicy1 = createPackagePolicyMock();
+    const mockPackagePolicy2 = createPackagePolicyMock();
+    mockPackagePolicy1.id = packagePolicyId1;
+    mockPackagePolicy2.id = packagePolicyId2;
+    const packagePolicies = mockPackagePolicy1;
+
+    const dataYaml = 'activated_rules:\n  cis_k8s:\n    - 1.1.1\n    - 1.1.2\n';
+
+    await updatePackagePolicy(
+      mockPackagePolicyService,
+      packagePolicies,
+      mockEsClient,
+      mockSoClient,
+      dataYaml
+    );
+
+    expect(mockPackagePolicyService.update).toBeCalledTimes(1);
+    expect(mockPackagePolicyService.update.mock.calls[0][2]).toEqual(packagePolicyId1);
+  });
+});

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type {
+  ElasticsearchClient,
+  IRouter,
+  SavedObjectsClientContract,
+  SavedObjectsFindResponse,
+} from 'src/core/server';
+import { schema as rt } from '@kbn/config-schema';
+import { transformError } from '@kbn/securitysolution-es-utils';
+
+import { produce } from 'immer';
+import { unset } from 'lodash';
+import yaml from 'js-yaml';
+
+import { PackagePolicy, PackagePolicyConfigRecord } from '../../../../fleet/common';
+import { CspAppContext } from '../../plugin';
+import { CspRulesConfigSchema } from '../../../common/schemas/csp_configuration';
+import { CspRuleSchema, cspRuleAssetSavedObjectType } from '../../../common/schemas/csp_rule';
+import { UPDATE_RULES_CONFIG_ROUTE_PATH } from '../../../common/constants';
+import { CIS_KUBERNETES_PACKAGE_NAME } from '../../../common/constants';
+import { PackagePolicyServiceInterface } from '../../../../fleet/server';
+
+export const getPackagePolicy = async (
+  soClient: SavedObjectsClientContract,
+  packagePolicyService: PackagePolicyServiceInterface,
+  packagePolicyId: string
+): Promise<PackagePolicy> => {
+  const packagePolicies = await packagePolicyService.getByIDs(soClient, [packagePolicyId]);
+
+  // PackagePolicies always contains one element, even when package does not exist
+  if (!packagePolicies || !packagePolicies[0].version) {
+    throw new Error(`package policy Id '${packagePolicyId}' is not exist`);
+  }
+  if (packagePolicies[0].package?.name !== CIS_KUBERNETES_PACKAGE_NAME) {
+    // TODO: improve this validator to support any future CSP package
+    throw new Error(`Package Policy Id '${packagePolicyId}' is not CSP package`);
+  }
+
+  return packagePolicies![0];
+};
+
+export const getCspRules = async (soClient: SavedObjectsClientContract) => {
+  const cspRules = await soClient.find<CspRuleSchema>({
+    type: cspRuleAssetSavedObjectType,
+    search: '',
+    searchFields: ['name'],
+    // TODO: research how to get all rules
+    perPage: 10000,
+  });
+  return cspRules;
+};
+
+export const createRulesConfig = (
+  cspRules: SavedObjectsFindResponse<CspRuleSchema>
+): CspRulesConfigSchema => {
+  const activatedRules = cspRules.saved_objects.filter((cspRule) => cspRule.attributes.enabled);
+
+  const config = {
+    activated_rules: {
+      cis_k8s: activatedRules.map((activatedRule) => activatedRule.id),
+    },
+  };
+  return config;
+};
+
+export const convertRulesConfigToYaml = (config: CspRulesConfigSchema): string => {
+  return yaml.safeDump(config);
+};
+
+export const setVarToPackagePolicy = (
+  packagePolicy: PackagePolicy,
+  dataYaml: string
+): PackagePolicy => {
+  const configFile: PackagePolicyConfigRecord = {
+    dataYaml: { type: 'config', value: dataYaml },
+  };
+  const updatedPackagePolicy = produce(packagePolicy, (draft) => {
+    unset(draft, 'id');
+    draft.vars = configFile;
+    // TODO: disable comments after adding base config to integration
+    // draft.inputs[0].vars = configFile;
+  });
+  return updatedPackagePolicy;
+};
+
+export const updatePackagePolicy = (
+  packagePolicyService: PackagePolicyServiceInterface,
+  packagePolicy: PackagePolicy,
+  esClient: ElasticsearchClient,
+  soClient: SavedObjectsClientContract,
+  dataYaml: string
+): Promise<PackagePolicy> => {
+  const updatedPackagePolicy = setVarToPackagePolicy(packagePolicy, dataYaml);
+  return packagePolicyService.update(soClient, esClient, packagePolicy.id, updatedPackagePolicy);
+};
+
+export const defineUpdateRulesConfigRoute = (router: IRouter, cspContext: CspAppContext): void =>
+  router.post(
+    {
+      path: UPDATE_RULES_CONFIG_ROUTE_PATH,
+      validate: { query: configurationUpdateInputSchema },
+    },
+    async (context, request, response) => {
+      try {
+        const esClient = context.core.elasticsearch.client.asCurrentUser;
+        const soClient = context.core.savedObjects.client;
+        const packagePolicyService = cspContext.service.packagePolicyService;
+        const packagePolicyId = request.query.package_policy_id;
+
+        if (!packagePolicyService) {
+          throw new Error(`Failed to get Fleet services`);
+        }
+        const packagePolicy = await getPackagePolicy(
+          soClient,
+          packagePolicyService,
+          packagePolicyId
+        );
+
+        const cspRules = await getCspRules(soClient);
+        const rulesConfig = createRulesConfig(cspRules);
+        const dataYaml = convertRulesConfigToYaml(rulesConfig);
+
+        const updatedPackagePolicies = await updatePackagePolicy(
+          packagePolicyService!,
+          packagePolicy,
+          esClient,
+          soClient,
+          dataYaml
+        );
+
+        return response.ok({ body: updatedPackagePolicies });
+      } catch (err) {
+        const error = transformError(err);
+        cspContext.logger.error(
+          `Failed to update rules configuration on package policy ${error.message}`
+        );
+        return response.customError({
+          body: { message: error.message },
+          statusCode: error.statusCode,
+        });
+      }
+    }
+  );
+
+export const configurationUpdateInputSchema = rt.object({
+  /**
+   * CSP integration instance ID
+   */
+  package_policy_id: rt.string(),
+});

--- a/x-pack/plugins/cloud_security_posture/server/routes/index.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/index.ts
@@ -9,10 +9,12 @@ import type { IRouter } from '../../../../../src/core/server';
 import { defineGetComplianceDashboardRoute } from './compliance_dashboard/compliance_dashboard';
 import { defineGetBenchmarksRoute } from './benchmarks/benchmarks';
 import { defineFindingsIndexRoute as defineGetFindingsIndexRoute } from './findings/findings';
+import { defineUpdateRulesConfigRoute } from './configuration/update_rules_configuration';
 import { CspAppContext } from '../plugin';
 
 export function defineRoutes(router: IRouter, cspContext: CspAppContext) {
   defineGetComplianceDashboardRoute(router, cspContext);
   defineGetFindingsIndexRoute(router, cspContext);
   defineGetBenchmarksRoute(router, cspContext);
+  defineUpdateRulesConfigRoute(router, cspContext);
 }


### PR DESCRIPTION
Resolves: #126987 

Add support for updating dataYaml for specific package. 
To test the endpoint:
1. add `CIS Kubernetes Benchmark integration` Integration
2. fetch the integration instance id (inspect the package page)
3. call the API with:
```
curl --location --request GET 'http://localhost:5601/api/csp/update_rules_config?package_policy_id=b62ba402-ef79-4f2e-b3c2-6e6e60d226d9' \
--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
--header 'kbn-xsrf;'
```