### PR TITLE
Remove License Requirement for Enterprise Search App Search Meta Engines

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.test.ts
@@ -23,6 +23,7 @@ describe('getRoleAbilities', () => {
       // Has access
       canViewAccountCredentials: true,
       canManageEngines: true,
+      canManageMetaEngines: true,
       // Does not have access
       canViewMetaEngines: false,
       canViewEngineAnalytics: false,
@@ -35,7 +36,6 @@ describe('getRoleAbilities', () => {
       canViewMetaEngineSourceEngines: false,
       canViewSettings: false,
       canViewRoleMappings: false,
-      canManageMetaEngines: false,
       canManageLogSettings: false,
       canManageSettings: false,
       canManageEngineCrawler: false,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.test.ts
@@ -81,10 +81,10 @@ describe('getRoleAbilities', () => {
       expect(myRole.canManageMetaEngines).toEqual(true);
     });
 
-    it('returns false when the user can manage any engines but the account does not have a platinum license', () => {
+    it('returns true when the user can manage any engines but the account does not have a platinum license', () => {
       const myRole = getRoleAbilities({ ...mockRole, ...canManageEngines }, false);
 
-      expect(myRole.canManageMetaEngines).toEqual(false);
+      expect(myRole.canManageMetaEngines).toEqual(true);
     });
 
     it('returns false when has a platinum license but the user cannot manage any engines', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.ts
@@ -49,7 +49,7 @@ export const getRoleAbilities = (role: Account['role'], hasPlatinumLicense = fal
     canViewSettings: myRole.can('view', 'account_settings'),
     canViewRoleMappings: myRole.can('view', 'role_mappings'),
     canManageEngines: myRole.can('manage', 'account_engines'),
-    canManageMetaEngines: hasPlatinumLicense && myRole.can('manage', 'account_engines'),
+    canManageMetaEngines: myRole.can('manage', 'account_engines'),
     canManageLogSettings: myRole.can('manage', 'account_log_settings'),
     canManageSettings: myRole.can('manage', 'account_settings'),
     canManageEngineCrawler: myRole.can('manage', 'engine_crawler'),


### PR DESCRIPTION
## Summary

As [part of changes to Enterprise Search / App Search meta engines](https://github.com/elastic/enterprise-search-team/issues/1495), we are removing the license requirement for 8.2.0. This PR removes the constraint (and also updates the unit test for it). The back-end work for this has already been completed under https://github.com/elastic/ent-search/pull/6247

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
