### PR TITLE
[APM][PoC] Trace sampling Service maps v2

### DIFF
--- a/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids.ts
@@ -4,9 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import { rangeQuery } from '../../../../observability/server';
-import { ProcessorEvent } from '../../../common/processor_event';
 import {
   AGENT_NAME,
   PARENT_ID,
@@ -20,6 +18,7 @@ import {
   TRACE_ID,
   TRANSACTION_ID,
 } from '../../../common/elasticsearch_fieldnames';
+import { ProcessorEvent } from '../../../common/processor_event';
 import {
   ConnectionNode,
   ExternalConnectionNode,
@@ -34,201 +33,12 @@ export async function fetchServicePathsFromTraceIds(
   start: number,
   end: number
 ) {
-  const { apmEventClient } = setup;
-
   // make sure there's a range so ES can skip shards
   const dayInMs = 24 * 60 * 60 * 1000;
   const startRange = start - dayInMs;
   const endRange = end + dayInMs;
 
-  const serviceMapParams = {
-    apm: {
-      events: [ProcessorEvent.span, ProcessorEvent.transaction],
-    },
-    body: {
-      size: 0,
-      query: {
-        bool: {
-          filter: [
-            {
-              terms: {
-                [TRACE_ID]: traceIds,
-              },
-            },
-            ...rangeQuery(startRange, endRange),
-          ],
-        },
-      },
-      aggs: {
-        service_map: {
-          scripted_metric: {
-            init_script: {
-              lang: 'painless',
-              source: `state.eventsById = new HashMap();
-
-              String[] fieldsToCopy = new String[] {
-                  'parent.id',
-                  'service.name',
-                  'service.environment',
-                  'span.destination.service.resource',
-                  'trace.id',
-                  'processor.event',
-                  'span.type',
-                  'span.subtype',
-                  'agent.name'
-                };
-                state.fieldsToCopy = fieldsToCopy;`,
-            },
-            map_script: {
-              lang: 'painless',
-              source: `def id;
-                if (!doc['span.id'].empty) {
-                  id = doc['span.id'].value;
-                } else {
-                  id = doc['transaction.id'].value;
-                }
-
-                def copy = new HashMap();
-                copy.id = id;
-
-                for(key in state.fieldsToCopy) {
-                  if (!doc[key].empty) {
-                    copy[key] = doc[key].value;
-                  }
-                }
-
-                state.eventsById[id] = copy`,
-            },
-            combine_script: {
-              lang: 'painless',
-              source: `return state.eventsById;`,
-            },
-            reduce_script: {
-              lang: 'painless',
-              source: `
-              def getDestination ( def event ) {
-                def destination = new HashMap();
-                destination['span.destination.service.resource'] = event['span.destination.service.resource'];
-                destination['span.type'] = event['span.type'];
-                destination['span.subtype'] = event['span.subtype'];
-                return destination;
-              }
-
-              def processAndReturnEvent(def context, def eventId) {
-                if (context.processedEvents[eventId] != null) {
-                  return context.processedEvents[eventId];
-                }
-
-                def event = context.eventsById[eventId];
-
-                if (event == null) {
-                  return null;
-                }
-
-                def service = new HashMap();
-                service['service.name'] = event['service.name'];
-                service['service.environment'] = event['service.environment'];
-                service['agent.name'] = event['agent.name'];
-
-                def basePath = new ArrayList();
-
-                def parentId = event['parent.id'];
-                def parent;
-
-                if (parentId != null && parentId != event['id']) {
-                  parent = processAndReturnEvent(context, parentId);
-                  if (parent != null) {
-                    /* copy the path from the parent */
-                    basePath.addAll(parent.path);
-                    /* flag parent path for removal, as it has children */
-                    context.locationsToRemove.add(parent.path);
-
-                    /* if the parent has 'span.destination.service.resource' set, and the service is different,
-                    we've discovered a service */
-
-                    if (parent['span.destination.service.resource'] != null
-                      && parent['span.destination.service.resource'] != ""
-                      && (parent['service.name'] != event['service.name']
-                        || parent['service.environment'] != event['service.environment']
-                      )
-                    ) {
-                      def parentDestination = getDestination(parent);
-                      context.externalToServiceMap.put(parentDestination, service);
-                    }
-                  }
-                }
-
-                def lastLocation = basePath.size() > 0 ? basePath[basePath.size() - 1] : null;
-
-                def currentLocation = service;
-
-                /* only add the current location to the path if it's different from the last one*/
-                if (lastLocation == null || !lastLocation.equals(currentLocation)) {
-                  basePath.add(currentLocation);
-                }
-
-                /* if there is an outgoing span, create a new path */
-                if (event['span.destination.service.resource'] != null
-                  && event['span.destination.service.resource'] != '') {
-                  def outgoingLocation = getDestination(event);
-                  def outgoingPath = new ArrayList(basePath);
-                  outgoingPath.add(outgoingLocation);
-                  context.paths.add(outgoingPath);
-                }
-
-                event.path = basePath;
-
-                context.processedEvents[eventId] = event;
-                return event;
-              }
-
-              def context = new HashMap();
-
-              context.processedEvents = new HashMap();
-              context.eventsById = new HashMap();
-
-              context.paths = new HashSet();
-              context.externalToServiceMap = new HashMap();
-              context.locationsToRemove = new HashSet();
-
-              for (state in states) {
-                context.eventsById.putAll(state);
-              }
-
-              for (entry in context.eventsById.entrySet()) {
-                processAndReturnEvent(context, entry.getKey());
-              }
-
-              def paths = new HashSet();
-
-              for(foundPath in context.paths) {
-                if (!context.locationsToRemove.contains(foundPath)) {
-                  paths.add(foundPath);
-                }
-              }
-
-              def response = new HashMap();
-              response.paths = paths;
-
-              def discoveredServices = new HashSet();
-
-              for(entry in context.externalToServiceMap.entrySet()) {
-                def map = new HashMap();
-                map.from = entry.getKey();
-                map.to = entry.getValue();
-                discoveredServices.add(map);
-              }
-              response.discoveredServices = discoveredServices;
-
-              return response;`,
-            },
-          },
-        } as const,
-      },
-    },
-  };
-
-  const response = await fetchServicePathsFromTraceIdsHits({
+  const response = await fetchTraces({
     setup,
     traceIds,
     startRange,
@@ -258,31 +68,11 @@ export async function fetchServicePathsFromTraceIds(
       };
     };
   };
-
-  //   const serviceMapFromTraceIdsScriptResponse = await apmEventClient.search(
-  //     'get_service_paths_from_trace_ids_scripted_metrics',
-  //     serviceMapParams
-  //   );
-  // return serviceMapFromTraceIdsScriptResponse as {
-  //   aggregations?: {
-  //     service_map: {
-  //       value: {
-  //         paths: ConnectionNode[][];
-  //         discoveredServices: Array<{
-  //           from: ExternalConnectionNode;
-  //           to: ServiceConnectionNode;
-  //         }>;
-  //       };
-  //     };
-  //   };
-  // };
 }
 
-export type ServicePathsFromTraceIds = Awaited<
-  ReturnType<typeof fetchServicePathsFromTraceIdsHits>
->;
+export type ServicePathsFromTraceIds = Awaited<ReturnType<typeof fetchTraces>>;
 
-async function fetchServicePathsFromTraceIdsHits({
+async function fetchTraces({
   setup,
   traceIds,
   startRange,
@@ -304,6 +94,7 @@ async function fetchServicePathsFromTraceIdsHits({
         from,
         size,
         _source: [
+          '@timestamp',
           PARENT_ID,
           SERVICE_NAME,
           SERVICE_ENVIRONMENT,
@@ -328,29 +119,41 @@ async function fetchServicePathsFromTraceIdsHits({
     };
 
     return await apmEventClient.search(
-      'fetch_service_paths_from_trace_ids_hitsParams',
+      'fetch_service_paths_from_trace_ids',
       hitsParams
     );
   }
-
   const hits = [];
   let pageIndex = 0;
   const pageSize = 1000;
-  let hasNext = true;
+  const promises = [];
+
+  // Fetch first page
+  const firstPageResult = await fetch({
+    from: pageIndex * pageSize,
+    size: pageSize,
+  });
+  hits.push(...firstPageResult.hits.hits);
+
+  // Round up to guarantee all items will be fetched and minus 1 because we've already fetched the first page
+  const totalPagesAvailable =
+    Math.ceil(firstPageResult.hits.total.value / pageSize) - 1;
+  let hasNext = pageIndex < totalPagesAvailable;
+
   while (hasNext) {
-    const response = await fetch({
-      from: pageIndex * pageSize,
-      size: pageSize,
-    });
-    hits.push(...response.hits.hits);
-    // Round up to guarantee all items will be fetched and minus 1 because we've already fetched the first page
-    const totalPagesAvailable =
-      Math.ceil(response.hits.total.value / pageSize) - 1;
+    promises.push(
+      fetch({
+        from: pageIndex * pageSize,
+        size: pageSize,
+      })
+    );
+    pageIndex++;
     hasNext = pageIndex < totalPagesAvailable;
-    if (hasNext) {
-      pageIndex++;
-    }
   }
 
+  const pagesResult = await Promise.all(promises);
+  pagesResult.forEach((data) => {
+    hits.push(...data.hits.hits);
+  });
   return hits;
 }

--- a/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids_scripted_metric.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids_scripted_metric.ts
@@ -1,0 +1,236 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rangeQuery } from '../../../../observability/server';
+import { ProcessorEvent } from '../../../common/processor_event';
+import { TRACE_ID } from '../../../common/elasticsearch_fieldnames';
+import {
+  ConnectionNode,
+  ExternalConnectionNode,
+  ServiceConnectionNode,
+} from '../../../common/service_map';
+import { Setup } from '../../lib/helpers/setup_request';
+
+export async function fetchServicePathsFromTraceIdsScriptedMetric(
+  setup: Setup,
+  traceIds: string[],
+  start: number,
+  end: number
+) {
+  const { apmEventClient } = setup;
+
+  // make sure there's a range so ES can skip shards
+  const dayInMs = 24 * 60 * 60 * 1000;
+  const startRange = start - dayInMs;
+  const endRange = end + dayInMs;
+
+  const serviceMapParams = {
+    apm: {
+      events: [ProcessorEvent.span, ProcessorEvent.transaction],
+    },
+    body: {
+      size: 0,
+      query: {
+        bool: {
+          filter: [
+            {
+              terms: {
+                [TRACE_ID]: traceIds,
+              },
+            },
+            ...rangeQuery(startRange, endRange),
+          ],
+        },
+      },
+      aggs: {
+        service_map: {
+          scripted_metric: {
+            init_script: {
+              lang: 'painless',
+              source: `state.eventsById = new HashMap();
+
+              String[] fieldsToCopy = new String[] {
+                  'parent.id',
+                  'service.name',
+                  'service.environment',
+                  'span.destination.service.resource',
+                  'trace.id',
+                  'processor.event',
+                  'span.type',
+                  'span.subtype',
+                  'agent.name'
+                };
+                state.fieldsToCopy = fieldsToCopy;`,
+            },
+            map_script: {
+              lang: 'painless',
+              source: `def id;
+                if (!doc['span.id'].empty) {
+                  id = doc['span.id'].value;
+                } else {
+                  id = doc['transaction.id'].value;
+                }
+
+                def copy = new HashMap();
+                copy.id = id;
+
+                for(key in state.fieldsToCopy) {
+                  if (!doc[key].empty) {
+                    copy[key] = doc[key].value;
+                  }
+                }
+
+                state.eventsById[id] = copy`,
+            },
+            combine_script: {
+              lang: 'painless',
+              source: `return state.eventsById;`,
+            },
+            reduce_script: {
+              lang: 'painless',
+              source: `
+              def getDestination ( def event ) {
+                def destination = new HashMap();
+                destination['span.destination.service.resource'] = event['span.destination.service.resource'];
+                destination['span.type'] = event['span.type'];
+                destination['span.subtype'] = event['span.subtype'];
+                return destination;
+              }
+
+              def processAndReturnEvent(def context, def eventId) {
+                if (context.processedEvents[eventId] != null) {
+                  return context.processedEvents[eventId];
+                }
+
+                def event = context.eventsById[eventId];
+
+                if (event == null) {
+                  return null;
+                }
+
+                def service = new HashMap();
+                service['service.name'] = event['service.name'];
+                service['service.environment'] = event['service.environment'];
+                service['agent.name'] = event['agent.name'];
+
+                def basePath = new ArrayList();
+
+                def parentId = event['parent.id'];
+                def parent;
+
+                if (parentId != null && parentId != event['id']) {
+                  parent = processAndReturnEvent(context, parentId);
+                  if (parent != null) {
+                    /* copy the path from the parent */
+                    basePath.addAll(parent.path);
+                    /* flag parent path for removal, as it has children */
+                    context.locationsToRemove.add(parent.path);
+
+                    /* if the parent has 'span.destination.service.resource' set, and the service is different,
+                    we've discovered a service */
+
+                    if (parent['span.destination.service.resource'] != null
+                      && parent['span.destination.service.resource'] != ""
+                      && (parent['service.name'] != event['service.name']
+                        || parent['service.environment'] != event['service.environment']
+                      )
+                    ) {
+                      def parentDestination = getDestination(parent);
+                      context.externalToServiceMap.put(parentDestination, service);
+                    }
+                  }
+                }
+
+                def lastLocation = basePath.size() > 0 ? basePath[basePath.size() - 1] : null;
+
+                def currentLocation = service;
+
+                /* only add the current location to the path if it's different from the last one*/
+                if (lastLocation == null || !lastLocation.equals(currentLocation)) {
+                  basePath.add(currentLocation);
+                }
+
+                /* if there is an outgoing span, create a new path */
+                if (event['span.destination.service.resource'] != null
+                  && event['span.destination.service.resource'] != '') {
+                  def outgoingLocation = getDestination(event);
+                  def outgoingPath = new ArrayList(basePath);
+                  outgoingPath.add(outgoingLocation);
+                  context.paths.add(outgoingPath);
+                }
+
+                event.path = basePath;
+
+                context.processedEvents[eventId] = event;
+                return event;
+              }
+
+              def context = new HashMap();
+
+              context.processedEvents = new HashMap();
+              context.eventsById = new HashMap();
+
+              context.paths = new HashSet();
+              context.externalToServiceMap = new HashMap();
+              context.locationsToRemove = new HashSet();
+
+              for (state in states) {
+                context.eventsById.putAll(state);
+              }
+
+              for (entry in context.eventsById.entrySet()) {
+                processAndReturnEvent(context, entry.getKey());
+              }
+
+              def paths = new HashSet();
+
+              for(foundPath in context.paths) {
+                if (!context.locationsToRemove.contains(foundPath)) {
+                  paths.add(foundPath);
+                }
+              }
+
+              def response = new HashMap();
+              response.paths = paths;
+
+              def discoveredServices = new HashSet();
+
+              for(entry in context.externalToServiceMap.entrySet()) {
+                def map = new HashMap();
+                map.from = entry.getKey();
+                map.to = entry.getValue();
+                discoveredServices.add(map);
+              }
+              response.discoveredServices = discoveredServices;
+
+              return response;`,
+            },
+          },
+        } as const,
+      },
+    },
+  };
+
+  const serviceMapFromTraceIdsScriptResponse = await apmEventClient.search(
+    'get_service_paths_from_trace_ids_scripted_metric',
+    serviceMapParams
+  );
+
+  return serviceMapFromTraceIdsScriptResponse as {
+    aggregations?: {
+      service_map: {
+        value: {
+          paths: ConnectionNode[][];
+          discoveredServices: Array<{
+            from: ExternalConnectionNode;
+            to: ServiceConnectionNode;
+          }>;
+        };
+      };
+    };
+  };
+}

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map.ts
@@ -64,29 +64,42 @@ async function getConnectionData({
       return init;
     }
 
+    // const chunkedResponses = await withApmSpan(
+    //   'get_service_paths_from_all_trace_ids',
+    //   () =>
+    //     Promise.all(
+    //       chunks.map((traceIdsChunk) =>
+    //         getServiceMapFromTraceIds({
+    //           setup,
+    //           traceIds: traceIdsChunk,
+    //           start,
+    //           end,
+    //         })
+    //       )
+    //     )
+    // );
+
+    // return chunkedResponses.reduce((prev, current) => {
+    //   return {
+    //     connections: prev.connections.concat(current.connections),
+    //     discoveredServices: prev.discoveredServices.concat(
+    //       current.discoveredServices
+    //     ),
+    //   };
+    // });
+
     const chunkedResponses = await withApmSpan(
       'get_service_paths_from_all_trace_ids',
       () =>
-        Promise.all(
-          chunks.map((traceIdsChunk) =>
-            getServiceMapFromTraceIds({
-              setup,
-              traceIds: traceIdsChunk,
-              start,
-              end,
-            })
-          )
-        )
+        getServiceMapFromTraceIds({
+          setup,
+          traceIds,
+          start,
+          end,
+        })
     );
 
-    return chunkedResponses.reduce((prev, current) => {
-      return {
-        connections: prev.connections.concat(current.connections),
-        discoveredServices: prev.discoveredServices.concat(
-          current.discoveredServices
-        ),
-      };
-    });
+    return chunkedResponses;
   });
 }
 

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_from_trace_ids.ts
@@ -8,7 +8,7 @@
 import { find, uniqBy } from 'lodash';
 import { Connection, ConnectionNode } from '../../../common/service_map';
 import { Setup } from '../../lib/helpers/setup_request';
-import { fetchServicePathsFromTraceIdsScriptedMetric } from './fetch_service_paths_from_trace_ids_scripted_metric';
+import { fetchServicePathsFromTraceIds } from './fetch_service_paths_from_trace_ids';
 
 export function getConnections({
   paths,
@@ -51,12 +51,7 @@ export async function getServiceMapFromTraceIds({
   end: number;
 }) {
   const serviceMapFromTraceIdsScriptResponse =
-    await fetchServicePathsFromTraceIdsScriptedMetric(
-      setup,
-      traceIds,
-      start,
-      end
-    );
+    await fetchServicePathsFromTraceIds(setup, traceIds, start, end);
 
   const serviceMapScriptedAggValue =
     serviceMapFromTraceIdsScriptResponse.aggregations?.service_map.value;

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_from_trace_ids.ts
@@ -8,7 +8,7 @@
 import { find, uniqBy } from 'lodash';
 import { Connection, ConnectionNode } from '../../../common/service_map';
 import { Setup } from '../../lib/helpers/setup_request';
-import { fetchServicePathsFromTraceIds } from './fetch_service_paths_from_trace_ids';
+import { fetchServicePathsFromTraceIdsScriptedMetric } from './fetch_service_paths_from_trace_ids_scripted_metric';
 
 export function getConnections({
   paths,
@@ -51,7 +51,12 @@ export async function getServiceMapFromTraceIds({
   end: number;
 }) {
   const serviceMapFromTraceIdsScriptResponse =
-    await fetchServicePathsFromTraceIds(setup, traceIds, start, end);
+    await fetchServicePathsFromTraceIdsScriptedMetric(
+      setup,
+      traceIds,
+      start,
+      end
+    );
 
   const serviceMapScriptedAggValue =
     serviceMapFromTraceIdsScriptResponse.aggregations?.service_map.value;

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_paths_from_trace_ids.test.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_paths_from_trace_ids.test.ts
@@ -1,0 +1,381 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import {
+  processAndReturnEvent,
+  getEventsByIdMap,
+  getServicePathsFromTraceIds,
+} from './get_service_paths_from_trace_ids';
+import type { Context, EventSpan } from './get_service_paths_from_trace_ids';
+import { ServicePathsFromTraceIds } from './fetch_service_paths_from_trace_ids';
+import { Span } from '../../../typings/es_schemas/ui/span';
+
+/*
+ * this events creates this service maps
+ * bar  ->  foo  ->  python
+ *  ^-------baz--------^
+ */
+const esHits = [
+  {
+    _source: {
+      service: { name: 'foo', environment: 'prod' },
+      agent: { name: 'nodejs' },
+      processor: { event: 'span' },
+      parent: { id: 'A' },
+      span: {
+        id: 'B',
+        type: 'external',
+        subtype: 'http',
+        destination: { service: { resource: 'python' } },
+      },
+    },
+  },
+  {
+    _source: {
+      parent: { id: 'C' },
+      service: { name: 'foo', environment: 'prod' },
+      agent: { name: 'nodejs' },
+      transaction: { id: 'A' },
+      processor: { event: 'transaction' },
+    },
+  },
+  {
+    _source: {
+      parent: { id: 'D' },
+      service: { name: 'bar', environment: 'prod' },
+      agent: { name: 'java' },
+      transaction: { id: 'C' },
+      processor: { event: 'transaction' },
+    },
+  },
+  {
+    _source: {
+      service: { name: 'baz', environment: 'prod' },
+      agent: { name: 'ruby' },
+      transaction: { id: 'D' },
+      processor: { event: 'transaction' },
+    },
+  },
+  {
+    _source: {
+      service: { name: 'baz', environment: 'prod' },
+      agent: { name: 'ruby' },
+      processor: { event: 'span' },
+      parent: { id: 'D' },
+      span: {
+        id: 'D2',
+        type: 'external',
+        subtype: 'http',
+        destination: { service: { resource: 'python' } },
+      },
+    },
+  },
+] as unknown as ServicePathsFromTraceIds;
+
+describe('get_service_paths_from_trace_ids', () => {
+  describe('getEventsByIdMap', () => {
+    it('returns empty when processor event is not available', () => {
+      const servicePathsFromTraceIds = [
+        { _source: {} },
+      ] as unknown as ServicePathsFromTraceIds;
+      expect(getEventsByIdMap(servicePathsFromTraceIds)).toEqual({});
+    });
+    it('returns empty when not Span or Transaction type', () => {
+      const servicePathsFromTraceIds = [
+        { _source: { processor: { event: 'metric' } } },
+        { _source: { processor: { event: 'error' } } },
+      ] as unknown as ServicePathsFromTraceIds;
+      expect(getEventsByIdMap(servicePathsFromTraceIds)).toEqual({});
+    });
+    it('returns map fo events', () => {
+      const servicePathsFromTraceIds = [
+        {
+          _source: {
+            processor: { event: 'transaction' },
+            transaction: { id: 'foo' },
+          },
+        },
+        {
+          _source: {
+            processor: { event: 'span' },
+            span: { id: 'bar' },
+          },
+        },
+        {
+          _source: {
+            processor: { event: 'transaction' },
+            transaction: { id: 'baz' },
+          },
+        },
+        {
+          _source: {
+            processor: { event: 'span' },
+            span: { id: 'qux' },
+          },
+        },
+      ] as unknown as ServicePathsFromTraceIds;
+      expect(getEventsByIdMap(servicePathsFromTraceIds)).toEqual({
+        foo: {
+          docType: 'transaction',
+          doc: {
+            processor: { event: 'transaction' },
+            transaction: { id: 'foo' },
+          },
+        },
+        bar: {
+          docType: 'span',
+          doc: { processor: { event: 'span' }, span: { id: 'bar' } },
+        },
+        baz: {
+          docType: 'transaction',
+          doc: {
+            processor: { event: 'transaction' },
+            transaction: { id: 'baz' },
+          },
+        },
+        qux: {
+          docType: 'span',
+          doc: {
+            processor: { event: 'span' },
+            span: { id: 'qux' },
+          },
+        },
+      });
+    });
+  });
+
+  describe('processAndReturnEvent', () => {
+    it('returns events already processed', () => {
+      const processedEvents = {
+        foo: { docType: 'span', doc: {} as Span },
+      };
+      expect(
+        processAndReturnEvent({
+          context: {
+            eventsById: {},
+            processedEvents,
+            paths: {},
+            externalToServiceMap: {},
+            locationsToRemove: {},
+          } as Context,
+          id: 'foo',
+        })
+      ).toEqual({ docType: 'span', doc: {} as Span });
+    });
+
+    it('returns null when event is not found', () => {
+      const eventsById = {
+        foo: { docType: 'span', doc: {} as Span },
+      };
+      expect(
+        processAndReturnEvent({
+          context: {
+            eventsById,
+            processedEvents: {},
+            paths: {},
+            externalToServiceMap: {},
+            locationsToRemove: {},
+          } as Context,
+          id: 'bar',
+        })
+      ).toEqual(null);
+    });
+
+    it('returns single event when parent is not available', () => {
+      const eventsById = {
+        foo: {
+          docType: 'span',
+          doc: {
+            service: { name: 'foo service.name', environment: 'foo env' },
+            agent: { name: 'nodejs' },
+            processor: { event: 'span' },
+            span: {
+              id: 'foo',
+              type: 'external',
+              subtype: 'http',
+              destination: { service: { resource: 'bar' } },
+            },
+          },
+        } as EventSpan,
+      };
+      const context: Context = {
+        eventsById,
+        processedEvents: {},
+        paths: {},
+        externalToServiceMap: {},
+        locationsToRemove: {},
+      };
+
+      const expectedEvent = {
+        docType: 'span',
+        doc: {
+          service: { name: 'foo service.name', environment: 'foo env' },
+          agent: { name: 'nodejs' },
+          processor: { event: 'span' },
+          span: {
+            id: 'foo',
+            type: 'external',
+            subtype: 'http',
+            destination: { service: { resource: 'bar' } },
+          },
+        },
+        path: [
+          {
+            'agent.name': 'nodejs',
+            'service.environment': 'foo env',
+            'service.name': 'foo service.name',
+          },
+        ],
+      };
+
+      expect(processAndReturnEvent({ context, id: 'foo' })).toEqual(
+        expectedEvent
+      );
+      expect(context.processedEvents).toEqual({ foo: expectedEvent });
+      expect(Object.values(context.paths)).toEqual([
+        [
+          {
+            'service.name': 'foo service.name',
+            'service.environment': 'foo env',
+            'agent.name': 'nodejs',
+          },
+          {
+            'span.destination.service.resource': 'bar',
+            'span.type': 'external',
+            'span.subtype': 'http',
+          },
+        ],
+      ]);
+    });
+
+    it('returns multiple events', () => {
+      const eventsById = getEventsByIdMap(esHits);
+      const context: Context = {
+        eventsById,
+        processedEvents: {},
+        paths: {},
+        externalToServiceMap: {},
+        locationsToRemove: {},
+      };
+      processAndReturnEvent({ context, id: 'B' });
+      expect(Object.keys(context.processedEvents)).toEqual([
+        'D',
+        'C',
+        'A',
+        'B',
+      ]);
+      expect(Object.values(context.paths)).toEqual([
+        [
+          {
+            'service.name': 'baz',
+            'service.environment': 'prod',
+            'agent.name': 'ruby',
+          },
+          {
+            'service.name': 'bar',
+            'service.environment': 'prod',
+            'agent.name': 'java',
+          },
+          {
+            'service.name': 'foo',
+            'service.environment': 'prod',
+            'agent.name': 'nodejs',
+          },
+          {
+            'span.destination.service.resource': 'python',
+            'span.type': 'external',
+            'span.subtype': 'http',
+          },
+        ],
+      ]);
+      expect(Object.values(context.locationsToRemove)).toEqual([
+        [
+          {
+            'service.name': 'baz',
+            'service.environment': 'prod',
+            'agent.name': 'ruby',
+          },
+        ],
+        [
+          {
+            'service.name': 'baz',
+            'service.environment': 'prod',
+            'agent.name': 'ruby',
+          },
+          {
+            'service.name': 'bar',
+            'service.environment': 'prod',
+            'agent.name': 'java',
+          },
+        ],
+        [
+          {
+            'service.name': 'baz',
+            'service.environment': 'prod',
+            'agent.name': 'ruby',
+          },
+          {
+            'service.name': 'bar',
+            'service.environment': 'prod',
+            'agent.name': 'java',
+          },
+          {
+            'service.name': 'foo',
+            'service.environment': 'prod',
+            'agent.name': 'nodejs',
+          },
+        ],
+      ]);
+    });
+  });
+
+  describe('getServicePathsFromTraceIds', () => {
+    it('returns paths', async () => {
+      const response = await getServicePathsFromTraceIds({
+        servicePathsFromTraceIds: esHits,
+      });
+
+      expect(response.paths).toEqual([
+        [
+          {
+            'service.name': 'baz',
+            'service.environment': 'prod',
+            'agent.name': 'ruby',
+          },
+          {
+            'service.name': 'bar',
+            'service.environment': 'prod',
+            'agent.name': 'java',
+          },
+          {
+            'service.name': 'foo',
+            'service.environment': 'prod',
+            'agent.name': 'nodejs',
+          },
+          {
+            'span.destination.service.resource': 'python',
+            'span.type': 'external',
+            'span.subtype': 'http',
+          },
+        ],
+        [
+          {
+            'service.name': 'baz',
+            'service.environment': 'prod',
+            'agent.name': 'ruby',
+          },
+          {
+            'span.destination.service.resource': 'python',
+            'span.type': 'external',
+            'span.subtype': 'http',
+          },
+        ],
+      ]);
+
+      expect(response.discoveredServices).toEqual([]);
+    });
+  });
+});

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_paths_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_paths_from_trace_ids.ts
@@ -54,6 +54,18 @@ export interface Context {
   locationsToRemove: Record<string, unknown>;
 }
 
+export async function getServicePathsFromTraceIds({
+  servicePathsFromTraceIds,
+}: {
+  servicePathsFromTraceIds: ServicePathsFromTraceIds;
+}) {
+  return withApmSpan('get_service_paths_from_trace_ids', async () => {
+    return await asyncGetServicePathsFromTraceIds({
+      servicePathsFromTraceIds,
+    });
+  });
+}
+
 export function getEventsByIdMap(
   servicePathsFromTraceIds: ServicePathsFromTraceIds
 ) {
@@ -84,12 +96,12 @@ export function getEventsByIdMap(
   }, {} as EventsById);
 }
 
-export function getServicePathsFromTraceIds({
+function asyncGetServicePathsFromTraceIds({
   servicePathsFromTraceIds,
 }: {
   servicePathsFromTraceIds: ServicePathsFromTraceIds;
 }) {
-  return withApmSpan('get_service_paths_fromt_trace_ids', async () => {
+  return new Promise((resolve) => {
     const eventsByIdMap = getEventsByIdMap(servicePathsFromTraceIds);
 
     const context: Context = {
@@ -111,10 +123,10 @@ export function getServicePathsFromTraceIds({
       }
     });
 
-    return {
+    resolve({
       paths,
       discoveredServices: Object.values(context.externalToServiceMap),
-    };
+    });
   });
 }
 

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_paths_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_paths_from_trace_ids.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isEqual, last } from 'lodash';
+import {
+  AGENT_NAME,
+  SERVICE_ENVIRONMENT,
+  SERVICE_NAME,
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+  SPAN_SUBTYPE,
+  SPAN_TYPE,
+} from '../../../common/elasticsearch_fieldnames';
+import { ProcessorEvent } from '../../../common/processor_event';
+import { Span } from '../../../typings/es_schemas/ui/span';
+import { Transaction } from '../../../typings/es_schemas/ui/transaction';
+import { withApmSpan } from '../../utils/with_apm_span';
+import { ServicePathsFromTraceIds } from './fetch_service_paths_from_trace_ids';
+
+interface EventsById {
+  [id: string]: (Span | Transaction) & { path?: Location[] };
+}
+
+interface Context {
+  processedEvents: EventsById;
+  eventsById: EventsById;
+  paths: Record<string, unknown>;
+  externalToServiceMap: Record<
+    string,
+    { from: ReturnType<typeof getSpanDestination>; to: Location }
+  >;
+  locationsToRemove: Record<string, unknown>;
+}
+
+export function getServicePathsFromTraceIds({
+  servicePathsFromTraceIds,
+}: {
+  servicePathsFromTraceIds: ServicePathsFromTraceIds;
+}) {
+  return withApmSpan('get_service_paths_fromt_trace_ids', async () => {
+    const eventsByIdMap = servicePathsFromTraceIds.reduce((acc, doc) => {
+      const source = doc._source as Transaction | Span;
+      const id =
+        source.processor.event === ProcessorEvent.transaction
+          ? (source as Transaction).transaction?.id
+          : (source as Span).span.id;
+      return { ...acc, [id]: source };
+    }, {} as EventsById);
+
+    const context: Context = {
+      processedEvents: {},
+      eventsById: eventsByIdMap,
+      paths: {},
+      externalToServiceMap: {},
+      locationsToRemove: {},
+    };
+    Object.keys(eventsByIdMap).forEach((id) => {
+      return processAndReturnEvent({ context, id });
+    });
+
+    const paths: any[] = [];
+    Object.keys(context.paths).forEach((key) => {
+      if (!context.locationsToRemove[key]) {
+        paths.push(context.paths[key]);
+      }
+    });
+
+    return {
+      paths,
+      discoveredServices: Object.values(context.externalToServiceMap),
+    };
+  });
+}
+
+function getSpanDestination(span: Span) {
+  return {
+    [SPAN_DESTINATION_SERVICE_RESOURCE]:
+      span.span.destination?.service.resource,
+    [SPAN_TYPE]: span.span.type,
+    [SPAN_SUBTYPE]: span.span.subtype,
+  };
+}
+
+interface Location {
+  [SERVICE_NAME]: string;
+  [SERVICE_ENVIRONMENT]?: string;
+  [AGENT_NAME]: string;
+}
+
+function processAndReturnEvent({
+  context,
+  id,
+}: {
+  context: Context;
+  id: string;
+}) {
+  if (context.processedEvents[id]) {
+    return context.processedEvents[id];
+  }
+
+  const event = context.eventsById[id];
+  if (!event) {
+    return null;
+  }
+
+  const eventLocation: Location = {
+    [SERVICE_NAME]: event.service.name,
+    [SERVICE_ENVIRONMENT]: event.service.environment,
+    [AGENT_NAME]: event.agent.name,
+  };
+
+  const basePath: Location[] = [];
+  const parentId = event.parent?.id;
+  let parent;
+
+  if (parentId && parentId !== id) {
+    parent = processAndReturnEvent({ context, id: parentId });
+    if (parent) {
+      if (parent.path) {
+        basePath.push(...parent.path);
+        context.locationsToRemove[JSON.stringify(parent.path)] = parent.path;
+      }
+
+      if (
+        parent.processor.event === ProcessorEvent.span &&
+        (parent as Span).span.destination?.service.resource &&
+        (parent.service.name !== event.service.name ||
+          parent.service.environment !== event.service.environment)
+      ) {
+        const parentDestination = getSpanDestination(parent as Span);
+        const destination = { from: parentDestination, to: eventLocation };
+        context.externalToServiceMap[JSON.stringify(destination)] = destination;
+      }
+    }
+  }
+
+  const lastLocation = last(basePath);
+
+  if (lastLocation === undefined || !isEqual(eventLocation, lastLocation)) {
+    basePath.push(eventLocation);
+  }
+
+  if (
+    event.processor.event === ProcessorEvent.span &&
+    (event as Span).span.destination?.service.resource
+  ) {
+    const outgoingLocation = getSpanDestination(event as Span);
+    const outgoingPath = [...basePath, outgoingLocation];
+    context.paths[JSON.stringify(outgoingPath)] = outgoingPath;
+  }
+
+  event.path = basePath;
+
+  context.processedEvents[id] = event;
+  return event;
+}


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/126910

I replaced the current scripted metrics aggregation, with a _search by traces and calculate the service paths on the kibana server (with the exact same logic the scripted metrics uses). After testing a couple of scenarios, I think my problems are listed below:

- Since the _search request returns a maximum of 10k results, we might miss some connections on the service maps.
- Batching the traces is necessary to mitigate(not solve it) the problem mentioned above, but that increased the time took to load data.
- Performance: the current service map is already slow, by moving the logic to the Kibana server is even slower, check the trace waterfall result.

This waterfall shows the performance of batching the traces (50), and paginating (1k) it until all data is returned and run the function that generates the service paths for each batch result.
<img width="2542" alt="Screen Shot 2022-03-14 at 11 56 30 AM" src="https://user-images.githubusercontent.com/55978943/158214497-1ef240c3-bd96-4754-a7e8-d8e796f552af.png">
Full trace waterfall
https://user-images.githubusercontent.com/55978943/158214446-8d495bff-fa38-4712-96d1-b99c7d9c4e33.mov

FYI: This PR is not ready to merge, I still need to fix some parts of the code and improve others. I opened this PR so we can discuss if it is worth to keep working towards this direction, or if we should start thinking about an alternative solution.