### PR TITLE
Fix up overview query

### DIFF
--- a/x-pack/plugins/monitoring/dev_docs/runbook/diagnostic_queries.md
+++ b/x-pack/plugins/monitoring/dev_docs/runbook/diagnostic_queries.md
@@ -16,19 +16,39 @@ POST .monitoring-*/_search
     "clusters": {
       "terms": {
         "field": "cluster_uuid",
-        "size": 1000
+        "size": 100
       },
       "aggs": {
         "indices": {
           "terms": {
             "field": "_index",
-            "size": 1000
+            "size": 100
           },
           "aggs": {
-            "documentTypes": {
+            "types": {
               "terms": {
                 "field": "type",
-                "size": 1000
+                "size": 100
+              },
+              "aggs": {
+                "latest_timestamp": {
+                  "max": {
+                    "field": "timestamp"
+                  }
+                }
+              }
+            },
+            "metricset_names": {
+              "terms": {
+                "field": "metricset.name",
+                "size": 100
+              },
+              "aggs": {
+                "latest_timestamp": {
+                  "max": {
+                    "field": "timestamp"
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION

## Summary

The previous version didn't work on 8 and I found the `latest_timestamp` idea on https://github.com/elastic/stack-monitoring-dev/blob/master/useful_queries.md

Rel: https://github.com/elastic/observability-dev/issues/2005
