### PR TITLE
[Cloud Posture] Update resource type field query

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_resources_types.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_resources_types.ts
@@ -31,7 +31,7 @@ export interface ResourceTypeBucket extends KeyDocCount {
 export const resourceTypeAggQuery = {
   aggs_by_resource_type: {
     terms: {
-      field: 'resource.type.keyword',
+      field: 'type.keyword',
     },
     aggs: {
       failed_findings: {


### PR DESCRIPTION
## Summary

This PR simply replaces the field which we used to query the resource type from our mocking tool.
In order for this PR to function, [another PR](https://github.com/build-security/integrations/pull/17) was opened in our integration repo which will update the index template accordingly.
