### PR TITLE
[Stack Monitoring] [DOCS] update docs to remove mention of watcher alerts

### DIFF
--- a/docs/user/monitoring/xpack-monitoring.asciidoc
+++ b/docs/user/monitoring/xpack-monitoring.asciidoc
@@ -17,9 +17,6 @@ instance, and Beat is considered unique based on its persistent
 UUID, which is written to the <<settings,`path.data`>> directory when the node
 or instance starts. 
 
-NOTE: Watcher must be enabled to view cluster alerts. If you have a Basic
-license, Top Cluster Alerts are not displayed.
-
 For more information, see <<configuring-monitoring>> and 
 {ref}/monitor-elasticsearch-cluster.html[Monitor a cluster].  
 


### PR DESCRIPTION
Since Watcher alerts were removed in 7.11, this Note is invalid and should be removed:

<img width="771" alt="Screen Shot 2022-03-09 at 1 25 09 PM" src="https://user-images.githubusercontent.com/1676003/157506753-cb2862b7-1328-43ad-91cf-6795e6177742.png">

https://www.elastic.co/guide/en/kibana/master/xpack-monitoring.html

[skip-ci]
