### PR TITLE
[8.1] [Ingest Pipelines] Fix dot expander processor to accept wildcard (#122508) (#123522)

### DIFF
--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/dot_expander.test.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/dot_expander.test.tsx
@@ -56,7 +56,7 @@ describe('Processor: Dot Expander', () => {
     expect(form.getErrorsMessages()).toEqual(['A field value is required.']);
   });
 
-  test('prevents form submission if field does not contain a . for the dot notation', async () => {
+  test('prevents form submission if field for the dot notation does not contain a . and not equal to *', async () => {
     const {
       actions: { saveNewProcessor },
       form,
@@ -77,9 +77,28 @@ describe('Processor: Dot Expander', () => {
 
     // Expect form error as "field" does not contain '.'
     expect(form.getErrorsMessages()).toEqual([
-      'A field value requires at least one dot character.',
+      'The field name must be an asterisk or contain a dot character.',
     ]);
   });
+
+  test('allows form submission if the field for the dot notation is equal to *', async () => {
+    const {
+      actions: { saveNewProcessor },
+      form,
+    } = testBed;
+
+    // Set "field" value to a * for expanding all top-level dotted field names
+    form.setInputValue('fieldNameField.input', '*');
+
+    // Save the field
+    await saveNewProcessor();
+
+    const processors = getProcessorValue(onUpdate, DOT_EXPANDER_TYPE);
+    expect(processors[0][DOT_EXPANDER_TYPE]).toEqual({
+      field: '*',
+    });
+  });
+
   test('saves with default parameter values', async () => {
     const {
       actions: { saveNewProcessor },

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/dot_expander.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/dot_expander.tsx
@@ -40,11 +40,15 @@ export const DotExpander: FunctionComponent = () => {
           {
             validator: ({ value }) => {
               if (typeof value === 'string' && value.length) {
-                return !value.includes('.')
+                const allowedPattern = value.includes('.') || value === '*';
+                return !allowedPattern
                   ? {
                       message: i18n.translate(
                         'xpack.ingestPipelines.pipelineEditor.dotExpanderForm.fieldNameRequiresDotError',
-                        { defaultMessage: 'A field value requires at least one dot character.' }
+                        {
+                          defaultMessage:
+                            'The field name must be an asterisk or contain a dot character.',
+                        }
                       ),
                     }
                   : undefined;

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/shared/map_processor_type_to_form.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/shared/map_processor_type_to_form.tsx
@@ -256,13 +256,24 @@ export const mapProcessorTypeToDescriptor: MapProcessorTypeToDescriptor = {
       defaultMessage:
         'Expands a field containing dot notation into an object field. The object field is then accessible by other processors in the pipeline.',
     }),
-    getDefaultDescription: ({ field }) =>
-      i18n.translate('xpack.ingestPipelines.processors.defaultDescription.dot_expander', {
-        defaultMessage: 'Expands "{field}" into an object field',
-        values: {
-          field,
-        },
-      }),
+    getDefaultDescription: ({ field }) => {
+      return field === '*'
+        ? i18n.translate(
+            'xpack.ingestPipelines.processors.defaultDescription.dot_expander.wildcard',
+            {
+              defaultMessage: 'All top-level fields will be expanded',
+            }
+          )
+        : i18n.translate(
+            'xpack.ingestPipelines.processors.defaultDescription.dot_expander.dot_notation',
+            {
+              defaultMessage: 'Expands "{field}" into an object field',
+              values: {
+                field,
+              },
+            }
+          );
+    },
   },
   drop: {
     FieldsComponent: Drop,

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -15886,7 +15886,6 @@
     "xpack.ingestPipelines.processors.defaultDescription.dateIndexName.indexNamePrefixDefault.noPrefixValueLabel": "プレフィックスなし",
     "xpack.ingestPipelines.processors.defaultDescription.dateIndexName.indexNamePrefixDefault.prefixValueLabel": "プレフィックス\"{prefix}\"を使用",
     "xpack.ingestPipelines.processors.defaultDescription.dissect": "分離したパターンと一致する値を\"{field}\"から抽出します",
-    "xpack.ingestPipelines.processors.defaultDescription.dot_expander": "\"{field}\"をオブジェクトフィールドに拡張します",
     "xpack.ingestPipelines.processors.defaultDescription.drop": "エラーを返さずにドキュメントを破棄します",
     "xpack.ingestPipelines.processors.defaultDescription.enrich": "\"{policy_name}\"ポリシーが\"{field}\"と一致した場合に、データを\"{target_field}\"に改善します",
     "xpack.ingestPipelines.processors.defaultDescription.fail": "実行を停止する例外を発生させます",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -15910,7 +15910,6 @@
     "xpack.ingestPipelines.processors.defaultDescription.dateIndexName.indexNamePrefixDefault.noPrefixValueLabel": "无前缀",
     "xpack.ingestPipelines.processors.defaultDescription.dateIndexName.indexNamePrefixDefault.prefixValueLabel": "带前缀“{prefix}”",
     "xpack.ingestPipelines.processors.defaultDescription.dissect": "从“{field}”提取匹配分解模式的值",
-    "xpack.ingestPipelines.processors.defaultDescription.dot_expander": "将“{field}”扩展成对象字段",
     "xpack.ingestPipelines.processors.defaultDescription.drop": "丢弃文档而不返回错误",
     "xpack.ingestPipelines.processors.defaultDescription.enrich": "如果策略“{policy_name}”匹配“{field}”，将数据扩充到“{target_field}”",
     "xpack.ingestPipelines.processors.defaultDescription.fail": "引发使执行停止的异常",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Ingest Pipelines] Fix dot expander processor to accept wildcard (#122508) (#123522)](https://github.com/elastic/kibana/pull/123522)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)