### PR TITLE
[Cases] Pass owner to the getRelatedCases API

### DIFF
--- a/x-pack/plugins/cases/README.md
+++ b/x-pack/plugins/cases/README.md
@@ -115,6 +115,14 @@ Arguments
 | Property | Description  | Type   |
 | -------- | ------------ | ------ |
 | alertId  | The alert ID | string |
+| query    | The alert ID | object |
+
+`query`
+
+| Property | Description                                                                                                                       | Type                            |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| owner    | The type of cases to retrieve given an alert ID. If no owner is provided, all cases that the user has access to will be returned. | string \| string[] \| undefined |
+
 
 Response
 

--- a/x-pack/plugins/cases/public/client/api/index.test.ts
+++ b/x-pack/plugins/cases/public/client/api/index.test.ts
@@ -35,5 +35,12 @@ describe('createClientAPI', () => {
         query: { owner: 'test' },
       });
     });
+
+    it('should accept an empty object with no owner', async () => {
+      await api.getRelatedCases('alert-id', {});
+      expect(http.get).toHaveBeenCalledWith('/api/cases/alerts/alert-id', {
+        query: {},
+      });
+    });
   });
 });

--- a/x-pack/plugins/cases/public/client/api/index.test.ts
+++ b/x-pack/plugins/cases/public/client/api/index.test.ts
@@ -26,12 +26,14 @@ describe('createClientAPI', () => {
     http.get.mockResolvedValue(res);
 
     it('should return the correct response', async () => {
-      expect(await api.getRelatedCases('alert-id')).toEqual(res);
+      expect(await api.getRelatedCases('alert-id', { owner: 'test' })).toEqual(res);
     });
 
     it('should have been called with the correct path', async () => {
-      await api.getRelatedCases('alert-id');
-      expect(http.get).toHaveBeenCalledWith('/api/cases/alerts/alert-id');
+      await api.getRelatedCases('alert-id', { owner: 'test' });
+      expect(http.get).toHaveBeenCalledWith('/api/cases/alerts/alert-id', {
+        query: { owner: 'test' },
+      });
     });
   });
 });

--- a/x-pack/plugins/cases/public/client/api/index.ts
+++ b/x-pack/plugins/cases/public/client/api/index.ts
@@ -6,11 +6,15 @@
  */
 
 import { HttpStart } from 'kibana/public';
-import { CasesByAlertId, getCasesFromAlertsUrl } from '../../../common/api';
+import { CasesByAlertId, CasesByAlertIDRequest, getCasesFromAlertsUrl } from '../../../common/api';
+import { CasesUiStart } from '../../types';
 
-export const createClientAPI = ({ http }: { http: HttpStart }) => {
+export const createClientAPI = ({ http }: { http: HttpStart }): CasesUiStart['api'] => {
   return {
-    getRelatedCases: async (alertId: string): Promise<CasesByAlertId> =>
-      http.get<CasesByAlertId>(getCasesFromAlertsUrl(alertId)),
+    getRelatedCases: async (
+      alertId: string,
+      query: CasesByAlertIDRequest
+    ): Promise<CasesByAlertId> =>
+      http.get<CasesByAlertId>(getCasesFromAlertsUrl(alertId), { query }),
   };
 };

--- a/x-pack/plugins/cases/public/types.ts
+++ b/x-pack/plugins/cases/public/types.ts
@@ -20,7 +20,12 @@ import type { LensPublicStart } from '../../lens/public';
 import type { SecurityPluginSetup } from '../../security/public';
 import type { SpacesPluginStart } from '../../spaces/public';
 import type { TriggersAndActionsUIPublicPluginStart as TriggersActionsStart } from '../../triggers_actions_ui/public';
-import { CasesByAlertId, CommentRequestAlertType, CommentRequestUserType } from '../common/api';
+import {
+  CasesByAlertId,
+  CasesByAlertIDRequest,
+  CommentRequestAlertType,
+  CommentRequestUserType,
+} from '../common/api';
 import { UseCasesAddToExistingCaseModal } from './components/all_cases/selector_modal/use_cases_add_to_existing_case_modal';
 import { UseCasesAddToNewCaseFlyout } from './components/create/flyout/use_cases_add_to_new_case_flyout';
 import type { CasesOwners } from './client/helpers/can_use_cases';
@@ -68,7 +73,7 @@ export interface RenderAppProps {
 
 export interface CasesUiStart {
   api: {
-    getRelatedCases: (alertId: string) => Promise<CasesByAlertId>;
+    getRelatedCases: (alertId: string, query: CasesByAlertIDRequest) => Promise<CasesByAlertId>;
   };
   ui: {
     /**

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -15744,7 +15744,6 @@
     "xpack.ml.management.jobsList.noPermissionToAccessLabel": "Accès refusé",
     "xpack.ml.management.jobsList.syncFlyoutButton": "Synchroniser les objets enregistrés",
     "xpack.ml.management.jobsListTitle": "Tâches de Machine Learning",
-    "xpack.ml.management.jobsSpacesList.objectNoun": "tâche",
     "xpack.ml.management.jobsSpacesList.updateSpaces.error": "Erreur lors de la mise à jour de {id}",
     "xpack.ml.management.syncSavedObjectsFlyout.closeButton": "Fermer",
     "xpack.ml.management.syncSavedObjectsFlyout.datafeedsAdded.description": "Si des objets enregistrés n'ont pas d'ID de flux de données pour les tâches de détection des anomalies, l'ID sera ajouté.",


### PR DESCRIPTION
## Summary

PR https://github.com/elastic/kibana/pull/127065 introduced the `getRelatedCases` API function. This PR fixes a bug where the owner were not passing to the query.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
