### PR TITLE
[Fleet] Improve Fleet output UI

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/outputs_table/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/outputs_table/index.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import { EuiBasicTable, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
+import { EuiBasicTable, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -59,7 +59,14 @@ export const OutputsTable: React.FunctionComponent<OutputsTableProps> = ({
             </NameFlexItemWithMaxWidth>
             {output.is_preconfigured && (
               <EuiFlexItem grow={false}>
-                <EuiIcon type="lock" />
+                <EuiIconTip
+                  content={i18n.translate('xpack.fleet.settings.outputsTable.managedTooltip', {
+                    defaultMessage: 'This outputs is managed outside of Fleet.',
+                  })}
+                  type="lock"
+                  size="m"
+                  color="subdued"
+                />
               </EuiFlexItem>
             )}
           </EuiFlexGroup>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/hooks/use_confirm_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/hooks/use_confirm_modal.tsx
@@ -13,13 +13,14 @@ import React, { useCallback, useContext, useState } from 'react';
 interface ModalState {
   title?: React.ReactNode;
   description?: React.ReactNode;
-  buttonColor?: EuiConfirmModalProps['buttonColor'];
+  options?: ModalOptions;
   onConfirm: () => void;
   onCancel: () => void;
 }
 
 interface ModalOptions {
   buttonColor?: EuiConfirmModalProps['buttonColor'];
+  confirmButtonText?: string;
 }
 
 const ModalContext = React.createContext<null | {
@@ -40,7 +41,7 @@ export function useConfirmModal() {
           description,
           onConfirm: () => resolve(true),
           onCancel: () => resolve(false),
-          buttonColor: options?.buttonColor,
+          options,
         });
       });
     },
@@ -67,7 +68,7 @@ export const ConfirmModalProvider: React.FunctionComponent = ({ children }) => {
     onConfirm: () => {},
   });
 
-  const showModal = useCallback(({ title, description, onConfirm, onCancel }) => {
+  const showModal = useCallback(({ title, description, onConfirm, onCancel, options }) => {
     setIsVisible(true);
     setModal({
       title,
@@ -80,6 +81,7 @@ export const ConfirmModalProvider: React.FunctionComponent = ({ children }) => {
         setIsVisible(false);
         onCancel();
       },
+      options,
     });
   }, []);
 
@@ -89,18 +91,18 @@ export const ConfirmModalProvider: React.FunctionComponent = ({ children }) => {
         <EuiPortal>
           <EuiConfirmModal
             title={modal.title}
-            buttonColor={modal.buttonColor}
+            buttonColor={modal.options?.buttonColor}
             onCancel={modal.onCancel}
             onConfirm={modal.onConfirm}
             cancelButtonText={i18n.translate('xpack.fleet.settings.confirmModal.cancelButtonText', {
               defaultMessage: 'Cancel',
             })}
-            confirmButtonText={i18n.translate(
-              'xpack.fleet.settings.confirmModal.confirmButtonText',
-              {
+            confirmButtonText={
+              modal.options?.confirmButtonText ??
+              i18n.translate('xpack.fleet.settings.confirmModal.confirmButtonText', {
                 defaultMessage: 'Save and deploy',
-              }
-            )}
+              })
+            }
             defaultFocusedButton="confirm"
           >
             {modal.description}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/hooks/use_delete_output.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/hooks/use_delete_output.tsx
@@ -81,6 +81,12 @@ export function useDeleteOutput(onSuccess: () => void) {
           />,
           {
             buttonColor: 'danger',
+            confirmButtonText: i18n.translate(
+              'xpack.fleet.settings.deleteOutputs.confirmButtonLabel',
+              {
+                defaultMessage: 'Delete and deploy',
+              }
+            ),
           }
         );
 


### PR DESCRIPTION
## Summary

Resolve #121989 #127103 

That PR improve some UI in Fleet:
* a tooltip is now provided with the lock icon for managed output in the output table
* The button copy when deleting an output is now `Delete and deploy` instead of `save and deploy`

## UI changes

<img width="1012" alt="Screen Shot 2022-03-14 at 2 24 09 PM" src="https://user-images.githubusercontent.com/1336873/158237424-d76f935b-7358-45ac-ae32-220c863df74c.png">
<img width="550" alt="Screen Shot 2022-03-14 at 2 19 36 PM" src="https://user-images.githubusercontent.com/1336873/158237426-a77a1ff4-76a4-49a4-b097-bcc2be04a3d1.png">
