### PR TITLE
[Actionable Observability] link to old rules page if rules flag is disabled

### DIFF
--- a/x-pack/plugins/observability/public/hooks/create_use_rules_link.ts
+++ b/x-pack/plugins/observability/public/hooks/create_use_rules_link.ts
@@ -15,7 +15,7 @@ export function createUseRulesLink(isNewRuleManagementEnabled = false) {
         }
       : {
           app: 'management',
-          pathname: '/insightsAndAlerting/triggersActions/alerts',
+          pathname: '/insightsAndAlerting/triggersActions/rules',
         };
     return useLinkProps(linkProps, options);
   };

--- a/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
@@ -140,7 +140,7 @@ function AlertsPage() {
 
   const manageRulesHref = config.unsafe.rules.enabled
     ? prepend('/app/observability/rules')
-    : prepend('/insightsAndAlerting/triggersActions/alerts');
+    : prepend('/app/management/insightsAndAlerting/triggersActions/rules');
 
   const dynamicIndexPatternsAsyncState = useAsync(async (): Promise<DataViewBase[]> => {
     if (indexNames.length === 0) {

--- a/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
@@ -138,7 +138,7 @@ function AlertsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const manageRulesHref = config.unsafe.rules
+  const manageRulesHref = config.unsafe.rules.enabled
     ? prepend('/app/observability/rules')
     : prepend('/insightsAndAlerting/triggersActions/alerts');
 

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -15744,7 +15744,6 @@
     "xpack.ml.management.jobsList.noPermissionToAccessLabel": "Accès refusé",
     "xpack.ml.management.jobsList.syncFlyoutButton": "Synchroniser les objets enregistrés",
     "xpack.ml.management.jobsListTitle": "Tâches de Machine Learning",
-    "xpack.ml.management.jobsSpacesList.objectNoun": "tâche",
     "xpack.ml.management.jobsSpacesList.updateSpaces.error": "Erreur lors de la mise à jour de {id}",
     "xpack.ml.management.syncSavedObjectsFlyout.closeButton": "Fermer",
     "xpack.ml.management.syncSavedObjectsFlyout.datafeedsAdded.description": "Si des objets enregistrés n'ont pas d'ID de flux de données pour les tâches de détection des anomalies, l'ID sera ajouté.",


### PR DESCRIPTION
This PR fixes the `Manage Rules` link in the Alerts page.

### ACCs

- if `xpack.observability.unsafe.rules.enabled: false` Manage Rules link in the Alerts page should link to the old Rule Management Page
-  if `xpack.observability.unsafe.rules.enabled: true` Manage Rules link in the Alerts page should link to the new Rule Management Page
