### PR TITLE
[7.17] [Telemetry] Refresh config before send (#127454)

### DIFF
--- a/src/plugins/telemetry/public/plugin.ts
+++ b/src/plugins/telemetry/public/plugin.ts
@@ -113,6 +113,7 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
   private telemetryNotifications?: TelemetryNotifications;
   private telemetryService?: TelemetryService;
   private canUserChangeSettings: boolean = true;
+  private savedObjectsClient?: SavedObjectsClientContract;
 
   constructor(initializerContext: PluginInitializerContext<TelemetryPluginConfig>) {
     this.currentKibanaVersion = initializerContext.env.packageInfo.version;
@@ -133,7 +134,9 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
       currentKibanaVersion,
     });
 
-    this.telemetrySender = new TelemetrySender(this.telemetryService);
+    this.telemetrySender = new TelemetrySender(this.telemetryService, async () => {
+      await this.refreshConfig();
+    });
 
     return {
       telemetryService: this.getTelemetryServicePublicApis(),
@@ -155,18 +158,17 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
     });
     this.telemetryNotifications = telemetryNotifications;
 
+    this.savedObjectsClient = savedObjects.client;
+
     application.currentAppId$.subscribe(async () => {
       const isUnauthenticated = this.getIsUnauthenticated(http);
       if (isUnauthenticated) {
         return;
       }
 
-      // Update the telemetry config based as a mix of the config files and saved objects
-      const telemetrySavedObject = await this.getTelemetrySavedObject(savedObjects.client);
-      const updatedConfig = await this.updateConfigsBasedOnSavedObjects(telemetrySavedObject);
-      this.telemetryService!.config = updatedConfig;
-
-      const telemetryBanner = updatedConfig.banner;
+      // Refresh and get telemetry config
+      const updatedConfig = await this.refreshConfig();
+      const telemetryBanner = updatedConfig?.banner;
 
       this.maybeStartTelemetryPoller();
       if (telemetryBanner) {
@@ -196,6 +198,16 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
       getCanChangeOptInStatus: () => telemetryService.getCanChangeOptInStatus(),
       fetchExample: () => telemetryService.fetchExample(),
     };
+  }
+
+  private async refreshConfig(): Promise<TelemetryPluginConfig | undefined> {
+    if (this.savedObjectsClient && this.telemetryService) {
+      // Update the telemetry config based as a mix of the config files and saved objects
+      const telemetrySavedObject = await this.getTelemetrySavedObject(this.savedObjectsClient);
+      const updatedConfig = await this.updateConfigsBasedOnSavedObjects(telemetrySavedObject);
+      this.telemetryService.config = updatedConfig;
+      return updatedConfig;
+    }
   }
 
   /**

--- a/src/plugins/telemetry/public/services/telemetry_sender.ts
+++ b/src/plugins/telemetry/public/services/telemetry_sender.ts
@@ -6,51 +6,97 @@
  * Side Public License, v 1.
  */
 
-import {
-  REPORT_INTERVAL_MS,
-  LOCALSTORAGE_KEY,
-  PAYLOAD_CONTENT_ENCODING,
-} from '../../common/constants';
+import type { Subscription } from 'rxjs';
+import { fromEvent, interval, merge } from 'rxjs';
+import { exhaustMap } from 'rxjs/operators';
+import { LOCALSTORAGE_KEY, PAYLOAD_CONTENT_ENCODING } from '../../common/constants';
 import { TelemetryService } from './telemetry_service';
 import { Storage } from '../../../kibana_utils/public';
 import type { EncryptedTelemetryPayload } from '../../common/types';
+import { isReportIntervalExpired } from '../../common/is_report_interval_expired';
 
 export class TelemetrySender {
-  private readonly telemetryService: TelemetryService;
-  private lastReported?: string;
+  private lastReported?: number;
   private readonly storage: Storage;
-  private intervalId: number = 0; // setInterval returns a positive integer, 0 means no interval is set
+  private sendIfDue$?: Subscription;
   private retryCount: number = 0;
 
   static getRetryDelay(retryCount: number) {
     return 60 * (1000 * Math.min(Math.pow(2, retryCount), 64)); // 120s, 240s, 480s, 960s, 1920s, 3840s, 3840s, 3840s
   }
 
-  constructor(telemetryService: TelemetryService) {
-    this.telemetryService = telemetryService;
+  constructor(
+    private readonly telemetryService: TelemetryService,
+    private readonly refreshConfig: () => Promise<void>
+  ) {
     this.storage = new Storage(window.localStorage);
 
     const attributes = this.storage.get(LOCALSTORAGE_KEY);
     if (attributes) {
-      this.lastReported = attributes.lastReport;
+      this.lastReported = parseInt(attributes.lastReport, 10);
     }
   }
 
-  private saveToBrowser = () => {
+  private updateLastReported = (lastReported: number) => {
+    this.lastReported = lastReported;
     // we are the only code that manipulates this key, so it's safe to blindly overwrite the whole object
-    this.storage.set(LOCALSTORAGE_KEY, { lastReport: this.lastReported });
+    this.storage.set(LOCALSTORAGE_KEY, { lastReport: `${this.lastReported}` });
   };
 
-  private shouldSendReport = (): boolean => {
-    if (this.telemetryService.canSendTelemetry()) {
-      if (!this.lastReported) {
-        return true;
-      }
-      // returns NaN for any malformed or unset (null/undefined) value
-      const lastReported = parseInt(this.lastReported, 10);
-      // If it's been a day since we last sent telemetry
-      if (isNaN(lastReported) || Date.now() - lastReported > REPORT_INTERVAL_MS) {
-        return true;
+  /**
+   * Using the local and SO's `lastReported` values, it decides whether the last report should be considered as expired
+   * @returns `true` if a new report should be generated. `false` otherwise.
+   */
+  private isReportDue = async (): Promise<boolean> => {
+    // Try to decide with the local `lastReported` to avoid querying the server
+    if (!isReportIntervalExpired(this.lastReported)) {
+      // If it is not expired locally, there's no need to send it again yet.
+      return false;
+    }
+
+    // Double-check with the server's value
+    const globalLastReported = await this.telemetryService.fetchLastReported();
+
+    if (globalLastReported) {
+      // Update the local value to avoid repetitions of this request (it was already expired, so it doesn't really matter if the server's value is older)
+      this.updateLastReported(globalLastReported);
+    }
+
+    return isReportIntervalExpired(globalLastReported);
+  };
+
+  /**
+   * Returns `true` when the page is visible and active in the browser.
+   */
+  private isActiveWindow = () => {
+    // Using `document.hasFocus()` instead of `document.visibilityState` because the latter may return "visible"
+    // if 2 windows are open side-by-side because they are "technically" visible.
+    return document.hasFocus();
+  };
+
+  /**
+   * Using configuration, page visibility state and the lastReported dates,
+   * it decides whether a new telemetry report should be sent.
+   * @returns `true` if a new report should be sent. `false` otherwise.
+   */
+  private shouldSendReport = async (): Promise<boolean> => {
+    if (this.isActiveWindow() && this.telemetryService.canSendTelemetry()) {
+      if (await this.isReportDue()) {
+        /*
+         * If we think it should send telemetry (local optIn config is `true` and the last report is expired),
+         * let's refresh the config and make sure optIn is still true.
+         *
+         * This change is to ensure that if the user opts-out of telemetry, background tabs realize about it without needing to refresh the page or navigate to another app.
+         *
+         * We are checking twice to avoid making too many requests to fetch the SO:
+         * `sendIfDue` is triggered every minute or when the page regains focus.
+         * If the previously fetched config already dismisses the telemetry, there's no need to fetch the telemetry config.
+         *
+         * The edge case is: if previously opted-out and the user opts-in, background tabs won't realize about that until they navigate to another app.
+         * We are fine with that compromise for now.
+         */
+        await this.refreshConfig();
+        return this.telemetryService.canSendTelemetry();
       }
     }
 
@@ -58,12 +104,11 @@ export class TelemetrySender {
   };
 
   private sendIfDue = async (): Promise<void> => {
-    if (!this.shouldSendReport()) {
+    if (!(await this.shouldSendReport())) {
       return;
     }
     // optimistically update the report date and reset the retry counter for a new time report interval window
-    this.lastReported = `${Date.now()}`;
-    this.saveToBrowser();
+    this.updateLastReported(Date.now());
     this.retryCount = 0;
     await this.sendUsageData();
   };
@@ -89,6 +134,8 @@ export class TelemetrySender {
             })
         )
       );
+
+      await this.telemetryService.updateLastReported().catch(() => {}); // Let's catch the error. Worst-case scenario another Telemetry report will be generated somewhere else.
     } catch (err) {
       // ignore err and try again but after a longer wait period.
       this.retryCount = this.retryCount + 1;
@@ -105,8 +152,20 @@ export class TelemetrySender {
   };
 
   public startChecking = () => {
-    if (this.intervalId === 0) {
-      this.intervalId = window.setInterval(this.sendIfDue, 60000);
+    if (!this.sendIfDue$) {
+      // Trigger sendIfDue...
+      this.sendIfDue$ = merge(
+        // ... periodically
+        interval(60000),
+        // ... when it regains `focus`
+        fromEvent(window, 'focus') // Using `window` instead of `document` because Chrome only emits on the first one.
+      )
+        .pipe(exhaustMap(this.sendIfDue))
+        .subscribe();
     }
+  };
+
+  public stop = () => {
+    this.sendIfDue$?.unsubscribe();
   };
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Telemetry] Refresh config before send (#127454)](https://github.com/elastic/kibana/pull/127454)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)