### PR TITLE
[7.16] [DOCS] Adds missing `monitoring.cluster_alerts.email_notifications.email_address` monitoring setting (#126826)

### DIFF
--- a/docs/settings/monitoring-settings.asciidoc
+++ b/docs/settings/monitoring-settings.asciidoc
@@ -31,6 +31,10 @@ For more information, see
 
 [cols="2*<"]
 |===
+| `monitoring.cluster_alerts.email_notifications.email_address` {ess-icon}::
+  | deprecated:[7.11.0] 
+  When enabled, specifies the email address where you want to receive cluster alert notifications.
+
 | `monitoring.enabled`
   | deprecated:[7.16.0,"In 8.0 and later, this setting will no longer be supported."]
   Set to `true` (default) to enable the {monitor-features} in {kib}. Unlike the


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.16`:
 - [[DOCS] Adds missing `monitoring.cluster_alerts.email_notifications.email_address` monitoring setting (#126826)](https://github.com/elastic/kibana/pull/126826)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)