### PR TITLE
[7.17] Fix security solutions upgrade tests

### DIFF
--- a/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
@@ -399,13 +399,13 @@ export const expandEventAction = () => {
 };
 
 export const setKibanaTimezoneToUTC = () =>
-  cy.request({
-    method: 'POST',
-    url: 'api/kibana/settings',
-    body: {"changes": {"dateFormat:tz": "UTC"}},
-    headers: { 'kbn-xsrf': 'set-kibana-timezone-utc' },
-  }).then(
-    () => {
+  cy
+    .request({
+      method: 'POST',
+      url: 'api/kibana/settings',
+      body: { changes: { 'dateFormat:tz': 'UTC' } },
+      headers: { 'kbn-xsrf': 'set-kibana-timezone-utc' },
+    })
+    .then(() => {
       cy.reload();
-    }
-  );
+    });

--- a/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
@@ -397,3 +397,15 @@ export const expandEventAction = () => {
   });
   cy.get(TIMELINE_COLLAPSED_ITEMS_BTN).click();
 };
+
+export const setKibanaTimezoneToUTC = () =>
+  cy.request({
+    method: 'POST',
+    url: 'api/kibana/settings',
+    body: {"changes": {"dateFormat:tz": "UTC"}},
+    headers: { 'kbn-xsrf': 'set-kibana-timezone-utc' },
+  }).then(
+    () => {
+      cy.reload();
+    }
+  );

--- a/x-pack/plugins/security_solution/cypress/upgrade_integration/custom_query_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/upgrade_integration/custom_query_rule.spec.ts
@@ -53,8 +53,8 @@ const rule = {
   severity: 'Low',
   riskScore: '7',
   timelineTemplate: 'none',
-  runsEvery: '10s',
-  lookBack: '179999990s',
+  runsEvery: '24h',
+  lookBack: '49976h',
   timeline: 'None',
 };
 

--- a/x-pack/plugins/security_solution/cypress/upgrade_integration/import_timeline.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/upgrade_integration/import_timeline.spec.ts
@@ -38,7 +38,13 @@ import {
 } from '../screens/timelines';
 
 import { loginAndWaitForPageWithoutDateRange } from '../tasks/login';
-import { closeTimeline, deleteTimeline, goToCorrelationTab, goToNotesTab, setKibanaTimezoneToUTC } from '../tasks/timeline';
+import {
+  closeTimeline,
+  deleteTimeline,
+  goToCorrelationTab,
+  goToNotesTab,
+  setKibanaTimezoneToUTC,
+} from '../tasks/timeline';
 import { expandNotes, importTimeline, openTimeline } from '../tasks/timelines';
 
 import { TIMELINES_URL } from '../urls/navigation';

--- a/x-pack/plugins/security_solution/cypress/upgrade_integration/import_timeline.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/upgrade_integration/import_timeline.spec.ts
@@ -38,7 +38,7 @@ import {
 } from '../screens/timelines';
 
 import { loginAndWaitForPageWithoutDateRange } from '../tasks/login';
-import { closeTimeline, deleteTimeline, goToCorrelationTab, goToNotesTab } from '../tasks/timeline';
+import { closeTimeline, deleteTimeline, goToCorrelationTab, goToNotesTab, setKibanaTimezoneToUTC } from '../tasks/timeline';
 import { expandNotes, importTimeline, openTimeline } from '../tasks/timelines';
 
 import { TIMELINES_URL } from '../urls/navigation';
@@ -47,9 +47,9 @@ const timeline = '7_15_timeline.ndjson';
 const username = 'elastic';
 
 const timelineDetails = {
-  dateStart: 'Oct 11, 2020 @ 00:00:00.000',
-  dateEnd: 'Oct 11, 2030 @ 17:13:15.851',
-  queryTab: 'Query2',
+  dateStart: 'Oct 10, 2020 @ 22:00:00.000',
+  dateEnd: 'Oct 11, 2030 @ 15:13:15.851',
+  queryTab: 'Query4',
   correlationTab: 'Correlation',
   analyzerTab: 'Analyzer',
   notesTab: 'Notes2',
@@ -57,7 +57,6 @@ const timelineDetails = {
 };
 
 const detectionAlert = {
-  timestamp: 'Nov 17, 2021 @ 09:36:25.499',
   message: '—',
   eventCategory: 'file',
   eventAction: 'initial_scan',
@@ -68,7 +67,7 @@ const detectionAlert = {
 };
 
 const event = {
-  timestamp: 'Nov 4, 2021 @ 11:09:29.438',
+  timestamp: 'Nov 4, 2021 @ 10:09:29.438',
   message: '—',
   eventCategory: 'file',
   eventAction: 'initial_scan',
@@ -82,6 +81,7 @@ describe('Import timeline after upgrade', () => {
   before(() => {
     loginAndWaitForPageWithoutDateRange(TIMELINES_URL);
     importTimeline(timeline);
+    setKibanaTimezoneToUTC();
   });
 
   after(() => {
@@ -142,7 +142,6 @@ describe('Import timeline after upgrade', () => {
       cy.get(NOTES_TAB_BUTTON).should('have.text', timelineDetails.notesTab);
       cy.get(PINNED_TAB_BUTTON).should('have.text', timelineDetails.pinnedTab);
 
-      cy.get(QUERY_EVENT_TABLE_CELL).eq(0).should('contain', detectionAlert.timestamp);
       cy.get(QUERY_EVENT_TABLE_CELL).eq(1).should('contain', detectionAlert.message);
       cy.get(QUERY_EVENT_TABLE_CELL).eq(2).should('contain', detectionAlert.eventCategory);
       cy.get(QUERY_EVENT_TABLE_CELL).eq(3).should('contain', detectionAlert.eventAction);


### PR DESCRIPTION
These tests have been failing for awhile on 7.17.x upgrade testing.  Since the tests fail for each upgrade path it sums around 50+ failures and it makes it hard to analyze the upgrade test failures.  

These fixes pass all tests in my local testing environment against one upgrade path, after merging I will run in CI if any other updates are needed for the other paths, this should however fix the bulk/if not all the failures.  I will create a separate PR for the 8.x fixes, since the code base is different. 

- Added a method to set the kibana time zone to UTC in advanced settings ```setKibanaTimezoneToUTC()```, since the data being imported is in UTC.
- Fixed some value verification to match what is imported from file: ```7_15_timeline.ndjson``` for rule ```runsEvery``` and ```lookBack``` fields.
- Updated the time range values that are being verified to UTC.
- Removed detection alert time stamp verification since it appears to be dynamic (looks like it takes import time). 

Relates to: https://github.com/elastic/elastic-stack-testing/issues/1075
