### PR TITLE
[data view mgmt] fix data view name wrap

### DIFF
--- a/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -140,7 +140,7 @@ export const IndexPatternTable = ({
         defaultMessage: 'Name',
       }),
       render: (name: string, dataView: IndexPatternTableItem) => (
-        <>
+        <div>
           <EuiLink {...reactRouterNavigate(history, `patterns/${dataView.id}`)}>{name}</EuiLink>
           {dataView?.id?.indexOf(securitySolution) === 0 && (
             <>
@@ -149,10 +149,10 @@ export const IndexPatternTable = ({
           )}
           {dataView?.tags?.map(({ key: tagKey, name: tagName }) => (
             <>
-              &emsp;<EuiBadge>{tagName}</EuiBadge>
+              &emsp;<EuiBadge key={tagKey}>{tagName}</EuiBadge>
             </>
           ))}
-        </>
+        </div>
       ),
       dataType: 'string' as const,
       sortable: ({ sort }: { sort: string }) => sort,

--- a/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -141,21 +141,17 @@ export const IndexPatternTable = ({
       }),
       render: (name: string, dataView: IndexPatternTableItem) => (
         <>
-          <EuiFlexGroup gutterSize="s" wrap>
-            <EuiFlexItem grow={false} css={flexItemStyles}>
-              <EuiLink {...reactRouterNavigate(history, `patterns/${dataView.id}`)}>{name}</EuiLink>
-            </EuiFlexItem>
-            {dataView?.id?.indexOf(securitySolution) === 0 && (
-              <EuiFlexItem grow={false} css={flexItemStyles}>
-                <EuiBadge>{securityDataView}</EuiBadge>
-              </EuiFlexItem>
-            )}
-            {dataView?.tags?.map(({ key: tagKey, name: tagName }) => (
-              <EuiFlexItem grow={false} css={flexItemStyles} key={tagKey}>
-                <EuiBadge>{tagName}</EuiBadge>
-              </EuiFlexItem>
-            ))}
-          </EuiFlexGroup>
+          <EuiLink {...reactRouterNavigate(history, `patterns/${dataView.id}`)}>{name}</EuiLink>
+          {dataView?.id?.indexOf(securitySolution) === 0 && (
+            <>
+              &emsp;<EuiBadge>{securityDataView}</EuiBadge>
+            </>
+          )}
+          {dataView?.tags?.map(({ key: tagKey, name: tagName }) => (
+            <>
+              &emsp;<EuiBadge>{tagName}</EuiBadge>
+            </>
+          ))}
         </>
       ),
       dataType: 'string' as const,

--- a/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -9,7 +9,7 @@ import { css } from '@emotion/react';
 import {
   EuiBadge,
   EuiButton,
-  EuiButtonEmpty,
+  EuiLink,
   EuiInMemoryTable,
   EuiPageHeader,
   EuiSpacer,
@@ -143,9 +143,7 @@ export const IndexPatternTable = ({
         <>
           <EuiFlexGroup gutterSize="s" wrap>
             <EuiFlexItem grow={false} css={flexItemStyles}>
-              <EuiButtonEmpty size="s" {...reactRouterNavigate(history, `patterns/${dataView.id}`)}>
-                {name}
-              </EuiButtonEmpty>
+              <EuiLink {...reactRouterNavigate(history, `patterns/${dataView.id}`)}>{name}</EuiLink>
             </EuiFlexItem>
             {dataView?.id?.indexOf(securitySolution) === 0 && (
               <EuiFlexItem grow={false} css={flexItemStyles}>

--- a/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { css } from '@emotion/react';
+
 import {
   EuiBadge,
   EuiButton,
@@ -13,8 +13,6 @@ import {
   EuiInMemoryTable,
   EuiPageHeader,
   EuiSpacer,
-  EuiFlexItem,
-  EuiFlexGroup,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { RouteComponentProps, withRouter, useLocation } from 'react-router-dom';
@@ -52,10 +50,6 @@ const securityDataView = i18n.translate(
 );
 
 const securitySolution = 'security-solution';
-
-const flexItemStyles = css`
-  justify-content: center;
-`;
 
 interface Props extends RouteComponentProps {
   canSave: boolean;

--- a/test/functional/page_objects/settings_page.ts
+++ b/test/functional/page_objects/settings_page.ts
@@ -357,7 +357,7 @@ export class SettingsPageObject extends FtrService {
   }
 
   async clickIndexPatternByName(name: string) {
-    const indexLink = await this.find.byXPath(`//a[descendant::*[text()='${name}']]`);
+    const indexLink = await this.find.byXPath(`//a[text()='${name}']`);
     await indexLink.click();
   }
 


### PR DESCRIPTION
## Summary

Closes - https://github.com/elastic/kibana/issues/126632

Fix rendering of long data view names -

<img width="1255" alt="Screen Shot 2022-03-09 at 3 51 57 PM" src="https://user-images.githubusercontent.com/216176/157542541-58afc244-89e3-48b6-8f16-26274d990114.png">

