### PR TITLE
[eslint] automatically determine dev packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,11 @@
  * Side Public License, v 1.
  */
 
+const Path = require('path');
+const Fs = require('fs');
+
+const globby = require('globby');
+
 const APACHE_2_0_LICENSE_HEADER = `
 /*
  * Licensed to Elasticsearch B.V. under one or more contributor
@@ -89,23 +94,16 @@ const SAFER_LODASH_SET_DEFINITELYTYPED_HEADER = `
  */
 `;
 
+const packagePkgJsons = globby.sync('*/package.json', {
+  cwd: Path.resolve(__dirname, 'packages'),
+  absolute: true,
+});
+
 /** Packages which should not be included within production code. */
-const DEV_PACKAGES = [
-  'kbn-babel-code-parser',
-  'kbn-dev-utils',
-  'kbn-cli-dev-mode',
-  'kbn-docs-utils',
-  'kbn-es*',
-  'kbn-eslint*',
-  'kbn-optimizer',
-  'kbn-plugin-generator',
-  'kbn-plugin-helpers',
-  'kbn-pm',
-  'kbn-storybook',
-  'kbn-telemetry-tools',
-  'kbn-test',
-  'kbn-type-summarizer',
-];
+const DEV_PACKAGES = packagePkgJsons.flatMap((path) => {
+  const pkg = JSON.parse(Fs.readFileSync(path, 'utf8'));
+  return pkg.kibana && pkg.kibana.devOnly ? Path.dirname(Path.basename(path)) : [];
+});
 
 /** Directories (at any depth) which include dev-only code. */
 const DEV_DIRECTORIES = [

--- a/packages/kbn-babel-code-parser/package.json
+++ b/packages/kbn-babel-code-parser/package.json
@@ -8,5 +8,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/elastic/kibana/tree/main/packages/kbn-babel-code-parser"
+  },
+  "kibana": {
+    "devOnly": true
   }
 }

--- a/packages/kbn-optimizer/package.json
+++ b/packages/kbn-optimizer/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target_node/index.js"
+  "main": "./target_node/index.js",
+  "kibana": {
+    "devOnly": true
+  }
 }

--- a/packages/kbn-plugin-generator/package.json
+++ b/packages/kbn-plugin-generator/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "target_node/index.js"
+  "main": "target_node/index.js",
+  "kibana": {
+    "devOnly": true
+  }
 }

--- a/packages/kbn-test-jest-helpers/src/enzyme_helpers.tsx
+++ b/packages/kbn-test-jest-helpers/src/enzyme_helpers.tsx
@@ -14,7 +14,6 @@
  */
 
 import { I18nProvider, InjectedIntl, intlShape, __IntlProvider } from '@kbn/i18n-react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { mount, ReactWrapper, render, shallow } from 'enzyme';
 import React, { ReactElement, ValidationMap } from 'react';
 import { act as reactAct } from 'react-dom/test-utils';

--- a/packages/kbn-test-jest-helpers/src/find_test_subject.ts
+++ b/packages/kbn-test-jest-helpers/src/find_test_subject.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ReactWrapper } from 'enzyme';
 
 type Matcher = '=' | '~=' | '|=' | '^=' | '$=' | '*=';

--- a/packages/kbn-test-jest-helpers/src/random.ts
+++ b/packages/kbn-test-jest-helpers/src/random.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import Chance from 'chance';
 
 const chance = new Chance();

--- a/packages/kbn-test-jest-helpers/src/testbed/mount_component.tsx
+++ b/packages/kbn-test-jest-helpers/src/testbed/mount_component.tsx
@@ -8,7 +8,6 @@
 
 import React, { ComponentType } from 'react';
 import { Store } from 'redux';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 

--- a/packages/kbn-test-jest-helpers/src/testbed/testbed.ts
+++ b/packages/kbn-test-jest-helpers/src/testbed/testbed.ts
@@ -7,7 +7,6 @@
  */
 
 import { Component as ReactComponent } from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentType, HTMLAttributes, ReactWrapper } from 'enzyme';
 
 import { findTestSubject } from '../find_test_subject';

--- a/packages/kbn-test-jest-helpers/src/testbed/types.ts
+++ b/packages/kbn-test-jest-helpers/src/testbed/types.ts
@@ -7,7 +7,6 @@
  */
 
 import { Store } from 'redux';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ReactWrapper as GenericReactWrapper } from 'enzyme';
 import { LocationDescriptor } from 'history';
 

--- a/packages/kbn-type-summarizer/package.json
+++ b/packages/kbn-type-summarizer/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "main": "./target_node/index.js",
-  "private": true
+  "private": true,
+  "kibana": {
+    "devOnly": true
+  }
 }

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/method_keys_of.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/method_keys_of.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectType } from 'tsd';
 import { MethodKeysOf } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/public_contract.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/public_contract.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectType } from 'tsd';
 import { PublicContract } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/public_keys.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/public_keys.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectType } from 'tsd';
 import { PublicKeys } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/public_methods_of.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/public_methods_of.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable, expectNotAssignable } from 'tsd';
 import { PublicMethodsOf } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/shallow_promise.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/shallow_promise.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectType } from 'tsd';
 import { ShallowPromise } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/union_to_intersection.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/union_to_intersection.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable } from 'tsd';
 import { UnionToIntersection } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/unwrap_observable.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/unwrap_observable.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable } from 'tsd';
 import { UnwrapObservable, ObservableLike } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/values.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/values.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable } from 'tsd';
 import { Values } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/writable.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/writable.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable } from 'tsd';
 import { Writable } from '../..';
 


### PR DESCRIPTION
We've added several devOnly packages since https://github.com/elastic/kibana/pull/80549, and several new dev packages have been added without the `kibana.devOnly` config. This is an effort to ensure that new packages use this property by tying it to dev-only eslint configs (especially related to using dev-dependencies. This isn't fool proof, but it's also one less list to update when you're creating a dev-only package.