### PR TITLE
[Fleet] Update CODEOWNERS for fleet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,7 +118,12 @@
 /x-pack/test/api_integration/apis/monitoring @elastic/infra-monitoring-ui
 
 # Fleet
+/fleet_packages.json @elastic/fleet
 /x-pack/plugins/fleet/ @elastic/fleet
+/x-pack/plugins/fleet/ @elastic/fleet
+/x-pack/test/fleet_api_integration @elastic/fleet
+/x-pack/test/fleet_cypress @elastic/fleet
+/x-pack/test/fleet_functional @elastic/fleet
 
 # APM
 /x-pack/plugins/apm/  @elastic/apm-ui

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,7 +120,6 @@
 # Fleet
 /fleet_packages.json @elastic/fleet
 /x-pack/plugins/fleet/ @elastic/fleet
-/x-pack/plugins/fleet/ @elastic/fleet
 /x-pack/test/fleet_api_integration @elastic/fleet
 /x-pack/test/fleet_cypress @elastic/fleet
 /x-pack/test/fleet_functional @elastic/fleet


### PR DESCRIPTION
## Summary

Adds a few new directories to be owned by @elastic/fleet:

- /fleet_packages.json 
- /x-pack/plugins/fleet/
- /x-pack/test/fleet_api_integration
- /x-pack/test/fleet_cypress
- /x-pack/test/fleet_functional
