### PR TITLE
[Cloud Posture] Add rules page

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/utils/helpers.ts
+++ b/x-pack/plugins/cloud_security_posture/common/utils/helpers.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
 
 /**
  * @example
@@ -16,7 +15,7 @@ export const isNonNullable = <T extends unknown>(v: T): v is NonNullable<T> =>
 
 export const extractErrorMessage = (e: unknown, defaultMessage = 'Unknown Error'): string => {
   if (e instanceof Error) return e.message;
-  if (t.record(t.literal('message'), t.string).is(e)) return e.message;
+  if (typeof e === 'string') return e;
 
   return defaultMessage; // TODO: i18n
 };

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
@@ -12,7 +12,7 @@ import type { CspPage, CspNavigationItem } from './types';
 export const allNavigationItems: Record<CspPage, CspNavigationItem> = {
   dashboard: { name: TEXT.DASHBOARD, path: '/dashboard' },
   findings: { name: TEXT.FINDINGS, path: '/findings' },
-  rules: { name: 'Rules', path: '/rules', disabled: true },
+  rules: { name: 'Rules', path: '/rules', disabled: !INTERNAL_FEATURE_FLAGS.showBenchmarks },
   benchmarks: {
     name: TEXT.MY_BENCHMARKS,
     path: '/benchmarks',

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -8,6 +8,8 @@ import React from 'react';
 import type { EuiPageHeaderProps } from '@elastic/eui';
 import { CspPageTemplate } from '../../components/page_template';
 import { RulesContainer } from './rules_container';
+import { allNavigationItems } from '../../common/navigation/constants';
+import { useCspBreadcrumbs } from '../../common/navigation/use_csp_breadcrumbs';
 
 // TODO:
 // - get selected integration
@@ -16,7 +18,11 @@ const pageHeader: EuiPageHeaderProps = {
   pageTitle: 'Rules',
 };
 
+const breadcrumbs = [allNavigationItems.rules];
+
 export const Rules = () => {
+  useCspBreadcrumbs(breadcrumbs);
+
   return (
     <CspPageTemplate pageHeader={pageHeader}>
       <RulesContainer />

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import type { EuiPageHeaderProps } from '@elastic/eui';
 import { CspPageTemplate } from '../../components/page_template';
+import { RulesContainer } from './rules_container';
 
 // TODO:
 // - get selected integration
@@ -16,5 +17,9 @@ const pageHeader: EuiPageHeaderProps = {
 };
 
 export const Rules = () => {
-  return <CspPageTemplate pageHeader={pageHeader} />;
+  return (
+    <CspPageTemplate pageHeader={pageHeader}>
+      <RulesContainer />
+    </CspPageTemplate>
+  );
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bottom_bar.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bottom_bar.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiBottomBar, EuiButton } from '@elastic/eui';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+
+interface RulesBottomBarProps {
+  onSave(): void;
+  onCancel(): void;
+  isLoading: boolean;
+}
+
+export const RulesBottomBar = ({ onSave, onCancel, isLoading }: RulesBottomBarProps) => (
+  <EuiBottomBar>
+    <EuiFlexGroup justifyContent="flexEnd">
+      <EuiFlexItem grow={false}>
+        <EuiButton size="m" iconType="cross" isLoading={isLoading} onClick={onCancel} color="ghost">
+          {TEXT.CANCEL}
+        </EuiButton>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          size="m"
+          iconType="save"
+          isLoading={isLoading}
+          onClick={onSave}
+          fill
+          data-test-subj={TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON}
+        >
+          {TEXT.SAVE}
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiBottomBar>
+);

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bulk_actions_menu.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bulk_actions_menu.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useState } from 'react';
+import {
+  EuiContextMenuPanel,
+  EuiContextMenuItem,
+  EuiPopover,
+  useGeneratedHtmlId,
+  EuiButtonEmpty,
+  type EuiContextMenuItemProps,
+} from '@elastic/eui';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+
+interface RulesBulkActionsMenuProps {
+  items: ReadonlyArray<EuiContextMenuItemProps & { text: JSX.Element }>;
+}
+
+export const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
+  const [isPopoverOpen, setPopover] = useState(false);
+  const smallContextMenuPopoverId = useGeneratedHtmlId({
+    prefix: 'smallContextMenuPopover',
+  });
+
+  const onButtonClick = () => setPopover(!isPopoverOpen);
+  const closePopover = () => setPopover(false);
+
+  const panelItems = items.map((item, i) => (
+    <EuiContextMenuItem
+      {...item}
+      key={i}
+      children={item.text}
+      onClick={(e) => {
+        closePopover();
+        item.onClick?.(e);
+      }}
+    />
+  ));
+
+  const button = (
+    <EuiButtonEmpty
+      iconType={'arrowDown'}
+      onClick={onButtonClick}
+      data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON}
+    >
+      {TEXT.BULK_ACTIONS}
+    </EuiButtonEmpty>
+  );
+
+  return (
+    <EuiPopover
+      id={smallContextMenuPopoverId}
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downLeft"
+    >
+      <EuiContextMenuPanel size="s" items={panelItems} />
+    </EuiPopover>
+  );
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bulk_actions_menu.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bulk_actions_menu.tsx
@@ -9,7 +9,6 @@ import {
   EuiContextMenuPanel,
   EuiContextMenuItem,
   EuiPopover,
-  useGeneratedHtmlId,
   EuiButtonEmpty,
   type EuiContextMenuItemProps,
 } from '@elastic/eui';
@@ -22,10 +21,6 @@ interface RulesBulkActionsMenuProps {
 
 export const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
   const [isPopoverOpen, setPopover] = useState(false);
-  const smallContextMenuPopoverId = useGeneratedHtmlId({
-    prefix: 'smallContextMenuPopover',
-  });
-
   const onButtonClick = () => setPopover(!isPopoverOpen);
   const closePopover = () => setPopover(false);
 
@@ -53,7 +48,6 @@ export const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
 
   return (
     <EuiPopover
-      id={smallContextMenuPopoverId}
       button={button}
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bulk_actions_menu.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bulk_actions_menu.tsx
@@ -5,18 +5,12 @@
  * 2.0.
  */
 import React, { useState } from 'react';
