### PR TITLE
[7.17] [Monitoring-sourced telemetry] Use time-ranged queries (#127273)

### DIFF
--- a/x-pack/plugins/monitoring/server/telemetry_collection/get_all_stats.ts
+++ b/x-pack/plugins/monitoring/server/telemetry_collection/get_all_stats.ts
@@ -36,9 +36,9 @@ export async function getAllStats(
   const end = moment(timestamp).toISOString();
 
   const [esClusters, kibana, logstash, beats] = await Promise.all([
-    getElasticsearchStats(callCluster, clusterUuids, maxBucketSize), // cluster_stats, stack_stats.xpack, cluster_name/uuid, license, version
+    getElasticsearchStats(callCluster, clusterUuids, start, end, maxBucketSize), // cluster_stats, stack_stats.xpack, cluster_name/uuid, license, version
     getKibanaStats(callCluster, clusterUuids, start, end, maxBucketSize), // stack_stats.kibana
-    getLogstashStats(callCluster, clusterUuids), // stack_stats.logstash
+    getLogstashStats(callCluster, clusterUuids, start, end), // stack_stats.logstash
     getBeatsStats(callCluster, clusterUuids, start, end), // stack_stats.beats
   ]);
 

--- a/x-pack/plugins/monitoring/server/telemetry_collection/get_es_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/telemetry_collection/get_es_stats.test.ts
@@ -28,14 +28,16 @@ describe('get_es_stats', () => {
   const expectedClusters = body.hits.hits.map((hit) => hit._source);
   const clusterUuids = expectedClusters.map((cluster) => cluster.cluster_uuid);
   const maxBucketSize = 1;
+  const start = '2022-03-09T00:00:00.000Z';
+  const end = '2022-03-09T00:20:00.000Z';
 
   describe('getElasticsearchStats', () => {
     it('returns clusters', async () => {
       searchMock.returns(Promise.resolve({ body }));
 
-      expect(await getElasticsearchStats(client, clusterUuids, maxBucketSize)).toStrictEqual(
-        expectedClusters
-      );
+      expect(
+        await getElasticsearchStats(client, clusterUuids, start, end, maxBucketSize)
+      ).toStrictEqual(expectedClusters);
     });
   });
 
@@ -43,9 +45,9 @@ describe('get_es_stats', () => {
     it('searches for clusters', async () => {
       searchMock.returns({ body });
 
-      expect(await fetchElasticsearchStats(client, clusterUuids, maxBucketSize)).toStrictEqual(
-        body
-      );
+      expect(
+        await fetchElasticsearchStats(client, clusterUuids, start, end, maxBucketSize)
+      ).toStrictEqual(body);
     });
   });
 

--- a/x-pack/plugins/monitoring/server/telemetry_collection/get_es_stats.ts
+++ b/x-pack/plugins/monitoring/server/telemetry_collection/get_es_stats.ts
@@ -7,6 +7,7 @@
 
 import { ElasticsearchClient } from 'kibana/server';
 import { estypes } from '@elastic/elasticsearch';
+import moment from 'moment';
 import { INDEX_PATTERN_ELASTICSEARCH } from '../../common/constants';
 
 /**
@@ -19,9 +20,17 @@ import { INDEX_PATTERN_ELASTICSEARCH } from '../../common/constants';
 export async function getElasticsearchStats(
   callCluster: ElasticsearchClient,
   clusterUuids: string[],
+  start: string,
+  end: string,
   maxBucketSize: number
 ) {
-  const response = await fetchElasticsearchStats(callCluster, clusterUuids, maxBucketSize);
+  const response = await fetchElasticsearchStats(
+    callCluster,
+    clusterUuids,
+    start,
+    end,
+    maxBucketSize
+  );
   return handleElasticsearchStats(response);
 }
 
@@ -37,6 +46,8 @@ export async function getElasticsearchStats(
 export async function fetchElasticsearchStats(
   callCluster: ElasticsearchClient,
   clusterUuids: string[],
+  start: string,
+  end: string,
   maxBucketSize: number
 ) {
   const params: estypes.SearchRequest = {
@@ -61,6 +72,15 @@ export async function fetchElasticsearchStats(
              */
             { term: { type: 'cluster_stats' } },
             { terms: { cluster_uuid: clusterUuids } },
+            {
+              range: {
+                timestamp: {
+                  format: 'epoch_millis',
+                  gte: moment.utc(start).valueOf(),
+                  lte: moment.utc(end).valueOf(),
+                },
+              },
+            },
           ],
         },
       },

--- a/x-pack/plugins/monitoring/server/telemetry_collection/get_licenses.test.ts
+++ b/x-pack/plugins/monitoring/server/telemetry_collection/get_licenses.test.ts
@@ -11,6 +11,7 @@ import { getLicenses, handleLicenses, fetchLicenses } from './get_licenses';
 
 describe('get_licenses', () => {
   const searchMock = sinon.stub();
+  const timestamp = 1646785200000;
   const client = { search: searchMock } as unknown as ElasticsearchClient;
   const body = {
     hits: {
@@ -33,7 +34,7 @@ describe('get_licenses', () => {
     it('returns clusters', async () => {
       searchMock.returns(Promise.resolve({ body }));
 
-      expect(await getLicenses(clusterUuids, client, 1)).toStrictEqual(expectedLicenses);
+      expect(await getLicenses(clusterUuids, client, timestamp, 1)).toStrictEqual(expectedLicenses);
     });
   });
 
@@ -41,7 +42,7 @@ describe('get_licenses', () => {
     it('searches for clusters', async () => {
       searchMock.returns({ body });
 
-      expect(await fetchLicenses(client, clusterUuids, 1)).toStrictEqual(body);
+      expect(await fetchLicenses(client, clusterUuids, timestamp, 1)).toStrictEqual(body);
     });
   });
 

--- a/x-pack/plugins/monitoring/server/telemetry_collection/get_licenses.ts
+++ b/x-pack/plugins/monitoring/server/telemetry_collection/get_licenses.ts
@@ -8,17 +8,18 @@
 import { ElasticsearchClient } from 'kibana/server';
 import { estypes } from '@elastic/elasticsearch';
 import { ESLicense } from '../../../telemetry_collection_xpack/server';
-import { INDEX_PATTERN_ELASTICSEARCH } from '../../common/constants';
+import { INDEX_PATTERN_ELASTICSEARCH, USAGE_FETCH_INTERVAL } from '../../common/constants';
 
 /**
  * Get statistics for all selected Elasticsearch clusters.
  */
 export async function getLicenses(
   clusterUuids: string[],
-  callCluster: ElasticsearchClient, // TODO: To be changed to the new ES client when the plugin migrates
+  callCluster: ElasticsearchClient,
+  timestamp: number,
   maxBucketSize: number
 ): Promise<{ [clusterUuid: string]: ESLicense | undefined }> {
-  const response = await fetchLicenses(callCluster, clusterUuids, maxBucketSize);
+  const response = await fetchLicenses(callCluster, clusterUuids, timestamp, maxBucketSize);
   return handleLicenses(response);
 }
 
@@ -34,6 +35,7 @@ export async function getLicenses(
 export async function fetchLicenses(
   callCluster: ElasticsearchClient,
   clusterUuids: string[],
+  timestamp: number,
   maxBucketSize: number
 ) {
   const params: estypes.SearchRequest = {
@@ -51,6 +53,15 @@ export async function fetchLicenses(
              */
             { term: { type: 'cluster_stats' } },
             { terms: { cluster_uuid: clusterUuids } },
+            {
+              range: {
+                timestamp: {
+                  format: 'epoch_millis',
+                  gte: timestamp - USAGE_FETCH_INTERVAL,
+                  lte: timestamp,
+                },
+              },
+            },
           ],
         },
       },

--- a/x-pack/plugins/monitoring/server/telemetry_collection/get_logstash_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/telemetry_collection/get_logstash_stats.test.ts
@@ -36,6 +36,8 @@ describe('Get Logstash Stats', () => {
   const clusterUuids = ['aCluster', 'bCluster', 'cCluster'];
   const searchMock = sinon.stub();
   const callCluster = { search: searchMock } as unknown as ElasticsearchClient;
+  const start = '2022-03-09T00:00:00.000Z';
+  const end = '2022-03-09T00:20:00.000Z';
 
   beforeEach(() => {
     searchMock.returns(Promise.resolve({ body: {} }));
@@ -53,6 +55,15 @@ describe('Get Logstash Stats', () => {
         bool: {
           filter: [
             {
+              range: {
+                timestamp: {
+                  format: 'epoch_millis',
+                  gte: 1646784000000,
+                  lte: 1646785200000,
+                },
+              },
+            },
+            {
               terms: {
                 'logstash_state.pipeline.ephemeral_id': ['a', 'b', 'c'],
               },
@@ -68,68 +79,28 @@ describe('Get Logstash Stats', () => {
         },
       };
 
-      await fetchLogstashState(callCluster, clusterUuid, ephemeralIds, {} as any);
+      await fetchLogstashState(callCluster, clusterUuid, ephemeralIds, start, end, {} as any);
       const { args } = searchMock.firstCall;
       const [{ body }] = args;
       expect(body.query).toEqual(expected);
     });
 
     it('should set `from: 0, to: 10000` in the query', async () => {
-      await fetchLogstashState(callCluster, clusterUuid, ephemeralIds, {} as any);
+      await fetchLogstashState(callCluster, clusterUuid, ephemeralIds, start, end, {} as any);
       const { args } = searchMock.firstCall;
       const [{ body }] = args;
       expect(body.from).toEqual(0);
-      expect(body.size).toEqual(10000);
-    });
-
-    it('should set `from: 10000, to: 10000` in the query', async () => {
-      await fetchLogstashState(callCluster, clusterUuid, ephemeralIds, {
-        page: 1,
-      } as any);
-      const { args } = searchMock.firstCall;
-      const [{ body }] = args;
-
-      expect(body.from).toEqual(10000);
-      expect(body.size).toEqual(10000);
-    });
-
-    it('should set `from: 20000, to: 10000` in the query', async () => {
-      await fetchLogstashState(callCluster, clusterUuid, ephemeralIds, {
-        page: 2,
-      } as any);
-      const { args } = searchMock.firstCall;
-      const [{ body }] = args;
-
-      expect(body.from).toEqual(20000);
       expect(body.size).toEqual(10000);
     });
   });
 
   describe('fetchLogstashStats', () => {
     it('should set `from: 0, to: 10000` in the query', async () => {
-      await fetchLogstashStats(callCluster, clusterUuids, {} as any);
+      await fetchLogstashStats(callCluster, clusterUuids, start, end, {} as any);
       const { args } = searchMock.firstCall;
       const [{ body }] = args;
 
       expect(body.from).toEqual(0);
-      expect(body.size).toEqual(10000);
-    });
-
-    it('should set `from: 10000, to: 10000` in the query', async () => {
-      await fetchLogstashStats(callCluster, clusterUuids, { page: 1 } as any);
-      const { args } = searchMock.firstCall;
-      const [{ body }] = args;
-
-      expect(body.from).toEqual(10000);
-      expect(body.size).toEqual(10000);
-    });
-
-    it('should set `from: 20000, to: 10000` in the query', async () => {
-      await fetchLogstashStats(callCluster, clusterUuids, { page: 2 } as any);
-      const { args } = searchMock.firstCall;
-      const [{ body }] = args;
-
-      expect(body.from).toEqual(20000);
       expect(body.size).toEqual(10000);
     });
   });

--- a/x-pack/plugins/monitoring/server/telemetry_collection/get_logstash_stats.ts
+++ b/x-pack/plugins/monitoring/server/telemetry_collection/get_logstash_stats.ts
@@ -263,6 +263,8 @@ export function processLogstashStateResults(
 export async function fetchLogstashStats(
   callCluster: ElasticsearchClient,
   clusterUuids: string[],
+  start: string,
+  end: string,
   { page = 0, ...options }: { page?: number } & LogstashProcessOptions
 ): Promise<void> {
   const params: estypes.SearchRequest = {
@@ -281,6 +283,8 @@ export async function fetchLogstashStats(
     ],
     body: {
       query: createQuery({
+        start,
+        end,
         filters: [
           { terms: { cluster_uuid: clusterUuids } },
           {
@@ -310,17 +314,6 @@ export async function fetchLogstashStats(
   if (hitsLength > 0) {
     // further augment the clusters object with more stats
     processStatsResults(results, options);
-
-    if (hitsLength === HITS_SIZE) {
-      // call recursively
-      const nextOptions = {
-        page: page + 1,
-        ...options,
-      };
-
-      // returns a promise and keeps the caller blocked from returning until the entire clusters object is built
-      return fetchLogstashStats(callCluster, clusterUuids, nextOptions);
-    }
   }
   return Promise.resolve();
 }
@@ -329,6 +322,8 @@ export async function fetchLogstashState(
   callCluster: ElasticsearchClient,
   clusterUuid: string,
   ephemeralIds: string[],
+  start: string,
+  end: string,
   { page = 0, ...options }: { page?: number } & LogstashProcessOptions
 ): Promise<void> {
   const params: estypes.SearchRequest = {
@@ -345,6 +340,8 @@ export async function fetchLogstashState(
     ],
     body: {
       query: createQuery({
+        start,
+        end,
         filters: [
           { terms: { 'logstash_state.pipeline.ephemeral_id': ephemeralIds } },
           {
@@ -371,17 +368,6 @@ export async function fetchLogstashState(
   if (hitsLength > 0) {
     // further augment the clusters object with more stats
     processLogstashStateResults(results, clusterUuid, options);
-
-    if (hitsLength === HITS_SIZE) {
-      // call recursively
-      const nextOptions = {
-        page: page + 1,
-        ...options,
-      };
-
-      // returns a promise and keeps the caller blocked from returning until the entire clusters object is built
-      return fetchLogstashState(callCluster, clusterUuid, ephemeralIds, nextOptions);
-    }
   }
   return Promise.resolve();
 }
@@ -396,7 +382,9 @@ export interface LogstashStatsByClusterUuid {
  */
 export async function getLogstashStats(
   callCluster: ElasticsearchClient,
-  clusterUuids: string[]
+  clusterUuids: string[],
+  start: string,
+  end: string
 ): Promise<LogstashStatsByClusterUuid> {
   const options: LogstashProcessOptions = {
     clusters: {}, // the result object to be built up
@@ -405,7 +393,7 @@ export async function getLogstashStats(
     plugins: {},
   };
 
-  await fetchLogstashStats(callCluster, clusterUuids, options);
+  await fetchLogstashStats(callCluster, clusterUuids, start, end, options);
   await Promise.all(
     clusterUuids.map(async (clusterUuid) => {
       if (options.clusters[clusterUuid] !== undefined) {
@@ -413,6 +401,8 @@ export async function getLogstashStats(
           callCluster,
           clusterUuid,
           options.allEphemeralIds[clusterUuid],
+          start,
+          end,
           options
         );
       }

--- a/x-pack/plugins/monitoring/server/telemetry_collection/register_monitoring_telemetry_collection.ts
+++ b/x-pack/plugins/monitoring/server/telemetry_collection/register_monitoring_telemetry_collection.ts
@@ -146,7 +146,7 @@ export function registerMonitoringTelemetryCollection(
       const callCluster = kibanaRequest ? esClient : getClient().asInternalUser;
       const clusterDetails = await getClusterUuids(callCluster, timestamp, maxBucketSize);
       const [licenses, stats] = await Promise.all([
-        getLicenses(clusterDetails, callCluster, maxBucketSize),
+        getLicenses(clusterDetails, callCluster, timestamp, maxBucketSize),
         getAllStats(clusterDetails, callCluster, timestamp, maxBucketSize),
       ]);
 

--- a/x-pack/test/api_integration/apis/telemetry/telemetry.ts
+++ b/x-pack/test/api_integration/apis/telemetry/telemetry.ts
@@ -50,44 +50,24 @@ function updateMonitoringDates(
   toTimestamp: string,
   timestamp: string
 ) {
-  return Promise.all([
-    esSupertest
-      .post('/.monitoring-es-*/_update_by_query?refresh=true')
-      .send({
-        query: {
-          range: {
-            timestamp: {
-              format: 'epoch_millis',
-              gte: moment(fromTimestamp).valueOf(),
-              lte: moment(toTimestamp).valueOf(),
-            },
+  return esSupertest
+    .post('/.monitoring-*/_update_by_query?refresh=true')
+    .send({
+      query: {
+        range: {
+          timestamp: {
+            format: 'epoch_millis',
+            gte: moment(fromTimestamp).valueOf(),
+            lte: moment(toTimestamp).valueOf(),
           },
         },
-        script: {
-          source: `ctx._source.timestamp='${timestamp}'`,
-          lang: 'painless',
-        },
-      })
-      .expect(200),
-    esSupertest
-      .post('/.monitoring-kibana-*/_update_by_query?refresh=true')
-      .send({
-        query: {
-          range: {
-            timestamp: {
-              format: 'epoch_millis',
-              gte: moment(fromTimestamp).valueOf(),
-              lte: moment(toTimestamp).valueOf(),
-            },
-          },
-        },
-        script: {
-          source: `ctx._source.timestamp='${timestamp}'`,
-          lang: 'painless',
-        },
-      })
-      .expect(200),
-  ]);
+      },
+      script: {
+        source: `ctx._source.timestamp='${timestamp}'`,
+        lang: 'painless',
+      },
+    })
+    .expect(200);
 }
 
 export default function ({ getService }: FtrProviderContext) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Monitoring-sourced telemetry] Use time-ranged queries (#127273)](https://github.com/elastic/kibana/pull/127273)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)