### PR TITLE
[Cloud Posture] set max width for dashboard page, some text changes for risks table

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.tsx
@@ -37,6 +37,7 @@ export const ComplianceDashboard = () => {
       pageHeader={{
         pageTitle: TEXT.CLOUD_POSTURE,
       }}
+      restrictWidth={1600}
     >
       <CompliancePage />
     </CspPageTemplate>

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -87,7 +87,7 @@ export const BenchmarksSection = () => {
                       <EuiSpacer size="xs" />
                       <EuiText size="xs" color="subdued" style={{ textAlign: 'center' }}>
                         <EuiIcon type="clock" />
-                        {moment(cluster.meta.lastUpdate).fromNow()}
+                        {` ${moment(cluster.meta.lastUpdate).fromNow()}`}
                       </EuiText>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/translations.ts
@@ -15,8 +15,8 @@ export const CLOUD_POSTURE_SCORE = i18n.translate('xpack.csp.cloud_posture_score
   defaultMessage: 'Cloud Posture Score',
 });
 
-export const RISKS = i18n.translate('xpack.csp.risks', {
-  defaultMessage: 'Risks',
+export const RISKS = i18n.translate('xpack.csp.complianceDashboard.failedFindingsChartLabel', {
+  defaultMessage: 'Failed Findings',
 });
 
 export const OPEN_CASES = i18n.translate('xpack.csp.open_cases', {


### PR DESCRIPTION
## Summary
- Set max-width for our dashboard page
- Text changes

### Before
No max-width restriction:
![image](https://user-images.githubusercontent.com/51442161/158187694-1c0cdc46-ce75-462f-974b-82791ae7c1e6.png)


### After
Max-width set to `1600` (discussed with @einatjacoby):
![image](https://user-images.githubusercontent.com/51442161/158187496-4d76c670-5a8f-440e-a865-e6001a7bd863.png)
