### PR TITLE
[RAM] Fix bug to not modify filter's params who does not belong to mapped_params

### DIFF
--- a/x-pack/plugins/alerting/server/rules_client/lib/mapped_params_utils.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/lib/mapped_params_utils.test.ts
@@ -128,4 +128,23 @@ describe('modifyFilterKueryNode', () => {
       value: '40-medium',
     });
   });
+
+  it('do NOT modify the resulting kuery node AST filter for alert params when they are not part of mapped params', () => {
+    // Make sure it works for both camel and snake case params
+    const astFilter = fromKueryExpression(
+      'alert.attributes.name: "Rule I" and alert.attributes.tags: "fast" and alert.attributes.params.threat.tactic.name: Exfiltration'
+    );
+
+    modifyFilterKueryNode({ astFilter });
+
+    expect(astFilter.arguments[2].arguments[0]).toEqual({
+      type: 'literal',
+      value: 'alert.attributes.params.threat.tactic.name',
+    });
+
+    expect(astFilter.arguments[2].arguments[1]).toEqual({
+      type: 'literal',
+      value: 'Exfiltration',
+    });
+  });
 });

--- a/x-pack/plugins/alerting/server/rules_client/lib/mapped_params_utils.ts
+++ b/x-pack/plugins/alerting/server/rules_client/lib/mapped_params_utils.ts
@@ -145,7 +145,16 @@ export const modifyFilterKueryNode = ({
       const firstAttribute = getFieldNameAttribute(fieldName, ['alert', 'attributes']);
       // Replace the ast.value for params to mapped_params
       if (firstAttribute === 'params') {
-        ast.value = getModifiedFilter(ast.value);
+        const attributeAfterParams = getFieldNameAttribute(fieldName, [
+          'alert',
+          'attributes',
+          'params',
+        ]);
+        if (
+          MAPPED_PARAMS_PROPERTIES.includes(attributeAfterParams as keyof MappedParamsProperties)
+        ) {
+          ast.value = getModifiedFilter(ast.value);
+        }
       }
     }
 
@@ -155,8 +164,16 @@ export const modifyFilterKueryNode = ({
 
       // Replace the ast.value for params value to the modified mapped_params value
       if (firstAttribute === 'params' && ast.value) {
-        const attribute = getFieldNameAttribute(localFieldName, ['alert', 'attributes', 'params']);
-        ast.value = getModifiedValue(attribute, ast.value);
+        const attributeAfterParams = getFieldNameAttribute(localFieldName, [
+          'alert',
+          'attributes',
+          'params',
+        ]);
+        if (
+          MAPPED_PARAMS_PROPERTIES.includes(attributeAfterParams as keyof MappedParamsProperties)
+        ) {
+          ast.value = getModifiedValue(attributeAfterParams, ast.value);
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/127876


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
