### PR TITLE
[data view mgmt] fix privileges problem for field preview

### DIFF
--- a/src/plugins/data_view_field_editor/__jest__/client_integration/field_editor_flyout_preview.test.ts
+++ b/src/plugins/data_view_field_editor/__jest__/client_integration/field_editor_flyout_preview.test.ts
@@ -302,7 +302,7 @@ describe('Field editor Preview panel', () => {
           title: 'First doc - title',
         },
         documentId: '001',
-        index: 'testIndex',
+        index: 'testIndexPattern',
         script: {
           source: 'echo("hello")',
         },

--- a/src/plugins/data_view_field_editor/public/components/preview/field_preview_context.tsx
+++ b/src/plugins/data_view_field_editor/public/components/preview/field_preview_context.tsx
@@ -333,7 +333,7 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
     const currentApiCall = ++previewCount.current;
 
     const response = await getFieldPreview({
-      index: currentDocIndex!,
+      index: dataView.title,
       document: document!,
       context: `${type!}_field` as PainlessExecuteContext,
       script: script!,
@@ -384,7 +384,6 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
     type,
     script,
     document,
-    currentDocIndex,
     currentDocId,
     getFieldPreview,
     notifications.toasts,
@@ -392,6 +391,7 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
     allParamsDefined,
     scriptEditorValidation,
     hasSomeParamsChanged,
+    dataView.title,
   ]);
 
   const goToNextDoc = useCallback(() => {


### PR DESCRIPTION
## Summary

In situations where a user has access to a specific set of indices they might see errors on preview when creating a runtime field.

Steps to reproduce:

1) Create an alias that points to an existing index or data stream.
2) Create a user and role that has access only to the alias but otherwise has full privileges. 
3) Create a data view and add a runtime field. You should be able to see a preview of a runtime field without seeing an error.

Closes: https://github.com/elastic/kibana/issues/123861

## Release Notes

Resolves errors seen when creating a runtime field with a user that has access to a limit set of indices.