### PR TITLE
[Security Solution][CI Stats] - Add cypress tests to flaky test runner

### DIFF
--- a/.buildkite/pipelines/flaky_tests/groups.json
+++ b/.buildkite/pipelines/flaky_tests/groups.json
@@ -14,9 +14,16 @@
       "name": "OSS Accessibility"
     },
     {
-      "key": "xpack/cypress",
-      "name": "Default Cypress",
-      "ciGroups": 3
+      "key": "xpack/cypress/security_solution",
+      "name": "Security Solution - Cypress"
+    },
+    {
+      "key": "xpack/cypress/osquery_cypress",
+      "name": "Osquery - Cypress"
+    },
+    {
+      "key": "xpack/cypress/fleet_cypress",
+      "name": "Fleet - Cypress"
     },
     {
       "key": "xpack/cigroup",

--- a/.buildkite/pipelines/flaky_tests/groups.json
+++ b/.buildkite/pipelines/flaky_tests/groups.json
@@ -14,6 +14,11 @@
       "name": "OSS Accessibility"
     },
     {
+      "key": "xpack/cypress",
+      "name": "Default Cypress",
+      "cypressSuites": ["security_solution", "osquery_cypress", "fleet_cypress"]
+    },
+    {
       "key": "xpack/cigroup",
       "name": "Default CI Group",
       "ciGroups": 27

--- a/.buildkite/pipelines/flaky_tests/groups.json
+++ b/.buildkite/pipelines/flaky_tests/groups.json
@@ -16,7 +16,7 @@
     {
       "key": "xpack/cypress",
       "name": "Default Cypress",
-      "ciGroups": ["security_solution", "osquery_cypress", "fleet_cypress"]
+      "ciGroups": 3
     },
     {
       "key": "xpack/cigroup",

--- a/.buildkite/pipelines/flaky_tests/groups.json
+++ b/.buildkite/pipelines/flaky_tests/groups.json
@@ -16,7 +16,7 @@
     {
       "key": "xpack/cypress",
       "name": "Default Cypress",
-      "cypressSuites": ["security_solution", "osquery_cypress", "fleet_cypress"]
+      "ciGroups": ["security_solution", "osquery_cypress", "fleet_cypress"]
     },
     {
       "key": "xpack/cigroup",

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -32,14 +32,14 @@ const inputs = [
 for (const group of groups) {
   if (!group.ciGroups) {
     inputs.push(stepInput(group.key, group.name));
-  } else if (group.ciGroups === 3) {
+  } else if (group.key.includes('cypress')) {
     for (let i = 0; i < group.ciGroups; i++) {
       const cypressSuites = ['security_solution', 'osquery_cypress', 'fleet_cypress'];
       const testSuite = cypressSuites[i];
       inputs.push(stepInput(`${group.key}/${testSuite}`, `${group.name} ${testSuite}`));
     }
   } else {
-    for (let i = 3; i <= group.ciGroups; i++) {
+    for (let i = 1; i <= group.ciGroups; i++) {
       inputs.push(stepInput(`${group.key}/${i}`, `${group.name} ${i}`));
     }
   }

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -29,13 +29,12 @@ const inputs = [
   },
 ];
 
-const cypressSuites = ['security_solution', 'osquery_cypress', 'fleet_cypress'];
-
 for (const group of groups) {
   if (!group.ciGroups) {
     inputs.push(stepInput(group.key, group.name));
-  } else if (group.key.includes('cypress')) {
+  } else if (group.ciGroups === 3) {
     for (let i = 0; i < group.ciGroups; i++) {
+      const cypressSuites = ['security_solution', 'osquery_cypress', 'fleet_cypress'];
       const testSuite = cypressSuites[i];
       inputs.push(stepInput(`${group.key}/${testSuite}`, `${group.name} ${testSuite}`));
     }

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -7,7 +7,7 @@
  */
 
 const groups =
-  /** @type {Array<{key: string, name: string, ciGroups: number, cypressSuites: Array<string> }>} */ (
+  /** @type {Array<{key: string, name: string, ciGroups: number | Array<string> }>} */ (
     require('./groups.json').groups
   );
 
@@ -30,13 +30,13 @@ const inputs = [
 ];
 
 for (const group of groups) {
-  if (group.cypressSuites) {
-    for (let i = 1; i <= group.cypressSuites.length; i++) {
-      const testSuite = group.cypressSuites[i];
+  if (!group.ciGroups) {
+    inputs.push(stepInput(group.key, group.name));
+  } else if (Array.isArray(group.ciGroups)) {
+    for (let i = 1; i <= group.ciGroups.length; i++) {
+      const testSuite = group.ciGroups[i];
       inputs.push(stepInput(`${group.key}/${testSuite}`, `${group.name} ${testSuite}`));
     }
-  } else if (!group.ciGroups) {
-    inputs.push(stepInput(group.key, group.name));
   } else {
     for (let i = 1; i <= group.ciGroups; i++) {
       inputs.push(stepInput(`${group.key}/${i}`, `${group.name} ${i}`));

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -6,10 +6,9 @@
  * Side Public License, v 1.
  */
 
-const groups =
-  /** @type {Array<{key: string, name: string, ciGroups: number | Array<string> }>} */ (
-    require('./groups.json').groups
-  );
+const groups = /** @type {Array<{key: string, name: string, ciGroups: number }>} */ (
+  require('./groups.json').groups
+);
 
 const stepInput = (key, nameOfSuite) => {
   return {

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -35,7 +35,7 @@ for (const group of groups) {
   if (!group.ciGroups) {
     inputs.push(stepInput(group.key, group.name));
   } else if (group.key === 'xpack/cypress') {
-    for (let i = 1; i <= group.ciGroups.length; i++) {
+    for (let i = 1; i <= group.ciGroups; i++) {
       const testSuite = cypressSuites[i];
       inputs.push(stepInput(`${group.key}/${testSuite}`, `${group.name} ${testSuite}`));
     }

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -29,12 +29,14 @@ const inputs = [
   },
 ];
 
+const cypressSuites = ['security_solution', 'osquery_cypress', 'fleet_cypress'];
+
 for (const group of groups) {
   if (!group.ciGroups) {
     inputs.push(stepInput(group.key, group.name));
-  } else if (Array.isArray(group.ciGroups)) {
+  } else if (group.key === 'xpack/cypress') {
     for (let i = 1; i <= group.ciGroups.length; i++) {
-      const testSuite = group.ciGroups[i];
+      const testSuite = cypressSuites[i];
       inputs.push(stepInput(`${group.key}/${testSuite}`, `${group.name} ${testSuite}`));
     }
   } else {

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -34,8 +34,8 @@ const cypressSuites = ['security_solution', 'osquery_cypress', 'fleet_cypress'];
 for (const group of groups) {
   if (!group.ciGroups) {
     inputs.push(stepInput(group.key, group.name));
-  } else if (group.key === 'xpack/cypress') {
-    for (let i = 1; i <= group.ciGroups; i++) {
+  } else if (group.key.includes('cypress')) {
+    for (let i = 0; i < group.ciGroups; i++) {
       const testSuite = cypressSuites[i];
       inputs.push(stepInput(`${group.key}/${testSuite}`, `${group.name} ${testSuite}`));
     }

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -39,7 +39,7 @@ for (const group of groups) {
       inputs.push(stepInput(`${group.key}/${testSuite}`, `${group.name} ${testSuite}`));
     }
   } else {
-    for (let i = 1; i <= group.ciGroups; i++) {
+    for (let i = 3; i <= group.ciGroups; i++) {
       inputs.push(stepInput(`${group.key}/${i}`, `${group.name} ${i}`));
     }
   }

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -31,12 +31,6 @@ const inputs = [
 for (const group of groups) {
   if (!group.ciGroups) {
     inputs.push(stepInput(group.key, group.name));
-  } else if (group.key.includes('cypress')) {
-    for (let i = 0; i < group.ciGroups; i++) {
-      const cypressSuites = ['security_solution', 'osquery_cypress', 'fleet_cypress'];
-      const testSuite = cypressSuites[i];
-      inputs.push(stepInput(`${group.key}/${testSuite}`, `${group.name} ${testSuite}`));
-    }
   } else {
     for (let i = 1; i <= group.ciGroups; i++) {
       inputs.push(stepInput(`${group.key}/${i}`, `${group.name} ${i}`));

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -6,9 +6,10 @@
  * Side Public License, v 1.
  */
 
-const groups = /** @type {Array<{key: string, name: string, ciGroups: number }>} */ (
-  require('./groups.json').groups
-);
+const groups =
+  /** @type {Array<{key: string, name: string, ciGroups: number, cypressSuites: Array<string> }>} */ (
+    require('./groups.json').groups
+  );
 
 const stepInput = (key, nameOfSuite) => {
   return {
@@ -29,7 +30,12 @@ const inputs = [
 ];
 
 for (const group of groups) {
-  if (!group.ciGroups) {
+  if (group.cypressSuites) {
+    for (let i = 1; i <= group.cypressSuites.length; i++) {
+      const testSuite = group.cypressSuites[i];
+      inputs.push(stepInput(`${group.key}/${testSuite}`, `${group.name} ${testSuite}`));
+    }
+  } else if (!group.ciGroups) {
     inputs.push(stepInput(group.key, group.name));
   } else {
     for (let i = 1; i <= group.ciGroups; i++) {

--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -186,7 +186,7 @@ for (const testSuite of testSuites) {
     case 'cypress':
       steps.push({
         command: `.buildkite/scripts/steps/functional/${CI_GROUP}.sh`,
-        label: `Default Cypress`,
+        label: 'Default Cypress',
         agents: { queue: 'ci-group-6' },
         depends_on: 'build',
         parallelism: RUN_COUNT,

--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -183,6 +183,18 @@ for (const testSuite of testSuites) {
         concurrency_group: UUID,
         concurrency_method: 'eager',
       });
+    case 'cypress':
+      const CYPRESS_SUITE = CI_GROUP;
+      steps.push({
+        command: `.buildkite/scripts/steps/functional/${CYPRESS_SUITE}.sh`,
+        label: `Default Cypress`,
+        agents: { queue: 'ci-group-6' },
+        depends_on: 'build',
+        parallelism: RUN_COUNT,
+        concurrency: concurrency,
+        concurrency_group: UUID,
+        concurrency_method: 'eager',
+      });
       break;
   }
 }

--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -7,6 +7,9 @@
  */
 
 const { execSync } = require('child_process');
+const groups = /** @type {Array<{key: string, name: string, ciGroups: number }>} */ (
+  require('./groups.json').groups
+);
 
 const concurrency = 25;
 const defaultCount = concurrency * 2;
@@ -184,10 +187,13 @@ for (const testSuite of testSuites) {
         concurrency_method: 'eager',
       });
     case 'cypress':
-      const cypressSuites = ['not_used', 'security_solution', 'osquery_cypress', 'fleet_cypress'];
+      const CYPRESS_SUITE = CI_GROUP;
+      const label =
+        groups.find((group) => group.key.includes(CYPRESS_SUITE))?.name || 'Unknown Cypress Suite';
+
       steps.push({
-        command: `.buildkite/scripts/steps/functional/${cypressSuites[CI_GROUP]}.sh`,
-        label: 'Default Cypress',
+        command: `.buildkite/scripts/steps/functional/${[CYPRESS_SUITE]}.sh`,
+        label,
         agents: { queue: 'ci-group-6' },
         depends_on: 'build',
         parallelism: RUN_COUNT,

--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -184,8 +184,9 @@ for (const testSuite of testSuites) {
         concurrency_method: 'eager',
       });
     case 'cypress':
+      const cypressSuites = ['security_solution', 'osquery_cypress', 'fleet_cypress'];
       steps.push({
-        command: `.buildkite/scripts/steps/functional/${CI_GROUP}.sh`,
+        command: `.buildkite/scripts/steps/functional/${cypressSuites[CI_GROUP]}.sh`,
         label: 'Default Cypress',
         agents: { queue: 'ci-group-6' },
         depends_on: 'build',

--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -184,7 +184,7 @@ for (const testSuite of testSuites) {
         concurrency_method: 'eager',
       });
     case 'cypress':
-      const cypressSuites = ['security_solution', 'osquery_cypress', 'fleet_cypress'];
+      const cypressSuites = ['not_used', 'security_solution', 'osquery_cypress', 'fleet_cypress'];
       steps.push({
         command: `.buildkite/scripts/steps/functional/${cypressSuites[CI_GROUP]}.sh`,
         label: 'Default Cypress',

--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -184,9 +184,8 @@ for (const testSuite of testSuites) {
         concurrency_method: 'eager',
       });
     case 'cypress':
-      const CYPRESS_SUITE = CI_GROUP;
       steps.push({
-        command: `.buildkite/scripts/steps/functional/${CYPRESS_SUITE}.sh`,
+        command: `.buildkite/scripts/steps/functional/${CI_GROUP}.sh`,
         label: `Default Cypress`,
         agents: { queue: 'ci-group-6' },
         depends_on: 'build',

--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -188,12 +188,15 @@ for (const testSuite of testSuites) {
       });
     case 'cypress':
       const CYPRESS_SUITE = CI_GROUP;
-      const label =
-        groups.find((group) => group.key.includes(CYPRESS_SUITE))?.name || 'Unknown Cypress Suite';
-
+      const group = groups.find((group) => group.key.includes(CYPRESS_SUITE));
+      if (!group) {
+        throw new Error(
+          `Group configuration was not found in groups.json for the following cypress suite: {${CYPRESS_SUITE}}.`
+        );
+      }
       steps.push({
-        command: `.buildkite/scripts/steps/functional/${[CYPRESS_SUITE]}.sh`,
-        label,
+        command: `.buildkite/scripts/steps/functional/${CYPRESS_SUITE}.sh`,
+        label: group.name,
         agents: { queue: 'ci-group-6' },
         depends_on: 'build',
         parallelism: RUN_COUNT,

--- a/x-pack/plugins/security_solution/cypress/cypress.json
+++ b/x-pack/plugins/security_solution/cypress/cypress.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://localhost:5601",
-  "defaultCommandTimeout": 20000,
+  "defaultCommandTimeout": 40000,
   "execTimeout": 60000,
   "pageLoadTimeout": 60000,
   "nodeVersion": "system",

--- a/x-pack/plugins/security_solution/cypress/cypress.json
+++ b/x-pack/plugins/security_solution/cypress/cypress.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://localhost:5601",
-  "defaultCommandTimeout": 4000,
+  "defaultCommandTimeout": 20000,
   "execTimeout": 60000,
   "pageLoadTimeout": 60000,
   "nodeVersion": "system",

--- a/x-pack/plugins/security_solution/cypress/cypress.json
+++ b/x-pack/plugins/security_solution/cypress/cypress.json
@@ -1,8 +1,8 @@
 {
   "baseUrl": "http://localhost:5601",
-  "defaultCommandTimeout": 120000,
-  "execTimeout": 120000,
-  "pageLoadTimeout": 120000,
+  "defaultCommandTimeout": 4000,
+  "execTimeout": 60000,
+  "pageLoadTimeout": 60000,
   "nodeVersion": "system",
   "retries": {
     "runMode": 2

--- a/x-pack/plugins/security_solution/cypress/cypress.json
+++ b/x-pack/plugins/security_solution/cypress/cypress.json
@@ -1,8 +1,8 @@
 {
   "baseUrl": "http://localhost:5601",
-  "defaultCommandTimeout": 40000,
-  "execTimeout": 60000,
-  "pageLoadTimeout": 60000,
+  "defaultCommandTimeout": 120000,
+  "execTimeout": 120000,
+  "pageLoadTimeout": 120000,
   "nodeVersion": "system",
   "retries": {
     "runMode": 2


### PR DESCRIPTION
## Summary

This PR adds the cypress tests for security solution, fleet, and osquery as options to the flaky test runner tool implemented by Kibana operations:

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/17211684/157692461-2d462fcb-3c1e-47fc-a2f2-a5162ba91663.png">

