### PR TITLE
[WIP] Isolate DataView code to the Kibana service implementation

### DIFF
--- a/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.tsx
+++ b/src/plugins/shared_ux/public/components/empty_state/no_data_views/no_data_views.tsx
@@ -8,18 +8,14 @@
 
 import React, { useCallback, useEffect, useRef } from 'react';
 
-import { DataView } from '../../../../../data_views/public';
 import { useEditors, usePermissions } from '../../../services';
-import type { SharedUXEditorsService } from '../../../services/editors';
 
 import { NoDataViews as NoDataViewsComponent } from './no_data_views.component';
 
 export interface Props {
-  onDataViewCreated: (dataView: DataView) => void;
+  onDataViewCreated: (dataView: unknown) => void;
   dataViewsDocLink: string;
 }
-
-type CloseDataViewEditorFn = ReturnType<SharedUXEditorsService['openDataViewEditor']>;
 
 /**
  * A service-enabled component that provides Kibana-specific functionality to the `NoDataViews`
@@ -33,13 +29,11 @@ type CloseDataViewEditorFn = ReturnType<SharedUXEditorsService['openDataViewEdit
 export const NoDataViews = ({ onDataViewCreated, dataViewsDocLink }: Props) => {
   const { canCreateNewDataView } = usePermissions();
   const { openDataViewEditor } = useEditors();
-  const closeDataViewEditor = useRef<CloseDataViewEditorFn>();
+  const closeDataViewEditor = useRef(() => {});
 
   useEffect(() => {
     const cleanup = () => {
-      if (closeDataViewEditor?.current) {
-        closeDataViewEditor?.current();
-      }
+      closeDataViewEditor.current();
     };
 
     return () => {
@@ -48,7 +42,7 @@ export const NoDataViews = ({ onDataViewCreated, dataViewsDocLink }: Props) => {
     };
   }, []);
 
-  const setDataViewEditorRef = useCallback((ref: CloseDataViewEditorFn) => {
+  const setDataViewEditorRef = useCallback((ref) => {
     closeDataViewEditor.current = ref;
   }, []);
 

--- a/src/plugins/shared_ux/public/services/editors.ts
+++ b/src/plugins/shared_ux/public/services/editors.ts
@@ -5,11 +5,11 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { DataView } from '../../../data_views/common';
 
-export interface SharedUxDataViewEditorProps {
-  onSave: (dataView: DataView) => void;
+export interface DataViewEditorOptions<TDataView extends unknown = unknown> {
+  onSave: (dataView: TDataView) => void;
 }
-export interface SharedUXEditorsService {
-  openDataViewEditor: (options: SharedUxDataViewEditorProps) => () => void;
+
+export interface SharedUXEditorsService<TDataView extends unknown = unknown> {
+  openDataViewEditor: (options: DataViewEditorOptions<TDataView>) => () => void;
 }

--- a/src/plugins/shared_ux/public/services/kibana/editors.ts
+++ b/src/plugins/shared_ux/public/services/kibana/editors.ts
@@ -6,12 +6,14 @@
  * Side Public License, v 1.
  */
 
-import { KibanaPluginServiceFactory } from '../types';
-import { SharedUXEditorsService } from '../editors';
-import { SharedUXPluginStartDeps } from '../../types';
+import type { DataView } from 'src/plugins/data_views/common';
+
+import type { SharedUXPluginStartDeps } from '../../types';
+import type { KibanaPluginServiceFactory } from '../types';
+import type { SharedUXEditorsService } from '../editors';
 
 export type EditorsServiceFactory = KibanaPluginServiceFactory<
-  SharedUXEditorsService,
+  SharedUXEditorsService<DataView>,
   SharedUXPluginStartDeps
 >;
 

--- a/src/plugins/shared_ux/public/services/storybook/editors.ts
+++ b/src/plugins/shared_ux/public/services/storybook/editors.ts
@@ -8,7 +8,7 @@
 
 import { action } from '@storybook/addon-actions';
 import { PluginServiceFactory } from '../types';
-import { SharedUxDataViewEditorProps, SharedUXEditorsService } from '../editors';
+import { SharedUXEditorsService } from '../editors';
 
 export type SharedUXEditorsServiceFactory = PluginServiceFactory<SharedUXEditorsService>;
 
@@ -16,7 +16,5 @@ export type SharedUXEditorsServiceFactory = PluginServiceFactory<SharedUXEditors
  * A factory function for creating a storybook implementation of `SharedUXEditorsService`.
  */
 export const editorsServiceFactory: SharedUXEditorsServiceFactory = () => ({
-  openDataViewEditor: action('openEditor') as SharedUXEditorsService['openDataViewEditor'] as (
-    options: SharedUxDataViewEditorProps
-  ) => () => void,
+  openDataViewEditor: action('openEditor') as SharedUXEditorsService['openDataViewEditor'],
 });


### PR DESCRIPTION
## Summary

This is a WIP/draft to isolate the use of `DataView` and `startPlugins.dataViewEditor.openEditor` to the `kibana` implementation of the service.

## Why?

I'm going to be moving components and services to packages, and in order to do that, I have to isolate the Kibana implementations of our service abstractions so the components can exist in isolation themselves.

## Open Questions

The only way I can get the `EditorsServiceFactory` to accept the method from `startPlugins.dataViewEditor` is to create a generic and default it to `unknown`.  I'm curious if there's a better, cleaner way to do this...?
