### PR TITLE
Add Fleet authz checks to CSP endpoints

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/server/plugin.ts
@@ -18,6 +18,7 @@ import type {
   CspServerPluginStart,
   CspServerPluginSetupDeps,
   CspServerPluginStartDeps,
+  CspRequestHandlerContext,
 } from './types';
 import { defineRoutes } from './routes';
 import { cspRuleAssetType } from './saved_objects/cis_1_4_1/csp_rule_type';
@@ -55,7 +56,7 @@ export class CspPlugin
 
     core.savedObjects.registerType(cspRuleAssetType);
 
-    const router = core.http.createRouter();
+    const router = core.http.createRouter<CspRequestHandlerContext>();
 
     // Register server side APIs
     defineRoutes(router, cspAppContext);

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
@@ -23,6 +23,7 @@ import { BENCHMARKS_ROUTE_PATH, CIS_KUBERNETES_PACKAGE_NAME } from '../../../com
 import { CspAppContext } from '../../plugin';
 import type { Benchmark } from '../../../common/types';
 import { isNonNullable } from '../../../common/utils/helpers';
+import { CspRouter } from '../../types';
 
 type BenchmarksQuerySchema = TypeOf<typeof benchmarksInputSchema>;
 
@@ -132,13 +133,17 @@ const createBenchmarks = (
       .filter(isNonNullable);
   });
 
