### PR TITLE
[Uptime ON-Week] Add link to uptime monitor in alert message

### DIFF
--- a/x-pack/plugins/uptime/common/translations.ts
+++ b/x-pack/plugins/uptime/common/translations.ts
@@ -21,15 +21,33 @@ export const VALUE_MUST_BE_AN_INTEGER = i18n.translate('xpack.uptime.settings.in
 export const MonitorStatusTranslations = {
   defaultActionMessage: i18n.translate('xpack.uptime.alerts.monitorStatus.defaultActionMessage', {
     defaultMessage:
-      'Monitor {monitorName} with url {monitorUrl} from {observerLocation} {statusMessage} The latest error message is {latestErrorMessage}',
+      'Monitor {monitorName} with url {monitorUrl} from {observerLocation} {statusMessage} The latest error message is {latestErrorMessage} View status in uptime app {monitorUptimeUrl}',
     values: {
       monitorName: '{{state.monitorName}}',
       monitorUrl: '{{{state.monitorUrl}}}',
       statusMessage: '{{{state.statusMessage}}}',
       latestErrorMessage: '{{{state.latestErrorMessage}}}',
       observerLocation: '{{state.observerLocation}}',
+      monitorUptimeUrl: '{{state.monitorUptimeUrl}}',
+      kibanaBaseUrl: '{{kibanaBaseUrl}}',
     },
   }),
+  defaultSlackActionMessage: i18n.translate(
+    'xpack.uptime.alerts.monitorStatus.defaultActionMessage.slack',
+    {
+      defaultMessage: `*Monitor: {monitorName} is down* :warning: <{monitorUptimeUrl}|View status in Uptime> | <{kibanaBaseUrl}/app/management/insightsAndAlerting/triggersActions/rule/{ruleId}|Mute alert rule> \n{monitorName} with url {monitorUrl} is {statusMessage} from {observerLocation}. The latest error message is {latestErrorMessage}`,
+      values: {
+        monitorName: '{{state.monitorName}}',
+        monitorUrl: '{{{state.monitorUrl}}}',
+        statusMessage: '{{state.statusMessage}}',
+        latestErrorMessage: '{{{state.latestErrorMessage}}}',
+        observerLocation: '{{state.observerLocation}}',
+        monitorUptimeUrl: '{{state.monitorUptimeUrl}}',
+        kibanaBaseUrl: '{{kibanaBaseUrl}}',
+        ruleId: '{{rule.id}}',
+      },
+    }
+  ),
   name: i18n.translate('xpack.uptime.alerts.monitorStatus.clientName', {
     defaultMessage: 'Uptime monitor status',
   }),

--- a/x-pack/plugins/uptime/server/lib/adapters/framework/adapter_types.ts
+++ b/x-pack/plugins/uptime/server/lib/adapters/framework/adapter_types.ts
@@ -6,7 +6,12 @@
  */
 
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
-import type { SavedObjectsClientContract, IScopedClusterClient, Logger } from 'src/core/server';
+import type {
+  SavedObjectsClientContract,
+  IScopedClusterClient,
+  Logger,
+  CoreSetup,
+} from 'src/core/server';
 import type { TelemetryPluginSetup, TelemetryPluginStart } from 'src/plugins/telemetry/server';
 import { ObservabilityPluginSetup } from '../../../../../observability/server';
 import {
@@ -43,6 +48,7 @@ export type UMSavedObjectsQueryFn<T = any, P = undefined> = (
 ) => Promise<T> | T;
 
 export interface UptimeServerSetup {
+  coreSetup: CoreSetup;
   router: UptimeRouter;
   config: UptimeConfig;
   cloud?: CloudSetup;

--- a/x-pack/plugins/uptime/server/lib/alerts/translations.ts
+++ b/x-pack/plugins/uptime/server/lib/alerts/translations.ts
@@ -78,6 +78,15 @@ export const commonMonitorStateI18 = [
       }
     ),
   },
+  {
+    name: 'monitorUptimeUrl',
+    description: i18n.translate(
+      'xpack.uptime.alerts.monitorStatus.actionVariables.state.monitorUptimeUrl',
+      {
+        defaultMessage: 'Uptime app monitor detail url, appended alongside kibanaBaseUrl.',
+      }
+    ),
+  },
 ];
 
 export const commonStateTranslations = [

--- a/x-pack/plugins/uptime/server/plugin.ts
+++ b/x-pack/plugins/uptime/server/plugin.ts
@@ -75,6 +75,7 @@ export class Plugin implements PluginType {
 
     this.server = {
       config,
+      coreSetup: core,
       router: core.http.createRouter(),
       cloud: plugins.cloud,
       kibanaVersion: this.initContext.env.packageInfo.version,


### PR DESCRIPTION
## Summary

User can set kibana public url in config via

`server.publicBaseUrl: http://localhost:5601
`

And this is auto set in elastic cloud.

Added a new field in alert message , if that is part of the message, user can add a link back to uptime monitor from the UI

`monitorUptimeUrl` this field contains the link back to uptime ui, so that user can further investigate the issue.

So user can edit/delete the monitor etc

Also added an example if we user can directly go to edit rule page, like for example if they want to mute the rule.

Slack message will look like this, formatted slack url or raw url, see both examples

<img width="1530" alt="image" src="https://user-images.githubusercontent.com/3505601/157070900-d2b87d37-8137-4b24-8cd5-18181a990ed5.png">
