### PR TITLE
Add instructions for how to connect to local ES cluster started with `yarn es snapshot`

### DIFF
--- a/x-pack/plugins/apm/dev_docs/local_setup.md
+++ b/x-pack/plugins/apm/dev_docs/local_setup.md
@@ -32,6 +32,15 @@ node ./scripts/es_archiver load "x-pack/plugins/apm/ftr_e2e/cypress/fixtures/es_
 node packages/elastic-apm-synthtrace/src/scripts/run packages/elastic-apm-synthtrace/src/scripts/examples/01_simple_trace.ts --target=http://elastic:changeme@localhost:9200
 ```
 
+**Connect Kibana to ES**
+Update `config/kibana.dev.yml` with:
+
+```yml
+elasticsearch.hosts: http://localhost:9200
+elasticsearch.username: kibana_system
+elasticsearch.password: changeme
+```
+
 Documentation for [Synthtrace](https://github.com/elastic/kibana/blob/main/packages/elastic-apm-synthtrace/README.md)
 
 ## 2. Cloud-based ES Cluster (internal devs only)


### PR DESCRIPTION
We didn't have instructions for how to connect to a local ES cluster  started with `yarn es snapshot`