### PR TITLE
[8.1] [Lens] Values formatting not working in case of multi-field selection (#127283)

### DIFF
--- a/src/plugins/data/common/search/aggs/utils/get_aggs_formats.ts
+++ b/src/plugins/data/common/search/aggs/utils/get_aggs_formats.ts
@@ -140,9 +140,7 @@ export function getAggsFormats(getFieldFormat: GetFieldFormat): FieldFormatInsta
         const params = this._params;
         const formats = (params.paramsPerField as SerializedFieldFormat[]).map((fieldParams) => {
           const isCached = this.formatCache.has(fieldParams);
-          const cachedFormat =
-            this.formatCache.get(fieldParams) ||
-            getFieldFormat({ id: fieldParams.id, params: fieldParams });
+          const cachedFormat = this.formatCache.get(fieldParams) || getFieldFormat(fieldParams);
           if (!isCached) {
             this.formatCache.set(fieldParams, cachedFormat);
           }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Lens] Values formatting not working in case of multi-field selection (#127283)](https://github.com/elastic/kibana/pull/127283)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)