### PR TITLE
backport cleanStandardList from https://github.com/elastic/kibana/pull/127508

### DIFF
--- a/packages/kbn-test/src/kbn_client/kbn_client_saved_objects.ts
+++ b/packages/kbn-test/src/kbn_client/kbn_client_saved_objects.ts
@@ -214,6 +214,25 @@ export class KbnClientSavedObjects {
     this.log.success('deleted', deleted, 'objects');
   }
 
+  public async cleanStandardList(options?: { space?: string }) {
+    // add types here
+    const types = [
+      'search',
+      'index-pattern',
+      'visualization',
+      'dashboard',
+      'lens',
+      'map',
+      'graph-workspace',
+      'query',
+      'tag',
+      'url',
+      'canvas-workpad',
+    ];
+    const newOptions = { types, space: options?.space };
+    await this.clean(newOptions);
+  }
+
   public async bulkDelete(options: DeleteObjectsOptions) {
     let deleted = 0;
     let missing = 0;


### PR DESCRIPTION
## Summary

All of https://github.com/elastic/kibana/pull/127508 didn't backport cleanly into 7.17 branch, but this new cleanStandardList method was part of that PR and will be very useful as we continue the kbn_archiver migrations.