### PR TITLE
[bazel/packages] make package discovery dirs easier to extend

### DIFF
--- a/packages/kbn-bazel-packages/src/bazel_package_dirs.ts
+++ b/packages/kbn-bazel-packages/src/bazel_package_dirs.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * This is a list of repo-relative paths to directories containing packages. Do not
+ * include `**` in these, one or two `*` segments is acceptable, we need this search
+ * to be super fast so please avoid deep recursive searching.
+ *
+ *   eg. src/vis-editors     => would find a package at src/vis-editors/foo/package.json
+ *       src/vis-editors/*   => would find a package at src/vis-editors/foo/bar/package.json
+ */
+export const BAZEL_PACKAGE_DIRS = ['packages'];

--- a/packages/kbn-bazel-packages/src/discover_packages.ts
+++ b/packages/kbn-bazel-packages/src/discover_packages.ts
@@ -13,20 +13,24 @@ import { REPO_ROOT } from '@kbn/utils';
 import { asyncMapWithLimit } from '@kbn/std';
 
 import { BazelPackage } from './bazel_package';
+import { BAZEL_PACKAGE_DIRS } from './bazel_package_dirs';
 
 /**
  * Search the local Kibana repo for bazel packages and return an array of BazelPackage objects
  * representing each package found.
  */
 export async function discoverBazelPackages() {
-  const packageJsons = globby.sync('*/package.json', {
-    cwd: Path.resolve(REPO_ROOT, 'packages'),
-    absolute: true,
-  });
+  const packageJsons = globby.sync(
+    BAZEL_PACKAGE_DIRS.map((dir) => `${dir}/*/package.json`),
+    {
+      cwd: REPO_ROOT,
+      absolute: true,
+    }
+  );
 
   return await asyncMapWithLimit(
     packageJsons.sort((a, b) => a.localeCompare(b)),
-    10,
-    (path) => BazelPackage.fromDir(Path.dirname(path))
+    100,
+    async (path) => await BazelPackage.fromDir(Path.dirname(path))
   );
 }

--- a/packages/kbn-bazel-packages/src/index.ts
+++ b/packages/kbn-bazel-packages/src/index.ts
@@ -6,5 +6,6 @@
  * Side Public License, v 1.
  */
 
+export * from './bazel_package_dirs';
 export * from './discover_packages';
 export type { BazelPackage } from './bazel_package';

--- a/packages/kbn-generate/BUILD.bazel
+++ b/packages/kbn-generate/BUILD.bazel
@@ -30,6 +30,7 @@ RUNTIME_DEPS = [
   "//packages/kbn-bazel-packages",
   "//packages/kbn-utils",
   "@npm//ejs",
+  "@npm//micromatch",
   "@npm//normalize-path",
 ]
 
@@ -37,7 +38,9 @@ TYPES_DEPS = [
   "//packages/kbn-dev-utils:npm_module_types",
   "//packages/kbn-bazel-packages:npm_module_types",
   "//packages/kbn-utils:npm_module_types",
+  "@npm//@types/micromatch",
   "@npm//ejs",
+  "@npm//micromatch",
   "@npm//normalize-path",
   "@npm//@types/ejs",
 ]


### PR DESCRIPTION
This change makes the package discovery mechanism in `@kbn/bazel-packages` a little easier to extend by splitting the package search dirs out into a module with some docs. Additionally, `node scripts/generate package` now validates the `--dir` options against this list as a match with this list is required for successful package generation.

If someone tries to generate a package outside of these directories a helpful error is logged pointing to the place to update.

Operations codeowner is applied to the `@kbn/bazel-packages` package so we will be able to manually verify that people aren't searching too deeply in those patterns.