### PR TITLE
Reenable Flaky Test #109017

### DIFF
--- a/x-pack/test/fleet_functional/apps/home/welcome.ts
+++ b/x-pack/test/fleet_functional/apps/home/welcome.ts
@@ -14,7 +14,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'home']);
   const kibanaServer = getService('kibanaServer');
 
-  describe.only('Welcome interstitial', () => {
+  describe('Welcome interstitial', () => {
     before(async () => {
       // Need to navigate to page first to clear storage before test can be run
       await PageObjects.common.navigateToUrl('home', undefined);

--- a/x-pack/test/fleet_functional/apps/home/welcome.ts
+++ b/x-pack/test/fleet_functional/apps/home/welcome.ts
@@ -14,8 +14,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'home']);
   const kibanaServer = getService('kibanaServer');
 
-  // flaky https://github.com/elastic/kibana/issues/109017
-  describe.skip('Welcome interstitial', () => {
+  describe.only('Welcome interstitial', () => {
     before(async () => {
       // Need to navigate to page first to clear storage before test can be run
       await PageObjects.common.navigateToUrl('home', undefined);


### PR DESCRIPTION
## Summary

Unskip flaky test #109017. After speaking with the Fleet team, it looks like this test should be good now after many internal improvements in the Fleet setup logic.

Resolves #109017.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/231
