### PR TITLE
[8.1] unksips cypress creation (#127024)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/cases/creation.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/cases/creation.spec.ts
@@ -50,8 +50,7 @@ import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 
 import { CASES_URL } from '../../urls/navigation';
 
-// Flaky: https://github.com/elastic/kibana/issues/69847
-describe.skip('Cases', () => {
+describe('Cases', () => {
   beforeEach(() => {
     cleanKibana();
     createTimeline(getCase1().timeline).then((response) =>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [unksips cypress creation (#127024)](https://github.com/elastic/kibana/pull/127024)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)