### PR TITLE
[Fleet] Improve handling of frozen variables

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -4247,6 +4247,9 @@
           },
           "description": {
             "type": "string"
+          },
+          "force": {
+            "type": "boolean"
           }
         },
         "required": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2676,6 +2676,8 @@ components:
           type: string
         description:
           type: string
+        force:
+          type: boolean
       required:
         - name
         - namespace

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/update_package_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/update_package_policy.yaml
@@ -53,6 +53,8 @@ properties:
     type: string
   description:
     type: string
+  force:
+    type: boolean
 required:
   - name
   - namespace

--- a/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
@@ -139,7 +139,7 @@ export const updatePackagePolicyHandler: RequestHandler<
     throw Boom.notFound('Package policy not found');
   }
 
-  const body = { ...request.body };
+  const { force, ...body } = request.body;
   // removed fields not recognized by schema
   const packagePolicyInputs = packagePolicy.inputs.map((input) => {
     const newInput = {
@@ -180,7 +180,7 @@ export const updatePackagePolicyHandler: RequestHandler<
       esClient,
       request.params.packagePolicyId,
       newData,
-      { user },
+      { user, force },
       packagePolicy.package?.version
     );
     return response.ok({

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { omit, partition } from 'lodash';
+import { omit, partition, isEqual } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import semverLt from 'semver/functions/lt';
 import { getFlattenedObject } from '@kbn/std';
@@ -358,7 +358,7 @@ class PackagePolicyService implements PackagePolicyServiceInterface {
     esClient: ElasticsearchClient,
     id: string,
     packagePolicyUpdate: UpdatePackagePolicy,
-    options?: { user?: AuthenticatedUser },
+    options?: { user?: AuthenticatedUser; force?: boolean },
     currentVersion?: string
   ): Promise<PackagePolicy> {
     const packagePolicy = { ...packagePolicyUpdate, name: packagePolicyUpdate.name.trim() };
@@ -386,7 +386,7 @@ class PackagePolicyService implements PackagePolicyServiceInterface {
       assignStreamIdToInput(oldPackagePolicy.id, input)
     );
 
-    inputs = enforceFrozenInputs(oldPackagePolicy.inputs, inputs);
+    inputs = enforceFrozenInputs(oldPackagePolicy.inputs, inputs, options?.force);
     let elasticsearch: PackagePolicy['elasticsearch'];
     if (packagePolicy.package?.name) {
       const pkgInfo = await getPackageInfo({
@@ -1119,21 +1119,25 @@ async function _compilePackageStream(
   return { ...stream };
 }
 
-function enforceFrozenInputs(oldInputs: PackagePolicyInput[], newInputs: PackagePolicyInput[]) {
+function enforceFrozenInputs(
+  oldInputs: PackagePolicyInput[],
+  newInputs: PackagePolicyInput[],
+  force = false
+) {
   const resultInputs = [...newInputs];
 
   for (const input of resultInputs) {
     const oldInput = oldInputs.find((i) => i.type === input.type);
     if (oldInput?.keep_enabled) input.enabled = oldInput.enabled;
     if (input.vars && oldInput?.vars) {
-      input.vars = _enforceFrozenVars(oldInput.vars, input.vars);
+      input.vars = _enforceFrozenVars(oldInput.vars, input.vars, force);
     }
     if (input.streams && oldInput?.streams) {
       for (const stream of input.streams) {
         const oldStream = oldInput.streams.find((s) => s.id === stream.id);
         if (oldStream?.keep_enabled) stream.enabled = oldStream.enabled;
         if (stream.vars && oldStream?.vars) {
-          stream.vars = _enforceFrozenVars(oldStream.vars, stream.vars);
+          stream.vars = _enforceFrozenVars(oldStream.vars, stream.vars, force);
         }
       }
     }
@@ -1144,12 +1148,21 @@ function enforceFrozenInputs(oldInputs: PackagePolicyInput[], newInputs: Package
 
 function _enforceFrozenVars(
   oldVars: Record<string, PackagePolicyConfigRecordEntry>,
-  newVars: Record<string, PackagePolicyConfigRecordEntry>
+  newVars: Record<string, PackagePolicyConfigRecordEntry>,
+  force = false
 ) {
   const resultVars: Record<string, PackagePolicyConfigRecordEntry> = {};
   for (const [key, val] of Object.entries(newVars)) {
     if (oldVars[key]?.frozen) {
-      resultVars[key] = oldVars[key];
+      if (force) {
+        resultVars[key] = val;
+      } else if (!isEqual(oldVars[key].value, val.value) || oldVars[key].type !== val.type) {
+        throw new PackagePolicyValidationError(
+          `${key} is a frozen variable and cannot be modified`
+        );
+      } else {
+        resultVars[key] = oldVars[key];
+      }
     } else {
       resultVars[key] = val;
     }
@@ -1206,7 +1219,7 @@ export interface PackagePolicyServiceInterface {
     esClient: ElasticsearchClient,
     id: string,
     packagePolicyUpdate: UpdatePackagePolicy,
-    options?: { user?: AuthenticatedUser },
+    options?: { user?: AuthenticatedUser; force?: boolean },
     currentVersion?: string
   ): Promise<PackagePolicy>;
 

--- a/x-pack/plugins/fleet/server/types/models/package_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/package_policy.ts
@@ -138,6 +138,7 @@ export const UpdatePackagePolicyRequestBodySchema = schema.object({
     )
   ),
   version: schema.maybe(schema.string()),
+  force: schema.maybe(schema.boolean()),
 });
 
 export const UpdatePackagePolicySchema = schema.object({


### PR DESCRIPTION
## Description

Resolve #124543

Improve handling of frozen variables when updating a package policy: 
* we now throw when the user modify a frozen variable 
* a user can modify a frozen variable by providing the `force: true` flag in the update request

## How to test


This change is tested with unit test, you can manually test it  with the following kibana config and curl calls

```yaml
xpack.fleet.agentPolicies:
  # Cloud Agent policy
  - name: Elastic Cloud agent policy 00123123
    id: 'test123'
    description: Default agent policy for agents hosted on Elastic Cloud
    is_default: false
    is_default_fleet_server: false
    is_managed: false
    namespace: default
    monitoring_enabled: []
    package_policies:
      - name: fleet_server123456789
        id: elastic-fleet-server
        package:
          name: fleet_server
        inputs:
          - type: fleet-server
            keep_enabled: true
            vars:
              - name: host
                value: 127.0.0.1
                frozen: true
xpack.fleet.packages:
- name: system
  version: latest
- name: elastic_agent
  version: latest
- name: fleet_server
  version: latest
```



```
curl --request PUT \
  --url http://localhost:5601/api/fleet/package_policies/elastic-fleet-server \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: xxxxx' \
  --data '{
	"name": "fleet_server123456789",
	"namespace": "default",
	"package": {
		"name": "fleet_server",
		"title": "Fleet Server",
		"version": "1.1.1"
	},
	"enabled": true,
	"policy_id": "test123",
	"output_id": "testlogstash",
	"inputs": [
		{
			"type": "fleet-server",
			"policy_template": "fleet_server",
			"enabled": true,
			"keep_enabled": true,
			"streams": [],
			"vars": {
				"host": {
					"value": "127.0.0.3",
					"type": "text",
					"frozen": true
				},
				"port": {
					"value": [
						8220
					],
					"type": "integer"
				},
				"max_connections": {
					"type": "integer"
				},
				"custom": {
					"value": "",
					"type": "yaml"
				}
			}
		}
	],
	"description": "test",
	"force": true
}'
```


