### PR TITLE
Add data to user details page

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -100,6 +100,8 @@ export enum SecurityPageName {
   hostsExternalAlerts = 'hosts-external_alerts',
   hostsRisk = 'hosts-risk',
   users = 'users',
+  usersAnomalies = 'users-anomalies',
+  usersRisk = 'users-risk',
   investigate = 'investigate',
   network = 'network',
   networkAnomalies = 'network-anomalies',

--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/hosts/all/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/hosts/all/index.ts
@@ -29,5 +29,6 @@ export interface HostsRequestOptions extends RequestOptionsPaginated<HostsFields
 
 export interface HostsSortField {
   field: HostsFields;
+
   direction: Direction;
 }

--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/index.ts
@@ -81,6 +81,8 @@ import {
   KpiRiskScoreStrategyResponse,
   KpiRiskScoreRequestOptions,
 } from './risk_score';
+import { UsersQueries } from './users';
+import { UserDetailsRequestOptions, UserDetailsStrategyResponse } from './users/details';
 
 export * from './cti';
 export * from './hosts';
@@ -91,6 +93,7 @@ export * from './network';
 export type FactoryQueryTypes =
   | HostsQueries
   | HostsKpiQueries
+  | UsersQueries
   | NetworkQueries
   | NetworkKpiQueries
   | RiskQueries
@@ -136,6 +139,8 @@ export type StrategyResponseType<T extends FactoryQueryTypes> = T extends HostsQ
   ? HostsKpiHostsStrategyResponse
   : T extends HostsKpiQueries.kpiUniqueIps
   ? HostsKpiUniqueIpsStrategyResponse
+  : T extends UsersQueries.details
+  ? UserDetailsStrategyResponse
   : T extends NetworkQueries.details
   ? NetworkDetailsStrategyResponse
   : T extends NetworkQueries.dns
@@ -192,6 +197,8 @@ export type StrategyRequestType<T extends FactoryQueryTypes> = T extends HostsQu
   ? HostsKpiHostsRequestOptions
   : T extends HostsKpiQueries.kpiUniqueIps
   ? HostsKpiUniqueIpsRequestOptions
+  : T extends UsersQueries.details
+  ? UserDetailsRequestOptions
   : T extends NetworkQueries.details
   ? NetworkDetailsRequestOptions
   : T extends NetworkQueries.dns

--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/risk_score/common/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/risk_score/common/index.ts
@@ -19,6 +19,10 @@ export const buildHostNamesFilter = (hostNames: string[]) => {
   return { terms: { 'host.name': hostNames } };
 };
 
+export const buildUserNamesFilter = (userNames: string[]) => {
+  return { terms: { 'user.name': userNames } };
+};
+
 export enum RiskQueries {
   riskScore = 'riskScore',
   kpiRiskScore = 'kpiRiskScore',

--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/users/common/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/users/common/index.ts
@@ -6,6 +6,8 @@
  */
 
 import { Maybe, RiskSeverity } from '../../..';
+import { HostEcs } from '../../../../ecs/host';
+import { UserEcs } from '../../../../ecs/user';
 
 export const enum UserRiskScoreFields {
   timestamp = '@timestamp',
@@ -19,4 +21,34 @@ export interface UserRiskScoreItem {
   [UserRiskScoreFields.userName]: Maybe<string>;
   [UserRiskScoreFields.risk]: Maybe<RiskSeverity>;
   [UserRiskScoreFields.riskScore]: Maybe<number>;
+}
+
+export interface UserItem {
+  user?: Maybe<UserEcs>;
+  host?: Maybe<HostEcs>;
+  lastSeen?: Maybe<string>;
+  firstSeen?: Maybe<string>;
+}
+
+export enum UsersFields {
+  lastSeen = 'lastSeen',
+  hostName = 'userName',
+}
+
+export interface UserAggEsItem {
+  user_id?: UserBuckets;
+  user_domain?: UserBuckets;
+  user_name?: UserBuckets;
+  host_os_name?: UserBuckets;
+  host_ip?: UserBuckets;
+  host_os_family?: UserBuckets;
+  first_seen?: { value_as_string: string };
+  last_seen?: { value_as_string: string };
+}
+
+export interface UserBuckets {
+  buckets: Array<{
+    key: string;
+    doc_count: number;
+  }>;
 }

--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/users/details/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/users/details/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { IEsSearchResponse } from '../../../../../../../../src/plugins/data/common';
+
+import { Inspect, Maybe, TimerangeInput } from '../../../common';
+import { UserItem, UsersFields } from '../common';
+import { RequestOptionsPaginated } from '../..';
+
+export interface UserDetailsStrategyResponse extends IEsSearchResponse {
+  userDetails: UserItem;
+  inspect?: Maybe<Inspect>;
+}
+
+export interface UserDetailsRequestOptions extends Partial<RequestOptionsPaginated<UsersFields>> {
+  userName: string;
+  skip?: boolean;
+  timerange: TimerangeInput;
+  inspect?: Maybe<Inspect>;
+}
+
+export interface AggregationRequest {
+  [aggField: string]: estypes.AggregationsAggregationContainer;
+}

--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/users/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/users/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export enum UsersQueries {
+  details = 'userDetails',
+}

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -256,6 +256,31 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
           }),
         ],
         order: 9004,
