### PR TITLE
[7.17] [DOCS] Adds missing `monitoring.cluster_alerts.email_notifications.enabled` setting (#127323)

### DIFF
--- a/docs/settings/monitoring-settings.asciidoc
+++ b/docs/settings/monitoring-settings.asciidoc
@@ -29,6 +29,10 @@ For more information, see
 [[monitoring-general-settings]]
 ==== General monitoring settings
 
+`monitoring.cluster_alerts.email_notifications.enabled`::
+deprecated:[7.11.0] 
+When enabled, sends email notifications for Watcher alerts to the specified email address. The default is `true`. 
+
 `monitoring.cluster_alerts.email_notifications.email_address` {ess-icon}::
 deprecated:[7.11.0] 
 When enabled, specifies the email address where you want to receive cluster alert notifications.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[DOCS] Adds missing `monitoring.cluster_alerts.email_notifications.enabled` setting (#127323)](https://github.com/elastic/kibana/pull/127323)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)