### PR TITLE
[Security Solution] Fixes Rules configured to run a Slack action on an interval fail with an [index_not_found_exception] Reason: no such index [.alerts-security.alerts] error

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -330,7 +330,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                     id: alertId,
                     kibanaSiemAppUrl: (meta as { kibana_siem_app_url?: string } | undefined)
                       ?.kibana_siem_app_url,
-                    outputIndex: ruleDataClient.indexName,
+                    outputIndex: ruleDataClient.indexNameWithNamespace(spaceId),
                     ruleId,
                     esClient: services.scopedClusterClient.asCurrentUser,
                     notificationRuleParams,
@@ -352,7 +352,9 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               logger.debug(buildRuleMessage('[+] Signal Rule execution completed.'));
               logger.debug(
                 buildRuleMessage(
-                  `[+] Finished indexing ${createdSignalsCount} signals into ${ruleDataClient.indexName}`
+                  `[+] Finished indexing ${createdSignalsCount} signals into ${ruleDataClient.indexNameWithNamespace(
+                    spaceId
+                  )}`
                 )
               );
 
@@ -377,23 +379,6 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 )
               );
             } else {
-              // NOTE: Since this is throttled we have to call it even on an error condition, otherwise it will "reset" the throttle and fire early
-              if (completeRule.ruleConfig.throttle != null) {
-                await scheduleThrottledNotificationActions({
-                  alertInstance: services.alertFactory.create(alertId),
-                  throttle: completeRule.ruleConfig.throttle ?? '',
-                  startedAt,
-                  id: completeRule.alertId,
-                  kibanaSiemAppUrl: (meta as { kibana_siem_app_url?: string } | undefined)
-                    ?.kibana_siem_app_url,
-                  outputIndex: ruleDataClient.indexName,
-                  ruleId,
-                  esClient: services.scopedClusterClient.asCurrentUser,
-                  notificationRuleParams,
-                  signals: result.createdSignals,
-                  logger,
-                });
-              }
               const errorMessage = buildRuleMessage(
                 'Bulk Indexing of signals failed:',
                 truncateList(result.errors).join()
@@ -407,26 +392,25 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                   indexingDurations: result.bulkCreateTimes,
                 },
               });
+              // NOTE: Since this is throttled we have to call it even on an error condition, otherwise it will "reset" the throttle and fire early
+              if (completeRule.ruleConfig.throttle != null) {
+                await scheduleThrottledNotificationActions({
+                  alertInstance: services.alertFactory.create(alertId),
+                  throttle: completeRule.ruleConfig.throttle ?? '',
+                  startedAt,
+                  id: completeRule.alertId,
+                  kibanaSiemAppUrl: (meta as { kibana_siem_app_url?: string } | undefined)
+                    ?.kibana_siem_app_url,
+                  outputIndex: ruleDataClient.indexNameWithNamespace(spaceId),
+                  ruleId,
+                  esClient: services.scopedClusterClient.asCurrentUser,
+                  notificationRuleParams,
+                  signals: result.createdSignals,
+                  logger,
+                });
+              }
             }
           } catch (error) {
-            // NOTE: Since this is throttled we have to call it even on an error condition, otherwise it will "reset" the throttle and fire early
-            if (completeRule.ruleConfig.throttle != null) {
-              await scheduleThrottledNotificationActions({
-                alertInstance: services.alertFactory.create(alertId),
-                throttle: completeRule.ruleConfig.throttle ?? '',
-                startedAt,
-                id: completeRule.alertId,
-                kibanaSiemAppUrl: (meta as { kibana_siem_app_url?: string } | undefined)
-                  ?.kibana_siem_app_url,
-                outputIndex: ruleDataClient.indexName,
-                ruleId,
-                esClient: services.scopedClusterClient.asCurrentUser,
-                notificationRuleParams,
-                signals: result.createdSignals,
-                logger,
-              });
-            }
-
             const errorMessage = error.message ?? '(no error message given)';
             const message = buildRuleMessage(
               'An error occurred during rule execution:',
@@ -442,6 +426,23 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 indexingDurations: result.bulkCreateTimes,
               },
             });
+            // NOTE: Since this is throttled we have to call it even on an error condition, otherwise it will "reset" the throttle and fire early
+            if (completeRule.ruleConfig.throttle != null) {
+              await scheduleThrottledNotificationActions({
+                alertInstance: services.alertFactory.create(alertId),
+                throttle: completeRule.ruleConfig.throttle ?? '',
+                startedAt,
+                id: completeRule.alertId,
+                kibanaSiemAppUrl: (meta as { kibana_siem_app_url?: string } | undefined)
+                  ?.kibana_siem_app_url,
+                outputIndex: ruleDataClient.indexNameWithNamespace(spaceId),
+                ruleId,
+                esClient: services.scopedClusterClient.asCurrentUser,
+                notificationRuleParams,
+                signals: result.createdSignals,
+                logger,
+              });
+            }
           }
 
           return result.state;


### PR DESCRIPTION
## Summary

See https://github.com/elastic/kibana/issues/127088, this fixes it by adding the throttle with the spaceId

Before when you create a rule:

You see it stuck in "running at"
<img width="775" alt="Screen Shot 2022-03-15 at 1 38 12 PM" src="https://user-images.githubusercontent.com/1151048/158460199-980d630d-742f-45e0-b3a9-33c32b77e2a9.png">

And an error when you go to alerts -> rules and connectors:
<img width="2104" alt="Screen Shot 2022-03-15 at 1 38 52 PM" src="https://user-images.githubusercontent.com/1151048/158460265-351bfbb9-7919-415b-9374-205c3f030adb.png">

Now you see it complete running:
<img width="782" alt="Screen Shot 2022-03-15 at 1 51 15 PM" src="https://user-images.githubusercontent.com/1151048/158460297-cd5b49e0-2891-4704-8a9a-4965f6b1df42.png">

And you see it without an error.
<img width="2085" alt="Screen Shot 2022-03-15 at 1 51 32 PM" src="https://user-images.githubusercontent.com/1151048/158460305-861275fa-a336-4afb-8ef3-3697f95f6114.png">

### Checklist

Did not take the time to figure out a clean way to create e2e tests for this. We need them for throttle but right now there is not an easy way and this is fixing a high priority bug.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
