### PR TITLE
[kbn/generate] fix type deps and --web help

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,6 +224,7 @@
 /packages/kbn-es-archiver/ @elastic/kibana-operations
 /packages/kbn-utils/ @elastic/kibana-operations
 /packages/kbn-cli-dev-mode/ @elastic/kibana-operations
+/packages/kbn-generate/ @elastic/kibana-operations
 /src/cli/keystore/ @elastic/kibana-operations
 /.ci/es-snapshots/ @elastic/kibana-operations
 /.github/workflows/ @elastic/kibana-operations

--- a/packages/kbn-generate/src/cli.ts
+++ b/packages/kbn-generate/src/cli.ts
@@ -58,7 +58,8 @@ export function runGenerateCli() {
         string: ['dir'],
         help: `
           --dev          Generate a package which is intended for dev-only use and can access things like devDependencies
-          --web          Build webpack-compatible version of sources for this package
+          --web          Build webpack-compatible version of sources for this package. If your package is intended to be
+                          used in the browser and Node.js then you need to opt-into these sources being created.
           --dir          Directory where this package will live, defaults to [./packages]
           --force        If the packageDir already exists, delete it before generation
         `,

--- a/packages/kbn-generate/templates/package/BUILD.bazel.ejs
+++ b/packages/kbn-generate/templates/package/BUILD.bazel.ejs
@@ -48,8 +48,8 @@ RUNTIME_DEPS = [
 #
 #  References to NPM packages work the same as RUNTIME_DEPS
 TYPES_DEPS = [
-  "//@npm//@types/node",
-  "//@npm//@types/jest",
+  "@npm//@types/node",
+  "@npm//@types/jest",
 ]
 
 jsts_transpiler(


### PR DESCRIPTION
Applies a minor fix to the template spotted by @clintandrewhall, updates the help text for `--web` to make it more clear, and adds `@elastic/kibana-operations` as codeowner for the package.