### PR TITLE
Create useSearchStrategy hook

### DIFF
--- a/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/index.test.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useSearchStrategy } from './index';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useObservable } from '@kbn/securitysolution-hook-utils';
+
+jest.mock('../../../transforms/containers/use_transforms', () => ({
+  useTransforms: jest.fn(() => ({
+    getTransformChangesIfTheyExist: null,
+  })),
+}));
+
+const mockAddToastError = jest.fn();
+
+jest.mock('../../hooks/use_app_toasts', () => ({
+  useAppToasts: jest.fn(() => ({
+    addError: mockAddToastError,
+  })),
+}));
+
+jest.mock('@kbn/securitysolution-hook-utils');
+
+const useObservableHookResult = {
+  start: jest.fn(),
+  error: null,
+  result: null,
+  loading: false,
+};
+
+const userSearchStrategyProps = {
+  factoryQueryType: 'testFactoryQueryType',
+  initialResult: {},
+  errorMessage: 'testErrorMessage',
+};
+
+describe('useSearchStrategy', () => {
+  it("returns the provided initial result while the query hasn't returned data", () => {
+    const initialResult = {};
+    (useObservable as jest.Mock).mockReturnValue(useObservableHookResult);
+
+    const { result } = renderHook(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useSearchStrategy<any>({ ...userSearchStrategyProps, initialResult })
+    );
+
+    expect(result.current.result).toBe(initialResult);
+  });
+
+  it('calls start with the given factoryQueryType', () => {
+    const factoryQueryType = 'fakeQueryType';
+    const start = jest.fn();
+
+    (useObservable as jest.Mock).mockReturnValue({ ...useObservableHookResult, start });
+
+    const { result } = renderHook(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useSearchStrategy<any>({
+        ...userSearchStrategyProps,
+        factoryQueryType,
+      })
+    );
+
+    result.current.search({});
+
+    expect(start).toBeCalledWith(expect.objectContaining({ factoryQueryType }));
+  });
+
+  it('returns inspect', () => {
+    const dsl = 'testDsl';
+
+    (useObservable as jest.Mock).mockReturnValue({
+      ...useObservableHookResult,
+      result: {
+        rawResponse: {},
+        inspect: {
+          dsl,
+        },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useSearchStrategy<any>(userSearchStrategyProps)
+    );
+
+    expect(result.current.inspect).toEqual({
+      dsl,
+      response: ['{}'],
+    });
+  });
+
+  it('shows toast error when the API returns error', () => {
+    const error = 'test error';
+    const errorMessage = 'error message title';
+    (useObservable as jest.Mock).mockReturnValue({
+      ...useObservableHookResult,
+      error,
+    });
+
+    renderHook(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useSearchStrategy<any>({ ...userSearchStrategyProps, errorMessage })
+    );
+
+    expect(mockAddToastError).toBeCalledWith(error, { title: errorMessage });
+  });
+
+  it('start should be called when search is called ', () => {
+    const start = jest.fn();
+    const searchParams = {};
+
+    (useObservable as jest.Mock).mockReturnValue({ ...useObservableHookResult, start });
+
+    const { result } = renderHook(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useSearchStrategy<any>(userSearchStrategyProps)
+    );
+
+    result.current.search(searchParams);
+
+    expect(start).toBeCalled();
+  });
+
+  it('refetch should execute the previous search again with the same params', async () => {
+    const start = jest.fn();
+    const searchParams = {};
+
+    (useObservable as jest.Mock).mockReturnValue({ ...useObservableHookResult, start });
+
+    const { result, rerender } = renderHook(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useSearchStrategy<any>(userSearchStrategyProps)
+    );
+
+    result.current.search(searchParams);
+
+    rerender();
+
+    result.current.refetch();
+
+    expect(start).toBeCalledTimes(2);
+    expect(start.mock.calls[0]).toEqual(start.mock.calls[1]);
+  });
+
+  it('aborts previous search when a subsequent search is triggered', async () => {
+    const searchParams = {};
+    const abortFunction = jest.fn();
+    jest
+      .spyOn(window, 'AbortController')
+      .mockReturnValue({ abort: abortFunction, signal: {} as AbortSignal });
+
+    (useObservable as jest.Mock).mockReturnValue(useObservableHookResult);
+
+    const { result } = renderHook(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useSearchStrategy<any>(userSearchStrategyProps)
+    );
+
+    result.current.search(searchParams);
+    result.current.search(searchParams);
+
+    expect(abortFunction).toBeCalledTimes(2);
+  });
+
+  it('aborts search when component unmounts', async () => {
+    const searchParams = {};
+    const abortFunction = jest.fn();
+    jest
+      .spyOn(window, 'AbortController')
+      .mockReturnValue({ abort: abortFunction, signal: {} as AbortSignal });
+
+    (useObservable as jest.Mock).mockReturnValue(useObservableHookResult);
+
+    const { result, unmount } = renderHook(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useSearchStrategy<any>(userSearchStrategyProps)
+    );
+
+    result.current.search(searchParams);
+    unmount();
+
+    expect(abortFunction).toBeCalledTimes(2);
+  });
+
+  it('calls start with the AbortController signal', () => {
+    const factoryQueryType = 'fakeQueryType';
+    const start = jest.fn();
+    const signal = new AbortController().signal;
+    jest.spyOn(window, 'AbortController').mockReturnValue({ abort: jest.fn(), signal });
+
+    (useObservable as jest.Mock).mockReturnValue({ ...useObservableHookResult, start });
+
+    const { result } = renderHook(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useSearchStrategy<any>({
+        ...userSearchStrategyProps,
+        factoryQueryType,
+      })
+    );
+
+    result.current.search({});
+
+    expect(start).toBeCalledWith(expect.objectContaining({ signal }));
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/index.test.ts
@@ -9,6 +9,7 @@ import { useSearchStrategy } from './index';
 import { renderHook } from '@testing-library/react-hooks';
 
 import { useObservable } from '@kbn/securitysolution-hook-utils';
+import { FactoryQueryTypes } from '../../../../common/search_strategy';
 
 jest.mock('../../../transforms/containers/use_transforms', () => ({
   useTransforms: jest.fn(() => ({
@@ -34,7 +35,7 @@ const useObservableHookResult = {
 };
 
 const userSearchStrategyProps = {
-  factoryQueryType: 'testFactoryQueryType',
+  factoryQueryType: 'testFactoryQueryType' as FactoryQueryTypes,
   initialResult: {},
   errorMessage: 'testErrorMessage',
 };
@@ -45,22 +46,20 @@ describe('useSearchStrategy', () => {
     (useObservable as jest.Mock).mockReturnValue(useObservableHookResult);
 
     const { result } = renderHook(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      useSearchStrategy<any>({ ...userSearchStrategyProps, initialResult })
+      useSearchStrategy<FactoryQueryTypes>({ ...userSearchStrategyProps, initialResult })
     );
 
     expect(result.current.result).toBe(initialResult);
   });
 
   it('calls start with the given factoryQueryType', () => {
-    const factoryQueryType = 'fakeQueryType';
+    const factoryQueryType = 'fakeQueryType' as FactoryQueryTypes;
     const start = jest.fn();
 
     (useObservable as jest.Mock).mockReturnValue({ ...useObservableHookResult, start });
 
     const { result } = renderHook(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      useSearchStrategy<any>({
+      useSearchStrategy<FactoryQueryTypes>({
         ...userSearchStrategyProps,
         factoryQueryType,
       })
@@ -85,8 +84,7 @@ describe('useSearchStrategy', () => {
     });
 
     const { result } = renderHook(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      useSearchStrategy<any>(userSearchStrategyProps)
+      useSearchStrategy<FactoryQueryTypes>(userSearchStrategyProps)
     );
 
     expect(result.current.inspect).toEqual({
@@ -104,8 +102,7 @@ describe('useSearchStrategy', () => {
     });
 
     renderHook(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      useSearchStrategy<any>({ ...userSearchStrategyProps, errorMessage })
+      useSearchStrategy<FactoryQueryTypes>({ ...userSearchStrategyProps, errorMessage })
     );
 
     expect(mockAddToastError).toBeCalledWith(error, { title: errorMessage });
@@ -118,8 +115,7 @@ describe('useSearchStrategy', () => {
     (useObservable as jest.Mock).mockReturnValue({ ...useObservableHookResult, start });
 
     const { result } = renderHook(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      useSearchStrategy<any>(userSearchStrategyProps)
+      useSearchStrategy<FactoryQueryTypes>(userSearchStrategyProps)
     );
 
     result.current.search(searchParams);
@@ -134,8 +130,7 @@ describe('useSearchStrategy', () => {
     (useObservable as jest.Mock).mockReturnValue({ ...useObservableHookResult, start });
 
     const { result, rerender } = renderHook(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      useSearchStrategy<any>(userSearchStrategyProps)
+      useSearchStrategy<FactoryQueryTypes>(userSearchStrategyProps)
     );
 
     result.current.search(searchParams);
@@ -158,8 +153,7 @@ describe('useSearchStrategy', () => {
     (useObservable as jest.Mock).mockReturnValue(useObservableHookResult);
 
     const { result } = renderHook(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      useSearchStrategy<any>(userSearchStrategyProps)
+      useSearchStrategy<FactoryQueryTypes>(userSearchStrategyProps)
     );
 
     result.current.search(searchParams);
@@ -178,8 +172,7 @@ describe('useSearchStrategy', () => {
     (useObservable as jest.Mock).mockReturnValue(useObservableHookResult);
 
     const { result, unmount } = renderHook(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      useSearchStrategy<any>(userSearchStrategyProps)
+      useSearchStrategy<FactoryQueryTypes>(userSearchStrategyProps)
     );
 
     result.current.search(searchParams);
@@ -189,7 +182,7 @@ describe('useSearchStrategy', () => {
   });
 
   it('calls start with the AbortController signal', () => {
-    const factoryQueryType = 'fakeQueryType';
+    const factoryQueryType = 'fakeQueryType' as FactoryQueryTypes;
     const start = jest.fn();
     const signal = new AbortController().signal;
     jest.spyOn(window, 'AbortController').mockReturnValue({ abort: jest.fn(), signal });
@@ -197,8 +190,7 @@ describe('useSearchStrategy', () => {
     (useObservable as jest.Mock).mockReturnValue({ ...useObservableHookResult, start });
 
     const { result } = renderHook(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      useSearchStrategy<any>({
+      useSearchStrategy<FactoryQueryTypes>({
         ...userSearchStrategyProps,
         factoryQueryType,
       })

--- a/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/index.tsx
@@ -20,6 +20,7 @@ import * as i18n from './translations';
 import {
   FactoryQueryTypes,
   RequestBasicOptions,
+  StrategyRequestType,
   StrategyResponseType,
 } from '../../../../common/search_strategy/security_solution';
 import { IKibanaSearchResponse } from '../../../../../../../src/plugins/data/common';
@@ -90,6 +91,7 @@ const searchComplete = <ResponseType extends IKibanaSearchResponse>(
   );
 };
 
+// TODO add unit tests
 export const useSearchStrategy = <QueryType extends FactoryQueryTypes>({
   factoryQueryType,
   initialResult,
@@ -99,7 +101,7 @@ export const useSearchStrategy = <QueryType extends FactoryQueryTypes>({
   /**
    * `result` initial value. It is used until the search strategy returns some data.
    */
-  initialResult: Omit<StrategyResponseType<QueryType>, 'rawResponse' | 'inspect'>;
+  initialResult: Omit<StrategyResponseType<QueryType>, 'rawResponse'>;
   /**
    * Message displayed to the user on a Toast when an erro happens.
    */
@@ -131,16 +133,9 @@ export const useSearchStrategy = <QueryType extends FactoryQueryTypes>({
   }, [addError, error, errorMessage, factoryQueryType]);
 
   const searchCb = useCallback(
-    (
-      props: OptionalSignalArgs<
-        Omit<
-          UseSearchStrategyRequestArgs,
-          'data' | 'factoryQueryType' | 'getTransformChangesIfTheyExist'
-        >
-      >
-    ) => {
+    (props: OptionalSignalArgs<StrategyRequestType<QueryType>>) => {
       const asyncSearch = () => {
-        start({ ...props, data, factoryQueryType, getTransformChangesIfTheyExist });
+        start({ ...props, data, factoryQueryType, getTransformChangesIfTheyExist } as never); // This typescast is required because every StrategyRequestType instance has different fields.
       };
 
       asyncSearch();
@@ -170,4 +165,3 @@ export const useSearchStrategy = <QueryType extends FactoryQueryTypes>({
     inspect,
   };
 };
-// TODO add unit test

--- a/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/index.tsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { filter } from 'rxjs/operators';
+import { noop, omit } from 'lodash/fp';
+import { useCallback, useEffect, useRef, useMemo } from 'react';
+import { Observable } from 'rxjs';
+
+import {
+  OptionalSignalArgs,
+  useObservable,
+  withOptionalSignal,
+} from '@kbn/securitysolution-hook-utils';
+
+import * as i18n from './translations';
+
+import {
+  FactoryQueryTypes,
+  RequestBasicOptions,
+  StrategyResponseType,
+} from '../../../../common/search_strategy/security_solution';
+import { IKibanaSearchResponse } from '../../../../../../../src/plugins/data/common';
+import {
+  DataPublicPluginStart,
+  isCompleteResponse,
+  isErrorResponse,
+} from '../../../../../../../src/plugins/data/public';
+import {
+  TransformChangesIfTheyExist,
+  useTransforms,
+} from '../../../transforms/containers/use_transforms';
+import { getInspectResponse } from '../../../helpers';
+import { inputsModel } from '../../store';
+import { useKibana } from '../../lib/kibana';
+import { useAppToasts } from '../../hooks/use_app_toasts';
+
+type UseSearchStrategyRequestArgs = RequestBasicOptions & {
+  data: DataPublicPluginStart;
+  signal: AbortSignal;
+  factoryQueryType: FactoryQueryTypes;
+  getTransformChangesIfTheyExist: TransformChangesIfTheyExist;
+};
+
+const search = <ResponseType extends IKibanaSearchResponse>({
+  data,
+  signal,
+  factoryQueryType,
+  defaultIndex,
+  filterQuery,
+  timerange,
+  getTransformChangesIfTheyExist,
+  ...requestProps
+}: UseSearchStrategyRequestArgs): Observable<ResponseType> => {
+  const {
+    indices: transformIndices,
+    factoryQueryType: transformFactoryQueryType,
+    timerange: transformTimerange,
+  } = getTransformChangesIfTheyExist({
+    factoryQueryType,
+    indices: defaultIndex,
+    filterQuery,
+    timerange,
+  });
+
+  return data.search.search<RequestBasicOptions, ResponseType>(
+    {
+      ...requestProps,
+      factoryQueryType: transformFactoryQueryType,
+      defaultIndex: transformIndices,
+      timerange: transformTimerange,
+      filterQuery,
+    },
+    {
+      strategy: 'securitySolutionSearchStrategy',
+      abortSignal: signal,
+    }
+  );
+};
+
+const searchComplete = <ResponseType extends IKibanaSearchResponse>(
+  props: UseSearchStrategyRequestArgs
+): Observable<ResponseType> => {
+  return search<ResponseType>(props).pipe(
+    filter((response) => {
+      return isErrorResponse(response) || isCompleteResponse(response);
+    })
+  );
+};
+
+export const useSearchStrategy = <QueryType extends FactoryQueryTypes>({
+  factoryQueryType,
+  initialResult,
+  errorMessage,
+}: {
+  factoryQueryType: QueryType;
+  /**
+   * `result` initial value. It is used until the search strategy returns some data.
+   */
+  initialResult: Omit<StrategyResponseType<QueryType>, 'rawResponse' | 'inspect'>;
+  /**
+   * Message displayed to the user on a Toast when an erro happens.
+   */
+  errorMessage?: string;
+}) => {
+  const { getTransformChangesIfTheyExist } = useTransforms();
+
+  const refetch = useRef<inputsModel.Refetch>(noop);
+  const { data } = useKibana().services;
+  const { addError } = useAppToasts();
+
+  // It needs to be memoized otherwise `useObservable` would receive a new instance on every render
+  const searchDataOptionalSignal = useMemo(
+    () =>
+      withOptionalSignal<UseSearchStrategyRequestArgs, Observable<StrategyResponseType<QueryType>>>(
+        searchComplete
+      ),
+    []
+  );
+
+  const { start, error, result, loading } = useObservable(searchDataOptionalSignal);
+
+  useEffect(() => {
+    if (error != null) {
+      addError(error, {
+        title: errorMessage ?? i18n.DEFAULT_ERROR_SEARCH_STRATEGY(factoryQueryType),
+      });
+    }
+  }, [addError, error, errorMessage, factoryQueryType]);
+
+  const searchCb = useCallback(
+    (
+      props: OptionalSignalArgs<
+        Omit<
+          UseSearchStrategyRequestArgs,
+          'data' | 'factoryQueryType' | 'getTransformChangesIfTheyExist'
+        >
+      >
+    ) => {
+      const asyncSearch = () => {
+        start({ ...props, data, factoryQueryType, getTransformChangesIfTheyExist });
+      };
+
+      asyncSearch();
+
+      refetch.current = asyncSearch;
+    },
+    [data, start, factoryQueryType, getTransformChangesIfTheyExist]
+  );
+
+  const [formatedResult, inspect] = useMemo(
+    () => [
+      omit<StrategyResponseType<QueryType>, 'rawResponse'>('rawResponse', result),
+      getInspectResponse(result, {
+        dsl: [],
+        response: [],
+      }),
+    ],
+    [result]
+  );
+
+  return {
+    loading,
+    result: result ? formatedResult : initialResult,
+    error,
+    search: searchCb,
+    refetch: refetch.current,
+    inspect,
+  };
+};
+// TODO add unit test

--- a/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/index.tsx
@@ -87,6 +87,11 @@ const searchComplete = <ResponseType extends IKibanaSearchResponse>(
   );
 };
 
+const EMPTY_INSPECT = {
+  dsl: [],
+  response: [],
+};
+
 export const useSearchStrategy = <QueryType extends FactoryQueryTypes>({
   factoryQueryType,
   initialResult,
@@ -151,18 +156,17 @@ export const useSearchStrategy = <QueryType extends FactoryQueryTypes>({
 
   const [formatedResult, inspect] = useMemo(
     () => [
-      omit<StrategyResponseType<QueryType>, 'rawResponse'>('rawResponse', result),
-      getInspectResponse(result, {
-        dsl: [],
-        response: [],
-      }),
+      result
+        ? omit<StrategyResponseType<QueryType>, 'rawResponse'>('rawResponse', result)
+        : initialResult,
+      result ? getInspectResponse(result, EMPTY_INSPECT) : EMPTY_INSPECT,
     ],
-    [result]
+    [result, initialResult]
   );
 
   return {
     loading,
-    result: result ? formatedResult : initialResult,
+    result: formatedResult,
     error,
     search: searchCb,
     refetch: refetch.current,

--- a/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { FactoryQueryTypes } from '../../../../../common/search_strategy';
+
+export const DEFAULT_ERROR_SEARCH_STRATEGY = (factoryQueryType: FactoryQueryTypes) =>
+  i18n.translate('xpack.securitySolution.?????.errorSearchStrategy', {
+    values: { factoryQueryType },
+    defaultMessage: `Failed to run search: {factoryQueryType}`,
+  });

--- a/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/translations.ts
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 import { FactoryQueryTypes } from '../../../../common/search_strategy';
 
 export const DEFAULT_ERROR_SEARCH_STRATEGY = (factoryQueryType: FactoryQueryTypes) =>
-  i18n.translate('xpack.securitySolution.?????.errorSearchStrategy', {
+  i18n.translate('xpack.securitySolution.searchStrategy.error', {
     values: { factoryQueryType },
     defaultMessage: `Failed to run search: {factoryQueryType}`,
   });

--- a/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/use_search_strategy/translations.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { FactoryQueryTypes } from '../../../../../common/search_strategy';
+import { FactoryQueryTypes } from '../../../../common/search_strategy';
 
 export const DEFAULT_ERROR_SEARCH_STRATEGY = (factoryQueryType: FactoryQueryTypes) =>
   i18n.translate('xpack.securitySolution.?????.errorSearchStrategy', {

--- a/x-pack/plugins/security_solution/public/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/helpers.tsx
@@ -147,7 +147,7 @@ export const manageOldSiemRoutes = async (coreStart: CoreStart) => {
 };
 
 export const getInspectResponse = <T extends FactoryQueryTypes>(
-  response: StrategyResponseType<T> | TimelineEqlResponse,
+  response: StrategyResponseType<T> | TimelineEqlResponse | undefined,
   prevResponse: InspectResponse
 ): InspectResponse => ({
   dsl: response?.inspect?.dsl ?? prevResponse?.dsl ?? [],


### PR DESCRIPTION
## Summary

Create a hook to simplify the client-side code of security solutions search strategy.

Not included:
* Make `search` return a promise
* Make `useSearchStrategy` return a canccelable callback function.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
