### PR TITLE
[Enterprise Search] Enable unused var linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1488,7 +1488,10 @@ module.exports = {
         'import/newline-after-import': 'error',
         'react-hooks/exhaustive-deps': 'off',
         'react/jsx-boolean-value': ['error', 'never'],
-        '@typescript-eslint/no-unused-vars': 'error',
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          { vars: 'all', args: 'after-used', ignoreRestSiblings: true, varsIgnorePattern: '^_' },
+        ],
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1488,6 +1488,7 @@ module.exports = {
         'import/newline-after-import': 'error',
         'react-hooks/exhaustive-deps': 'off',
         'react/jsx-boolean-value': ['error', 'never'],
+        '@typescript-eslint/no-unused-vars': 'error',
       },
     },
     {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
@@ -44,7 +44,7 @@ export const AppLogic = kea<MakeLogicType<AppValues, AppActions, Required<Initia
   selectors: {
     myRole: [
       (selectors) => [selectors.account, LicensingLogic.selectors.hasPlatinumLicense],
-      ({ role }, hasPlatinumLicense) => (role ? getRoleAbilities(role, hasPlatinumLicense) : {}),
+      ({ role }) => (role ? getRoleAbilities(role) : {}),
     ],
   },
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience_content.tsx
@@ -11,7 +11,7 @@ import { useValues } from 'kea';
 
 import { EuiFlexGroup, EuiSpacer, EuiEmptyPrompt } from '@elastic/eui';
 // @ts-expect-error types are not available for this package yet
-import { Results, Paging, ResultsPerPage } from '@elastic/react-search-ui';
+import { Results } from '@elastic/react-search-ui';
 import { i18n } from '@kbn/i18n';
 
 import { Loading } from '../../../../shared/loading';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/library/library.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/library/library.tsx
@@ -364,7 +364,7 @@ export const Library: React.FC = () => {
             items={[{ id: 1 }, { id: 2 }, { id: 3 }]}
             columns={[
               { name: 'ID', render: (item) => <div>{item.id}</div> },
-              { name: 'Whatever', render: (item) => <div>Whatever</div> },
+              { name: 'Whatever', render: () => <div>Whatever</div> },
             ]}
           />
           <EuiSpacer />
@@ -379,7 +379,7 @@ export const Library: React.FC = () => {
             items={[{ id: 1 }, { id: 2 }, { id: 3 }]}
             columns={[
               { name: 'ID', render: (item) => <div>{item.id}</div> },
-              { name: 'Whatever', render: (item) => <div>Whatever</div> },
+              { name: 'Whatever', render: () => <div>Whatever</div> },
             ]}
           />
           <EuiSpacer />
@@ -394,7 +394,7 @@ export const Library: React.FC = () => {
             items={[{ id: 1 }, { id: 2 }, { id: 3 }]}
             columns={[
               { name: 'ID', render: (item) => <div>{item.id}</div> },
-              { name: 'Whatever', render: (item) => <div>Whatever</div> },
+              { name: 'Whatever', render: () => <div>Whatever</div> },
             ]}
           />
           <EuiSpacer />
@@ -409,7 +409,7 @@ export const Library: React.FC = () => {
             unreorderableItems={[{ id: 4 }, { id: 5 }]}
             columns={[
               { name: 'ID', render: (item) => <div>{item.id}</div> },
-              { name: 'Whatever', render: (item) => <div>Whatever</div> },
+              { name: 'Whatever', render: () => <div>Whatever</div> },
             ]}
           />
           <EuiSpacer />
@@ -428,7 +428,7 @@ export const Library: React.FC = () => {
             items={[{ id: 1 }, { id: 2 }, { id: 3 }]}
             columns={[
               { name: 'ID', render: (item) => <div>{item.id}</div> },
-              { name: 'Whatever', render: (item) => <div>Whatever</div> },
+              { name: 'Whatever', render: () => <div>Whatever</div> },
             ]}
           />
 
@@ -442,7 +442,7 @@ export const Library: React.FC = () => {
             items={[]}
             columns={[
               { name: 'ID', render: (item: { id: number }) => <div>{item.id}</div> },
-              { name: 'Whatever', render: (item) => <div>Whatever</div> },
+              { name: 'Whatever', render: () => <div>Whatever</div> },
             ]}
           />
           <EuiSpacer />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.test.ts
@@ -76,19 +76,19 @@ describe('getRoleAbilities', () => {
     const canManageEngines = { ability: { manage: ['account_engines'] } };
 
     it('returns true when the user can manage any engines and the account has a platinum license', () => {
-      const myRole = getRoleAbilities({ ...mockRole, ...canManageEngines }, true);
+      const myRole = getRoleAbilities({ ...mockRole, ...canManageEngines });
 
       expect(myRole.canManageMetaEngines).toEqual(true);
     });
 
     it('returns true when the user can manage any engines but the account does not have a platinum license', () => {
-      const myRole = getRoleAbilities({ ...mockRole, ...canManageEngines }, false);
+      const myRole = getRoleAbilities({ ...mockRole, ...canManageEngines });
 
       expect(myRole.canManageMetaEngines).toEqual(true);
     });
 
     it('returns false when has a platinum license but the user cannot manage any engines', () => {
-      const myRole = getRoleAbilities({ ...mockRole, ability: { manage: [] } }, true);
+      const myRole = getRoleAbilities({ ...mockRole, ability: { manage: [] } });
 
       expect(myRole.canManageMetaEngines).toEqual(false);
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.ts
@@ -13,7 +13,7 @@ import { RoleTypes, AbilityTypes, Role } from './types';
  * Transforms the `role` data we receive from the Enterprise Search
  * server into a more convenient format for front-end use
  */
-export const getRoleAbilities = (role: Account['role'], hasPlatinumLicense = false): Role => {
+export const getRoleAbilities = (role: Account['role']): Role => {
   // Role ability function helpers
   const myRole = {
     can: (action: AbilityTypes, subject: string): boolean => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/hidden_text/hidden_text.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/hidden_text/hidden_text.test.tsx
@@ -14,9 +14,7 @@ import { HiddenText } from '.';
 describe('HiddenText', () => {
   it('provides the passed "text" in a "hiddenText" field, with all characters obfuscated', () => {
     const wrapper = shallow(
-      <HiddenText text="hidden_test">
-        {({ hiddenText, isHidden, toggle }) => <div>{hiddenText}</div>}
-      </HiddenText>
+      <HiddenText text="hidden_test">{({ hiddenText }) => <div>{hiddenText}</div>}</HiddenText>
     );
     expect(wrapper.text()).toEqual('•••••••••••');
   });
@@ -26,7 +24,7 @@ describe('HiddenText', () => {
 
     const wrapper = shallow(
       <HiddenText text="hidden_test">
-        {({ hiddenText, isHidden, toggle }) => {
+        {({ hiddenText, toggle }) => {
           toggleFn = toggle;
           return <div>{hiddenText}</div>;
         }}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
@@ -93,7 +93,6 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
   description,
   isLoading,
   lastItemWarning,
-  defaultItem,
   noItemsMessage = () => null,
   uneditableItems,
   ...rest

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/cell.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/cell.tsx
@@ -11,14 +11,12 @@ import { EuiFlexItem } from '@elastic/eui';
 
 import { DraggableUXStyles } from './types';
 
-type CellProps<Item> = DraggableUXStyles;
-
-export const Cell = <Item extends object>({
+export const Cell = ({
   children,
   alignItems,
   flexBasis,
   flexGrow,
-}: CellProps<Item> & { children?: React.ReactNode }) => {
+}: DraggableUXStyles & { children?: React.ReactNode }) => {
   return (
     <EuiFlexItem
       style={{

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/synchronization_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/synchronization_logic.ts
@@ -254,7 +254,7 @@ export const SynchronizationLogic = kea<
 
           return schedule;
         },
-        addBlockedWindow: (state, _) => {
+        addBlockedWindow: (state) => {
           const schedule = cloneDeep(state);
           const blockedWindows = schedule.blockedWindows || [];
           blockedWindows.push(emptyBlockedWindow);


### PR DESCRIPTION
## Summary

This enables linting unused variables in the Enterprise Search plugin. TypeScript currently breaks on all unused variables in the Enterprise Search plugin, but the (pre-commit) linter does not filter those out. That means it's common to accidentally miss an unused variable, wait for CI, and then have to add (multiple) commits to remove unused variables. Adding this as a linting rule will help avoid unnecessary CI runs and developer waiting times.