+        deepLinks: [
+          {
+            id: SecurityPageName.authentications,
+            title: i18n.translate('xpack.securitySolution.search.users.allUsers', {
+              defaultMessage: 'All',
+            }),
+            path: `${USERS_PATH}/allUsers`,
+          },
+          {
+            id: SecurityPageName.usersAnomalies,
+            title: i18n.translate('xpack.securitySolution.search.users.anomalies', {
+              defaultMessage: 'Anomalies',
+            }),
+            path: `${USERS_PATH}/anomalies`,
+            isPremium: true,
+          },
+          {
+            id: SecurityPageName.usersRisk,
+            title: i18n.translate('xpack.securitySolution.search.users.risk', {
+              defaultMessage: 'Risk',
+            }),
+            path: `${USERS_PATH}/userRisk`,
+            isPremium: true,
+          },
+        ],
       },
     ],
   },

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -258,13 +258,6 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         order: 9004,
         deepLinks: [
           {
-            id: SecurityPageName.authentications,
-            title: i18n.translate('xpack.securitySolution.search.users.allUsers', {
-              defaultMessage: 'All',
-            }),
-            path: `${USERS_PATH}/allUsers`,
-          },
-          {
             id: SecurityPageName.usersAnomalies,
             title: i18n.translate('xpack.securitySolution.search.users.anomalies', {
               defaultMessage: 'Anomalies',

--- a/x-pack/plugins/security_solution/public/overview/components/user_overview/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/overview/components/user_overview/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,359 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`User Summary Component rendering it renders the default User Summary 1`] = `
+<UserOverview
+  anomaliesData={
+    Object {
+      "anomalies": Array [
+        Object {
+          "detectorIndex": 0,
+          "entityName": "process.name",
+          "entityValue": "du",
+          "influencers": Array [
+            Object {
+              "host.name": "zeek-iowa",
+            },
+            Object {
+              "process.name": "du",
+            },
+            Object {
+              "user.name": "root",
+            },
+          ],
+          "jobId": "job-1",
+          "rowId": "1561157194802_0",
+          "severity": 16.193669439507826,
+          "source": Object {
+            "actual": Array [
+              1,
+            ],
+            "bucket_span": 900,
+            "by_field_name": "process.name",
+            "by_field_value": "du",
+            "detector_index": 0,
+            "function": "rare",
+            "function_description": "rare",
+            "influencers": Array [
+              Object {
+                "influencer_field_name": "user.name",
+                "influencer_field_values": Array [
+                  "root",
+                ],
+              },
+              Object {
+                "influencer_field_name": "process.name",
+                "influencer_field_values": Array [
+                  "du",
+                ],
+              },
+              Object {
+                "influencer_field_name": "host.name",
+                "influencer_field_values": Array [
+                  "zeek-iowa",
+                ],
+              },
+            ],
+            "initial_record_score": 16.193669439507826,
+            "is_interim": false,
+            "job_id": "job-1",
+            "multi_bucket_impact": 0,
+            "partition_field_name": "host.name",
+            "partition_field_value": "zeek-iowa",
+            "probability": 0.024041164411288146,
+            "record_score": 16.193669439507826,
+            "result_type": "record",
+            "timestamp": 1560664800000,
+            "typical": Array [
+              0.024041164411288146,
+            ],
+          },
+          "time": 1560664800000,
+        },
+        Object {
+          "detectorIndex": 0,
+          "entityName": "process.name",
+          "entityValue": "ls",
+          "influencers": Array [
+            Object {
+              "host.name": "zeek-iowa",
+            },
+            Object {
+              "process.name": "ls",
+            },
+            Object {
+              "user.name": "root",
+            },
+          ],
+          "jobId": "job-2",
+          "rowId": "1561157194802_1",
+          "severity": 16.193669439507826,
+          "source": Object {
+            "actual": Array [
+              1,
+            ],
+            "bucket_span": 900,
+            "by_field_name": "process.name",
+            "by_field_value": "ls",
+            "detector_index": 0,
+            "function": "rare",
+            "function_description": "rare",
+            "influencers": Array [
+              Object {
+                "influencer_field_name": "user.name",
+                "influencer_field_values": Array [
+                  "root",
+                ],
+              },
+              Object {
+                "influencer_field_name": "process.name",
+                "influencer_field_values": Array [
+                  "ls",
+                ],
+              },
+              Object {
+                "influencer_field_name": "host.name",
+                "influencer_field_values": Array [
+                  "zeek-iowa",
+                ],
+              },
+            ],
+            "initial_record_score": 16.193669439507826,
+            "is_interim": false,
+            "job_id": "job-2",
+            "multi_bucket_impact": 0,
+            "partition_field_name": "host.name",
+            "partition_field_value": "zeek-iowa",
+            "probability": 0.024041164411288146,
+            "record_score": 16.193669439507826,
+            "result_type": "record",
+            "timestamp": 1560664800000,
+            "typical": Array [
+              0.024041164411288146,
+            ],
+          },
+          "time": 1560664800000,
+        },
+      ],
+      "interval": "day",
+    }
+  }
+  data={
+    Object {
+      "firstSeen": undefined,
+      "host": Object {
+        "ip": Array [
+          "10.142.0.7",
+          "fe80::4001:aff:fe8e:7",
+        ],
+        "os": Object {
+          "family": Array [
+            "debian",
+          ],
+          "name": Array [
+            "Debian GNU/Linux",
+          ],
+        },
+      },
+      "lastSeen": undefined,
+      "user": Object {
+        "domain": Array [
+          "domain",
+        ],
+        "id": Array [
+          "aa7ca589f1b8220002f2fc61c64cfbf1",
+        ],
+        "name": Array [
+          "username",
+        ],
+      },
+    }
+  }
+  endDate="2019-06-18T06:00:00.000Z"
+  id="userOverview"
+  isInDetailsSidePanel={false}
+  isLoadingAnomaliesData={false}
+  loading={false}
+  narrowDateRange={[MockFunction]}
+  startDate="2019-06-15T06:00:00.000Z"
+  userName="testUserName"
+/>
+`;
+
+exports[`User Summary Component rendering it renders the panel view User Summary 1`] = `
+<UserOverview
+  anomaliesData={
+    Object {
+      "anomalies": Array [
+        Object {
+          "detectorIndex": 0,
+          "entityName": "process.name",
+          "entityValue": "du",
+          "influencers": Array [
+            Object {
+              "host.name": "zeek-iowa",
+            },
+            Object {
+              "process.name": "du",
+            },
+            Object {
+              "user.name": "root",
+            },
+          ],
+          "jobId": "job-1",
+          "rowId": "1561157194802_0",
+          "severity": 16.193669439507826,
+          "source": Object {
+            "actual": Array [
+              1,
+            ],
+            "bucket_span": 900,
+            "by_field_name": "process.name",
+            "by_field_value": "du",
+            "detector_index": 0,
+            "function": "rare",
+            "function_description": "rare",
+            "influencers": Array [
+              Object {
+                "influencer_field_name": "user.name",
+                "influencer_field_values": Array [
+                  "root",
+                ],
+              },
+              Object {
+                "influencer_field_name": "process.name",
+                "influencer_field_values": Array [
+                  "du",
+                ],
+              },
+              Object {
+                "influencer_field_name": "host.name",
+                "influencer_field_values": Array [
+                  "zeek-iowa",
+                ],
+              },
+            ],
+            "initial_record_score": 16.193669439507826,
+            "is_interim": false,
+            "job_id": "job-1",
+            "multi_bucket_impact": 0,
+            "partition_field_name": "host.name",
+            "partition_field_value": "zeek-iowa",
+            "probability": 0.024041164411288146,
+            "record_score": 16.193669439507826,
+            "result_type": "record",
+            "timestamp": 1560664800000,
+            "typical": Array [
+              0.024041164411288146,
+            ],
+          },
+          "time": 1560664800000,
+        },
+        Object {
+          "detectorIndex": 0,
+          "entityName": "process.name",
+          "entityValue": "ls",
+          "influencers": Array [
+            Object {
+              "host.name": "zeek-iowa",
+            },
+            Object {
+              "process.name": "ls",
+            },
+            Object {
+              "user.name": "root",
+            },
+          ],
+          "jobId": "job-2",
+          "rowId": "1561157194802_1",
+          "severity": 16.193669439507826,
+          "source": Object {
+            "actual": Array [
+              1,
+            ],
+            "bucket_span": 900,
+            "by_field_name": "process.name",
+            "by_field_value": "ls",
+            "detector_index": 0,
+            "function": "rare",
+            "function_description": "rare",
+            "influencers": Array [
+              Object {
+                "influencer_field_name": "user.name",
+                "influencer_field_values": Array [
+                  "root",
+                ],
+              },
+              Object {
+                "influencer_field_name": "process.name",
+                "influencer_field_values": Array [
+                  "ls",
+                ],
+              },
+              Object {
+                "influencer_field_name": "host.name",
+                "influencer_field_values": Array [
+                  "zeek-iowa",
+                ],
+              },
+            ],
+            "initial_record_score": 16.193669439507826,
+            "is_interim": false,
+            "job_id": "job-2",
+            "multi_bucket_impact": 0,
+            "partition_field_name": "host.name",
+            "partition_field_value": "zeek-iowa",
+            "probability": 0.024041164411288146,
+            "record_score": 16.193669439507826,
+            "result_type": "record",
+            "timestamp": 1560664800000,
+            "typical": Array [
+              0.024041164411288146,
+            ],
+          },
+          "time": 1560664800000,
+        },
+      ],
+      "interval": "day",
+    }
+  }
+  data={
+    Object {
+      "firstSeen": undefined,
+      "host": Object {
+        "ip": Array [
+          "10.142.0.7",
+          "fe80::4001:aff:fe8e:7",
+        ],
+        "os": Object {
+          "family": Array [
+            "debian",
+          ],
+          "name": Array [
+            "Debian GNU/Linux",
+          ],
+        },
+      },
+      "lastSeen": undefined,
+      "user": Object {
+        "domain": Array [
+          "domain",
+        ],
+        "id": Array [
+          "aa7ca589f1b8220002f2fc61c64cfbf1",
+        ],
+        "name": Array [
+          "username",
+        ],
+      },
+    }
+  }
+  endDate="2019-06-18T06:00:00.000Z"
+  id="userOverview"
+  isInDetailsSidePanel={true}
+  isLoadingAnomaliesData={false}
+  loading={false}
+  narrowDateRange={[MockFunction]}
+  startDate="2019-06-15T06:00:00.000Z"
+  userName="testUserName"
+/>
+`;

--- a/x-pack/plugins/security_solution/public/overview/components/user_overview/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/user_overview/index.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
+import React from 'react';
+import '../../../common/mock/match_media';
+import { TestProviders } from '../../../common/mock';
+
+import { mockAnomalies } from '../../../common/components/ml/mock';
+import { useUserRiskScore } from '../../../risk_score/containers/all';
+import { UserOverview, UserSummaryProps } from '.';
+
+jest.mock('../../../risk_score/containers/all', () => ({
+  useUserRiskScore: jest.fn().mockReturnValue([
+    true,
+    {
+      data: [],
+      isModuleEnabled: false,
+    },
+  ]),
+}));
+
+describe('User Summary Component', () => {
+  describe('rendering', () => {
+    const mockProps: UserSummaryProps = {
+      anomaliesData: mockAnomalies,
+      data: {
+        user: {
+          id: ['aa7ca589f1b8220002f2fc61c64cfbf1'],
+          name: ['username'],
+          domain: ['domain'],
+        },
+        host: {
+          ip: ['10.142.0.7', 'fe80::4001:aff:fe8e:7'],
+          os: {
+            family: ['debian'],
+            name: ['Debian GNU/Linux'],
+          },
+        },
+        lastSeen: undefined,
+        firstSeen: undefined,
+      },
+      endDate: '2019-06-18T06:00:00.000Z',
+      id: 'userOverview',
+      isInDetailsSidePanel: false,
+      isLoadingAnomaliesData: false,
+      loading: false,
+      narrowDateRange: jest.fn(),
+      startDate: '2019-06-15T06:00:00.000Z',
+      userName: 'testUserName',
+    };
+
+    test('it renders the default User Summary', () => {
+      const wrapper = shallow(
+        <TestProviders>
+          <UserOverview {...mockProps} />
+        </TestProviders>
+      );
+
+      expect(wrapper.find('UserOverview')).toMatchSnapshot();
+    });
+
+    test('it renders the panel view User Summary', () => {
+      const panelViewProps = {
+        ...mockProps,
+        isInDetailsSidePanel: true,
+      };
+
+      const wrapper = shallow(
+        <TestProviders>
+          <UserOverview {...panelViewProps} />
+        </TestProviders>
+      );
+
+      expect(wrapper.find('UserOverview')).toMatchSnapshot();
+    });
+
+    test('it renders user risk score and level', () => {
+      const panelViewProps = {
+        ...mockProps,
+        isInDetailsSidePanel: true,
+      };
+      const risk = 'very high hos risk';
+      const riskScore = 9999999;
+
+      (useUserRiskScore as jest.Mock).mockReturnValue([
+        false,
+        {
+          data: [
+            {
+              host: {
+                name: 'testUsermame',
+              },
+              risk,
+              risk_stats: {
+                rule_risks: [],
+                risk_score: riskScore,
+              },
+            },
+          ],
+          isModuleEnabled: true,
+        },
+      ]);
+
+      const { getByTestId } = render(
+        <TestProviders>
+          <UserOverview {...panelViewProps} />
+        </TestProviders>
+      );
+
+      expect(getByTestId('user-risk-overview')).toHaveTextContent(risk);
+      expect(getByTestId('user-risk-overview')).toHaveTextContent(riskScore.toString());
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/overview/components/user_overview/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/user_overview/index.tsx
@@ -1,0 +1,249 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
+import { euiLightVars as lightTheme, euiDarkVars as darkTheme } from '@kbn/ui-theme';
+import { getOr } from 'lodash/fp';
+import React, { useCallback, useMemo } from 'react';
+import styled from 'styled-components';
+import { buildUserNamesFilter, RiskSeverity } from '../../../../common/search_strategy';
+import { DEFAULT_DARK_MODE } from '../../../../common/constants';
+import { DescriptionList } from '../../../../common/utility_types';
+import { useUiSetting$ } from '../../../common/lib/kibana';
+import { getEmptyTagValue } from '../../../common/components/empty_value';
+import {
+  dateRenderer,
+  DefaultFieldRenderer,
+} from '../../../timelines/components/field_renderers/field_renderers';
+import { InspectButton, InspectButtonContainer } from '../../../common/components/inspect';
+import { Loader } from '../../../common/components/loader';
+import { NetworkDetailsLink } from '../../../common/components/links';
+import { hasMlUserPermissions } from '../../../../common/machine_learning/has_ml_user_permissions';
+import { useMlCapabilities } from '../../../common/components/ml/hooks/use_ml_capabilities';
+import { AnomalyScores } from '../../../common/components/ml/score/anomaly_scores';
+import { Anomalies, NarrowDateRange } from '../../../common/components/ml/types';
+import { DescriptionListStyled, OverviewWrapper } from '../../../common/components/page';
+
+import * as i18n from './translations';
+
+import { OverviewDescriptionList } from '../../../common/components/overview_description_list';
+import { useUserRiskScore } from '../../../risk_score/containers';
+import { RiskScore } from '../../../common/components/severity/common';
+import { UserItem } from '../../../../common/search_strategy/security_solution/users/common';
+
+export interface UserSummaryProps {
+  contextID?: string; // used to provide unique draggable context when viewing in the side panel
+  data: UserItem;
+  id: string;
+  isDraggable?: boolean;
+  isInDetailsSidePanel: boolean;
+  loading: boolean;
+  isLoadingAnomaliesData: boolean;
+  anomaliesData: Anomalies | null;
+  startDate: string;
+  endDate: string;
+  narrowDateRange: NarrowDateRange;
+  userName: string;
+}
+
+const UserRiskOverviewWrapper = styled(EuiFlexGroup)`
+  padding-top: ${({ theme }) => theme.eui.euiSizeM};
+  width: 66.6%;
+`;
+
+export const UserOverview = React.memo<UserSummaryProps>(
+  ({
+    anomaliesData,
+    contextID,
+    data,
+    id,
+    isDraggable = false,
+    isInDetailsSidePanel = false, // Rather than duplicate the component, alter the structure based on it's location
+    isLoadingAnomaliesData,
+    loading,
+    narrowDateRange,
+    startDate,
+    endDate,
+    userName,
+  }) => {
+    const capabilities = useMlCapabilities();
+    const userPermissions = hasMlUserPermissions(capabilities);
+    const [darkMode] = useUiSetting$<boolean>(DEFAULT_DARK_MODE);
+    const [_, { data: userRisk, isModuleEnabled }] = useUserRiskScore({
+      filterQuery: userName ? buildUserNamesFilter([userName]) : undefined,
+    });
+
+    const getDefaultRenderer = useCallback(
+      (fieldName: string, fieldData: UserItem) => (
+        <DefaultFieldRenderer
+          rowItems={getOr([], fieldName, fieldData)}
+          attrName={fieldName}
+          idPrefix={contextID ? `user-overview-${contextID}` : 'iuser-overview'}
+          isDraggable={isDraggable}
+        />
+      ),
+      [contextID, isDraggable]
+    );
+
+    const [userRiskScore, userRiskLevel] = useMemo(() => {
+      if (isModuleEnabled) {
+        const userRiskData = userRisk && userRisk.length > 0 ? userRisk[0] : undefined;
+        return [
+          {
+            title: i18n.USER_RISK_SCORE,
+            description: (
+              <>
+                {userRiskData ? Math.round(userRiskData.risk_stats.risk_score) : getEmptyTagValue()}
+              </>
+            ),
+          },
+          {
+            title: i18n.USER_RISK_CLASSIFICATION,
+            description: (
+              <>
+                {userRiskData ? (
+                  <RiskScore severity={userRiskData.risk as RiskSeverity} hideBackgroundColor />
+                ) : (
+                  getEmptyTagValue()
+                )}
+              </>
+            ),
+          },
+        ];
+      }
+      return [undefined, undefined];
+    }, [userRisk, isModuleEnabled]);
+
+    const column = useMemo(
+      () => [
+        {
+          title: i18n.USER_ID,
+          description: data && data.user ? getDefaultRenderer('user.id', data) : getEmptyTagValue(),
+        },
+        {
+          title: i18n.USER_DOMAIN,
+          description:
+            data && data.user ? getDefaultRenderer('user.domain', data) : getEmptyTagValue(),
+        },
+      ],
+      [data, getDefaultRenderer]
+    );
+
+    const firstColumn = useMemo(
+      () =>
+        userPermissions
+          ? [
+              ...column,
+              {
+                title: i18n.MAX_ANOMALY_SCORE_BY_JOB,
+                description: (
+                  <AnomalyScores
+                    anomalies={anomaliesData}
+                    startDate={startDate}
+                    endDate={endDate}
+                    isLoading={isLoadingAnomaliesData}
+                    narrowDateRange={narrowDateRange}
+                  />
+                ),
+              },
+            ]
+          : column,
+      [
+        anomaliesData,
+        column,
+        endDate,
+        isLoadingAnomaliesData,
+        narrowDateRange,
+        startDate,
+        userPermissions,
+      ]
+    );
+
+    const descriptionLists: Readonly<DescriptionList[][]> = useMemo(
+      () => [
+        firstColumn,
+        [
+          {
+            title: i18n.FIRST_SEEN,
+            description: data ? dateRenderer(data.firstSeen) : getEmptyTagValue(),
+          },
+          {
+            title: i18n.LAST_SEEN,
+            description: data ? dateRenderer(data.lastSeen) : getEmptyTagValue(),
+          },
+        ],
+        [
+          {
+            title: i18n.HOST_OS,
+            description: getDefaultRenderer('host.os.name', data),
+          },
+
+          {
+            title: i18n.HOST_FAMILY,
+            description: getDefaultRenderer('host.os.family', data),
+          },
+          {
+            title: i18n.HOST_IP,
+            description: (
+              <DefaultFieldRenderer
+                rowItems={getOr([], 'host.ip', data)}
+                attrName={'host.ip'}
+                idPrefix={contextID ? `user-overview-${contextID}` : 'user-overview'}
+                isDraggable={isDraggable}
+                render={(ip) => (ip != null ? <NetworkDetailsLink ip={ip} /> : getEmptyTagValue())}
+              />
+            ),
+          },
+        ],
+      ],
+      [data, getDefaultRenderer, contextID, isDraggable, firstColumn]
+    );
+    return (
+      <>
+        <InspectButtonContainer>
+          <OverviewWrapper
+            direction={isInDetailsSidePanel ? 'column' : 'row'}
+            data-test-subj="user-overview"
+          >
+            {!isInDetailsSidePanel && (
+              <InspectButton queryId={id} title={i18n.INSPECT_TITLE} inspectIndex={0} />
+            )}
+            {descriptionLists.map((descriptionList, index) => (
+              <OverviewDescriptionList descriptionList={descriptionList} key={index} />
+            ))}
+
+            {loading && (
+              <Loader
+                overlay
+                overlayBackground={
+                  darkMode ? darkTheme.euiPageBackgroundColor : lightTheme.euiPageBackgroundColor
+                }
+                size="xl"
+              />
+            )}
+          </OverviewWrapper>
+        </InspectButtonContainer>
+        {userRiskScore && userRiskLevel && (
+          <UserRiskOverviewWrapper
+            gutterSize={isInDetailsSidePanel ? 'm' : 'none'}
+            direction={isInDetailsSidePanel ? 'column' : 'row'}
+            data-test-subj="user-risk-overview"
+          >
+            <EuiFlexItem>
+              <DescriptionListStyled listItems={[userRiskScore]} />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <DescriptionListStyled listItems={[userRiskLevel]} />
+            </EuiFlexItem>
+          </UserRiskOverviewWrapper>
+        )}
+      </>
+    );
+  }
+);
+
+UserOverview.displayName = 'UserOverview';

--- a/x-pack/plugins/security_solution/public/overview/components/user_overview/translations.ts
+++ b/x-pack/plugins/security_solution/public/overview/components/user_overview/translations.ts
@@ -12,7 +12,7 @@ export const USER_ID = i18n.translate('xpack.securitySolution.user.details.overv
 });
 
 export const USER_DOMAIN = i18n.translate(
-  'xpack.securitySolution.host.details.overview.userDomainTitle',
+  'xpack.securitySolution.user.details.overview.userDomainTitle',
   {
     defaultMessage: 'Domain',
   }
@@ -32,7 +32,7 @@ export const HOST_IP = i18n.translate(
   }
 );
 
-export const HOST_OS = i18n.translate('xpack.securitySolution.host.details.overview.osTitle', {
+export const HOST_OS = i18n.translate('xpack.securitySolution.user.details.overview.osTitle', {
   defaultMessage: 'Operating system',
 });
 
@@ -44,7 +44,7 @@ export const FIRST_SEEN = i18n.translate(
 );
 
 export const LAST_SEEN = i18n.translate(
-  'xpack.securitySolution.network.ipDetails.ipOverview.lastSeenTitle',
+  'xpack.securitySolution.user.ipDetails.ipOverview.lastSeenTitle',
   {
     defaultMessage: 'Last seen',
   }

--- a/x-pack/plugins/security_solution/public/overview/components/user_overview/translations.ts
+++ b/x-pack/plugins/security_solution/public/overview/components/user_overview/translations.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const USER_ID = i18n.translate('xpack.securitySolution.user.details.overview.userIdTitle', {
+  defaultMessage: 'User ID',
+});
+
+export const USER_DOMAIN = i18n.translate(
+  'xpack.securitySolution.host.details.overview.userDomainTitle',
+  {
+    defaultMessage: 'Domain',
+  }
+);
+
+export const HOST_FAMILY = i18n.translate(
+  'xpack.securitySolution.user.details.overview.familyTitle',
+  {
+    defaultMessage: 'Family',
+  }
+);
+
+export const HOST_IP = i18n.translate(
+  'xpack.securitySolution.user.details.overview.ipAddressesTitle',
+  {
+    defaultMessage: 'IP addresses',
+  }
+);
+
+export const HOST_OS = i18n.translate('xpack.securitySolution.host.details.overview.osTitle', {
+  defaultMessage: 'Operating system',
+});
+
+export const FIRST_SEEN = i18n.translate(
+  'xpack.securitySolution.network.ipDetails.ipOverview.firstSeenTitle',
+  {
+    defaultMessage: 'First seen',
+  }
+);
+
+export const LAST_SEEN = i18n.translate(
+  'xpack.securitySolution.network.ipDetails.ipOverview.lastSeenTitle',
+  {
+    defaultMessage: 'Last seen',
+  }
+);
+export const INSPECT_TITLE = i18n.translate(
+  'xpack.securitySolution.user.details.overview.inspectTitle',
+  {
+    defaultMessage: 'User overview',
+  }
+);
+
+export const MAX_ANOMALY_SCORE_BY_JOB = i18n.translate(
+  'xpack.securitySolution.user.details.overview.maxAnomalyScoreByJobTitle',
+  {
+    defaultMessage: 'Max anomaly score by job',
+  }
+);
+
+export const USER_RISK_SCORE = i18n.translate(
+  'xpack.securitySolution.user.details.overview.userRiskScoreTitle',
+  {
+    defaultMessage: 'User risk score',
+  }
+);
+
+export const USER_RISK_CLASSIFICATION = i18n.translate(
+  'xpack.securitySolution.user.details.overview.userRiskClassification',
+  {
+    defaultMessage: 'User risk classification',
+  }
+);

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/user_details/expandable_user.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/user_details/expandable_user.tsx
@@ -10,7 +10,17 @@ import { i18n } from '@kbn/i18n';
 import styled from 'styled-components';
 import React from 'react';
 import { UserDetailsLink } from '../../../../common/components/links';
+import { UserOverview } from '../../../../overview/components/user_overview';
+import { useUserDetails } from '../../../../users/containers/users/details';
+import { useGlobalTime } from '../../../../common/containers/use_global_time';
+import { useSourcererDataView } from '../../../../common/containers/sourcerer';
+import { setAbsoluteRangeDatePicker } from '../../../../common/store/inputs/actions';
+import { getCriteriaFromUsersType } from '../../../../common/components/ml/criteria/get_criteria_from_users_type';
+import { scoreIntervalToDateTime } from '../../../../common/components/ml/score/score_interval_to_datetime';
+import { AnomalyTableProvider } from '../../../../common/components/ml/anomaly/anomaly_table_provider';
+import { UsersType } from '../../../../users/store/model';
 
+export const QUERY_ID = 'usersDetailsQuery';
 export interface ExpandableUserProps {
   userName: string;
 }
@@ -45,5 +55,47 @@ export const ExpandableUserDetails = ({
   userName,
   isDraggable,
 }: ExpandableUserProps & { contextID: string; isDraggable?: boolean }) => {
-  return <>{'TODO I am empty'}</>;
+  const { to, from, isInitializing } = useGlobalTime();
+  const { selectedPatterns } = useSourcererDataView();
+
+  const [loading, { userDetails }] = useUserDetails({
+    endDate: to,
+    startDate: from,
+    userName,
+    indexNames: selectedPatterns,
+    skip: isInitializing,
+  });
+
+  return (
+    <AnomalyTableProvider
+      criteriaFields={getCriteriaFromUsersType(UsersType.details, userName)}
+      startDate={from}
+      endDate={to}
+      skip={isInitializing}
+    >
+      {({ isLoadingAnomaliesData, anomaliesData }) => (
+        <UserOverview
+          userName={userName}
+          isInDetailsSidePanel={true}
+          data={userDetails}
+          loading={loading}
+          contextID={contextID}
+          isDraggable={isDraggable}
+          id={QUERY_ID}
+          anomaliesData={anomaliesData}
+          isLoadingAnomaliesData={isLoadingAnomaliesData}
+          startDate={from}
+          endDate={to}
+          narrowDateRange={(score, interval) => {
+            const fromTo = scoreIntervalToDateTime(score, interval);
+            setAbsoluteRangeDatePicker({
+              id: 'global',
+              from: fromTo.from,
+              to: fromTo.to,
+            });
+          }}
+        />
+      )}
+    </AnomalyTableProvider>
+  );
 };

--- a/x-pack/plugins/security_solution/public/users/containers/users/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/containers/users/details/index.tsx
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import deepEqual from 'fast-deep-equal';
+import { noop } from 'lodash/fp';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Subscription } from 'rxjs';
+
+import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
+import { inputsModel } from '../../../../common/store';
+import { useKibana } from '../../../../common/lib/kibana';
+
+import * as i18n from './translations';
+import {
+  isCompleteResponse,
+  isErrorResponse,
+} from '../../../../../../../../src/plugins/data/common';
+import { getInspectResponse } from '../../../../helpers';
+import { InspectResponse } from '../../../../types';
+import {
+  UserDetailsRequestOptions,
+  UserDetailsStrategyResponse,
+} from '../../../../../common/search_strategy/security_solution/users/details';
+import { UsersQueries } from '../../../../../common/search_strategy/security_solution/users';
+import { UserItem } from '../../../../../common/search_strategy/security_solution/users/common';
+
+export const ID = 'usersDetailsQuery';
+
+export interface UserDetailsArgs {
+  id: string;
+  inspect: InspectResponse;
+  userDetails: UserItem;
+  refetch: inputsModel.Refetch;
+  startDate: string;
+  endDate: string;
+}
+
+interface UseUserDetails {
+  endDate: string;
+  userName: string;
+  id?: string;
+  indexNames: string[];
+  skip?: boolean;
+  startDate: string;
+}
+
+export const useUserDetails = ({
+  endDate,
+  userName,
+  indexNames,
+  id = ID,
+  skip = false,
+  startDate,
+}: UseUserDetails): [boolean, UserDetailsArgs] => {
+  const { data } = useKibana().services;
+  const refetch = useRef<inputsModel.Refetch>(noop);
+  const abortCtrl = useRef(new AbortController());
+  const searchSubscription$ = useRef(new Subscription());
+  const [loading, setLoading] = useState(false);
+  const [userDetailsRequest, setUserDetailsRequest] = useState<UserDetailsRequestOptions | null>(
+    null
+  );
+  const { addError, addWarning } = useAppToasts();
+
+  const [userDetailsResponse, setUserDetailsResponse] = useState<UserDetailsArgs>({
+    endDate,
+    userDetails: {},
+    id,
+    inspect: {
+      dsl: [],
+      response: [],
+    },
+    refetch: refetch.current,
+    startDate,
+  });
+
+  const userDetailsSearch = useCallback(
+    (request: UserDetailsRequestOptions | null) => {
+      if (request == null || skip) {
+        return;
+      }
+
+      const asyncSearch = async () => {
+        abortCtrl.current = new AbortController();
+        setLoading(true);
+
+        searchSubscription$.current = data.search
+          .search<UserDetailsRequestOptions, UserDetailsStrategyResponse>(request, {
+            strategy: 'securitySolutionSearchStrategy',
+            abortSignal: abortCtrl.current.signal,
+          })
+          .subscribe({
+            next: (response) => {
+              if (isCompleteResponse(response)) {
+                setLoading(false);
+                setUserDetailsResponse((prevResponse) => ({
+                  ...prevResponse,
+                  userDetails: response.userDetails,
+                  inspect: getInspectResponse(response, prevResponse.inspect),
+                  refetch: refetch.current,
+                }));
+                searchSubscription$.current.unsubscribe();
+              } else if (isErrorResponse(response)) {
+                setLoading(false);
+                addWarning(i18n.ERROR_USER_DETAILS);
+                searchSubscription$.current.unsubscribe();
+              }
+            },
+            error: (msg) => {
+              setLoading(false);
+              addError(msg, {
+                title: i18n.FAIL_USER_DETAILS,
+              });
+              searchSubscription$.current.unsubscribe();
+            },
+          });
+      };
+      searchSubscription$.current.unsubscribe();
+      abortCtrl.current.abort();
+      asyncSearch();
+      refetch.current = asyncSearch;
+    },
+    [data.search, addError, addWarning, skip]
+  );
+
+  useEffect(() => {
+    setUserDetailsRequest((prevRequest) => {
+      const myRequest = {
+        ...(prevRequest ?? {}),
+        defaultIndex: indexNames,
+        factoryQueryType: UsersQueries.details,
+        userName,
+        timerange: {
+          interval: '12h',
+          from: startDate,
+          to: endDate,
+        },
+      };
+      if (!deepEqual(prevRequest, myRequest)) {
+        return myRequest;
+      }
+      return prevRequest;
+    });
+  }, [endDate, userName, indexNames, startDate]);
+
+  useEffect(() => {
+    userDetailsSearch(userDetailsRequest);
+    return () => {
+      searchSubscription$.current.unsubscribe();
+      abortCtrl.current.abort();
+    };
+  }, [userDetailsRequest, userDetailsSearch]);
+
+  return [loading, userDetailsResponse];
+};

--- a/x-pack/plugins/security_solution/public/users/containers/users/details/translations.ts
+++ b/x-pack/plugins/security_solution/public/users/containers/users/details/translations.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const ERROR_USER_DETAILS = i18n.translate(
+  'xpack.securitySolution.userDetails.errorSearchDescription',
+  {
+    defaultMessage: `An error has occurred on user details search`,
+  }
+);
+
+export const FAIL_USER_DETAILS = i18n.translate(
+  'xpack.securitySolution.userDetails.failSearchDescription',
+  {
+    defaultMessage: `Failed to run search on user details`,
+  }
+);

--- a/x-pack/plugins/security_solution/public/users/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/details/index.tsx
@@ -42,7 +42,15 @@ import { useDeepEqualSelector, useShallowEqualSelector } from '../../../common/h
 import { useInvalidFilterQuery } from '../../../common/hooks/use_invalid_filter_query';
 import { LastEventTime } from '../../../common/components/last_event_time';
 import { LastEventIndexKey } from '../../../../common/search_strategy';
-const ID = 'UsersDetailsQueryId';
+
+import { AnomalyTableProvider } from '../../../common/components/ml/anomaly/anomaly_table_provider';
+import { UserOverview } from '../../../overview/components/user_overview';
+import { useUserDetails } from '../../containers/users/details';
+import { useQueryInspector } from '../../../common/components/page/manage_query';
+import { scoreIntervalToDateTime } from '../../../common/components/ml/score/score_interval_to_datetime';
+import { getCriteriaFromUsersType } from '../../../common/components/ml/criteria/get_criteria_from_users_type';
+import { UsersType } from '../../store/model';
+const QUERY_ID = 'UsersDetailsQueryId';
 
 const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
   detailName,
@@ -80,11 +88,29 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
     filters: getFilters(),
   });
 
-  useInvalidFilterQuery({ id: ID, filterQuery, kqlError, query, startDate: from, endDate: to });
+  useInvalidFilterQuery({
+    id: QUERY_ID,
+    filterQuery,
+    kqlError,
+    query,
+    startDate: from,
+    endDate: to,
+  });
 
   useEffect(() => {
     dispatch(setUsersDetailsTablesActivePageToZero());
   }, [dispatch, detailName]);
+
+  const [loading, { inspect, userDetails, refetch }] = useUserDetails({
+    id: QUERY_ID,
+    endDate: to,
+    startDate: from,
+    userName: detailName,
+    indexNames: selectedPatterns,
+    skip: selectedPatterns.length === 0,
+  });
+
+  useQueryInspector({ setQuery, deleteQuery, refetch, inspect, loading, queryId: QUERY_ID });
 
   return (
     <>
@@ -108,11 +134,41 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
               }
               title={detailName}
             />
+            <AnomalyTableProvider
+              criteriaFields={getCriteriaFromUsersType(UsersType.details, detailName)}
+              startDate={from}
+              endDate={to}
+              skip={isInitializing}
+            >
+              {({ isLoadingAnomaliesData, anomaliesData }) => (
+                <UserOverview
+                  userName={detailName}
+                  id={QUERY_ID}
+                  isInDetailsSidePanel={false}
+                  data={userDetails}
+                  anomaliesData={anomaliesData}
+                  isLoadingAnomaliesData={isLoadingAnomaliesData}
+                  loading={loading}
+                  startDate={from}
+                  endDate={to}
+                  narrowDateRange={(score, interval) => {
+                    const fromTo = scoreIntervalToDateTime(score, interval);
+                    setAbsoluteRangeDatePicker({
+                      id: 'global',
+                      from: fromTo.from,
+                      to: fromTo.to,
+                    });
+                  }}
+                />
+              )}
+            </AnomalyTableProvider>
+
             <EuiSpacer />
 
             <SecuritySolutionTabNavigation navTabs={navTabsUsersDetails(detailName)} />
 
             <EuiSpacer />
+
             <UsersDetailsTabs
               deleteQuery={deleteQuery}
               detailName={detailName}

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/index.ts
@@ -13,12 +13,14 @@ import { matrixHistogramFactory } from './matrix_histogram';
 import { networkFactory } from './network';
 import { ctiFactoryTypes } from './cti';
 import { riskScoreFactory } from './risk_score';
+import { usersFactory } from './users';
 
 export const securitySolutionFactory: Record<
   FactoryQueryTypes,
   SecuritySolutionFactory<FactoryQueryTypes>
 > = {
   ...hostsFactory,
+  ...usersFactory,
   ...matrixHistogramFactory,
   ...networkFactory,
   ...ctiFactoryTypes,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/__mocks__/index.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IEsSearchResponse } from '../../../../../../../../../../src/plugins/data/common';
+import { UsersQueries } from '../../../../../../../common/search_strategy/security_solution/users';
+
+import { UserDetailsRequestOptions } from '../../../../../../../common/search_strategy/security_solution/users/details';
+
+export const mockOptions: UserDetailsRequestOptions = {
+  defaultIndex: ['test_indices*'],
+  docValueFields: [
+    {
+      field: '@timestamp',
+      format: 'date_time',
+    },
+  ],
+  factoryQueryType: UsersQueries.details,
+  filterQuery:
+    '{"bool":{"must":[],"filter":[{"match_all":{}},{"match_phrase":{"user.name":{"query":"test_user"}}}],"should":[],"must_not":[]}}',
+  timerange: {
+    interval: '12h',
+    from: '2020-09-02T15:17:13.678Z',
+    to: '2020-09-03T15:17:13.678Z',
+  },
+  params: {},
+  userName: 'bastion00.siem.estc.dev',
+} as UserDetailsRequestOptions;
+
+export const mockSearchStrategyResponse: IEsSearchResponse<unknown> = {
+  rawResponse: {
+    took: 1,
+    timed_out: false,
+    _shards: {
+      total: 2,
+      successful: 2,
+      skipped: 1,
+      failed: 0,
+    },
+    hits: {
+      max_score: null,
+      hits: [],
+    },
+    aggregations: {
+      host_ip: {
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 665,
+        buckets: [
+          {
+            key: '11.245.5.152',
+            doc_count: 133,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+          {
+            key: '149.175.90.37',
+            doc_count: 133,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+          {
+            key: '16.3.124.77',
+            doc_count: 133,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+          {
+            key: '161.120.111.159',
+            doc_count: 133,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+          {
+            key: '179.124.88.33',
+            doc_count: 133,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+          {
+            key: '203.248.113.63',
+            doc_count: 133,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+          {
+            key: '205.6.104.210',
+            doc_count: 133,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+          {
+            key: '209.233.30.0',
+            doc_count: 133,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+          {
+            key: '238.165.244.247',
+            doc_count: 133,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+          {
+            key: '29.73.212.149',
+            doc_count: 133,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+        ],
+      },
+      first_seen: {
+        value: 1644837532000,
+        value_as_string: '2022-02-14T11:18:52.000Z',
+      },
+      last_seen: {
+        value: 1644837532000,
+        value_as_string: '2022-02-14T11:18:52.000Z',
+      },
+      user_domain: {
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0,
+        buckets: [
+          {
+            key: 'NT AUTHORITY',
+            doc_count: 1905,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+        ],
+      },
+      user_id: {
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0,
+        buckets: [
+          {
+            key: 'S-1-5-18',
+            doc_count: 1995,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+        ],
+      },
+      user_name: {
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0,
+        buckets: [
+          {
+            key: 'SYSTEM',
+            doc_count: 1995,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+        ],
+      },
+      host_os_family: {
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0,
+        buckets: [
+          {
+            key: 'Windows',
+            doc_count: 1995,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+        ],
+      },
+      host_os_name: {
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0,
+        buckets: [
+          {
+            key: 'Windows',
+            doc_count: 1995,
+            timestamp: {
+              value: 1644837532000,
+              value_as_string: '2022-02-14T11:18:52.000Z',
+            },
+          },
+        ],
+      },
+    },
+  },
+  isPartial: false,
+  isRunning: false,
+  total: 2,
+  loaded: 2,
+};

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,373 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`userDetails search strategy parse should parse data correctly 1`] = `
+Object {
+  "inspect": Object {
+    "dsl": Array [
+      "{
+  \\"allow_no_indices\\": true,
+  \\"index\\": [
+    \\"test_indices*\\"
+  ],
+  \\"ignore_unavailable\\": true,
+  \\"track_total_hits\\": false,
+  \\"body\\": {
+    \\"aggregations\\": {
+      \\"first_seen\\": {
+        \\"min\\": {
+          \\"field\\": \\"@timestamp\\"
+        }
+      },
+      \\"last_seen\\": {
+        \\"max\\": {
+          \\"field\\": \\"@timestamp\\"
+        }
+      },
+      \\"user_id\\": {
+        \\"terms\\": {
+          \\"field\\": \\"user.id\\",
+          \\"size\\": 10,
+          \\"order\\": {
+            \\"timestamp\\": \\"desc\\"
+          }
+        },
+        \\"aggs\\": {
+          \\"timestamp\\": {
+            \\"max\\": {
+              \\"field\\": \\"@timestamp\\"
+            }
+          }
+        }
+      },
+      \\"user_domain\\": {
+        \\"terms\\": {
+          \\"field\\": \\"user.domain\\",
+          \\"size\\": 10,
+          \\"order\\": {
+            \\"timestamp\\": \\"desc\\"
+          }
+        },
+        \\"aggs\\": {
+          \\"timestamp\\": {
+            \\"max\\": {
+              \\"field\\": \\"@timestamp\\"
+            }
+          }
+        }
+      },
+      \\"user_name\\": {
+        \\"terms\\": {
+          \\"field\\": \\"user.name\\",
+          \\"size\\": 10,
+          \\"order\\": {
+            \\"timestamp\\": \\"desc\\"
+          }
+        },
+        \\"aggs\\": {
+          \\"timestamp\\": {
+            \\"max\\": {
+              \\"field\\": \\"@timestamp\\"
+            }
+          }
+        }
+      },
+      \\"host_os_name\\": {
+        \\"terms\\": {
+          \\"field\\": \\"host.os.name\\",
+          \\"size\\": 10,
+          \\"order\\": {
+            \\"timestamp\\": \\"desc\\"
+          }
+        },
+        \\"aggs\\": {
+          \\"timestamp\\": {
+            \\"max\\": {
+              \\"field\\": \\"@timestamp\\"
+            }
+          }
+        }
+      },
+      \\"host_ip\\": {
+        \\"terms\\": {
+          \\"script\\": {
+            \\"source\\": \\"doc['host.ip']\\",
+            \\"lang\\": \\"painless\\"
+          },
+          \\"size\\": 10,
+          \\"order\\": {
+            \\"timestamp\\": \\"desc\\"
+          }
+        },
+        \\"aggs\\": {
+          \\"timestamp\\": {
+            \\"max\\": {
+              \\"field\\": \\"@timestamp\\"
+            }
+          }
+        }
+      },
+      \\"host_os_family\\": {
+        \\"terms\\": {
+          \\"field\\": \\"host.os.family\\",
+          \\"size\\": 10,
+          \\"order\\": {
+            \\"timestamp\\": \\"desc\\"
+          }
+        },
+        \\"aggs\\": {
+          \\"timestamp\\": {
+            \\"max\\": {
+              \\"field\\": \\"@timestamp\\"
+            }
+          }
+        }
+      }
+    },
+    \\"query\\": {
+      \\"bool\\": {
+        \\"filter\\": [
+          {
+            \\"term\\": {
+              \\"user.name\\": \\"bastion00.siem.estc.dev\\"
+            }
+          },
+          {
+            \\"range\\": {
+              \\"@timestamp\\": {
+                \\"format\\": \\"strict_date_optional_time\\",
+                \\"gte\\": \\"2020-09-02T15:17:13.678Z\\",
+                \\"lte\\": \\"2020-09-03T15:17:13.678Z\\"
+              }
+            }
+          }
+        ]
+      }
+    },
+    \\"size\\": 0
+  }
+}",
+    ],
+  },
+  "isPartial": false,
+  "isRunning": false,
+  "loaded": 2,
+  "rawResponse": Object {
+    "_shards": Object {
+      "failed": 0,
+      "skipped": 1,
+      "successful": 2,
+      "total": 2,
+    },
+    "aggregations": Object {
+      "first_seen": Object {
+        "value": 1644837532000,
+        "value_as_string": "2022-02-14T11:18:52.000Z",
+      },
+      "host_ip": Object {
+        "buckets": Array [
+          Object {
+            "doc_count": 133,
+            "key": "11.245.5.152",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+          Object {
+            "doc_count": 133,
+            "key": "149.175.90.37",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+          Object {
+            "doc_count": 133,
+            "key": "16.3.124.77",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+          Object {
+            "doc_count": 133,
+            "key": "161.120.111.159",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+          Object {
+            "doc_count": 133,
+            "key": "179.124.88.33",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+          Object {
+            "doc_count": 133,
+            "key": "203.248.113.63",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+          Object {
+            "doc_count": 133,
+            "key": "205.6.104.210",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+          Object {
+            "doc_count": 133,
+            "key": "209.233.30.0",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+          Object {
+            "doc_count": 133,
+            "key": "238.165.244.247",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+          Object {
+            "doc_count": 133,
+            "key": "29.73.212.149",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+        ],
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 665,
+      },
+      "host_os_family": Object {
+        "buckets": Array [
+          Object {
+            "doc_count": 1995,
+            "key": "Windows",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+        ],
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+      },
+      "host_os_name": Object {
+        "buckets": Array [
+          Object {
+            "doc_count": 1995,
+            "key": "Windows",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+        ],
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+      },
+      "last_seen": Object {
+        "value": 1644837532000,
+        "value_as_string": "2022-02-14T11:18:52.000Z",
+      },
+      "user_domain": Object {
+        "buckets": Array [
+          Object {
+            "doc_count": 1905,
+            "key": "NT AUTHORITY",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+        ],
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+      },
+      "user_id": Object {
+        "buckets": Array [
+          Object {
+            "doc_count": 1995,
+            "key": "S-1-5-18",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+        ],
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+      },
+      "user_name": Object {
+        "buckets": Array [
+          Object {
+            "doc_count": 1995,
+            "key": "SYSTEM",
+            "timestamp": Object {
+              "value": 1644837532000,
+              "value_as_string": "2022-02-14T11:18:52.000Z",
+            },
+          },
+        ],
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+      },
+    },
+    "hits": Object {
+      "hits": Array [],
+      "max_score": null,
+    },
+    "timed_out": false,
+    "took": 1,
+  },
+  "total": 2,
+  "userDetails": Object {
+    "firstSeen": "2022-02-14T11:18:52.000Z",
+    "host": Object {
+      "ip": Array [
+        "11.245.5.152",
+        "149.175.90.37",
+        "16.3.124.77",
+        "161.120.111.159",
+        "179.124.88.33",
+        "203.248.113.63",
+        "205.6.104.210",
+        "209.233.30.0",
+        "238.165.244.247",
+        "29.73.212.149",
+      ],
+      "os": Object {
+        "family": Array [
+          "Windows",
+        ],
+        "name": Array [
+          "Windows",
+        ],
+      },
+    },
+    "lastSeen": "2022-02-14T11:18:52.000Z",
+    "user": Object {
+      "domain": Array [
+        "NT AUTHORITY",
+      ],
+      "id": Array [
+        "S-1-5-18",
+      ],
+      "name": Array [
+        "SYSTEM",
+      ],
+    },
+  },
+}
+`;

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/__snapshots__/query.user_details.dsl.test.ts.snap
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/__snapshots__/query.user_details.dsl.test.ts.snap
@@ -1,0 +1,146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildUserDetailsQuery build query from options correctly 1`] = `
+Object {
+  "allow_no_indices": true,
+  "body": Object {
+    "aggregations": Object {
+      "first_seen": Object {
+        "min": Object {
+          "field": "@timestamp",
+        },
+      },
+      "host_ip": Object {
+        "aggs": Object {
+          "timestamp": Object {
+            "max": Object {
+              "field": "@timestamp",
+            },
+          },
+        },
+        "terms": Object {
+          "order": Object {
+            "timestamp": "desc",
+          },
+          "script": Object {
+            "lang": "painless",
+            "source": "doc['host.ip']",
+          },
+          "size": 10,
+        },
+      },
+      "host_os_family": Object {
+        "aggs": Object {
+          "timestamp": Object {
+            "max": Object {
+              "field": "@timestamp",
+            },
+          },
+        },
+        "terms": Object {
+          "field": "host.os.family",
+          "order": Object {
+            "timestamp": "desc",
+          },
+          "size": 10,
+        },
+      },
+      "host_os_name": Object {
+        "aggs": Object {
+          "timestamp": Object {
+            "max": Object {
+              "field": "@timestamp",
+            },
+          },
+        },
+        "terms": Object {
+          "field": "host.os.name",
+          "order": Object {
+            "timestamp": "desc",
+          },
+          "size": 10,
+        },
+      },
+      "last_seen": Object {
+        "max": Object {
+          "field": "@timestamp",
+        },
+      },
+      "user_domain": Object {
+        "aggs": Object {
+          "timestamp": Object {
+            "max": Object {
+              "field": "@timestamp",
+            },
+          },
+        },
+        "terms": Object {
+          "field": "user.domain",
+          "order": Object {
+            "timestamp": "desc",
+          },
+          "size": 10,
+        },
+      },
+      "user_id": Object {
+        "aggs": Object {
+          "timestamp": Object {
+            "max": Object {
+              "field": "@timestamp",
+            },
+          },
+        },
+        "terms": Object {
+          "field": "user.id",
+          "order": Object {
+            "timestamp": "desc",
+          },
+          "size": 10,
+        },
+      },
+      "user_name": Object {
+        "aggs": Object {
+          "timestamp": Object {
+            "max": Object {
+              "field": "@timestamp",
+            },
+          },
+        },
+        "terms": Object {
+          "field": "user.name",
+          "order": Object {
+            "timestamp": "desc",
+          },
+          "size": 10,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "user.name": "bastion00.siem.estc.dev",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "strict_date_optional_time",
+                "gte": "2020-09-02T15:17:13.678Z",
+                "lte": "2020-09-03T15:17:13.678Z",
+              },
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "ignore_unavailable": true,
+  "index": Array [
+    "test_indices*",
+  ],
+  "track_total_hits": false,
+}
+`;

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/helper.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/helper.test.ts
@@ -8,10 +8,6 @@
 import { UserAggEsItem } from '../../../../../../common/search_strategy/security_solution/users/common';
 import { fieldNameToAggField, formatUserItem } from './helpers';
 
-// fieldNameToAggField = (fieldName: string)
-
-// formatUserItem = (aggregations: UserAggEsItem): UserItem => {
-
 describe('helpers', () => {
   it('it convert field name to aggregation field name', () => {
     expect(fieldNameToAggField('host.os.family')).toBe('host_os_family');

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/helper.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/helper.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { UserAggEsItem } from '../../../../../../common/search_strategy/security_solution/users/common';
+import { fieldNameToAggField, formatUserItem } from './helpers';
+
+// fieldNameToAggField = (fieldName: string)
+
+// formatUserItem = (aggregations: UserAggEsItem): UserItem => {
+
+describe('helpers', () => {
+  it('it convert field name to aggregation field name', () => {
+    expect(fieldNameToAggField('host.os.family')).toBe('host_os_family');
+  });
+
+  it('it formats UserItem', () => {
+    const userId = '123';
+    const aggregations: UserAggEsItem = {
+      user_id: {
+        buckets: [
+          {
+            key: userId,
+            doc_count: 1,
+          },
+        ],
+      },
+      first_seen: { value_as_string: '123456789' },
+      last_seen: { value_as_string: '987654321' },
+    };
+
+    expect(formatUserItem(aggregations)).toEqual({
+      firstSeen: '123456789',
+      lastSeen: '987654321',
+      user: { id: [userId] },
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/helpers.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/helpers.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { set } from '@elastic/safer-lodash-set/fp';
+import { get, has } from 'lodash/fp';
+import {
+  UserAggEsItem,
+  UserBuckets,
+  UserItem,
+} from '../../../../../../common/search_strategy/security_solution/users/common';
+
+export const USER_FIELDS = [
+  'user.id',
+  'user.domain',
+  'user.name',
+  'host.os.name',
+  'host.ip',
+  'host.os.family',
+];
+
+export const fieldNameToAggField = (fieldName: string) => fieldName.replace(/\./g, '_');
+
+export const formatUserItem = (aggregations: UserAggEsItem): UserItem => {
+  const firstLastSeen = {
+    firstSeen: get('first_seen.value_as_string', aggregations),
+    lastSeen: get('last_seen.value_as_string', aggregations),
+  };
+
+  return USER_FIELDS.reduce<UserItem>((flattenedFields, fieldName) => {
+    const aggField = fieldNameToAggField(fieldName);
+
+    if (has(aggField, aggregations)) {
+      const data: UserBuckets = get(aggField, aggregations);
+      const fieldValue = data.buckets.map((obj) => obj.key);
+
+      return set(fieldName, fieldValue, flattenedFields);
+    }
+    return flattenedFields;
+  }, firstLastSeen);
+};

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/index.test.tsx
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/index.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as buildQuery from './query.user_details.dsl';
+import { userDetails } from '.';
+import { mockOptions, mockSearchStrategyResponse } from './__mocks__';
+
+describe('userDetails search strategy', () => {
+  const buildHostDetailsQuery = jest.spyOn(buildQuery, 'buildUserDetailsQuery');
+
+  afterEach(() => {
+    buildHostDetailsQuery.mockClear();
+  });
+
+  describe('buildDsl', () => {
+    test('should build dsl query', () => {
+      userDetails.buildDsl(mockOptions);
+      expect(buildHostDetailsQuery).toHaveBeenCalledWith(mockOptions);
+    });
+  });
+
+  describe('parse', () => {
+    test('should parse data correctly', async () => {
+      const result = await userDetails.parse(mockOptions, mockSearchStrategyResponse);
+      expect(result).toMatchSnapshot();
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/index.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IEsSearchResponse } from '../../../../../../../../../src/plugins/data/common';
+
+import { inspectStringifyObject } from '../../../../../utils/build_query';
+import { SecuritySolutionFactory } from '../../types';
+import { buildUserDetailsQuery } from './query.user_details.dsl';
+
+import { UsersQueries } from '../../../../../../common/search_strategy/security_solution/users';
+import {
+  UserDetailsRequestOptions,
+  UserDetailsStrategyResponse,
+} from '../../../../../../common/search_strategy/security_solution/users/details';
+import { formatUserItem } from './helpers';
+
+export const userDetails: SecuritySolutionFactory<UsersQueries.details> = {
+  buildDsl: (options: UserDetailsRequestOptions) => buildUserDetailsQuery(options),
+  parse: async (
+    options: UserDetailsRequestOptions,
+    response: IEsSearchResponse<unknown>
+  ): Promise<UserDetailsStrategyResponse> => {
+    const aggregations = response.rawResponse.aggregations;
+
+    const inspect = {
+      dsl: [inspectStringifyObject(buildUserDetailsQuery(options))],
+    };
+
+    if (aggregations == null) {
+      return { ...response, inspect, userDetails: {} };
+    }
+
+    return {
+      ...response,
+      inspect,
+      userDetails: formatUserItem(aggregations),
+    };
+  },
+};

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/query.user_details.dsl.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/query.user_details.dsl.test.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildUserDetailsQuery } from './query.user_details.dsl';
+import { mockOptions } from './__mocks__/';
+
+describe('buildUserDetailsQuery', () => {
+  test('build query from options correctly', () => {
+    expect(buildUserDetailsQuery(mockOptions)).toMatchSnapshot();
+  });
+});

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/query.user_details.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/details/query.user_details.dsl.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ISearchRequestParams } from '../../../../../../../../../src/plugins/data/common';
+import { UserDetailsRequestOptions } from '../../../../../../common/search_strategy/security_solution/users/details';
+import { buildFieldsTermAggregation } from '../../hosts/details/helpers';
+import { USER_FIELDS } from './helpers';
+
+export const buildUserDetailsQuery = ({
+  userName,
+  defaultIndex,
+  timerange: { from, to },
+}: UserDetailsRequestOptions): ISearchRequestParams => {
+  const filter = [
+    { term: { 'user.name': userName } },
+    {
+      range: {
+        '@timestamp': {
+          format: 'strict_date_optional_time',
+          gte: from,
+          lte: to,
+        },
+      },
+    },
+  ];
+
+  const dslQuery = {
+    allow_no_indices: true,
+    index: defaultIndex,
+    ignore_unavailable: true,
+    track_total_hits: false,
+    body: {
+      aggregations: {
+        first_seen: {
+          min: {
+            field: '@timestamp',
+          },
+        },
+        last_seen: {
+          max: {
+            field: '@timestamp',
+          },
+        },
+        ...buildFieldsTermAggregation(USER_FIELDS),
+      },
+      query: { bool: { filter } },
+      size: 0,
+    },
+  };
+
+  return dslQuery;
+};

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FactoryQueryTypes } from '../../../../../common/search_strategy/security_solution';
+import { UsersQueries } from '../../../../../common/search_strategy/security_solution/users';
+
+import { SecuritySolutionFactory } from '../types';
+import { userDetails } from './details';
+
+export const usersFactory: Record<UsersQueries, SecuritySolutionFactory<FactoryQueryTypes>> = {
+  [UsersQueries.details]: userDetails,
+};


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/126769


## Summary

Add user overview information to user details page
<img width="1792" alt="Screenshot 2022-03-08 at 12 25 46" src="https://user-images.githubusercontent.com/1490444/157229402-4ac03642-fcef-4804-8223-77b6f1617f17.png">



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
