### PR TITLE
[8.1] Fix automated curations history tab log views. (#127612)

### DIFF
--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -72,4 +72,5 @@ export const READ_ONLY_MODE_HEADER = 'x-ent-search-read-only-mode';
 
 export const ENTERPRISE_SEARCH_KIBANA_COOKIE = '_enterprise_search';
 
-export const LOGS_SOURCE_ID = 'ent-search-logs';
+export const ENTERPRISE_SEARCH_RELEVANCE_LOGS_SOURCE_ID = 'ent-search-logs';
+export const ENTERPRISE_SEARCH_AUDIT_LOGS_SOURCE_ID = 'ent-search-audit-logs';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/automated_curations_history_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/automated_curations_history_panel.tsx
@@ -11,6 +11,7 @@ import { useValues } from 'kea';
 
 import { i18n } from '@kbn/i18n';
 
+import { ENTERPRISE_SEARCH_RELEVANCE_LOGS_SOURCE_ID } from '../../../../../../../../common/constants';
 import { EntSearchLogStream } from '../../../../../../shared/log_stream';
 import { DataPanel } from '../../../../data_panel';
 import { EngineLogic } from '../../../../engine';
@@ -49,6 +50,7 @@ export const AutomatedCurationsHistoryPanel: React.FC = () => {
       hasBorder
     >
       <EntSearchLogStream
+        sourceId={ENTERPRISE_SEARCH_RELEVANCE_LOGS_SOURCE_ID}
         hoursAgo={720}
         query={filters.join(' and ')}
         columns={[

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/rejected_curations_history_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/rejected_curations_history_panel.tsx
@@ -11,6 +11,7 @@ import { useValues } from 'kea';
 
 import { i18n } from '@kbn/i18n';
 
+import { ENTERPRISE_SEARCH_RELEVANCE_LOGS_SOURCE_ID } from '../../../../../../../../common/constants';
 import { EntSearchLogStream } from '../../../../../../shared/log_stream';
 import { DataPanel } from '../../../../data_panel';
 import { EngineLogic } from '../../../../engine';
@@ -48,6 +49,7 @@ export const RejectedCurationsHistoryPanel: React.FC = () => {
       hasBorder
     >
       <EntSearchLogStream
+        sourceId={ENTERPRISE_SEARCH_RELEVANCE_LOGS_SOURCE_ID}
         hoursAgo={720}
         query={filters.join(' and ')}
         columns={[

--- a/x-pack/plugins/enterprise_search/public/applications/shared/log_stream/log_stream.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/log_stream/log_stream.test.tsx
@@ -11,6 +11,8 @@ import { shallow } from 'enzyme';
 
 import { EntSearchLogStream } from './';
 
+const fakeSourceId = 'fake-source-id';
+
 describe('EntSearchLogStream', () => {
   const mockDateNow = jest.spyOn(global.Date, 'now').mockReturnValue(160000000);
 
@@ -22,8 +24,8 @@ describe('EntSearchLogStream', () => {
       expect(wrapper.type()).toEqual(React.Suspense);
     });
 
-    it('renders with the enterprise search log source ID', () => {
-      expect(wrapper.prop('sourceId')).toEqual('ent-search-logs');
+    it('renders with the empty sourceId', () => {
+      expect(wrapper.prop('sourceId')).toBeUndefined();
     });
 
     it('renders with a default last-24-hours timestamp if no timestamp is passed', () => {
@@ -46,7 +48,9 @@ describe('EntSearchLogStream', () => {
     });
 
     it('allows passing a custom hoursAgo that modifies the default start timestamp', () => {
-      const wrapper = shallow(shallow(<EntSearchLogStream hoursAgo={1} />).prop('children'));
+      const wrapper = shallow(
+        shallow(<EntSearchLogStream sourceId={fakeSourceId} hoursAgo={1} />).prop('children')
+      );
 
       expect(wrapper.prop('startTimestamp')).toEqual(156400000);
       expect(wrapper.prop('endTimestamp')).toEqual(160000000);
@@ -56,6 +60,7 @@ describe('EntSearchLogStream', () => {
       const wrapper = shallow(
         shallow(
           <EntSearchLogStream
+            sourceId={fakeSourceId}
             height={500}
             highlight="some-log-id"
             columns={[

--- a/x-pack/plugins/enterprise_search/public/applications/shared/log_stream/log_stream.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/log_stream/log_stream.tsx
@@ -10,8 +10,6 @@ import React from 'react';
 import { EuiThemeProvider } from '../../../../../../../src/plugins/kibana_react/common';
 import { LogStream, LogStreamProps } from '../../../../../infra/public';
 
-import { LOGS_SOURCE_ID } from '../../../../common/constants';
-
 /*
  * EnterpriseSearchLogStream is a light wrapper on top of infra's embeddable LogStream component.
  * It prepopulates our log source ID (set in server/plugin.ts) and sets a basic 24-hours-ago
@@ -23,12 +21,14 @@ import { LOGS_SOURCE_ID } from '../../../../common/constants';
  */
 
 interface Props extends Omit<LogStreamProps, 'startTimestamp' | 'endTimestamp'> {
+  sourceId?: string;
   startTimestamp?: LogStreamProps['startTimestamp'];
   endTimestamp?: LogStreamProps['endTimestamp'];
   hoursAgo?: number;
 }
 
 export const EntSearchLogStream: React.FC<Props> = ({
+  sourceId,
   startTimestamp,
   endTimestamp,
   hoursAgo = 24,
@@ -40,7 +40,7 @@ export const EntSearchLogStream: React.FC<Props> = ({
   return (
     <EuiThemeProvider>
       <LogStream
-        sourceId={LOGS_SOURCE_ID}
+        sourceId={sourceId}
         startTimestamp={startTimestamp}
         endTimestamp={endTimestamp}
         {...props}

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -26,7 +26,7 @@ import {
   ENTERPRISE_SEARCH_PLUGIN,
   APP_SEARCH_PLUGIN,
   WORKPLACE_SEARCH_PLUGIN,
-  LOGS_SOURCE_ID,
+  ENTERPRISE_SEARCH_RELEVANCE_LOGS_SOURCE_ID,
 } from '../common/constants';
 
 import { registerTelemetryUsageCollector as registerASTelemetryUsageCollector } from './collectors/app_search/telemetry';
@@ -174,11 +174,11 @@ export class EnterpriseSearchPlugin implements Plugin {
      * Register logs source configuration, used by LogStream components
      * @see https://github.com/elastic/kibana/blob/main/x-pack/plugins/infra/public/components/log_stream/log_stream.stories.mdx#with-a-source-configuration
      */
-    infra.defineInternalSourceConfiguration(LOGS_SOURCE_ID, {
-      name: 'Enterprise Search Logs',
+    infra.defineInternalSourceConfiguration(ENTERPRISE_SEARCH_RELEVANCE_LOGS_SOURCE_ID, {
+      name: 'Enterprise Search Search Relevance Logs',
       logIndices: {
         type: 'index_name',
-        indexName: '.ent-search-*',
+        indexName: 'logs-app_search.search_relevance_suggestions-*',
       },
     });
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [Fix automated curations history tab log views. (#127612)](https://github.com/elastic/kibana/pull/127612)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)