### PR TITLE
[CTI] Indicator Match rule preview minor UI updates

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/helpers.test.ts
@@ -75,6 +75,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
+        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -90,6 +91,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
+        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -105,6 +107,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
+        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -120,6 +123,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
+        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -133,6 +137,7 @@ describe('query_preview/helpers', () => {
         threatIndex: ['threat-*'],
         threatMapping: [],
         machineLearningJobId: ['test-ml-job-id'],
+        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -146,6 +151,21 @@ describe('query_preview/helpers', () => {
         threatIndex: ['threat-*'],
         threatMapping: [],
         machineLearningJobId: [],
+        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+      });
+      expect(isDisabled).toEqual(true);
+    });
+
+    test('disabled when eql rule with no query', () => {
+      const isDisabled = getIsRulePreviewDisabled({
+        ruleType: 'eql',
+        isQueryBarValid: true,
+        isThreatQueryBarValid: true,
+        index: ['test-*'],
+        threatIndex: ['threat-*'],
+        threatMapping: [],
+        machineLearningJobId: [],
+        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -161,6 +181,21 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
+        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+      });
+      expect(isDisabled).toEqual(false);
+    });
+
+    test('enabled when eql rule with query', () => {
+      const isDisabled = getIsRulePreviewDisabled({
+        ruleType: 'eql',
+        isQueryBarValid: true,
+        isThreatQueryBarValid: true,
+        index: ['test-*'],
+        threatIndex: ['threat-*'],
+        threatMapping: [],
+        machineLearningJobId: [],
+        queryBar: { filters: [], query: { query: 'any where true', language: 'testlang' } },
       });
       expect(isDisabled).toEqual(false);
     });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/helpers.ts
@@ -209,6 +209,7 @@ export const getIsRulePreviewDisabled = ({
   threatIndex,
   threatMapping,
   machineLearningJobId,
+  queryBar,
 }: {
   ruleType: Type;
   isQueryBarValid: boolean;
@@ -217,6 +218,7 @@ export const getIsRulePreviewDisabled = ({
   threatIndex: string[];
   threatMapping: ThreatMapping;
   machineLearningJobId: string[];
+  queryBar: FieldValueQueryBar;
 }) => {
   if (!isQueryBarValid || index.length === 0) return true;
   if (ruleType === 'threat_match') {
@@ -231,6 +233,9 @@ export const getIsRulePreviewDisabled = ({
   }
   if (ruleType === 'machine_learning') {
     return machineLearningJobId.length === 0;
+  }
+  if (ruleType === 'eql') {
+    return queryBar.query.query.length === 0;
   }
   return false;
 };

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_logs.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_logs.tsx
@@ -67,7 +67,7 @@ export const PreviewLogsComponent: React.FC<PreviewLogsComponentProps> = ({
       {hasNoiseWarning ?? <CustomWarning message={i18n.QUERY_PREVIEW_NOISE_WARNING} />}
       <LogAccordion logs={sortedLogs.errors} isError />
       <LogAccordion logs={sortedLogs.warnings}>
-        {isAborted && <CustomWarning message={i18n.PREVIEW_TIMEOUT_WARNING} />}
+        {isAborted ? <CustomWarning message={i18n.PREVIEW_TIMEOUT_WARNING} /> : null}
       </LogAccordion>
     </>
   );

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -514,6 +514,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
             threatIndex,
             threatMapping: formThreatMapping,
             machineLearningJobId,
+            queryBar: formQuery ?? initialState.queryBar,
           })}
           query={formQuery}
           ruleType={ruleType}


### PR DESCRIPTION
## Summary

- fixes UI bug where the first warning message from many rule preview warnings may not appear over the EuiAccordion component. (preview_logs.tsx line 70)

how it looks when fixed
<img width="500" alt="Screen Shot 2022-03-15 at 4 45 25 PM" src="https://user-images.githubusercontent.com/18617331/158706536-e34e9f89-7feb-4e00-ab69-0c7f1ce0848e.png">

<img width="500" alt="Screen Shot 2022-03-15 at 4 45 18 PM" src="https://user-images.githubusercontent.com/18617331/158706535-ef81dcb2-5de4-4755-875b-800ed2674dc4.png">

- disables eql rule preview if queryBar is valid but there is no query value present

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
