### PR TITLE
[Workplace Search] Add DocsLink for SharePoint Online external

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -120,6 +120,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       customSourcePermissions: `${WORKPLACE_SEARCH_DOCS}workplace-search-custom-api-sources.html#custom-api-source-document-level-access-control`,
       documentPermissions: `${WORKPLACE_SEARCH_DOCS}workplace-search-sources-document-permissions.html`,
       dropbox: `${WORKPLACE_SEARCH_DOCS}workplace-search-dropbox-connector.html`,
+      externalSharePointOnline: `${WORKPLACE_SEARCH_DOCS}sharepoint-online-external.html`,
       externalIdentities: `${WORKPLACE_SEARCH_DOCS}workplace-search-external-identities-api.html`,
       gettingStarted: `${WORKPLACE_SEARCH_DOCS}workplace-search-getting-started.html`,
       gitHub: `${WORKPLACE_SEARCH_DOCS}workplace-search-github-connector.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -110,6 +110,7 @@ export interface DocLinks {
     readonly customSourcePermissions: string;
     readonly documentPermissions: string;
     readonly dropbox: string;
+    readonly externalSharePointOnline: string;
     readonly externalIdentities: string;
     readonly gitHub: string;
     readonly gettingStarted: string;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -43,6 +43,7 @@ class DocLinks {
   public workplaceSearchCustomSourcePermissions: string;
   public workplaceSearchDocumentPermissions: string;
   public workplaceSearchDropbox: string;
+  public workplaceSearchExternalSharePointOnline: string;
   public workplaceSearchExternalIdentities: string;
   public workplaceSearchGettingStarted: string;
   public workplaceSearchGitHub: string;
@@ -97,6 +98,7 @@ class DocLinks {
     this.workplaceSearchCustomSourcePermissions = '';
     this.workplaceSearchDocumentPermissions = '';
     this.workplaceSearchDropbox = '';
+    this.workplaceSearchExternalSharePointOnline = '';
     this.workplaceSearchExternalIdentities = '';
     this.workplaceSearchGettingStarted = '';
     this.workplaceSearchGitHub = '';
@@ -153,6 +155,8 @@ class DocLinks {
       docLinks.links.workplaceSearch.customSourcePermissions;
     this.workplaceSearchDocumentPermissions = docLinks.links.workplaceSearch.documentPermissions;
     this.workplaceSearchDropbox = docLinks.links.workplaceSearch.dropbox;
+    this.workplaceSearchExternalSharePointOnline =
+      docLinks.links.workplaceSearch.externalSharePointOnline;
     this.workplaceSearchExternalIdentities = docLinks.links.workplaceSearch.externalIdentities;
     this.workplaceSearchGettingStarted = docLinks.links.workplaceSearch.gettingStarted;
     this.workplaceSearchGitHub = docLinks.links.workplaceSearch.gitHub;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/external_connector_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/external_connector_config.tsx
@@ -31,6 +31,7 @@ import { NAV, REMOVE_BUTTON } from '../../../../constants';
 import { SourceDataItem } from '../../../../types';
 
 import { AddSourceHeader } from './add_source_header';
+import { ConfigDocsLinks } from './config_docs_links';
 import { OAUTH_SAVE_CONFIG_BUTTON, OAUTH_BACK_BUTTON } from './constants';
 import { ExternalConnectorLogic } from './external_connector_logic';
 
@@ -40,7 +41,11 @@ interface SaveConfigProps {
   onDeleteConfig?: () => void;
 }
 
-export const ExternalConnectorConfig: React.FC<SaveConfigProps> = ({ goBack, onDeleteConfig }) => {
+export const ExternalConnectorConfig: React.FC<SaveConfigProps> = ({
+  sourceData,
+  goBack,
+  onDeleteConfig,
+}) => {
   const serviceType = 'external';
   const {
     fetchExternalSource,
@@ -67,6 +72,9 @@ export const ExternalConnectorConfig: React.FC<SaveConfigProps> = ({ goBack, onD
   };
 
   const { name, categories } = sourceConfigData;
+  const {
+    configuration: { documentationUrl, applicationLinkTitle, applicationPortalUrl },
+  } = sourceData;
   const { isOrganization } = useValues(AppLogic);
 
   const saveButton = (
@@ -97,13 +105,12 @@ export const ExternalConnectorConfig: React.FC<SaveConfigProps> = ({ goBack, onD
 
   const connectorForm = (
     <EuiFlexGroup justifyContent="flexStart" direction="column" responsive={false}>
-      {/* TODO: get a docs link in here for the external connector
       <ConfigDocsLinks
         name={name}
         documentationUrl={documentationUrl}
         applicationPortalUrl={applicationPortalUrl}
         applicationLinkTitle={applicationLinkTitle}
-      /> */}
+      />
       <EuiSpacer />
       <EuiForm>
         <EuiFormRow

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_config.tsx
@@ -115,13 +115,6 @@ export const SaveConfig: React.FC<SaveConfigProps> = ({
 
   const externalConnectorFields = (
     <>
-      {/* TODO: get a docs link in here for the external connector
-      <ConfigDocsLinks
-        name={name}
-        documentationUrl={documentationUrl}
-        applicationPortalUrl={applicationPortalUrl}
-        applicationLinkTitle={applicationLinkTitle}
-      /> */}
       <EuiFormRow
         label={i18n.translate(
           'xpack.enterpriseSearch.workplaceSearch.contentSource.saveConfig.externalConnectorConfig.urlLabel',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -511,7 +511,7 @@ export const staticSourceData: SourceDataItem[] = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: false,
-      documentationUrl: docLinks.workplaceSearchSharePoint,
+      documentationUrl: docLinks.workplaceSearchExternalSharePointOnline,
       applicationPortalUrl: 'https://portal.azure.com/',
     },
     objTypes: [SOURCE_OBJ_TYPES.FOLDERS, SOURCE_OBJ_TYPES.SITES, SOURCE_OBJ_TYPES.ALL_FILES],


### PR DESCRIPTION
This adds a docs link for the External SharePoint Online connector

Pending confirmation of URL https://github.com/elastic/enterprise-search-team/issues/1407