### PR TITLE
[Workplace Search] Add row indicies and an uneditable bottom row to the Indexing Rules Table

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
@@ -38,6 +38,7 @@ export interface InlineEditableTableProps<Item extends ItemWithAnID> {
   lastItemWarning?: string;
   noItemsMessage?: (editNewItem: () => void) => React.ReactNode;
   uneditableItems?: Item[];
+  showRowIndex?: boolean;
 }
 
 export const InlineEditableTable = <Item extends ItemWithAnID>(

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
@@ -38,6 +38,7 @@ export interface InlineEditableTableProps<Item extends ItemWithAnID> {
   lastItemWarning?: string;
   noItemsMessage?: (editNewItem: () => void) => React.ReactNode;
   uneditableItems?: Item[];
+  bottomRows?: React.ReactNode[];
   showRowIndex?: boolean;
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiCallOut } from '@elastic/eui';
+import { EuiCallOut, EuiToken } from '@elastic/eui';
 
 import { BodyRow } from './body_row';
 import { Cell } from './cell';
@@ -37,17 +37,15 @@ describe('BodyRow', () => {
 
   it('renders a table row from the provided item and columns', () => {
     const wrapper = shallow(<BodyRow columns={columns} item={item} />);
-
     const cells = wrapper.find(Cell);
-    expect(cells.length).toBe(2);
 
+    expect(cells.length).toBe(2);
     expect(cells.at(0).props()).toEqual({
       alignItems: 'bar',
       children: 1,
       flexBasis: 'foo',
       flexGrow: 0,
     });
-
     expect(cells.at(1).props()).toEqual({
       children: 'Whatever',
     });
@@ -72,7 +70,17 @@ describe('BodyRow', () => {
       <BodyRow columns={columns} item={item} leftAction={<div>Left Action</div>} />
     );
     const cells = wrapper.find(Cell);
+
     expect(cells.length).toBe(3);
+    expect(cells.at(0).html()).toContain('Left Action');
+  });
+
+  it('will render a row identifier if one is provided', () => {
+    const wrapper = shallow(<BodyRow columns={columns} item={item} rowIdentifier="21" />);
+    const cells = wrapper.find(Cell);
+
+    expect(cells.length).toBe(3);
+    expect(cells.at(0).find(EuiToken)).toHaveLength(1);
   });
 
   it('will render row errors', () => {
@@ -80,6 +88,7 @@ describe('BodyRow', () => {
       <BodyRow columns={columns} item={item} errors={['first error', 'second error']} />
     );
     const callouts = wrapper.find(EuiCallOut);
+
     expect(callouts.length).toBe(2);
     expect(callouts.at(0).prop('title')).toEqual('first error');
     expect(callouts.at(1).prop('title')).toEqual('second error');

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { EuiCallOut, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiText, EuiToken } from '@elastic/eui';
 
 import { Cell } from './cell';
 import { DRAGGABLE_UX_STYLE } from './constants';
@@ -18,9 +18,9 @@ export interface BodyRowProps<Item> {
   item: Item;
   additionalProps?: object;
   // Cell to put in first column before other columns
-  leftAction?: React.ReactNode | React.ReactNode[];
+  leftAction?: React.ReactNode;
   errors?: string[];
-  rowIndicator?: string;
+  rowIdentifier?: string;
 }
 
 export const BodyRow = <Item extends object>({
@@ -29,18 +29,19 @@ export const BodyRow = <Item extends object>({
   additionalProps,
   leftAction,
   errors = [],
+  rowIdentifier,
 }: BodyRowProps<Item>) => {
-  const leftActions: React.ReactNode[] = Array.isArray(leftAction) ? leftAction : [leftAction];
   return (
     <div className="reorderableTableRow">
       <EuiFlexGroup data-test-subj="row" alignItems="center" {...(additionalProps || {})}>
         <EuiFlexItem>
-          <EuiFlexGroup alignItems="flexStart">
-            {leftActions.map((action, actionIndex) => (
-              <Cell key={actionIndex} {...DRAGGABLE_UX_STYLE}>
-                {action}
+          <EuiFlexGroup alignItems="center">
+            {leftAction && <Cell {...DRAGGABLE_UX_STYLE}>{leftAction}</Cell>}
+            {rowIdentifier && (
+              <Cell {...DRAGGABLE_UX_STYLE} flexBasis="24px">
+                <EuiToken size="m" iconType={() => <EuiText size="s">{rowIdentifier}</EuiText>} />
               </Cell>
-            ))}
+            )}
             {columns.map((column, columnIndex) => (
               <Cell
                 key={`table_row_cell_${columnIndex}`}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
@@ -39,7 +39,14 @@ export const BodyRow = <Item extends object>({
             {leftAction && <Cell {...DRAGGABLE_UX_STYLE}>{leftAction}</Cell>}
             {rowIdentifier && (
               <Cell {...DRAGGABLE_UX_STYLE} flexBasis="24px">
-                <EuiToken size="m" iconType={() => <EuiText size="s">{rowIdentifier}</EuiText>} />
+                <EuiToken
+                  size="m"
+                  iconType={() => (
+                    <EuiText size="xs">
+                      <strong>{rowIdentifier}</strong>
+                    </EuiText>
+                  )}
+                />
               </Cell>
             )}
             {columns.map((column, columnIndex) => (

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
@@ -18,8 +18,9 @@ export interface BodyRowProps<Item> {
   item: Item;
   additionalProps?: object;
   // Cell to put in first column before other columns
-  leftAction?: React.ReactNode;
+  leftAction?: React.ReactNode | React.ReactNode[];
   errors?: string[];
+  rowIndicator?: string;
 }
 
 export const BodyRow = <Item extends object>({
@@ -29,12 +30,17 @@ export const BodyRow = <Item extends object>({
   leftAction,
   errors = [],
 }: BodyRowProps<Item>) => {
+  const leftActions: React.ReactNode[] = Array.isArray(leftAction) ? leftAction : [leftAction];
   return (
     <div className="reorderableTableRow">
       <EuiFlexGroup data-test-subj="row" alignItems="center" {...(additionalProps || {})}>
         <EuiFlexItem>
           <EuiFlexGroup alignItems="flexStart">
-            {!!leftAction && <Cell {...DRAGGABLE_UX_STYLE}>{leftAction}</Cell>}
+            {leftActions.map((action, actionIndex) => (
+              <Cell key={actionIndex} {...DRAGGABLE_UX_STYLE}>
+                {action}
+              </Cell>
+            ))}
             {columns.map((column, columnIndex) => (
               <Cell
                 key={`table_row_cell_${columnIndex}`}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { EuiDraggable, EuiIcon } from '@elastic/eui';
+import { EuiDraggable, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiToken } from '@elastic/eui';
 
 import { BodyRow } from './body_row';
 import { Column } from './types';
@@ -19,6 +19,7 @@ export interface DraggableBodyRowProps<Item> {
   additionalProps?: object;
   disableDragging?: boolean;
   errors?: string[];
+  rowIdentifier?: string;
 }
 
 export const DraggableBodyRow = <Item extends object>({
@@ -28,6 +29,7 @@ export const DraggableBodyRow = <Item extends object>({
   additionalProps,
   disableDragging = false,
   errors,
+  rowIdentifier,
 }: DraggableBodyRowProps<Item>) => {
   const draggableId = `draggable_row_${rowIndex}`;
 
@@ -43,7 +45,18 @@ export const DraggableBodyRow = <Item extends object>({
         columns={columns}
         item={item}
         additionalProps={additionalProps}
-        leftAction={!disableDragging ? <EuiIcon type="grab" /> : <></>}
+        leftAction={
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem>{disableDragging ? <></> : <EuiIcon type="grab" />}</EuiFlexItem>
+            <EuiFlexItem>
+              {rowIdentifier ? (
+                <EuiToken iconType={() => <EuiText>{rowIdentifier}</EuiText>} />
+              ) : (
+                <></>
+              )}
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
         errors={errors}
       />
     </EuiDraggable>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { EuiDraggable, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiToken } from '@elastic/eui';
+import { EuiDraggable, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
 
 import { BodyRow } from './body_row';
 import { Column } from './types';
@@ -47,16 +47,12 @@ export const DraggableBodyRow = <Item extends object>({
         additionalProps={additionalProps}
         leftAction={
           <EuiFlexGroup justifyContent="spaceBetween">
-            <EuiFlexItem>{disableDragging ? <></> : <EuiIcon type="grab" />}</EuiFlexItem>
             <EuiFlexItem>
-              {rowIdentifier ? (
-                <EuiToken size="m" iconType={() => <EuiText size="s">{rowIdentifier}</EuiText>} />
-              ) : (
-                <></>
-              )}
+              {disableDragging ? <div style={{ width: '16px' }} /> : <EuiIcon type="grab" />}
             </EuiFlexItem>
           </EuiFlexGroup>
         }
+        rowIdentifier={rowIdentifier}
         errors={errors}
       />
     </EuiDraggable>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/draggable_body_row.tsx
@@ -50,7 +50,7 @@ export const DraggableBodyRow = <Item extends object>({
             <EuiFlexItem>{disableDragging ? <></> : <EuiIcon type="grab" />}</EuiFlexItem>
             <EuiFlexItem>
               {rowIdentifier ? (
-                <EuiToken iconType={() => <EuiText>{rowIdentifier}</EuiText>} />
+                <EuiToken size="m" iconType={() => <EuiText size="s">{rowIdentifier}</EuiText>} />
               ) : (
                 <></>
               )}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/header_row.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/header_row.test.tsx
@@ -34,5 +34,13 @@ describe('HeaderRow', () => {
     const wrapper = shallow(<HeaderRow columns={columns} leftAction={<div>Left Action</div>} />);
     const cells = wrapper.find(Cell);
     expect(cells.length).toBe(3);
+    expect(cells.at(0).html()).toContain('Left Action');
+  });
+
+  it('will add space for row identifiers', () => {
+    const wrapper = shallow(<HeaderRow columns={columns} spacingForRowIdentifier />);
+    const cells = wrapper.find(Cell);
+    expect(cells.length).toBe(3);
+    expect(cells.at(0).children()).toHaveLength(0);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/header_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/header_row.tsx
@@ -16,22 +16,22 @@ import { Column } from './types';
 interface HeaderRowProps<Item> {
   columns: Array<Column<Item>>;
   // Cell to put in first column before other columns
-  leftAction?: React.ReactNode | React.ReactNode[];
+  leftAction?: React.ReactNode;
+  spacingForRowIdentifier?: boolean;
 }
 
-export const HeaderRow = <Item extends object>({ columns, leftAction }: HeaderRowProps<Item>) => {
-  const leftActions: React.ReactNode[] = Array.isArray(leftAction) ? leftAction : [leftAction];
-
+export const HeaderRow = <Item extends object>({
+  columns,
+  leftAction,
+  spacingForRowIdentifier = false,
+}: HeaderRowProps<Item>) => {
   return (
     <div className="reorderableTableHeader">
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiFlexGroup>
-            {leftActions.map((action, actionIndex) => (
-              <Cell key={actionIndex} {...DRAGGABLE_UX_STYLE}>
-                {action}
-              </Cell>
-            ))}
+            {leftAction && <Cell {...DRAGGABLE_UX_STYLE}>{leftAction}</Cell>}
+            {spacingForRowIdentifier && <Cell {...DRAGGABLE_UX_STYLE} flexBasis="24px" />}
             {columns.map((column, columnIndex) => (
               <Cell key={`table_header_cell_${columnIndex}`} {...column}>
                 <EuiText size="s">

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/header_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/header_row.tsx
@@ -16,16 +16,22 @@ import { Column } from './types';
 interface HeaderRowProps<Item> {
   columns: Array<Column<Item>>;
   // Cell to put in first column before other columns
-  leftAction?: React.ReactNode;
+  leftAction?: React.ReactNode | React.ReactNode[];
 }
 
 export const HeaderRow = <Item extends object>({ columns, leftAction }: HeaderRowProps<Item>) => {
+  const leftActions: React.ReactNode[] = Array.isArray(leftAction) ? leftAction : [leftAction];
+
   return (
     <div className="reorderableTableHeader">
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiFlexGroup>
-            {!!leftAction && <Cell {...DRAGGABLE_UX_STYLE}>{leftAction}</Cell>}
+            {leftActions.map((action, actionIndex) => (
+              <Cell key={actionIndex} {...DRAGGABLE_UX_STYLE}>
+                {action}
+              </Cell>
+            ))}
             {columns.map((column, columnIndex) => (
               <Cell key={`table_header_cell_${columnIndex}`} {...column}>
                 <EuiText size="s">

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.scss
@@ -27,4 +27,8 @@
   .euiDraggable .euiDraggable__item.euiDraggable__item--isDisabled {
     cursor: unset;
   }
+
+  .unorderableRows .reorderableTableRow {
+    background-color: $euiColorLightestShade;
+  }
 }

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.test.tsx
@@ -5,6 +5,13 @@
  * 2.0.
  */
 
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. unreorderableItemsder one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 import React from 'react';
 
 import { shallow } from 'enzyme';
@@ -129,6 +136,20 @@ describe('ReorderableTable', () => {
         leftAction: expect.anything(),
       });
     });
+
+    it('will render bottom rows that cant be reordered', () => {
+      const bottomRows = [<div />, <div />];
+      const wrapper = shallow(
+        <ReorderableTable
+          noItemsMessage={<p>No Items</p>}
+          items={items}
+          bottomRows={bottomRows}
+          columns={columns}
+        />
+      );
+
+      expect(wrapper.find('[data-test-subj="BottomRow"]')).toHaveLength(2);
+    });
   });
 
   describe('when reorderable is turned off on the table', () => {
@@ -177,6 +198,7 @@ describe('ReorderableTable', () => {
     const wrapper = shallow(
       <ReorderableTable noItemsMessage={<p>No Items</p>} items={[]} columns={[]} className="foo" />
     );
+
     expect(wrapper.hasClass('foo')).toBe(true);
   });
 
@@ -184,6 +206,7 @@ describe('ReorderableTable', () => {
     const wrapper = shallow(
       <ReorderableTable noItemsMessage={<p>No Items</p>} items={[]} columns={columns} />
     );
+
     expect(wrapper.find('[data-test-subj="NoItems"]').exists()).toBe(true);
     expect(wrapper.find(BodyRows).exists()).toBe(false);
     expect(wrapper.find(DraggableBodyRows).exists()).toBe(false);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.test.tsx
@@ -5,13 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. unreorderableItemsder one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
 import React from 'react';
 
 import { shallow } from 'enzyme';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.tsx
@@ -120,12 +120,13 @@ export const ReorderableTable = <Item extends object>({
         )}
 
         {bottomRows.map((row, rowIndex) => (
-          <BodyRow
+          <BodyRow // Shoving a generic ReactNode into a BodyRow is kind of a hack
             key={rowIndex}
             rowIdentifier={showRowIndex ? '∞' : undefined}
             columns={[{ render: () => row }]}
             item={{}}
             leftAction={disableReordering ? undefined : <> </>}
+            data-test-subj="BottomRow"
           />
         ))}
       </div>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 
 import './reorderable_table.scss';
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiToken } from '@elastic/eui';
 
 import { BodyRow } from './body_row';
 import { BodyRows } from './body_rows';
@@ -28,6 +28,7 @@ interface ReorderableTableProps<Item> {
   className?: string;
   disableDragging?: boolean;
   disableReordering?: boolean;
+  showRowIndex?: boolean;
   onReorder?: (items: Item[], oldItems: Item[]) => void;
   rowProps?: (item: Item) => object;
   rowErrors?: (item: Item) => string[] | undefined;
@@ -44,10 +45,26 @@ export const ReorderableTable = <Item extends object>({
   onReorder = () => undefined,
   rowProps = () => ({}),
   rowErrors = () => undefined,
+  showRowIndex = false,
 }: ReorderableTableProps<Item>) => {
+  const headerRowActions = [];
+
+  if (!disableReordering) {
+    headerRowActions.push(<></>);
+  }
+  if (showRowIndex) {
+    headerRowActions.push(<></>);
+  }
+
+  const unorderableActions = [<></>];
+
+  if (showRowIndex) {
+    unorderableActions.push(<EuiToken iconType={() => <EuiText>∞</EuiText>} />);
+  }
+
   return (
     <div className={classNames(className, 'reorderableTable')}>
-      <HeaderRow columns={columns} leftAction={!disableReordering ? <></> : undefined} />
+      <HeaderRow columns={columns} leftAction={headerRowActions} />
 
       {items.length === 0 && unreorderableItems.length === 0 && (
         <EuiFlexGroup alignItems="center" justifyContent="center">
@@ -55,6 +72,24 @@ export const ReorderableTable = <Item extends object>({
             {noItemsMessage}
           </EuiFlexItem>
         </EuiFlexGroup>
+      )}
+
+      {items.length > 0 && disableReordering && (
+        <BodyRows
+          items={items}
+          renderItem={(item, itemIndex) => (
+            <BodyRow
+              key={`table_draggable_row_${itemIndex}`}
+              columns={columns}
+              item={item}
+              additionalProps={rowProps(item)}
+              errors={rowErrors(item)}
+              leftAction={
+                showRowIndex ? <EuiToken iconType={() => <EuiText>{itemIndex}</EuiText>} /> : <></>
+              }
+            />
+          )}
+        />
       )}
 
       {items.length > 0 && !disableReordering && (
@@ -70,26 +105,12 @@ export const ReorderableTable = <Item extends object>({
                 disableDragging={disableDragging}
                 rowIndex={itemIndex}
                 errors={rowErrors(item)}
+                rowIdentifier={`${itemIndex + 1}`}
               />
             )}
             onReorder={onReorder}
           />
         </>
-      )}
-
-      {items.length > 0 && disableReordering && (
-        <BodyRows
-          items={items}
-          renderItem={(item, itemIndex) => (
-            <BodyRow
-              key={`table_draggable_row_${itemIndex}`}
-              columns={columns}
-              item={item}
-              additionalProps={rowProps(item)}
-              errors={rowErrors(item)}
-            />
-          )}
-        />
       )}
 
       {unreorderableItems.length > 0 && (
@@ -102,7 +123,7 @@ export const ReorderableTable = <Item extends object>({
               item={item}
               additionalProps={rowProps(item)}
               errors={rowErrors(item)}
-              leftAction={<></>}
+              leftAction={unorderableActions}
             />
           )}
         />

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 
 import './reorderable_table.scss';
 
-import { EuiFlexGroup, EuiFlexItem, EuiText, EuiToken } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import { BodyRow } from './body_row';
 import { BodyRows } from './body_rows';
@@ -49,28 +49,15 @@ export const ReorderableTable = <Item extends object>({
   rowErrors = () => undefined,
   showRowIndex = false,
 }: ReorderableTableProps<Item>) => {
-  const headerRowActions = [];
-
-  if (!disableReordering) {
-    headerRowActions.push(<></>);
-  }
-  if (showRowIndex) {
-    headerRowActions.push(<></>);
-  }
-
-  const unorderableActions = [<></>];
-
-  if (showRowIndex) {
-    unorderableActions.push(
-      <EuiToken size="m" fill="dark" iconType={() => <EuiText size="s">∞</EuiText>} />
-    );
-  }
-
   return (
     <div className={classNames(className, 'reorderableTable')}>
-      <HeaderRow columns={columns} leftAction={headerRowActions} />
+      <HeaderRow
+        columns={columns}
+        leftAction={disableReordering ? undefined : <></>}
+        spacingForRowIdentifier={showRowIndex}
+      />
 
-      {items.length === 0 && unreorderableItems.length === 0 && (
+      {items.length === 0 && unreorderableItems.length === 0 && bottomRows.length === 0 && (
         <EuiFlexGroup alignItems="center" justifyContent="center">
           <EuiFlexItem data-test-subj="NoItems" className="reorderableTableNoItems">
             {noItemsMessage}
@@ -88,13 +75,7 @@ export const ReorderableTable = <Item extends object>({
               item={item}
               additionalProps={rowProps(item)}
               errors={rowErrors(item)}
-              leftAction={
-                showRowIndex ? (
-                  <EuiToken size="m" iconType={() => <EuiText size="s">{itemIndex}</EuiText>} />
-                ) : (
-                  <></>
-                )
-              }
+              rowIdentifier={showRowIndex ? `${itemIndex + 1}` : undefined}
             />
           )}
         />
@@ -113,7 +94,7 @@ export const ReorderableTable = <Item extends object>({
                 disableDragging={disableDragging}
                 rowIndex={itemIndex}
                 errors={rowErrors(item)}
-                rowIdentifier={`${itemIndex + 1}`}
+                rowIdentifier={showRowIndex ? `${itemIndex + 1}` : undefined}
               />
             )}
             onReorder={onReorder}
@@ -131,7 +112,8 @@ export const ReorderableTable = <Item extends object>({
                 item={item}
                 additionalProps={rowProps(item)}
                 errors={rowErrors(item)}
-                leftAction={unorderableActions}
+                leftAction={disableReordering ? undefined : <> </>}
+                rowIdentifier={showRowIndex ? '∞' : undefined}
               />
             )}
           />
@@ -140,9 +122,10 @@ export const ReorderableTable = <Item extends object>({
         {bottomRows.map((row, rowIndex) => (
           <BodyRow
             key={rowIndex}
-            leftAction={unorderableActions}
+            rowIdentifier={showRowIndex ? '∞' : undefined}
             columns={[{ render: () => row }]}
             item={{}}
+            leftAction={disableReordering ? undefined : <> </>}
           />
         ))}
       </div>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.tsx
@@ -25,6 +25,7 @@ interface ReorderableTableProps<Item> {
   items: Item[];
   noItemsMessage: React.ReactNode;
   unreorderableItems?: Item[];
+  bottomRows?: React.ReactNode[];
   className?: string;
   disableDragging?: boolean;
   disableReordering?: boolean;
@@ -39,6 +40,7 @@ export const ReorderableTable = <Item extends object>({
   items,
   noItemsMessage,
   unreorderableItems = [],
+  bottomRows = [],
   className = '',
   disableDragging = false,
   disableReordering = false,
@@ -59,7 +61,9 @@ export const ReorderableTable = <Item extends object>({
   const unorderableActions = [<></>];
 
   if (showRowIndex) {
-    unorderableActions.push(<EuiToken iconType={() => <EuiText>∞</EuiText>} />);
+    unorderableActions.push(
+      <EuiToken size="m" fill="dark" iconType={() => <EuiText size="s">∞</EuiText>} />
+    );
   }
 
   return (
@@ -85,7 +89,11 @@ export const ReorderableTable = <Item extends object>({
               additionalProps={rowProps(item)}
               errors={rowErrors(item)}
               leftAction={
-                showRowIndex ? <EuiToken iconType={() => <EuiText>{itemIndex}</EuiText>} /> : <></>
+                showRowIndex ? (
+                  <EuiToken size="m" iconType={() => <EuiText size="s">{itemIndex}</EuiText>} />
+                ) : (
+                  <></>
+                )
               }
             />
           )}
@@ -112,22 +120,32 @@ export const ReorderableTable = <Item extends object>({
           />
         </>
       )}
+      <div className="unorderableRows">
+        {unreorderableItems.length > 0 && (
+          <BodyRows
+            items={unreorderableItems}
+            renderItem={(item, itemIndex) => (
+              <BodyRow
+                key={`table_draggable_row_${itemIndex}`}
+                columns={columns}
+                item={item}
+                additionalProps={rowProps(item)}
+                errors={rowErrors(item)}
+                leftAction={unorderableActions}
+              />
+            )}
+          />
+        )}
 
-      {unreorderableItems.length > 0 && (
-        <BodyRows
-          items={unreorderableItems}
-          renderItem={(item, itemIndex) => (
-            <BodyRow
-              key={`table_draggable_row_${itemIndex}`}
-              columns={columns}
-              item={item}
-              additionalProps={rowProps(item)}
-              errors={rowErrors(item)}
-              leftAction={unorderableActions}
-            />
-          )}
-        />
-      )}
+        {bottomRows.map((row, rowIndex) => (
+          <BodyRow
+            key={rowIndex}
+            leftAction={unorderableActions}
+            columns={[{ render: () => row }]}
+            item={{}}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/indexing_rules_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/indexing_rules_table.test.tsx
@@ -247,4 +247,11 @@ describe('IndexingRulesTable', () => {
       expect(clearFlashMessages).toHaveBeenCalled();
     });
   });
+
+  it('includes a bottom row message', () => {
+    const wrapper = shallow(<IndexingRulesTable />);
+    const table = wrapper.find(InlineEditableTable);
+
+    expect(table.prop('bottomRows')).toHaveLength(1);
+  });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/indexing_rules_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/indexing_rules_table.tsx
@@ -229,7 +229,16 @@ export const IndexingRulesTable: React.FC = () => {
         clearFlashMessages();
       }}
       title=""
-      bottomRows={[<EuiText size="s">Include everything else from this source</EuiText>]}
+      bottomRows={[
+        <EuiText size="s">
+          {i18n.translate(
+            'xpack.enterpriseSearch.workplaceSearch.sources.indexingRulesTable.includeEverythingMessage',
+            {
+              defaultMessage: 'Include everything else from this source',
+            }
+          )}
+        </EuiText>,
+      ]}
       canRemoveLastItem
       showRowIndex
     />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/indexing_rules_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/indexing_rules_table.tsx
@@ -229,26 +229,6 @@ export const IndexingRulesTable: React.FC = () => {
         clearFlashMessages();
       }}
       title=""
-      // uneditableItems={[
-      //   {
-      //     id: 0,
-      //     filterType: 'object_type',
-      //     valueType: 'include',
-      //     value: '*',
-      //   },
-      //   {
-      //     id: 0,
-      //     filterType: 'path_template',
-      //     valueType: 'include',
-      //     value: '*',
-      //   },
-      //   {
-      //     id: 0,
-      //     filterType: 'file_extension',
-      //     valueType: 'include',
-      //     value: '*',
-      //   },
-      // ]}
       bottomRows={[<EuiText size="s">Include everything else from this source</EuiText>]}
       canRemoveLastItem
       showRowIndex

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/indexing_rules_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/indexing_rules_table.tsx
@@ -86,7 +86,7 @@ export const IndexingRulesTable: React.FC = () => {
         'xpack.enterpriseSearch.workplaceSearch.sources.sourceAssetsAndObjectsObjectsDescription',
         {
           defaultMessage:
-            'Include or exclude high level items, file types and (file or folder) paths to synchronize from {contentSourceName}. Everything is included by default. Each document is tested against the rules below and the first rule that matches will be applied.',
+            'Add an indexing rule to customize what data is synchronized from {contentSourceName}. Everything is included by default, and documents are validated against the configured set of indexing rules starting from the top listed down.',
           values: { contentSourceName: contentSource.name },
         }
       )}
@@ -95,7 +95,7 @@ export const IndexingRulesTable: React.FC = () => {
         {i18n.translate(
           'xpack.enterpriseSearch.workplaceSearch.sources.sourceAssetsAndObjectsSyncLearnMoreLink',
           {
-            defaultMessage: 'Learn more about sync rules.',
+            defaultMessage: 'Learn more about customizing your index rules.',
           }
         )}
       </EuiLink>
@@ -229,7 +229,29 @@ export const IndexingRulesTable: React.FC = () => {
         clearFlashMessages();
       }}
       title=""
+      // uneditableItems={[
+      //   {
+      //     id: 0,
+      //     filterType: 'object_type',
+      //     valueType: 'include',
+      //     value: '*',
+      //   },
+      //   {
+      //     id: 0,
+      //     filterType: 'path_template',
+      //     valueType: 'include',
+      //     value: '*',
+      //   },
+      //   {
+      //     id: 0,
+      //     filterType: 'file_extension',
+      //     valueType: 'include',
+      //     value: '*',
+      //   },
+      // ]}
+      bottomRows={[<EuiText size="s">Include everything else from this source</EuiText>]}
       canRemoveLastItem
+      showRowIndex
     />
   );
 };


### PR DESCRIPTION
## Summary

Updates the Indexing Rules Table with some visual tweaks to clarify the cascading order of rules.

<img width="799" alt="image" src="https://user-images.githubusercontent.com/2479295/158257730-ce323887-8ec9-4a28-8613-12d4ebf15d1d.png">

<img width="799" alt="image" src="https://user-images.githubusercontent.com/2479295/158257752-b726fb0c-9bc6-4c30-8925-ae8b01c33e65.png">


### Checklist


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
