### PR TITLE
[bk/flaky] fix env var for reusing artifacts

### DIFF
--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -116,7 +116,7 @@ steps.push({
   label: 'Build Kibana Distribution and Plugins',
   agents: { queue: 'c2-8' },
   key: 'build',
-  if: "build.env('BUILD_ID_FOR_ARTIFACTS') == null || build.env('BUILD_ID_FOR_ARTIFACTS') == ''",
+  if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''",
 });
 
 for (const testSuite of testSuites) {


### PR DESCRIPTION
I'm guessing that `BUILD_ID_FOR_ARTIFACTS` is an old env var that we don't use anymore, but `KIBANA_BUILD_ID` is the env var expected by `.buildkite/scripts/download_build_artifacts.sh` so we should also gate the build step on this environment var.