### PR TITLE
[XY] Remove opacity for fitting line series

### DIFF
--- a/src/plugins/vis_types/xy/public/utils/render_all_series.tsx
+++ b/src/plugins/vis_types/xy/public/utils/render_all_series.tsx
@@ -196,6 +196,11 @@ export const renderAllSeries = (
                 area: {
                   ...(type === ChartType.Line ? { opacity: 0 } : { opacity: fillOpacity }),
                 },
+                fit: {
+                  area: {
+                    ...(type === ChartType.Line ? { opacity: 0 } : { opacity: fillOpacity }),
+                  },
+                },
                 line: {
                   strokeWidth,
                   visible: drawLinesBetweenPoints,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/125906 by applying MarcoVs fix. It's not using a `LineSeries` for lines because otherwise it's not possible to stack lines which is a feature that got grandfathered in.

Line:
<img width="1196" alt="Screenshot 2022-03-08 at 18 20 10" src="https://user-images.githubusercontent.com/1508364/157291287-bfb19c67-433a-4a7c-9b3f-f7d77999b850.png">

Area:
<img width="1052" alt="Screenshot 2022-03-08 at 18 20 03" src="https://user-images.githubusercontent.com/1508364/157291304-c78a8958-e830-4d53-898a-8d57c0942a92.png">
