### PR TITLE
[8.0] [Upgrade Assistant] Add deprecation logging as step on overview page (#126693)

### DIFF
--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -27528,12 +27528,7 @@
     "xpack.upgradeAssistant.overview.deprecationLogs.updateErrorMessage": "ログ状態を更新できませんでした。",
     "xpack.upgradeAssistant.overview.deprecationsCountCheckpointTitle": "廃止予定の問題を解決して変更を検証",
     "xpack.upgradeAssistant.overview.documentationLinkText": "ドキュメント",
-<<<<<<< HEAD
-    "xpack.upgradeAssistant.overview.esDeprecationLogsLink": "Elasticsearchの廃止予定ログ",
-    "xpack.upgradeAssistant.overview.fixIssuesStepDescription": "Elastic 8.xにアップグレードする前に、重大なElasticsearchおよびKibana構成の問題を解決する必要があります。警告を無視すると、アップグレード後に動作が変更される場合があります。{accessDeprecationLogsMessage}",
-=======
     "xpack.upgradeAssistant.overview.errorLoadingUpgradeStatus": "アップグレードステータスの取得中にエラーが発生しました",
->>>>>>> f4358d5fbd5... [Upgrade Assistant] Add deprecation logging as step on overview page (#126693)
     "xpack.upgradeAssistant.overview.fixIssuesStepTitle": "廃止予定設定を確認し、問題を解決",
     "xpack.upgradeAssistant.overview.loadingLogsLabel": "廃止予定ログ収集状態を読み込んでいます...",
     "xpack.upgradeAssistant.overview.observe.discoveryDescription": "廃止予定ログを検索およびフィルターし、必要な変更のタイプを把握します。",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -27505,7 +27505,6 @@
     "xpack.upgradeAssistant.noDeprecationsPrompt.nextStepsDescription": "他のスタック廃止予定については、{overviewButton}を確認してください。",
     "xpack.upgradeAssistant.noDeprecationsPrompt.overviewLinkText": "概要ページ",
     "xpack.upgradeAssistant.noPartialDeprecationsMessage": "なし",
-    "xpack.upgradeAssistant.overview.accessEsDeprecationLogsLabel": "Elasticsearch APIを呼び出すアプリケーションコードがある場合は、{esDeprecationLogsLink}を確認して、廃止予定のAPIを使用していないことを確かめてください。",
     "xpack.upgradeAssistant.overview.analyzeTitle": "廃止予定ログを分析",
     "xpack.upgradeAssistant.overview.apiCompatibilityNoteBody": "アップグレード前にすべての廃止予定の問題を解決することをお勧めします。必要に応じて、廃止予定の機能を使用する要求にAPI互換性ヘッダーを適用できます。{learnMoreLink}。",
     "xpack.upgradeAssistant.overview.apiCompatibilityNoteLink": "詳細",
@@ -27529,8 +27528,12 @@
     "xpack.upgradeAssistant.overview.deprecationLogs.updateErrorMessage": "ログ状態を更新できませんでした。",
     "xpack.upgradeAssistant.overview.deprecationsCountCheckpointTitle": "廃止予定の問題を解決して変更を検証",
     "xpack.upgradeAssistant.overview.documentationLinkText": "ドキュメント",
+<<<<<<< HEAD
     "xpack.upgradeAssistant.overview.esDeprecationLogsLink": "Elasticsearchの廃止予定ログ",
     "xpack.upgradeAssistant.overview.fixIssuesStepDescription": "Elastic 8.xにアップグレードする前に、重大なElasticsearchおよびKibana構成の問題を解決する必要があります。警告を無視すると、アップグレード後に動作が変更される場合があります。{accessDeprecationLogsMessage}",
+=======
+    "xpack.upgradeAssistant.overview.errorLoadingUpgradeStatus": "アップグレードステータスの取得中にエラーが発生しました",
+>>>>>>> f4358d5fbd5... [Upgrade Assistant] Add deprecation logging as step on overview page (#126693)
     "xpack.upgradeAssistant.overview.fixIssuesStepTitle": "廃止予定設定を確認し、問題を解決",
     "xpack.upgradeAssistant.overview.loadingLogsLabel": "廃止予定ログ収集状態を読み込んでいます...",
     "xpack.upgradeAssistant.overview.observe.discoveryDescription": "廃止予定ログを検索およびフィルターし、必要な変更のタイプを把握します。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -27976,7 +27976,6 @@
     "xpack.upgradeAssistant.noDeprecationsPrompt.nextStepsDescription": "查看{overviewButton}以了解其他 Stack 弃用。",
     "xpack.upgradeAssistant.noDeprecationsPrompt.overviewLinkText": "“概览”页面",
     "xpack.upgradeAssistant.noPartialDeprecationsMessage": "无",
-    "xpack.upgradeAssistant.overview.accessEsDeprecationLogsLabel": "如果有应用程序代码调用 Elasticsearch API，请复查 {esDeprecationLogsLink}以确保您未使用已弃用的 API。",
     "xpack.upgradeAssistant.overview.analyzeTitle": "分析弃用日志",
     "xpack.upgradeAssistant.overview.apiCompatibilityNoteBody": "建议您在升级之前解决所有弃用问题。如果需要，您可以将 API 兼容性标头应用于使用过时功能的请求。{learnMoreLink}。",
     "xpack.upgradeAssistant.overview.apiCompatibilityNoteLink": "了解详情",
@@ -28001,8 +28000,12 @@
     "xpack.upgradeAssistant.overview.deprecationLogs.updateErrorMessage": "无法更新日志记录状态。",
     "xpack.upgradeAssistant.overview.deprecationsCountCheckpointTitle": "解决弃用问题并验证您的更改",
     "xpack.upgradeAssistant.overview.documentationLinkText": "文档",
+<<<<<<< HEAD
     "xpack.upgradeAssistant.overview.esDeprecationLogsLink": "Elasticsearch 弃用日志",
     "xpack.upgradeAssistant.overview.fixIssuesStepDescription": "在升级到 Elastic 8.x 之前，必须解决任何严重的 Elasticsearch 和 Kibana 配置问题。在您升级后，忽略警告可能会导致行为差异。{accessDeprecationLogsMessage}",
+=======
+    "xpack.upgradeAssistant.overview.errorLoadingUpgradeStatus": "检索升级状态时出错",
+>>>>>>> f4358d5fbd5... [Upgrade Assistant] Add deprecation logging as step on overview page (#126693)
     "xpack.upgradeAssistant.overview.fixIssuesStepTitle": "复查已弃用设置并解决问题",
     "xpack.upgradeAssistant.overview.loadingLogsLabel": "正在加载弃用日志收集状态……",
     "xpack.upgradeAssistant.overview.observe.discoveryDescription": "搜索并筛选弃用日志以了解需要进行的更改类型。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -28000,12 +28000,7 @@
     "xpack.upgradeAssistant.overview.deprecationLogs.updateErrorMessage": "无法更新日志记录状态。",
     "xpack.upgradeAssistant.overview.deprecationsCountCheckpointTitle": "解决弃用问题并验证您的更改",
     "xpack.upgradeAssistant.overview.documentationLinkText": "文档",
-<<<<<<< HEAD
-    "xpack.upgradeAssistant.overview.esDeprecationLogsLink": "Elasticsearch 弃用日志",
-    "xpack.upgradeAssistant.overview.fixIssuesStepDescription": "在升级到 Elastic 8.x 之前，必须解决任何严重的 Elasticsearch 和 Kibana 配置问题。在您升级后，忽略警告可能会导致行为差异。{accessDeprecationLogsMessage}",
-=======
     "xpack.upgradeAssistant.overview.errorLoadingUpgradeStatus": "检索升级状态时出错",
->>>>>>> f4358d5fbd5... [Upgrade Assistant] Add deprecation logging as step on overview page (#126693)
     "xpack.upgradeAssistant.overview.fixIssuesStepTitle": "复查已弃用设置并解决问题",
     "xpack.upgradeAssistant.overview.loadingLogsLabel": "正在加载弃用日志收集状态……",
     "xpack.upgradeAssistant.overview.observe.discoveryDescription": "搜索并筛选弃用日志以了解需要进行的更改类型。",

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/logs_step/logs_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/logs_step/logs_step.test.tsx
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act } from 'react-dom/test-utils';
+import { DEPRECATION_LOGS_INDEX } from '../../../../common/constants';
+import { setupEnvironment } from '../../helpers';
+import { OverviewTestBed, setupOverviewPage } from '../overview.helpers';
+
+describe('Overview - Logs Step', () => {
+  let testBed: OverviewTestBed;
+
+  const { server, httpRequestsMockHelpers } = setupEnvironment();
+
+  afterAll(() => {
+    server.restore();
+  });
+
+  describe('error state', () => {
+    beforeEach(async () => {
+      const error = {
+        statusCode: 500,
+        error: 'Internal server error',
+        message: 'Internal server error',
+      };
+
+      httpRequestsMockHelpers.setLoadDeprecationLogsCountResponse(undefined, error);
+
+      await act(async () => {
+        testBed = await setupOverviewPage();
+      });
+
+      testBed.component.update();
+    });
+
+    test('is rendered', () => {
+      const { exists } = testBed;
+      expect(exists('deprecationLogsErrorCallout')).toBe(true);
+      expect(exists('deprecationLogsRetryButton')).toBe(true);
+    });
+  });
+
+  describe('success state', () => {
+    describe('logging enabled', () => {
+      beforeEach(() => {
+        httpRequestsMockHelpers.setLoadDeprecationLoggingResponse({
+          isDeprecationLogIndexingEnabled: true,
+          isDeprecationLoggingEnabled: true,
+        });
+      });
+
+      test('renders step as complete when a user has 0 logs', async () => {
+        httpRequestsMockHelpers.setLoadDeprecationLogsCountResponse({
+          count: 0,
+        });
+
+        await act(async () => {
+          testBed = await setupOverviewPage();
+        });
+
+        const { component, exists } = testBed;
+
+        component.update();
+
+        expect(exists('logsStep-complete')).toBe(true);
+      });
+
+      test('renders step as incomplete when a user has >0 logs', async () => {
+        httpRequestsMockHelpers.setLoadDeprecationLogsCountResponse({
+          count: 10,
+        });
+
+        await act(async () => {
+          testBed = await setupOverviewPage();
+        });
+
+        const { component, exists } = testBed;
+
+        component.update();
+
+        expect(exists('logsStep-incomplete')).toBe(true);
+      });
+
+      test('renders deprecation issue count and button to view logs', async () => {
+        httpRequestsMockHelpers.setLoadDeprecationLogsCountResponse({
+          count: 10,
+        });
+
+        await act(async () => {
+          testBed = await setupOverviewPage();
+        });
+
+        const { component, find } = testBed;
+
+        component.update();
+
+        expect(find('logsCountDescription').text()).toContain('You have 10 deprecation issues');
+        expect(find('viewLogsLink').text()).toContain('View logs');
+      });
+    });
+
+    describe('logging disabled', () => {
+      beforeEach(async () => {
+        httpRequestsMockHelpers.setLoadDeprecationLoggingResponse({
+          isDeprecationLogIndexingEnabled: false,
+          isDeprecationLoggingEnabled: true,
+        });
+
+        await act(async () => {
+          testBed = await setupOverviewPage();
+        });
+
+        const { component } = testBed;
+
+        component.update();
+      });
+
+      test('renders button to enable logs', () => {
+        const { find, exists } = testBed;
+
+        expect(exists('logsCountDescription')).toBe(false);
+        expect(find('enableLogsLink').text()).toContain('Enable logging');
+      });
+    });
+  });
+
+  describe('privileges', () => {
+    beforeEach(async () => {
+      httpRequestsMockHelpers.setLoadDeprecationLoggingResponse({
+        isDeprecationLogIndexingEnabled: true,
+        isDeprecationLoggingEnabled: true,
+      });
+
+      await act(async () => {
+        testBed = await setupOverviewPage({
+          privileges: {
+            hasAllPrivileges: true,
+            missingPrivileges: {
+              index: [DEPRECATION_LOGS_INDEX],
+            },
+          },
+        });
+      });
+
+      const { component } = testBed;
+
+      component.update();
+    });
+
+    test('warns the user of missing index privileges', () => {
+      const { exists } = testBed;
+
+      expect(exists('missingPrivilegesCallout')).toBe(true);
+    });
+  });
+});

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/index.ts
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { FixDeprecationLogs } from './fix_deprecation_logs';
+export { useDeprecationLogging } from './use_deprecation_logging';

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/fix_issues_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/fix_issues_step.tsx
@@ -7,13 +7,11 @@
 
 import React, { FunctionComponent, useState, useEffect } from 'react';
 
-import { EuiText, EuiFlexItem, EuiFlexGroup, EuiSpacer, EuiLink } from '@elastic/eui';
+import { EuiText, EuiFlexItem, EuiFlexGroup, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { EuiStepProps } from '@elastic/eui/src/components/steps/step';
 
-import { DEPRECATION_LOGS_INDEX } from '../../../../../common/constants';
-import { WithPrivileges } from '../../../../shared_imports';
 import type { OverviewStepProps } from '../../types';
 import { EsDeprecationIssuesPanel, KibanaDeprecationIssuesPanel } from './components';
 
@@ -51,48 +49,10 @@ const FixIssuesStep: FunctionComponent<Props> = ({ setIsComplete }) => {
   );
 };
 
-interface CustomProps {
-  navigateToEsDeprecationLogs: () => void;
-}
-
-const AccessDeprecationLogsMessage = ({ navigateToEsDeprecationLogs }: CustomProps) => {
-  return (
-    <WithPrivileges privileges={`index.${DEPRECATION_LOGS_INDEX}`}>
-      {({ hasPrivileges, isLoading }) => {
-        if (isLoading || !hasPrivileges) {
-          // Don't show the message with the link to access deprecation logs
-          // to users who can't access the UI anyways.
-          return null;
-        }
-
-        return (
-          <FormattedMessage
-            id="xpack.upgradeAssistant.overview.accessEsDeprecationLogsLabel"
-            defaultMessage="If you have application code that calls Elasticsearch APIs, review the {esDeprecationLogsLink} to make sure you are not using deprecated APIs."
-            values={{
-              esDeprecationLogsLink: (
-                <EuiLink
-                  onClick={navigateToEsDeprecationLogs}
-                  data-test-subj="viewElasticsearchDeprecationLogs"
-                >
-                  {i18n.translate('xpack.upgradeAssistant.overview.esDeprecationLogsLink', {
-                    defaultMessage: 'Elasticsearch deprecation logs',
-                  })}
-                </EuiLink>
-              ),
-            }}
-          />
-        );
-      }}
-    </WithPrivileges>
-  );
-};
-
 export const getFixIssuesStep = ({
   isComplete,
   setIsComplete,
-  navigateToEsDeprecationLogs,
-}: OverviewStepProps & CustomProps): EuiStepProps => {
+}: OverviewStepProps): EuiStepProps => {
   const status = isComplete ? 'complete' : 'incomplete';
 
   return {
@@ -105,14 +65,7 @@ export const getFixIssuesStep = ({
           <p>
             <FormattedMessage
               id="xpack.upgradeAssistant.overview.fixIssuesStepDescription"
-              defaultMessage="You must resolve any critical Elasticsearch and Kibana configuration issues before upgrading to Elastic 8.x. Ignoring warnings might result in differences in behavior after you upgrade. {accessDeprecationLogsMessage}"
-              values={{
-                accessDeprecationLogsMessage: (
-                  <AccessDeprecationLogsMessage
-                    navigateToEsDeprecationLogs={navigateToEsDeprecationLogs}
-                  />
-                ),
-              }}
+              defaultMessage="You must resolve any critical Elasticsearch and Kibana configuration issues before upgrading to Elastic 8.x. Ignoring warnings might result in differences in behavior after you upgrade."
             />
           </p>
         </EuiText>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/logs_step/index.ts
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/logs_step/index.ts
@@ -5,5 +5,4 @@
  * 2.0.
  */
 
-export { EsDeprecationLogs } from './es_deprecation_logs';
-export { useDeprecationLogging } from './fix_deprecation_logs';
+export { getLogsStep } from './logs_step';

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/logs_step/logs_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/logs_step/logs_step.tsx
@@ -1,0 +1,243 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+
+import {
+  EuiText,
+  EuiSpacer,
+  EuiButton,
+  EuiCallOut,
+  EuiLoadingContent,
+  EuiCode,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedDate, FormattedTime, FormattedMessage } from '@kbn/i18n-react';
+import type { EuiStepProps } from '@elastic/eui/src/components/steps/step';
+
+import { DEPRECATION_LOGS_INDEX } from '../../../../../common/constants';
+import { WithPrivileges, MissingPrivileges } from '../../../../shared_imports';
+import { useAppContext } from '../../../app_context';
+import { loadLogsCheckpoint } from '../../../lib/logs_checkpoint';
+import type { OverviewStepProps } from '../../types';
+import { useDeprecationLogging } from '../../es_deprecation_logs';
+
+const i18nTexts = {
+  logsStepTitle: i18n.translate('xpack.upgradeAssistant.overview.logsStep.title', {
+    defaultMessage: 'Address API deprecations',
+  }),
+  logsStepDescription: i18n.translate('xpack.upgradeAssistant.overview.logsStep.description', {
+    defaultMessage: `Review the Elasticsearch deprecation logs to ensure you're not using deprecated APIs.`,
+  }),
+  viewLogsButtonLabel: i18n.translate(
+    'xpack.upgradeAssistant.overview.logsStep.viewLogsButtonLabel',
+    {
+      defaultMessage: 'View logs',
+    }
+  ),
+  enableLogsButtonLabel: i18n.translate(
+    'xpack.upgradeAssistant.overview.logsStep.enableLogsButtonLabel',
+    {
+      defaultMessage: 'Enable logging',
+    }
+  ),
+  logsCountDescription: (deprecationCount: number, checkpoint: string) => (
+    <FormattedMessage
+      id="xpack.upgradeAssistant.overview.logsStep.countDescription"
+      defaultMessage="You have {deprecationCount, plural, =0 {no} other {{deprecationCount}}} deprecation {deprecationCount, plural, one {issue} other {issues}} since {checkpoint}."
+      values={{
+        deprecationCount,
+        checkpoint: (
+          <>
+            <FormattedDate value={checkpoint} year="numeric" month="long" day="2-digit" />{' '}
+            <FormattedTime value={checkpoint} timeZoneName="short" hour12={false} />
+          </>
+        ),
+      }}
+    />
+  ),
+  missingPrivilegesTitle: i18n.translate(
+    'xpack.upgradeAssistant.overview.logsStep.missingPrivilegesTitle',
+    {
+      defaultMessage: 'You require index privileges to analyze the deprecation logs',
+    }
+  ),
+  missingPrivilegesDescription: (privilegesMissing: MissingPrivileges) => (
+    <FormattedMessage
+      id="xpack.upgradeAssistant.overview.logsStep.missingPrivilegesDescription"
+      defaultMessage="The deprecation logs will continue to be indexed, but you won't be able to analyze them until you have the read index {privilegesCount, plural, one {privilege} other {privileges}} for: {missingPrivileges}"
+      values={{
+        missingPrivileges: (
+          <EuiCode transparentBackground={true}>{privilegesMissing?.index?.join(', ')}</EuiCode>
+        ),
+        privilegesCount: privilegesMissing?.index?.length,
+      }}
+    />
+  ),
+  loadingError: i18n.translate('xpack.upgradeAssistant.overview.logsStep.loadingError', {
+    defaultMessage: 'An error occurred while retrieving the deprecation log count',
+  }),
+  retryButton: i18n.translate('xpack.upgradeAssistant.overview.logsStep.retryButton', {
+    defaultMessage: 'Try again',
+  }),
+};
+
+interface LogStepProps {
+  setIsComplete: (isComplete: boolean) => void;
+  hasPrivileges: boolean;
+  privilegesMissing: MissingPrivileges;
+  navigateToEsDeprecationLogs: () => void;
+}
+
+const LogStepDescription = () => (
+  <EuiText>
+    <p>{i18nTexts.logsStepDescription}</p>
+  </EuiText>
+);
+
+const LogsStep = ({
+  setIsComplete,
+  hasPrivileges,
+  privilegesMissing,
+  navigateToEsDeprecationLogs,
+}: LogStepProps) => {
+  const {
+    services: { api },
+  } = useAppContext();
+
+  const { isDeprecationLogIndexingEnabled } = useDeprecationLogging();
+
+  const checkpoint = loadLogsCheckpoint();
+
+  const {
+    data: logsCount,
+    error,
+    isLoading,
+    resendRequest,
+    isInitialRequest,
+  } = api.getDeprecationLogsCount(checkpoint);
+
+  useEffect(() => {
+    if (!isDeprecationLogIndexingEnabled) {
+      setIsComplete(false);
+    }
+
+    setIsComplete(logsCount?.count === 0);
+
+    // Depending upon setIsComplete would create an infinite loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDeprecationLogIndexingEnabled, logsCount]);
+
+  if (hasPrivileges === false && isDeprecationLogIndexingEnabled) {
+    return (
+      <>
+        <LogStepDescription />
+
+        <EuiSpacer />
+
+        <EuiCallOut
+          iconType="help"
+          color="warning"
+          title={i18nTexts.missingPrivilegesTitle}
+          data-test-subj="missingPrivilegesCallout"
+        >
+          <p>{i18nTexts.missingPrivilegesDescription(privilegesMissing)}</p>
+        </EuiCallOut>
+      </>
+    );
+  }
+
+  if (isLoading && isInitialRequest) {
+    return <EuiLoadingContent lines={3} />;
+  }
+
+  if (hasPrivileges && error) {
+    return (
+      <EuiCallOut
+        title={i18nTexts.loadingError}
+        color="danger"
+        iconType="alert"
+        data-test-subj="deprecationLogsErrorCallout"
+      >
+        <p>
+          {error.statusCode} - {error.message}
+        </p>
+
+        <EuiButton
+          color="danger"
+          onClick={resendRequest}
+          data-test-subj="deprecationLogsRetryButton"
+        >
+          {i18nTexts.retryButton}
+        </EuiButton>
+      </EuiCallOut>
+    );
+  }
+
+  return (
+    <>
+      <LogStepDescription />
+
+      {isDeprecationLogIndexingEnabled && logsCount ? (
+        <>
+          <EuiSpacer />
+
+          <EuiText>
+            <p data-test-subj="logsCountDescription">
+              {i18nTexts.logsCountDescription(logsCount.count, checkpoint)}
+            </p>
+          </EuiText>
+
+          <EuiSpacer />
+
+          <EuiButton onClick={navigateToEsDeprecationLogs} data-test-subj="viewLogsLink">
+            {i18nTexts.viewLogsButtonLabel}
+          </EuiButton>
+        </>
+      ) : (
+        <>
+          <EuiSpacer />
+
+          <EuiButton onClick={navigateToEsDeprecationLogs} data-test-subj="enableLogsLink">
+            {i18nTexts.enableLogsButtonLabel}
+          </EuiButton>
+        </>
+      )}
+      <EuiSpacer size="m" />
+    </>
+  );
+};
+
+interface CustomProps {
+  navigateToEsDeprecationLogs: () => void;
+}
+
+export const getLogsStep = ({
+  isComplete,
+  setIsComplete,
+  navigateToEsDeprecationLogs,
+}: OverviewStepProps & CustomProps): EuiStepProps => {
+  const status = isComplete ? 'complete' : 'incomplete';
+
+  return {
+    status,
+    title: i18nTexts.logsStepTitle,
+    'data-test-subj': `logsStep-${status}`,
+    children: (
+      <WithPrivileges privileges={`index.${DEPRECATION_LOGS_INDEX}`}>
+        {({ hasPrivileges, isLoading, privilegesMissing }) => (
+          <LogsStep
+            setIsComplete={setIsComplete}
+            hasPrivileges={!isLoading && hasPrivileges}
+            navigateToEsDeprecationLogs={navigateToEsDeprecationLogs}
+            privilegesMissing={privilegesMissing}
+          />
+        )}
+      </WithPrivileges>
+    ),
+  };
+};

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/overview.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/overview.tsx
@@ -28,8 +28,9 @@ import { getBackupStep } from './backup_step';
 import { getFixIssuesStep } from './fix_issues_step';
 import { getUpgradeStep } from './upgrade_step';
 import { getMigrateSystemIndicesStep } from './migrate_system_indices';
+import { getLogsStep } from './logs_step';
 
-type OverviewStep = 'backup' | 'migrate_system_indices' | 'fix_issues';
+type OverviewStep = 'backup' | 'migrate_system_indices' | 'fix_issues' | 'logs';
 
 export const Overview = withRouter(({ history }: RouteComponentProps) => {
   const {
@@ -52,6 +53,7 @@ export const Overview = withRouter(({ history }: RouteComponentProps) => {
     backup: false,
     migrate_system_indices: false,
     fix_issues: false,
+    logs: false,
   });
 
   const isStepComplete = (step: OverviewStep) => completedStepsMap[step];
@@ -114,6 +116,10 @@ export const Overview = withRouter(({ history }: RouteComponentProps) => {
             getFixIssuesStep({
               isComplete: isStepComplete('fix_issues'),
               setIsComplete: setCompletedStep.bind(null, 'fix_issues'),
+            }),
+            getLogsStep({
+              isComplete: isStepComplete('logs'),
+              setIsComplete: setCompletedStep.bind(null, 'logs'),
               navigateToEsDeprecationLogs: () => history.push('/es_deprecation_logs'),
             }),
             getUpgradeStep(),

--- a/x-pack/test/functional/page_objects/upgrade_assistant_page.ts
+++ b/x-pack/test/functional/page_objects/upgrade_assistant_page.ts
@@ -31,9 +31,9 @@ export class UpgradeAssistantPageObject extends FtrService {
 
   async navigateToEsDeprecationLogs() {
     return await this.retry.try(async () => {
-      await this.common.navigateToApp('settings');
-      await this.testSubjects.click('upgrade_assistant');
-      await this.testSubjects.click('viewElasticsearchDeprecationLogs');
+      await this.common.navigateToUrl('management', 'stack/upgrade_assistant/es_deprecation_logs', {
+        shouldUseHashForSubUrl: false,
+      });
       await this.retry.waitFor(
         'url to contain /upgrade_assistant/es_deprecation_logs',
         async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[Upgrade Assistant] Add deprecation logging as step on overview page (#126693)](https://github.com/elastic/kibana/pull/126693)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)