### PR TITLE
[vscode] automatically disable repo discovery

### DIFF
--- a/packages/kbn-dev-utils/src/vscode_config/managed_config_keys.ts
+++ b/packages/kbn-dev-utils/src/vscode_config/managed_config_keys.ts
@@ -51,6 +51,10 @@ export const MANAGED_CONFIG_KEYS: ManagedConfigKey[] = [
     value: true,
   },
   {
+    key: 'git.autoRepositoryDetection',
+    value: false,
+  },
+  {
     key: 'typescript.tsserver.maxTsServerMemory',
     value: 4096,
   },


### PR DESCRIPTION
When people end up in the bazel-output for whatever reason VSCode will automatically discover the "repo" at `/private/var/tmp/_bazel_{user}/{hash}/execroot/kibana`. The problem with this is that this "repo" has the `.git` folder from the user's actual Kibana repo but none of files (just symlinks to them). This leads VSCode to report that all of the files are deleted and basically break VSCode's Git integration. I've also seen a number of other issues pop up because of this. I think it's in the best interest of all Kibana devs to just disable this functionality when the Kibana repo is loaded up as a project in VSCode by setting `git.autoRepositoryDetection` to `false` in our project `.vscode/settings.json`.