### PR TITLE
[Fleet] Enable debug logs for functional tests

### DIFF
--- a/x-pack/test/fleet_api_integration/config.ts
+++ b/x-pack/test/fleet_api_integration/config.ts
@@ -67,7 +67,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         ...(registryPort ? [`--xpack.fleet.registryUrl=http://localhost:${registryPort}`] : []),
         `--xpack.fleet.developer.bundledPackageLocation=${BUNDLED_PACKAGE_DIR}`,
         // Enable debug fleet logs by default
-        `--logging.loggers=[{"name": "plugins.fleet", "level": "debug"}]`,
+        `--logging.loggers[0].name=plugins.fleet`,
+        `--logging.loggers[0].level=debug`,
+        `--logging.loggers[0].appenders=${JSON.stringify(['default'])}`,
       ],
     },
   };

--- a/x-pack/test/fleet_api_integration/config.ts
+++ b/x-pack/test/fleet_api_integration/config.ts
@@ -66,6 +66,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         `--xpack.fleet.packages.0.version=latest`,
         ...(registryPort ? [`--xpack.fleet.registryUrl=http://localhost:${registryPort}`] : []),
         `--xpack.fleet.developer.bundledPackageLocation=${BUNDLED_PACKAGE_DIR}`,
+        // Enable debug fleet logs by default
+        `--logging.loggers=[{"name": "plugins.fleet", "level": "debug"}]`,
       ],
     },
   };

--- a/x-pack/test/fleet_cypress/config.ts
+++ b/x-pack/test/fleet_cypress/config.ts
@@ -38,6 +38,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--csp.strict=false',
         // define custom kibana server args here
         `--elasticsearch.ssl.certificateAuthorities=${CA_CERT_PATH}`,
+        // Enable debug fleet logs by default
+        `--logging.loggers=[{"name": "plugins.fleet", "level": "debug"}]`,
       ],
     },
   };

--- a/x-pack/test/fleet_cypress/config.ts
+++ b/x-pack/test/fleet_cypress/config.ts
@@ -39,7 +39,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         // define custom kibana server args here
         `--elasticsearch.ssl.certificateAuthorities=${CA_CERT_PATH}`,
         // Enable debug fleet logs by default
-        `--logging.loggers=[{"name": "plugins.fleet", "level": "debug"}]`,
+        `--logging.loggers[0].name=plugins.fleet`,
+        `--logging.loggers[0].level=debug`,
+        `--logging.loggers[0].appenders=${JSON.stringify(['default'])}`,
       ],
     },
   };

--- a/x-pack/test/fleet_functional/config.ts
+++ b/x-pack/test/fleet_functional/config.ts
@@ -29,7 +29,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     },
     kbnTestServer: {
       ...xpackFunctionalConfig.get('kbnTestServer'),
-      serverArgs: [...xpackFunctionalConfig.get('kbnTestServer.serverArgs')],
+      serverArgs: [
+        ...xpackFunctionalConfig.get('kbnTestServer.serverArgs'),
+        // Enable debug fleet logs by default
+        `--logging.loggers=[{"name": "plugins.fleet", "level": "debug"}]`,
+      ],
     },
     layout: {
       fixedHeaderHeight: 200,

--- a/x-pack/test/fleet_functional/config.ts
+++ b/x-pack/test/fleet_functional/config.ts
@@ -32,7 +32,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...xpackFunctionalConfig.get('kbnTestServer.serverArgs'),
         // Enable debug fleet logs by default
-        `--logging.loggers=[{"name": "plugins.fleet", "level": "debug"}]`,
+        `--logging.loggers[0].name=plugins.fleet`,
+        `--logging.loggers[0].level=debug`,
+        `--logging.loggers[0].appenders=${JSON.stringify(['default'])}`,
       ],
     },
     layout: {


### PR DESCRIPTION
## Summary

Turns on debug logging for the Fleet plugin in our functional test suites. Helpful for debugging test failures both on CI and in local dev