### PR TITLE
[8.1] [DOCS] Adds missing `monitoring.cluster_alerts.email_notifications.email_address` monitoring setting (#126826)

### DIFF
--- a/docs/settings/monitoring-settings.asciidoc
+++ b/docs/settings/monitoring-settings.asciidoc
@@ -29,9 +29,12 @@ For more information, see
 [[monitoring-general-settings]]
 ==== General monitoring settings
 
+`monitoring.cluster_alerts.email_notifications.email_address` {ess-icon}::
+deprecated:[7.11.0,"In 8.2.0 and later, this setting will no longer be supported."] 
+When enabled, specifies the email address where you want to receive cluster alert notifications.
+
 `monitoring.ui.ccs.enabled`::
 Set to `true` (default) to enable {ref}/modules-cross-cluster-search.html[cross-cluster search] of your monitoring data. The {ref}/modules-remote-clusters.html#remote-cluster-settings[`remote_cluster_client`] role must exist on each node.
-
 
 `monitoring.ui.elasticsearch.hosts`::
 Specifies the location of the {es} cluster where your monitoring data is stored.

--- a/docs/settings/monitoring-settings.asciidoc
+++ b/docs/settings/monitoring-settings.asciidoc
@@ -30,7 +30,7 @@ For more information, see
 ==== General monitoring settings
 
 `monitoring.cluster_alerts.email_notifications.email_address` {ess-icon}::
-deprecated:[7.11.0,"In 8.2.0 and later, this setting will no longer be supported."] 
+deprecated:[7.11.0] 
 When enabled, specifies the email address where you want to receive cluster alert notifications.
 
 `monitoring.ui.ccs.enabled`::


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[DOCS] Adds missing `monitoring.cluster_alerts.email_notifications.email_address` monitoring setting (#126826)](https://github.com/elastic/kibana/pull/126826)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)