### PR TITLE
[type-summarizer/integration] fix flaky tests

### DIFF
--- a/packages/kbn-type-summarizer/tests/integration_tests/class.test.ts
+++ b/packages/kbn-type-summarizer/tests/integration_tests/class.test.ts
@@ -69,7 +69,7 @@ it('prints basic class correctly', async () => {
     }
   `);
   expect(output.logs).toMatchInlineSnapshot(`
-    "debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts
+    "debug loaded sourcemaps for [ 'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts' ]
     debug Ignoring 1 global declarations for \\"Record\\"
     debug Ignoring 5 global declarations for \\"Promise\\"
     "

--- a/packages/kbn-type-summarizer/tests/integration_tests/function.test.ts
+++ b/packages/kbn-type-summarizer/tests/integration_tests/function.test.ts
@@ -74,8 +74,10 @@ it('prints the function declaration, including comments', async () => {
     }
   `);
   expect(result.logs).toMatchInlineSnapshot(`
-    "debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/bar.d.ts
-    debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts
+    "debug loaded sourcemaps for [
+      'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/bar.d.ts',
+      'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts'
+    ]
     "
   `);
 });

--- a/packages/kbn-type-summarizer/tests/integration_tests/import_boundary.test.ts
+++ b/packages/kbn-type-summarizer/tests/integration_tests/import_boundary.test.ts
@@ -52,7 +52,7 @@ it('output type links to named import from node modules', async () => {
     }
   `);
   expect(output.logs).toMatchInlineSnapshot(`
-    "debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts
+    "debug loaded sourcemaps for [ 'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts' ]
     "
   `);
 });
@@ -84,7 +84,7 @@ it('output type links to default import from node modules', async () => {
     }
   `);
   expect(output.logs).toMatchInlineSnapshot(`
-    "debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts
+    "debug loaded sourcemaps for [ 'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts' ]
     "
   `);
 });

--- a/packages/kbn-type-summarizer/tests/integration_tests/interface.test.ts
+++ b/packages/kbn-type-summarizer/tests/integration_tests/interface.test.ts
@@ -55,7 +55,7 @@ it('prints the whole interface, including comments', async () => {
     }
   `);
   expect(result.logs).toMatchInlineSnapshot(`
-    "debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts
+    "debug loaded sourcemaps for [ 'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts' ]
     debug Ignoring 5 global declarations for \\"Promise\\"
     "
   `);

--- a/packages/kbn-type-summarizer/tests/integration_tests/references.test.ts
+++ b/packages/kbn-type-summarizer/tests/integration_tests/references.test.ts
@@ -59,9 +59,11 @@ it('collects references from source files which contribute to result', async () 
     }
   `);
   expect(result.logs).toMatchInlineSnapshot(`
-    "debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/files/foo.d.ts
-    debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/files/index.d.ts
-    debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts
+    "debug loaded sourcemaps for [
+      'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/files/foo.d.ts',
+      'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/files/index.d.ts',
+      'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts'
+    ]
     debug Ignoring 5 global declarations for \\"Promise\\"
     debug Ignoring 4 global declarations for \\"Symbol\\"
     debug Ignoring 2 global declarations for \\"Component\\"

--- a/packages/kbn-type-summarizer/tests/integration_tests/type_alias.test.ts
+++ b/packages/kbn-type-summarizer/tests/integration_tests/type_alias.test.ts
@@ -36,7 +36,7 @@ it('prints basic type alias', async () => {
     }
   `);
   expect(output.logs).toMatchInlineSnapshot(`
-    "debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts
+    "debug loaded sourcemaps for [ 'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts' ]
     "
   `);
 });

--- a/packages/kbn-type-summarizer/tests/integration_tests/variables.test.ts
+++ b/packages/kbn-type-summarizer/tests/integration_tests/variables.test.ts
@@ -62,7 +62,7 @@ it('prints basic variable exports with sourcemaps', async () => {
     }
   `);
   expect(output.logs).toMatchInlineSnapshot(`
-    "debug loaded sourcemap for packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts
+    "debug loaded sourcemaps for [ 'packages/kbn-type-summarizer/tests/__tmp__/dist_dts/index.d.ts' ]
     "
   `);
 });


### PR DESCRIPTION
When loading sourceMaps in parallel _most_ of the time the files were loaded in the order they were requested, leading to consistent logging output, but sometimes they loaded in a different order causing log messages to switch places, along with the property order of the consumers map. This fixes that inconsistency by loading all the entries with `Promise.all()` so they are in the same order as the sourceFiles and then creating the map and logging after the fact to maintain consistency.