### PR TITLE
[Synthetics Service] Add warnings for when service nodes bandwidth is exceeded

### DIFF
--- a/x-pack/plugins/uptime/common/runtime_types/monitor_management/locations.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/monitor_management/locations.ts
@@ -7,6 +7,26 @@
 
 import { isLeft } from 'fp-ts/lib/Either';
 import * as t from 'io-ts';
+import { tEnum } from '../../utils/t_enum';
+
+export enum BandwidthLimitKey {
+  DOWNLOAD = 'download',
+  UPLOAD = 'upload',
+  LATENCY = 'latency',
+}
+
+export const DEFAULT_BANDWIDTH_LIMIT = {
+  [BandwidthLimitKey.DOWNLOAD]: 100,
+  [BandwidthLimitKey.UPLOAD]: 30,
+  [BandwidthLimitKey.LATENCY]: 1000,
+};
+
+export const BandwidthLimitKeyCodec = tEnum<BandwidthLimitKey>(
+  'BandwidthLimitKey',
+  BandwidthLimitKey
+);
+
+export type BandwidthLimitKeyType = t.TypeOf<typeof BandwidthLimitKeyCodec>;
 
 const LocationGeoCodec = t.interface({
   lat: t.number,
@@ -61,7 +81,14 @@ export const LocationsCodec = t.array(LocationCodec);
 export const isServiceLocationInvalid = (location: ServiceLocation) =>
   isLeft(ServiceLocationCodec.decode(location));
 
+export const ThrottlingOptionsCodec = t.interface({
+  [BandwidthLimitKey.DOWNLOAD]: t.number,
+  [BandwidthLimitKey.UPLOAD]: t.number,
+  [BandwidthLimitKey.LATENCY]: t.number,
+});
+
 export const ServiceLocationsApiResponseCodec = t.interface({
+  throttling: t.union([ThrottlingOptionsCodec, t.undefined]),
   locations: ServiceLocationsCodec,
 });
 
@@ -70,4 +97,5 @@ export type ServiceLocation = t.TypeOf<typeof ServiceLocationCodec>;
 export type ServiceLocations = t.TypeOf<typeof ServiceLocationsCodec>;
 export type ServiceLocationsApiResponse = t.TypeOf<typeof ServiceLocationsApiResponseCodec>;
 export type ServiceLocationErrors = t.TypeOf<typeof ServiceLocationErrors>;
+export type ThrottlingOptions = t.TypeOf<typeof ThrottlingOptionsCodec>;
 export type Locations = t.TypeOf<typeof LocationsCodec>;

--- a/x-pack/plugins/uptime/common/runtime_types/monitor_management/locations.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/monitor_management/locations.ts
@@ -21,6 +21,12 @@ export const DEFAULT_BANDWIDTH_LIMIT = {
   [BandwidthLimitKey.LATENCY]: 1000,
 };
 
+export const DEFAULT_THROTTLING = {
+  [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
+  [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
+  [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
+};
+
 export const BandwidthLimitKeyCodec = tEnum<BandwidthLimitKey>(
   'BandwidthLimitKey',
   BandwidthLimitKey

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.test.tsx
@@ -220,7 +220,9 @@ describe('<ThrottlingFields />', () => {
 
     it('shows automatic throttling warnings only when throttling is disabled', () => {
       const { getByTestId, queryByText } = render(
-        <WrappedComponent policyConfigOverrides={{ throttling, defaultLocations }} />
+        <WrappedComponent
+          policyConfigOverrides={{ throttling, defaultLocations, runsOnService: true }}
+        />
       );
 
       expect(queryByText('Automatic cap')).not.toBeInTheDocument();
@@ -243,7 +245,9 @@ describe('<ThrottlingFields />', () => {
 
     it("shows throttling warnings when exceeding the node's download limits", () => {
       const { getByLabelText, queryByText } = render(
-        <WrappedComponent policyConfigOverrides={{ throttling, defaultLocations }} />
+        <WrappedComponent
+          policyConfigOverrides={{ throttling, defaultLocations, runsOnService: true }}
+        />
       );
 
       const downloadLimit = throttling[BandwidthLimitKey.DOWNLOAD];
@@ -289,7 +293,9 @@ describe('<ThrottlingFields />', () => {
 
     it("shows throttling warnings when exceeding the node's upload limits", () => {
       const { getByLabelText, queryByText } = render(
-        <WrappedComponent policyConfigOverrides={{ throttling, defaultLocations }} />
+        <WrappedComponent
+          policyConfigOverrides={{ throttling, defaultLocations, runsOnService: true }}
+        />
       );
 
       const uploadLimit = throttling[BandwidthLimitKey.UPLOAD];
@@ -335,7 +341,9 @@ describe('<ThrottlingFields />', () => {
 
     it("shows latency warnings when exceeding the node's latency limits", () => {
       const { getByLabelText, queryByText } = render(
-        <WrappedComponent policyConfigOverrides={{ throttling, defaultLocations }} />
+        <WrappedComponent
+          policyConfigOverrides={{ throttling, defaultLocations, runsOnService: true }}
+        />
       );
 
       const latencyLimit = throttling[BandwidthLimitKey.LATENCY];

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.test.tsx
@@ -16,10 +16,14 @@ import {
   BrowserSimpleFields,
   Validation,
   ConfigKey,
+  BandwidthLimitKey,
 } from '../types';
 import {
   BrowserAdvancedFieldsContextProvider,
   BrowserSimpleFieldsContextProvider,
+  PolicyConfigContextProvider,
+  IPolicyConfigContextProvider,
+  defaultPolicyConfigValues,
   defaultBrowserAdvancedFields as defaultConfig,
   defaultBrowserSimpleFields,
 } from '../contexts';
@@ -34,22 +38,35 @@ jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => ({
 }));
 
 describe('<ThrottlingFields />', () => {
+  const defaultLocation = {
+    id: 'test',
+    label: 'Test',
+    geo: { lat: 1, lon: 2 },
+    url: 'https://example.com',
+  };
+
   const WrappedComponent = ({
     defaultValues = defaultConfig,
     defaultSimpleFields = defaultBrowserSimpleFields,
+    policyConfigOverrides = {},
     validate = defaultValidation,
     onFieldBlur,
   }: {
     defaultValues?: BrowserAdvancedFields;
     defaultSimpleFields?: BrowserSimpleFields;
+    policyConfigOverrides?: Partial<IPolicyConfigContextProvider>;
     validate?: Validation;
     onFieldBlur?: (field: ConfigKey) => void;
   }) => {
+    const policyConfigValues = { ...defaultPolicyConfigValues, ...policyConfigOverrides };
+
     return (
       <IntlProvider locale="en">
         <BrowserSimpleFieldsContextProvider defaultValues={defaultSimpleFields}>
           <BrowserAdvancedFieldsContextProvider defaultValues={defaultValues}>
-            <ThrottlingFields validate={validate} onFieldBlur={onFieldBlur} />
+            <PolicyConfigContextProvider {...policyConfigValues}>
+              <ThrottlingFields validate={validate} onFieldBlur={onFieldBlur} />
+            </PolicyConfigContextProvider>
           </BrowserAdvancedFieldsContextProvider>
         </BrowserSimpleFieldsContextProvider>
       </IntlProvider>
@@ -189,6 +206,177 @@ describe('<ThrottlingFields />', () => {
       userEvent.clear(latency);
       userEvent.type(latency, '1');
       expect(queryByText('Latency must not be negative.')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('throttling warnings', () => {
+    const throttling = {
+      [BandwidthLimitKey.DOWNLOAD]: 100,
+      [BandwidthLimitKey.UPLOAD]: 50,
+      [BandwidthLimitKey.LATENCY]: 25,
+    };
+
+    const defaultLocations = [defaultLocation];
+
+    it('shows automatic throttling warnings only when throttling is disabled', () => {
+      const { getByTestId, queryByText } = render(
+        <WrappedComponent policyConfigOverrides={{ throttling, defaultLocations }} />
+      );
+
+      expect(queryByText('Automatic cap')).not.toBeInTheDocument();
+      expect(
+        queryByText(
+          "When disabling throttling, your monitor will still have its bandwidth capped by the configurations of the Synthetics Nodes in which it's running."
+        )
+      ).not.toBeInTheDocument();
+
+      const enableSwitch = getByTestId('syntheticsBrowserIsThrottlingEnabled');
+      userEvent.click(enableSwitch);
+
+      expect(queryByText('Automatic cap')).toBeInTheDocument();
+      expect(
+        queryByText(
+          "When disabling throttling, your monitor will still have its bandwidth capped by the configurations of the Synthetics Nodes in which it's running."
+        )
+      ).toBeInTheDocument();
+    });
+
+    it("shows throttling warnings when exceeding the node's download limits", () => {
+      const { getByLabelText, queryByText } = render(
+        <WrappedComponent policyConfigOverrides={{ throttling, defaultLocations }} />
+      );
+
+      const downloadLimit = throttling[BandwidthLimitKey.DOWNLOAD];
+
+      const download = getByLabelText('Download Speed') as HTMLInputElement;
+      userEvent.clear(download);
+      userEvent.type(download, String(downloadLimit + 1));
+
+      expect(
+        queryByText(
+          `You have exceeded the download limit for Synthetic Nodes. The download value can't be larger than ${downloadLimit}Mbps.`
+        )
+      ).toBeInTheDocument();
+
+      expect(
+        queryByText("You've exceeded the Synthetics Node bandwidth limits")
+      ).toBeInTheDocument();
+
+      expect(
+        queryByText(
+          'When using throttling values larger than a Synthetics Node bandwidth limit, your monitor will still have its bandwidth capped.'
+        )
+      ).toBeInTheDocument();
+
+      userEvent.clear(download);
+      userEvent.type(download, String(downloadLimit - 1));
+      expect(
+        queryByText(
+          `You have exceeded the download limit for Synthetic Nodes. The download value can't be larger than ${downloadLimit}Mbps.`
+        )
+      ).not.toBeInTheDocument();
+
+      expect(
+        queryByText("You've exceeded the Synthetics Node bandwidth limits")
+      ).not.toBeInTheDocument();
+
+      expect(
+        queryByText(
+          'When using throttling values larger than a Synthetics Node bandwidth limit, your monitor will still have its bandwidth capped.'
+        )
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows throttling warnings when exceeding the node's upload limits", () => {
+      const { getByLabelText, queryByText } = render(
+        <WrappedComponent policyConfigOverrides={{ throttling, defaultLocations }} />
+      );
+
+      const uploadLimit = throttling[BandwidthLimitKey.UPLOAD];
+
+      const upload = getByLabelText('Upload Speed') as HTMLInputElement;
+      userEvent.clear(upload);
+      userEvent.type(upload, String(uploadLimit + 1));
+
+      expect(
+        queryByText(
+          `You have exceeded the upload limit for Synthetic Nodes. The upload value can't be larger than ${uploadLimit}Mbps.`
+        )
+      ).toBeInTheDocument();
+
+      expect(
+        queryByText("You've exceeded the Synthetics Node bandwidth limits")
+      ).toBeInTheDocument();
+
+      expect(
+        queryByText(
+          'When using throttling values larger than a Synthetics Node bandwidth limit, your monitor will still have its bandwidth capped.'
+        )
+      ).toBeInTheDocument();
+
+      userEvent.clear(upload);
+      userEvent.type(upload, String(uploadLimit - 1));
+      expect(
+        queryByText(
+          `You have exceeded the upload limit for Synthetic Nodes. The upload value can't be larger than ${uploadLimit}Mbps.`
+        )
+      ).not.toBeInTheDocument();
+
+      expect(
+        queryByText("You've exceeded the Synthetics Node bandwidth limits")
+      ).not.toBeInTheDocument();
+
+      expect(
+        queryByText(
+          'When using throttling values larger than a Synthetics Node bandwidth limit, your monitor will still have its bandwidth capped.'
+        )
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows latency warnings when exceeding the node's latency limits", () => {
+      const { getByLabelText, queryByText } = render(
+        <WrappedComponent policyConfigOverrides={{ throttling, defaultLocations }} />
+      );
+
+      const latencyLimit = throttling[BandwidthLimitKey.LATENCY];
+
+      const latency = getByLabelText('Latency') as HTMLInputElement;
+      userEvent.clear(latency);
+      userEvent.type(latency, String(latencyLimit + 1));
+
+      expect(
+        queryByText(
+          `You have exceeded the latency limit for Synthetic Nodes. The latency value can't be larger than ${latencyLimit}ms.`
+        )
+      ).toBeInTheDocument();
+
+      expect(
+        queryByText("You've exceeded the Synthetics Node bandwidth limits")
+      ).toBeInTheDocument();
+
+      expect(
+        queryByText(
+          'When using throttling values larger than a Synthetics Node bandwidth limit, your monitor will still have its bandwidth capped.'
+        )
+      ).toBeInTheDocument();
+
+      userEvent.clear(latency);
+      userEvent.type(latency, String(latencyLimit - 1));
+      expect(
+        queryByText(
+          `You have exceeded the latency limit for Synthetic Nodes. The latency value can't be larger than ${latencyLimit}ms.`
+        )
+      ).not.toBeInTheDocument();
+
+      expect(
+        queryByText("You've exceeded the Synthetics Node bandwidth limits")
+      ).not.toBeInTheDocument();
+
+      expect(
+        queryByText(
+          'When using throttling values larger than a Synthetics Node bandwidth limit, your monitor will still have its bandwidth capped.'
+        )
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.tsx
@@ -93,7 +93,7 @@ export const ThrottlingExceededMessage = ({
 
 export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onFieldBlur }) => {
   const { fields, setFields } = useBrowserAdvancedFieldsContext();
-  const { throttling, locations: selectedLocations = [] } = usePolicyConfigContext();
+  const { runsOnService, throttling } = usePolicyConfigContext();
 
   const maxDownload = throttling[BandwidthLimitKey.DOWNLOAD];
   const maxUpload = throttling[BandwidthLimitKey.UPLOAD];
@@ -106,7 +106,6 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
     [setFields]
   );
 
-  const runsOnService = selectedLocations && selectedLocations.length > 0;
   const exceedsDownloadLimits =
     runsOnService && parseFloat(fields[ConfigKey.DOWNLOAD_SPEED]) > maxDownload;
   const exceedsUploadLimits =

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.tsx
@@ -7,12 +7,19 @@
 
 import React, { memo, useCallback } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiSwitch, EuiSpacer, EuiFormRow, EuiFieldNumber, EuiText } from '@elastic/eui';
+import {
+  EuiSwitch,
+  EuiSpacer,
+  EuiFormRow,
+  EuiFieldNumber,
+  EuiText,
+  EuiCallOut,
+} from '@elastic/eui';
 import { DescribedFormGroupWithWrap } from '../common/described_form_group_with_wrap';
 
 import { OptionalLabel } from '../optional_label';
-import { useBrowserAdvancedFieldsContext } from '../contexts';
-import { Validation, ConfigKey } from '../types';
+import { useBrowserAdvancedFieldsContext, usePolicyConfigContext } from '../contexts';
+import { Validation, ConfigKey, BandwidthLimitKey } from '../types';
 
 interface Props {
   validate: Validation;
@@ -26,8 +33,71 @@ type ThrottlingConfigs =
   | ConfigKey.UPLOAD_SPEED
   | ConfigKey.LATENCY;
 
+export const ThrottlingDisabledCallout = () => {
+  return (
+    <EuiCallOut
+      title={
+        <FormattedMessage
+          id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.automatic_node_cap.title"
+          defaultMessage="Automatic cap"
+        />
+      }
+      color="warning"
+      iconType="alert"
+    >
+      <FormattedMessage
+        id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.automatic_node_cap.message"
+        defaultMessage="When disabling throttling, your monitor will still have its bandwidth capped by the configurations of the Synthetics Nodes in which it's running."
+      />
+    </EuiCallOut>
+  );
+};
+
+export const ThrottlingExceededCallout = () => {
+  return (
+    <EuiCallOut
+      title={
+        <FormattedMessage
+          id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.exceeded_throttling.title"
+          defaultMessage="You've exceeded the Synthetics Node bandwidth limits"
+        />
+      }
+      color="warning"
+      iconType="alert"
+    >
+      <FormattedMessage
+        id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.exceeded_throttling.message"
+        defaultMessage="When using throttling values larger than a Synthetics Node bandwidth limit, your monitor will still have its bandwidth capped."
+      />
+    </EuiCallOut>
+  );
+};
+
+export const ThrottlingExceededMessage = ({
+  throttlingField,
+  limit,
+  unit,
+}: {
+  throttlingField: string;
+  limit: number;
+  unit: string;
+}) => {
+  return (
+    <FormattedMessage
+      id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.throttling_exceeded.message"
+      defaultMessage="You have exceeded the { throttlingField } limit for Synthetic Nodes. The { throttlingField } value can't be larger than { limit }{unit}."
+      values={{ throttlingField, limit, unit }}
+    />
+  );
+};
+
 export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onFieldBlur }) => {
   const { fields, setFields } = useBrowserAdvancedFieldsContext();
+  const { throttling, locations: selectedLocations = [] } = usePolicyConfigContext();
+
+  const maxDownload = throttling[BandwidthLimitKey.DOWNLOAD];
+  const maxUpload = throttling[BandwidthLimitKey.UPLOAD];
+  const maxLatency = throttling[BandwidthLimitKey.LATENCY];
 
   const handleInputChange = useCallback(
     ({ value, configKey }: { value: unknown; configKey: ThrottlingConfigs }) => {
@@ -36,7 +106,15 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
     [setFields]
   );
 
-  const throttlingInputs = fields[ConfigKey.IS_THROTTLING_ENABLED] ? (
+  const runsOnService = selectedLocations && selectedLocations.length > 0;
+  const exceedsDownloadLimits =
+    runsOnService && parseFloat(fields[ConfigKey.DOWNLOAD_SPEED]) > maxDownload;
+  const exceedsUploadLimits =
+    runsOnService && parseFloat(fields[ConfigKey.UPLOAD_SPEED]) > maxUpload;
+  const exceedsLatencyLimits = runsOnService && parseFloat(fields[ConfigKey.LATENCY]) > maxLatency;
+  const isThrottlingEnabled = fields[ConfigKey.IS_THROTTLING_ENABLED];
+
+  const throttlingInputs = isThrottlingEnabled ? (
     <>
       <EuiSpacer size="m" />
       <EuiFormRow
@@ -47,12 +125,16 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
           />
         }
         labelAppend={<OptionalLabel />}
-        isInvalid={!!validate[ConfigKey.DOWNLOAD_SPEED]?.(fields)}
+        isInvalid={!!validate[ConfigKey.DOWNLOAD_SPEED]?.(fields) || exceedsDownloadLimits}
         error={
-          <FormattedMessage
-            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.error"
-            defaultMessage="Download speed must be greater than zero."
-          />
+          exceedsDownloadLimits ? (
+            <ThrottlingExceededMessage throttlingField="download" limit={maxDownload} unit="Mbps" />
+          ) : (
+            <FormattedMessage
+              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.error"
+              defaultMessage="Download speed must be greater than zero."
+            />
+          )
         }
       >
         <EuiFieldNumber
@@ -82,12 +164,16 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
           />
         }
         labelAppend={<OptionalLabel />}
-        isInvalid={!!validate[ConfigKey.UPLOAD_SPEED]?.(fields)}
+        isInvalid={!!validate[ConfigKey.UPLOAD_SPEED]?.(fields) || exceedsUploadLimits}
         error={
-          <FormattedMessage
-            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.error"
-            defaultMessage="Upload speed must be greater than zero."
-          />
+          exceedsUploadLimits ? (
+            <ThrottlingExceededMessage throttlingField="upload" limit={maxUpload} unit="Mbps" />
+          ) : (
+            <FormattedMessage
+              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.error"
+              defaultMessage="Upload speed must be greater than zero."
+            />
+          )
         }
       >
         <EuiFieldNumber
@@ -117,12 +203,16 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
           />
         }
         labelAppend={<OptionalLabel />}
-        isInvalid={!!validate[ConfigKey.LATENCY]?.(fields)}
+        isInvalid={!!validate[ConfigKey.LATENCY]?.(fields) || exceedsLatencyLimits}
         error={
-          <FormattedMessage
-            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.error"
-            defaultMessage="Latency must not be negative."
-          />
+          exceedsLatencyLimits ? (
+            <ThrottlingExceededMessage throttlingField="latency" limit={maxLatency} unit="ms" />
+          ) : (
+            <FormattedMessage
+              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.error"
+              defaultMessage="Latency must not be negative."
+            />
+          )
         }
       >
         <EuiFieldNumber
@@ -144,7 +234,12 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
         />
       </EuiFormRow>
     </>
-  ) : null;
+  ) : (
+    <>
+      <EuiSpacer />
+      <ThrottlingDisabledCallout />
+    </>
+  );
 
   return (
     <DescribedFormGroupWithWrap
@@ -183,6 +278,13 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
         }
         onBlur={() => onFieldBlur?.(ConfigKey.IS_THROTTLING_ENABLED)}
       />
+      {isThrottlingEnabled &&
+      (exceedsDownloadLimits || exceedsUploadLimits || exceedsLatencyLimits) ? (
+        <>
+          <EuiSpacer />
+          <ThrottlingExceededCallout />
+        </>
+      ) : null}
       {throttlingInputs}
     </DescribedFormGroupWithWrap>
   );

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/index.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/index.ts
@@ -14,10 +14,12 @@ import { initialValues as defaultBrowserSimpleFields } from './browser_context';
 import { initialValues as defaultBrowserAdvancedFields } from './browser_context_advanced';
 import { initialValues as defaultTLSFields } from './tls_fields_context';
 
+export type { IPolicyConfigContextProvider } from './policy_config_context';
 export {
   PolicyConfigContext,
   PolicyConfigContextProvider,
   initialValue as defaultPolicyConfig,
+  defaultContext as defaultPolicyConfigValues,
   usePolicyConfigContext,
 } from './policy_config_context';
 export {

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/policy_config_context.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/policy_config_context.tsx
@@ -7,7 +7,13 @@
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
 import { DEFAULT_NAMESPACE_STRING } from '../../../../common/constants';
-import { ScheduleUnit, ServiceLocations } from '../../../../common/runtime_types';
+import {
+  ScheduleUnit,
+  ServiceLocations,
+  ThrottlingOptions,
+  BandwidthLimitKey,
+  DEFAULT_BANDWIDTH_LIMIT,
+} from '../../../../common/runtime_types';
 import { DataStream } from '../types';
 
 interface IPolicyConfigContext {
@@ -32,6 +38,7 @@ interface IPolicyConfigContext {
   allowedScheduleUnits?: ScheduleUnit[];
   defaultNamespace?: string;
   namespace?: string;
+  throttling: ThrottlingOptions;
 }
 
 export interface IPolicyConfigContextProvider {
@@ -45,11 +52,12 @@ export interface IPolicyConfigContextProvider {
   isEditable?: boolean;
   isZipUrlSourceEnabled?: boolean;
   allowedScheduleUnits?: ScheduleUnit[];
+  throttling?: ThrottlingOptions;
 }
 
 export const initialValue = DataStream.HTTP;
 
-const defaultContext: IPolicyConfigContext = {
+export const defaultContext: IPolicyConfigContext = {
   setMonitorType: (_monitorType: React.SetStateAction<DataStream>) => {
     throw new Error('setMonitorType was not initialized, set it when you invoke the context');
   },
@@ -80,12 +88,22 @@ const defaultContext: IPolicyConfigContext = {
   isZipUrlSourceEnabled: true,
   allowedScheduleUnits: [ScheduleUnit.MINUTES, ScheduleUnit.SECONDS],
   defaultNamespace: DEFAULT_NAMESPACE_STRING,
+  throttling: {
+    [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
+    [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
+    [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
+  },
 };
 
 export const PolicyConfigContext = createContext(defaultContext);
 
 export function PolicyConfigContextProvider<ExtraFields = unknown>({
   children,
+  throttling = {
+    [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
+    [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
+    [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
+  },
   defaultMonitorType = initialValue,
   defaultIsTLSEnabled = false,
   defaultIsZipUrlTLSEnabled = false,
@@ -125,6 +143,7 @@ export function PolicyConfigContextProvider<ExtraFields = unknown>({
       allowedScheduleUnits,
       namespace,
       setNamespace,
+      throttling,
     } as IPolicyConfigContext;
   }, [
     monitorType,
@@ -141,6 +160,7 @@ export function PolicyConfigContextProvider<ExtraFields = unknown>({
     defaultLocations,
     allowedScheduleUnits,
     namespace,
+    throttling,
   ]);
 
   return <PolicyConfigContext.Provider value={value} children={children} />;

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/policy_config_context.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/policy_config_context.tsx
@@ -11,8 +11,7 @@ import {
   ScheduleUnit,
   ServiceLocations,
   ThrottlingOptions,
-  BandwidthLimitKey,
-  DEFAULT_BANDWIDTH_LIMIT,
+  DEFAULT_THROTTLING,
 } from '../../../../common/runtime_types';
 import { DataStream } from '../types';
 
@@ -28,6 +27,7 @@ interface IPolicyConfigContext {
   isTLSEnabled?: boolean;
   isZipUrlTLSEnabled?: boolean;
   isZipUrlSourceEnabled?: boolean;
+  runsOnService?: boolean;
   defaultIsTLSEnabled?: boolean;
   defaultIsZipUrlTLSEnabled?: boolean;
   isEditable?: boolean;
@@ -44,6 +44,7 @@ interface IPolicyConfigContext {
 export interface IPolicyConfigContextProvider {
   children: React.ReactNode;
   defaultMonitorType?: DataStream;
+  runsOnService?: boolean;
   defaultIsTLSEnabled?: boolean;
   defaultIsZipUrlTLSEnabled?: boolean;
   defaultName?: string;
@@ -80,6 +81,7 @@ export const defaultContext: IPolicyConfigContext = {
   },
   monitorType: initialValue, // mutable
   defaultMonitorType: initialValue, // immutable,
+  runsOnService: false,
   defaultIsTLSEnabled: false,
   defaultIsZipUrlTLSEnabled: false,
   defaultName: '',
@@ -88,22 +90,14 @@ export const defaultContext: IPolicyConfigContext = {
   isZipUrlSourceEnabled: true,
   allowedScheduleUnits: [ScheduleUnit.MINUTES, ScheduleUnit.SECONDS],
   defaultNamespace: DEFAULT_NAMESPACE_STRING,
-  throttling: {
-    [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
-    [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
-    [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
-  },
+  throttling: DEFAULT_THROTTLING,
 };
 
 export const PolicyConfigContext = createContext(defaultContext);
 
 export function PolicyConfigContextProvider<ExtraFields = unknown>({
   children,
-  throttling = {
-    [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
-    [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
-    [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
-  },
+  throttling = DEFAULT_THROTTLING,
   defaultMonitorType = initialValue,
   defaultIsTLSEnabled = false,
   defaultIsZipUrlTLSEnabled = false,
@@ -111,6 +105,7 @@ export function PolicyConfigContextProvider<ExtraFields = unknown>({
   defaultLocations = [],
   defaultNamespace = DEFAULT_NAMESPACE_STRING,
   isEditable = false,
+  runsOnService = false,
   isZipUrlSourceEnabled = true,
   allowedScheduleUnits = [ScheduleUnit.MINUTES, ScheduleUnit.SECONDS],
 }: IPolicyConfigContextProvider) {
@@ -126,6 +121,7 @@ export function PolicyConfigContextProvider<ExtraFields = unknown>({
       monitorType,
       setMonitorType,
       defaultMonitorType,
+      runsOnService,
       isTLSEnabled,
       isZipUrlTLSEnabled,
       setIsTLSEnabled,
@@ -148,6 +144,7 @@ export function PolicyConfigContextProvider<ExtraFields = unknown>({
   }, [
     monitorType,
     defaultMonitorType,
+    runsOnService,
     isTLSEnabled,
     isZipUrlSourceEnabled,
     isZipUrlTLSEnabled,

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/synthetics_context_providers.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/synthetics_context_providers.tsx
@@ -36,7 +36,7 @@ export const SyntheticsProviders = ({
   policyDefaultValues,
 }: Props) => {
   return (
-    <PolicyConfigContextProvider {...(policyDefaultValues || {})}>
+    <PolicyConfigContextProvider {...policyDefaultValues}>
       <HTTPContextProvider defaultValues={httpDefaultValues}>
         <TCPContextProvider defaultValues={tcpDefaultValues}>
           <TLSFieldsContextProvider defaultValues={tlsDefaultValues}>

--- a/x-pack/plugins/uptime/public/components/monitor_management/edit_monitor_config.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/edit_monitor_config.tsx
@@ -12,6 +12,7 @@ import {
   TLSFields,
   DataStream,
   ScheduleUnit,
+  ThrottlingOptions,
 } from '../../../common/runtime_types';
 import { useTrackPageview } from '../../../../observability/public';
 import { SyntheticsProviders } from '../fleet_package/contexts';
@@ -21,9 +22,10 @@ import { DEFAULT_NAMESPACE_STRING } from '../../../common/constants';
 
 interface Props {
   monitor: MonitorFields;
+  throttling: ThrottlingOptions;
 }
 
-export const EditMonitorConfig = ({ monitor }: Props) => {
+export const EditMonitorConfig = ({ monitor, throttling }: Props) => {
   useTrackPageview({ app: 'uptime', path: 'edit-monitor' });
   useTrackPageview({ app: 'uptime', path: 'edit-monitor', delay: 15000 });
 
@@ -72,6 +74,7 @@ export const EditMonitorConfig = ({ monitor }: Props) => {
   return (
     <SyntheticsProviders
       policyDefaultValues={{
+        throttling,
         defaultIsTLSEnabled: isTLSEnabled,
         defaultIsZipUrlTLSEnabled: isZipUrlTLSEnabled,
         defaultMonitorType: monitorType,
@@ -81,6 +84,7 @@ export const EditMonitorConfig = ({ monitor }: Props) => {
         isEditable: true,
         isZipUrlSourceEnabled: false,
         allowedScheduleUnits: [ScheduleUnit.MINUTES],
+        runsOnService: true,
       }}
       httpDefaultValues={fullDefaultConfig[DataStream.HTTP]}
       tcpDefaultValues={fullDefaultConfig[DataStream.TCP]}

--- a/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_inline_errors.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_inline_errors.test.tsx
@@ -8,6 +8,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { MockRedux } from '../../../lib/helper/rtl_helpers';
 import { useInlineErrors } from './use_inline_errors';
+import { DEFAULT_THROTTLING } from '../../../../common/runtime_types';
 import * as obsvPlugin from '../../../../../observability/public/hooks/use_es_search';
 
 function mockNow(date: string | number | Date) {
@@ -74,6 +75,7 @@ describe('useInlineErrors', function () {
           syntheticsService: {
             loading: false,
           },
+          throttling: DEFAULT_THROTTLING,
         },
         1641081600000,
         true,

--- a/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_inline_errors_count.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_inline_errors_count.test.tsx
@@ -9,6 +9,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { MockRedux } from '../../../lib/helper/rtl_helpers';
 import { useInlineErrorsCount } from './use_inline_errors_count';
 import * as obsvPlugin from '../../../../../observability/public/hooks/use_es_search';
+import { DEFAULT_THROTTLING } from '../../../../common/runtime_types';
 
 function mockNow(date: string | number | Date) {
   const fakeNow = new Date(date).getTime();
@@ -73,6 +74,7 @@ describe('useInlineErrorsCount', function () {
           syntheticsService: {
             loading: false,
           },
+          throttling: DEFAULT_THROTTLING,
         },
         1641081600000,
       ],

--- a/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_locations.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_locations.test.tsx
@@ -14,6 +14,8 @@ import { useLocations } from './use_locations';
 import * as reactRedux from 'react-redux';
 import { getServiceLocations } from '../../../state/actions';
 
+import { BandwidthLimitKey, DEFAULT_BANDWIDTH_LIMIT } from '../../../../common/runtime_types';
+
 describe('useExpViewTimeRange', function () {
   const dispatch = jest.fn();
   jest.spyOn(reactRedux, 'useDispatch').mockReturnValue(dispatch);
@@ -26,10 +28,17 @@ describe('useExpViewTimeRange', function () {
   });
 
   it('returns loading and error from redux store', async function () {
+    const throttling = {
+      [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
+      [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
+      [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
+    };
+
     const error = new Error('error');
     const loading = true;
     const state = {
       monitorManagementList: {
+        throttling,
         list: {
           perPage: 10,
           page: 1,
@@ -58,6 +67,6 @@ describe('useExpViewTimeRange', function () {
       wrapper: Wrapper,
     });
 
-    expect(result.current).toEqual({ loading, error, locations: [] });
+    expect(result.current).toEqual({ loading, error, throttling, locations: [] });
   });
 });

--- a/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_locations.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_locations.test.tsx
@@ -14,7 +14,7 @@ import { useLocations } from './use_locations';
 import * as reactRedux from 'react-redux';
 import { getServiceLocations } from '../../../state/actions';
 
-import { BandwidthLimitKey, DEFAULT_BANDWIDTH_LIMIT } from '../../../../common/runtime_types';
+import { DEFAULT_THROTTLING } from '../../../../common/runtime_types';
 
 describe('useExpViewTimeRange', function () {
   const dispatch = jest.fn();
@@ -28,11 +28,7 @@ describe('useExpViewTimeRange', function () {
   });
 
   it('returns loading and error from redux store', async function () {
-    const throttling = {
-      [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
-      [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
-      [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
-    };
+    const throttling = DEFAULT_THROTTLING;
 
     const error = new Error('error');
     const loading = true;

--- a/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_locations.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_locations.ts
@@ -16,6 +16,7 @@ export function useLocations() {
     error: { serviceLocations: serviceLocationsError },
     loading: { serviceLocations: serviceLocationsLoading },
     locations,
+    throttling,
   } = useSelector(monitorManagementListSelector);
 
   useEffect(() => {
@@ -23,6 +24,7 @@ export function useLocations() {
   }, [dispatch]);
 
   return {
+    throttling,
     locations,
     error: serviceLocationsError,
     loading: serviceLocationsLoading,

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/invalid_monitors.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/invalid_monitors.tsx
@@ -8,8 +8,12 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { MonitorManagementList, MonitorManagementListPageState } from './monitor_list';
-import { MonitorManagementListResult, Ping } from '../../../../common/runtime_types';
 import { monitorManagementListSelector } from '../../../state/selectors';
+import {
+  MonitorManagementListResult,
+  Ping,
+  DEFAULT_THROTTLING,
+} from '../../../../common/runtime_types';
 
 interface Props {
   loading: boolean;
@@ -49,6 +53,7 @@ export const InvalidMonitors = ({
         loading: { monitorList: summariesLoading, serviceLocations: false },
         locations: monitorList.locations,
         syntheticsService: monitorList.syntheticsService,
+        throttling: DEFAULT_THROTTLING,
       }}
       onPageStateChange={onPageStateChange}
       onUpdate={onUpdate}

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.test.tsx
@@ -8,7 +8,14 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { ConfigKey, DataStream, HTTPFields, ScheduleUnit } from '../../../../common/runtime_types';
+import {
+  ConfigKey,
+  DataStream,
+  HTTPFields,
+  ScheduleUnit,
+  BandwidthLimitKey,
+  DEFAULT_BANDWIDTH_LIMIT,
+} from '../../../../common/runtime_types';
 import { render } from '../../../lib/helper/rtl_helpers';
 import { MonitorManagementList as MonitorManagementListState } from '../../../state/reducers/monitor_management';
 import { MonitorManagementList, MonitorManagementListPageState } from './monitor_list';
@@ -36,6 +43,11 @@ describe('<MonitorManagementList />', () => {
   }
   const state = {
     monitorManagementList: {
+      throttling: {
+        [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
+        [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
+        [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
+      },
       list: {
         perPage: 5,
         page: 1,

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.test.tsx
@@ -13,8 +13,7 @@ import {
   DataStream,
   HTTPFields,
   ScheduleUnit,
-  BandwidthLimitKey,
-  DEFAULT_BANDWIDTH_LIMIT,
+  DEFAULT_THROTTLING,
 } from '../../../../common/runtime_types';
 import { render } from '../../../lib/helper/rtl_helpers';
 import { MonitorManagementList as MonitorManagementListState } from '../../../state/reducers/monitor_management';
@@ -43,11 +42,7 @@ describe('<MonitorManagementList />', () => {
   }
   const state = {
     monitorManagementList: {
-      throttling: {
-        [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
-        [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
-        [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
-      },
+      throttling: DEFAULT_THROTTLING,
       list: {
         perPage: 5,
         page: 1,

--- a/x-pack/plugins/uptime/public/lib/__mocks__/uptime_store.mock.ts
+++ b/x-pack/plugins/uptime/public/lib/__mocks__/uptime_store.mock.ts
@@ -6,6 +6,7 @@
  */
 
 import { DYNAMIC_SETTINGS_DEFAULTS } from '../../../common/constants';
+import { BandwidthLimitKey, DEFAULT_BANDWIDTH_LIMIT } from '../../../common/runtime_types';
 import { AppState } from '../../state';
 
 /**
@@ -62,6 +63,11 @@ export const mockState: AppState = {
     refreshedMonitorIds: [],
   },
   monitorManagementList: {
+    throttling: {
+      [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
+      [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
+      [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
+    },
     list: {
       page: 1,
       perPage: 10,

--- a/x-pack/plugins/uptime/public/lib/__mocks__/uptime_store.mock.ts
+++ b/x-pack/plugins/uptime/public/lib/__mocks__/uptime_store.mock.ts
@@ -6,7 +6,7 @@
  */
 
 import { DYNAMIC_SETTINGS_DEFAULTS } from '../../../common/constants';
-import { BandwidthLimitKey, DEFAULT_BANDWIDTH_LIMIT } from '../../../common/runtime_types';
+import { DEFAULT_THROTTLING } from '../../../common/runtime_types';
 import { AppState } from '../../state';
 
 /**
@@ -63,11 +63,7 @@ export const mockState: AppState = {
     refreshedMonitorIds: [],
   },
   monitorManagementList: {
-    throttling: {
-      [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
-      [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
-      [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
-    },
+    throttling: DEFAULT_THROTTLING,
     list: {
       page: 1,
       perPage: 10,

--- a/x-pack/plugins/uptime/public/pages/monitor_management/add_monitor.tsx
+++ b/x-pack/plugins/uptime/public/pages/monitor_management/add_monitor.tsx
@@ -19,7 +19,7 @@ export const AddMonitorPage: React.FC = () => {
   useTrackPageview({ app: 'uptime', path: 'add-monitor' });
   useTrackPageview({ app: 'uptime', path: 'add-monitor', delay: 15000 });
 
-  const { error, loading, locations } = useLocations();
+  const { error, loading, locations, throttling } = useLocations();
 
   useMonitorManagementBreadcrumbs({ isAddMonitor: true });
 
@@ -33,6 +33,7 @@ export const AddMonitorPage: React.FC = () => {
     >
       <SyntheticsProviders
         policyDefaultValues={{
+          throttling,
           isZipUrlSourceEnabled: false,
           allowedScheduleUnits: [ScheduleUnit.MINUTES],
         }}

--- a/x-pack/plugins/uptime/public/pages/monitor_management/add_monitor.tsx
+++ b/x-pack/plugins/uptime/public/pages/monitor_management/add_monitor.tsx
@@ -34,6 +34,7 @@ export const AddMonitorPage: React.FC = () => {
       <SyntheticsProviders
         policyDefaultValues={{
           throttling,
+          runsOnService: true,
           isZipUrlSourceEnabled: false,
           allowedScheduleUnits: [ScheduleUnit.MINUTES],
         }}

--- a/x-pack/plugins/uptime/public/pages/monitor_management/edit_monitor.tsx
+++ b/x-pack/plugins/uptime/public/pages/monitor_management/edit_monitor.tsx
@@ -28,7 +28,7 @@ export const EditMonitorPage: React.FC = () => {
   }, [monitorId]);
 
   const monitor = data?.attributes as MonitorFields;
-  const { error: locationsError, loading: locationsLoading } = useLocations();
+  const { error: locationsError, loading: locationsLoading, throttling } = useLocations();
 
   return (
     <Loader
@@ -38,7 +38,7 @@ export const EditMonitorPage: React.FC = () => {
       errorTitle={ERROR_HEADING_LABEL}
       errorBody={locationsError ? SERVICE_LOCATIONS_ERROR_LABEL : MONITOR_LOADING_ERROR_LABEL}
     >
-      {monitor && <EditMonitorConfig monitor={monitor} />}
+      {monitor && <EditMonitorConfig monitor={monitor} throttling={throttling} />}
     </Loader>
   );
 };

--- a/x-pack/plugins/uptime/public/state/actions/monitor_management.ts
+++ b/x-pack/plugins/uptime/public/state/actions/monitor_management.ts
@@ -9,6 +9,7 @@ import { createAction } from '@reduxjs/toolkit';
 import {
   MonitorManagementListResult,
   ServiceLocations,
+  ThrottlingOptions,
   FetchMonitorManagementListQueryArgs,
 } from '../../../common/runtime_types';
 import { createAsyncAction } from './utils';
@@ -23,9 +24,10 @@ export const getMonitorsSuccess = createAction<MonitorManagementListResult>(
 export const getMonitorsFailure = createAction<Error>('GET_MONITOR_MANAGEMENT_LIST_FAILURE');
 
 export const getServiceLocations = createAction('GET_SERVICE_LOCATIONS_LIST');
-export const getServiceLocationsSuccess = createAction<ServiceLocations>(
-  'GET_SERVICE_LOCATIONS_LIST_SUCCESS'
-);
+export const getServiceLocationsSuccess = createAction<{
+  throttling: ThrottlingOptions | undefined;
+  locations: ServiceLocations;
+}>('GET_SERVICE_LOCATIONS_LIST_SUCCESS');
 export const getServiceLocationsFailure = createAction<Error>('GET_SERVICE_LOCATIONS_LIST_FAILURE');
 
 export const getSyntheticsServiceAllowed = createAsyncAction<void, SyntheticsServiceAllowed>(

--- a/x-pack/plugins/uptime/public/state/api/monitor_management.ts
+++ b/x-pack/plugins/uptime/public/state/api/monitor_management.ts
@@ -14,6 +14,7 @@ import {
   SyntheticsMonitor,
   ServiceLocationsApiResponseCodec,
   ServiceLocationErrors,
+  ThrottlingOptions,
 } from '../../../common/runtime_types';
 import { SyntheticsMonitorSavedObject, SyntheticsServiceAllowed } from '../../../common/types';
 import { apiService } from './utils';
@@ -50,13 +51,16 @@ export const fetchMonitorManagementList = async (
   );
 };
 
-export const fetchServiceLocations = async (): Promise<ServiceLocations> => {
-  const { locations } = await apiService.get(
+export const fetchServiceLocations = async (): Promise<{
+  throttling: ThrottlingOptions | undefined;
+  locations: ServiceLocations;
+}> => {
+  const { throttling, locations } = await apiService.get(
     API_URLS.SERVICE_LOCATIONS,
     undefined,
     ServiceLocationsApiResponseCodec
   );
-  return locations;
+  return { throttling, locations };
 };
 
 export const runOnceMonitor = async ({

--- a/x-pack/plugins/uptime/public/state/reducers/monitor_management.ts
+++ b/x-pack/plugins/uptime/public/state/reducers/monitor_management.ts
@@ -23,8 +23,7 @@ import {
   MonitorManagementListResult,
   ServiceLocations,
   ThrottlingOptions,
-  BandwidthLimitKey,
-  DEFAULT_BANDWIDTH_LIMIT,
+  DEFAULT_THROTTLING,
 } from '../../../common/runtime_types';
 
 export interface MonitorManagementList {
@@ -35,12 +34,6 @@ export interface MonitorManagementList {
   syntheticsService: { isAllowed?: boolean; loading: boolean };
   throttling: ThrottlingOptions;
 }
-
-const defaultThrottling = {
-  [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
-  [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
-  [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
-};
 
 export const initialState: MonitorManagementList = {
   list: {
@@ -61,7 +54,7 @@ export const initialState: MonitorManagementList = {
   syntheticsService: {
     loading: false,
   },
-  throttling: defaultThrottling,
+  throttling: DEFAULT_THROTTLING,
 };
 
 export const monitorManagementListReducer = createReducer(initialState, (builder) => {
@@ -131,7 +124,7 @@ export const monitorManagementListReducer = createReducer(initialState, (builder
           serviceLocations: null,
         },
         locations: action.payload.locations,
-        throttling: action.payload.throttling || defaultThrottling,
+        throttling: action.payload.throttling || DEFAULT_THROTTLING,
       })
     )
     .addCase(

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.test.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.test.ts
@@ -6,6 +6,7 @@
  */
 import axios from 'axios';
 import { getServiceLocations } from './get_service_locations';
+import { BandwidthLimitKey } from '../../../common/runtime_types';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -14,6 +15,11 @@ describe('getServiceLocations', function () {
   mockedAxios.get.mockRejectedValue('Network error: Something went wrong');
   mockedAxios.get.mockResolvedValue({
     data: {
+      throttling: {
+        [BandwidthLimitKey.DOWNLOAD]: 100,
+        [BandwidthLimitKey.UPLOAD]: 50,
+        [BandwidthLimitKey.LATENCY]: 20,
+      },
       locations: {
         us_central: {
           url: 'https://local.dev',
@@ -26,7 +32,8 @@ describe('getServiceLocations', function () {
       },
     },
   });
-  it('should return parsed locations', async () => {
+
+  it('should return parsed locations and throttling', async () => {
     const locations = await getServiceLocations({
       config: {
         service: {
@@ -40,6 +47,11 @@ describe('getServiceLocations', function () {
     });
 
     expect(locations).toEqual({
+      throttling: {
+        [BandwidthLimitKey.DOWNLOAD]: 100,
+        [BandwidthLimitKey.UPLOAD]: 50,
+        [BandwidthLimitKey.LATENCY]: 20,
+      },
       locations: [
         {
           geo: {

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/synthetics_service.ts
@@ -28,6 +28,7 @@ import {
   MonitorFields,
   ServiceLocations,
   SyntheticsMonitor,
+  ThrottlingOptions,
   SyntheticsMonitorWithId,
 } from '../../../common/runtime_types';
 import { getServiceLocations } from './get_service_locations';
@@ -50,6 +51,7 @@ export class SyntheticsService {
   private apiKey: SyntheticsServiceApiKey | undefined;
 
   public locations: ServiceLocations;
+  public throttling: ThrottlingOptions | undefined;
 
   private indexTemplateExists?: boolean;
   private indexTemplateInstalling?: boolean;
@@ -104,8 +106,10 @@ export class SyntheticsService {
 
   public async registerServiceLocations() {
     const service = this;
+
     try {
       const result = await getServiceLocations(service.server);
+      service.throttling = result.throttling;
       service.locations = result.locations;
       service.apiClient.locations = result.locations;
     } catch (e) {

--- a/x-pack/plugins/uptime/server/rest_api/synthetics_service/get_service_locations.ts
+++ b/x-pack/plugins/uptime/server/rest_api/synthetics_service/get_service_locations.ts
@@ -15,7 +15,8 @@ export const getServiceLocationsRoute: UMRestApiRouteFactory = () => ({
   validate: {},
   handler: async ({ server }): Promise<any> => {
     if (server.syntheticsService.locations.length > 0) {
-      return { locations: server.syntheticsService.locations };
+      const { throttling, locations } = server.syntheticsService;
+      return { throttling, locations };
     }
 
     return getServiceLocations(server);


### PR DESCRIPTION
> ⚠️ **WARNING**: Please notice that part of this functionality (latency alerts) should _not_ be shown anymore as per the following PR: https://github.com/elastic/kibana/pull/129597. Make sure to test the requirements in that PR instead of this one.

## Summary

This PR addresses the Synthetics Service issue about network bandwidth limits. I can't link it here as it's on a non-public repo.

It does so by adding warnings for when the user exceeds throttling limits, or does not enable throttling when assigning monitors to a location.

![Screenshot 2022-03-17 at 11 24 38](https://user-images.githubusercontent.com/6868147/158799294-3e69774c-e468-45c4-8e06-080c0fd456d6.png)

![Screenshot 2022-03-17 at 11 24 27](https://user-images.githubusercontent.com/6868147/158799305-572ce051-18c0-4041-9bd2-7681e040cebd.png)

## How to test this PR Locally

1. Create a new `manifest.json` with the following content and place it under a folder named, for example, `manifest_folder`.
    ```json
    {
      "throttling": {
        "downloadBandwidthLimit": 20,
        "uploadBandwidthLimit": 10,
        "latencyLimit": 5000
      },
      "locations": {
        "Local Synth Node [MANIFEST]": {
          "url": "https://localhost:10001",
          "geo": {
            "name": "Example - Local",
            "location": {"lat": 41.25, "lon": -95.86}
          },
          "status": "beta"
        }
      }
    }
    ```
2. Run an HTTP server to serve the contents of the `manifest_folder`
    ```
    $ npx http-server manifest_folder --port 8082
    ```
3. In Kibana's config, fill the following options:
    ```yaml
    # Make sure your pods will be able to send data to ES which should be bound to your host's 9200 port
    xpack.uptime.service.hosts: [http://host.docker.internal:9200]
    
    # Add the URL for the manifest with the `throttling` configs you're serving
    xpack.uptime.service.manifestUrl: http://localhost:8082/manifest.json

    # Make sure to disable the devUrl so you're only fetching locations from the `manifest` as we'll do in production
    # xpack.uptime.service.devUrl: https://localhost:10001

    # Enable the Monitor Management UI
    xpack.uptime.ui.monitorManagement.enabled: true
    ```
4. Run the service locally
    ```
    $ DEV=true LOGLEVEL=trace CACERTFILE=./k8s/cert-test/build/bundle.pem SERVERCERT=./k8s/cert-test/build/local-server.pem SERVERKEYFILE=./k8s/cert-test/build/local-server.key PORT=10001 ./synthetics-service
    ```
5. Run Kibana and try to add a monitor. You should see the warnings above when exceeding the limits defined in your `manifest.json` file.
6. Disable throttling and you should see a warning about the automatic caps.
7. Create a monitor with a particular throttling value set and save it. Use the following code for that monitor:
    ```js
    step("load homepage", async () => {
        await page.goto('https://www.fast.com');
    });
    
    step("wait for test", async () => {
      await page.waitForSelector('#show-more-details-link');
      await page.waitForTimeout(10000);
      await page.click("#show-more-details-link");
    });
    
    step("wait for up/lat", async () => {
      await page.waitForSelector(".extra-measurement-value-container.succeeded");
      await page.waitForTimeout(10000);
    });
    ```
8. Wait for that monitor to run and ensure your throttling values have been applied.
9. Create a monitor with throttling disabled using the same script as above and confirm that your script has not been throtted.
    ⚠️ It will be throttled on the service because of platform limits.
10. Create a monitor with throttling values which exceed the limits for the node. You should still be able to save such monitors.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials -> **Do we need this now or should we wait until we're out of beta?**
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release note

Show warning when users exceed a Synthetics Node throttling limits.