### PR TITLE
[Fleet] Fix timeserie dimension mapping

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -700,7 +700,6 @@ describe('EPM template', () => {
         example: {
           properties: {
             id: {
-              ignore_above: 1024,
               time_series_dimension: true,
               type: 'keyword',
             },

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -269,6 +269,7 @@ function generateKeywordMapping(field: Field): IndexTemplateMapping {
   }
   if (field.dimension) {
     mapping.time_series_dimension = field.dimension;
+    delete mapping.ignore_above;
   }
   return mapping;
 }


### PR DESCRIPTION
## Summary

Resolve #127327

We were generating incorrect mapping for timeserie dimension mapping with both `ignore_above` field and `time_series_dimension`

## How to test 

Try to install kubernetes integration it should work and it's currently broken on main
 http://localhost:5601/app/integrations/detail/kubernetes-1.17.2/settings 