### PR TITLE
[Cases] Remove temporal public methods from the cases plugin

### DIFF
--- a/x-pack/plugins/cases/public/mocks.ts
+++ b/x-pack/plugins/cases/public/mocks.ts
@@ -13,10 +13,8 @@ export const mockCasesContract = (): jest.Mocked<CasesUiStart> => ({
   getCases: jest.fn(),
   getCasesContext: jest.fn().mockImplementation(() => mockCasesContext),
   getAllCasesSelectorModal: jest.fn(),
-  getAllCasesSelectorModalNoProvider: jest.fn(),
   getCreateCaseFlyout: jest.fn(),
   getRecentCases: jest.fn(),
-  getCreateCaseFlyoutNoProvider: jest.fn(),
   hooks: {
     getUseCasesAddToNewCaseFlyout: jest.fn(),
     getUseCasesAddToExistingCaseModal: jest.fn(),

--- a/x-pack/plugins/cases/public/plugin.ts
+++ b/x-pack/plugins/cases/public/plugin.ts
@@ -14,8 +14,6 @@ import {
   getAllCasesSelectorModalLazy,
   getCreateCaseFlyoutLazy,
   canUseCases,
-  getCreateCaseFlyoutLazyNoProvider,
-  getAllCasesSelectorModalNoProviderLazy,
 } from './methods';
 import { CasesUiConfigType } from '../common/ui/types';
 import { APP_ID, APP_PATH } from '../common/constants';
@@ -93,12 +91,10 @@ export class CasesUiPlugin
       getCases: getCasesLazy,
       getCasesContext: getCasesContextLazy,
       getRecentCases: getRecentCasesLazy,
+      // @deprecated Please use the hook getUseCasesAddToNewCaseFlyout
       getCreateCaseFlyout: getCreateCaseFlyoutLazy,
+      // @deprecated Please use the hook getUseCasesAddToExistingCaseModal
       getAllCasesSelectorModal: getAllCasesSelectorModalLazy,
-      // Temporal methods to remove timelines and cases deep integration
-      // https://github.com/elastic/kibana/issues/123183
-      getCreateCaseFlyoutNoProvider: getCreateCaseFlyoutLazyNoProvider,
-      getAllCasesSelectorModalNoProvider: getAllCasesSelectorModalNoProviderLazy,
       hooks: {
         getUseCasesAddToNewCaseFlyout: useCasesAddToNewCaseFlyout,
         getUseCasesAddToExistingCaseModal: useCasesAddToExistingCaseModal,

--- a/x-pack/plugins/cases/public/types.ts
+++ b/x-pack/plugins/cases/public/types.ts
@@ -22,7 +22,6 @@ import type { SpacesPluginStart } from '../../spaces/public';
 import type { TriggersAndActionsUIPublicPluginStart as TriggersActionsStart } from '../../triggers_actions_ui/public';
 import { CommentRequestAlertType, CommentRequestUserType } from '../common/api';
 import { UseCasesAddToExistingCaseModal } from './components/all_cases/selector_modal/use_cases_add_to_existing_case_modal';
-import { CreateCaseFlyoutProps } from './components/create/flyout';
 import { UseCasesAddToNewCaseFlyout } from './components/create/flyout/use_cases_add_to_new_case_flyout';
 
 import type {
@@ -97,18 +96,12 @@ export interface CasesUiStart {
   getAllCasesSelectorModal: (
     props: GetAllCasesSelectorModalProps
   ) => ReactElement<GetAllCasesSelectorModalProps>;
-  getAllCasesSelectorModalNoProvider: (
-    props: GetAllCasesSelectorModalProps
-  ) => ReactElement<GetAllCasesSelectorModalProps>;
   /**
    * Flyout with the form to create a case for the owner
    * @param props GetCreateCaseFlyoutProps
    * @returns A react component that is a flyout for creating a case
    */
   getCreateCaseFlyout: (props: GetCreateCaseFlyoutProps) => ReactElement<GetCreateCaseFlyoutProps>;
-  getCreateCaseFlyoutNoProvider: (
-    props: CreateCaseFlyoutProps
-  ) => ReactElement<CreateCaseFlyoutProps>;
   /**
    * Get the recent cases component
    * @param props GetRecentCasesProps


### PR DESCRIPTION
## Summary

Epic: https://github.com/elastic/kibana/issues/123183

Follow up to https://github.com/elastic/kibana/pull/127003

Closes: https://github.com/elastic/kibana/issues/127124

This is the final PR to close the epic. It removes old public methods from the cases plugin that are not longer in use and not required by other plugins.

No business logic or UI is modified  by this PR.