### PR TITLE
[Cloud Posture] Cluster card last update time

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -24,7 +24,6 @@ export const RULE_FAILED = `failed`;
 export const INTERNAL_FEATURE_FLAGS = {
   showBenchmarks: false,
   showTrendLineMock: false,
-  showClusterMetaMock: false,
   showManageRulesMock: false,
   showRisksMock: false,
 } as const;

--- a/x-pack/plugins/cloud_security_posture/common/types.ts
+++ b/x-pack/plugins/cloud_security_posture/common/types.ts
@@ -27,6 +27,7 @@ export interface Cluster {
   meta: {
     clusterId: string;
     benchmarkName: string;
+    lastUpdate: number; // unix epoch time
   };
   stats: Stats;
   resourcesTypes: ResourceType[];

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -84,7 +84,7 @@ export const BenchmarksSection = () => {
                       <EuiText style={{ textAlign: 'center' }}>
                         <h4>{`Cluster ID ${shortId || mockClusterId}`}</h4>
                       </EuiText>
-                      <EuiSpacer size='xs' />
+                      <EuiSpacer size="xs" />
                       <EuiText size="xs" color="subdued" style={{ textAlign: 'center' }}>
                         <EuiIcon type="clock" />
                         {moment(cluster.meta.lastUpdate).fromNow()}

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -16,6 +16,7 @@ import {
   EuiButtonEmpty,
   useEuiTheme,
 } from '@elastic/eui';
+import moment from 'moment';
 import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
 import { PartitionElementEvent } from '@elastic/charts';
 import { EuiThemeComputed } from '@elastic/eui/src/services/theme/types';
@@ -83,12 +84,11 @@ export const BenchmarksSection = () => {
                       <EuiText style={{ textAlign: 'center' }}>
                         <h4>{`Cluster ID ${shortId || mockClusterId}`}</h4>
                       </EuiText>
-                      {INTERNAL_FEATURE_FLAGS.showClusterMetaMock && (
-                        <EuiText size="xs" color="subdued" style={{ textAlign: 'center' }}>
-                          <EuiIcon type="clock" />
-                          {' Updated 7 second ago'}
-                        </EuiText>
-                      )}
+                      <EuiSpacer size='xs' />
+                      <EuiText size="xs" color="subdued" style={{ textAlign: 'center' }}>
+                        <EuiIcon type="clock" />
+                        {moment(cluster.meta.lastUpdate).fromNow()}
+                      </EuiText>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiIcon type={getBenchmarkLogo(cluster.meta.benchmarkName)} size="xxl" />

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.test.ts
@@ -14,6 +14,9 @@ const mockClusterBuckets: ClusterBucket[] = [
     benchmarks: {
       buckets: [{ key: 'CIS Kubernetes', doc_count: 10 }],
     },
+    timestamps: {
+      buckets: [{ key: 123, doc_count: 1 }],
+    },
     failed_findings: {
       doc_count: 6,
     },
@@ -53,6 +56,7 @@ describe('getClustersFromAggs', () => {
     expect(clusters).toEqual([
       {
         meta: {
+          lastUpdate: 123,
           clusterId: 'cluster_id',
           benchmarkName: 'CIS Kubernetes',
         },

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
@@ -18,6 +18,8 @@ import { CSP_KUBEBEAT_INDEX_PATTERN } from '../../../common/constants';
 import { findingsEvaluationAggsQuery, getStatsFromFindingsEvaluationsAggs } from './get_stats';
 import { KeyDocCount } from './compliance_dashboard';
 
+type UnixEpochTime = number
+
 export interface ClusterBucket extends ResourceTypeQueryResult, KeyDocCount {
   failed_findings: {
     doc_count: number;
@@ -26,6 +28,7 @@ export interface ClusterBucket extends ResourceTypeQueryResult, KeyDocCount {
     doc_count: number;
   };
   benchmarks: Aggregation<KeyDocCount>;
+  timestamps: Aggregation<KeyDocCount<UnixEpochTime>>;
 }
 
 interface ClustersQueryResult {
@@ -47,6 +50,15 @@ export const getClustersQuery = (query: QueryDslQueryContainer): SearchRequest =
             field: 'rule.benchmark.name.keyword',
           },
         },
+        timestamps: {
+          terms: {
+            field: "@timestamp",
+            size: 1,
+            order: {
+              _key: "desc"
+            }
+          }
+        },
         ...resourceTypeAggQuery,
         ...findingsEvaluationAggsQuery,
       },
@@ -59,10 +71,13 @@ export const getClustersFromAggs = (clusters: ClusterBucket[]): CloudPostureStat
     // get cluster's meta data
     const benchmarks = cluster.benchmarks.buckets;
     if (!Array.isArray(benchmarks)) throw new Error('missing aggs by benchmarks per cluster');
+    const timestamps = cluster.timestamps.buckets;
+    if (!Array.isArray(timestamps)) throw new Error('missing aggs by timestamps per cluster');
 
     const meta = {
       clusterId: cluster.key,
       benchmarkName: benchmarks[0].key,
+      lastUpdate: timestamps[0].key
     };
 
     // get cluster's stats

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
@@ -55,7 +55,7 @@ export const getClustersQuery = (query: QueryDslQueryContainer): SearchRequest =
             field: '@timestamp',
             size: 1,
             order: {
-              _key: 'desc'
+              _key: 'desc',
             },
           },
         },

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
@@ -18,7 +18,7 @@ import { CSP_KUBEBEAT_INDEX_PATTERN } from '../../../common/constants';
 import { findingsEvaluationAggsQuery, getStatsFromFindingsEvaluationsAggs } from './get_stats';
 import { KeyDocCount } from './compliance_dashboard';
 
-type UnixEpochTime = number
+type UnixEpochTime = number;
 
 export interface ClusterBucket extends ResourceTypeQueryResult, KeyDocCount {
   failed_findings: {
@@ -52,12 +52,12 @@ export const getClustersQuery = (query: QueryDslQueryContainer): SearchRequest =
         },
         timestamps: {
           terms: {
-            field: "@timestamp",
+            field: '@timestamp',
             size: 1,
             order: {
-              _key: "desc"
-            }
-          }
+              _key: 'desc'
+            },
+          },
         },
         ...resourceTypeAggQuery,
         ...findingsEvaluationAggsQuery,
@@ -77,7 +77,7 @@ export const getClustersFromAggs = (clusters: ClusterBucket[]): CloudPostureStat
     const meta = {
       clusterId: cluster.key,
       benchmarkName: benchmarks[0].key,
-      lastUpdate: timestamps[0].key
+      lastUpdate: timestamps[0].key,
     };
 
     // get cluster's stats


### PR DESCRIPTION
## Summary

This PR adds a query to get the latest finding time stamp per cluster-id aggregation and utilize `moment.js` to display this UNIX Epoch time in an `x time ago` format in accordance with the Figma designs

![image](https://user-images.githubusercontent.com/51442161/157478243-662efcfc-2160-4c28-8176-9e28aa2d678c.png)