### PR TITLE
[8.0] [eslint] automatically determine dev packages (#127089)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,11 @@
  * Side Public License, v 1.
  */
 
+const Path = require('path');
+const Fs = require('fs');
+
+const globby = require('globby');
+
 const APACHE_2_0_LICENSE_HEADER = `
 /*
  * Licensed to Elasticsearch B.V. under one or more contributor
@@ -89,22 +94,16 @@ const SAFER_LODASH_SET_DEFINITELYTYPED_HEADER = `
  */
 `;
 
+const packagePkgJsons = globby.sync('*/package.json', {
+  cwd: Path.resolve(__dirname, 'packages'),
+  absolute: true,
+});
+
 /** Packages which should not be included within production code. */
-const DEV_PACKAGES = [
-  'kbn-babel-code-parser',
-  'kbn-dev-utils',
-  'kbn-cli-dev-mode',
-  'kbn-docs-utils',
-  'kbn-es*',
-  'kbn-eslint*',
-  'kbn-optimizer',
-  'kbn-plugin-generator',
-  'kbn-plugin-helpers',
-  'kbn-pm',
-  'kbn-storybook',
-  'kbn-telemetry-tools',
-  'kbn-test',
-];
+const DEV_PACKAGES = packagePkgJsons.flatMap((path) => {
+  const pkg = JSON.parse(Fs.readFileSync(path, 'utf8'));
+  return pkg.kibana && pkg.kibana.devOnly ? Path.dirname(Path.basename(path)) : [];
+});
 
 /** Directories (at any depth) which include dev-only code. */
 const DEV_DIRECTORIES = [

--- a/packages/kbn-babel-code-parser/package.json
+++ b/packages/kbn-babel-code-parser/package.json
@@ -8,5 +8,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/elastic/kibana/tree/main/packages/kbn-babel-code-parser"
+  },
+  "kibana": {
+    "devOnly": true
   }
 }

--- a/packages/kbn-optimizer/package.json
+++ b/packages/kbn-optimizer/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "main": "./target_node/index.js",
-  "types": "./target_types/index.d.ts"
+  "types": "./target_types/index.d.ts",
+  "kibana": {
+    "devOnly": true
+  }
 }

--- a/packages/kbn-plugin-generator/package.json
+++ b/packages/kbn-plugin-generator/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "main": "target_node/index.js",
-  "types": "target_types/index.d.ts"
+  "types": "target_types/index.d.ts",
+  "kibana": {
+    "devOnly": true
+  }
 }

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/method_keys_of.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/method_keys_of.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectType } from 'tsd';
 import { MethodKeysOf } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/public_contract.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/public_contract.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectType } from 'tsd';
 import { PublicContract } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/public_keys.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/public_keys.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectType } from 'tsd';
 import { PublicKeys } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/public_methods_of.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/public_methods_of.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable, expectNotAssignable } from 'tsd';
 import { PublicMethodsOf } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/shallow_promise.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/shallow_promise.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectType } from 'tsd';
 import { ShallowPromise } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/union_to_intersection.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/union_to_intersection.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable } from 'tsd';
 import { UnionToIntersection } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/unwrap_observable.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/unwrap_observable.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable } from 'tsd';
 import { UnwrapObservable, ObservableLike } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/unwrap_promise.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/unwrap_promise.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable } from 'tsd';
 import { UnwrapPromise } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/values.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/values.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable } from 'tsd';
 import { Values } from '../..';
 

--- a/packages/kbn-utility-types/src/tsd_tests/test_d/writable.ts
+++ b/packages/kbn-utility-types/src/tsd_tests/test_d/writable.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectAssignable } from 'tsd';
 import { Writable } from '../..';
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[eslint] automatically determine dev packages (#127089)](https://github.com/elastic/kibana/pull/127089)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)