### PR TITLE
[Lens] Fix mosaic color syncing

### DIFF
--- a/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_color.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_color.ts
@@ -167,7 +167,7 @@ export const getColor = (
   rows: DatatableRow[],
   visParams: PartitionVisParams,
   palettes: PaletteRegistry | null,
-  byDataPalette: ReturnType<typeof byDataColorPaletteMap>,
+  byDataPalette: ReturnType<typeof byDataColorPaletteMap> | undefined,
   syncColors: boolean,
   isDarkMode: boolean,
   formatter: FieldFormatsStart,
@@ -216,9 +216,13 @@ export const getColor = (
     if (layerIndex < columns.length - 1) {
       return defaultColor;
     }
-    // only use the top level series layer for coloring
+    // for treemap use the top layer for coloring, for mosaic use the second layer
     if (seriesLayers.length > 1) {
-      seriesLayers.pop();
+      if (chartType === ChartTypes.MOSAIC) {
+        seriesLayers.shift();
+      } else {
+        seriesLayers.pop();
+      }
     }
   }
 

--- a/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_layers.test.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_layers.test.ts
@@ -198,4 +198,82 @@ describe('computeColor', () => {
     );
     expect(color).toEqual('#3F6833');
   });
+
+  it('should only pass the second layer for mosaic', () => {
+    const d = {
+      dataName: 'Second level 1',
+      depth: 2,
+      sortIndex: 0,
+      parent: {
+        children: [['Second level 1'], ['Second level 2']],
+        depth: 1,
+        sortIndex: 0,
+        parent: {
+          children: [['First level']],
+          depth: 0,
+          sortIndex: 0,
+        },
+      },
+    } as unknown as ShapeTreeNode;
+    const registry = getPaletteRegistry();
+    getColor(
+      ChartTypes.MOSAIC,
+      d,
+      1,
+      true,
+      {},
+      buckets,
+      visData.rows,
+      visParams,
+      registry,
+      undefined,
+      true,
+      false,
+      dataMock.fieldFormats
+    );
+    expect(registry.get().getCategoricalColor).toHaveBeenCalledWith(
+      [expect.objectContaining({ name: 'Second level 1' })],
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('should only pass the first layer for treemap', () => {
+    const d = {
+      dataName: 'Second level 1',
+      depth: 2,
+      sortIndex: 0,
+      parent: {
+        children: [['Second level 1'], ['Second level 2']],
+        depth: 1,
+        sortIndex: 0,
+        parent: {
+          children: [['First level']],
+          depth: 0,
+          sortIndex: 0,
+        },
+      },
+    } as unknown as ShapeTreeNode;
+    const registry = getPaletteRegistry();
+    getColor(
+      ChartTypes.TREEMAP,
+      d,
+      1,
+      true,
+      {},
+      buckets,
+      visData.rows,
+      visParams,
+      registry,
+      undefined,
+      true,
+      false,
+      dataMock.fieldFormats
+    );
+    expect(registry.get().getCategoricalColor).toHaveBeenCalledWith(
+      [expect.objectContaining({ name: 'First level' })],
+      expect.anything(),
+      expect.anything()
+    );
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/125831

<img width="1068" alt="Screenshot 2022-03-15 at 09 56 35" src="https://user-images.githubusercontent.com/1508364/158341946-fe245fa2-07ff-4e9a-906b-93d5febbfbcb.png">

In case of sync colors being enabled, the second layer should be used to determine the color, not the first one (which is different than treemap behavior). The old code was handling both chart types the same way, this fix makes sure the right layer is used.