### PR TITLE
[7.17] [Security Solution][Alerts] Update EQL rules to use EQL method of ES client (#127684)

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/get_query_filter.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/get_query_filter.test.ts
@@ -1125,8 +1125,8 @@ describe('get_filter', () => {
         undefined
       );
       expect(request).toEqual({
-        method: 'POST',
-        path: `/testindex1,testindex2/_eql/search?allow_no_indices=true`,
+        allow_no_indices: true,
+        index: ['testindex1', 'testindex2'],
         body: {
           size: 100,
           query: 'process where true',
@@ -1171,8 +1171,8 @@ describe('get_filter', () => {
         'event.other_category'
       );
       expect(request).toEqual({
-        method: 'POST',
-        path: `/testindex1,testindex2/_eql/search?allow_no_indices=true`,
+        allow_no_indices: true,
+        index: ['testindex1', 'testindex2'],
         body: {
           event_category_field: 'event.other_category',
           size: 100,
@@ -1222,8 +1222,8 @@ describe('get_filter', () => {
         undefined
       );
       expect(request).toEqual({
-        method: 'POST',
-        path: `/testindex1,testindex2/_eql/search?allow_no_indices=true`,
+        allow_no_indices: true,
+        index: ['testindex1', 'testindex2'],
         body: {
           size: 100,
           query: 'process where true',

--- a/x-pack/plugins/security_solution/common/detection_engine/get_query_filter.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/get_query_filter.ts
@@ -12,6 +12,10 @@ import type {
 } from '@kbn/securitysolution-io-ts-list-types';
 import { buildExceptionFilter } from '@kbn/securitysolution-list-utils';
 import { Filter, EsQueryConfig, IndexPatternBase, buildEsQuery } from '@kbn/es-query';
+import {
+  EqlSearchRequest,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 import { ESBoolQuery } from '../typed_json';
 import { Query, Index, TimestampOverrideOrUndefined } from './schemas/common/schemas';
@@ -58,12 +62,6 @@ export const getAllFilters = (filters: Filter[], exceptionFilter: Filter | undef
   }
 };
 
-interface EqlSearchRequest {
-  method: string;
-  path: string;
-  body: object;
-}
-
 export const buildEqlSearchRequest = (
   query: string,
   index: string[],
@@ -93,8 +91,7 @@ export const buildEqlSearchRequest = (
     excludeExceptions: true,
     chunkSize: 1024,
   });
-  const indexString = index.join();
-  const requestFilter: unknown[] = [
+  const requestFilter: QueryDslQueryContainer[] = [
     {
       range: {
         [timestamp]: {
@@ -114,9 +111,16 @@ export const buildEqlSearchRequest = (
       },
     });
   }
+  const fields = [
+    {
+      field: '*',
+      include_unmapped: true,
+    },
+    ...docFields,
+  ];
   return {
-    method: 'POST',
-    path: `/${indexString}/_eql/search?allow_no_indices=true`,
+    index,
+    allow_no_indices: true,
     body: {
       size,
       query,
@@ -126,13 +130,7 @@ export const buildEqlSearchRequest = (
         },
       },
       event_category_field: eventCategoryOverride,
-      fields: [
-        {
-          field: '*',
-          include_unmapped: true,
-        },
-        ...docFields,
-      ],
+      fields,
     },
   };
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/executors/eql.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/executors/eql.test.ts
@@ -14,8 +14,6 @@ import { getEntryListMock } from '../../../../../../lists/common/schemas/types/e
 import { getEqlRuleParams } from '../../schemas/rule_schemas.mock';
 import { getIndexVersion } from '../../routes/index/get_index_version';
 import { SIGNALS_TEMPLATE_VERSION } from '../../routes/index/get_signals_template';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { elasticsearchClientMock } from 'src/core/server/elasticsearch/client/mocks';
 import { allowedExperimentalValues } from '../../../../../common/experimental_features';
 
 jest.mock('../../routes/index/get_index_version');
@@ -58,14 +56,12 @@ describe('eql_executor', () => {
   beforeEach(() => {
     alertServices = alertsMock.createAlertServices();
     logger = loggingSystemMock.createLogger();
-    alertServices.scopedClusterClient.asCurrentUser.transport.request.mockResolvedValue(
-      elasticsearchClientMock.createSuccessTransportRequestPromise({
-        hits: {
-          total: { value: 10 },
-          events: [],
-        },
-      })
-    );
+    alertServices.scopedClusterClient.asCurrentUser.eql.search.mockResolvedValue({
+      hits: {
+        total: { relation: 'eq', value: 10 },
+        events: [],
+      },
+    });
   });
 
   describe('eqlExecutor', () => {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/executors/eql.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/executors/eql.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { ApiResponse } from '@elastic/elasticsearch';
 import { performance } from 'perf_hooks';
 import { SavedObject } from 'src/core/types';
 import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
@@ -28,10 +27,10 @@ import {
   BulkCreate,
   WrapHits,
   WrapSequences,
-  EqlSignalSearchResponse,
   RuleRangeTuple,
   SearchAfterAndBulkCreateReturnType,
   SimpleHit,
+  SignalSource,
 } from '../types';
 import { createSearchAfterReturnType, makeFloatString } from '../utils';
 import { ExperimentalFeatures } from '../../../../../common/experimental_features';
@@ -111,16 +110,11 @@ export const eqlExecutor = async ({
   );
 
   const eqlSignalSearchStart = performance.now();
-  logger.debug(
-    `EQL query request path: ${request.path}, method: ${request.method}, body: ${JSON.stringify(
-      request.body
-    )}`
-  );
+  logger.debug(`EQL query request: ${JSON.stringify(request)}`);
 
-  // TODO: fix this later
-  const { body: response } = (await services.scopedClusterClient.asCurrentUser.transport.request(
+  const response = await services.scopedClusterClient.asCurrentUser.eql.search<SignalSource>(
     request
-  )) as ApiResponse<EqlSignalSearchResponse>;
+  );
 
   const eqlSignalSearchEnd = performance.now();
   const eqlSearchDuration = makeFloatString(eqlSignalSearchEnd - eqlSignalSearchStart);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/types.ts
@@ -21,7 +21,6 @@ import {
 } from '../../../../../alerting/server';
 import { TermAggregationBucket } from '../../types';
 import {
-  EqlSearchResponse,
   BaseHit,
   RuleAlertAction,
   SearchTypes,
@@ -180,8 +179,6 @@ export type SignalSearchResponse = estypes.SearchResponse<SignalSource>;
 export type SignalSourceHit = estypes.SearchHit<SignalSource>;
 export type WrappedSignalHit = BaseHit<SignalHit>;
 export type BaseSignalHit = estypes.SearchHit<SignalSource>;
-
-export type EqlSignalSearchResponse = EqlSearchResponse<SignalSource>;
 
 export type RuleExecutorOptions = AlertExecutorOptions<
   RuleParams,

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/generating_signals.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/generating_signals.ts
@@ -833,6 +833,18 @@ export default ({ getService }: FtrProviderContext) => {
           expect(shellSignals.length).eql(100);
           expect(buildingBlocks.length).eql(200);
         });
+
+        it('generates signals when an index name contains special characters to encode', async () => {
+          const rule: EqlCreateSchema = {
+            ...getEqlRuleForSignalTesting(['auditbeat-*', '<my-index-{now/d}*>']),
+            query: 'configuration where agent.id=="a1d7b39c-f898-4dbe-a761-efb61939302d"',
+          };
+          const { id } = await createRule(supertest, log, rule);
+          await waitForRuleSuccessOrStatus(supertest, log, id);
+          await waitForSignalsToBePresent(supertest, log, 1, [id]);
+          const signals = await getSignalsByIds(supertest, log, [id]);
+          expect(signals.hits.hits.length).eql(1);
+        });
       });
 
       describe('Threshold Rules', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Security Solution][Alerts] Update EQL rules to use EQL method of ES client (#127684)](https://github.com/elastic/kibana/pull/127684)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)