### PR TITLE
[Enterprise Search] Add link to Troubleshoot Setup documentation to self-hosted and cloud setup guides

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -109,6 +109,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       configuration: `${ENTERPRISE_SEARCH_DOCS}configuration.html`,
       licenseManagement: `${ENTERPRISE_SEARCH_DOCS}license-management.html`,
       mailService: `${ENTERPRISE_SEARCH_DOCS}mailer-configuration.html`,
+      troubleshootSetup: `${ENTERPRISE_SEARCH_DOCS}troubleshoot-setup.html`,
       usersAccess: `${ENTERPRISE_SEARCH_DOCS}users-access.html`,
     },
     workplaceSearch: {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -32,6 +32,7 @@ class DocLinks {
   public cloudIndexManagement: string;
   public enterpriseSearchConfig: string;
   public enterpriseSearchMailService: string;
+  public enterpriseSearchTroubleshootSetup: string;
   public enterpriseSearchUsersAccess: string;
   public kibanaSecurity: string;
   public licenseManagement: string;
@@ -86,6 +87,7 @@ class DocLinks {
     this.cloudIndexManagement = '';
     this.enterpriseSearchConfig = '';
     this.enterpriseSearchMailService = '';
+    this.enterpriseSearchTroubleshootSetup = '';
     this.enterpriseSearchUsersAccess = '';
     this.kibanaSecurity = '';
     this.licenseManagement = '';
@@ -141,6 +143,7 @@ class DocLinks {
     this.cloudIndexManagement = docLinks.links.cloud.indexManagement;
     this.enterpriseSearchConfig = docLinks.links.enterpriseSearch.configuration;
     this.enterpriseSearchMailService = docLinks.links.enterpriseSearch.mailService;
+    this.enterpriseSearchTroubleshootSetup = docLinks.links.enterpriseSearch.troubleshootSetup;
     this.enterpriseSearchUsersAccess = docLinks.links.enterpriseSearch.usersAccess;
     this.kibanaSecurity = docLinks.links.kibana.xpackSecurity;
     this.licenseManagement = docLinks.links.enterpriseSearch.licenseManagement;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.tsx
@@ -135,6 +135,37 @@ export const CloudSetupInstructions: React.FC<Props> = ({ productName, cloudDepl
             </EuiCallOut>
           ),
         },
+        {
+          title: i18n.translate('xpack.enterpriseSearch.setupGuide.cloud.step6.title', {
+            defaultMessage: 'Troubleshooting issues',
+          }),
+          children: (
+            <>
+              <EuiText>
+                <p>
+                  <FormattedMessage
+                    id="xpack.enterpriseSearch.setupGuide.cloud.step6.instruction1"
+                    defaultMessage="For help with common setup issues, read our {link} guide."
+                    values={{
+                      link: (
+                        <EuiLink
+                          href={docLinks.enterpriseSearchTroubleshootSetup}
+                          target="_blank"
+                          external
+                        >
+                          {i18n.translate(
+                            'xpack.enterpriseSearch.setupGuide.cloud.step6.instruction1LinkText',
+                            { defaultMessage: 'Troubleshoot Enterprise Search setup' }
+                          )}
+                        </EuiLink>
+                      ),
+                    }}
+                  />
+                </p>
+              </EuiText>
+            </>
+          ),
+        },
       ]}
     />
   </EuiPageContent>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/instructions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/instructions.tsx
@@ -14,9 +14,13 @@ import {
   EuiCode,
   EuiCodeBlock,
   EuiAccordion,
+  EuiLink,
+  EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+
+import { docLinks } from '../doc_links';
 
 interface Props {
   productName: string;
@@ -94,6 +98,29 @@ export const SetupInstructions: React.FC<Props> = ({ productName }) => (
                   </p>
                 </EuiText>
               </EuiAccordion>
+              <EuiSpacer />
+              <EuiText>
+                <p>
+                  <FormattedMessage
+                    id="xpack.enterpriseSearch.troubleshooting.setup.description"
+                    defaultMessage="For help with other common setup issues, read our {link} guide."
+                    values={{
+                      link: (
+                        <EuiLink
+                          href={docLinks.enterpriseSearchTroubleshootSetup}
+                          target="_blank"
+                          external
+                        >
+                          {i18n.translate(
+                            'xpack.enterpriseSearch.troubleshooting.setup.documentationLinkLabel',
+                            { defaultMessage: 'Troubleshoot Enterprise Search setup' }
+                          )}
+                        </EuiLink>
+                      ),
+                    }}
+                  />
+                </p>
+              </EuiText>
             </>
           ),
         },


### PR DESCRIPTION
## Summary

We've added a new documentation page at /enterprise-search/<version>/troubleshoot-setup.html in https://github.com/elastic/enterprise-search-pubs/pull/1920. This PR links to that documentation from the setup guides for both cloud and self-hosted deployments of Enterprise Search.

![image](https://user-images.githubusercontent.com/2479295/158387188-94a0272e-5417-4c9a-ac3f-8ada12e23e10.png)

![image](https://user-images.githubusercontent.com/2479295/158387219-4cfdbb0d-27bc-48b2-80f3-4416d76ed078.png)

### Checklist
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)