### PR TITLE
[i18n] a few docs updates

### DIFF
--- a/docs/developer/contributing/index.asciidoc
+++ b/docs/developer/contributing/index.asciidoc
@@ -30,8 +30,8 @@ Please make sure you have signed the [Contributor License Agreement](http://www.
 
 Read <<kibana-localization-best-practices>> for details on our localization practices.
 
-Note that we cannot support accepting contributions to the translations from any source other than the translators we have engaged to do the work.
-We are still to develop a proper process to accept any contributed translations. We certainly appreciate that people care enough about the localization effort to want to help improve the quality. We aim to build out a more comprehensive localization process for the future and will notify you once contributions can be supported, but for the time being, we are not able to incorporate suggestions.
+Note that we cannot support accepting contributions to the translations from any source other than the translators we have engaged in doing the work.
+We are yet to develop a proper process to accept any contributed translations. We certainly appreciate that people care enough about the localization effort to want to help improve the quality. We aim to build out a more comprehensive localization process for the future and will notify you once Kibana supports external contributions. Still, for the time being, we cannot incorporate suggestions.
 
 [discrete]
 [[kibana-release-notes-process]]
@@ -73,7 +73,7 @@ To make sure that your PR is included in the Release Notes, add the right label.
   * `release_note:fix` — Fixes for bugs that existed in the previous release. 
   * `release_note:deprecation` — Deprecates functionality that existed in previous releases.
   * `release_note:breaking` — Breaking changes that weren't present in previous releases.
-  * `release_note:skip` — Changes that should not appear in the Release Notes. For example, docs, build, and test fixes, or unreleased issues that are only in `master`.
+  * `release_note:skip` — Changes that should not appear in the Release Notes. For example, docs, build, and test fixes, or unreleased issues that are only in `main`.
 
 
 include::development-github.asciidoc[leveloffset=+1]

--- a/docs/developer/plugin/external-plugin-localization.asciidoc
+++ b/docs/developer/plugin/external-plugin-localization.asciidoc
@@ -83,18 +83,12 @@ node scripts/i18n_check --fix --include-config ../kibana-extra/myPlugin/.i18nrc.
 [discrete]
 === Implementing i18n in the UI
 
-{kib} relies on several UI frameworks (ReactJS and AngularJS) and
-requires localization in different environments (browser and NodeJS).
+{kib} relies on ReactJS and requires localization in different environments (browser and NodeJS).
 The internationalization engine is framework agnostic and consumable in
-all parts of {kib} (ReactJS, AngularJS and NodeJS).
+all parts of {kib} (ReactJS, and NodeJS).
 
-To simplify
-internationalization in UI frameworks, additional abstractions are
-built around the I18n engine: `react-intl` for React and custom
-components for AngularJS. https://github.com/yahoo/react-intl[React-intl]
-is built around https://github.com/yahoo/intl-messageformat[intl-messageformat],
-so both React and AngularJS frameworks use the same engine and the same
-message syntax.
+To simplify internationalization in React, an additional abstraction is
+built around the I18n engine using https://github.com/yahoo/react-intl[React-intl] for React.
 
 
 [discrete]
@@ -109,7 +103,7 @@ export const HELLO_WORLD = i18n.translate('hello.wonderful.world', {
 });
 -----------
 
-Full details are {kib-repo}tree/master/packages/kbn-i18n#vanilla-js[here].
+Full details are {kib-repo}tree/main/packages/kbn-i18n#vanilla-js[here].
 
 [discrete]
 ==== i18n for React
@@ -133,14 +127,14 @@ export const Component = () => {
 };
 -----------
 
-Full details are {kib-repo}tree/master/packages/kbn-i18n#react[here].
+Full details are {kib-repo}tree/main/packages/kbn-i18n#react[here].
 
 [discrete]
 === Resources
 
-To learn more about i18n tooling, see {blob}src/dev/i18n/README.md[i18n dev tooling].
+To learn more about i18n tooling, see {kib-repo}blob/{branch}src/dev/i18n/README.md[i18n dev tooling].
 
 To learn more about implementing i18n in the UI, use the following links:
 
-* {blob}packages/kbn-i18n/README.md[i18n plugin]
-* {blob}packages/kbn-i18n/GUIDELINE.md[i18n guidelines]
+* {kib-repo}blob/{branch}packages/kbn-i18n/README.md[i18n plugin]
+* {kib-repo}blob/{branch}packages/kbn-i18n/GUIDELINE.md[i18n guidelines]

--- a/docs/settings/i18n-settings.asciidoc
+++ b/docs/settings/i18n-settings.asciidoc
@@ -16,3 +16,4 @@ You do not need to configure any settings to run Kibana in English.
   * English - `en` (default)
   * Chinese - `zh-CN`
   * Japanese - `ja-JP`
+  * French - `fr-FR`


### PR DESCRIPTION
- update broken links
- replace master -> main
- rephrase the note about the external contributions.
- add french as a supported language
- remove angular from the i18n docs

