### PR TITLE
[Lens] fix loosing tables in activeData

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
@@ -430,12 +430,15 @@ describe('workspace_panel', () => {
 
     const onData = expressionRendererMock.mock.calls[0][0].onData$!;
 
-    const tableData = { table1: { columns: [], rows: [] } };
-    onData(undefined, { tables: { tables: tableData } });
+    const tablesData = {
+      table1: { columns: [], rows: [] },
+      table2: { columns: [], rows: [] },
+    };
+    onData(undefined, { tables: { tables: tablesData } });
 
     expect(mounted.lensStore.dispatch).toHaveBeenCalledWith({
       type: 'lens/onActiveDataChange',
-      payload: tableData,
+      payload: tablesData,
     });
   });
 

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -504,6 +504,7 @@ export const VisualizationWrapper = ({
           onActiveDataChange(
             Object.entries(adapters.tables?.tables).reduce<Record<string, Datatable>>(
               (acc, [key, value], index, tables) => ({
+                ...acc,
                 [tables.length === 1 ? defaultLayerId : key]: value,
               }),
               {}


### PR DESCRIPTION
## Summary

When new activeData is coming, it only contains last layer. Introduced minutes ago: https://github.com/elastic/kibana/pull/126786 
