### PR TITLE
[8.1] [APM] set default value for Infrastructure View flag to false (#127127)

### DIFF
--- a/x-pack/plugins/observability/server/ui_settings.ts
+++ b/x-pack/plugins/observability/server/ui_settings.ts
@@ -58,7 +58,7 @@ export const uiSettings: Record<string, UiSettingsParams<boolean | number>> = {
     name: i18n.translate('xpack.observability.enableInfrastructureView', {
       defaultMessage: 'Infrastructure feature',
     }),
-    value: true,
+    value: false,
     description: i18n.translate('xpack.observability.enableInfrastructureViewDescription', {
       defaultMessage: 'Enable the Infrastruture view feature in APM app',
     }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[APM] set default value for Infrastructure View flag to false (#127127)](https://github.com/elastic/kibana/pull/127127)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)