### PR TITLE
[Fleet] Add agents list screen cypress tests

### DIFF
--- a/x-pack/plugins/fleet/cypress/README.md
+++ b/x-pack/plugins/fleet/cypress/README.md
@@ -81,6 +81,8 @@ Cypress convention. Fixtures are used as external pieces of static data when we 
 
 Cypress convention. As a convenience, by default Cypress will automatically include the plugins file cypress/plugins/index.js before every single spec file it runs.
 
+We use the plugins file to register [tasks](https://docs.cypress.io/api/commands/task#Syntax) which are helper functions which run in the parent node process instead of the browser. Tasks can be used to make elastic commands for example.
+
 ### screens/
 
 Contains the elements we want to interact with in our tests.

--- a/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
@@ -144,7 +144,6 @@ describe('View agents', () => {
   describe('Upgrade available filter', () => {
     it('should only show agents with upgrade available after click', () => {
       cy.visit('/app/fleet/agents');
-      cy.contains('agent-1');
 
       cy.getBySel('agentList.showUpgradeable').click();
       // 2 trs = header row + 1 row
@@ -154,7 +153,6 @@ describe('View agents', () => {
 
     it('should clear filter on second click', () => {
       cy.visit('/app/fleet/agents');
-      cy.contains('agent-1');
 
       cy.getBySel('agentList.showUpgradeable').click();
       cy.getBySel('agentList.showUpgradeable').click();
@@ -168,7 +166,6 @@ describe('View agents', () => {
   describe('Agent policy filter', () => {
     it('should should show all policies as options', () => {
       cy.visit('/app/fleet/agents');
-      cy.contains('agent-1');
 
       cy.getBySel('agentList.policyFilter').click();
 
@@ -178,7 +175,6 @@ describe('View agents', () => {
     });
     it('should filter on single policy (no results)', () => {
       cy.visit('/app/fleet/agents');
-      cy.contains('agent-1');
 
       cy.getBySel('agentList.policyFilter').click();
 
@@ -188,7 +184,6 @@ describe('View agents', () => {
     });
     it('should filter on single policy', () => {
       cy.visit('/app/fleet/agents');
-      cy.contains('agent-1');
 
       cy.getBySel('agentList.policyFilter').click();
 
@@ -199,7 +194,6 @@ describe('View agents', () => {
     });
     it('should filter on multiple policies', () => {
       cy.visit('/app/fleet/agents');
-      cy.contains('agent-1');
 
       cy.getBySel('agentList.policyFilter').click();
 
@@ -214,7 +208,6 @@ describe('View agents', () => {
   describe('Agent status filter', () => {
     it('should filter on healthy (1 result)', () => {
       cy.visit('/app/fleet/agents');
-      cy.contains('agent-1');
 
       cy.getBySel('agentList.statusFilter').click();
 
@@ -225,7 +218,6 @@ describe('View agents', () => {
     });
     it('should filter on unhealthy (1 result)', () => {
       cy.visit('/app/fleet/agents');
-      cy.contains('agent-1');
 
       cy.getBySel('agentList.statusFilter').click();
 
@@ -236,7 +228,6 @@ describe('View agents', () => {
     });
     it('should filter on inactive (0 result)', () => {
       cy.visit('/app/fleet/agents');
-      cy.contains('agent-1');
 
       cy.getBySel('agentList.statusFilter').click();
 
@@ -246,7 +237,6 @@ describe('View agents', () => {
     });
     it('should filter on healthy and unhealthy', () => {
       cy.visit('/app/fleet/agents');
-      cy.contains('agent-1');
 
       cy.getBySel('agentList.statusFilter').click();
 

--- a/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
@@ -135,7 +135,6 @@ describe('View agents', () => {
       cy.visit('/app/fleet/agents');
       cy.getBySel('agentList.queryInput').type('agent.id: agent-1{enter}');
       cy.getBySel('fleetAgentListTable');
-      // 2 trs = header row + 1 row
       cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 2);
       cy.getBySel('fleetAgentListTable').contains('agent-1');
     });
@@ -146,7 +145,6 @@ describe('View agents', () => {
       cy.visit('/app/fleet/agents');
 
       cy.getBySel('agentList.showUpgradeable').click();
-      // 2 trs = header row + 1 row
       cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 2);
       cy.getBySel('fleetAgentListTable').contains('agent-1');
     });
@@ -156,7 +154,6 @@ describe('View agents', () => {
 
       cy.getBySel('agentList.showUpgradeable').click();
       cy.getBySel('agentList.showUpgradeable').click();
-      // 2 trs = header row + 1 row
       cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 3);
       cy.getBySel('fleetAgentListTable').contains('agent-1');
       cy.getBySel('fleetAgentListTable').contains('agent-2');

--- a/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
@@ -4,34 +4,40 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-const agent = {
-  id: 'agent-1',
+
+// 8.1.0 is not significant its just a version < current version
+const createAgentDoc = (
+  id: string,
+  policy: string,
+  status = 'online',
+  version: string = '8.1.0'
+) => ({
   access_api_key_id: 'abcdefghijklmn',
   action_seq_no: [-1],
   active: true,
   agent: {
-    id: 'agent-1',
-    version: '8.1.0',
+    id,
+    version,
   },
   enrolled_at: '2022-03-07T14:02:00Z',
   local_metadata: {
     elastic: {
       agent: {
-        'build.original': '8.1.0',
-        id: 'agent-1',
+        'build.original': version,
+        id,
         log_level: 'info',
         snapshot: true,
         upgradeable: true,
-        version: '8.1.0',
+        version,
       },
     },
     host: {
       architecture: 'x86_64',
-      hostname: 'agent-1',
+      hostname: id,
       id: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
       ip: ['127.0.0.1/8'],
       mac: ['ab:cd:12:34:56:78'],
-      name: 'agent-1',
+      name: id,
     },
     os: {
       family: 'darwin',
@@ -42,20 +48,25 @@ const agent = {
       version: '10.16',
     },
   },
-  policy_id: 'policy-1',
+  policy_id: policy,
   type: 'PERMANENT',
   default_api_key: 'abcdefg',
   default_api_key_id: 'abcd',
   policy_output_permissions_hash: 'somehash',
   updated_at: '2022-03-07T16:35:03Z',
-  last_checkin_status: 'online',
-  last_checkin: '2022-03-07T16:34:56Z',
+  last_checkin_status: status,
+  last_checkin: new Date(),
   policy_revision_idx: 1,
   policy_coordinator_idx: 1,
   policy_revision: 1,
-  status: 'online',
+  status,
   packages: [],
-};
+});
+
+const createAgentDocs = (kibanaVersion: string) => [
+  createAgentDoc('agent-1', 'policy-1'), // this agent will have upgrade available
+  createAgentDoc('agent-2', 'policy-2', 'error', kibanaVersion),
+];
 
 // getAgents can be called many times on load, wait() was grabbing the wrong call
 // .all returns all requests performed so far, allowing us to reliably grab the most recent call
@@ -67,7 +78,24 @@ const getLatestRequestUrl = (selector: string) =>
     return new URL(latestRequest?.request?.url);
   });
 
+let docs: any[] = [];
 describe('View agents', () => {
+  before(() => {
+    cy.task('deleteDocsByQuery', {
+      index: '.fleet-agents',
+      query: { match_all: {} },
+    });
+    cy.getKibanaVersion().then((version) => {
+      docs = createAgentDocs(version);
+      cy.task('insertDocs', { index: '.fleet-agents', docs });
+    });
+  });
+  after(() => {
+    cy.task('deleteDocsByQuery', {
+      index: '.fleet-agents',
+      query: { match_all: {} },
+    });
+  });
   beforeEach(() => {
     cy.intercept('/api/fleet/agents/setup', { isReady: true });
     cy.intercept('/api/fleet/setup', { isInitialized: true, nonFatalErrors: [] });
@@ -89,72 +117,50 @@ describe('View agents', () => {
           monitoring_enabled: ['logs', 'metrics'],
           status: 'active',
         },
+        {
+          id: 'policy-3',
+          name: 'Agent policy 3',
+          description: '',
+          namespace: 'default',
+          monitoring_enabled: ['logs', 'metrics'],
+          status: 'active',
+        },
       ],
     });
-    cy.intercept('/api/fleet/agent_status', {
-      results: {
-        total: 1,
-        inactive: 0,
-        online: 1,
-        error: 0,
-        offline: 0,
-        updating: 0,
-        other: 0,
-        events: 0,
-      },
-    });
-    cy.intercept(/\/api\/fleet\/agents(\?.*)?$/, {
-      items: [agent],
-      list: [agent],
-      total: 1,
-    }).as('getAgents');
   });
 
   describe('Agent filter suggestions', () => {
-    it('should show correct suggestions for agent.id', () => {
-      cy.intercept(/\/api\/index_patterns*/, {
-        fields: [
-          {
-            name: 'agent.id',
-            type: 'string',
-            esTypes: ['keyword'],
-            searchable: true,
-            aggregatable: true,
-            readFromDocValues: true,
-            metadata_field: false,
-          },
-        ],
-      });
-      cy.intercept('/api/kibana/suggestions/values/.fleet-agents', [
-        'suggestion1',
-        'suggestion2',
-      ]).as('getSuggestions');
-
+    it('should filter based on agent id', () => {
       cy.visit('/app/fleet/agents');
-      cy.getBySel('queryInput').clear().type('agent.id: ');
-
-      cy.wait('@getSuggestions').then(({ request }) => {
-        expect(request.body.field).to.equal('agent.id');
-      });
-
-      cy.get('.kbnTypeahead').within(() => {
-        cy.contains('suggestion1');
-        cy.contains('suggestion2');
-      });
+      cy.getBySel('agentList.queryInput').type('agent.id: agent-1{enter}');
+      cy.getBySel('fleetAgentListTable');
+      // 2 trs = header row + 1 row
+      cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 2);
+      cy.getBySel('fleetAgentListTable').contains('agent-1');
     });
   });
 
   describe('Upgrade available filter', () => {
-    it('should call API with correct query param on click ', () => {
+    it('should only show agents with upgrade available after click', () => {
       cy.visit('/app/fleet/agents');
       cy.contains('agent-1');
 
       cy.getBySel('agentList.showUpgradeable').click();
-      getLatestRequestUrl('@getAgents').then((url) => {
-        expect(url).instanceOf(URL);
-        // @ts-ignore
-        expect(url.searchParams.get('showUpgradeable')).equals('true');
-      });
+      // 2 trs = header row + 1 row
+      cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 2);
+      cy.getBySel('fleetAgentListTable').contains('agent-1');
+    });
+
+    it('should clear filter on second click', () => {
+      cy.visit('/app/fleet/agents');
+      cy.contains('agent-1');
+
+      cy.getBySel('agentList.showUpgradeable').click();
+      cy.getBySel('agentList.showUpgradeable').click();
+      // 2 trs = header row + 1 row
+      cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 3);
+      cy.getBySel('fleetAgentListTable').contains('agent-1');
+      cy.getBySel('fleetAgentListTable').contains('agent-2');
     });
   });
 
@@ -167,19 +173,88 @@ describe('View agents', () => {
 
       cy.get('button').contains('Agent policy 1');
       cy.get('button').contains('Agent policy 2');
+      cy.get('button').contains('Agent policy 3');
     });
-    it('should filter on policy', () => {
+    it('should filter on single policy (no results)', () => {
       cy.visit('/app/fleet/agents');
       cy.contains('agent-1');
 
       cy.getBySel('agentList.policyFilter').click();
 
+      cy.get('button').contains('Agent policy 3').click();
+
+      cy.getBySel('fleetAgentListTable').contains('No agents found');
+    });
+    it('should filter on single policy', () => {
+      cy.visit('/app/fleet/agents');
+      cy.contains('agent-1');
+
+      cy.getBySel('agentList.policyFilter').click();
+
+      cy.get('button').contains('Agent policy 1').click();
+
+      cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 2);
+      cy.getBySel('fleetAgentListTable').contains('agent-1');
+    });
+    it('should filter on multiple policies', () => {
+      cy.visit('/app/fleet/agents');
+      cy.contains('agent-1');
+
+      cy.getBySel('agentList.policyFilter').click();
+
+      cy.get('button').contains('Agent policy 1').click();
       cy.get('button').contains('Agent policy 2').click();
-      getLatestRequestUrl('@getAgents').then((url) => {
-        expect(url).instanceOf(URL);
-        // @ts-ignore
-        expect(url.searchParams.get('kuery')).contains('fleet-agents.policy_id : ("policy-2")');
-      });
+
+      cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 3);
+      cy.getBySel('fleetAgentListTable').contains('agent-1');
+      cy.getBySel('fleetAgentListTable').contains('agent-2');
+    });
+  });
+  describe('Agent status filter', () => {
+    it('should filter on healthy (1 result)', () => {
+      cy.visit('/app/fleet/agents');
+      cy.contains('agent-1');
+
+      cy.getBySel('agentList.statusFilter').click();
+
+      cy.get('button').contains('Healthy').click();
+
+      cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 2);
+      cy.getBySel('fleetAgentListTable').contains('agent-1');
+    });
+    it('should filter on unhealthy (1 result)', () => {
+      cy.visit('/app/fleet/agents');
+      cy.contains('agent-1');
+
+      cy.getBySel('agentList.statusFilter').click();
+
+      cy.get('button').contains('Unhealthy').click();
+
+      cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 2);
+      cy.getBySel('fleetAgentListTable').contains('agent-2');
+    });
+    it('should filter on inactive (0 result)', () => {
+      cy.visit('/app/fleet/agents');
+      cy.contains('agent-1');
+
+      cy.getBySel('agentList.statusFilter').click();
+
+      cy.get('button').contains('Inactive').click();
+
+      cy.getBySel('fleetAgentListTable').contains('No agents found');
+    });
+    it('should filter on healthy and unhealthy', () => {
+      cy.visit('/app/fleet/agents');
+      cy.contains('agent-1');
+
+      cy.getBySel('agentList.statusFilter').click();
+
+      cy.get('button').contains('healthy').click();
+      cy.get('button').contains('Unhealthy').click();
+
+      cy.getBySel('fleetAgentListTable').find('tr').should('have.length', 3);
+      cy.getBySel('fleetAgentListTable').contains('agent-1');
+      cy.getBySel('fleetAgentListTable').contains('agent-2');
     });
   });
 });

--- a/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
@@ -68,16 +68,6 @@ const createAgentDocs = (kibanaVersion: string) => [
   createAgentDoc('agent-2', 'policy-2', 'error', kibanaVersion),
 ];
 
-// getAgents can be called many times on load, wait() was grabbing the wrong call
-// .all returns all requests performed so far, allowing us to reliably grab the most recent call
-const getLatestRequestUrl = (selector: string) =>
-  cy.get(selector + '.all').then((requests) => {
-    if (!requests.length) return undefined;
-    const latestRequest = requests[requests.length - 1];
-    // @ts-ignore no property url, typing is wrong for return type of .all
-    return new URL(latestRequest?.request?.url);
-  });
-
 let docs: any[] = [];
 describe('View agents', () => {
   before(() => {

--- a/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
@@ -84,6 +84,7 @@ describe('View agents', () => {
     cy.task('deleteDocsByQuery', {
       index: '.fleet-agents',
       query: { match_all: {} },
+      ignoreUnavailable: true,
     });
     cy.getKibanaVersion().then((version) => {
       docs = createAgentDocs(version);

--- a/x-pack/plugins/fleet/cypress/integration/agent.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+const agent = {
+  id: 'agent-1',
+  access_api_key_id: 'abcdefghijklmn',
+  action_seq_no: [-1],
+  active: true,
+  agent: {
+    id: 'agent-1',
+    version: '8.1.0',
+  },
+  enrolled_at: '2022-03-07T14:02:00Z',
+  local_metadata: {
+    elastic: {
+      agent: {
+        'build.original': '8.1.0',
+        id: 'agent-1',
+        log_level: 'info',
+        snapshot: true,
+        upgradeable: true,
+        version: '8.1.0',
+      },
+    },
+    host: {
+      architecture: 'x86_64',
+      hostname: 'agent-1',
+      id: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+      ip: ['127.0.0.1/8'],
+      mac: ['ab:cd:12:34:56:78'],
+      name: 'agent-1',
+    },
+    os: {
+      family: 'darwin',
+      full: 'Mac OS X(10.16)',
+      kernel: '21.3.0',
+      name: 'Mac OS X',
+      platform: 'darwin',
+      version: '10.16',
+    },
+  },
+  policy_id: 'policy-1',
+  type: 'PERMANENT',
+  default_api_key: 'abcdefg',
+  default_api_key_id: 'abcd',
+  policy_output_permissions_hash: 'somehash',
+  updated_at: '2022-03-07T16:35:03Z',
+  last_checkin_status: 'online',
+  last_checkin: '2022-03-07T16:34:56Z',
+  policy_revision_idx: 1,
+  policy_coordinator_idx: 1,
+  policy_revision: 1,
+  status: 'online',
+  packages: [],
+};
+
+describe('View agents', () => {
+  beforeEach(() => {
+    cy.intercept('/api/fleet/agents/setup', { isReady: true });
+    cy.intercept('/api/fleet/setup', { isInitialized: true, nonFatalErrors: [] });
+    cy.intercept(/\/api\/fleet\/agent_policies(\?.*)?$/, {
+      items: [
+        {
+          id: 'policy-1',
+          name: 'Agent policy 1',
+          description: '',
+          namespace: 'default',
+          monitoring_enabled: ['logs', 'metrics'],
+          status: 'active',
+        },
+      ],
+    });
+    cy.intercept('/api/fleet/agent_status', {
+      results: {
+        total: 1,
+        inactive: 0,
+        online: 1,
+        error: 0,
+        offline: 0,
+        updating: 0,
+        other: 0,
+        events: 0,
+      },
+    });
+    cy.intercept(/\/api\/fleet\/agents(\?.*)?$/, {
+      items: [agent],
+      list: [agent],
+      total: 1,
+    });
+  });
+
+  describe('autocomplete', () => {
+    it('should show correct suggestions for agent.id', async () => {
+      cy.intercept(/\/api\/index_patterns*/, {
+        fields: [
+          {
+            name: 'agent.id',
+            type: 'string',
+            esTypes: ['keyword'],
+            searchable: true,
+            aggregatable: true,
+            readFromDocValues: true,
+            metadata_field: false,
+          },
+        ],
+      });
+      cy.intercept('/api/kibana/suggestions/values/.fleet-agents', [
+        'suggestion1',
+        'suggestion2',
+      ]).as('getSuggestions');
+
+      cy.visit('/app/fleet/agents');
+      cy.get('[data-test-subj="queryInput"]').clear().type('agent.id: ');
+
+      cy.wait('@getSuggestions').then(({ request }) => {
+        expect(request.body.field).to.equal('agent.id');
+      });
+
+      cy.get('.kbnTypeahead').within(() => {
+        cy.contains('suggestion1');
+        cy.contains('suggestion2');
+      });
+    });
+  });
+});

--- a/x-pack/plugins/fleet/cypress/integration/agent.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.ts
@@ -89,7 +89,7 @@ describe('View agents', () => {
       items: [agent],
       list: [agent],
       total: 1,
-    });
+    }).as('getAgents');
   });
 
   describe('autocomplete', () => {
@@ -122,6 +122,25 @@ describe('View agents', () => {
       cy.get('.kbnTypeahead').within(() => {
         cy.contains('suggestion1');
         cy.contains('suggestion2');
+      });
+    });
+  });
+
+  describe('Upgrade available filter', () => {
+    it('should call API with correct query param on click ', async () => {
+      cy.visit('/app/fleet/agents');
+      cy.contains('agent-1');
+
+      cy.get('[data-test-subj="filterShowUpgradable"]').click();
+      // getAgents can be called many times on load, wait() was grabbing the wrong call
+      // .all returns all requests performed so far, allowing us to reliably grab the most recent call
+      // the tick is needed to ensure the call is collected, test is flaky without it
+      cy.tick(500);
+      cy.get('@getAgents.all').then((requests) => {
+        // @ts-ignore no property request, typings are incorrect for .all
+        const latestRequest = requests[requests.length - 1].request;
+        const latestRequestUrl = new URL(latestRequest.url);
+        expect(latestRequestUrl.searchParams.get('showUpgradeable')).equals('true');
       });
     });
   });

--- a/x-pack/plugins/fleet/cypress/plugins/index.ts
+++ b/x-pack/plugins/fleet/cypress/plugins/index.ts
@@ -17,8 +17,16 @@ const plugin: Cypress.PluginConfig = (on, config) => {
 
       return client.bulk({ operations });
     },
-    async deleteDocsByQuery({ index, query }: { index: string; query: any }) {
-      return client.deleteByQuery({ index, query });
+    async deleteDocsByQuery({
+      index,
+      query,
+      ignoreUnavailable = false,
+    }: {
+      index: string;
+      query: any;
+      ignoreUnavailable?: boolean;
+    }) {
+      return client.deleteByQuery({ index, query, ignore_unavailable: ignoreUnavailable });
     },
   });
 };

--- a/x-pack/plugins/fleet/cypress/plugins/index.ts
+++ b/x-pack/plugins/fleet/cypress/plugins/index.ts
@@ -4,25 +4,23 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+// eslint-disable-next-line
+import { createEsClientForTesting } from '@kbn/test';
 
-// / <reference types="cypress" />
-// ***********************************************************
-// This example plugins/index.js can be used to load plugins
-//
-// You can change the location of this file or turn off loading
-// the plugins file with the 'pluginsFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/plugins-guide
-// ***********************************************************
+const plugin: Cypress.PluginConfig = (on, config) => {
+  const client = createEsClientForTesting({
+    esUrl: config.env.ELASTICSEARCH_URL,
+  });
+  on('task', {
+    async insertDocs({ index, docs }: { index: string; docs: any[] }) {
+      const operations = docs.flatMap((doc) => [{ index: { _index: index } }, doc]);
 
-// This function is called when a project is opened or re-opened (e.g. due to
-// the project's config changing)
-
-/**
- * @type {Cypress.PluginConfig}
- */
-module.exports = (_on: any, _config: any) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+      return client.bulk({ operations });
+    },
+    async deleteDocsByQuery({ index, query }: { index: string; query: any }) {
+      return client.deleteByQuery({ index, query });
+    },
+  });
 };
+
+module.exports = plugin;

--- a/x-pack/plugins/fleet/cypress/support/index.ts
+++ b/x-pack/plugins/fleet/cypress/support/index.ts
@@ -30,6 +30,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       getBySel(value: string, ...args: any[]): Chainable<any>;
+      getKibanaVersion(): Chainable<string>;
     }
   }
 }
@@ -38,7 +39,14 @@ function getBySel(selector: string, ...args: any[]) {
   return cy.get(`[data-test-subj="${selector}"]`, ...args);
 }
 
+function getKibanaVersion() {
+  return cy.request('/api/status').then(({ body }) => {
+    return body.version.number;
+  });
+}
+
 Cypress.Commands.add('getBySel', getBySel);
+Cypress.Commands.add('getKibanaVersion', getKibanaVersion);
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.tsx
@@ -22,6 +22,7 @@ interface Props {
   onChange: (newValue: string, submit?: boolean) => void;
   placeholder?: string;
   indexPattern?: string;
+  dataTestSubj?: string;
 }
 
 export const SearchBar: React.FunctionComponent<Props> = ({
@@ -30,6 +31,7 @@ export const SearchBar: React.FunctionComponent<Props> = ({
   onChange,
   placeholder,
   indexPattern = INDEX_NAME,
+  dataTestSubj,
 }) => {
   const { data } = useStartServices();
   const [indexPatternFields, setIndexPatternFields] = useState<FieldSpec[]>();
@@ -101,6 +103,7 @@ export const SearchBar: React.FunctionComponent<Props> = ({
       submitOnBlur
       isClearable
       autoSubmit
+      {...(dataTestSubj && { dataTestSubj })}
     />
   );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -174,6 +174,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                       numActiveFilters={selectedAgentPolicies.length}
                       numFilters={agentPolicies.length}
                       disabled={agentPolicies.length === 0}
+                      data-test-subj="agentList.policyFilter"
                     >
                       <FormattedMessage
                         id="xpack.fleet.agentList.policyFilterText"
@@ -208,7 +209,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                   onClick={() => {
                     onShowUpgradeableChange(!showUpgradeable);
                   }}
-                  data-test-subj="filterShowUpgradable"
+                  data-test-subj="agentList.showUpgradeable"
                 >
                   <FormattedMessage
                     id="xpack.fleet.agentList.showUpgradeableFilterLabel"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -136,6 +136,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                       isSelected={isStatusFilterOpen}
                       hasActiveFilters={selectedStatus.length > 0}
                       disabled={agentPolicies.length === 0}
+                      data-test-subj="agentList.statusFilter"
                     >
                       <FormattedMessage
                         id="xpack.fleet.agentList.statusFilterText"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -114,6 +114,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
             <EuiFlexItem grow={6}>
               <SearchBar
                 value={draftKuery}
+                data-test-subj="agentList.queryInput"
                 onChange={(newSearch, submit) => {
                   onDraftKueryChange(newSearch);
                   if (submit) {
@@ -121,6 +122,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                   }
                 }}
                 indexPattern={AGENTS_INDEX}
+                dataTestSubj="agentList.queryInput"
               />
             </EuiFlexItem>
             <EuiFlexItem grow={2}>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -208,6 +208,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                   onClick={() => {
                     onShowUpgradeableChange(!showUpgradeable);
                   }}
+                  data-test-subj="filterShowUpgradable"
                 >
                   <FormattedMessage
                     id="xpack.fleet.agentList.showUpgradeableFilterLabel"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -114,7 +114,6 @@ export const SearchAndFilterBar: React.FunctionComponent<{
             <EuiFlexItem grow={6}>
               <SearchBar
                 value={draftKuery}
-                data-test-subj="agentList.queryInput"
                 onChange={(newSearch, submit) => {
                   onDraftKueryChange(newSearch);
                   if (submit) {


### PR DESCRIPTION
## Summary

Closes #125237. 

Add cypress tests for the agent list screen:
- Search bar suggestions
- Search bar filter by ID
- Status filter
- upgrade available filter
- policy filter

 