-import {
-  EuiContextMenuPanel,
-  EuiContextMenuItem,
-  EuiPopover,
-  EuiButtonEmpty,
-  type EuiContextMenuItemProps,
-} from '@elastic/eui';
+import { EuiContextMenuPanel, EuiContextMenuItem, EuiPopover, EuiButtonEmpty } from '@elastic/eui';
 import * as TEST_SUBJECTS from './test_subjects';
 import * as TEXT from './translations';
 
 interface RulesBulkActionsMenuProps {
-  items: ReadonlyArray<EuiContextMenuItemProps & { text: JSX.Element }>;
+  items: ReadonlyArray<React.ComponentProps<typeof EuiContextMenuItem>>;
 }
 
 export const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
@@ -28,7 +22,6 @@ export const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
     <EuiContextMenuItem
       {...item}
       key={i}
-      children={item.text}
       onClick={(e) => {
         closePopover();
         item.onClick?.(e);

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
@@ -35,7 +35,7 @@ const getWrapper =
 const getRuleMock = ({ id = chance.guid(), enabled }: { id?: string; enabled: boolean }) =>
   ({
     id,
-    updated_at: chance.date().toISOString(),
+    updatedAt: chance.date().toISOString(),
     attributes: {
       id,
       name: chance.word(),

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
@@ -1,0 +1,339 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { RulesContainer } from './rules_container';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient } from 'react-query';
+import { useFindCspRules, useBulkUpdateCspRules, type RuleSavedObject } from './use_csp_rules';
+import * as TEST_SUBJECTS from './test_subjects';
+import { Chance } from 'chance';
+import { TestProvider } from '../../test/test_provider';
+
+const chance = new Chance();
+
+jest.mock('./use_csp_rules', () => ({
+  useFindCspRules: jest.fn(),
+  useBulkUpdateCspRules: jest.fn(),
+}));
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+  },
+});
+
+const getWrapper =
+  (): React.FC =>
+  ({ children }) =>
+    <TestProvider>{children}</TestProvider>;
+
+const getRuleMock = ({ id = chance.guid(), enabled }: { id?: string; enabled: boolean }) =>
+  ({
+    id,
+    updated_at: chance.date().toISOString(),
+    attributes: {
+      id,
+      name: chance.word(),
+      enabled,
+    },
+  } as RuleSavedObject);
+
+describe('<RulesContainer />', () => {
+  beforeEach(() => {
+    queryClient.clear();
+    jest.clearAllMocks();
+    (useBulkUpdateCspRules as jest.Mock).mockReturnValue({
+      status: 'idle',
+      mutate: jest.fn(),
+    });
+  });
+
+  it('displays rules with their initial state', async () => {
+    const Wrapper = getWrapper();
+    const rule1 = getRuleMock({ enabled: true });
+
+    (useFindCspRules as jest.Mock).mockReturnValue({
+      status: 'success',
+      data: {
+        total: 1,
+        savedObjects: [rule1],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    expect(await screen.findByTestId(TEST_SUBJECTS.CSP_RULES_CONTAINER)).toBeInTheDocument();
+    expect(await screen.findByText(rule1.attributes.name)).toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId(TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id))
+        .getAttribute('aria-checked')
+    ).toEqual('true');
+  });
+
+  it('toggles rules locally', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getRuleMock({ enabled: false });
+    const rule2 = getRuleMock({ enabled: true });
+
+    (useFindCspRules as jest.Mock).mockReturnValue({
+      status: 'success',
+      data: {
+        total: 2,
+        savedObjects: [rule1, rule2],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const switchId1 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id);
+    const switchId2 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule2.id);
+
+    fireEvent.click(screen.getByTestId(switchId1));
+    fireEvent.click(screen.getByTestId(switchId2));
+
+    expect(screen.getByTestId(switchId1).getAttribute('aria-checked')).toEqual(
+      (!rule1.attributes.enabled).toString()
+    );
+    expect(screen.getByTestId(switchId2).getAttribute('aria-checked')).toEqual(
+      (!rule2.attributes.enabled).toString()
+    );
+  });
+
+  it('bulk toggles rules locally', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getRuleMock({ enabled: true });
+    const rule2 = getRuleMock({ enabled: true });
+    const rule3 = getRuleMock({ enabled: false });
+
+    (useFindCspRules as jest.Mock).mockReturnValue({
+      status: 'success',
+      data: {
+        total: 3,
+        savedObjects: [rule1, rule2, rule3],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const switchId1 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id);
+    const switchId2 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule2.id);
+    const switchId3 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule3.id);
+
+    fireEvent.click(screen.getByTestId('checkboxSelectAll'));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON));
+
+    expect(screen.getByTestId(switchId1).getAttribute('aria-checked')).toEqual(
+      (!rule1.attributes.enabled).toString()
+    );
+    expect(screen.getByTestId(switchId2).getAttribute('aria-checked')).toEqual(
+      (!rule2.attributes.enabled).toString()
+    );
+    expect(screen.getByTestId(switchId3).getAttribute('aria-checked')).toEqual(
+      rule3.attributes.enabled.toString()
+    );
+  });
+
+  it('updates rules with local changes done by non-bulk toggles', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getRuleMock({ enabled: false });
+    const rule2 = getRuleMock({ enabled: true });
+    const rule3 = getRuleMock({ enabled: true });
+
+    (useFindCspRules as jest.Mock).mockReturnValue({
+      status: 'success',
+      data: {
+        total: 3,
+        savedObjects: [rule1, rule2, rule3],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+    const { mutate } = useBulkUpdateCspRules();
+
+    const switchId1 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id);
+    const switchId2 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule2.id);
+    const switchId3 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule3.id);
+
+    fireEvent.click(screen.getByTestId(switchId1));
+    fireEvent.click(screen.getByTestId(switchId2));
+    fireEvent.click(screen.getByTestId(switchId3)); // adds
+    fireEvent.click(screen.getByTestId(switchId3)); // removes
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+      { ...rule2.attributes, enabled: !rule2.attributes.enabled },
+    ]);
+  });
+
+  it('updates rules with local changes done by bulk toggles', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getRuleMock({ enabled: false });
+    const rule2 = getRuleMock({ enabled: true });
+    const rule3 = getRuleMock({ enabled: true });
+
+    (useFindCspRules as jest.Mock).mockReturnValue({
+      status: 'success',
+      data: {
+        total: 3,
+        savedObjects: [rule1, rule2, rule3],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId('checkboxSelectAll'));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON)); // This should only change rule1
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+    ]);
+  });
+
+  it('only changes selected rules in bulk operations', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getRuleMock({ enabled: false });
+    const rule2 = getRuleMock({ enabled: true });
+    const rule3 = getRuleMock({ enabled: false });
+    const rule4 = getRuleMock({ enabled: false });
+    const rule5 = getRuleMock({ enabled: true });
+
+    (useFindCspRules as jest.Mock).mockReturnValue({
+      status: 'success',
+      data: {
+        total: 4,
+        savedObjects: [rule1, rule2, rule3, rule4, rule5],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule1.id}`)); // changes
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule2.id}`)); // doesn't change
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule4.id}`)); // changes
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule5.id))); // changes
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+      { ...rule4.attributes, enabled: !rule4.attributes.enabled },
+      { ...rule5.attributes, enabled: !rule5.attributes.enabled },
+    ]);
+  });
+
+  it('updates rules with changes of both bulk/non-bulk toggles', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getRuleMock({ enabled: false });
+    const rule2 = getRuleMock({ enabled: true });
+    const rule3 = getRuleMock({ enabled: false });
+    const rule4 = getRuleMock({ enabled: false });
+    const rule5 = getRuleMock({ enabled: true });
+
+    (useFindCspRules as jest.Mock).mockReturnValue({
+      status: 'success',
+      data: {
+        total: 4,
+        savedObjects: [rule1, rule2, rule3, rule4, rule5],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule1.id}`)); // changes rule1
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule2.id}`)); // doesn't change
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule4.id}`)); // changes rule4
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON)); // changes rule2
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON)); // reverts rule2
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule5.id))); // changes rule5
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+      { ...rule4.attributes, enabled: !rule4.attributes.enabled },
+      { ...rule5.attributes, enabled: !rule5.attributes.enabled },
+    ]);
+  });
+
+  it('selects and updates all rules', async () => {
+    const Wrapper = getWrapper();
+    const enabled = true;
+    const rules = Array.from({ length: 20 }, () => getRuleMock({ enabled }));
+
+    (useFindCspRules as jest.Mock).mockReturnValue({
+      status: 'success',
+      data: {
+        total: rules.length,
+        savedObjects: rules,
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_SELECT_ALL_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith(
+      rules.map((rule) => ({
+        ...rule.attributes,
+        enabled: !enabled,
+      }))
+    );
+  });
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import { type EuiBasicTable, EuiPanel } from '@elastic/eui';
+import { extractErrorMessage } from '../../../common/utils/helpers';
+import { RulesTable } from './rules_table';
+import { RulesBottomBar } from './rules_bottom_bar';
+import { RulesTableHeader } from './rules_table_header';
+import {
+  useFindCspRules,
+  useBulkUpdateCspRules,
+  type RuleSavedObject,
+  type RulesQuery,
+  type RulesQueryResult,
+} from './use_csp_rules';
+import * as TEST_SUBJECTS from './test_subjects';
+
+interface RulesPageData {
+  rules_page: RuleSavedObject[];
+  all_rules: RuleSavedObject[];
+  rules_map: Map<string, RuleSavedObject>;
+  total: number;
+  error?: string;
+  loading: boolean;
+}
+
+export type RulesState = RulesPageData & RulesQuery;
+
+const getSimpleQueryString = (searchValue?: string): string =>
+  searchValue ? `${searchValue}*` : '';
+
+const getChangedRules = (
+  baseRules: ReadonlyMap<string, RuleSavedObject>,
+  currentChangedRules: ReadonlyMap<string, RuleSavedObject>,
+  rulesToChange: readonly RuleSavedObject[]
+): Map<string, RuleSavedObject> => {
+  const changedRules = new Map(currentChangedRules);
+
+  rulesToChange.forEach((ruleToChange) => {
+    const baseRule = baseRules.get(ruleToChange.id);
+    const changedRule = changedRules.get(ruleToChange.id);
+
+    if (!baseRule) throw new Error('expected base rule to exists');
+
+    const baseRuleChanged = baseRule.attributes.enabled !== ruleToChange.attributes.enabled;
+
+    if (!changedRule && baseRuleChanged) changedRules.set(ruleToChange.id, ruleToChange);
+
+    if (changedRule && !baseRuleChanged) changedRules.delete(ruleToChange.id);
+  });
+
+  return changedRules;
+};
+
+const getRulesPageData = (
+  { status, data, error }: Pick<RulesQueryResult, 'data' | 'status' | 'error'>,
+  changedRules: Map<string, RuleSavedObject>,
+  query: RulesQuery
+): RulesPageData => {
+  const rules = data?.savedObjects || [];
+  const page = getPage(rules, query);
+  return {
+    loading: status === 'loading',
+    error: error ? extractErrorMessage(error) : undefined,
+    all_rules: rules,
+    rules_map: new Map(rules.map((rule) => [rule.id, rule])),
+    rules_page: page.map((rule) => changedRules.get(rule.attributes.id) || rule),
+    total: data?.total || 0,
+  };
+};
+
+const getPage = (data: readonly RuleSavedObject[], { page, perPage }: RulesQuery) =>
+  data.slice(page * perPage, (page + 1) * perPage);
+
+const MAX_ITEMS_PER_PAGE = 10000;
+
+export const RulesContainer = () => {
+  const tableRef = useRef<EuiBasicTable>(null);
+  const [changedRules, setChangedRules] = useState<Map<string, RuleSavedObject>>(new Map());
+  const [isAllSelected, setIsAllSelected] = useState<boolean>(false);
+  const [visibleSelectedRulesIds, setVisibleSelectedRulesIds] = useState<string[]>([]);
+  const [rulesQuery, setRulesQuery] = useState<RulesQuery>({ page: 0, perPage: 5, search: '' });
+
+  const { data, status, error, refetch } = useFindCspRules({
+    search: getSimpleQueryString(rulesQuery.search),
+    page: 1,
+    perPage: MAX_ITEMS_PER_PAGE,
+  });
+
+  const { mutate: bulkUpdate, isLoading: isUpdating } = useBulkUpdateCspRules();
+
+  const rulesPageData = useMemo(
+    () => getRulesPageData({ data, error, status }, changedRules, rulesQuery),
+    [data, error, status, changedRules, rulesQuery]
+  );
+
+  const hasChanges = !!changedRules.size;
+
+  const selectAll = () => {
+    if (!tableRef.current) return;
+    tableRef.current.setSelection(rulesPageData.rules_page);
+    setIsAllSelected(true);
+  };
+
+  const toggleRules = (rules: RuleSavedObject[], enabled: boolean) =>
+    setChangedRules(
+      getChangedRules(
+        rulesPageData.rules_map,
+        changedRules,
+        rules.map((rule) => ({
+          ...rule,
+          attributes: { ...rule.attributes, enabled },
+        }))
+      )
+    );
+
+  const bulkToggleRules = (enabled: boolean) =>
+    toggleRules(
+      isAllSelected
+        ? rulesPageData.all_rules
+        : visibleSelectedRulesIds.map((ruleId) => rulesPageData.rules_map.get(ruleId)!),
+      enabled
+    );
+
+  const toggleRule = (rule: RuleSavedObject) => toggleRules([rule], !rule.attributes.enabled);
+
+  const bulkUpdateRules = () => bulkUpdate([...changedRules].map(([, rule]) => rule.attributes));
+
+  const discardChanges = useCallback(() => setChangedRules(new Map()), []);
+
+  const clearSelection = useCallback(() => {
+    if (!tableRef.current) return;
+    tableRef.current.setSelection([]);
+    setIsAllSelected(false);
+  }, []);
+
+  useEffect(discardChanges, [data, discardChanges]);
+  useEffect(clearSelection, [rulesQuery, clearSelection]);
+
+  return (
+    <div data-test-subj={TEST_SUBJECTS.CSP_RULES_CONTAINER}>
+      <EuiPanel hasBorder hasShadow={false}>
+        <RulesTableHeader
+          search={(value) => setRulesQuery((currentQuery) => ({ ...currentQuery, search: value }))}
+          refresh={() => {
+            clearSelection();
+            refetch();
+          }}
+          bulkEnable={() => bulkToggleRules(true)}
+          bulkDisable={() => bulkToggleRules(false)}
+          selectAll={selectAll}
+          clearSelection={clearSelection}
+          selectedRulesCount={
+            isAllSelected ? rulesPageData.all_rules.length : visibleSelectedRulesIds.length
+          }
+          searchValue={rulesQuery.search}
+          totalRulesCount={rulesPageData.all_rules.length}
+          isSearching={status === 'loading'}
+        />
+        <RulesTable
+          rules_page={rulesPageData.rules_page}
+          total={rulesPageData.total}
+          error={rulesPageData.error}
+          loading={rulesPageData.loading}
+          perPage={rulesQuery.perPage}
+          page={rulesQuery.page}
+          tableRef={tableRef}
+          toggleRule={toggleRule}
+          setSelectedRules={(rules) => {
+            setIsAllSelected(false);
+            setVisibleSelectedRulesIds(rules.map((rule) => rule.id));
+          }}
+          setPagination={(paginationQuery) =>
+            setRulesQuery((currentQuery) => ({ ...currentQuery, ...paginationQuery }))
+          }
+        />
+      </EuiPanel>
+      {hasChanges && (
+        <RulesBottomBar onSave={bulkUpdateRules} onCancel={discardChanges} isLoading={isUpdating} />
+      )}
+    </div>
+  );
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
-import { type EuiBasicTable, EuiPanel } from '@elastic/eui';
+import { type EuiBasicTable, EuiPanel, EuiSpacer } from '@elastic/eui';
 import { extractErrorMessage } from '../../../common/utils/helpers';
 import { RulesTable } from './rules_table';
 import { RulesBottomBar } from './rules_bottom_bar';
@@ -161,6 +161,7 @@ export const RulesContainer = () => {
           totalRulesCount={rulesPageData.all_rules.length}
           isSearching={status === 'loading'}
         />
+        <EuiSpacer />
         <RulesTable
           rules_page={rulesPageData.rules_page}
           total={rulesPageData.total}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -97,7 +97,8 @@ const createRuleEnabledSwitchRenderer =
   (value: any, rule: RuleSavedObject) =>
     (
       <EuiSwitch
-        label=""
+        showLabel={false}
+        label={value ? TEXT.DISABLE : TEXT.ENABLE}
         checked={value}
         onChange={() => toggleRule(rule)}
         data-test-subj={TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule.attributes.id)}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -13,7 +13,7 @@ import {
   EuiBasicTable,
   EuiBasicTableProps,
 } from '@elastic/eui';
-// import moment from 'moment';
+import moment from 'moment';
 import type { RulesState } from './rules_container';
 import * as TEST_SUBJECTS from './test_subjects';
 import * as TEXT from './translations';
@@ -85,8 +85,8 @@ const ruleNameRenderer = (name: string) => (
   </EuiLink>
 );
 
-// const timestampRenderer = (timestamp: string) =>
-//   moment.duration(moment().diff(timestamp)).humanize();
+const timestampRenderer = (timestamp: string) =>
+  moment.duration(moment().diff(timestamp)).humanize();
 
 interface GetColumnProps {
   toggleRule: (rule: RuleSavedObject) => void;
@@ -121,12 +121,10 @@ const getColumns = ({
     width: '15%',
   },
   {
-    // TODO: get timestamp value
-    // add SavedObject["updated_at"] to SimpleSavedObject?
-    field: 'updated_at',
+    field: 'updatedAt',
     name: TEXT.UPDATED_AT,
     width: '15%',
-    // render: timestampRenderer,
+    render: timestampRenderer,
   },
   {
     field: 'attributes.enabled',

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useMemo } from 'react';
+import {
+  Criteria,
+  EuiLink,
+  EuiSwitch,
+  EuiTableFieldDataColumnType,
+  EuiBasicTable,
+  EuiBasicTableProps,
+} from '@elastic/eui';
+// import moment from 'moment';
+import type { RulesState } from './rules_container';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+import type { RuleSavedObject } from './use_csp_rules';
+
+type RulesTableProps = Pick<
+  RulesState,
+  'loading' | 'error' | 'rules_page' | 'total' | 'perPage' | 'page'
+> & {
+  toggleRule(rule: RuleSavedObject): void;
+  setSelectedRules(rules: RuleSavedObject[]): void;
+  setPagination(pagination: Pick<RulesState, 'perPage' | 'page'>): void;
+  // ForwardRef makes this ref not available in parent callbacks
+  tableRef: React.RefObject<EuiBasicTable<any>>;
+};
+
+export const RulesTable = ({
+  toggleRule,
+  setSelectedRules,
+  setPagination,
+  perPage: pageSize,
+  rules_page: items,
+  page,
+  tableRef,
+  total,
+  loading,
+  error,
+}: RulesTableProps) => {
+  const columns = useMemo(() => getColumns({ toggleRule }), [toggleRule]);
+
+  const euiPagination: EuiBasicTableProps<RuleSavedObject>['pagination'] = {
+    pageIndex: page,
+    pageSize,
+    totalItemCount: total,
+    pageSizeOptions: [1, 5, 10, 25],
+    hidePerPageOptions: false,
+  };
+
+  const selection: EuiBasicTableProps<RuleSavedObject>['selection'] = {
+    selectable: () => true,
+    onSelectionChange: setSelectedRules,
+  };
+
+  const onTableChange = ({ page: pagination }: Criteria<RuleSavedObject>) => {
+    if (!pagination) return;
+    setPagination({ page: pagination.index, perPage: pagination.size });
+  };
+
+  return (
+    <EuiBasicTable
+      ref={tableRef}
+      data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE}
+      loading={loading}
+      error={error}
+      items={items}
+      columns={columns}
+      pagination={euiPagination}
+      onChange={onTableChange}
+      isSelectable={true}
+      selection={selection}
+      itemId={(v) => v.id}
+    />
+  );
+};
+
+const ruleNameRenderer = (name: string) => (
+  <EuiLink className="eui-textTruncate" title={name}>
+    {name}
+  </EuiLink>
+);
+
+// const timestampRenderer = (timestamp: string) =>
+//   moment.duration(moment().diff(timestamp)).humanize();
+
+interface GetColumnProps {
+  toggleRule: (rule: RuleSavedObject) => void;
+}
+
+const createRuleEnabledSwitchRenderer =
+  ({ toggleRule }: GetColumnProps) =>
+  (value: any, rule: RuleSavedObject) =>
+    (
+      <EuiSwitch
+        label=""
+        checked={value}
+        onChange={() => toggleRule(rule)}
+        data-test-subj={TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule.attributes.id)}
+      />
+    );
+
+const getColumns = ({
+  toggleRule,
+}: GetColumnProps): Array<EuiTableFieldDataColumnType<RuleSavedObject>> => [
+  {
+    field: 'attributes.name',
+    name: TEXT.RULE_NAME,
+    width: '60%',
+    truncateText: true,
+    render: ruleNameRenderer,
+  },
+  {
+    field: 'section', // TODO: what field is this?
+    name: TEXT.SECTION,
+    width: '15%',
+  },
+  {
+    // TODO: get timestamp value
+    // add SavedObject["updated_at"] to SimpleSavedObject?
+    field: 'updated_at',
+    name: TEXT.UPDATED_AT,
+    width: '15%',
+    // render: timestampRenderer,
+  },
+  {
+    field: 'attributes.enabled',
+    name: TEXT.ENABLED,
+    render: createRuleEnabledSwitchRenderer({ toggleRule }),
+    width: '10%',
+  },
+];

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -27,7 +27,7 @@ type RulesTableProps = Pick<
   setSelectedRules(rules: RuleSavedObject[]): void;
   setPagination(pagination: Pick<RulesState, 'perPage' | 'page'>): void;
   // ForwardRef makes this ref not available in parent callbacks
-  tableRef: React.RefObject<EuiBasicTable<any>>;
+  tableRef: React.RefObject<EuiBasicTable<RuleSavedObject>>;
 };
 
 export const RulesTable = ({
@@ -94,7 +94,7 @@ interface GetColumnProps {
 
 const createRuleEnabledSwitchRenderer =
   ({ toggleRule }: GetColumnProps) =>
-  (value: any, rule: RuleSavedObject) =>
+  (value: boolean, rule: RuleSavedObject) =>
     (
       <EuiSwitch
         showLabel={false}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React, { useState } from 'react';
-import { EuiSpacer, EuiFieldSearch, EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFieldSearch, EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import useDebounce from 'react-use/lib/useDebounce';
@@ -46,24 +46,21 @@ export const RulesTableHeader = ({
   searchValue,
   isSearching,
 }: RulesTableToolbarProps) => (
-  <div>
-    <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false} wrap>
-      <Counters total={totalRulesCount} selected={selectedRulesCount} />
-      <SelectAllToggle
-        isSelectAll={selectedRulesCount === totalRulesCount}
-        clear={clearSelection}
-        select={selectAll}
-      />
-      <BulkMenu
-        bulkEnable={bulkEnable}
-        bulkDisable={bulkDisable}
-        selectedRulesCount={selectedRulesCount}
-      />
-      <RefreshButton onClick={refresh} />
-      <SearchField isSearching={isSearching} searchValue={searchValue} search={search} />
-    </EuiFlexGroup>
-    <EuiSpacer />
-  </div>
+  <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false} wrap>
+    <Counters total={totalRulesCount} selected={selectedRulesCount} />
+    <SelectAllToggle
+      isSelectAll={selectedRulesCount === totalRulesCount}
+      clear={clearSelection}
+      select={selectAll}
+    />
+    <BulkMenu
+      bulkEnable={bulkEnable}
+      bulkDisable={bulkDisable}
+      selectedRulesCount={selectedRulesCount}
+    />
+    <RefreshButton onClick={refresh} />
+    <SearchField isSearching={isSearching} searchValue={searchValue} search={search} />
+  </EuiFlexGroup>
 );
 
 const Counters = ({ total, selected }: { total: number; selected: number }) => (
@@ -115,6 +112,8 @@ const BulkMenu = ({
   </EuiFlexItem>
 );
 
+const SEARCH_DEBOUNCE_MS = 300;
+
 const SearchField = ({
   search,
   isSearching,
@@ -122,7 +121,7 @@ const SearchField = ({
 }: Pick<RulesTableToolbarProps, 'isSearching' | 'searchValue' | 'search'>) => {
   const [localValue, setLocalValue] = useState(searchValue);
 
-  useDebounce(() => search(localValue), 300, [localValue]);
+  useDebounce(() => search(localValue), SEARCH_DEBOUNCE_MS, [localValue]);
 
   return (
     <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -96,14 +96,14 @@ const BulkMenu = ({
         {
           icon: 'eye',
           disabled: !selectedRulesCount,
-          text: <ActivateRulesMenuItemText count={selectedRulesCount} />,
+          children: <ActivateRulesMenuItemText count={selectedRulesCount} />,
           'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON,
           onClick: bulkEnable,
         },
         {
           icon: 'eyeClosed',
           disabled: !selectedRulesCount,
-          text: <DeactivateRulesMenuItemText count={selectedRulesCount} />,
+          children: <DeactivateRulesMenuItemText count={selectedRulesCount} />,
           'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON,
           onClick: bulkDisable,
         },

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -1,0 +1,225 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useState } from 'react';
+import { EuiSpacer, EuiFieldSearch, EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { css } from '@emotion/react';
+import useDebounce from 'react-use/lib/useDebounce';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+import { RulesBulkActionsMenu } from './rules_bulk_actions_menu';
+
+interface RulesTableToolbarProps {
+  search(value: string): void;
+  refresh(): void;
+  bulkEnable(): void;
+  bulkDisable(): void;
+  selectAll(): void;
+  clearSelection(): void;
+  totalRulesCount: number;
+  selectedRulesCount: number;
+  searchValue: string;
+  isSearching: boolean;
+}
+
+interface CounterProps {
+  count: number;
+}
+
+interface ButtonProps {
+  onClick(): void;
+}
+
+export const RulesTableHeader = ({
+  search,
+  refresh,
+  bulkEnable,
+  bulkDisable,
+  selectAll,
+  clearSelection,
+  totalRulesCount,
+  selectedRulesCount,
+  searchValue,
+  isSearching,
+}: RulesTableToolbarProps) => (
+  <div>
+    <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false} wrap>
+      <Counters total={totalRulesCount} selected={selectedRulesCount} />
+      <SelectAllToggle
+        isSelectAll={selectedRulesCount === totalRulesCount}
+        clear={clearSelection}
+        select={selectAll}
+      />
+      <BulkMenu
+        bulkEnable={bulkEnable}
+        bulkDisable={bulkDisable}
+        selectedRulesCount={selectedRulesCount}
+      />
+      <RefreshButton onClick={refresh} />
+      <SearchField isSearching={isSearching} searchValue={searchValue} search={search} />
+    </EuiFlexGroup>
+    <EuiSpacer />
+  </div>
+);
+
+const Counters = ({ total, selected }: { total: number; selected: number }) => (
+  <EuiFlexItem grow={false} style={{ flexDirection: 'row', fontVariantNumeric: 'tabular-nums' }}>
+    <TotalRulesCount count={total} />
+    {Spacer}
+    <SelectedRulesCount count={selected} />
+  </EuiFlexItem>
+);
+
+const SelectAllToggle = ({
+  isSelectAll,
+  select,
+  clear,
+}: {
+  select(): void;
+  clear(): void;
+  isSelectAll: boolean;
+}) => (
+  <EuiFlexItem grow={false}>
+    {isSelectAll ? <ClearSelectionButton onClick={clear} /> : <SelectAllButton onClick={select} />}
+  </EuiFlexItem>
+);
+
+const BulkMenu = ({
+  bulkEnable,
+  bulkDisable,
+  selectedRulesCount,
+}: Pick<RulesTableToolbarProps, 'bulkDisable' | 'bulkEnable' | 'selectedRulesCount'>) => (
+  <EuiFlexItem grow={false}>
+    <RulesBulkActionsMenu
+      items={[
+        {
+          icon: 'eye',
+          disabled: !selectedRulesCount,
+          text: <ActivateRulesMenuItemText count={selectedRulesCount} />,
+          'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON,
+          onClick: bulkEnable,
+        },
+        {
+          icon: 'eyeClosed',
+          disabled: !selectedRulesCount,
+          text: <DeactivateRulesMenuItemText count={selectedRulesCount} />,
+          'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON,
+          onClick: bulkDisable,
+        },
+      ]}
+    />
+  </EuiFlexItem>
+);
+
+const SearchField = ({
+  search,
+  isSearching,
+  searchValue,
+}: Pick<RulesTableToolbarProps, 'isSearching' | 'searchValue' | 'search'>) => {
+  const [localValue, setLocalValue] = useState(searchValue);
+
+  useDebounce(() => search(localValue), 300, [localValue]);
+
+  return (
+    <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>
+      <EuiFieldSearch
+        isLoading={isSearching}
+        placeholder={TEXT.SEARCH}
+        value={localValue}
+        onChange={(e) => setLocalValue(e.target.value)}
+        style={{ minWidth: 150 }}
+      />
+    </EuiFlexItem>
+  );
+};
+
+const TotalRulesCount = ({ count }: CounterProps) => (
+  <FormattedMessage
+    id="xpack.csp.rules.header.totalRulesCount"
+    defaultMessage="Showing {rules}"
+    values={{ rules: <RulesCountBold count={count} /> }}
+  />
+);
+
+const SelectedRulesCount = ({ count }: CounterProps) => (
+  <FormattedMessage
+    id="xpack.csp.rules.header.selectedRulesCount"
+    defaultMessage="Selected {rules}"
+    values={{ rules: <RulesCountBold count={count} /> }}
+  />
+);
+
+const ActivateRulesMenuItemText = ({ count }: CounterProps) => (
+  <FormattedMessage
+    id="xpack.csp.rules.activateAllButtonLabel"
+    defaultMessage="Activate {count, plural, one {# rule} other {# rules}}"
+    values={{ count }}
+  />
+);
+
+const DeactivateRulesMenuItemText = ({ count }: CounterProps) => (
+  <FormattedMessage
+    id="xpack.csp.rules.deactivateAllButtonLabel"
+    defaultMessage="Deactivate {count, plural, one {# rule} other {# rules}}"
+    values={{ count }}
+  />
+);
+
+const RulesCountBold = ({ count }: CounterProps) => (
+  <>
+    <strong style={{ margin: '0 4px' }}>{count}</strong>
+    <FormattedMessage
+      id="xpack.csp.rules.header.rulesCountLabel"
+      defaultMessage="{count, plural, one { rule} other { rules}}"
+      values={{ count }}
+    />
+  </>
+);
+
+const ClearSelectionButton = ({ onClick }: ButtonProps) => (
+  <EuiButtonEmpty
+    onClick={onClick}
+    iconType={'cross'}
+    data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_CLEAR_SELECTION_BUTTON}
+  >
+    <FormattedMessage
+      id="xpack.csp.rules.clearSelectionButtonLabel"
+      defaultMessage="Clear Selection"
+    />
+  </EuiButtonEmpty>
+);
+
+const SelectAllButton = ({ onClick }: ButtonProps) => (
+  <EuiButtonEmpty
+    onClick={onClick}
+    iconType={'pagesSelect'}
+    data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_SELECT_ALL_BUTTON}
+  >
+    <FormattedMessage id="xpack.csp.rules.selectAllButtonLabel" defaultMessage="Select All" />
+  </EuiButtonEmpty>
+);
+
+const RefreshButton = ({ onClick }: ButtonProps) => (
+  <EuiFlexItem grow={false}>
+    <EuiButtonEmpty
+      onClick={onClick}
+      iconType={'refresh'}
+      data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_REFRESH_BUTTON}
+    >
+      {TEXT.REFRESH}
+    </EuiButtonEmpty>
+  </EuiFlexItem>
+);
+
+const Spacer = (
+  <span
+    css={css`
+      border-right: 1px solid;
+      margin: 0px 8px;
+    `}
+  />
+);

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/test_subjects.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/test_subjects.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const CSP_RULES_CONTAINER = 'csp_rules_container';
+export const CSP_RULES_TABLE_ITEM_SWITCH = 'csp_rules_table_item_switch';
+export const CSP_RULES_SAVE_BUTTON = 'csp_rules_table_save_button';
+export const CSP_RULES_TABLE = 'csp_rules_table';
+export const CSP_RULES_TABLE_BULK_MENU_BUTTON = 'csp_rules_table_bulk_menu_button';
+export const CSP_RULES_TABLE_BULK_ENABLE_BUTTON = 'csp_rules_table_bulk_enable_button';
+export const CSP_RULES_TABLE_BULK_DISABLE_BUTTON = 'csp_rules_table_bulk_disable_button';
+export const CSP_RULES_TABLE_REFRESH_BUTTON = 'csp_rules_table_refresh_button';
+export const CSP_RULES_TABLE_SELECT_ALL_BUTTON = 'rules_select_all';
+export const CSP_RULES_TABLE_CLEAR_SELECTION_BUTTON = 'rules_clear_selection';
+
+export const getCspRulesTableItemSwitchTestId = (id: string) =>
+  `${CSP_RULES_TABLE_ITEM_SWITCH}_${id}`;

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
@@ -51,6 +51,14 @@ export const ENABLED = i18n.translate('xpack.cloudSecurityPosture.rules.enabledC
   defaultMessage: 'Enabled',
 });
 
+export const DISABLE = i18n.translate('xpack.cloudSecurityPosture.rules.disableLabel', {
+  defaultMessage: 'Disable',
+});
+
+export const ENABLE = i18n.translate('xpack.cloudSecurityPosture.rules.enableLabel', {
+  defaultMessage: 'Enable',
+});
+
 export const MISSING_RULES = i18n.translate(
   'xpack.cloudSecurityPosture.rules.missingRulesMessage',
   { defaultMessage: 'Rules are missing' }

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const SAVE = i18n.translate('xpack.cloudSecurityPosture.rules.saveButtonLabel', {
+  defaultMessage: 'Save',
+});
+
+export const CANCEL = i18n.translate('xpack.cloudSecurityPosture.rules.cancelButtonLabel', {
+  defaultMessage: 'Cancel',
+});
+
+export const UNKNOWN_ERROR = i18n.translate(
+  'xpack.cloudSecurityPosture.rules.unknownErrorMessage',
+  { defaultMessage: 'Unknown Error' }
+);
+
+export const REFRESH = i18n.translate('xpack.cloudSecurityPosture.rules.refreshButtonLabel', {
+  defaultMessage: 'Refresh',
+});
+
+export const SEARCH = i18n.translate('xpack.cloudSecurityPosture.rules.searchPlaceholder', {
+  defaultMessage: 'Search',
+});
+
+export const BULK_ACTIONS = i18n.translate(
+  'xpack.cloudSecurityPosture.rules.bulkActionsButtonLabel',
+  { defaultMessage: 'Bulk Actions' }
+);
+
+export const RULE_NAME = i18n.translate(
+  'xpack.cloudSecurityPosture.rules.ruleNameColumnHeaderLabel',
+  { defaultMessage: 'Rule Name' }
+);
+
+export const SECTION = i18n.translate('xpack.cloudSecurityPosture.rules.sectionColumnHeaderLabel', {
+  defaultMessage: 'Section',
+});
+
+export const UPDATED_AT = i18n.translate(
+  'xpack.cloudSecurityPosture.rules.updatedAtColumnHeaderLabel',
+  { defaultMessage: 'Updated at' }
+);
+
+export const ENABLED = i18n.translate('xpack.cloudSecurityPosture.rules.enabledColumnHeaderLabel', {
+  defaultMessage: 'Enabled',
+});
+
+export const MISSING_RULES = i18n.translate(
+  'xpack.cloudSecurityPosture.rules.missingRulesMessage',
+  { defaultMessage: 'Rules are missing' }
+);
+
+export const UPDATE_FAILED = i18n.translate(
+  'xpack.cloudSecurityPosture.rules.updateFailedMessage',
+  { defaultMessage: 'Update failed' }
+);

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
@@ -7,64 +7,58 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const SAVE = i18n.translate('xpack.cloudSecurityPosture.rules.saveButtonLabel', {
+export const SAVE = i18n.translate('xpack.csp.rules.saveButtonLabel', {
   defaultMessage: 'Save',
 });
 
-export const CANCEL = i18n.translate('xpack.cloudSecurityPosture.rules.cancelButtonLabel', {
+export const CANCEL = i18n.translate('xpack.csp.rules.cancelButtonLabel', {
   defaultMessage: 'Cancel',
 });
 
-export const UNKNOWN_ERROR = i18n.translate(
-  'xpack.cloudSecurityPosture.rules.unknownErrorMessage',
-  { defaultMessage: 'Unknown Error' }
-);
+export const UNKNOWN_ERROR = i18n.translate('xpack.csp.rules.unknownErrorMessage', {
+  defaultMessage: 'Unknown Error',
+});
 
-export const REFRESH = i18n.translate('xpack.cloudSecurityPosture.rules.refreshButtonLabel', {
+export const REFRESH = i18n.translate('xpack.csp.rules.refreshButtonLabel', {
   defaultMessage: 'Refresh',
 });
 
-export const SEARCH = i18n.translate('xpack.cloudSecurityPosture.rules.searchPlaceholder', {
+export const SEARCH = i18n.translate('xpack.csp.rules.searchPlaceholder', {
   defaultMessage: 'Search',
 });
 
-export const BULK_ACTIONS = i18n.translate(
-  'xpack.cloudSecurityPosture.rules.bulkActionsButtonLabel',
-  { defaultMessage: 'Bulk Actions' }
-);
+export const BULK_ACTIONS = i18n.translate('xpack.csp.rules.bulkActionsButtonLabel', {
+  defaultMessage: 'Bulk Actions',
+});
 
-export const RULE_NAME = i18n.translate(
-  'xpack.cloudSecurityPosture.rules.ruleNameColumnHeaderLabel',
-  { defaultMessage: 'Rule Name' }
-);
+export const RULE_NAME = i18n.translate('xpack.csp.rules.ruleNameColumnHeaderLabel', {
+  defaultMessage: 'Rule Name',
+});
 
-export const SECTION = i18n.translate('xpack.cloudSecurityPosture.rules.sectionColumnHeaderLabel', {
+export const SECTION = i18n.translate('xpack.csp.rules.sectionColumnHeaderLabel', {
   defaultMessage: 'Section',
 });
 
-export const UPDATED_AT = i18n.translate(
-  'xpack.cloudSecurityPosture.rules.updatedAtColumnHeaderLabel',
-  { defaultMessage: 'Updated at' }
-);
+export const UPDATED_AT = i18n.translate('xpack.csp.rules.updatedAtColumnHeaderLabel', {
+  defaultMessage: 'Updated at',
+});
 
-export const ENABLED = i18n.translate('xpack.cloudSecurityPosture.rules.enabledColumnHeaderLabel', {
+export const ENABLED = i18n.translate('xpack.csp.rules.enabledColumnHeaderLabel', {
   defaultMessage: 'Enabled',
 });
 
-export const DISABLE = i18n.translate('xpack.cloudSecurityPosture.rules.disableLabel', {
+export const DISABLE = i18n.translate('xpack.csp.rules.disableLabel', {
   defaultMessage: 'Disable',
 });
 
-export const ENABLE = i18n.translate('xpack.cloudSecurityPosture.rules.enableLabel', {
+export const ENABLE = i18n.translate('xpack.csp.rules.enableLabel', {
   defaultMessage: 'Enable',
 });
 
-export const MISSING_RULES = i18n.translate(
-  'xpack.cloudSecurityPosture.rules.missingRulesMessage',
-  { defaultMessage: 'Rules are missing' }
-);
+export const MISSING_RULES = i18n.translate('xpack.csp.rules.missingRulesMessage', {
+  defaultMessage: 'Rules are missing',
+});
 
-export const UPDATE_FAILED = i18n.translate(
-  'xpack.cloudSecurityPosture.rules.updateFailedMessage',
-  { defaultMessage: 'Update failed' }
-);
+export const UPDATE_FAILED = i18n.translate('xpack.csp.rules.updateFailedMessage', {
+  defaultMessage: 'Update failed',
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
@@ -6,34 +6,25 @@
  */
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { cspRuleAssetSavedObjectType, type CspRuleSchema } from '../../../common/schemas/csp_rule';
-import type {
-  SavedObjectsBatchResponse,
-  SavedObjectsFindOptions,
-} from '../../../../../../src/core/public';
+import type { SavedObject, SavedObjectsFindOptions } from '../../../../../../src/core/public';
 import { useKibana } from '../../common/hooks/use_kibana';
+import { UPDATE_FAILED } from './translations';
 
-export type UseCspRulesOptions = Pick<
-  SavedObjectsFindOptions,
-  'search' | 'searchFields' | 'page' | 'perPage'
->;
+export type RuleSavedObject = SavedObject<CspRuleSchema>; // SimpleSavedObject
+export type RulesQuery = Required<Pick<SavedObjectsFindOptions, 'search' | 'page' | 'perPage'>>;
+export type RulesQueryResult = ReturnType<typeof useFindCspRules>;
 
-export const useFindCspRules = ({
-  search,
-  searchFields,
-  page = 1,
-  perPage = 10,
-}: UseCspRulesOptions) => {
+export const useFindCspRules = ({ search, page, perPage }: RulesQuery) => {
   const { savedObjects } = useKibana().services;
   return useQuery(
-    [cspRuleAssetSavedObjectType, { search, searchFields, page, perPage }],
+    [cspRuleAssetSavedObjectType, { search, page, perPage }],
     () =>
       savedObjects.client.find<CspRuleSchema>({
         type: cspRuleAssetSavedObjectType,
         search,
-        searchFields,
-        page,
-        // NOTE: 'name.raw' is a field maping we defined on 'name' so it'd also be sortable
-        // TODO: this needs to be shared or removed
+        searchFields: ['name'],
+        page: 1,
+        // NOTE: 'name.raw' is a field mapping we defined on 'name'
         sortField: 'name.raw',
         perPage,
       }),
@@ -42,21 +33,25 @@ export const useFindCspRules = ({
 };
 
 export const useBulkUpdateCspRules = () => {
-  const { savedObjects } = useKibana().services;
+  const { savedObjects, notifications } = useKibana().services;
   const queryClient = useQueryClient();
 
   return useMutation(
     (rules: CspRuleSchema[]) =>
-      savedObjects.client.bulkUpdate(
+      savedObjects.client.bulkUpdate<CspRuleSchema>(
         rules.map((rule) => ({
           type: cspRuleAssetSavedObjectType,
           id: rule.id,
           attributes: rule,
         }))
-        // TODO: fix bulkUpdate types in core
-      ) as Promise<SavedObjectsBatchResponse<CspRuleSchema>>,
+      ),
     {
+      onError: (err) => {
+        if (err instanceof Error) notifications.toasts.addError(err, { title: UPDATE_FAILED });
+        else notifications.toasts.addDanger(UPDATE_FAILED);
+      },
       onSettled: () =>
+        // Invalidate all queries for simplicity
         queryClient.invalidateQueries({
           queryKey: cspRuleAssetSavedObjectType,
           exact: false,

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
@@ -5,12 +5,17 @@
  * 2.0.
  */
 import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { FunctionKeys } from 'utility-types';
 import { cspRuleAssetSavedObjectType, type CspRuleSchema } from '../../../common/schemas/csp_rule';
-import type { SavedObject, SavedObjectsFindOptions } from '../../../../../../src/core/public';
+import type { SavedObjectsFindOptions, SimpleSavedObject } from '../../../../../../src/core/public';
 import { useKibana } from '../../common/hooks/use_kibana';
 import { UPDATE_FAILED } from './translations';
 
-export type RuleSavedObject = SavedObject<CspRuleSchema>; // SimpleSavedObject
+export type RuleSavedObject = Omit<
+  SimpleSavedObject<CspRuleSchema>,
+  FunctionKeys<SimpleSavedObject>
+>;
+
 export type RulesQuery = Required<Pick<SavedObjectsFindOptions, 'search' | 'page' | 'perPage'>>;
 export type RulesQueryResult = ReturnType<typeof useFindCspRules>;
 


### PR DESCRIPTION
## Summary

this PR adds the CSP rules page with its table. currently with pre-installed data (2 rules) 

features include: search, pagination, togging (with bulk enable/disable) and sorting (just by name for now)

Missing: 
- table `section` column
- table `updated_at` column 

<details>
<summary>Quick Demo</summary>
<video src="https://user-images.githubusercontent.com/20814186/156933257-874437ed-55e9-405b-9c9e-4341f93ee3cb.mov"/>
</details>

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

- not applicable ? 

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Notes
- review from https://github.com/build-security/kibana/pull/121 has been applied here