-export const defineGetBenchmarksRoute = (router: IRouter, cspContext: CspAppContext): void =>
+export const defineGetBenchmarksRoute = (router: CspRouter, cspContext: CspAppContext): void =>
   router.get(
     {
       path: BENCHMARKS_ROUTE_PATH,
       validate: { query: benchmarksInputSchema },
     },
     async (context, request, response) => {
+      if (!context.fleet.authz.fleet.all) {
+        return response.forbidden();
+      }
+
       try {
         const soClient = context.core.savedObjects.client;
         const { query } = request;

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.ts
@@ -19,6 +19,7 @@ import { CspAppContext } from '../../plugin';
 import { getResourcesTypes } from './get_resources_types';
 import { getClusters } from './get_clusters';
 import { getStats } from './get_stats';
+import { CspRouter } from '../../types';
 
 export interface ClusterBucket {
   ordered_top_hits: AggregationsTopHitsAggregate;
@@ -75,7 +76,7 @@ const getLatestCyclesIds = async (esClient: ElasticsearchClient): Promise<string
 
 // TODO: Utilize ES "Point in Time" feature https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html
 export const defineGetComplianceDashboardRoute = (
-  router: IRouter,
+  router: CspRouter,
   cspContext: CspAppContext
 ): void =>
   router.get(

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -24,6 +24,7 @@ import { CspRuleSchema, cspRuleAssetSavedObjectType } from '../../../common/sche
 import { UPDATE_RULES_CONFIG_ROUTE_PATH } from '../../../common/constants';
 import { CIS_KUBERNETES_PACKAGE_NAME } from '../../../common/constants';
 import { PackagePolicyServiceInterface } from '../../../../fleet/server';
+import { CspRouter } from '../../types';
 
 export const getPackagePolicy = async (
   soClient: SavedObjectsClientContract,
@@ -99,13 +100,17 @@ export const updatePackagePolicy = (
   return packagePolicyService.update(soClient, esClient, packagePolicy.id, updatedPackagePolicy);
 };
 
-export const defineUpdateRulesConfigRoute = (router: IRouter, cspContext: CspAppContext): void =>
+export const defineUpdateRulesConfigRoute = (router: CspRouter, cspContext: CspAppContext): void =>
   router.post(
     {
       path: UPDATE_RULES_CONFIG_ROUTE_PATH,
       validate: { query: configurationUpdateInputSchema },
     },
     async (context, request, response) => {
+      if (!context.fleet.authz.fleet.all) {
+        return response.forbidden();
+      }
+
       try {
         const esClient = context.core.elasticsearch.client.asCurrentUser;
         const soClient = context.core.savedObjects.client;

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { IRouter, Logger } from 'src/core/server';
+import type { Logger } from 'src/core/server';
 import { SearchRequest, QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 import { QueryDslBoolQuery } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
@@ -16,6 +16,7 @@ import { getLatestCycleIds } from './get_latest_cycle_ids';
 
 import { CSP_KUBEBEAT_INDEX_PATTERN, FINDINGS_ROUTE_PATH } from '../../../common/constants';
 import { CspAppContext } from '../../plugin';
+import { CspRouter } from '../../types';
 
 type FindingsQuerySchema = TypeOf<typeof findingsInputSchema>;
 
@@ -103,7 +104,7 @@ const buildOptionsRequest = (queryParams: FindingsQuerySchema): FindingsOptions 
   ...getSearchFields(queryParams.fields),
 });
 
-export const defineFindingsIndexRoute = (router: IRouter, cspContext: CspAppContext): void =>
+export const defineFindingsIndexRoute = (router: CspRouter, cspContext: CspAppContext): void =>
   router.get(
     {
       path: FINDINGS_ROUTE_PATH,

--- a/x-pack/plugins/cloud_security_posture/server/routes/index.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/index.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import type { IRouter } from '../../../../../src/core/server';
 import { defineGetComplianceDashboardRoute } from './compliance_dashboard/compliance_dashboard';
 import { defineGetBenchmarksRoute } from './benchmarks/benchmarks';
 import { defineFindingsIndexRoute as defineGetFindingsIndexRoute } from './findings/findings';
 import { defineUpdateRulesConfigRoute } from './configuration/update_rules_configuration';
 import { CspAppContext } from '../plugin';
+import { CspRouter } from '../types';
 
-export function defineRoutes(router: IRouter, cspContext: CspAppContext) {
+export function defineRoutes(router: CspRouter, cspContext: CspAppContext) {
   defineGetComplianceDashboardRoute(router, cspContext);
   defineGetFindingsIndexRoute(router, cspContext);
   defineGetBenchmarksRoute(router, cspContext);

--- a/x-pack/plugins/cloud_security_posture/server/types.ts
+++ b/x-pack/plugins/cloud_security_posture/server/types.ts
@@ -10,7 +10,14 @@ import type {
   PluginStart as DataPluginStart,
 } from '../../../../src/plugins/data/server';
 
-import type { FleetStartContract } from '../../fleet/server';
+import type {
+  RouteMethod,
+  KibanaResponseFactory,
+  RequestHandler,
+  IRouter,
+} from '../../../../src/core/server';
+
+import type { FleetStartContract, FleetRequestHandlerContext } from '../../fleet/server';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CspServerPluginSetup {}
@@ -29,3 +36,23 @@ export interface CspServerPluginStartDeps {
   data: DataPluginStart;
   fleet: FleetStartContract;
 }
+
+export type CspRequestHandlerContext = FleetRequestHandlerContext;
+
+/**
+ * Convenience type for request handlers in CSP that includes the CspRequestHandlerContext type
+ * @internal
+ */
+export type CspRequestHandler<
+  P = unknown,
+  Q = unknown,
+  B = unknown,
+  Method extends RouteMethod = any,
+  ResponseFactory extends KibanaResponseFactory = KibanaResponseFactory
+> = RequestHandler<P, Q, B, CspRequestHandlerContext, Method, ResponseFactory>;
+
+/**
+ * Convenience type for routers in Csp that includes the CspRequestHandlerContext type
+ * @internal
+ */
+export type CspRouter = IRouter<CspRequestHandlerContext>;


### PR DESCRIPTION
## Summary

Since the CSP plugin is using Fleet's internal APIs, it needs to be enforcing that the end user has access to Fleet privileges. This PR fixes this issue.

@kfirpeled would someone from your team be able to take this forward to complete? We need to have this included in 8.2.0 to avoid any security issues.

To do:
- [ ] Add API tests

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
