### PR TITLE
[APM] Invalidate keys created by other when user has privileges 

### DIFF
--- a/x-pack/plugins/apm/server/routes/agent_keys/invalidate_agent_key.ts
+++ b/x-pack/plugins/apm/server/routes/agent_keys/invalidate_agent_key.ts
@@ -15,14 +15,10 @@ export async function invalidateAgentKey({
   id: string;
   isAdmin: boolean;
 }) {
-  const body: { ids: string[]; owner?: boolean } = { ids: [id] };
-  if (!isAdmin) {
-    body.owner = true;
-  }
   const { invalidated_api_keys: invalidatedAgentKeys } =
     await context.core.elasticsearch.client.asCurrentUser.security.invalidateApiKey(
       {
-        body,
+        body: { ids: [id], owner: !isAdmin },
       }
     );
 

--- a/x-pack/plugins/apm/server/routes/agent_keys/invalidate_agent_key.ts
+++ b/x-pack/plugins/apm/server/routes/agent_keys/invalidate_agent_key.ts
@@ -9,17 +9,20 @@ import { ApmPluginRequestHandlerContext } from '../typings';
 export async function invalidateAgentKey({
   context,
   id,
+  isAdmin,
 }: {
   context: ApmPluginRequestHandlerContext;
   id: string;
+  isAdmin: boolean;
 }) {
+  const body: { ids: string[]; owner?: boolean } = { ids: [id] };
+  if (!isAdmin) {
+    body.owner = true;
+  }
   const { invalidated_api_keys: invalidatedAgentKeys } =
     await context.core.elasticsearch.client.asCurrentUser.security.invalidateApiKey(
       {
-        body: {
-          ids: [id],
-          owner: true,
-        },
+        body,
       }
     );
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/126090

### Summary

When the owner flag is true, the users with privileges can not invalidate the api key, but without this flag, a user with no privileges but owner of the key (`manage_own_api_key` role) can not invalidate it.

### What was done

Check if the user `isAdmin` and if not then set the owner to true, same workaround done by the security team https://github.com/elastic/kibana/blob/6693ef371f887eca639b09c4c9b15701b4ebabd4/x-pack/plugins/security/server/routes/api_keys/invalidate.ts#L39

