### PR TITLE
[Cloud Posture] Add integration metadata to rules page

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
@@ -14,7 +14,7 @@ export const allNavigationItems: Record<CspPage, CspNavigationItem> = {
   findings: { name: TEXT.FINDINGS, path: '/findings' },
   rules: {
     name: 'Rules',
-    path: '/benchmarks/:packageId/:policyId/rules',
+    path: '/benchmarks/:packagePolicyId/:policyId/rules',
     disabled: !INTERNAL_FEATURE_FLAGS.showBenchmarks,
   },
   benchmarks: {

--- a/x-pack/plugins/cloud_security_posture/public/components/csp_loading_state.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_loading_state.tsx
@@ -8,8 +8,10 @@
 import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import React from 'react';
 
+export const cspLoadingStateTestId = 'csp_loading_state';
+
 export const CspLoadingState: React.FunctionComponent = ({ children }) => (
-  <EuiFlexGroup direction="column" alignItems="center">
+  <EuiFlexGroup direction="column" alignItems="center" data-test-subj={cspLoadingStateTestId}>
     <EuiFlexItem>
       <EuiLoadingSpinner size="xl" />
     </EuiFlexItem>

--- a/x-pack/plugins/cloud_security_posture/public/components/page_template.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/page_template.tsx
@@ -81,9 +81,9 @@ export const CspPageTemplate: React.FC<KibanaPageTemplateProps> = ({ children, .
 
   return (
     <KibanaPageTemplate
+      template={template}
       {...DEFAULT_PROPS}
       {...props}
-      template={template}
       noDataConfig={noDataConfig}
     >
       <EuiErrorBoundary>

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
@@ -54,7 +54,7 @@ const BENCHMARKS_TABLE_COLUMNS: Array<EuiBasicTableColumn<Benchmark>> = [
     render: (packageName, benchmark) => (
       <Link
         to={generatePath(allNavigationItems.rules.path, {
-          packageId: benchmark.package_policy.id,
+          packagePolicyId: benchmark.package_policy.id,
           policyId: benchmark.package_policy.policy_id,
         })}
         title={packageName}
@@ -125,7 +125,7 @@ export const BenchmarksTable = ({
     onClick: () =>
       history.push(
         generatePath(allNavigationItems.rules.path, {
-          packageId: benchmark.package_policy.id,
+          packagePolicyId: benchmark.package_policy.id,
           policyId: benchmark.package_policy.policy_id,
         })
       ),

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -46,7 +46,7 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
   const pageProps: KibanaPageTemplateProps = useMemo(
     () => ({
       pageHeader: {
-        bottomBorder: false,
+        bottomBorder: false, // TODO: border still shows.
         pageTitle: 'Rules',
         description: integrationInfo.data && integrationInfo.data.package && (
           <PageDescription

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -5,29 +5,18 @@
  * 2.0.
  */
 import React, { useMemo } from 'react';
-import { useQuery } from 'react-query';
 import { RouteComponentProps } from 'react-router-dom';
-import { EuiText, EuiTextColor, EuiEmptyPrompt } from '@elastic/eui';
+import { EuiTextColor, EuiEmptyPrompt } from '@elastic/eui';
 import * as t from 'io-ts';
 import { CspPageTemplate } from '../../components/page_template';
 import { RulesContainer, type PageUrlParams } from './rules_container';
 import { allNavigationItems } from '../../common/navigation/constants';
 import { useCspBreadcrumbs } from '../../common/navigation/use_csp_breadcrumbs';
-import { useKibana } from '../../common/hooks/use_kibana';
-import { type PackagePolicy, packagePolicyRouteService } from '../../../../../plugins/fleet/common';
 import type { KibanaPageTemplateProps } from '../../../../../../src/plugins/kibana_react/public';
 import { CspLoadingState } from '../../components/csp_loading_state';
 import { CspNavigationItem } from '../../common/navigation/types';
 import { extractErrorMessage } from '../../../common/utils/helpers';
-
-const useCspIntegrationInfo = ({ packagePolicyId }: PageUrlParams) => {
-  const { http } = useKibana().services;
-  return useQuery(
-    ['packagePolicy', { packagePolicyId }],
-    () => http.get<{ item: PackagePolicy }>(packagePolicyRouteService.getInfoPath(packagePolicyId)),
-    { select: (response) => response.item, enabled: !!packagePolicyId }
-  );
-};
+import { useCspIntegration } from './use_csp_integration';
 
 const getRulesBreadcrumbs = (name?: string): CspNavigationItem[] =>
   [allNavigationItems.benchmarks, { ...allNavigationItems.rules, name }].filter(
@@ -35,7 +24,7 @@ const getRulesBreadcrumbs = (name?: string): CspNavigationItem[] =>
   );
 
 export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>) => {
-  const integrationInfo = useCspIntegrationInfo(params);
+  const integrationInfo = useCspIntegration(params);
   const breadcrumbs = useMemo(
     // TODO: make benchmark breadcrumb navigable
     () => getRulesBreadcrumbs(integrationInfo.data?.name),
@@ -84,9 +73,7 @@ const extractErrorBodyMessage = (err: unknown) => {
 };
 
 const PageDescription = ({ text }: { text: string }) => (
-  <EuiText size="s">
-    <EuiTextColor color="subdued">{text}</EuiTextColor>
-  </EuiText>
+  <EuiTextColor color="subdued">{text}</EuiTextColor>
 );
 
 const RulesErrorPrompt = ({ error }: { error: string }) => (

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -4,28 +4,86 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
-import type { EuiPageHeaderProps } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { useQuery } from 'react-query';
+import { RouteComponentProps } from 'react-router-dom';
+import { EuiText, EuiTextColor, EuiEmptyPrompt } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { CspPageTemplate } from '../../components/page_template';
-import { RulesContainer } from './rules_container';
+import { RulesContainer, type PageUrlParams } from './rules_container';
 import { allNavigationItems } from '../../common/navigation/constants';
 import { useCspBreadcrumbs } from '../../common/navigation/use_csp_breadcrumbs';
+import { useKibana } from '../../common/hooks/use_kibana';
+import { type PackagePolicy, packagePolicyRouteService } from '../../../../../plugins/fleet/common';
+import type { KibanaPageTemplateProps } from '../../../../../../src/plugins/kibana_react/public';
+import { CspLoadingState } from '../../components/csp_loading_state';
+import { CspNavigationItem } from '../../common/navigation/types';
 
-// TODO:
-// - get selected integration
-
-const pageHeader: EuiPageHeaderProps = {
-  pageTitle: 'Rules',
+const useCspIntegrationInfo = ({ packagePolicyId }: PageUrlParams) => {
+  const { http } = useKibana().services;
+  return useQuery(
+    ['packagePolicy', { packagePolicyId }],
+    () => http.get<{ item: PackagePolicy }>(packagePolicyRouteService.getInfoPath(packagePolicyId)),
+    { select: (response) => response.item, enabled: !!packagePolicyId }
+  );
 };
 
-const breadcrumbs = [allNavigationItems.rules];
+const getRulesBreadcrumbs = (name?: string): CspNavigationItem[] =>
+  [allNavigationItems.benchmarks, { ...allNavigationItems.rules, name }].filter(
+    (breadcrumb): breadcrumb is CspNavigationItem => !!breadcrumb.name
+  );
 
-export const Rules = () => {
+export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>) => {
+  const integrationInfo = useCspIntegrationInfo(params);
+  const breadcrumbs = useMemo(
+    // TODO: make benchmark breadcrumb navigable
+    () => getRulesBreadcrumbs(integrationInfo.data?.name),
+    [integrationInfo.data?.name]
+  );
+
   useCspBreadcrumbs(breadcrumbs);
 
+  const pageProps: KibanaPageTemplateProps = useMemo(
+    () => ({
+      pageHeader: {
+        bottomBorder: false,
+        pageTitle: 'Rules',
+        description: integrationInfo.data && integrationInfo.data.package && (
+          <PageDescription
+            text={`${integrationInfo.data.package.title}, ${integrationInfo.data.name}`}
+          />
+        ),
+      },
+    }),
+    [integrationInfo.data]
+  );
+
   return (
-    <CspPageTemplate pageHeader={pageHeader}>
-      <RulesContainer />
+    <CspPageTemplate {...pageProps}>
+      {integrationInfo.status === 'success' && <RulesContainer />}
+      {integrationInfo.status === 'error' && <RulesErrorPrompt />}
+      {integrationInfo.status === 'loading' && <CspLoadingState />}
     </CspPageTemplate>
   );
 };
+
+const PageDescription = ({ text }: { text: string }) => (
+  <EuiText size="s">
+    <EuiTextColor color="subdued">{text}</EuiTextColor>
+  </EuiText>
+);
+
+const RulesErrorPrompt = () => (
+  <EuiEmptyPrompt
+    {...{
+      color: 'danger',
+      iconType: 'alert',
+      title: (
+        <FormattedMessage
+          id="xpack.csp.rules.missingIntegrationErrorMessage"
+          defaultMessage="Missing integration"
+        />
+      ),
+    }}
+  />
+);

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { Rules } from './index';
+import { render, screen } from '@testing-library/react';
+import { QueryClient } from 'react-query';
+import { TestProvider } from '../../test/test_provider';
+import { useCspIntegration } from './use_csp_integration';
+import { type RouteComponentProps } from 'react-router-dom';
+import { cspLoadingStateTestId } from '../../components/csp_loading_state';
+import type { PageUrlParams } from './rules_container';
+import * as TEST_SUBJECTS from './test_subjects';
+
+jest.mock('./use_csp_integration', () => ({
+  useCspIntegration: jest.fn(),
+}));
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+  },
+});
+
+const getTestComponent =
+  (params: PageUrlParams): React.FC =>
+  () =>
+    (
+      <TestProvider>
+        <Rules
+          {...({
+            match: { params },
+          } as RouteComponentProps<PageUrlParams>)}
+        />
+      </TestProvider>
+    );
+
+describe('<Rules />', () => {
+  beforeEach(() => {
+    queryClient.clear();
+    jest.clearAllMocks();
+  });
+
+  it('calls API with URL params', async () => {
+    const params = { packagePolicyId: '1', policyId: '2' };
+    const Component = getTestComponent(params);
+    const result = {
+      status: 'loading',
+    };
+
+    (useCspIntegration as jest.Mock).mockReturnValue(result);
+
+    render(<Component />);
+
+    expect(useCspIntegration).toHaveBeenCalledWith(params);
+  });
+
+  it('displays error state when request had an error', async () => {
+    const Component = getTestComponent({ packagePolicyId: '1', policyId: '2' });
+    const request = {
+      status: 'error',
+      data: null,
+      error: new Error('some error message'),
+    };
+
+    (useCspIntegration as jest.Mock).mockReturnValue(request);
+
+    render(<Component />);
+
+    expect(await screen.findByText(request.error.message)).toBeInTheDocument();
+  });
+
+  it('displays loading state when request is pending', () => {
+    const Component = getTestComponent({ packagePolicyId: '21', policyId: '22' });
+    const request = {
+      status: 'loading',
+    };
+
+    (useCspIntegration as jest.Mock).mockReturnValue(request);
+
+    render(<Component />);
+
+    expect(screen.getByTestId(cspLoadingStateTestId)).toBeInTheDocument();
+  });
+
+  it('displays success state when result request is resolved', async () => {
+    const Component = getTestComponent({ packagePolicyId: '21', policyId: '22' });
+    const request = {
+      status: 'success',
+      data: {
+        name: 'CIS Kubernetes Benchmark',
+        package: {
+          title: 'my package',
+        },
+      },
+    };
+
+    (useCspIntegration as jest.Mock).mockReturnValue(request);
+
+    render(<Component />);
+
+    expect(
+      await screen.findByText(`${request.data.package.title}, ${request.data.name}`)
+    ).toBeInTheDocument();
+    expect(await screen.findByTestId(TEST_SUBJECTS.CSP_RULES_CONTAINER)).toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -5,7 +5,16 @@
  * 2.0.
  */
 import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
-import { type EuiBasicTable, EuiPanel, EuiSpacer } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonEmpty,
+  type EuiBasicTable,
+  EuiPanel,
+  EuiSpacer,
+} from '@elastic/eui';
+import { useParams } from 'react-router-dom';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { extractErrorMessage } from '../../../common/utils/helpers';
 import { RulesTable } from './rules_table';
 import { RulesBottomBar } from './rules_bottom_bar';
@@ -19,6 +28,8 @@ import {
 } from './use_csp_rules';
 import * as TEST_SUBJECTS from './test_subjects';
 import { RuleFlyout } from './rules_flyout';
+import { pagePathGetters } from '../../../../fleet/public';
+import { useKibana } from '../../common/hooks/use_kibana';
 
 interface RulesPageData {
   rules_page: RuleSavedObject[];
@@ -79,7 +90,10 @@ const getPage = (data: readonly RuleSavedObject[], { page, perPage }: RulesQuery
 
 const MAX_ITEMS_PER_PAGE = 10000;
 
+export type PageUrlParams = Record<'policyId' | 'packagePolicyId', string>;
+
 export const RulesContainer = () => {
+  const params = useParams<PageUrlParams>();
   const tableRef = useRef<EuiBasicTable>(null);
   const [changedRules, setChangedRules] = useState<Map<string, RuleSavedObject>>(new Map());
   const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
@@ -145,6 +159,8 @@ export const RulesContainer = () => {
 
   return (
     <div data-test-subj={TEST_SUBJECTS.CSP_RULES_CONTAINER}>
+      <ManageIntegrationButton {...params} />
+      <EuiSpacer />
       <EuiPanel hasBorder hasShadow={false}>
         <RulesTableHeader
           search={(value) => setRulesQuery((currentQuery) => ({ ...currentQuery, search: value }))}
@@ -194,5 +210,32 @@ export const RulesContainer = () => {
         />
       )}
     </div>
+  );
+};
+
+const ManageIntegrationButton = ({ policyId, packagePolicyId }: PageUrlParams) => {
+  const { http } = useKibana().services;
+  return (
+    <EuiFlexGroup>
+      <EuiFlexItem grow={1} style={{ alignItems: 'flex-end' }}>
+        <EuiButtonEmpty
+          href={http.basePath.prepend(
+            pagePathGetters
+              .edit_integration({
+                policyId,
+                packagePolicyId,
+              })
+              .join('')
+          )}
+          iconType="gear"
+          size="xs"
+        >
+          <FormattedMessage
+            id="xpack.csp.rules.manageIntegrationButtonLabel"
+            defaultMessage="Manage Integration"
+          />
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_integration.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_integration.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useQuery } from 'react-query';
+import { type PageUrlParams } from './rules_container';
+import { useKibana } from '../../common/hooks/use_kibana';
+import { type PackagePolicy, packagePolicyRouteService } from '../../../../../plugins/fleet/common';
+
+export const useCspIntegration = ({ packagePolicyId }: PageUrlParams) => {
+  const { http } = useKibana().services;
+  return useQuery(
+    ['packagePolicy', { packagePolicyId }],
+    () => http.get<{ item: PackagePolicy }>(packagePolicyRouteService.getInfoPath(packagePolicyId)),
+    { select: (response) => response.item, enabled: !!packagePolicyId }
+  );
+};


### PR DESCRIPTION
## Summary

- [x] adds `integration` description (as in - `CIS Benchmark, Some Name`) to the `integration` rules page.
- [x] adds `manage integration` button link from `integration` rules page to fleet integration edit page


<details>
<summary>Quick Demo</summary>
<video src="https://user-images.githubusercontent.com/20814186/158232664-ac40d892-d425-441a-bcd5-91f8d51f7645.mov
"></video>

</details>





