### PR TITLE
Increase agents and timeout for Jest integration tests

### DIFF
--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -67,7 +67,7 @@ steps:
 
   - command: .buildkite/scripts/steps/test/jest_integration.sh
     label: 'Jest Integration Tests'
-    parallelism: 2
+    parallelism: 3
     agents:
       queue: n2-4
     timeout_in_minutes: 120

--- a/.buildkite/pipelines/hourly.yml
+++ b/.buildkite/pipelines/hourly.yml
@@ -129,10 +129,10 @@ steps:
 
   - command: .buildkite/scripts/steps/test/jest_integration.sh
     label: 'Jest Integration Tests'
-    parallelism: 2
+    parallelism: 3
     agents:
       queue: n2-4
-    timeout_in_minutes: 90
+    timeout_in_minutes: 120
     key: jest-integration
 
   - command: .buildkite/scripts/steps/test/api_integration.sh

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -129,10 +129,10 @@ steps:
 
   - command: .buildkite/scripts/steps/test/jest_integration.sh
     label: 'Jest Integration Tests'
-    parallelism: 2
+    parallelism: 3
     agents:
       queue: n2-4
-    timeout_in_minutes: 90
+    timeout_in_minutes: 120
     key: jest-integration
 
   - command: .buildkite/scripts/steps/test/api_integration.sh


### PR DESCRIPTION
We're hitting timeouts and it's not apparent what is causing it. Adding another agent to hopefully get the times down, but also increasing the timeout so the tests will hopefully complete to identify the problem area.