### PR TITLE
[Fleet] Make input IDs unique in agent policy yaml

### DIFF
--- a/x-pack/plugins/fleet/common/services/package_policies_to_agent_inputs.test.ts
+++ b/x-pack/plugins/fleet/common/services/package_policies_to_agent_inputs.test.ts
@@ -118,7 +118,7 @@ describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
       ])
     ).toEqual([
       {
-        id: 'some-uuid',
+        id: 'test-logs-some-uuid',
         name: 'mock-package-policy',
         revision: 1,
         type: 'test-logs',
@@ -169,7 +169,7 @@ describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
       ])
     ).toEqual([
       {
-        id: 'some-uuid',
+        id: 'test-logs-some-uuid',
         name: 'mock-package-policy',
         revision: 1,
         type: 'test-logs',
@@ -201,7 +201,7 @@ describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
       ])
     ).toEqual([
       {
-        id: 'some-uuid',
+        id: 'test-logs-some-uuid',
         name: 'mock-package-policy',
         revision: 1,
         type: 'test-logs',
@@ -263,7 +263,7 @@ describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
       ])
     ).toEqual([
       {
-        id: 'some-uuid',
+        id: 'test-logs-some-uuid',
         revision: 1,
         name: 'mock-package-policy',
         type: 'test-logs',

--- a/x-pack/plugins/fleet/common/services/package_policies_to_agent_inputs.test.ts
+++ b/x-pack/plugins/fleet/common/services/package_policies_to_agent_inputs.test.ts
@@ -78,34 +78,34 @@ describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
   };
 
   const mockInput2: PackagePolicyInput = {
-  type: 'test-metrics',
-  policy_template: 'some-template',
-  enabled: true,
-  vars: {
-    inputVar: { value: 'input-value' },
-    inputVar2: { value: undefined },
-    inputVar3: {
-      type: 'yaml',
-      value: 'testField: test',
-    },
-    inputVar4: { value: '' },
-  },
-  streams: [
-    {
-      id: 'test-metrics-foo',
-      enabled: true,
-      data_stream: { dataset: 'foo', type: 'metrics' },
-      vars: {
-        fooVar: { value: 'foo-value' },
-        fooVar2: { value: [1, 2] },
+    type: 'test-metrics',
+    policy_template: 'some-template',
+    enabled: true,
+    vars: {
+      inputVar: { value: 'input-value' },
+      inputVar2: { value: undefined },
+      inputVar3: {
+        type: 'yaml',
+        value: 'testField: test',
       },
-      compiled_stream: {
-        fooKey: 'fooValue1',
-        fooKey2: ['fooValue2'],
-      },
+      inputVar4: { value: '' },
     },
-  ],
-};
+    streams: [
+      {
+        id: 'test-metrics-foo',
+        enabled: true,
+        data_stream: { dataset: 'foo', type: 'metrics' },
+        vars: {
+          fooVar: { value: 'foo-value' },
+          fooVar2: { value: [1, 2] },
+        },
+        compiled_stream: {
+          fooKey: 'fooValue1',
+          fooKey2: ['fooValue2'],
+        },
+      },
+    ],
+  };
 
   it('returns no inputs for package policy with no inputs, or only disabled inputs', () => {
     expect(storedPackagePoliciesToAgentInputs([mockPackagePolicy])).toEqual([]);

--- a/x-pack/plugins/fleet/common/services/package_policies_to_agent_inputs.test.ts
+++ b/x-pack/plugins/fleet/common/services/package_policies_to_agent_inputs.test.ts
@@ -77,6 +77,36 @@ describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
     ],
   };
 
+  const mockInput2: PackagePolicyInput = {
+  type: 'test-metrics',
+  policy_template: 'some-template',
+  enabled: true,
+  vars: {
+    inputVar: { value: 'input-value' },
+    inputVar2: { value: undefined },
+    inputVar3: {
+      type: 'yaml',
+      value: 'testField: test',
+    },
+    inputVar4: { value: '' },
+  },
+  streams: [
+    {
+      id: 'test-metrics-foo',
+      enabled: true,
+      data_stream: { dataset: 'foo', type: 'metrics' },
+      vars: {
+        fooVar: { value: 'foo-value' },
+        fooVar2: { value: [1, 2] },
+      },
+      compiled_stream: {
+        fooKey: 'fooValue1',
+        fooKey2: ['fooValue2'],
+      },
+    },
+  ],
+};
+
   it('returns no inputs for package policy with no inputs, or only disabled inputs', () => {
     expect(storedPackagePoliciesToAgentInputs([mockPackagePolicy])).toEqual([]);
 
@@ -140,6 +170,71 @@ describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
           {
             id: 'test-logs-bar',
             data_stream: { dataset: 'bar', type: 'logs' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('returns unique agent inputs IDs, with policy template name if one exists', () => {
+    expect(
+      storedPackagePoliciesToAgentInputs([
+        {
+          ...mockPackagePolicy,
+          package: {
+            name: 'mock-package',
+            title: 'Mock package',
+            version: '0.0.0',
+          },
+          inputs: [mockInput, mockInput2],
+        },
+      ])
+    ).toEqual([
+      {
+        id: 'test-logs-some-uuid',
+        name: 'mock-package-policy',
+        revision: 1,
+        type: 'test-logs',
+        data_stream: { namespace: 'default' },
+        use_output: 'default',
+        meta: {
+          package: {
+            name: 'mock-package',
+            version: '0.0.0',
+          },
+        },
+        streams: [
+          {
+            id: 'test-logs-foo',
+            data_stream: { dataset: 'foo', type: 'logs' },
+            fooKey: 'fooValue1',
+            fooKey2: ['fooValue2'],
+          },
+          {
+            id: 'test-logs-bar',
+            data_stream: { dataset: 'bar', type: 'logs' },
+          },
+        ],
+      },
+      {
+        id: 'test-metrics-some-template-some-uuid',
+        name: 'mock-package-policy',
+        revision: 1,
+        type: 'test-metrics',
+        data_stream: { namespace: 'default' },
+        use_output: 'default',
+        meta: {
+          package: {
+            name: 'mock-package',
+            version: '0.0.0',
+          },
+        },
+        streams: [
+          {
+            id: 'test-metrics-foo',
+            data_stream: { dataset: 'foo', type: 'metrics' },
+            fooKey: 'fooValue1',
+            fooKey2: ['fooValue2'],
           },
         ],
       },

--- a/x-pack/plugins/fleet/common/services/package_policies_to_agent_inputs.ts
+++ b/x-pack/plugins/fleet/common/services/package_policies_to_agent_inputs.ts
@@ -26,7 +26,9 @@ export const storedPackagePoliciesToAgentInputs = (
       }
 
       const fullInput: FullAgentPolicyInput = {
-        id: `${input.type}${input.policy_template ? `-${input.policy_template}-` : '-'}${packagePolicy.id}`,
+        id: `${input.type}${input.policy_template ? `-${input.policy_template}-` : '-'}${
+          packagePolicy.id
+        }`,
         revision: packagePolicy.revision,
         name: packagePolicy.name,
         type: input.type,

--- a/x-pack/plugins/fleet/common/services/package_policies_to_agent_inputs.ts
+++ b/x-pack/plugins/fleet/common/services/package_policies_to_agent_inputs.ts
@@ -26,7 +26,7 @@ export const storedPackagePoliciesToAgentInputs = (
       }
 
       const fullInput: FullAgentPolicyInput = {
-        id: packagePolicy.id || packagePolicy.name,
+        id: `${input.type}${input.policy_template ? `-${input.policy_template}-` : '-'}${packagePolicy.id}`,
         revision: packagePolicy.revision,
         name: packagePolicy.name,
         type: input.type,

--- a/x-pack/plugins/fleet/server/integration_tests/__snapshots__/cloud_preconfiguration.test.ts.snap
+++ b/x-pack/plugins/fleet/server/integration_tests/__snapshots__/cloud_preconfiguration.test.ts.snap
@@ -15,7 +15,7 @@ Object {
       "data_stream": Object {
         "namespace": "default",
       },
-      "id": "elastic-cloud-fleet-server",
+      "id": "fleet-server-fleet_server-elastic-cloud-fleet-server",
       "meta": Object {
         "package": Object {
           "name": "fleet_server",
@@ -111,7 +111,7 @@ Object {
       "data_stream": Object {
         "namespace": "default",
       },
-      "id": "elastic-cloud-apm",
+      "id": "apm-apmserver-elastic-cloud-apm",
       "meta": Object {
         "package": Object {
           "name": "apm",


### PR DESCRIPTION
## Summary

Resolves #125844. This PR makes input IDs in the final generated agent policy unique by building it from the parent package policy ID + input type + the associated policy template name (if any).

When a package policy is built, its streams are [grouped by input type+policy template](https://github.com/elastic/kibana/blob/1b30d982a0c44eda3d0826abdaddf143d9f9e3f9/x-pack/plugins/fleet/common/services/package_to_package_policy.ts#L78-L90), so that combination should be unique (and stable) on each package policy.

This screenshot shows an example of unique IDs being generated for AWS billing and Cloudtrail inputs:

![image](https://user-images.githubusercontent.com/1965714/157549966-35e42215-2de5-47cc-80cc-47983ffa808b.png)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios