### PR TITLE
[Core] Deprecated APIs audit

### DIFF
--- a/docs/development/core/public/kibana-plugin-core-public.appleavehandler.md
+++ b/docs/development/core/public/kibana-plugin-core-public.appleavehandler.md
@@ -6,7 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
-> [AppMountParameters.onAppLeave](./kibana-plugin-core-public.appmountparameters.onappleave.md) has been deprecated in favor of [ScopedHistory.block](./kibana-plugin-core-public.scopedhistory.block.md)
+> [AppMountParameters.onAppLeave](./kibana-plugin-core-public.appmountparameters.onappleave.md) has been deprecated in favor of [ScopedHistory.block](./kibana-plugin-core-public.scopedhistory.block.md)  8.8.0
 > 
 
 A handler that will be executed before leaving the application, either when going to another application or when closing the browser tab or manually changing the url. Should return `confirm` to prompt a message to the user before leaving the page, or `default` to keep the default behavior (doing nothing).

--- a/docs/development/core/public/kibana-plugin-core-public.appmountparameters.appbasepath.md
+++ b/docs/development/core/public/kibana-plugin-core-public.appmountparameters.appbasepath.md
@@ -6,7 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
-> Use [AppMountParameters.history](./kibana-plugin-core-public.appmountparameters.history.md) instead.
+> Use [AppMountParameters.history](./kibana-plugin-core-public.appmountparameters.history.md) instead.  8.8.0
 > 
 
 The route path for configuring navigation to the application. This string should not include the base path from HTTP.

--- a/docs/development/core/public/kibana-plugin-core-public.appmountparameters.onappleave.md
+++ b/docs/development/core/public/kibana-plugin-core-public.appmountparameters.onappleave.md
@@ -6,7 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
-> [ScopedHistory.block](./kibana-plugin-core-public.scopedhistory.block.md) should be used instead.
+> [ScopedHistory.block](./kibana-plugin-core-public.scopedhistory.block.md) should be used instead.  8.8.0
 > 
 
 A function that can be used to register a handler that will be called when the user is leaving the current application, allowing to prompt a confirmation message before actually changing the page.

--- a/docs/development/core/public/kibana-plugin-core-public.coresetup.injectedmetadata.md
+++ b/docs/development/core/public/kibana-plugin-core-public.coresetup.injectedmetadata.md
@@ -6,6 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
+>  8.8.0
 > 
 
 exposed temporarily until https://github.com/elastic/kibana/issues/41990 done use \*only\* to retrieve config values. There is no way to set injected values in the new platform.

--- a/docs/development/core/public/kibana-plugin-core-public.corestart.injectedmetadata.md
+++ b/docs/development/core/public/kibana-plugin-core-public.corestart.injectedmetadata.md
@@ -6,6 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
+>  8.8.0
 > 
 
 exposed temporarily until https://github.com/elastic/kibana/issues/41990 done use \*only\* to retrieve config values. There is no way to set injected values in the new platform.

--- a/docs/development/core/public/kibana-plugin-core-public.ihttpfetcherror.req.md
+++ b/docs/development/core/public/kibana-plugin-core-public.ihttpfetcherror.req.md
@@ -6,7 +6,9 @@
 
 > Warning: This API is now obsolete.
 > 
-> Provided for legacy compatibility. Prefer the `request` property instead.
+> Provided for legacy compatibility. Prefer the `request` property instead.  8.8.0
+> 
+> Note to maintainers: when looking at usages, mind that typical use could be inside a `catch` block, so TS and code-reference navigation might not highlight them.
 > 
 
 <b>Signature:</b>

--- a/docs/development/core/public/kibana-plugin-core-public.ihttpfetcherror.res.md
+++ b/docs/development/core/public/kibana-plugin-core-public.ihttpfetcherror.res.md
@@ -6,7 +6,9 @@
 
 > Warning: This API is now obsolete.
 > 
-> Provided for legacy compatibility. Prefer the `response` property instead.
+> Provided for legacy compatibility. Prefer the `response` property instead.  8.8.0
+> 
+> Note to maintainers: when looking at usages, mind that typical use could be inside a `catch` block, so TS and code-reference navigation might not highlight them.
 > 
 
 <b>Signature:</b>

--- a/docs/development/core/public/kibana-plugin-core-public.savedobjectsimportsuccess.createnewcopy.md
+++ b/docs/development/core/public/kibana-plugin-core-public.savedobjectsimportsuccess.createnewcopy.md
@@ -6,7 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
-> If `createNewCopy` is specified, the new object has a new (undefined) origin ID. This is only needed for the case where `createNewCopies` mode is disabled and ambiguous source conflicts are detected. When `createNewCopies` mode is permanently enabled, this field will be redundant and can be removed.
+> Can be removed when https://github.com/elastic/kibana/issues/91615 is done. If `createNewCopy` is specified, the new object has a new (undefined) origin ID. This is only needed for the case where `createNewCopies` mode is disabled and ambiguous source conflicts are detected. When `createNewCopies` mode is permanently enabled, this field will be redundant and can be removed.
 > 
 
 <b>Signature:</b>

--- a/docs/development/core/server/kibana-plugin-core-server.asyncplugin.md
+++ b/docs/development/core/server/kibana-plugin-core-server.asyncplugin.md
@@ -6,7 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
-> Asynchronous lifecycles are deprecated, and should be migrated to sync 
+> Asynchronous lifecycles are deprecated, and should be migrated to sync   8.8.0
 > 
 
 A plugin with asynchronous lifecycle methods.

--- a/docs/development/core/server/kibana-plugin-core-server.opsmetrics.process.md
+++ b/docs/development/core/server/kibana-plugin-core-server.opsmetrics.process.md
@@ -6,7 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
-> use the processes field instead.
+> use the processes field instead.  8.8.0
 > 
 
 Process related metrics.

--- a/docs/development/core/server/kibana-plugin-core-server.pluginmanifest.extrapublicdirs.md
+++ b/docs/development/core/server/kibana-plugin-core-server.pluginmanifest.extrapublicdirs.md
@@ -6,6 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
+> To be deleted when https://github.com/elastic/kibana/issues/101948 is done.
 > 
 
 Specifies directory names that can be imported by other ui-plugins built using the same instance of the @<!-- -->kbn/optimizer. A temporary measure we plan to replace with better mechanisms for sharing static code between plugins

--- a/docs/development/core/server/kibana-plugin-core-server.savedobjectsimportsuccess.createnewcopy.md
+++ b/docs/development/core/server/kibana-plugin-core-server.savedobjectsimportsuccess.createnewcopy.md
@@ -6,7 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
-> If `createNewCopy` is specified, the new object has a new (undefined) origin ID. This is only needed for the case where `createNewCopies` mode is disabled and ambiguous source conflicts are detected. When `createNewCopies` mode is permanently enabled, this field will be redundant and can be removed.
+> Can be removed when https://github.com/elastic/kibana/issues/91615 is done. If `createNewCopy` is specified, the new object has a new (undefined) origin ID. This is only needed for the case where `createNewCopies` mode is disabled and ambiguous source conflicts are detected. When `createNewCopies` mode is permanently enabled, this field will be redundant and can be removed.
 > 
 
 <b>Signature:</b>

--- a/docs/development/core/server/kibana-plugin-core-server.savedobjectsmigrationlogger.warning.md
+++ b/docs/development/core/server/kibana-plugin-core-server.savedobjectsmigrationlogger.warning.md
@@ -6,7 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
-> Use `warn` instead.
+> Use `warn` instead.  8.8.0
 > 
 
 <b>Signature:</b>

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -411,6 +411,7 @@ export interface AppMountParameters<HistoryLocationState = unknown> {
    * This string should not include the base path from HTTP.
    *
    * @deprecated Use {@link AppMountParameters.history} instead.
+   * @removeBy 8.8.0
    *
    * @example
    *
@@ -488,6 +489,7 @@ export interface AppMountParameters<HistoryLocationState = unknown> {
    * ```
    *
    * @deprecated {@link ScopedHistory.block} should be used instead.
+   * @removeBy 8.8.0
    */
   onAppLeave: (handler: AppLeaveHandler) => void;
 
@@ -557,6 +559,7 @@ export interface AppMountParameters<HistoryLocationState = unknown> {
  *
  * @public
  * @deprecated {@link AppMountParameters.onAppLeave} has been deprecated in favor of {@link ScopedHistory.block}
+ * @removeBy 8.8.0
  */
 export type AppLeaveHandler = (
   factory: AppLeaveActionFactory,

--- a/src/core/public/http/types.ts
+++ b/src/core/public/http/types.ts
@@ -351,10 +351,18 @@ export interface IHttpFetchError<TResponseBody = unknown> extends Error {
   readonly response?: Response;
   /**
    * @deprecated Provided for legacy compatibility. Prefer the `request` property instead.
+   * @removeBy 8.8.0
+   *
+   * Note to maintainers: when looking at usages, mind that typical use could be inside a `catch` block,
+   * so TS and code-reference navigation might not highlight them.
    */
   readonly req: Request;
   /**
    * @deprecated Provided for legacy compatibility. Prefer the `response` property instead.
+   * @removeBy 8.8.0
+   *
+   * Note to maintainers: when looking at usages, mind that typical use could be inside a `catch` block,
+   * so TS and code-reference navigation might not highlight them.
    */
   readonly res?: Response;
   readonly body?: TResponseBody;

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -227,6 +227,7 @@ export interface CoreSetup<TPluginsStart extends object = object, TStart = unkno
    * use *only* to retrieve config values. There is no way to set injected values
    * in the new platform.
    * @deprecated
+   * @removeBy 8.8.0
    * */
   injectedMetadata: {
     getInjectedVar: (name: string, defaultValue?: any) => unknown;
@@ -290,6 +291,7 @@ export interface CoreStart {
    * use *only* to retrieve config values. There is no way to set injected values
    * in the new platform.
    * @deprecated
+   * @removeBy 8.8.0
    * */
   injectedMetadata: {
     getInjectedVar: (name: string, defaultValue?: any) => unknown;

--- a/src/core/server/elasticsearch/types.ts
+++ b/src/core/server/elasticsearch/types.ts
@@ -86,7 +86,7 @@ export interface ElasticsearchServiceSetup {
     /**
      * Provide direct access to the current elasticsearch configuration.
      *
-     * @deprecated this will be removed in a later version.
+     * @deprecated Can be removed when https://github.com/elastic/kibana/issues/119862 is done.
      */
     readonly config$: Observable<ElasticsearchConfig>;
   };

--- a/src/core/server/metrics/types.ts
+++ b/src/core/server/metrics/types.ts
@@ -54,6 +54,7 @@ export interface OpsMetrics {
   /**
    * Process related metrics.
    * @deprecated use the processes field instead.
+   * @removeBy 8.8.0
    */
   process: OpsProcessMetrics;
   /** Process related metrics. Reports an array of objects for each kibana pid.*/

--- a/src/core/server/plugins/types.ts
+++ b/src/core/server/plugins/types.ts
@@ -215,7 +215,7 @@ export interface PluginManifest {
    * Specifies directory names that can be imported by other ui-plugins built
    * using the same instance of the @kbn/optimizer. A temporary measure we plan
    * to replace with better mechanisms for sharing static code between plugins
-   * @deprecated
+   * @deprecated To be deleted when https://github.com/elastic/kibana/issues/101948 is done.
    */
   readonly extraPublicDirs?: string[];
 
@@ -346,6 +346,7 @@ export interface Plugin<
  * A plugin with asynchronous lifecycle methods.
  *
  * @deprecated Asynchronous lifecycles are deprecated, and should be migrated to sync {@link Plugin | plugin}
+ * @removeBy 8.8.0
  * @public
  */
 export interface AsyncPlugin<
@@ -417,7 +418,8 @@ export interface PluginInitializerContext<ConfigSchema = unknown> {
      * Provide access to Kibana legacy configuration values.
      *
      * @remarks Naming not final here, it may be renamed in a near future
-     * @deprecated Accessing configuration values outside of the plugin's config scope is highly discouraged
+     * @deprecated Accessing configuration values outside of the plugin's config scope is highly discouraged.
+     * Can be removed when https://github.com/elastic/kibana/issues/119862 is done.
      */
     legacy: {
       globalConfig$: Observable<SharedGlobalConfig>;

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -89,7 +89,7 @@ export interface IRenderOptions {
 
   /**
    * Inject custom vars into the page metadata.
-   * @deprecated for legacy use only, remove with ui_render_mixin
+   * @deprecated for legacy use only, remove with ui_render_mixin. Can be removed when https://github.com/elastic/kibana/issues/127733 is done.
    * @internal
    */
   vars?: Record<string, any>;

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -89,7 +89,7 @@ export interface IRenderOptions {
 
   /**
    * Inject custom vars into the page metadata.
-   * @deprecated for legacy use only, remove with ui_render_mixin. Can be removed when https://github.com/elastic/kibana/issues/127733 is done.
+   * @deprecated for legacy use only. Can be removed when https://github.com/elastic/kibana/issues/127733 is done.
    * @internal
    */
   vars?: Record<string, any>;

--- a/src/core/server/saved_objects/import/types.ts
+++ b/src/core/server/saved_objects/import/types.ts
@@ -114,7 +114,7 @@ export interface SavedObjectsImportSuccess {
    */
   destinationId?: string;
   /**
-   * @deprecated
+   * @deprecated Can be removed when https://github.com/elastic/kibana/issues/91615 is done.
    * If `createNewCopy` is specified, the new object has a new (undefined) origin ID. This is only needed for the case where
    * `createNewCopies` mode is disabled and ambiguous source conflicts are detected. When `createNewCopies` mode is permanently enabled,
    * this field will be redundant and can be removed.

--- a/src/core/server/saved_objects/migrations/core/migration_logger.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_logger.ts
@@ -21,6 +21,7 @@ export interface SavedObjectsMigrationLogger {
   info: (msg: string) => void;
   /**
    * @deprecated Use `warn` instead.
+   * @removeBy 8.8.0
    */
   warning: (msg: string) => void;
   warn: (msg: string) => void;

--- a/src/core/server/server.api.md
+++ b/src/core/server/server.api.md
@@ -3158,8 +3158,8 @@ export const validBodyOutput: readonly ["data", "stream"];
 //
 // src/core/server/elasticsearch/client/types.ts:81:7 - (ae-forgotten-export) The symbol "Explanation" needs to be exported by the entry point index.d.ts
 // src/core/server/http/router/response.ts:302:3 - (ae-forgotten-export) The symbol "KibanaResponse" needs to be exported by the entry point index.d.ts
-// src/core/server/plugins/types.ts:375:3 - (ae-forgotten-export) The symbol "SharedGlobalConfigKeys" needs to be exported by the entry point index.d.ts
-// src/core/server/plugins/types.ts:377:3 - (ae-forgotten-export) The symbol "SavedObjectsConfigType" needs to be exported by the entry point index.d.ts
-// src/core/server/plugins/types.ts:483:5 - (ae-unresolved-link) The @link reference could not be resolved: The package "kibana" does not have an export "create"
+// src/core/server/plugins/types.ts:376:3 - (ae-forgotten-export) The symbol "SharedGlobalConfigKeys" needs to be exported by the entry point index.d.ts
+// src/core/server/plugins/types.ts:378:3 - (ae-forgotten-export) The symbol "SavedObjectsConfigType" needs to be exported by the entry point index.d.ts
+// src/core/server/plugins/types.ts:485:5 - (ae-unresolved-link) The @link reference could not be resolved: The package "kibana" does not have an export "create"
 
 ```

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -166,6 +166,7 @@ export interface HomePublicPluginSetup {
    * The environment service is only available for a transition period and will
    * be replaced by display specific extension points.
    * @deprecated
+   * @removeBy 8.8.0
    */
   environment: EnvironmentSetup;
 }

--- a/src/plugins/home/public/services/environment/environment.ts
+++ b/src/plugins/home/public/services/environment/environment.ts
@@ -36,6 +36,7 @@ export class EnvironmentService {
        * This API should not be extended for new features and will be removed in future versions
        * in favor of display specific extension apis.
        * @deprecated
+       * @removeBy 8.8.0
        * @param update
        */
       update: (update: Partial<Environment>) => {

--- a/src/plugins/kibana_usage_collection/server/collectors/application_usage/saved_objects_types.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/application_usage/saved_objects_types.ts
@@ -27,7 +27,10 @@ export interface ApplicationUsageTransactional extends ApplicationUsageTotal {
   timestamp: string;
 }
 
-/** @deprecated transactional type is no longer used, and only preserved for backward compatibility */
+/**
+ * @deprecated transactional type is no longer used, and only preserved for backward compatibility
+ * @removeBy 8.0.0
+ */
 export const SAVED_OBJECTS_TRANSACTIONAL_TYPE = 'application_usage_transactional';
 
 /**

--- a/src/plugins/kibana_usage_collection/server/collectors/application_usage/schema.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/application_usage/schema.ts
@@ -160,6 +160,7 @@ export const applicationUsageSchema = {
   securitySolutionUI: commonSchema,
   /**
    * @deprecated legacy key for users that still have bookmarks to the old siem name. "securitySolutionUI" key is the replacement
+   * @removeBy 9.0.0
    */
   siem: commonSchema,
   space_selector: commonSchema,

--- a/src/plugins/kibana_usage_collection/server/collectors/ui_counters/rollups/rollups.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/ui_counters/rollups/rollups.ts
@@ -65,6 +65,8 @@ export async function rollUiCounterIndices(
        * Migration from one SO registry to another is not yet supported.
        * In a future release we can remove this piece of code and
        * migrate any docs to the Usage Counters Saved object.
+       *
+       * @removeBy 8.0.0
        */
 
       stopUsingUiCounterIndicies$.complete();

--- a/src/plugins/kibana_usage_collection/server/collectors/ui_metric/schema.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/ui_metric/schema.ts
@@ -64,6 +64,7 @@ const uiMetricFromDataPluginSchema: MakeSchemaFrom<UIMetricUsage> = {
   'securitySolutionUI:administration': commonSchema,
   /**
    * @deprecated legacy key for users that still have bookmarks to the old siem name. "securitySolutionUI" key is the replacement
+   * @removeBy 9.0.0
    */
   siem: commonSchema,
   space_selector: commonSchema,

--- a/src/plugins/saved_objects/public/plugin.ts
+++ b/src/plugins/saved_objects/public/plugin.ts
@@ -24,13 +24,25 @@ export interface SavedObjectSetup {
 }
 
 export interface SavedObjectsStart {
-  /** @deprecated */
+  /**
+   * @deprecated
+   * @removeBy 8.8.0
+   */
   SavedObjectClass: new (raw: Record<string, any>) => SavedObject;
-  /** @deprecated */
+  /**
+   * @deprecated
+   * @removeBy 8.8.0
+   */
   settings: {
-    /** @deprecated */
+    /**
+     * @deprecated
+     * @removeBy 8.8.0
+     */
     getPerPage: () => number;
-    /** @deprecated */
+    /**
+     * @deprecated
+     * @removeBy 8.8.0
+     */
     getListingLimit: () => number;
   };
 }

--- a/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
+++ b/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
@@ -66,7 +66,10 @@ export interface SaveModalState {
 
 const generateId = htmlIdGenerator();
 
-/** @deprecated */
+/**
+ * @deprecated
+ * @removeBy 8.8.0
+ */
 export class SavedObjectSaveModal extends React.Component<Props, SaveModalState> {
   private warning = React.createRef<HTMLDivElement>();
   public readonly state = {

--- a/src/plugins/saved_objects/public/types.ts
+++ b/src/plugins/saved_objects/public/types.ts
@@ -21,7 +21,10 @@ import {
 } from '../../data/public';
 import { DataViewsContract } from '../../data_views/public';
 
-/** @deprecated */
+/**
+ * @deprecated
+ * @removeBy 8.8.0
+ */
 export interface SavedObject {
   _serialize: () => { attributes: SavedObjectAttributes; references: SavedObjectReference[] };
   _source: Record<string, unknown>;

--- a/x-pack/plugins/features/common/feature_elasticsearch_privileges.ts
+++ b/x-pack/plugins/features/common/feature_elasticsearch_privileges.ts
@@ -40,16 +40,6 @@ export interface FeatureElasticsearchPrivileges {
   };
 
   /**
-   * A set of Elasticsearch roles which are required for this feature to be enabled.
-   *
-   * @deprecated do not rely on hard-coded role names.
-   *
-   * This is relied on by the reporting feature, and should be removed once reporting
-   * migrates to using the Kibana Privilege model: https://github.com/elastic/kibana/issues/19914
-   */
-  requiredRoles?: string[];
-
-  /**
    * A list of UI Capabilities that should be granted to users with this privilege.
    * These capabilities will automatically be namespaces within your feature id.
    *

--- a/x-pack/plugins/features/common/feature_elasticsearch_privileges.ts
+++ b/x-pack/plugins/features/common/feature_elasticsearch_privileges.ts
@@ -40,6 +40,17 @@ export interface FeatureElasticsearchPrivileges {
   };
 
   /**
+   * A set of Elasticsearch roles which are required for this feature to be enabled.
+   *
+   * @deprecated do not rely on hard-coded role names.
+   * @removeBy 8.8.0
+   *
+   * This is relied on by the reporting feature, and should be removed once reporting
+   * migrates to using the Kibana Privilege model: https://github.com/elastic/kibana/issues/19914
+   */
+  requiredRoles?: string[];
+
+  /**
    * A list of UI Capabilities that should be granted to users with this privilege.
    * These capabilities will automatically be namespaces within your feature id.
    *

--- a/x-pack/plugins/features/common/feature_kibana_privileges.ts
+++ b/x-pack/plugins/features/common/feature_kibana_privileges.ts
@@ -23,6 +23,7 @@ export interface FeatureKibanaPrivileges {
   /**
    * Whether or not this privilege should be hidden in the roles UI and disallowed on the API. Defaults to `false`.
    * @deprecated
+   * @removeBy 8.8.0
    */
   disabled?: boolean;
 

--- a/x-pack/plugins/features/server/feature_registry.test.ts
+++ b/x-pack/plugins/features/server/feature_registry.test.ts
@@ -1953,8 +1953,7 @@ describe('FeatureRegistry', () => {
             ui: ['ui_a'],
           },
           {
-            requiredClusterPrivileges: [],
-            requiredRoles: ['some_role'],
+            requiredClusterPrivileges: ['monitor'],
             ui: ['ui_b'],
           },
         ],

--- a/x-pack/plugins/features/server/feature_registry.test.ts
+++ b/x-pack/plugins/features/server/feature_registry.test.ts
@@ -1953,7 +1953,8 @@ describe('FeatureRegistry', () => {
             ui: ['ui_a'],
           },
           {
-            requiredClusterPrivileges: ['monitor'],
+            requiredClusterPrivileges: [],
+            requiredRoles: ['some_role'],
             ui: ['ui_b'],
           },
         ],

--- a/x-pack/plugins/features/server/feature_schema.ts
+++ b/x-pack/plugins/features/server/feature_schema.ts
@@ -484,17 +484,9 @@ export function validateElasticsearchFeature(feature: ElasticsearchFeatureConfig
   // the following validation can't be enforced by the Joi schema without a very convoluted and verbose definition
   const { privileges } = feature;
   privileges.forEach((privilege, index) => {
-    const {
-      requiredClusterPrivileges = [],
-      requiredIndexPrivileges = [],
-      requiredRoles = [],
-    } = privilege;
+    const { requiredClusterPrivileges = [], requiredIndexPrivileges = [] } = privilege;
 
-    if (
-      requiredClusterPrivileges.length === 0 &&
-      requiredIndexPrivileges.length === 0 &&
-      requiredRoles.length === 0
-    ) {
+    if (requiredClusterPrivileges.length === 0 && requiredIndexPrivileges.length === 0) {
       throw new Error(
         `Feature ${feature.id} has a privilege definition at index ${index} without any privileges defined.`
       );

--- a/x-pack/plugins/features/server/feature_schema.ts
+++ b/x-pack/plugins/features/server/feature_schema.ts
@@ -484,9 +484,17 @@ export function validateElasticsearchFeature(feature: ElasticsearchFeatureConfig
   // the following validation can't be enforced by the Joi schema without a very convoluted and verbose definition
   const { privileges } = feature;
   privileges.forEach((privilege, index) => {
-    const { requiredClusterPrivileges = [], requiredIndexPrivileges = [] } = privilege;
+    const {
+      requiredClusterPrivileges = [],
+      requiredIndexPrivileges = [],
+      requiredRoles = [],
+    } = privilege;
 
-    if (requiredClusterPrivileges.length === 0 && requiredIndexPrivileges.length === 0) {
+    if (
+      requiredClusterPrivileges.length === 0 &&
+      requiredIndexPrivileges.length === 0 &&
+      requiredRoles.length === 0
+    ) {
       throw new Error(
         `Feature ${feature.id} has a privilege definition at index ${index} without any privileges defined.`
       );

--- a/x-pack/plugins/features/server/plugin.ts
+++ b/x-pack/plugins/features/server/plugin.ts
@@ -41,21 +41,23 @@ import {
 export interface PluginSetupContract {
   registerKibanaFeature(feature: KibanaFeatureConfig): void;
   registerElasticsearchFeature(feature: ElasticsearchFeatureConfig): void;
-  /*
+  /**
    * Calling this function during setup will crash Kibana.
    * Use start contract instead.
    * @deprecated
-   * */
+   * @removeBy 8.8.0
+   */
   getKibanaFeatures(): KibanaFeature[];
-  /*
+  /**
    * Calling this function during setup will crash Kibana.
    * Use start contract instead.
    * @deprecated
-   * */
+   * @removeBy 8.8.0
+   */
   getElasticsearchFeatures(): ElasticsearchFeature[];
   getFeaturesUICapabilities(): UICapabilities;
 
-  /*
+  /**
    * In the future, OSS features should register their own subfeature
    * privileges. This can be done when parts of Reporting are moved to
    * src/plugins. For now, this method exists for `reporting` to tell

--- a/x-pack/plugins/licensing/common/types.ts
+++ b/x-pack/plugins/licensing/common/types.ts
@@ -56,6 +56,7 @@ export interface PublicLicense {
   /**
    * The license type, being usually one of basic, standard, gold, platinum, or trial.
    * @deprecated use 'type' instead
+   * @removeBy 8.8.0
    */
   mode: LicenseType;
 }
@@ -123,6 +124,7 @@ export interface ILicense {
   /**
    * The license type, being usually one of basic, standard, gold, platinum, or trial.
    * @deprecated use 'type' instead.
+   * @removeBy 8.8.0
    */
   mode?: LicenseType;
 

--- a/x-pack/plugins/licensing/public/types.ts
+++ b/x-pack/plugins/licensing/public/types.ts
@@ -15,11 +15,13 @@ export interface LicensingPluginSetup {
   /**
    * Steam of licensing information {@link ILicense}.
    * @deprecated in favour of the counterpart provided from start contract
+   * @removeBy 8.8.0
    */
   license$: Observable<ILicense>;
   /**
    * Triggers licensing information re-fetch.
    * @deprecated in favour of the counterpart provided from start contract
+   * @removeBy 8.8.0
    */
   refresh(): Promise<ILicense>;
   /**

--- a/x-pack/plugins/licensing/server/types.ts
+++ b/x-pack/plugins/licensing/server/types.ts
@@ -49,12 +49,14 @@ export interface LicensingPluginSetup {
   /**
    * Steam of licensing information {@link ILicense}.
    * @deprecated in favour of the counterpart provided from start contract
+   * @removeBy 8.8.0
    */
   license$: Observable<ILicense>;
 
   /**
    * Triggers licensing information re-fetch.
    * @deprecated in favour of the counterpart provided from start contract
+   * @removeBy 8.8.0
    */
   refresh(): Promise<ILicense>;
 


### PR DESCRIPTION
## Summary

Resolves #119866.

Auditing the APIs that are `@deprecated` and owned by the @elastic/kibana-core team:

1. If still used and there's a suitable alternative, we added `@removeBy 8.8.0` to allow 12 months for other teams to migrate away from those APIs, according to our deprecation strategy. Except in those related to apps renamed during 7.x, where we'd wait till the next major.
2. If still used but we don't provide an alternative, added a link to the issue they depend on.
3. If not used, an issue was raised to track their removal.

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
