### PR TITLE
[App Search] Add an internal route to get the list of indices from Kibana

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -51,4 +51,4 @@ export interface Meta {
   page: MetaPage;
 }
 
-export { ElasticsearchIndex } from './indices';
+export type { ElasticsearchIndex } from './indices';

--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -50,3 +50,5 @@ export interface MetaPage {
 export interface Meta {
   page: MetaPage;
 }
+
+export { ElasticsearchIndex } from './indices';

--- a/x-pack/plugins/enterprise_search/common/types/indices.ts
+++ b/x-pack/plugins/enterprise_search/common/types/indices.ts
@@ -10,8 +10,14 @@ export interface ElasticsearchIndex {
   status?: string;
   name: string;
   uuid?: string;
-  documents: number;
-  documents_deleted: number;
-  size: string;
+  total: {
+    docs: {
+      count: number;
+      deleted: number;
+    };
+    store: {
+      size_in_bytes: string;
+    };
+  };
   aliases: string | string[];
 }

--- a/x-pack/plugins/enterprise_search/common/types/indices.ts
+++ b/x-pack/plugins/enterprise_search/common/types/indices.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface ElasticsearchIndex {
+  health?: string;
+  status?: string;
+  name: string;
+  uuid?: string;
+  documents: number;
+  documents_deleted: number;
+  size: string;
+  primary_size: string;
+  aliases: string | string[];
+}

--- a/x-pack/plugins/enterprise_search/common/types/indices.ts
+++ b/x-pack/plugins/enterprise_search/common/types/indices.ts
@@ -13,6 +13,5 @@ export interface ElasticsearchIndex {
   documents: number;
   documents_deleted: number;
   size: string;
-  primary_size: string;
   aliases: string | string[];
 }

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_indices.test.ts
@@ -52,7 +52,7 @@ describe('fetchIndices lib function', () => {
     jest.clearAllMocks();
   });
 
-  test('regular index', async () => {
+  it('should return regular index without aliases', async () => {
     mockClient.asCurrentUser.indices.get.mockImplementation(() => regularIndexResponse);
     mockClient.asCurrentUser.indices.stats.mockImplementation(() => regularIndexStatsResponse);
 
@@ -87,7 +87,8 @@ describe('fetchIndices lib function', () => {
       index: 'search-*',
     });
   });
-  test('index with aliases', async () => {
+
+  it('should return index with aliases', async () => {
     const aliasedIndexResponse = {
       'index-without-prefix': {
         ...regularIndexResponse['search-regular-index'],
@@ -124,7 +125,8 @@ describe('fetchIndices lib function', () => {
       },
     ]);
   });
-  test('index missing in stats call', async () => {
+
+  it('should handle index missing in stats call', async () => {
     const missingStatsResponse = {
       indices: {
         some_other_index: { ...regularIndexStatsResponse.indices['search-regular-index'] },
@@ -154,7 +156,8 @@ describe('fetchIndices lib function', () => {
       },
     ]);
   });
-  test('no index found', async () => {
+
+  it('should return empty array when no index found', async () => {
     mockClient.asCurrentUser.indices.get.mockImplementationOnce(() => ({}));
     await expect(fetchIndices(mockClient as unknown as IScopedClusterClient)).resolves.toEqual([]);
     expect(mockClient.asCurrentUser.indices.stats).not.toHaveBeenCalled();

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_indices.test.ts
@@ -43,7 +43,6 @@ describe('fetchIndices lib function', () => {
             size_in_bytes: 108000,
           },
         },
-        documents_deleted: 0,
         size: new ByteSizeValue(108000).toString(),
       },
     },
@@ -62,9 +61,15 @@ describe('fetchIndices lib function', () => {
         health: 'green',
         status: 'open',
         uuid: '83a81e7e-5955-4255-b008-5d6961203f57',
-        documents: 100,
-        documents_deleted: 0,
-        size: '105.47kb',
+        total: {
+          docs: {
+            count: 100,
+            deleted: 0,
+          },
+          store: {
+            size_in_bytes: '105.47kb',
+          },
+        },
         aliases: 'none',
         name: 'search-regular-index',
       },
@@ -105,9 +110,15 @@ describe('fetchIndices lib function', () => {
         health: 'green',
         status: 'open',
         uuid: '83a81e7e-5955-4255-b008-5d6961203f57',
-        documents: 100,
-        documents_deleted: 0,
-        size: '105.47kb',
+        total: {
+          docs: {
+            count: 100,
+            deleted: 0,
+          },
+          store: {
+            size_in_bytes: '105.47kb',
+          },
+        },
         aliases: ['search-aliased', 'search-double-aliased'],
         name: 'index-without-prefix',
       },
@@ -126,14 +137,20 @@ describe('fetchIndices lib function', () => {
     // deleted index won't be present in the indices stats call response
     await expect(fetchIndices(mockClient as unknown as IScopedClusterClient)).resolves.toEqual([
       {
-        documents_deleted: 0,
         aliases: 'none',
         name: 'search-regular-index',
+        total: {
+          docs: {
+            count: 0,
+            deleted: 0,
+          },
+          store: {
+            size_in_bytes: '0b',
+          },
+        },
         uuid: undefined,
         health: undefined,
         status: undefined,
-        documents: 0,
-        size: '0b',
       },
     ]);
   });

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_indices.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from 'kibana/server';
+
+import { ByteSizeValue } from '@kbn/config-schema';
+
+import { fetchIndices } from './fetch_indices';
+
+describe('fetchIndices lib function', () => {
+  const mockClient = {
+    asCurrentUser: {
+      indices: {
+        get: jest.fn(),
+        stats: jest.fn(),
+      },
+    },
+    asInternalUser: {},
+  };
+
+  const regularIndexResponse = {
+    'search-regular-index': {
+      aliases: {},
+    },
+  };
+
+  const regularIndexStatsResponse = {
+    indices: {
+      'search-regular-index': {
+        health: 'green',
+        status: 'open',
+        uuid: '83a81e7e-5955-4255-b008-5d6961203f57',
+        total: {
+          docs: {
+            count: 100,
+            deleted: 0,
+          },
+          store: {
+            size_in_bytes: 108000,
+          },
+        },
+        documents_deleted: 0,
+        size: new ByteSizeValue(108000).toString(),
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('regular index', async () => {
+    mockClient.asCurrentUser.indices.get.mockImplementation(() => regularIndexResponse);
+    mockClient.asCurrentUser.indices.stats.mockImplementation(() => regularIndexStatsResponse);
+
+    await expect(fetchIndices(mockClient as unknown as IScopedClusterClient)).resolves.toEqual([
+      {
+        health: 'green',
+        status: 'open',
+        uuid: '83a81e7e-5955-4255-b008-5d6961203f57',
+        documents: 100,
+        documents_deleted: 0,
+        size: '105.47kb',
+        aliases: 'none',
+        name: 'search-regular-index',
+      },
+    ]);
+    expect(mockClient.asCurrentUser.indices.get).toHaveBeenCalledWith({
+      expand_wildcards: ['open'],
+      features: ['aliases', 'settings'],
+      filter_path: ['*.aliases'],
+      index: 'search-*',
+    });
+
+    expect(mockClient.asCurrentUser.indices.stats).toHaveBeenCalledWith({
+      metric: ['docs', 'store'],
+      expand_wildcards: ['open'],
+      index: 'search-*',
+    });
+  });
+  test('index with aliases', async () => {
+    const aliasedIndexResponse = {
+      'index-without-prefix': {
+        ...regularIndexResponse['search-regular-index'],
+        aliases: {
+          'search-aliased': {},
+          'search-double-aliased': {},
+        },
+      },
+    };
+    const aliasedStatsResponse = {
+      indices: {
+        'index-without-prefix': { ...regularIndexStatsResponse.indices['search-regular-index'] },
+      },
+    };
+
+    mockClient.asCurrentUser.indices.get.mockImplementationOnce(() => aliasedIndexResponse);
+    mockClient.asCurrentUser.indices.stats.mockImplementationOnce(() => aliasedStatsResponse);
+    await expect(fetchIndices(mockClient as unknown as IScopedClusterClient)).resolves.toEqual([
+      {
+        health: 'green',
+        status: 'open',
+        uuid: '83a81e7e-5955-4255-b008-5d6961203f57',
+        documents: 100,
+        documents_deleted: 0,
+        size: '105.47kb',
+        aliases: ['search-aliased', 'search-double-aliased'],
+        name: 'index-without-prefix',
+      },
+    ]);
+  });
+  test('index missing in stats call', async () => {
+    const missingStatsResponse = {
+      indices: {
+        some_other_index: { ...regularIndexStatsResponse.indices['search-regular-index'] },
+      },
+    };
+
+    mockClient.asCurrentUser.indices.get.mockImplementationOnce(() => regularIndexResponse);
+    mockClient.asCurrentUser.indices.stats.mockImplementationOnce(() => missingStatsResponse);
+    // simulates when an index has been deleted after get indices call
+    // deleted index won't be present in the indices stats call response
+    await expect(fetchIndices(mockClient as unknown as IScopedClusterClient)).resolves.toEqual([
+      {
+        documents_deleted: 0,
+        aliases: 'none',
+        name: 'search-regular-index',
+        uuid: undefined,
+        health: undefined,
+        status: undefined,
+        documents: 0,
+        size: '0b',
+      },
+    ]);
+  });
+  test('no index found', async () => {
+    mockClient.asCurrentUser.indices.get.mockImplementationOnce(() => ({}));
+    await expect(fetchIndices(mockClient as unknown as IScopedClusterClient)).resolves.toEqual([]);
+    expect(mockClient.asCurrentUser.indices.stats).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_indices.ts
@@ -40,14 +40,28 @@ export const fetchIndices = async (client: IScopedClusterClient): Promise<Elasti
     const indexData = indices[indexName];
     const indexStats = indicesStats[indexName];
     const aliases = Object.keys(indexData.aliases!);
+    const size_in_bytes = new ByteSizeValue(
+      indexStats?.total?.store?.size_in_bytes ?? 0
+    ).toString();
+
+    const docCount = indexStats?.total?.docs?.count ?? 0;
+    const docDeleted = indexStats?.total?.docs?.deleted ?? 0;
+    const total = {
+      docs: {
+        count: docCount,
+        deleted: docDeleted,
+      },
+      store: {
+        size_in_bytes,
+      },
+    };
+
     return {
       health: indexStats?.health,
       status: indexStats?.status,
       name: indexName,
       uuid: indexStats?.uuid,
-      documents: indexStats?.total?.docs?.count ?? 0,
-      documents_deleted: indexStats?.total?.docs?.deleted ?? 0,
-      size: new ByteSizeValue(indexStats?.total?.store?.size_in_bytes ?? 0).toString(),
+      total,
       aliases: aliases.length ? aliases : 'none',
     };
   });

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_indices.ts
@@ -48,7 +48,6 @@ export const fetchIndices = async (client: IScopedClusterClient): Promise<Elasti
       documents: indexStats?.total?.docs?.count ?? 0,
       documents_deleted: indexStats?.total?.docs?.deleted ?? 0,
       size: new ByteSizeValue(indexStats?.total?.store?.size_in_bytes ?? 0).toString(),
-      primary_size: new ByteSizeValue(indexStats?.primaries?.store?.size_in_bytes ?? 0).toString(),
       aliases: aliases.length ? aliases : 'none',
     };
   });

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_indices.ts
@@ -40,9 +40,7 @@ export const fetchIndices = async (client: IScopedClusterClient): Promise<Elasti
     const indexData = indices[indexName];
     const indexStats = indicesStats[indexName];
     const aliases = Object.keys(indexData.aliases!);
-    const sizeInBytes = new ByteSizeValue(
-      indexStats?.total?.store?.size_in_bytes ?? 0
-    ).toString();
+    const sizeInBytes = new ByteSizeValue(indexStats?.total?.store?.size_in_bytes ?? 0).toString();
 
     const docCount = indexStats?.total?.docs?.count ?? 0;
     const docDeleted = indexStats?.total?.docs?.deleted ?? 0;
@@ -52,7 +50,7 @@ export const fetchIndices = async (client: IScopedClusterClient): Promise<Elasti
         deleted: docDeleted,
       },
       store: {
-        sizeInBytes,
+        size_in_bytes: sizeInBytes,
       },
     };
 

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_indices.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from 'kibana/server';
+
+import { ByteSizeValue } from '@kbn/config-schema';
+
+async function fetchIndicesCall(client: IScopedClusterClient): Promise<unknown> {
+  const indexNamesString = 'enterprise-search-index-*';
+
+  // This call retrieves alias and settings (incl. hidden status) information about indices
+  const indices = await client.asCurrentUser.indices.get({
+    index: indexNamesString,
+    expand_wildcards: ['open'],
+    // only get specified index properties from ES to keep the response under 536MB
+    // node.js string length limit: https://github.com/nodejs/node/issues/33960
+    filter_path: [
+      '*.aliases',
+      '*.settings.index.number_of_shards',
+      '*.settings.index.number_of_replicas',
+      '*.settings.index.frozen',
+      '*.settings.index.hidden',
+      '*.data_stream',
+    ],
+    // for better performance only compute aliases and settings of indices but not mappings
+    // @ts-expect-error new param https://github.com/elastic/elasticsearch-specification/issues/1382
+    features: ['aliases', 'settings'],
+  });
+
+  if (!Object.keys(indices).length) {
+    return [];
+  }
+
+  const { indices: indicesStats = {} } = await client.asCurrentUser.indices.stats({
+    index: indexNamesString,
+    expand_wildcards: ['open'],
+    metric: ['docs', 'store'],
+  });
+  const indicesNames = Object.keys(indices);
+  return indicesNames.map((indexName: string) => {
+    const indexData = indices[indexName];
+    const indexStats = indicesStats[indexName];
+    const aliases = Object.keys(indexData.aliases!);
+    return {
+      health: indexStats?.health,
+      status: indexStats?.status,
+      name: indexName,
+      uuid: indexStats?.uuid,
+      primary: indexData.settings?.index?.number_of_shards,
+      replica: indexData.settings?.index?.number_of_replicas,
+      documents: indexStats?.total?.docs?.count ?? 0,
+      documents_deleted: indexStats?.total?.docs?.deleted ?? 0,
+      size: new ByteSizeValue(indexStats?.total?.store?.size_in_bytes ?? 0).toString(),
+      primary_size: new ByteSizeValue(indexStats?.primaries?.store?.size_in_bytes ?? 0).toString(),
+      // @ts-expect-error
+      isFrozen: indexData.settings?.index?.frozen === 'true',
+      aliases: aliases.length ? aliases : 'none',
+      hidden: indexData.settings?.index?.hidden === 'true',
+      data_stream: indexData.data_stream,
+    };
+  });
+}
+
+export const fetchIndices = async (client: IScopedClusterClient, indexNames?: string[]) => {
+  const indices = await fetchIndicesCall(client, indexNames);
+  return indices;
+};

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_indices.ts
@@ -40,7 +40,7 @@ export const fetchIndices = async (client: IScopedClusterClient): Promise<Elasti
     const indexData = indices[indexName];
     const indexStats = indicesStats[indexName];
     const aliases = Object.keys(indexData.aliases!);
-    const size_in_bytes = new ByteSizeValue(
+    const sizeInBytes = new ByteSizeValue(
       indexStats?.total?.store?.size_in_bytes ?? 0
     ).toString();
 
@@ -52,7 +52,7 @@ export const fetchIndices = async (client: IScopedClusterClient): Promise<Elasti
         deleted: docDeleted,
       },
       store: {
-        size_in_bytes,
+        sizeInBytes,
       },
     };
 

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -44,6 +44,7 @@ import {
 
 import { registerAppSearchRoutes } from './routes/app_search';
 import { registerConfigDataRoute } from './routes/enterprise_search/config_data';
+import { registerListRoute } from './routes/enterprise_search/indices';
 import { registerTelemetryRoute } from './routes/enterprise_search/telemetry';
 import { registerWorkplaceSearchRoutes } from './routes/workplace_search';
 
@@ -155,6 +156,7 @@ export class EnterpriseSearchPlugin implements Plugin {
     registerConfigDataRoute(dependencies);
     registerAppSearchRoutes(dependencies);
     registerWorkplaceSearchRoutes(dependencies);
+    registerListRoute(dependencies);
 
     /**
      * Bootstrap the routes, saved objects, and collector for telemetry

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -5,20 +5,18 @@
  * 2.0.
  */
 
-import { HttpResponsePayload } from 'kibana/server';
-
 import { fetchIndices } from '../../lib/fetch_indices';
 import { RouteDependencies } from '../../plugin';
 
 export function registerListRoute({ router }: RouteDependencies) {
   router.get(
     { path: '/internal/enterprise_search/indices', validate: false },
-    async (context, request, response) => {
+    async (context, _, response) => {
       const { client } = context.core.elasticsearch;
       try {
         const indices = await fetchIndices(client);
         return response.ok({
-          body: indices as HttpResponsePayload,
+          body: indices,
           headers: { 'content-type': 'application/json' },
         });
       } catch (error) {

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { HttpResponsePayload } from 'kibana/server';
+
+import { fetchIndices } from '../../lib/fetch_indices';
+import { RouteDependencies } from '../../plugin';
+
+export function registerListRoute({ router }: RouteDependencies) {
+  router.get(
+    { path: '/internal/enterprise_search/indices', validate: false },
+    async (context, request, response) => {
+      const { client } = context.core.elasticsearch;
+      try {
+        const indices = await fetchIndices(client);
+        return response.ok({
+          body: indices as HttpResponsePayload,
+          headers: { 'content-type': 'application/json' },
+        });
+      } catch (error) {
+        return response.customError({
+          statusCode: 502,
+          body: 'Error fetching data from Enterprise Search',
+        });
+      }
+    }
+  );
+}


### PR DESCRIPTION
Closes https://github.com/elastic/enterprise-search-team/issues/1426

## Summary

Adds internal endpoint to get available Elasticsearch indices under Enterprise Search plugin.
This is intended to used as internal route, subject to change in future.


### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
