### PR TITLE
[App Search] Remove UI gating for Meta engines based on license

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/constants.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/constants.tsx
@@ -5,17 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
-
-import { EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
-
-import { META_ENGINES_DOCS_URL } from '../../routes';
-import {
-  META_ENGINE_CREATION_FORM_META_ENGINE_DESCRIPTION,
-  META_ENGINE_CREATION_FORM_DOCUMENTATION_LINK,
-} from '../meta_engine_creation/constants';
 
 export const ENGINES_TITLE = i18n.translate('xpack.enterpriseSearch.appSearch.engines.title', {
   defaultMessage: 'Engines',
@@ -29,24 +19,6 @@ export const ENGINES_OVERVIEW_TITLE = i18n.translate(
 export const META_ENGINES_TITLE = i18n.translate(
   'xpack.enterpriseSearch.appSearch.metaEngines.title',
   { defaultMessage: 'Meta Engines' }
-);
-
-export const META_ENGINES_DESCRIPTION = (
-  <>
-    {META_ENGINE_CREATION_FORM_META_ENGINE_DESCRIPTION}
-    <br />
-    <FormattedMessage
-      id="xpack.enterpriseSearch.appSearch.metaEngines.upgradeDescription"
-      defaultMessage="{readDocumentationLink} for more information or upgrade to a Platinum license to get started."
-      values={{
-        readDocumentationLink: (
-          <EuiLink href={META_ENGINES_DOCS_URL} target="_blank">
-            {META_ENGINE_CREATION_FORM_DOCUMENTATION_LINK}
-          </EuiLink>
-        ),
-      }}
-    />
-  </>
 );
 
 export const SOURCE_ENGINES_TITLE = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
@@ -156,19 +156,6 @@ describe('EnginesOverview', () => {
     });
   });
 
-  describe('when an account does not have a platinum license', () => {
-    it('renders a license call to action in place of the meta engines table', () => {
-      setMockValues({
-        ...valuesWithEngines,
-        hasPlatinumLicense: false,
-      });
-      const wrapper = shallow(<EnginesOverview />);
-
-      expect(wrapper.find('[data-test-subj="metaEnginesLicenseCTA"]')).toHaveLength(1);
-      expect(wrapper.find('[data-test-subj="appSearchMetaEngines"]')).toHaveLength(0);
-    });
-  });
-
   describe('pagination', () => {
     const getTablePagination = (wrapper: ShallowWrapper) =>
       wrapper.find(EnginesTable).prop('pagination');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
@@ -11,7 +11,6 @@ import { useValues, useActions } from 'kea';
 
 import { EuiSpacer } from '@elastic/eui';
 
-import { LicensingLogic, ManageLicenseButton } from '../../../shared/licensing';
 import { EuiButtonTo } from '../../../shared/react_router_helpers';
 import { convertMetaToPagination, handlePageChange } from '../../../shared/table_pagination';
 import { AppLogic } from '../../app_logic';
@@ -30,12 +29,10 @@ import {
   CREATE_A_META_ENGINE_BUTTON_LABEL,
   ENGINES_TITLE,
   META_ENGINES_TITLE,
-  META_ENGINES_DESCRIPTION,
 } from './constants';
 import { EnginesLogic } from './engines_logic';
 
 export const EnginesOverview: React.FC = () => {
-  const { hasPlatinumLicense } = useValues(LicensingLogic);
   const {
     myRole: { canManageEngines, canManageMetaEngines },
   } = useValues(AppLogic);
@@ -58,8 +55,8 @@ export const EnginesOverview: React.FC = () => {
   }, [enginesMeta.page.current]);
 
   useEffect(() => {
-    if (hasPlatinumLicense) loadMetaEngines();
-  }, [hasPlatinumLicense, metaEnginesMeta.page.current]);
+    loadMetaEngines();
+  }, [metaEnginesMeta.page.current]);
 
   return (
     <AppSearchPageTemplate
@@ -101,50 +98,37 @@ export const EnginesOverview: React.FC = () => {
         />
       </DataPanel>
       <EuiSpacer size="xxl" />
-      {hasPlatinumLicense ? (
-        <DataPanel
-          hasBorder
-          iconType={MetaEngineIcon}
-          title={<h2>{META_ENGINES_TITLE}</h2>}
-          titleSize="s"
-          action={
-            canManageMetaEngines && (
-              <EuiButtonTo
-                color="success"
-                size="s"
-                iconType="plusInCircle"
-                data-test-subj="appSearchEnginesMetaEngineCreationButton"
-                to={META_ENGINE_CREATION_PATH}
-              >
-                {CREATE_A_META_ENGINE_BUTTON_LABEL}
-              </EuiButtonTo>
-            )
-          }
-          data-test-subj="appSearchMetaEngines"
-        >
-          <MetaEnginesTable
-            items={metaEngines}
-            loading={metaEnginesLoading}
-            pagination={{
-              ...convertMetaToPagination(metaEnginesMeta),
-              hidePerPageOptions: true,
-            }}
-            noItemsMessage={<EmptyMetaEnginesState />}
-            onChange={handlePageChange(onMetaEnginesPagination)}
-          />
-        </DataPanel>
-      ) : (
-        <DataPanel
-          hasBorder
-          responsive
-          iconType={MetaEngineIcon}
-          title={<h2>{META_ENGINES_TITLE}</h2>}
-          titleSize="s"
-          subtitle={META_ENGINES_DESCRIPTION}
-          action={<ManageLicenseButton />}
-          data-test-subj="metaEnginesLicenseCTA"
+      <DataPanel
+        hasBorder
+        iconType={MetaEngineIcon}
+        title={<h2>{META_ENGINES_TITLE}</h2>}
+        titleSize="s"
+        action={
+          canManageMetaEngines && (
+            <EuiButtonTo
+              color="success"
+              size="s"
+              iconType="plusInCircle"
+              data-test-subj="appSearchEnginesMetaEngineCreationButton"
+              to={META_ENGINE_CREATION_PATH}
+            >
+              {CREATE_A_META_ENGINE_BUTTON_LABEL}
+            </EuiButtonTo>
+          )
+        }
+        data-test-subj="appSearchMetaEngines"
+      >
+        <MetaEnginesTable
+          items={metaEngines}
+          loading={metaEnginesLoading}
+          pagination={{
+            ...convertMetaToPagination(metaEnginesMeta),
+            hidePerPageOptions: true,
+          }}
+          noItemsMessage={<EmptyMetaEnginesState />}
+          onChange={handlePageChange(onMetaEnginesPagination)}
         />
-      )}
+      </DataPanel>
       <AuditLogsModal />
     </AppSearchPageTemplate>
   );

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -9122,7 +9122,6 @@
     "xpack.enterpriseSearch.appSearch.metaEngineCreation.successMessage": "Le métamoteur \"{name}\" a été créé",
     "xpack.enterpriseSearch.appSearch.metaEngineCreation.title": "Créer un métamoteur",
     "xpack.enterpriseSearch.appSearch.metaEngines.title": "Métamoteurs",
-    "xpack.enterpriseSearch.appSearch.metaEngines.upgradeDescription": "Veuillez {readDocumentationLink} pour en savoir plus ou effectuer une mise à niveau vers une licence Platinum pour commencer.",
     "xpack.enterpriseSearch.appSearch.multiInputRows.addValueButtonLabel": "Ajouter une valeur",
     "xpack.enterpriseSearch.appSearch.multiInputRows.inputRowPlaceholder": "Entrer une valeur",
     "xpack.enterpriseSearch.appSearch.multiInputRows.removeValueButtonLabel": "Retirer une valeur",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -10750,7 +10750,6 @@
     "xpack.enterpriseSearch.appSearch.metaEngineCreation.successMessage": "メタエンジン'{name}'が作成されました",
     "xpack.enterpriseSearch.appSearch.metaEngineCreation.title": "メタエンジンを作成",
     "xpack.enterpriseSearch.appSearch.metaEngines.title": "メタエンジン",
-    "xpack.enterpriseSearch.appSearch.metaEngines.upgradeDescription": "詳細またはPlatinumライセンスにアップグレードして開始するには、{readDocumentationLink}。",
     "xpack.enterpriseSearch.appSearch.multiInputRows.addValueButtonLabel": "値を追加",
     "xpack.enterpriseSearch.appSearch.multiInputRows.inputRowPlaceholder": "値を入力",
     "xpack.enterpriseSearch.appSearch.multiInputRows.removeValueButtonLabel": "値を削除",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -10771,7 +10771,6 @@
     "xpack.enterpriseSearch.appSearch.metaEngineCreation.successMessage": "元引擎“{name}”已创建",
     "xpack.enterpriseSearch.appSearch.metaEngineCreation.title": "创建元引擎",
     "xpack.enterpriseSearch.appSearch.metaEngines.title": "元引擎",
-    "xpack.enterpriseSearch.appSearch.metaEngines.upgradeDescription": "{readDocumentationLink}以了解更多信息，或升级到白金级许可证以开始。",
     "xpack.enterpriseSearch.appSearch.multiInputRows.addValueButtonLabel": "添加值",
     "xpack.enterpriseSearch.appSearch.multiInputRows.inputRowPlaceholder": "输入值",
     "xpack.enterpriseSearch.appSearch.multiInputRows.removeValueButtonLabel": "删除值",


### PR DESCRIPTION
closes https://github.com/elastic/enterprise-search-team/issues/1495
closes https://github.com/elastic/enterprise-search-team/issues/1500

## Summary

Removes UI gating for Meta engines based on license. 

**Before**

![before](https://user-images.githubusercontent.com/1869731/158451803-b88cc472-e044-41dd-b2d6-a2deb86ad008.png)

**After**

https://user-images.githubusercontent.com/1869731/158451820-5820b7e5-7c8e-48cf-b8e0-1e6f859eccc2.mp4

_Note: best to review with whitespace changes hidden._

### Checklist
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
