### PR TITLE
[reporting] ensure data dir exists before creating a temp dir

### DIFF
--- a/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
@@ -101,7 +101,7 @@ const DEFAULT_ARGS = [
 const DIAGNOSTIC_TIME = 5 * 1000;
 
 export class HeadlessChromiumDriverFactory {
-  private userDataDir = fs.mkdtempSync(path.join(getDataPath(), 'chromium-'));
+  private userDataDir;
   type = 'chromium';
 
   constructor(
@@ -111,6 +111,10 @@ export class HeadlessChromiumDriverFactory {
     private binaryPath: string,
     private basePath: string
   ) {
+    const dataDir = getDataPath();
+    fs.mkdirSync(dataDir, { recursive: true });
+    this.userDataDir = fs.mkdtempSync(path.join(dataDir, 'chromium-'));
+
     if (this.config.browser.chromium.disableSandbox) {
       logger.warn(`Enabling the Chromium sandbox provides an additional layer of protection.`);
     }

--- a/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
@@ -101,7 +101,7 @@ const DEFAULT_ARGS = [
 const DIAGNOSTIC_TIME = 5 * 1000;
 
 export class HeadlessChromiumDriverFactory {
-  private userDataDir;
+  private userDataDir: string;
   type = 'chromium';
 
   constructor(


### PR DESCRIPTION
I just got a failure in my PR because the data dir that screenshotting was trying to create a temp directory in didn't exist before this point. I'm not 100% sure why this is the case, but it seems logical to make sure that directory exists before trying to create a child directory inside of it.

Failure: https://buildkite.com/elastic/kibana-pull-request/builds/28428#bd228ff1-e919-494f-8392-a8bdec9d80cd