### PR TITLE
[7.17] Get rid of `axios` dependency in the Upgrade Assistant tests. (#127122)

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/app/app.helpers.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/app/app.helpers.tsx
@@ -8,6 +8,7 @@
 import { act } from 'react-dom/test-utils';
 import { registerTestBed, TestBed, AsyncTestBedConfig } from '@kbn/test/jest';
 
+import { HttpSetup } from 'src/core/public';
 import { App } from '../../../public/application/app';
 import { WithAppDependencies } from '../helpers';
 
@@ -39,8 +40,14 @@ const createActions = (testBed: TestBed) => {
   };
 };
 
-export const setupAppPage = async (overrides?: Record<string, unknown>): Promise<AppTestBed> => {
-  const initTestBed = registerTestBed(WithAppDependencies(App, overrides), testBedConfig);
+export const setupAppPage = async (
+  httpSetup: HttpSetup,
+  overrides?: Record<string, unknown>
+): Promise<AppTestBed> => {
+  const initTestBed = registerTestBed(
+    WithAppDependencies(App, httpSetup, overrides),
+    testBedConfig
+  );
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/app/cluster_upgrade.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/app/cluster_upgrade.test.tsx
@@ -12,20 +12,17 @@ import { AppTestBed, setupAppPage } from './app.helpers';
 
 describe('Cluster upgrade', () => {
   let testBed: AppTestBed;
-  let server: ReturnType<typeof setupEnvironment>['server'];
   let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
-
-  beforeEach(() => {
-    ({ server, httpRequestsMockHelpers } = setupEnvironment());
-  });
-
-  afterEach(() => {
-    server.restore();
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   describe('when user is still preparing for upgrade', () => {
     beforeEach(async () => {
-      testBed = await setupAppPage();
+      testBed = await setupAppPage(httpSetup);
     });
 
     test('renders overview', () => {
@@ -52,7 +49,7 @@ describe('Cluster upgrade', () => {
       });
 
       await act(async () => {
-        testBed = await setupAppPage();
+        testBed = await setupAppPage(httpSetup);
       });
     });
 
@@ -76,7 +73,7 @@ describe('Cluster upgrade', () => {
       });
 
       await act(async () => {
-        testBed = await setupAppPage();
+        testBed = await setupAppPage(httpSetup);
       });
     });
 

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecation_logs/es_deprecation_logs.helpers.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecation_logs/es_deprecation_logs.helpers.ts
@@ -7,7 +7,8 @@
 
 import { act } from 'react-dom/test-utils';
 import { registerTestBed, TestBed, AsyncTestBedConfig } from '@kbn/test/jest';
-import { EsDeprecationLogs } from '../../../public/application/components/es_deprecation_logs';
+import { HttpSetup } from 'src/core/public';
+import { EsDeprecationLogs } from '../../../public/application/components';
 import { WithAppDependencies } from '../helpers';
 
 const testBedConfig: AsyncTestBedConfig = {
@@ -65,10 +66,11 @@ const createActions = (testBed: TestBed) => {
 };
 
 export const setupESDeprecationLogsPage = async (
+  httpSetup: HttpSetup,
   overrides?: Record<string, unknown>
 ): Promise<EsDeprecationLogsTestBed> => {
   const initTestBed = registerTestBed(
-    WithAppDependencies(EsDeprecationLogs, overrides),
+    WithAppDependencies(EsDeprecationLogs, httpSetup, overrides),
     testBedConfig
   );
   const testBed = await initTestBed();

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/default_deprecation_flyout.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/default_deprecation_flyout.test.ts
@@ -13,13 +13,13 @@ import { esDeprecationsMockResponse, MOCK_SNAPSHOT_ID, MOCK_JOB_ID } from './moc
 
 describe('Default deprecation flyout', () => {
   let testBed: ElasticsearchTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
-  afterAll(() => {
-    server.restore();
-  });
-
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
   beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
+
     httpRequestsMockHelpers.setLoadEsDeprecationsResponse(esDeprecationsMockResponse);
     httpRequestsMockHelpers.setUpgradeMlSnapshotStatusResponse({
       nodeId: 'my_node',
@@ -27,7 +27,7 @@ describe('Default deprecation flyout', () => {
       jobId: MOCK_JOB_ID,
       status: 'idle',
     });
-    httpRequestsMockHelpers.setReindexStatusResponse({
+    httpRequestsMockHelpers.setReindexStatusResponse('reindex_index', {
       reindexOp: null,
       warnings: [],
       hasRequiredPrivileges: true,
@@ -39,7 +39,9 @@ describe('Default deprecation flyout', () => {
     });
 
     await act(async () => {
-      testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+      testBed = await setupElasticsearchPage(httpSetup, {
+        isReadOnlyMode: false,
+      });
     });
 
     testBed.component.update();

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/error_handling.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/error_handling.test.ts
@@ -12,10 +12,12 @@ import { ElasticsearchTestBed, setupElasticsearchPage } from './es_deprecations.
 
 describe('Error handling', () => {
   let testBed: ElasticsearchTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
-  afterAll(() => {
-    server.restore();
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   it('handles 403', async () => {
@@ -28,7 +30,7 @@ describe('Error handling', () => {
     httpRequestsMockHelpers.setLoadEsDeprecationsResponse(undefined, error);
 
     await act(async () => {
-      testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+      testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
     });
 
     const { component, find } = testBed;
@@ -53,7 +55,7 @@ describe('Error handling', () => {
     httpRequestsMockHelpers.setLoadEsDeprecationsResponse(undefined, error);
 
     await act(async () => {
-      testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+      testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
     });
 
     const { component, find } = testBed;
@@ -76,7 +78,7 @@ describe('Error handling', () => {
     httpRequestsMockHelpers.setLoadEsDeprecationsResponse(undefined, error);
 
     await act(async () => {
-      testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+      testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
     });
 
     const { component, find } = testBed;
@@ -96,7 +98,7 @@ describe('Error handling', () => {
     httpRequestsMockHelpers.setLoadEsDeprecationsResponse(undefined, error);
 
     await act(async () => {
-      testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+      testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
     });
 
     const { component, find } = testBed;

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/es_deprecations.helpers.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/es_deprecations.helpers.ts
@@ -7,7 +7,8 @@
 import { act } from 'react-dom/test-utils';
 
 import { registerTestBed, TestBed, AsyncTestBedConfig } from '@kbn/test/jest';
-import { EsDeprecations } from '../../../public/application/components/es_deprecations';
+import { HttpSetup } from 'src/core/public';
+import { EsDeprecations } from '../../../public/application/components';
 import { WithAppDependencies } from '../helpers';
 
 const testBedConfig: AsyncTestBedConfig = {
@@ -157,10 +158,11 @@ const createActions = (testBed: TestBed) => {
 };
 
 export const setupElasticsearchPage = async (
+  httpSetup: HttpSetup,
   overrides?: Record<string, unknown>
 ): Promise<ElasticsearchTestBed> => {
   const initTestBed = registerTestBed(
-    WithAppDependencies(EsDeprecations, overrides),
+    WithAppDependencies(EsDeprecations, httpSetup, overrides),
     testBedConfig
   );
   const testBed = await initTestBed();

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/index_settings_deprecation_flyout.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/index_settings_deprecation_flyout.test.ts
@@ -9,18 +9,23 @@ import { act } from 'react-dom/test-utils';
 
 import { setupEnvironment } from '../helpers';
 import { ElasticsearchTestBed, setupElasticsearchPage } from './es_deprecations.helpers';
-import { esDeprecationsMockResponse, MOCK_SNAPSHOT_ID, MOCK_JOB_ID } from './mocked_responses';
+import {
+  esDeprecationsMockResponse,
+  MOCK_SNAPSHOT_ID,
+  MOCK_JOB_ID,
+  MOCK_REINDEX_DEPRECATION,
+} from './mocked_responses';
 
 describe('Index settings deprecation flyout', () => {
   let testBed: ElasticsearchTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
   const indexSettingDeprecation = esDeprecationsMockResponse.deprecations[1];
-
-  afterAll(() => {
-    server.restore();
-  });
-
   beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
+
     httpRequestsMockHelpers.setLoadEsDeprecationsResponse(esDeprecationsMockResponse);
     httpRequestsMockHelpers.setUpgradeMlSnapshotStatusResponse({
       nodeId: 'my_node',
@@ -28,7 +33,7 @@ describe('Index settings deprecation flyout', () => {
       jobId: MOCK_JOB_ID,
       status: 'idle',
     });
-    httpRequestsMockHelpers.setReindexStatusResponse({
+    httpRequestsMockHelpers.setReindexStatusResponse(MOCK_REINDEX_DEPRECATION.index!, {
       reindexOp: null,
       warnings: [],
       hasRequiredPrivileges: true,
@@ -40,7 +45,7 @@ describe('Index settings deprecation flyout', () => {
     });
 
     await act(async () => {
-      testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+      testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
     });
 
     const { actions, component } = testBed;
@@ -48,7 +53,7 @@ describe('Index settings deprecation flyout', () => {
     await actions.table.clickDeprecationRowAt('indexSetting', 0);
   });
 
-  test('renders a flyout with deprecation details', async () => {
+  it('renders a flyout with deprecation details', async () => {
     const { find, exists } = testBed;
 
     expect(exists('indexSettingsDetails')).toBe(true);
@@ -64,7 +69,7 @@ describe('Index settings deprecation flyout', () => {
   it('removes deprecated index settings', async () => {
     const { find, actions, exists } = testBed;
 
-    httpRequestsMockHelpers.setUpdateIndexSettingsResponse({
+    httpRequestsMockHelpers.setUpdateIndexSettingsResponse(indexSettingDeprecation.index!, {
       acknowledged: true,
     });
 
@@ -72,13 +77,10 @@ describe('Index settings deprecation flyout', () => {
 
     await actions.indexSettingsDeprecationFlyout.clickDeleteSettingsButton();
 
-    const request = server.requests[server.requests.length - 1];
-
-    expect(request.method).toBe('POST');
-    expect(request.url).toBe(
-      `/api/upgrade_assistant/${indexSettingDeprecation.index!}/index_settings`
+    expect(httpSetup.post).toHaveBeenLastCalledWith(
+      `/api/upgrade_assistant/${indexSettingDeprecation.index!}/index_settings`,
+      expect.anything()
     );
-    expect(request.status).toEqual(200);
 
     // Verify the "Resolution" column of the table is updated
     expect(find('indexSettingsResolutionStatusCell').at(0).text()).toEqual(
@@ -104,17 +106,18 @@ describe('Index settings deprecation flyout', () => {
       message: 'Remove index settings error',
     };
 
-    httpRequestsMockHelpers.setUpdateIndexSettingsResponse(undefined, error);
+    httpRequestsMockHelpers.setUpdateIndexSettingsResponse(
+      indexSettingDeprecation.index!,
+      undefined,
+      error
+    );
 
     await actions.indexSettingsDeprecationFlyout.clickDeleteSettingsButton();
 
-    const request = server.requests[server.requests.length - 1];
-
-    expect(request.method).toBe('POST');
-    expect(request.url).toBe(
-      `/api/upgrade_assistant/${indexSettingDeprecation.index!}/index_settings`
+    expect(httpSetup.post).toHaveBeenLastCalledWith(
+      `/api/upgrade_assistant/${indexSettingDeprecation.index!}/index_settings`,
+      expect.anything()
     );
-    expect(request.status).toEqual(500);
 
     // Verify the "Resolution" column of the table is updated
     expect(find('indexSettingsResolutionStatusCell').at(0).text()).toEqual(

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/ml_snapshots_deprecation_flyout.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/ml_snapshots_deprecation_flyout.test.ts
@@ -14,14 +14,14 @@ import { esDeprecationsMockResponse, MOCK_SNAPSHOT_ID, MOCK_JOB_ID } from './moc
 
 describe('Machine learning deprecation flyout', () => {
   let testBed: ElasticsearchTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
   const mlDeprecation = esDeprecationsMockResponse.deprecations[0];
-
-  afterAll(() => {
-    server.restore();
-  });
-
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
   beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
+
     httpRequestsMockHelpers.setLoadEsDeprecationsResponse(esDeprecationsMockResponse);
     httpRequestsMockHelpers.setLoadMlUpgradeModeResponse({ mlUpgradeModeEnabled: false });
     httpRequestsMockHelpers.setUpgradeMlSnapshotStatusResponse({
@@ -30,7 +30,7 @@ describe('Machine learning deprecation flyout', () => {
       jobId: MOCK_JOB_ID,
       status: 'idle',
     });
-    httpRequestsMockHelpers.setReindexStatusResponse({
+    httpRequestsMockHelpers.setReindexStatusResponse('reindex_index', {
       reindexOp: null,
       warnings: [],
       hasRequiredPrivileges: true,
@@ -42,7 +42,7 @@ describe('Machine learning deprecation flyout', () => {
     });
 
     await act(async () => {
-      testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+      testBed = await setupElasticsearchPage(mockEnvironment.httpSetup, { isReadOnlyMode: false });
     });
 
     const { actions, component } = testBed;
@@ -84,15 +84,15 @@ describe('Machine learning deprecation flyout', () => {
       await actions.mlDeprecationFlyout.clickUpgradeSnapshot();
 
       // First, we expect a POST request to upgrade the snapshot
-      const upgradeRequest = server.requests[server.requests.length - 2];
-      expect(upgradeRequest.method).toBe('POST');
-      expect(upgradeRequest.url).toBe('/api/upgrade_assistant/ml_snapshots');
+      expect(httpSetup.post).toHaveBeenLastCalledWith(
+        '/api/upgrade_assistant/ml_snapshots',
+        expect.anything()
+      );
 
       // Next, we expect a GET request to check the status of the upgrade
-      const statusRequest = server.requests[server.requests.length - 1];
-      expect(statusRequest.method).toBe('GET');
-      expect(statusRequest.url).toBe(
-        `/api/upgrade_assistant/ml_snapshots/${MOCK_JOB_ID}/${MOCK_SNAPSHOT_ID}`
+      expect(httpSetup.get).toHaveBeenLastCalledWith(
+        `/api/upgrade_assistant/ml_snapshots/${MOCK_JOB_ID}/${MOCK_SNAPSHOT_ID}`,
+        expect.anything()
       );
 
       // Verify the "Resolution" column of the table is updated
@@ -128,9 +128,10 @@ describe('Machine learning deprecation flyout', () => {
 
       await actions.mlDeprecationFlyout.clickUpgradeSnapshot();
 
-      const upgradeRequest = server.requests[server.requests.length - 1];
-      expect(upgradeRequest.method).toBe('POST');
-      expect(upgradeRequest.url).toBe('/api/upgrade_assistant/ml_snapshots');
+      expect(httpSetup.post).toHaveBeenLastCalledWith(
+        '/api/upgrade_assistant/ml_snapshots',
+        expect.anything()
+      );
 
       // Verify the "Resolution" column of the table is updated
       expect(find('mlActionResolutionCell').text()).toContain('Upgrade failed');
@@ -147,10 +148,12 @@ describe('Machine learning deprecation flyout', () => {
     });
 
     it('Disables actions if ml_upgrade_mode is enabled', async () => {
-      httpRequestsMockHelpers.setLoadMlUpgradeModeResponse({ mlUpgradeModeEnabled: true });
+      httpRequestsMockHelpers.setLoadMlUpgradeModeResponse({
+        mlUpgradeModeEnabled: true,
+      });
 
       await act(async () => {
-        testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+        testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
       });
 
       const { actions, exists, component } = testBed;
@@ -172,7 +175,9 @@ describe('Machine learning deprecation flyout', () => {
     it('successfully deletes snapshots', async () => {
       const { find, actions, exists } = testBed;
 
-      httpRequestsMockHelpers.setDeleteMlSnapshotResponse({
+      const jobId = (mlDeprecation.correctiveAction! as MlAction).jobId;
+      const snapshotId = (mlDeprecation.correctiveAction! as MlAction).snapshotId;
+      httpRequestsMockHelpers.setDeleteMlSnapshotResponse(jobId, snapshotId, {
         acknowledged: true,
       });
 
@@ -181,13 +186,9 @@ describe('Machine learning deprecation flyout', () => {
 
       await actions.mlDeprecationFlyout.clickDeleteSnapshot();
 
-      const request = server.requests[server.requests.length - 1];
-
-      expect(request.method).toBe('DELETE');
-      expect(request.url).toBe(
-        `/api/upgrade_assistant/ml_snapshots/${
-          (mlDeprecation.correctiveAction! as MlAction).jobId
-        }/${(mlDeprecation.correctiveAction! as MlAction).snapshotId}`
+      expect(httpSetup.delete).toHaveBeenLastCalledWith(
+        `/api/upgrade_assistant/ml_snapshots/${jobId}/${snapshotId}`,
+        expect.anything()
       );
 
       // Verify the "Resolution" column of the table is updated
@@ -212,17 +213,15 @@ describe('Machine learning deprecation flyout', () => {
         message: 'Upgrade snapshot error',
       };
 
-      httpRequestsMockHelpers.setDeleteMlSnapshotResponse(undefined, error);
+      const jobId = (mlDeprecation.correctiveAction! as MlAction).jobId;
+      const snapshotId = (mlDeprecation.correctiveAction! as MlAction).snapshotId;
+      httpRequestsMockHelpers.setDeleteMlSnapshotResponse(jobId, snapshotId, undefined, error);
 
       await actions.mlDeprecationFlyout.clickDeleteSnapshot();
 
-      const request = server.requests[server.requests.length - 1];
-
-      expect(request.method).toBe('DELETE');
-      expect(request.url).toBe(
-        `/api/upgrade_assistant/ml_snapshots/${
-          (mlDeprecation.correctiveAction! as MlAction).jobId
-        }/${(mlDeprecation.correctiveAction! as MlAction).snapshotId}`
+      expect(httpSetup.delete).toHaveBeenLastCalledWith(
+        `/api/upgrade_assistant/ml_snapshots/${jobId}/${snapshotId}`,
+        expect.anything()
       );
 
       // Verify the "Resolution" column of the table is updated

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/mocked_responses.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/mocked_responses.ts
@@ -25,7 +25,7 @@ export const MOCK_ML_DEPRECATION: EnrichedDeprecationInfo = {
   },
 };
 
-const MOCK_REINDEX_DEPRECATION: EnrichedDeprecationInfo = {
+export const MOCK_REINDEX_DEPRECATION: EnrichedDeprecationInfo = {
   isCritical: true,
   resolveDuringUpgrade: false,
   type: 'index_settings',

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/reindex_deprecation_flyout.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecations/reindex_deprecation_flyout.test.ts
@@ -10,7 +10,12 @@ import { act } from 'react-dom/test-utils';
 import { ReindexStatus, ReindexStep, ReindexStatusResponse } from '../../../common/types';
 import { setupEnvironment } from '../helpers';
 import { ElasticsearchTestBed, setupElasticsearchPage } from './es_deprecations.helpers';
-import { esDeprecationsMockResponse, MOCK_SNAPSHOT_ID, MOCK_JOB_ID } from './mocked_responses';
+import {
+  esDeprecationsMockResponse,
+  MOCK_SNAPSHOT_ID,
+  MOCK_JOB_ID,
+  MOCK_REINDEX_DEPRECATION,
+} from './mocked_responses';
 
 const defaultReindexStatusMeta: ReindexStatusResponse['meta'] = {
   indexName: 'foo',
@@ -20,7 +25,6 @@ const defaultReindexStatusMeta: ReindexStatusResponse['meta'] = {
 
 describe('Reindex deprecation flyout', () => {
   let testBed: ElasticsearchTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
 
   beforeAll(() => {
     jest.useFakeTimers();
@@ -28,10 +32,15 @@ describe('Reindex deprecation flyout', () => {
 
   afterAll(() => {
     jest.useRealTimers();
-    server.restore();
   });
 
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
   beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
+
     httpRequestsMockHelpers.setLoadEsDeprecationsResponse(esDeprecationsMockResponse);
     httpRequestsMockHelpers.setUpgradeMlSnapshotStatusResponse({
       nodeId: 'my_node',
@@ -39,7 +48,7 @@ describe('Reindex deprecation flyout', () => {
       jobId: MOCK_JOB_ID,
       status: 'idle',
     });
-    httpRequestsMockHelpers.setReindexStatusResponse({
+    httpRequestsMockHelpers.setReindexStatusResponse(MOCK_REINDEX_DEPRECATION.index!, {
       reindexOp: null,
       warnings: [],
       hasRequiredPrivileges: true,
@@ -52,7 +61,7 @@ describe('Reindex deprecation flyout', () => {
     httpRequestsMockHelpers.setLoadNodeDiskSpaceResponse([]);
 
     await act(async () => {
-      testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+      testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
     });
 
     testBed.component.update();
@@ -71,15 +80,8 @@ describe('Reindex deprecation flyout', () => {
   });
 
   it('renders error callout when reindex fails', async () => {
-    httpRequestsMockHelpers.setReindexStatusResponse({
-      reindexOp: null,
-      warnings: [],
-      hasRequiredPrivileges: true,
-      meta: defaultReindexStatusMeta,
-    });
-
     await act(async () => {
-      testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+      testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
     });
 
     testBed.component.update();
@@ -88,7 +90,7 @@ describe('Reindex deprecation flyout', () => {
 
     await actions.table.clickDeprecationRowAt('reindex', 0);
 
-    httpRequestsMockHelpers.setStartReindexingResponse(undefined, {
+    httpRequestsMockHelpers.setStartReindexingResponse(MOCK_REINDEX_DEPRECATION.index!, undefined, {
       statusCode: 404,
       message: 'no such index [test]',
     });
@@ -99,13 +101,13 @@ describe('Reindex deprecation flyout', () => {
   });
 
   it('renders error callout when fetch status fails', async () => {
-    httpRequestsMockHelpers.setReindexStatusResponse(undefined, {
+    httpRequestsMockHelpers.setReindexStatusResponse(MOCK_REINDEX_DEPRECATION.index!, undefined, {
       statusCode: 404,
       message: 'no such index [test]',
     });
 
     await act(async () => {
-      testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+      testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
     });
 
     testBed.component.update();
@@ -127,7 +129,7 @@ describe('Reindex deprecation flyout', () => {
     });
 
     it('has started but not yet reindexing documents', async () => {
-      httpRequestsMockHelpers.setReindexStatusResponse({
+      httpRequestsMockHelpers.setReindexStatusResponse(MOCK_REINDEX_DEPRECATION.index!, {
         reindexOp: {
           status: ReindexStatus.inProgress,
           lastCompletedStep: ReindexStep.readonly,
@@ -139,7 +141,7 @@ describe('Reindex deprecation flyout', () => {
       });
 
       await act(async () => {
-        testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+        testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
       });
 
       testBed.component.update();
@@ -152,7 +154,7 @@ describe('Reindex deprecation flyout', () => {
     });
 
     it('has started reindexing documents', async () => {
-      httpRequestsMockHelpers.setReindexStatusResponse({
+      httpRequestsMockHelpers.setReindexStatusResponse(MOCK_REINDEX_DEPRECATION.index!, {
         reindexOp: {
           status: ReindexStatus.inProgress,
           lastCompletedStep: ReindexStep.reindexStarted,
@@ -164,7 +166,7 @@ describe('Reindex deprecation flyout', () => {
       });
 
       await act(async () => {
-        testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+        testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
       });
 
       testBed.component.update();
@@ -177,7 +179,7 @@ describe('Reindex deprecation flyout', () => {
     });
 
     it('has completed reindexing documents', async () => {
-      httpRequestsMockHelpers.setReindexStatusResponse({
+      httpRequestsMockHelpers.setReindexStatusResponse(MOCK_REINDEX_DEPRECATION.index!, {
         reindexOp: {
           status: ReindexStatus.inProgress,
           lastCompletedStep: ReindexStep.reindexCompleted,
@@ -189,7 +191,7 @@ describe('Reindex deprecation flyout', () => {
       });
 
       await act(async () => {
-        testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+        testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
       });
 
       testBed.component.update();
@@ -202,7 +204,7 @@ describe('Reindex deprecation flyout', () => {
     });
 
     it('has completed', async () => {
-      httpRequestsMockHelpers.setReindexStatusResponse({
+      httpRequestsMockHelpers.setReindexStatusResponse(MOCK_REINDEX_DEPRECATION.index!, {
         reindexOp: {
           status: ReindexStatus.completed,
           lastCompletedStep: ReindexStep.aliasCreated,
@@ -214,7 +216,7 @@ describe('Reindex deprecation flyout', () => {
       });
 
       await act(async () => {
-        testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+        testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
       });
 
       const { actions, find, exists, component } = testBed;
@@ -249,7 +251,7 @@ describe('Reindex deprecation flyout', () => {
       ]);
 
       await act(async () => {
-        testBed = await setupElasticsearchPage({ isReadOnlyMode: false });
+        testBed = await setupElasticsearchPage(httpSetup, { isReadOnlyMode: false });
       });
 
       testBed.component.update();

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/http_requests.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/http_requests.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import sinon, { SinonFakeServer } from 'sinon';
+import { httpServiceMock } from '../../../../../../src/core/public/mocks';
 
 import { API_BASE_PATH } from '../../../common/constants';
 import {
@@ -15,225 +15,136 @@ import {
   ResponseError,
 } from '../../../common/types';
 
+type HttpMethod = 'GET' | 'PUT' | 'DELETE' | 'POST';
+
 // Register helpers to mock HTTP Requests
-const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
-  const setLoadCloudBackupStatusResponse = (
-    response?: CloudBackupStatus,
-    error?: ResponseError
-  ) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
+const registerHttpRequestMockHelpers = (
+  httpSetup: ReturnType<typeof httpServiceMock.createStartContract>,
+  shouldDelayResponse: () => boolean
+) => {
+  const mockResponses = new Map<HttpMethod, Map<string, Promise<unknown>>>(
+    ['GET', 'PUT', 'DELETE', 'POST'].map(
+      (method) => [method, new Map()] as [HttpMethod, Map<string, Promise<unknown>>]
+    )
+  );
 
-    server.respondWith('GET', `${API_BASE_PATH}/cloud_backup_status`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
+  const mockMethodImplementation = (method: HttpMethod, path: string) => {
+    const responsePromise = mockResponses.get(method)?.get(path) ?? Promise.resolve({});
+    if (shouldDelayResponse()) {
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(responsePromise), 1000);
+      });
+    }
+
+    return responsePromise;
   };
 
-  const setLoadEsDeprecationsResponse = (response?: ESUpgradeStatus, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
+  httpSetup.get.mockImplementation((path) =>
+    mockMethodImplementation('GET', path as unknown as string)
+  );
+  httpSetup.delete.mockImplementation((path) =>
+    mockMethodImplementation('DELETE', path as unknown as string)
+  );
+  httpSetup.post.mockImplementation((path) =>
+    mockMethodImplementation('POST', path as unknown as string)
+  );
+  httpSetup.put.mockImplementation((path) =>
+    mockMethodImplementation('PUT', path as unknown as string)
+  );
 
-    server.respondWith('GET', `${API_BASE_PATH}/es_deprecations`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
+  const mockResponse = (method: HttpMethod, path: string, response?: unknown, error?: unknown) => {
+    const defuse = (promise: Promise<unknown>) => {
+      promise.catch(() => {});
+      return promise;
+    };
+
+    return mockResponses
+      .get(method)!
+      .set(path, error ? defuse(Promise.reject({ body: error })) : Promise.resolve(response));
   };
+
+  const setLoadCloudBackupStatusResponse = (response?: CloudBackupStatus, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/cloud_backup_status`, response, error);
+
+  const setLoadEsDeprecationsResponse = (response?: ESUpgradeStatus, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/es_deprecations`, response, error);
 
   const setLoadDeprecationLoggingResponse = (
     response?: DeprecationLoggingStatus,
     error?: ResponseError
-  ) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
-
-    server.respondWith('GET', `${API_BASE_PATH}/deprecation_logging`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  ) => mockResponse('GET', `${API_BASE_PATH}/deprecation_logging`, response, error);
 
   const setLoadDeprecationLogsCountResponse = (
     response?: { count: number },
     error?: ResponseError
-  ) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
+  ) => mockResponse('GET', `${API_BASE_PATH}/deprecation_logging/count`, response, error);
 
-    server.respondWith('GET', `${API_BASE_PATH}/deprecation_logging/count`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
-
-  const setDeleteLogsCacheResponse = (response?: string, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
-    server.respondWith('DELETE', `${API_BASE_PATH}/deprecation_logging/cache`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setDeleteLogsCacheResponse = (response?: string, error?: ResponseError) =>
+    mockResponse('DELETE', `${API_BASE_PATH}/deprecation_logging/cache`, response, error);
 
   const setUpdateDeprecationLoggingResponse = (
     response?: DeprecationLoggingStatus,
     error?: ResponseError
-  ) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
+  ) => mockResponse('PUT', `${API_BASE_PATH}/deprecation_logging`, response, error);
 
-    server.respondWith('PUT', `${API_BASE_PATH}/deprecation_logging`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setUpdateIndexSettingsResponse = (
+    indexName: string,
+    response?: object,
+    error?: ResponseError
+  ) => mockResponse('POST', `${API_BASE_PATH}/${indexName}/index_settings`, response, error);
 
-  const setUpdateIndexSettingsResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
-    server.respondWith('POST', `${API_BASE_PATH}/:indexName/index_settings`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setUpgradeMlSnapshotResponse = (response?: object, error?: ResponseError) =>
+    mockResponse('POST', `${API_BASE_PATH}/ml_snapshots`, response, error);
 
-  const setUpgradeMlSnapshotResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
+  const setUpgradeMlSnapshotStatusResponse = (
+    response?: Record<string, unknown>,
+    error?: ResponseError
+  ) =>
+    mockResponse(
+      'GET',
+      `${API_BASE_PATH}/ml_snapshots/${response?.jobId}/${response?.snapshotId}`,
+      response,
+      error
+    );
 
-    server.respondWith('POST', `${API_BASE_PATH}/ml_snapshots`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setReindexStatusResponse = (
+    indexName: string,
+    response?: Record<string, any>,
+    error?: ResponseError
+  ) => mockResponse('GET', `${API_BASE_PATH}/reindex/${indexName}`, response, error);
 
-  const setUpgradeMlSnapshotStatusResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
+  const setStartReindexingResponse = (
+    indexName: string,
+    response?: object,
+    error?: ResponseError
+  ) => mockResponse('POST', `${API_BASE_PATH}/reindex/${indexName}`, response, error);
 
-    server.respondWith('GET', `${API_BASE_PATH}/ml_snapshots/:jobId/:snapshotId`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setDeleteMlSnapshotResponse = (
+    jobId: string,
+    snapshotId: string,
+    response?: object,
+    error?: ResponseError
+  ) =>
+    mockResponse('DELETE', `${API_BASE_PATH}/ml_snapshots/${jobId}/${snapshotId}`, response, error);
 
-  const setReindexStatusResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
+  const setLoadSystemIndicesMigrationStatus = (response?: object, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/system_indices_migration`, response, error);
 
-    server.respondWith('GET', `${API_BASE_PATH}/reindex/:indexName`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setLoadMlUpgradeModeResponse = (response?: object, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/ml_upgrade_mode`, response, error);
 
-  const setStartReindexingResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
+  const setSystemIndicesMigrationResponse = (response?: object, error?: ResponseError) =>
+    mockResponse('POST', `${API_BASE_PATH}/system_indices_migration`, response, error);
 
-    server.respondWith('POST', `${API_BASE_PATH}/reindex/:indexName`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setGetUpgradeStatusResponse = (response?: object, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/status`, response, error);
 
-  const setDeleteMlSnapshotResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
+  const setLoadRemoteClustersResponse = (response?: object, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/remote_clusters`, response, error);
 
-    server.respondWith('DELETE', `${API_BASE_PATH}/ml_snapshots/:jobId/:snapshotId`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setLoadNodeDiskSpaceResponse = (response?: object, error?: ResponseError) => mockResponse('GET', `${API_BASE_PATH}/node_disk_space`, response, error);
 
-  const setLoadSystemIndicesMigrationStatus = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
-
-    server.respondWith('GET', `${API_BASE_PATH}/system_indices_migration`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
-
-  const setLoadMlUpgradeModeResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
-
-    server.respondWith('GET', `${API_BASE_PATH}/ml_upgrade_mode`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
-
-  const setSystemIndicesMigrationResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
-
-    server.respondWith('POST', `${API_BASE_PATH}/system_indices_migration`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
-
-  const setGetUpgradeStatusResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
-
-    server.respondWith('GET', `${API_BASE_PATH}/status`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
-
-  const setLoadRemoteClustersResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
-
-    server.respondWith('GET', `${API_BASE_PATH}/remote_clusters`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
-
-  const setLoadNodeDiskSpaceResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
-
-    server.respondWith('GET', `${API_BASE_PATH}/node_disk_space`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
-
-  const setClusterSettingsResponse = (response?: object, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ? error : response;
-    server.respondWith('POST', `${API_BASE_PATH}/cluster_settings`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setClusterSettingsResponse = (response?: object, error?: ResponseError) => mockResponse('POST', `${API_BASE_PATH}/cluster_settings`, response, error);
 
   return {
     setLoadCloudBackupStatusResponse,
@@ -259,29 +170,18 @@ const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
 };
 
 export const init = () => {
-  const server = sinon.fakeServer.create();
-  server.respondImmediately = true;
-
-  // Define default response for unhandled requests.
-  // We make requests to APIs which don't impact the component under test, e.g. UI metric telemetry,
-  // and we can mock them all with a 200 instead of mocking each one individually.
-  server.respondWith([200, {}, 'DefaultMockedResponse']);
-
-  const httpRequestsMockHelpers = registerHttpRequestMockHelpers(server);
-
-  const setServerAsync = (isAsync: boolean, timeout: number = 200) => {
-    if (isAsync) {
-      server.autoRespond = true;
-      server.autoRespondAfter = 1000;
-      server.respondImmediately = false;
-    } else {
-      server.respondImmediately = true;
-    }
+  let isResponseDelayed = false;
+  const getDelayResponse = () => isResponseDelayed;
+  const setDelayResponse = (shouldDelayResponse: boolean) => {
+    isResponseDelayed = shouldDelayResponse;
   };
 
+  const httpSetup = httpServiceMock.createSetupContract();
+  const httpRequestsMockHelpers = registerHttpRequestMockHelpers(httpSetup, getDelayResponse);
+
   return {
-    server,
-    setServerAsync,
+    setDelayResponse,
+    httpSetup,
     httpRequestsMockHelpers,
   };
 };

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/http_requests.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/http_requests.ts
@@ -142,9 +142,11 @@ const registerHttpRequestMockHelpers = (
   const setLoadRemoteClustersResponse = (response?: object, error?: ResponseError) =>
     mockResponse('GET', `${API_BASE_PATH}/remote_clusters`, response, error);
 
-  const setLoadNodeDiskSpaceResponse = (response?: object, error?: ResponseError) => mockResponse('GET', `${API_BASE_PATH}/node_disk_space`, response, error);
+  const setLoadNodeDiskSpaceResponse = (response?: object, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/node_disk_space`, response, error);
 
-  const setClusterSettingsResponse = (response?: object, error?: ResponseError) => mockResponse('POST', `${API_BASE_PATH}/cluster_settings`, response, error);
+  const setClusterSettingsResponse = (response?: object, error?: ResponseError) =>
+    mockResponse('POST', `${API_BASE_PATH}/cluster_settings`, response, error);
 
   return {
     setLoadCloudBackupStatusResponse,

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/setup_environment.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/setup_environment.tsx
@@ -6,11 +6,8 @@
  */
 
 import React from 'react';
-import axios from 'axios';
 import SemVer from 'semver/classes/semver';
 import { merge } from 'lodash';
-// @ts-ignore
-import axiosXhrAdapter from 'axios/lib/adapters/xhr';
 
 import { HttpSetup } from 'src/core/public';
 
@@ -26,8 +23,6 @@ import { init as initHttpRequests } from './http_requests';
 
 const { GlobalFlyoutProvider } = GlobalFlyout;
 
-const mockHttpClient = axios.create({ adapter: axiosXhrAdapter });
-
 const createAuthorizationContextValue = (privileges: Privileges) => {
   return {
     isLoading: false,
@@ -38,9 +33,9 @@ const createAuthorizationContextValue = (privileges: Privileges) => {
 export const kibanaVersion = new SemVer(MAJOR_VERSION);
 
 export const WithAppDependencies =
-  (Comp: any, { privileges, ...overrides }: Record<string, unknown> = {}) =>
+  (Comp: any, httpSetup: HttpSetup, { privileges, ...overrides }: Record<string, unknown> = {}) =>
   (props: Record<string, unknown>) => {
-    apiService.setup(mockHttpClient as unknown as HttpSetup);
+    apiService.setup(httpSetup);
     breadcrumbService.setup(() => '');
 
     const appContextMock = getAppContextMock(kibanaVersion) as unknown as AppDependencies;
@@ -59,11 +54,5 @@ export const WithAppDependencies =
   };
 
 export const setupEnvironment = () => {
-  const { server, setServerAsync, httpRequestsMockHelpers } = initHttpRequests();
-
-  return {
-    server,
-    setServerAsync,
-    httpRequestsMockHelpers,
-  };
+  return initHttpRequests();
 };

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/deprecation_details_flyout/deprecation_details_flyout.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/deprecation_details_flyout/deprecation_details_flyout.test.ts
@@ -14,21 +14,15 @@ import { KibanaTestBed, setupKibanaPage } from '../kibana_deprecations.helpers';
 
 describe('Kibana deprecations - Deprecation details flyout', () => {
   let testBed: KibanaTestBed;
-  const { server } = setupEnvironment();
   const {
     defaultMockedResponses: { mockedKibanaDeprecations },
   } = kibanaDeprecationsServiceHelpers;
   const deprecationService = deprecationsServiceMock.createStartContract();
-
-  afterAll(() => {
-    server.restore();
-  });
-
   beforeEach(async () => {
     await act(async () => {
       kibanaDeprecationsServiceHelpers.setLoadDeprecations({ deprecationService });
 
-      testBed = await setupKibanaPage({
+      testBed = await setupKibanaPage(setupEnvironment().httpSetup, {
         services: {
           core: {
             deprecations: deprecationService,

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/deprecations_table/deprecations_table.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/deprecations_table/deprecations_table.test.ts
@@ -17,7 +17,6 @@ describe('Kibana deprecations - Deprecations table', () => {
   let testBed: KibanaTestBed;
   let deprecationService: jest.Mocked<DeprecationsServiceStart>;
 
-  const { server } = setupEnvironment();
   const {
     mockedKibanaDeprecations,
     mockedCriticalKibanaDeprecations,
@@ -25,17 +24,16 @@ describe('Kibana deprecations - Deprecations table', () => {
     mockedConfigKibanaDeprecations,
   } = kibanaDeprecationsServiceHelpers.defaultMockedResponses;
 
-  afterAll(() => {
-    server.restore();
-  });
-
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
   beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpSetup = mockEnvironment.httpSetup;
     deprecationService = deprecationsServiceMock.createStartContract();
 
     await act(async () => {
       kibanaDeprecationsServiceHelpers.setLoadDeprecations({ deprecationService });
 
-      testBed = await setupKibanaPage({
+      testBed = await setupKibanaPage(httpSetup, {
         services: {
           core: {
             deprecations: deprecationService,
@@ -108,7 +106,7 @@ describe('Kibana deprecations - Deprecations table', () => {
   describe('No deprecations', () => {
     beforeEach(async () => {
       await act(async () => {
-        testBed = await setupKibanaPage({ isReadOnlyMode: false });
+        testBed = await setupKibanaPage(httpSetup, { isReadOnlyMode: false });
       });
 
       const { component } = testBed;

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/deprecations_table/error_handling.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/deprecations_table/error_handling.test.ts
@@ -14,11 +14,12 @@ import { KibanaTestBed, setupKibanaPage } from '../kibana_deprecations.helpers';
 
 describe('Kibana deprecations - Deprecations table - Error handling', () => {
   let testBed: KibanaTestBed;
-  const { server } = setupEnvironment();
   const deprecationService = deprecationsServiceMock.createStartContract();
 
-  afterAll(() => {
-    server.restore();
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   test('handles plugin errors', async () => {
@@ -57,7 +58,7 @@ describe('Kibana deprecations - Deprecations table - Error handling', () => {
         ],
       });
 
-      testBed = await setupKibanaPage({
+      testBed = await setupKibanaPage(httpSetup, {
         services: {
           core: {
             deprecations: deprecationService,
@@ -83,7 +84,7 @@ describe('Kibana deprecations - Deprecations table - Error handling', () => {
         mockRequestErrorMessage: 'Internal Server Error',
       });
 
-      testBed = await setupKibanaPage({
+      testBed = await setupKibanaPage(httpSetup, {
         services: {
           core: {
             deprecations: deprecationService,

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/kibana_deprecations.helpers.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/kibana_deprecations.helpers.ts
@@ -6,6 +6,7 @@
  */
 import { act } from 'react-dom/test-utils';
 import { registerTestBed, TestBed, AsyncTestBedConfig, findTestSubject } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { KibanaDeprecations } from '../../../public/application/components';
 import { WithAppDependencies } from '../helpers';
 
@@ -112,10 +113,11 @@ const createActions = (testBed: TestBed) => {
 };
 
 export const setupKibanaPage = async (
+  httpSetup: HttpSetup,
   overrides?: Record<string, unknown>
 ): Promise<KibanaTestBed> => {
   const initTestBed = registerTestBed(
-    WithAppDependencies(KibanaDeprecations, overrides),
+    WithAppDependencies(KibanaDeprecations, httpSetup, overrides),
     testBedConfig
   );
   const testBed = await initTestBed();

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/backup_step/backup_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/backup_step/backup_step.test.tsx
@@ -14,21 +14,19 @@ import { OverviewTestBed, setupOverviewPage } from '../overview.helpers';
 
 describe('Overview - Backup Step', () => {
   let testBed: OverviewTestBed;
-  let server: ReturnType<typeof setupEnvironment>['server'];
-  let setServerAsync: ReturnType<typeof setupEnvironment>['setServerAsync'];
   let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
-
-  beforeEach(() => {
-    ({ server, setServerAsync, httpRequestsMockHelpers } = setupEnvironment());
-  });
-
-  afterEach(() => {
-    server.restore();
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+  let setDelayResponse: ReturnType<typeof setupEnvironment>['setDelayResponse'];
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
+    setDelayResponse = mockEnvironment.setDelayResponse;
   });
 
   describe('On-prem', () => {
     beforeEach(async () => {
-      testBed = await setupOverviewPage();
+      testBed = await setupOverviewPage(httpSetup);
     });
 
     test('Shows link to Snapshot and Restore', () => {
@@ -45,7 +43,7 @@ describe('Overview - Backup Step', () => {
 
   describe('On Cloud', () => {
     const setupCloudOverviewPage = async () =>
-      setupOverviewPage({
+      setupOverviewPage(httpSetup, {
         plugins: {
           cloud: {
             isCloudEnabled: true,
@@ -57,12 +55,8 @@ describe('Overview - Backup Step', () => {
     describe('initial loading state', () => {
       beforeEach(async () => {
         // We don't want the request to load backup status to resolve immediately.
-        setServerAsync(true);
+        setDelayResponse(true);
         testBed = await setupCloudOverviewPage();
-      });
-
-      afterEach(() => {
-        setServerAsync(false);
       });
 
       test('is rendered', () => {

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/fix_issues_step/elasticsearch_deprecation_issues.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/fix_issues_step/elasticsearch_deprecation_issues.test.tsx
@@ -19,10 +19,12 @@ import {
 
 describe('Overview - Fix deprecation issues step - Elasticsearch deprecations', () => {
   let testBed: OverviewTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
-  afterAll(() => {
-    server.restore();
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   describe('When load succeeds', () => {
@@ -32,7 +34,7 @@ describe('Overview - Fix deprecation issues step - Elasticsearch deprecations', 
         const deprecationService = deprecationsServiceMock.createStartContract();
         kibanaDeprecationsServiceHelpers.setLoadDeprecations({ deprecationService, response: [] });
 
-        testBed = await setupOverviewPage({
+        testBed = await setupOverviewPage(httpSetup, {
           services: {
             core: {
               deprecations: deprecationService,
@@ -116,7 +118,7 @@ describe('Overview - Fix deprecation issues step - Elasticsearch deprecations', 
       httpRequestsMockHelpers.setLoadEsDeprecationsResponse(undefined, error);
 
       await act(async () => {
-        testBed = await setupOverviewPage();
+        testBed = await setupOverviewPage(httpSetup);
       });
 
       const { component, find } = testBed;
@@ -136,7 +138,7 @@ describe('Overview - Fix deprecation issues step - Elasticsearch deprecations', 
       httpRequestsMockHelpers.setLoadEsDeprecationsResponse(undefined, error);
 
       await act(async () => {
-        testBed = await setupOverviewPage();
+        testBed = await setupOverviewPage(httpSetup);
       });
 
       const { component, find } = testBed;
@@ -159,7 +161,7 @@ describe('Overview - Fix deprecation issues step - Elasticsearch deprecations', 
       httpRequestsMockHelpers.setLoadEsDeprecationsResponse(undefined, error);
 
       await act(async () => {
-        testBed = await setupOverviewPage({ isReadOnlyMode: false });
+        testBed = await setupOverviewPage(httpSetup, { isReadOnlyMode: false });
       });
 
       const { component, find } = testBed;
@@ -182,7 +184,7 @@ describe('Overview - Fix deprecation issues step - Elasticsearch deprecations', 
       httpRequestsMockHelpers.setLoadEsDeprecationsResponse(undefined, error);
 
       await act(async () => {
-        testBed = await setupOverviewPage({ isReadOnlyMode: false });
+        testBed = await setupOverviewPage(httpSetup, { isReadOnlyMode: false });
       });
 
       const { component, find } = testBed;

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/fix_issues_step/fix_issues_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/fix_issues_step/fix_issues_step.test.tsx
@@ -15,10 +15,12 @@ import { esCriticalAndWarningDeprecations, esNoDeprecations } from './mock_es_is
 
 describe('Overview - Fix deprecation issues step', () => {
   let testBed: OverviewTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
-  afterAll(() => {
-    server.restore();
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   describe('when there are critical issues in one panel', () => {
@@ -29,7 +31,7 @@ describe('Overview - Fix deprecation issues step', () => {
         const deprecationService = deprecationsServiceMock.createStartContract();
         kibanaDeprecationsServiceHelpers.setLoadDeprecations({ deprecationService, response: [] });
 
-        testBed = await setupOverviewPage({
+        testBed = await setupOverviewPage(httpSetup, {
           services: {
             core: {
               deprecations: deprecationService,
@@ -55,7 +57,7 @@ describe('Overview - Fix deprecation issues step', () => {
         const deprecationService = deprecationsServiceMock.createStartContract();
         kibanaDeprecationsServiceHelpers.setLoadDeprecations({ deprecationService, response: [] });
 
-        testBed = await setupOverviewPage({
+        testBed = await setupOverviewPage(httpSetup, {
           services: {
             core: {
               deprecations: deprecationService,

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/fix_issues_step/kibana_deprecation_issues.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/fix_issues_step/kibana_deprecation_issues.test.tsx
@@ -16,12 +16,14 @@ import { esNoDeprecations } from './mock_es_issues';
 
 describe('Overview - Fix deprecation issues step - Kibana deprecations', () => {
   let testBed: OverviewTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
   const { mockedKibanaDeprecations, mockedCriticalKibanaDeprecations } =
     kibanaDeprecationsServiceHelpers.defaultMockedResponses;
-
-  afterAll(() => {
-    server.restore();
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   describe('When load succeeds', () => {
@@ -33,7 +35,7 @@ describe('Overview - Fix deprecation issues step - Kibana deprecations', () => {
         const deprecationService = deprecationsServiceMock.createStartContract();
         kibanaDeprecationsServiceHelpers.setLoadDeprecations({ deprecationService, response });
 
-        testBed = await setupOverviewPage({
+        testBed = await setupOverviewPage(httpSetup, {
           services: {
             core: {
               deprecations: deprecationService,
@@ -114,7 +116,7 @@ describe('Overview - Fix deprecation issues step - Kibana deprecations', () => {
           mockRequestErrorMessage: 'Internal Server Error',
         });
 
-        testBed = await setupOverviewPage({
+        testBed = await setupOverviewPage(httpSetup, {
           services: {
             core: {
               deprecations: deprecationService,

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/logs_step/logs_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/logs_step/logs_step.test.tsx
@@ -136,7 +136,7 @@ describe('Overview - Logs Step', () => {
       });
 
       await act(async () => {
-        testBed = await setupOverviewPage(httpSetup,{
+        testBed = await setupOverviewPage(httpSetup, {
           privileges: {
             hasAllPrivileges: true,
             missingPrivileges: {

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/logs_step/logs_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/logs_step/logs_step.test.tsx
@@ -12,11 +12,12 @@ import { OverviewTestBed, setupOverviewPage } from '../overview.helpers';
 
 describe('Overview - Logs Step', () => {
   let testBed: OverviewTestBed;
-
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
-  afterAll(() => {
-    server.restore();
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   describe('error state', () => {
@@ -30,7 +31,7 @@ describe('Overview - Logs Step', () => {
       httpRequestsMockHelpers.setLoadDeprecationLogsCountResponse(undefined, error);
 
       await act(async () => {
-        testBed = await setupOverviewPage();
+        testBed = await setupOverviewPage(httpSetup);
       });
 
       testBed.component.update();
@@ -58,7 +59,7 @@ describe('Overview - Logs Step', () => {
         });
 
         await act(async () => {
-          testBed = await setupOverviewPage();
+          testBed = await setupOverviewPage(httpSetup);
         });
 
         const { component, exists } = testBed;
@@ -74,7 +75,7 @@ describe('Overview - Logs Step', () => {
         });
 
         await act(async () => {
-          testBed = await setupOverviewPage();
+          testBed = await setupOverviewPage(httpSetup);
         });
 
         const { component, exists } = testBed;
@@ -90,7 +91,7 @@ describe('Overview - Logs Step', () => {
         });
 
         await act(async () => {
-          testBed = await setupOverviewPage();
+          testBed = await setupOverviewPage(httpSetup);
         });
 
         const { component, find } = testBed;
@@ -110,7 +111,7 @@ describe('Overview - Logs Step', () => {
         });
 
         await act(async () => {
-          testBed = await setupOverviewPage();
+          testBed = await setupOverviewPage(httpSetup);
         });
 
         const { component } = testBed;
@@ -135,7 +136,7 @@ describe('Overview - Logs Step', () => {
       });
 
       await act(async () => {
-        testBed = await setupOverviewPage({
+        testBed = await setupOverviewPage(httpSetup,{
           privileges: {
             hasAllPrivileges: true,
             missingPrivileges: {

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/migrate_system_indices/flyout.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/migrate_system_indices/flyout.test.ts
@@ -13,20 +13,20 @@ import { systemIndicesMigrationStatus } from './mocks';
 
 describe('Overview - Migrate system indices - Flyout', () => {
   let testBed: OverviewTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
   beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
+
     httpRequestsMockHelpers.setLoadSystemIndicesMigrationStatus(systemIndicesMigrationStatus);
 
     await act(async () => {
-      testBed = await setupOverviewPage();
+      testBed = await setupOverviewPage(httpSetup);
     });
 
     testBed.component.update();
-  });
-
-  afterAll(() => {
-    server.restore();
   });
 
   test('shows correct features in flyout table', async () => {

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/migrate_system_indices/migrate_system_indices.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/migrate_system_indices/migrate_system_indices.test.tsx
@@ -12,15 +12,15 @@ import { OverviewTestBed, setupOverviewPage } from '../overview.helpers';
 
 describe('Overview - Migrate system indices', () => {
   let testBed: OverviewTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
   beforeEach(async () => {
-    testBed = await setupOverviewPage();
-    testBed.component.update();
-  });
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
 
-  afterAll(() => {
-    server.restore();
+    testBed = await setupOverviewPage(httpSetup);
+    testBed.component.update();
   });
 
   describe('Error state', () => {
@@ -30,7 +30,7 @@ describe('Overview - Migrate system indices', () => {
         message: 'error',
       });
 
-      testBed = await setupOverviewPage();
+      testBed = await setupOverviewPage(httpSetup);
     });
 
     test('Is rendered', () => {
@@ -59,7 +59,7 @@ describe('Overview - Migrate system indices', () => {
       migration_status: 'NO_MIGRATION_NEEDED',
     });
 
-    testBed = await setupOverviewPage();
+    testBed = await setupOverviewPage(httpSetup);
 
     const { exists, component } = testBed;
 
@@ -75,7 +75,7 @@ describe('Overview - Migrate system indices', () => {
       migration_status: 'IN_PROGRESS',
     });
 
-    testBed = await setupOverviewPage();
+    testBed = await setupOverviewPage(httpSetup);
 
     const { exists, component, find } = testBed;
 
@@ -94,7 +94,7 @@ describe('Overview - Migrate system indices', () => {
         migration_status: 'MIGRATION_NEEDED',
       });
 
-      testBed = await setupOverviewPage();
+      testBed = await setupOverviewPage(httpSetup);
 
       const { exists, component, find } = testBed;
 
@@ -116,7 +116,7 @@ describe('Overview - Migrate system indices', () => {
         message: 'error',
       });
 
-      testBed = await setupOverviewPage();
+      testBed = await setupOverviewPage(httpSetup);
 
       const { exists, component, find } = testBed;
 
@@ -154,7 +154,7 @@ describe('Overview - Migrate system indices', () => {
         ],
       });
 
-      testBed = await setupOverviewPage();
+      testBed = await setupOverviewPage(httpSetup);
 
       const { exists } = testBed;
 

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/migrate_system_indices/step_completion.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/migrate_system_indices/step_completion.test.ts
@@ -13,10 +13,12 @@ import { SYSTEM_INDICES_MIGRATION_POLL_INTERVAL_MS } from '../../../../common/co
 
 describe('Overview - Migrate system indices - Step completion', () => {
   let testBed: OverviewTestBed;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
-  afterAll(() => {
-    server.restore();
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   test(`It's complete when no upgrade is needed`, async () => {
@@ -25,7 +27,7 @@ describe('Overview - Migrate system indices - Step completion', () => {
     });
 
     await act(async () => {
-      testBed = await setupOverviewPage();
+      testBed = await setupOverviewPage(httpSetup);
     });
 
     const { exists, component } = testBed;
@@ -41,7 +43,7 @@ describe('Overview - Migrate system indices - Step completion', () => {
     });
 
     await act(async () => {
-      testBed = await setupOverviewPage();
+      testBed = await setupOverviewPage(httpSetup);
     });
 
     const { exists, component } = testBed;
@@ -60,7 +62,7 @@ describe('Overview - Migrate system indices - Step completion', () => {
         migration_status: 'IN_PROGRESS',
       });
 
-      testBed = await setupOverviewPage();
+      testBed = await setupOverviewPage(httpSetup);
     });
 
     afterEach(() => {

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/overview.helpers.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/overview.helpers.ts
@@ -7,7 +7,8 @@
 
 import { act } from 'react-dom/test-utils';
 import { registerTestBed, TestBed, AsyncTestBedConfig } from '@kbn/test/jest';
-import { Overview } from '../../../public/application/components/overview';
+import { HttpSetup } from 'src/core/public';
+import { Overview } from '../../../public/application/components';
 import { WithAppDependencies } from '../helpers';
 
 const testBedConfig: AsyncTestBedConfig = {
@@ -54,9 +55,13 @@ const createActions = (testBed: TestBed) => {
 };
 
 export const setupOverviewPage = async (
+  httpSetup: HttpSetup,
   overrides?: Record<string, unknown>
 ): Promise<OverviewTestBed> => {
-  const initTestBed = registerTestBed(WithAppDependencies(Overview, overrides), testBedConfig);
+  const initTestBed = registerTestBed(
+    WithAppDependencies(Overview, httpSetup, overrides),
+    testBedConfig
+  );
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/overview.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/overview.test.tsx
@@ -10,15 +10,9 @@ import { OverviewTestBed, setupOverviewPage } from './overview.helpers';
 
 describe('Overview Page', () => {
   let testBed: OverviewTestBed;
-  const { server } = setupEnvironment();
-
   beforeEach(async () => {
-    testBed = await setupOverviewPage();
+    testBed = await setupOverviewPage(setupEnvironment().httpSetup);
     testBed.component.update();
-  });
-
-  afterAll(() => {
-    server.restore();
   });
 
   describe('Documentation links', () => {

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/upgrade_step/upgrade_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/upgrade_step/upgrade_step.test.tsx
@@ -9,28 +9,33 @@ import { setupEnvironment } from '../../helpers';
 import { OverviewTestBed, setupOverviewPage } from '../overview.helpers';
 
 const DEPLOYMENT_URL = 'https://cloud.elastic.co./deployments/bfdad4ef99a24212a06d387593686d63';
-const setupCloudOverviewPage = () => {
-  return setupOverviewPage({
-    plugins: {
-      cloud: {
-        isCloudEnabled: true,
-        deploymentUrl: DEPLOYMENT_URL,
-      },
-    },
-  });
-};
 
 describe('Overview - Upgrade Step', () => {
   let testBed: OverviewTestBed;
-  const { server, httpRequestsMockHelpers, setServerAsync } = setupEnvironment();
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+  let setDelayResponse: ReturnType<typeof setupEnvironment>['setDelayResponse'];
+  const setupCloudOverviewPage = () => {
+    return setupOverviewPage(httpSetup, {
+      plugins: {
+        cloud: {
+          isCloudEnabled: true,
+          deploymentUrl: DEPLOYMENT_URL,
+        },
+      },
+    });
+  };
 
-  afterAll(() => {
-    server.restore();
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
+    setDelayResponse = mockEnvironment.setDelayResponse;
   });
 
   describe('On-prem', () => {
     test('Shows link to setup upgrade docs', async () => {
-      testBed = await setupOverviewPage();
+      testBed = await setupOverviewPage(httpSetup);
       const { exists } = testBed;
 
       expect(exists('upgradeSetupDocsLink')).toBe(true);
@@ -75,10 +80,10 @@ describe('Overview - Upgrade Step', () => {
     });
 
     test('An error callout is displayed, if status check failed', async () => {
-      httpRequestsMockHelpers.setGetUpgradeStatusResponse(
-        {},
-        { statusCode: 500, message: 'Status check failed' }
-      );
+      httpRequestsMockHelpers.setGetUpgradeStatusResponse(undefined, {
+        statusCode: 500,
+        message: 'Status check failed',
+      });
 
       testBed = await setupCloudOverviewPage();
       const { exists, component } = testBed;
@@ -90,7 +95,7 @@ describe('Overview - Upgrade Step', () => {
     });
 
     test('The CTA button displays loading indicator', async () => {
-      setServerAsync(true);
+      setDelayResponse(true);
       testBed = await setupCloudOverviewPage();
       const { exists, find } = testBed;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Get rid of `axios` dependency in the Upgrade Assistant tests. (#127122)](https://github.com/elastic/kibana/pull/127122)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)