### PR TITLE
[7.17] [Fleet] Enable debug logs for functional tests (#127597)

### DIFF
--- a/x-pack/test/fleet_api_integration/config.ts
+++ b/x-pack/test/fleet_api_integration/config.ts
@@ -63,6 +63,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         `--xpack.fleet.packages.0.name=endpoint`,
         `--xpack.fleet.packages.0.version=latest`,
         ...(registryPort ? [`--xpack.fleet.registryUrl=http://localhost:${registryPort}`] : []),
+        // Enable debug fleet logs by default
+        `--logging.loggers[0].name=plugins.fleet`,
+        `--logging.loggers[0].level=debug`,
+        `--logging.loggers[0].appenders=${JSON.stringify(['default'])}`,
       ],
     },
   };

--- a/x-pack/test/fleet_functional/config.ts
+++ b/x-pack/test/fleet_functional/config.ts
@@ -32,6 +32,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...xpackFunctionalConfig.get('kbnTestServer.serverArgs'),
         '--xpack.fleet.enabled=true',
+        // Enable debug fleet logs by default
+        `--logging.loggers[0].name=plugins.fleet`,
+        `--logging.loggers[0].level=debug`,
+        `--logging.loggers[0].appenders=${JSON.stringify(['default'])}`,
       ],
     },
     layout: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Fleet] Enable debug logs for functional tests (#127597)](https://github.com/elastic/kibana/pull/127597)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)