### PR TITLE
[8.1] [Maps] Use Elastic Maps Service 8.1 (#126379)

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@elastic/charts": "43.1.1",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.1.0-canary.2",
-    "@elastic/ems-client": "8.0.0",
+    "@elastic/ems-client": "8.1.0",
     "@elastic/eui": "46.1.1",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "1.2.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -76,7 +76,7 @@ export const DEV_ONLY_LICENSE_ALLOWED = ['MPL-2.0'];
 export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
-  '@elastic/ems-client@8.0.0': ['Elastic License 2.0'],
+  '@elastic/ems-client@8.1.0': ['Elastic License 2.0'],
   '@elastic/eui@46.1.1': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
 };

--- a/src/plugins/maps_ems/common/ems_defaults.ts
+++ b/src/plugins/maps_ems/common/ems_defaults.ts
@@ -8,7 +8,7 @@
 
 export const DEFAULT_EMS_FILE_API_URL = 'https://vector.maps.elastic.co';
 export const DEFAULT_EMS_TILE_API_URL = 'https://tiles.maps.elastic.co';
-export const DEFAULT_EMS_LANDING_PAGE_URL = 'https://maps.elastic.co/v8.0';
+export const DEFAULT_EMS_LANDING_PAGE_URL = 'https://maps.elastic.co/v8.1';
 export const DEFAULT_EMS_FONT_LIBRARY_URL =
   'https://tiles.maps.elastic.co/fonts/{fontstack}/{range}.pbf';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
     "@elastic/transport" "^8.1.0-beta.1"
     tslib "^2.3.0"
 
-"@elastic/ems-client@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-8.0.0.tgz#94f682298f39f19d14a1eca927a22508029671e1"
-  integrity sha512-0nIEu+PHkWmTZUI27J/6BCPyY7bsmNTbDRn9EHPyciWq487G7TWoocoZog/mj1DoP2bo/ZxA8dpTKf6bJpy2Rg==
+"@elastic/ems-client@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-8.1.0.tgz#e33ec651314a9ceb9a8a7f3e4c6e205c39f20efb"
+  integrity sha512-u7Y8EakPk07nqRYqRxYTTLOIMb8Y+u7UM+2BGaw10jYVxdQ85sA4oi37GJJPJVn7jk/x9R7yTQ6Mpc3FbPGoRg==
   dependencies:
     "@types/geojson" "^7946.0.7"
     "@types/lru-cache" "^5.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Maps] Use Elastic Maps Service 8.1 (#126379)](https://github.com/elastic/kibana/pull/126379)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)