### PR TITLE
Fixing typo in describe statement of a11y tests for license management

### DIFF
--- a/x-pack/test/accessibility/apps/license_management.ts
+++ b/x-pack/test/accessibility/apps/license_management.ts
@@ -12,7 +12,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const a11y = getService('a11y');
   const testSubjects = getService('testSubjects');
 
-  describe('Upgrade Assistant a11y tests', () => {
+  describe('License Management page a11y tests', () => {
     before(async () => {
       await PageObjects.common.navigateToApp('licenseManagement');
     });


### PR DESCRIPTION
Made a typo here https://github.com/elastic/kibana/pull/127497 in the describe statement. 
This PR fixes it. 