### PR TITLE
[Fleet] Fix links to Agent logs for apm, endpoint, synthetics, osquery

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_type_utils.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_type_utils.ts
@@ -11,6 +11,10 @@ import {
   STATE_DATASET_FIELD,
   AGENT_DATASET_FILEBEAT,
   AGENT_DATASET_METRICBEAT,
+  AGENT_DATASET_APM_SERVER,
+  AGENT_DATASET_ENDPOINT_SECURITY,
+  AGENT_DATASET_OSQUERYBEAT,
+  AGENT_DATASET_HEARTBEAT,
 } from '../agent_logs/constants';
 
 export function displayInputType(inputType: string): string {
@@ -39,6 +43,18 @@ export function getLogsQueryByInputType(inputType: string) {
   }
   if (inputType.match(/\/metrics$/)) {
     return `(${STATE_DATASET_FIELD}:!(${AGENT_DATASET_METRICBEAT}))`;
+  }
+  if (inputType === 'osquery') {
+    return `(${STATE_DATASET_FIELD}:!(${AGENT_DATASET_OSQUERYBEAT}))`;
+  }
+  if (inputType.match(/^synthetics\//)) {
+    return `(${STATE_DATASET_FIELD}:!(${AGENT_DATASET_HEARTBEAT}))`;
+  }
+  if (inputType === 'apm') {
+    return `(${STATE_DATASET_FIELD}:!(${AGENT_DATASET_APM_SERVER}))`;
+  }
+  if (inputType === 'endpoint') {
+    return `(${STATE_DATASET_FIELD}:!(${AGENT_DATASET_ENDPOINT_SECURITY}))`;
   }
 
   return '';

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/constants.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/constants.tsx
@@ -11,6 +11,10 @@ export const AGENT_LOG_INDEX_PATTERN = 'logs-elastic_agent-*,logs-elastic_agent.
 export const AGENT_DATASET = 'elastic_agent';
 export const AGENT_DATASET_FILEBEAT = 'elastic_agent.filebeat';
 export const AGENT_DATASET_METRICBEAT = 'elastic_agent.metricbeat';
+export const AGENT_DATASET_OSQUERYBEAT = 'elastic_agent.osquerybeat';
+export const AGENT_DATASET_HEARTBEAT = 'elastic_agent.heartbeat';
+export const AGENT_DATASET_APM_SERVER = 'elastic_agent.apm_server';
+export const AGENT_DATASET_ENDPOINT_SECURITY = 'elastic_agent.endpoint_security';
 export const AGENT_DATASET_PATTERN = 'elastic_agent.*';
 export const AGENT_ID_FIELD = {
   name: 'elastic_agent.id',


### PR DESCRIPTION
## Summary

This fixes the "View logs" button on the Agent detail view to link to the filtered view for the following integrations:
- APM
- Synthetics
- Endpoint
- OSQuery

<img width="623" alt="image" src="https://user-images.githubusercontent.com/1813008/157699712-c6da901c-a850-4395-8888-bfdf2308e194.png">

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/1813008/157699694-32e4dd32-95f1-4201-950d-ca85222824a4.png">