### PR TITLE
[8.0] [data view mgmt] fix privileges problem for field preview (#127523)

### DIFF
--- a/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor_flyout_preview.test.ts
+++ b/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor_flyout_preview.test.ts
@@ -367,7 +367,7 @@ describe('Field editor Preview panel', () => {
           title: 'First doc - title',
         },
         documentId: '001',
-        index: 'testIndex',
+        index: 'testIndexPattern',
         script: {
           source: 'echo("hello")',
         },

--- a/src/plugins/index_pattern_field_editor/public/components/preview/field_preview_context.tsx
+++ b/src/plugins/index_pattern_field_editor/public/components/preview/field_preview_context.tsx
@@ -167,7 +167,6 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
     [documents, currentIdx]
   );
 
-  const currentDocIndex = currentDocument?._index;
   const currentDocId: string = currentDocument?._id ?? '';
   const totalDocs = documents.length;
   const { name, document, script, format, type } = params;
@@ -334,7 +333,7 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
     const currentApiCall = ++previewCount.current;
 
     const response = await getFieldPreview({
-      index: currentDocIndex,
+      index: indexPattern.title,
       document: params.document!,
       context: `${params.type!}_field` as FieldPreviewContext,
       script: params.script!,
@@ -386,11 +385,11 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
   }, [
     needToUpdatePreview,
     params,
-    currentDocIndex,
     currentDocId,
     getFieldPreview,
     notifications.toasts,
     valueFormatter,
+    indexPattern.title,
   ]);
 
   const goToNextDoc = useCallback(() => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[data view mgmt] fix privileges problem for field preview (#127523)](https://github.com/elastic/kibana/pull/127523)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)