### PR TITLE
[plugin-helpers] Skip build.test.ts log matching on ci-stats service

### DIFF
--- a/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
@@ -43,8 +43,14 @@ it('builds a generated plugin into a viable archive', async () => {
       all: true,
     }
   );
+  const filterLogs = (logs: string | undefined) => {
+    return logs
+      ?.split('\n')
+      .filter((l) => !l.includes('failed to reach ci-stats service'))
+      .join('\n');
+  };
 
-  expect(generateProc.all).toMatchInlineSnapshot(`
+  expect(filterLogs(generateProc.all)).toMatchInlineSnapshot(`
     " succ 🎉
 
           Your plugin has been created in plugins/foo_test_plugin
@@ -60,12 +66,7 @@ it('builds a generated plugin into a viable archive', async () => {
     }
   );
 
-  expect(
-    buildProc.all
-      ?.split('\n')
-      .filter((l) => !l.includes('failed to reach ci-stats service'))
-      .join('\n')
-  ).toMatchInlineSnapshot(`
+  expect(filterLogs(buildProc.all)).toMatchInlineSnapshot(`
     " info deleting the build and target directories
      info running @kbn/optimizer
      │ info initialized, 0 bundles cached


### PR DESCRIPTION
This copies the fix over from
https://github.com/elastic/kibana/pull/123510 to be used in both
plugin-helpers build calls.

Closes #89079

I verified this by appending `127.0.0.1 ci-stats.kibana.dev` in `/etc/hosts` and running `node scripts/jest_integration.js packages/kbn-plugin-helpers/src/integration_tests/build.test.ts`.  The tests pass successfully, however the jest process remains open until the ci-stats calls give up after 50 seconds.