### PR TITLE
[i18n] Correct label for source field(#127246)

### DIFF
--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -15582,7 +15582,7 @@
     "xpack.ingestPipelines.pipelineEditor.scriptForm.processorInvalidJsonError": "無効なJSON",
     "xpack.ingestPipelines.pipelineEditor.scriptForm.sourceFieldAriaLabel": "ソーススクリプトJSONエディター",
     "xpack.ingestPipelines.pipelineEditor.scriptForm.sourceFieldHelpText": "実行するインラインスクリプト。",
-    "xpack.ingestPipelines.pipelineEditor.scriptForm.sourceFieldLabel": "送信元",
+    "xpack.ingestPipelines.pipelineEditor.scriptForm.sourceFieldLabel": "ソース",
     "xpack.ingestPipelines.pipelineEditor.scriptForm.sourceRequiredError": "値が必要です。",
     "xpack.ingestPipelines.pipelineEditor.scriptForm.storedScriptIDFieldHelpText": "実行するストアドスクリプトのID。",
     "xpack.ingestPipelines.pipelineEditor.scriptForm.storedScriptIDFieldLabel": "ストアドスクリプトID",


### PR DESCRIPTION
## Summary

Japanese translation for "source" label for Script Processor is wrong. It should be "ソース" rather than "送信元". This PR changes the label as like below.

![image](https://user-images.githubusercontent.com/622436/158106424-107e9c36-1bb7-45d0-a41f-374c5c69fc2f.png)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
