### PR TITLE
[Upgrade Assistant] Fix broken test that is missing HttpSetup instance in setup method

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/logs_step/logs_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/logs_step/logs_step.test.tsx
@@ -12,11 +12,13 @@ import { OverviewTestBed, setupOverviewPage } from '../overview.helpers';
 
 describe('Overview - Logs Step', () => {
   let testBed: OverviewTestBed;
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
 
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
-  afterAll(() => {
-    server.restore();
+  beforeEach(async () => {
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   describe('error state', () => {
@@ -30,7 +32,7 @@ describe('Overview - Logs Step', () => {
       httpRequestsMockHelpers.setLoadDeprecationLogsCountResponse(undefined, error);
 
       await act(async () => {
-        testBed = await setupOverviewPage();
+        testBed = await setupOverviewPage(httpSetup);
       });
 
       testBed.component.update();
@@ -58,7 +60,7 @@ describe('Overview - Logs Step', () => {
         });
 
         await act(async () => {
-          testBed = await setupOverviewPage();
+          testBed = await setupOverviewPage(httpSetup);
         });
 
         const { component, exists } = testBed;
@@ -74,7 +76,7 @@ describe('Overview - Logs Step', () => {
         });
 
         await act(async () => {
-          testBed = await setupOverviewPage();
+          testBed = await setupOverviewPage(httpSetup);
         });
 
         const { component, exists } = testBed;
@@ -90,7 +92,7 @@ describe('Overview - Logs Step', () => {
         });
 
         await act(async () => {
-          testBed = await setupOverviewPage();
+          testBed = await setupOverviewPage(httpSetup);
         });
 
         const { component, find } = testBed;
@@ -110,7 +112,7 @@ describe('Overview - Logs Step', () => {
         });
 
         await act(async () => {
-          testBed = await setupOverviewPage();
+          testBed = await setupOverviewPage(httpSetup);
         });
 
         const { component } = testBed;
@@ -135,7 +137,7 @@ describe('Overview - Logs Step', () => {
       });
 
       await act(async () => {
-        testBed = await setupOverviewPage({
+        testBed = await setupOverviewPage(httpSetup, {
           privileges: {
             hasAllPrivileges: true,
             missingPrivileges: {


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/127722

With https://github.com/elastic/kibana/pull/127122 there might have been a small merge conflict that was wrongly unresolved  from https://github.com/elastic/kibana/pull/126693. This PR fixes that by providing the correct `HttpSetup` instance to the `setupOverviewPage` method.