### PR TITLE
[8.1] [Security Solution][Lists] - Hide exception list delete icon if Kibana read only (#126710)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/exceptions/exceptions_table.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/exceptions/exceptions_table.spec.ts
@@ -6,7 +6,11 @@
  */
 
 import { ROLES } from '../../../common/test';
-import { getExceptionList, expectedExportedExceptionList } from '../../objects/exception';
+import {
+  getException,
+  getExceptionList,
+  expectedExportedExceptionList,
+} from '../../objects/exception';
 import { getNewRule } from '../../objects/rule';
 
 import { RULE_STATUS } from '../../screens/create_new_rule';

--- a/x-pack/plugins/security_solution/cypress/integration/exceptions/exceptions_table.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/exceptions/exceptions_table.spec.ts
@@ -5,11 +5,8 @@
  * 2.0.
  */
 
-import {
-  getException,
-  getExceptionList,
-  expectedExportedExceptionList,
-} from '../../objects/exception';
+import { ROLES } from '../../../common/test';
+import { getExceptionList, expectedExportedExceptionList } from '../../objects/exception';
 import { getNewRule } from '../../objects/rule';
 
 import { RULE_STATUS } from '../../screens/create_new_rule';
@@ -38,6 +35,7 @@ import {
   clearSearchSelection,
 } from '../../tasks/exceptions_table';
 import {
+  EXCEPTIONS_TABLE_DELETE_BTN,
   EXCEPTIONS_TABLE_LIST_NAME,
   EXCEPTIONS_TABLE_SHOWING_LISTS,
 } from '../../screens/exceptions';
@@ -142,5 +140,24 @@ describe('Exceptions Table', () => {
     deleteExceptionListWithRuleReference();
 
     cy.get(EXCEPTIONS_TABLE_SHOWING_LISTS).should('have.text', `Showing 1 list`);
+  });
+});
+
+describe('Exceptions Table - read only', () => {
+  before(() => {
+    // First we login as a privileged user to create exception list
+    cleanKibana();
+    loginAndWaitForPageWithoutDateRange(EXCEPTIONS_URL, ROLES.platform_engineer);
+    createExceptionList(getExceptionList(), getExceptionList().list_id);
+
+    // Then we login as read-only user to test.
+    loginAndWaitForPageWithoutDateRange(EXCEPTIONS_URL, ROLES.reader);
+    waitForExceptionsTableToBeLoaded();
+
+    cy.get(EXCEPTIONS_TABLE_SHOWING_LISTS).should('have.text', `Showing 1 list`);
+  });
+
+  it('Delete icon is not shown', () => {
+    cy.get(EXCEPTIONS_TABLE_DELETE_BTN).should('not.exist');
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/columns.tsx
@@ -27,7 +27,8 @@ export const getAllExceptionListsColumns = (
   onExport: (arg: { id: string; listId: string; namespaceType: NamespaceType }) => () => void,
   onDelete: (arg: { id: string; listId: string; namespaceType: NamespaceType }) => () => void,
   formatUrl: FormatUrl,
-  navigateToUrl: (url: string) => Promise<void>
+  navigateToUrl: (url: string) => Promise<void>,
+  isKibanaReadOnly: boolean
 ): AllExceptionListsColumns[] => [
   {
     align: 'left',
@@ -155,7 +156,7 @@ export const getAllExceptionListsColumns = (
       },
       {
         render: ({ id, list_id: listId, namespace_type: namespaceType }: ExceptionListInfo) => {
-          return listId === 'endpoint_list' ? (
+          return listId === 'endpoint_list' || isKibanaReadOnly ? (
             <></>
           ) : (
             <EuiButtonIcon

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
@@ -60,7 +60,7 @@ const exceptionReferenceModalInitialState: ReferenceModalState = {
 
 export const ExceptionListsTable = React.memo(() => {
   const { formatUrl } = useFormatUrl(SecurityPageName.rules);
-  const [{ loading: userInfoLoading, canUserCRUD }] = useUserData();
+  const [{ loading: userInfoLoading, canUserCRUD, canUserREAD }] = useUserData();
   const hasPermissions = userHasPermissions(canUserCRUD);
 
   const { loading: listsConfigLoading } = useListsConfig();
@@ -193,8 +193,16 @@ export const ExceptionListsTable = React.memo(() => {
   );
 
   const exceptionsColumns = useMemo((): AllExceptionListsColumns[] => {
-    return getAllExceptionListsColumns(handleExport, handleDelete, formatUrl, navigateToUrl);
-  }, [handleExport, handleDelete, formatUrl, navigateToUrl]);
+    // Defaulting to true to default to the lower privilege first
+    const isKibanaReadOnly = (canUserREAD && !canUserCRUD) ?? true;
+    return getAllExceptionListsColumns(
+      handleExport,
+      handleDelete,
+      formatUrl,
+      navigateToUrl,
+      isKibanaReadOnly
+    );
+  }, [handleExport, handleDelete, formatUrl, navigateToUrl, canUserREAD, canUserCRUD]);
 
   const handleRefresh = useCallback((): void => {
     if (refreshExceptions != null) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Security Solution][Lists] - Hide exception list delete icon if Kibana read only (#126710)](https://github.com/elastic/kibana/pull/126710)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)