### PR TITLE
[8.1] [Upgrade Assistant] Update status API response (#126482) (#126620)

### DIFF
--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -28802,7 +28802,6 @@
     "xpack.upgradeAssistant.overview.whatsNewLink": "8.xの新機能",
     "xpack.upgradeAssistant.reindex.reindexPrivilegesErrorBatch": "「{indexName}」に再インデックスするための権限が不十分です。",
     "xpack.upgradeAssistant.status.allDeprecationsResolvedMessage": "すべての廃止予定の警告が解決されました。",
-    "xpack.upgradeAssistant.status.deprecationsUnresolvedMessage": "アップグレード前に移行が必要な{notMigratedSystemIndices}システム{notMigratedSystemIndices, plural, other  {インデックス}}と、解決が必要な{esTotalCriticalDeps} Elasticsearch廃止予定{esTotalCriticalDeps, plural, other  {問題}}および{kibanaTotalCriticalDeps} Kibana廃止予定{kibanaTotalCriticalDeps, plural, other  {問題}}があります。",
     "xpack.upgradeAssistant.upgradedDescription": "すべての Elasticsearch ノードがアップグレードされました。Kibana をアップデートする準備ができました。",
     "xpack.upgradeAssistant.upgradedTitle": "クラスターがアップグレードされました",
     "xpack.upgradeAssistant.upgradingDescription": "1 つまたは複数の Elasticsearch ノードに、 Kibana よりも新しいバージョンの Elasticsearch があります。すべてのノードがアップグレードされた後で Kibana をアップグレードしてください。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -28835,7 +28835,6 @@
     "xpack.upgradeAssistant.overview.whatsNewLink": "8.x 版新增功能",
     "xpack.upgradeAssistant.reindex.reindexPrivilegesErrorBatch": "您没有足够的权限重新索引“{indexName}”。",
     "xpack.upgradeAssistant.status.allDeprecationsResolvedMessage": "所有弃用警告均已解决。",
-    "xpack.upgradeAssistant.status.deprecationsUnresolvedMessage": "您具有 {notMigratedSystemIndices} 个必须迁移的系统{notMigratedSystemIndices, plural, other {索引}}以及 {esTotalCriticalDeps} 个 Elasticsearch 弃用{esTotalCriticalDeps, plural, other {问题}}和 {kibanaTotalCriticalDeps} 个 Kibana 弃用{kibanaTotalCriticalDeps, plural, other {问题}}，必须解决它们才能进行升级。",
     "xpack.upgradeAssistant.upgradedDescription": "所有 Elasticsearch 节点已升级。可以现在升级 Kibana。",
     "xpack.upgradeAssistant.upgradedTitle": "您的集群已升级",
     "xpack.upgradeAssistant.upgradingDescription": "一个或多个 Elasticsearch 节点的 Elasticsearch 版本比 Kibana 版本新。所有节点升级后，请升级 Kibana。",

--- a/x-pack/plugins/upgrade_assistant/server/routes/status.test.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/status.test.ts
@@ -121,8 +121,7 @@ describe('Status API', () => {
       expect(resp.payload).toEqual({
         readyForUpgrade: false,
         details:
-          'You have 0 system indices that must be migrated and ' +
-          '1 Elasticsearch deprecation issue and 1 Kibana deprecation issue that must be resolved before upgrading.',
+          'The following issues must be resolved before upgrading: 1 Elasticsearch deprecation issue, 1 Kibana deprecation issue.',
       });
     });
 
@@ -144,8 +143,7 @@ describe('Status API', () => {
       expect(resp.payload).toEqual({
         readyForUpgrade: false,
         details:
-          'You have 1 system index that must be migrated and ' +
-          '1 Elasticsearch deprecation issue and 1 Kibana deprecation issue that must be resolved before upgrading.',
+          'The following issues must be resolved before upgrading: 1 unmigrated system index, 1 Elasticsearch deprecation issue, 1 Kibana deprecation issue.',
       });
     });
 
@@ -167,8 +165,7 @@ describe('Status API', () => {
       expect(resp.payload).toEqual({
         readyForUpgrade: false,
         details:
-          'You have 1 system index that must be migrated and ' +
-          '0 Elasticsearch deprecation issues and 0 Kibana deprecation issues that must be resolved before upgrading.',
+          'The following issues must be resolved before upgrading: 1 unmigrated system index.',
       });
     });
 

--- a/x-pack/plugins/upgrade_assistant/server/routes/status.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/status.ts
@@ -63,12 +63,44 @@ export function registerUpgradeStatusRoute({ router, lib: { handleEsError } }: R
               );
             }
 
+            const upgradeIssues: string[] = [];
+
+            if (notMigratedSystemIndices) {
+              upgradeIssues.push(
+                i18n.translate('xpack.upgradeAssistant.status.systemIndicesMessage', {
+                  defaultMessage:
+                    '{notMigratedSystemIndices} unmigrated system {notMigratedSystemIndices, plural, one {index} other {indices}}',
+                  values: { notMigratedSystemIndices },
+                })
+              );
+            }
+
+            if (esTotalCriticalDeps) {
+              upgradeIssues.push(
+                i18n.translate('xpack.upgradeAssistant.status.esTotalCriticalDepsMessage', {
+                  defaultMessage:
+                    '{esTotalCriticalDeps} Elasticsearch deprecation {esTotalCriticalDeps, plural, one {issue} other {issues}}',
+                  values: { esTotalCriticalDeps },
+                })
+              );
+            }
+
+            if (kibanaTotalCriticalDeps) {
+              upgradeIssues.push(
+                i18n.translate('xpack.upgradeAssistant.status.kibanaTotalCriticalDepsMessage', {
+                  defaultMessage:
+                    '{kibanaTotalCriticalDeps} Kibana deprecation {kibanaTotalCriticalDeps, plural, one {issue} other {issues}}',
+                  values: { kibanaTotalCriticalDeps },
+                })
+              );
+            }
+
             return i18n.translate('xpack.upgradeAssistant.status.deprecationsUnresolvedMessage', {
               defaultMessage:
-                'You have {notMigratedSystemIndices} system {notMigratedSystemIndices, plural, one {index} other {indices}} that must be migrated ' +
-                'and {esTotalCriticalDeps} Elasticsearch deprecation {esTotalCriticalDeps, plural, one {issue} other {issues}} ' +
-                'and {kibanaTotalCriticalDeps} Kibana deprecation {kibanaTotalCriticalDeps, plural, one {issue} other {issues}} that must be resolved before upgrading.',
-              values: { esTotalCriticalDeps, kibanaTotalCriticalDeps, notMigratedSystemIndices },
+                'The following issues must be resolved before upgrading: {upgradeIssues}.',
+              values: {
+                upgradeIssues: upgradeIssues.join(', '),
+              },
             });
           };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Upgrade Assistant] Update status API response (#126482) (#126620)](https://github.com/elastic/kibana/pull/126620)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)