### PR TITLE
[Cloud Posture] Update rules table row UX 

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -18,6 +18,7 @@ import {
   type RulesQueryResult,
 } from './use_csp_rules';
 import * as TEST_SUBJECTS from './test_subjects';
+import { RuleFlyout } from './rules_flyout';
 
 interface RulesPageData {
   rules_page: RuleSavedObject[];
@@ -81,6 +82,7 @@ const MAX_ITEMS_PER_PAGE = 10000;
 export const RulesContainer = () => {
   const tableRef = useRef<EuiBasicTable>(null);
   const [changedRules, setChangedRules] = useState<Map<string, RuleSavedObject>>(new Map());
+  const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
   const [isAllSelected, setIsAllSelected] = useState<boolean>(false);
   const [visibleSelectedRulesIds, setVisibleSelectedRulesIds] = useState<string[]>([]);
   const [rulesQuery, setRulesQuery] = useState<RulesQuery>({ page: 0, perPage: 5, search: '' });
@@ -178,10 +180,18 @@ export const RulesContainer = () => {
           setPagination={(paginationQuery) =>
             setRulesQuery((currentQuery) => ({ ...currentQuery, ...paginationQuery }))
           }
+          setSelectedRuleId={setSelectedRuleId}
+          selectedRuleId={selectedRuleId}
         />
       </EuiPanel>
       {hasChanges && (
         <RulesBottomBar onSave={bulkUpdateRules} onCancel={discardChanges} isLoading={isUpdating} />
+      )}
+      {selectedRuleId && (
+        <RuleFlyout
+          rule={rulesPageData.rules_map.get(selectedRuleId)!}
+          onClose={() => setSelectedRuleId(null)}
+        />
       )}
     </div>
   );

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_flyout.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiSpacer, EuiFlyout, EuiFlyoutHeader, EuiFlyoutBody } from '@elastic/eui';
+import type { RuleSavedObject } from './use_csp_rules';
+
+interface FindingFlyoutProps {
+  onClose(): void;
+  rule: RuleSavedObject;
+}
+
+export const RuleFlyout = ({ onClose, rule }: FindingFlyoutProps) => {
+  return (
+    <EuiFlyout ownFocus={false} onClose={onClose} outsideClickCloses>
+      <EuiFlyoutHeader>
+        <h1>{rule.attributes.name}</h1>
+        <EuiSpacer />
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody />
+    </EuiFlyout>
+  );
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -147,12 +147,12 @@ const getColumns = ({
           enabled ? (
             <FormattedMessage
               id="xpack.csp.rules.deactivateRuleLabel"
-              defaultMessage={'Deactivate Rule'}
+              defaultMessage="Deactivate Rule"
             />
           ) : (
             <FormattedMessage
               id="xpack.csp.rules.activateRuleLabel"
-              defaultMessage={'Activate Rule'}
+              defaultMessage="Activate Rule"
             />
           )
         }

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -9,11 +9,14 @@ import {
   Criteria,
   EuiLink,
   EuiSwitch,
+  EuiToolTip,
   EuiTableFieldDataColumnType,
   EuiBasicTable,
   EuiBasicTableProps,
+  useEuiTheme,
 } from '@elastic/eui';
 import moment from 'moment';
+import { FormattedMessage } from '@kbn/i18n-react';
 import type { RulesState } from './rules_container';
 import * as TEST_SUBJECTS from './test_subjects';
 import * as TEXT from './translations';
@@ -26,6 +29,8 @@ type RulesTableProps = Pick<
   toggleRule(rule: RuleSavedObject): void;
   setSelectedRules(rules: RuleSavedObject[]): void;
   setPagination(pagination: Pick<RulesState, 'perPage' | 'page'>): void;
+  setSelectedRuleId(id: string | null): void;
+  selectedRuleId: string | null;
   // ForwardRef makes this ref not available in parent callbacks
   tableRef: React.RefObject<EuiBasicTable<RuleSavedObject>>;
 };
@@ -34,6 +39,7 @@ export const RulesTable = ({
   toggleRule,
   setSelectedRules,
   setPagination,
+  setSelectedRuleId,
   perPage: pageSize,
   rules_page: items,
   page,
@@ -41,8 +47,13 @@ export const RulesTable = ({
   total,
   loading,
   error,
+  selectedRuleId,
 }: RulesTableProps) => {
-  const columns = useMemo(() => getColumns({ toggleRule }), [toggleRule]);
+  const { euiTheme } = useEuiTheme();
+  const columns = useMemo(
+    () => getColumns({ toggleRule, setSelectedRuleId }),
+    [setSelectedRuleId, toggleRule]
+  );
 
   const euiPagination: EuiBasicTableProps<RuleSavedObject>['pagination'] = {
     pageIndex: page,
@@ -62,6 +73,16 @@ export const RulesTable = ({
     setPagination({ page: pagination.index, perPage: pagination.size });
   };
 
+  const rowProps = (row: RuleSavedObject) => ({
+    style: { background: row.id === selectedRuleId ? euiTheme.colors.highlight : undefined },
+    onClick: (e: MouseEvent) => {
+      const tag = (e.target as HTMLDivElement).tagName;
+      // Ignore checkbox and switch toggle columns
+      if (tag === 'BUTTON' || tag === 'INPUT') return;
+      setSelectedRuleId(row.id);
+    },
+  });
+
   return (
     <EuiBasicTable
       ref={tableRef}
@@ -75,45 +96,36 @@ export const RulesTable = ({
       isSelectable={true}
       selection={selection}
       itemId={(v) => v.id}
+      rowProps={rowProps}
     />
   );
 };
 
-const ruleNameRenderer = (name: string) => (
-  <EuiLink className="eui-textTruncate" title={name}>
-    {name}
-  </EuiLink>
-);
-
-const timestampRenderer = (timestamp: string) =>
-  moment.duration(moment().diff(timestamp)).humanize();
-
-interface GetColumnProps {
+interface GetColumnProps extends Pick<RulesTableProps, 'setSelectedRuleId'> {
   toggleRule: (rule: RuleSavedObject) => void;
 }
 
-const createRuleEnabledSwitchRenderer =
-  ({ toggleRule }: GetColumnProps) =>
-  (value: boolean, rule: RuleSavedObject) =>
-    (
-      <EuiSwitch
-        showLabel={false}
-        label={value ? TEXT.DISABLE : TEXT.ENABLE}
-        checked={value}
-        onChange={() => toggleRule(rule)}
-        data-test-subj={TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule.attributes.id)}
-      />
-    );
-
 const getColumns = ({
   toggleRule,
+  setSelectedRuleId,
 }: GetColumnProps): Array<EuiTableFieldDataColumnType<RuleSavedObject>> => [
   {
     field: 'attributes.name',
     name: TEXT.RULE_NAME,
     width: '60%',
     truncateText: true,
-    render: ruleNameRenderer,
+    render: (name, rule) => (
+      <EuiLink
+        className="eui-textTruncate"
+        title={name}
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          e.stopPropagation();
+          setSelectedRuleId(rule.id);
+        }}
+      >
+        {name}
+      </EuiLink>
+    ),
   },
   {
     field: 'section', // TODO: what field is this?
@@ -124,12 +136,36 @@ const getColumns = ({
     field: 'updatedAt',
     name: TEXT.UPDATED_AT,
     width: '15%',
-    render: timestampRenderer,
+    render: (timestamp) => moment.duration(moment().diff(timestamp)).humanize(),
   },
   {
     field: 'attributes.enabled',
     name: TEXT.ENABLED,
-    render: createRuleEnabledSwitchRenderer({ toggleRule }),
+    render: (enabled, rule) => (
+      <EuiToolTip
+        content={
+          enabled ? (
+            <FormattedMessage
+              id="xpack.csp.rules.deactivateRuleLabel"
+              defaultMessage={'Deactivate Rule'}
+            />
+          ) : (
+            <FormattedMessage
+              id="xpack.csp.rules.activateRuleLabel"
+              defaultMessage={'Activate Rule'}
+            />
+          )
+        }
+      >
+        <EuiSwitch
+          showLabel={false}
+          label={enabled ? TEXT.DISABLE : TEXT.ENABLE}
+          checked={enabled}
+          onChange={() => toggleRule(rule)}
+          data-test-subj={TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule.attributes.id)}
+        />
+      </EuiToolTip>
+    ),
     width: '10%',
   },
 ];

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -7,7 +7,7 @@
 import React, { useMemo } from 'react';
 import {
   Criteria,
-  EuiLink,
+  EuiButtonEmpty,
   EuiSwitch,
   EuiToolTip,
   EuiTableFieldDataColumnType,
@@ -115,7 +115,7 @@ const getColumns = ({
     width: '60%',
     truncateText: true,
     render: (name, rule) => (
-      <EuiLink
+      <EuiButtonEmpty
         className="eui-textTruncate"
         title={name}
         onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
@@ -124,7 +124,7 @@ const getColumns = ({
         }}
       >
         {name}
-      </EuiLink>
+      </EuiButtonEmpty>
     ),
   },
   {
@@ -136,7 +136,7 @@ const getColumns = ({
     field: 'updatedAt',
     name: TEXT.UPDATED_AT,
     width: '15%',
-    render: (timestamp) => moment.duration(moment().diff(timestamp)).humanize(),
+    render: (timestamp) => moment(timestamp).fromNow(),
   },
   {
     field: 'attributes.enabled',
@@ -146,12 +146,12 @@ const getColumns = ({
         content={
           enabled ? (
             <FormattedMessage
-              id="xpack.csp.rules.deactivateRuleLabel"
+              id="xpack.csp.rules.rulesTableHeader.deactivateRuleTooltip"
               defaultMessage="Deactivate Rule"
             />
           ) : (
             <FormattedMessage
-              id="xpack.csp.rules.activateRuleLabel"
+              id="xpack.csp.rules.rulesTableHeader.activateRuleTooltip"
               defaultMessage="Activate Rule"
             />
           )


### PR DESCRIPTION
## Summary

- [x] adds placeholder rule flyout
- [x] opens rule flyout on
   - rule name click
   - rule row click, except `switch` and `checkbox` 
- [x] highlights the  selected (opened) table row


![Screen Shot 2022-03-15 at 13 41 48](https://user-images.githubusercontent.com/20814186/158373232-34b56381-3c22-4f98-a6da-060f36ef5e19.png)

