### PR TITLE
[kbn/pm] add timings for more parts of bootstrap

### DIFF
--- a/packages/kbn-pm/src/commands/bootstrap.ts
+++ b/packages/kbn-pm/src/commands/bootstrap.ts
@@ -40,7 +40,19 @@ export const BootstrapCommand: ICommand = {
     const kibanaProjectPath = projects.get('kibana')?.path || '';
     const runOffline = options?.offline === true;
     const reporter = CiStatsReporter.fromEnv(log);
-    const timings = [];
+
+    const timings: Array<{ id: string; ms: number }> = [];
+    const time = async <T>(id: string, body: () => Promise<T>): Promise<T> => {
+      const start = Date.now();
+      try {
+        return await body();
+      } finally {
+        timings.push({
+          id,
+          ms: Date.now() - start,
+        });
+      }
+    };
 
     // Force install is set in case a flag is passed or
     // if the `.yarn-integrity` file is not found which
@@ -70,20 +82,14 @@ export const BootstrapCommand: ICommand = {
     //
 
     if (forceInstall) {
-      const forceInstallStartTime = Date.now();
-      await runBazel(['run', '@nodejs//:yarn'], runOffline);
-      timings.push({
-        id: 'force install dependencies',
-        ms: Date.now() - forceInstallStartTime,
+      await time('force install dependencies', async () => {
+        await runBazel(['run', '@nodejs//:yarn'], runOffline);
       });
     }
 
     // build packages
-    const packageStartTime = Date.now();
-    await runBazel(['build', '//packages:build', '--show_result=1'], runOffline);
-    timings.push({
-      id: 'build packages',
-      ms: Date.now() - packageStartTime,
+    await time('build packages', async () => {
+      await runBazel(['build', '//packages:build', '--show_result=1'], runOffline);
     });
 
     // Install monorepo npm dependencies outside of the Bazel managed ones
@@ -112,30 +118,38 @@ export const BootstrapCommand: ICommand = {
       }
     }
 
-    await sortPackageJson(kbn);
+    await time('sort package json', async () => {
+      await sortPackageJson(kbn);
+    });
 
-    const yarnLock = await readYarnLock(kbn);
+    const yarnLock = await time('read yarn.lock', async () => await readYarnLock(kbn));
 
     if (options.validate) {
-      await validateDependencies(kbn, yarnLock);
+      await time('validate dependencies', async () => {
+        await validateDependencies(kbn, yarnLock);
+      });
     }
 
     // Assure all kbn projects with bin defined scripts
     // copy those scripts into the top level node_modules folder
     //
     // NOTE: We don't probably need this anymore, is actually not being used
-    await linkProjectExecutables(projects, projectGraph);
+    await time('link project executables', async () => {
+      await linkProjectExecutables(projects, projectGraph);
+    });
 
-    // Update vscode settings
-    await spawnStreaming(
-      process.execPath,
-      ['scripts/update_vscode_config'],
-      {
-        cwd: kbn.getAbsolute(),
-        env: process.env,
-      },
-      { prefix: '[vscode]', debug: false }
-    );
+    await time('update vscode config', async () => {
+      // Update vscode settings
+      await spawnStreaming(
+        process.execPath,
+        ['scripts/update_vscode_config'],
+        {
+          cwd: kbn.getAbsolute(),
+          env: process.env,
+        },
+        { prefix: '[vscode]', debug: false }
+      );
+    });
 
     // send timings
     await reporter.timings({

--- a/scripts/update_vscode_config.js
+++ b/scripts/update_vscode_config.js
@@ -6,5 +6,5 @@
  * Side Public License, v 1.
  */
 
-require('../src/setup_node_env');
+require('../src/setup_node_env/no_transpilation');
 require('@kbn/dev-utils').runUpdateVscodeConfigCli();

--- a/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
@@ -101,7 +101,7 @@ const DEFAULT_ARGS = [
 const DIAGNOSTIC_TIME = 5 * 1000;
 
 export class HeadlessChromiumDriverFactory {
-  private userDataDir = fs.mkdtempSync(path.join(getDataPath(), 'chromium-'));
+  private userDataDir;
   type = 'chromium';
 
   constructor(
@@ -111,6 +111,10 @@ export class HeadlessChromiumDriverFactory {
     private binaryPath: string,
     private basePath: string
   ) {
+    const dataDir = getDataPath();
+    fs.mkdirSync(dataDir, { recursive: true });
+    this.userDataDir = fs.mkdtempSync(path.join(dataDir, 'chromium-'));
+
     if (this.config.browser.chromium.disableSandbox) {
       logger.warn(`Enabling the Chromium sandbox provides an additional layer of protection.`);
     }

--- a/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
@@ -101,7 +101,7 @@ const DEFAULT_ARGS = [
 const DIAGNOSTIC_TIME = 5 * 1000;
 
 export class HeadlessChromiumDriverFactory {
-  private userDataDir;
+  private userDataDir: string;
   type = 'chromium';
 
   constructor(


### PR DESCRIPTION
As I've been watching bootstrap run the last few days I've noticed that once bazel is done there is a considerable pause. Sometimes this is uploading stuff to buildbuddy, but sometimes it seems like the tasks after bazel are taking longer than they should. I'd like to start tracking timings for the other steps so we can monitor their performance widely and find places that need optimization there.

For example, bootstrapping this PR locally took bazel 21.4s, but the `yarn kbn bootstrap` time was 30.9s. I think it would be great if we could get those two times closer together.