### PR TITLE
[Security Solution][Rule Preview] Display alert table in rule preview result

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -22,10 +22,11 @@ const AlertSummaryViewComponent: React.FC<{
   timelineId: string;
   title: string;
   goToTable: () => void;
-}> = ({ browserFields, data, eventId, isDraggable, timelineId, title, goToTable }) => {
+  isReadOnly?: boolean;
+}> = ({ browserFields, data, eventId, isDraggable, timelineId, title, goToTable, isReadOnly }) => {
   const summaryRows = useMemo(
-    () => getSummaryRows({ browserFields, data, eventId, isDraggable, timelineId }),
-    [browserFields, data, eventId, isDraggable, timelineId]
+    () => getSummaryRows({ browserFields, data, eventId, isDraggable, timelineId, isReadOnly }),
+    [browserFields, data, eventId, isDraggable, timelineId, isReadOnly]
   );
 
   return <SummaryView rows={summaryRows} title={title} goToTable={goToTable} />;

--- a/x-pack/plugins/security_solution/public/common/components/event_details/columns.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/columns.tsx
@@ -48,6 +48,7 @@ export const getColumns = ({
   toggleColumn,
   getLinkValue,
   isDraggable,
+  isReadOnly,
 }: {
   browserFields: BrowserFields;
   columnHeaders: ColumnHeaderOptions[];
@@ -58,40 +59,45 @@ export const getColumns = ({
   toggleColumn: (column: ColumnHeaderOptions) => void;
   getLinkValue: (field: string) => string | null;
   isDraggable?: boolean;
+  isReadOnly?: boolean;
 }) => [
-  {
-    field: 'values',
-    name: (
-      <EuiText size="xs">
-        <strong>{i18n.ACTIONS}</strong>
-      </EuiText>
-    ),
-    sortable: false,
-    truncateText: false,
-    width: '132px',
-    render: (values: string[] | null | undefined, data: EventFieldsData) => {
-      const label = data.isObjectArray
-        ? i18n.NESTED_COLUMN(data.field)
-        : i18n.VIEW_COLUMN(data.field);
-      const fieldFromBrowserField = getFieldFromBrowserField(
-        [data.category, 'fields', data.field],
-        browserFields
-      );
-      return (
-        <ActionCell
-          aria-label={label}
-          contextId={contextId}
-          data={data}
-          eventId={eventId}
-          fieldFromBrowserField={fieldFromBrowserField}
-          getLinkValue={getLinkValue}
-          toggleColumn={toggleColumn}
-          timelineId={timelineId}
-          values={values}
-        />
-      );
-    },
-  },
+  ...(!isReadOnly
+    ? [
+        {
+          field: 'values',
+          name: (
+            <EuiText size="xs">
+              <strong>{i18n.ACTIONS}</strong>
+            </EuiText>
+          ),
+          sortable: false,
+          truncateText: false,
+          width: '132px',
+          render: (values: string[] | null | undefined, data: EventFieldsData) => {
+            const label = data.isObjectArray
+              ? i18n.NESTED_COLUMN(data.field)
+              : i18n.VIEW_COLUMN(data.field);
+            const fieldFromBrowserField = getFieldFromBrowserField(
+              [data.category, 'fields', data.field],
+              browserFields
+            );
+            return (
+              <ActionCell
+                aria-label={label}
+                contextId={contextId}
+                data={data}
+                eventId={eventId}
+                fieldFromBrowserField={fieldFromBrowserField}
+                getLinkValue={getLinkValue}
+                toggleColumn={toggleColumn}
+                timelineId={timelineId}
+                values={values}
+              />
+            );
+          },
+        },
+      ]
+    : []),
   {
     field: 'field',
     className: 'eventFieldsTable__fieldNameCell',

--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -69,6 +69,7 @@ interface Props {
   timelineId: string;
   hostRisk: HostRisk | null;
   handleOnEventClosed: () => void;
+  isReadOnly?: boolean;
 }
 
 export const Indent = styled.div`
@@ -117,6 +118,7 @@ const EventDetailsComponent: React.FC<Props> = ({
   timelineTabType,
   hostRisk,
   handleOnEventClosed,
+  isReadOnly,
 }) => {
   const [selectedTabId, setSelectedTabId] = useState<EventViewId>(EventsViewType.summaryView);
   const handleTabClick = useCallback(
@@ -168,6 +170,7 @@ const EventDetailsComponent: React.FC<Props> = ({
                   indexName={indexName}
                   timelineId={timelineId}
                   handleOnEventClosed={handleOnEventClosed}
+                  isReadOnly={isReadOnly}
                 />
                 <EuiSpacer size="l" />
                 <Reason eventId={id} data={data} />
@@ -181,6 +184,7 @@ const EventDetailsComponent: React.FC<Props> = ({
                     isDraggable,
                     timelineId,
                     title: i18n.HIGHLIGHTED_FIELDS,
+                    isReadOnly,
                   }}
                   goToTable={goToTableTab}
                 />
@@ -222,12 +226,13 @@ const EventDetailsComponent: React.FC<Props> = ({
       hostRisk,
       goToTableTab,
       handleOnEventClosed,
+      isReadOnly,
     ]
   );
 
   const threatIntelTab = useMemo(
     () =>
-      isAlert
+      isAlert && !isReadOnly
         ? {
             id: EventsViewType.threatIntelView,
             'data-test-subj': 'threatIntelTab',
@@ -270,7 +275,16 @@ const EventDetailsComponent: React.FC<Props> = ({
             ),
           }
         : undefined,
-    [allEnrichments, setRange, range, enrichmentCount, isAlert, eventFields, isEnrichmentsLoading]
+    [
+      allEnrichments,
+      setRange,
+      range,
+      enrichmentCount,
+      isAlert,
+      eventFields,
+      isEnrichmentsLoading,
+      isReadOnly,
+    ]
   );
 
   const tableTab = useMemo(
@@ -288,11 +302,12 @@ const EventDetailsComponent: React.FC<Props> = ({
             isDraggable={isDraggable}
             timelineId={timelineId}
             timelineTabType={timelineTabType}
+            isReadOnly={isReadOnly}
           />
         </>
       ),
     }),
-    [browserFields, data, id, isDraggable, timelineId, timelineTabType]
+    [browserFields, data, id, isDraggable, timelineId, timelineTabType, isReadOnly]
   );
 
   const jsonTab = useMemo(

--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_fields_browser.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_fields_browser.tsx
@@ -37,6 +37,7 @@ interface Props {
   isDraggable?: boolean;
   timelineId: string;
   timelineTabType: TimelineTabs | 'flyout';
+  isReadOnly?: boolean;
 }
 
 const TableWrapper = styled.div`
@@ -137,7 +138,7 @@ const StyledEuiInMemoryTable = styled(EuiInMemoryTable as any)`
 
 /** Renders a table view or JSON view of the `ECS` `data` */
 export const EventFieldsBrowser = React.memo<Props>(
-  ({ browserFields, data, eventId, isDraggable, timelineTabType, timelineId }) => {
+  ({ browserFields, data, eventId, isDraggable, timelineTabType, timelineId, isReadOnly }) => {
     const containerElement = useRef<HTMLDivElement | null>(null);
     const dispatch = useDispatch();
     const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
@@ -219,6 +220,7 @@ export const EventFieldsBrowser = React.memo<Props>(
           toggleColumn,
           getLinkValue,
           isDraggable,
+          isReadOnly,
         }),
       [
         browserFields,
@@ -230,6 +232,7 @@ export const EventFieldsBrowser = React.memo<Props>(
         toggleColumn,
         getLinkValue,
         isDraggable,
+        isReadOnly,
       ]
     );
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
@@ -227,12 +227,14 @@ export const getSummaryRows = ({
   timelineId,
   eventId,
   isDraggable = false,
+  isReadOnly = false,
 }: {
   data: TimelineEventsDetailsItem[];
   browserFields: BrowserFields;
   timelineId: string;
   eventId: string;
   isDraggable?: boolean;
+  isReadOnly?: boolean;
 }) => {
   const eventCategories = getEventCategoriesFromData(data);
 
@@ -280,6 +282,7 @@ export const getSummaryRows = ({
             field,
           }),
           isDraggable,
+          isReadOnly,
         };
 
         if (field.id === 'agent.id' && !isAlertFromEndpointEvent({ data })) {

--- a/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
@@ -56,6 +56,7 @@ export interface AlertSummaryRow {
   title: string;
   description: EnrichedFieldInfo & {
     isDraggable?: boolean;
+    isReadOnly?: boolean;
   };
 }
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/overview/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/overview/index.tsx
@@ -26,7 +26,7 @@ import {
   SIGNAL_STATUS_FIELD_NAME,
 } from '../../../../timelines/components/timeline/body/renderers/constants';
 import { FormattedFieldValue } from '../../../../timelines/components/timeline/body/renderers/formatted_field';
-import { OverviewCardWithActions } from '../overview/overview_card';
+import { OverviewCardWithActions, OverviewCard } from '../overview/overview_card';
 import { StatusPopoverButton } from '../overview/status_popover_button';
 import { SeverityBadge } from '../../../../../public/detections/components/rules/severity_badge';
 import { useThrottledResizeObserver } from '../../utils';
@@ -44,10 +44,20 @@ interface Props {
   handleOnEventClosed: () => void;
   indexName: string;
   timelineId: string;
+  isReadOnly?: boolean;
 }
 
 export const Overview = React.memo<Props>(
-  ({ browserFields, contextId, data, eventId, handleOnEventClosed, indexName, timelineId }) => {
+  ({
+    browserFields,
+    contextId,
+    data,
+    eventId,
+    handleOnEventClosed,
+    indexName,
+    timelineId,
+    isReadOnly,
+  }) => {
     const statusData = useMemo(() => {
       const item = find({ field: SIGNAL_STATUS_FIELD_NAME, category: 'kibana' }, data);
       return (
@@ -106,71 +116,83 @@ export const Overview = React.memo<Props>(
       );
     }, [browserFields, contextId, data, eventId, timelineId]);
 
-    const signalCard = hasData(statusData) ? (
-      <EuiFlexItem key="status">
-        <OverviewCardWithActions
-          title={SIGNAL_STATUS}
-          enrichedFieldInfo={statusData}
-          contextId={contextId}
-        >
-          <StatusPopoverButton
-            eventId={eventId}
-            contextId={contextId}
+    const signalCard =
+      hasData(statusData) && !isReadOnly ? (
+        <EuiFlexItem key="status">
+          <OverviewCardWithActions
+            title={SIGNAL_STATUS}
             enrichedFieldInfo={statusData}
-            indexName={indexName}
-            timelineId={timelineId}
-            handleOnEventClosed={handleOnEventClosed}
-          />
-        </OverviewCardWithActions>
-      </EuiFlexItem>
-    ) : null;
+            contextId={contextId}
+          >
+            <StatusPopoverButton
+              eventId={eventId}
+              contextId={contextId}
+              enrichedFieldInfo={statusData}
+              indexName={indexName}
+              timelineId={timelineId}
+              handleOnEventClosed={handleOnEventClosed}
+            />
+          </OverviewCardWithActions>
+        </EuiFlexItem>
+      ) : null;
 
     const severityCard = hasData(severityData) ? (
       <EuiFlexItem key="severity">
-        <OverviewCardWithActions
-          title={ALERTS_HEADERS_SEVERITY}
-          enrichedFieldInfo={severityData}
-          contextId={contextId}
-        >
-          <SeverityBadge value={severityData.values[0] as Severity} />
-        </OverviewCardWithActions>
+        {!isReadOnly ? (
+          <OverviewCardWithActions
+            title={ALERTS_HEADERS_SEVERITY}
+            enrichedFieldInfo={severityData}
+            contextId={contextId}
+          >
+            <SeverityBadge value={severityData.values[0] as Severity} />
+          </OverviewCardWithActions>
+        ) : (
+          <OverviewCard title={ALERTS_HEADERS_SEVERITY}>
+            <SeverityBadge value={severityData.values[0] as Severity} />
+          </OverviewCard>
+        )}
       </EuiFlexItem>
     ) : null;
 
     const riskScoreCard = hasData(riskScoreData) ? (
       <EuiFlexItem key="riskScore">
-        <OverviewCardWithActions
-          title={ALERTS_HEADERS_RISK_SCORE}
-          enrichedFieldInfo={riskScoreData}
-          contextId={contextId}
-          dataTestSubj="riskScore"
-        >
-          {riskScoreData.values[0]}
-        </OverviewCardWithActions>
+        {!isReadOnly ? (
+          <OverviewCardWithActions
+            title={ALERTS_HEADERS_RISK_SCORE}
+            enrichedFieldInfo={riskScoreData}
+            contextId={contextId}
+            dataTestSubj="riskScore"
+          >
+            {riskScoreData.values[0]}
+          </OverviewCardWithActions>
+        ) : (
+          <OverviewCard title={ALERTS_HEADERS_RISK_SCORE}>{riskScoreData.values[0]}</OverviewCard>
+        )}
       </EuiFlexItem>
     ) : null;
 
-    const ruleNameCard = hasData(ruleNameData) ? (
-      <EuiFlexItem key="ruleName">
-        <OverviewCardWithActions
-          title={ALERTS_HEADERS_RULE}
-          enrichedFieldInfo={ruleNameData}
-          contextId={contextId}
-        >
-          <FormattedFieldValue
+    const ruleNameCard =
+      hasData(ruleNameData) && !isReadOnly ? (
+        <EuiFlexItem key="ruleName">
+          <OverviewCardWithActions
+            title={ALERTS_HEADERS_RULE}
+            enrichedFieldInfo={ruleNameData}
             contextId={contextId}
-            eventId={eventId}
-            value={ruleNameData.values[0]}
-            fieldName={ruleNameData.data.field}
-            linkValue={ruleNameData.linkValue}
-            fieldType={ruleNameData.data.type}
-            fieldFormat={ruleNameData.data.format}
-            isDraggable={false}
-            truncate={false}
-          />
-        </OverviewCardWithActions>
-      </EuiFlexItem>
-    ) : null;
+          >
+            <FormattedFieldValue
+              contextId={contextId}
+              eventId={eventId}
+              value={ruleNameData.values[0]}
+              fieldName={ruleNameData.data.field}
+              linkValue={ruleNameData.linkValue}
+              fieldType={ruleNameData.data.type}
+              fieldFormat={ruleNameData.data.format}
+              isDraggable={false}
+              truncate={false}
+            />
+          </OverviewCardWithActions>
+        </EuiFlexItem>
+      ) : null;
 
     const { width, ref } = useThrottledResizeObserver();
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.tsx
@@ -20,6 +20,7 @@ export const SummaryValueCell: React.FC<AlertSummaryRow['description']> = ({
   linkValue,
   timelineId,
   values,
+  isReadOnly,
 }) => (
   <>
     <FieldValueCell
@@ -32,7 +33,7 @@ export const SummaryValueCell: React.FC<AlertSummaryRow['description']> = ({
       style={{ flexGrow: 0 }}
       values={values}
     />
-    {timelineId !== TimelineId.active && (
+    {timelineId !== TimelineId.active && !isReadOnly && (
       <ActionCell
         contextId={timelineId}
         data={data}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.test.tsx
@@ -17,6 +17,7 @@ import { PreviewHistogram } from './preview_histogram';
 
 jest.mock('../../../../common/containers/use_global_time');
 jest.mock('./use_preview_histogram');
+jest.mock('../../../../common/lib/kibana');
 
 describe('PreviewHistogram', () => {
   const mockSetQuery = jest.fn();

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
@@ -11,7 +11,6 @@ import { Unit } from '@elastic/datemath';
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiSpacer, EuiLoadingChart } from '@elastic/eui';
 import styled from 'styled-components';
 import { Type } from '@kbn/securitysolution-io-ts-alerting-types';
-import { getDefaultControlColumn } from '../../../../timelines/components/timeline/body/control_columns';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useKibana } from '../../../../common/lib/kibana';
 import * as i18n from './translations';
@@ -33,6 +32,7 @@ import { FIELDS_WITHOUT_CELL_ACTIONS } from '../../../../common/lib/cell_actions
 import { useSourcererDataView } from '../../../../common/containers/sourcerer';
 import { DetailsPanel } from '../../../../timelines/components/side_panel';
 import { PreviewRenderCellValue } from './preview_table_cell_renderer';
+import { getPreviewTableControlColumn } from './preview_table_control_columns';
 
 const LoadingChart = styled(EuiLoadingChart)`
   display: block;
@@ -225,7 +225,7 @@ export const PreviewHistogram = ({
           start: from,
           tGridEventRenderedViewEnabled,
           type: 'embedded',
-          leadingControlColumns: getDefaultControlColumn(1),
+          leadingControlColumns: getPreviewTableControlColumn(1.5),
         })}
         <DetailsPanel
           browserFields={browserFields}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
@@ -234,6 +234,7 @@ export const PreviewHistogram = ({
           isFlyoutView
           runtimeMappings={runtimeMappings}
           timelineId={TimelineId.detectionsPage}
+          isReadOnly
         />
       </CasesContext>
     </>

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
@@ -25,7 +25,6 @@ import { usePreviewHistogram } from './use_preview_histogram';
 import { formatDate } from '../../../../common/components/super_date_picker';
 import { FieldValueThreshold } from '../threshold_input';
 import { alertsDefaultModel } from '../../alerts_table/default_config';
-import { RenderCellValue } from '../../../configurations/security_solution_detections';
 import { SourcererScopeName } from '../../../../common/store/sourcerer/model';
 import { defaultRowRenderers } from '../../../../timelines/components/timeline/body/renderers';
 import { TimelineId } from '../../../../../common/types';
@@ -33,6 +32,7 @@ import { APP_ID, APP_UI_ID, DEFAULT_PREVIEW_INDEX } from '../../../../../common/
 import { FIELDS_WITHOUT_CELL_ACTIONS } from '../../../../common/lib/cell_actions/constants';
 import { useSourcererDataView } from '../../../../common/containers/sourcerer';
 import { DetailsPanel } from '../../../../timelines/components/side_panel';
+import { PreviewRenderCellValue } from './preview_table_cell_renderer';
 
 const LoadingChart = styled(EuiLoadingChart)`
   display: block;
@@ -217,7 +217,7 @@ export const PreviewHistogram = ({
           itemsPerPageOptions,
           kqlMode,
           query: { query: `kibana.alert.rule.uuid:${previewId}`, language: 'kuery' },
-          renderCellValue: RenderCellValue,
+          renderCellValue: PreviewRenderCellValue,
           rowRenderers: defaultRowRenderers,
           runtimeMappings,
           setQuery: () => {},

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
@@ -33,10 +33,19 @@ import { useSourcererDataView } from '../../../../common/containers/sourcerer';
 import { DetailsPanel } from '../../../../timelines/components/side_panel';
 import { PreviewRenderCellValue } from './preview_table_cell_renderer';
 import { getPreviewTableControlColumn } from './preview_table_control_columns';
+import { useGlobalFullScreen } from '../../../../common/containers/use_full_screen';
+import { InspectButtonContainer } from '../../../../common/components/inspect';
 
 const LoadingChart = styled(EuiLoadingChart)`
   display: block;
   margin: 0 auto;
+`;
+
+const FullScreenContainer = styled.div<{ $isFullScreen: boolean }>`
+  height: ${({ $isFullScreen }) => ($isFullScreen ? '100%' : undefined)};
+  flex: 1 1 auto;
+  display: flex;
+  width: 100%;
 `;
 
 export const ID = 'previewHistogram';
@@ -86,7 +95,6 @@ export const PreviewHistogram = ({
     dataProviders,
     deletedEventIds,
     kqlMode,
-    isLive,
     itemsPerPage,
     itemsPerPageOptions,
     graphEventId,
@@ -101,6 +109,7 @@ export const PreviewHistogram = ({
     loading: isLoadingIndexPattern,
   } = useSourcererDataView(SourcererScopeName.detections);
 
+  const { globalFullScreen } = useGlobalFullScreen();
   const previousPreviewId = usePrevious(previewId);
   const tGridEventRenderedViewEnabled = useIsExperimentalFeatureEnabled(
     'tGridEventRenderedViewEnabled'
@@ -193,40 +202,44 @@ export const PreviewHistogram = ({
       </Panel>
       <EuiSpacer />
       <CasesContext owner={[APP_ID]} userCanCrud={false}>
-        {timelinesUi.getTGrid<'embedded'>({
-          additionalFilters: <></>,
-          appId: APP_UI_ID,
-          browserFields,
-          columns,
-          dataProviders,
-          deletedEventIds,
-          disabledCellActions: FIELDS_WITHOUT_CELL_ACTIONS,
-          docValueFields,
-          end: to,
-          entityType: 'alerts',
-          filters: [],
-          globalFullScreen: false,
-          graphEventId,
-          hasAlertsCrud: false,
-          id: TimelineId.detectionsPage,
-          indexNames: [`${DEFAULT_PREVIEW_INDEX}-${spaceId}`],
-          indexPattern,
-          isLive,
-          isLoadingIndexPattern,
-          itemsPerPage,
-          itemsPerPageOptions,
-          kqlMode,
-          query: { query: `kibana.alert.rule.uuid:${previewId}`, language: 'kuery' },
-          renderCellValue: PreviewRenderCellValue,
-          rowRenderers: defaultRowRenderers,
-          runtimeMappings,
-          setQuery: () => {},
-          sort,
-          start: from,
-          tGridEventRenderedViewEnabled,
-          type: 'embedded',
-          leadingControlColumns: getPreviewTableControlColumn(1.5),
-        })}
+        <FullScreenContainer $isFullScreen={globalFullScreen}>
+          <InspectButtonContainer>
+            {timelinesUi.getTGrid<'embedded'>({
+              additionalFilters: <></>,
+              appId: APP_UI_ID,
+              browserFields,
+              columns,
+              dataProviders,
+              deletedEventIds,
+              disabledCellActions: FIELDS_WITHOUT_CELL_ACTIONS,
+              docValueFields,
+              end: to,
+              entityType: 'alerts',
+              filters: [],
+              globalFullScreen,
+              graphEventId,
+              hasAlertsCrud: false,
+              id: TimelineId.detectionsPage,
+              indexNames: [`${DEFAULT_PREVIEW_INDEX}-${spaceId}`],
+              indexPattern,
+              isLive: false,
+              isLoadingIndexPattern,
+              itemsPerPage,
+              itemsPerPageOptions,
+              kqlMode,
+              query: { query: `kibana.alert.rule.uuid:${previewId}`, language: 'kuery' },
+              renderCellValue: PreviewRenderCellValue,
+              rowRenderers: defaultRowRenderers,
+              runtimeMappings,
+              setQuery: () => {},
+              sort,
+              start: from,
+              tGridEventRenderedViewEnabled,
+              type: 'embedded',
+              leadingControlColumns: getPreviewTableControlColumn(1.5),
+            })}
+          </InspectButtonContainer>
+        </FullScreenContainer>
         <DetailsPanel
           browserFields={browserFields}
           entityType={'alerts'}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
@@ -63,7 +63,7 @@ export const PreviewHistogram = ({
   index,
 }: PreviewHistogramProps) => {
   const { setQuery, isInitializing } = useGlobalTime();
-  const { timelines: timelinesUi, cases: casesUi } = useKibana().services;
+  const { timelines: timelinesUi, cases } = useKibana().services;
   const from = useMemo(() => `now-1${timeFrame}`, [timeFrame]);
   const to = useMemo(() => 'now', []);
   const startDate = useMemo(() => formatDate(from), [from]);
@@ -156,7 +156,7 @@ export const PreviewHistogram = ({
         : i18n.QUERY_PREVIEW_TITLE(totalCount),
     [isLoading, totalCount, thresholdTotalCount, isThresholdRule]
   );
-  const CasesContext = casesUi.getCasesContext();
+  const CasesContext = cases.ui.getCasesContext();
 
   return (
     <>

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_table_cell_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_table_cell_renderer.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiDataGridCellValueElementProps } from '@elastic/eui';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import { StyledContent } from '../../../../common/lib/cell_actions/expanded_cell_value_actions';
+import { getLinkColumnDefinition } from '../../../../common/lib/cell_actions/helpers';
+import { useGetMappedNonEcsValue } from '../../../../timelines/components/timeline/body/data_driven_columns';
+import { columnRenderers } from '../../../../timelines/components/timeline/body/renderers';
+import { getColumnRenderer } from '../../../../timelines/components/timeline/body/renderers/get_column_renderer';
+import { CellValueElementProps } from '../../../../../../timelines/common';
+
+export const PreviewRenderCellValue: React.FC<
+  EuiDataGridCellValueElementProps & CellValueElementProps
+> = ({
+  browserFields,
+  columnId,
+  data,
+  ecsData,
+  eventId,
+  globalFilters,
+  header,
+  isDetails,
+  isDraggable,
+  isExpandable,
+  isExpanded,
+  linkValues,
+  rowIndex,
+  colIndex,
+  rowRenderers,
+  setCellProps,
+  timelineId,
+  truncate,
+}) => (
+  <PreviewTableCellRenderer
+    browserFields={browserFields}
+    columnId={columnId}
+    data={data}
+    ecsData={ecsData}
+    eventId={eventId}
+    globalFilters={globalFilters}
+    header={header}
+    isDetails={isDetails}
+    isDraggable={isDraggable}
+    isExpandable={isExpandable}
+    isExpanded={isExpanded}
+    linkValues={linkValues}
+    rowIndex={rowIndex}
+    colIndex={colIndex}
+    rowRenderers={rowRenderers}
+    setCellProps={setCellProps}
+    timelineId={timelineId}
+    truncate={truncate}
+  />
+);
+
+export const PreviewTableCellRenderer: React.FC<CellValueElementProps> = ({
+  browserFields,
+  data,
+  ecsData,
+  eventId,
+  header,
+  isDetails,
+  isDraggable,
+  isTimeline,
+  linkValues,
+  rowRenderers,
+  timelineId,
+  truncate,
+}) => {
+  const usersEnabled = useIsExperimentalFeatureEnabled('usersEnabled');
+
+  const asPlainText = useMemo(() => {
+    return (
+      getLinkColumnDefinition(header.id, header.type, undefined, usersEnabled) !== undefined &&
+      !isTimeline
+    );
+  }, [header.id, header.type, isTimeline, usersEnabled]);
+
+  const values = useGetMappedNonEcsValue({
+    data,
+    fieldName: header.id,
+  });
+  const styledContentClassName = isDetails
+    ? 'eui-textBreakWord'
+    : 'eui-displayInlineBlock eui-textTruncate';
+  return (
+    <>
+      <StyledContent className={styledContentClassName} $isDetails={isDetails}>
+        {getColumnRenderer(header.id, columnRenderers, data).renderColumn({
+          asPlainText,
+          browserFields,
+          columnName: header.id,
+          ecsData,
+          eventId,
+          field: header,
+          isDetails,
+          isDraggable,
+          linkValues,
+          rowRenderers,
+          timelineId,
+          truncate,
+          values,
+        })}
+      </StyledContent>
+    </>
+  );
+};

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_table_control_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_table_control_columns.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
+import React from 'react';
+import styled from 'styled-components';
+import { ControlColumnProps, ActionProps } from '../../../../../../timelines/common';
+import {
+  getActionsColumnWidth,
+  DEFAULT_ACTION_BUTTON_WIDTH,
+} from '../../../../../../timelines/public';
+import * as i18n from './translations';
+
+const EventsTdContent = styled.div.attrs(({ className }) => ({
+  className: `siemEventsTable__tdContent ${className != null ? className : ''}`,
+}))<{ textAlign?: string; width?: number }>`
+  font-size: ${({ theme }) => theme.eui.euiFontSizeXS};
+  line-height: ${({ theme }) => theme.eui.euiLineHeight};
+  min-width: 0;
+  padding: ${({ theme }) => theme.eui.paddingSizes.xs};
+  text-align: ${({ textAlign }) => textAlign};
+  width: ${({ width }) =>
+    width != null
+      ? `${width}px`
+      : '100%'}; /* Using width: 100% instead of flex: 1 and max-width: 100% for IE11 */
+
+  button.euiButtonIcon {
+    margin-left: ${({ theme }) => `-${theme.eui.paddingSizes.xs}`};
+  }
+`;
+
+export const getPreviewTableControlColumn = (actionButtonCount: number): ControlColumnProps[] => [
+  {
+    headerCellRender: () => <>{i18n.ACTIONS}</>,
+    id: 'default-timeline-control-column',
+    rowCellRender: PreviewActions,
+    width: getActionsColumnWidth(actionButtonCount),
+  },
+];
+
+const ActionsContainer = styled.div`
+  align-items: center;
+  display: flex;
+`;
+
+const PreviewActionsComponent: React.FC<ActionProps> = ({
+  ariaRowindex,
+  columnValues,
+  onEventDetailsPanelOpened,
+}) => {
+  return (
+    <ActionsContainer>
+      <div key="expand-event">
+        <EventsTdContent textAlign="center" width={DEFAULT_ACTION_BUTTON_WIDTH + 10}>
+          <EuiToolTip data-test-subj="expand-event-tool-tip" content={i18n.VIEW_DETAILS}>
+            <EuiButtonIcon
+              aria-label={i18n.VIEW_DETAILS_FOR_ROW({ ariaRowindex, columnValues })}
+              data-test-subj="expand-event"
+              iconType="expand"
+              onClick={onEventDetailsPanelOpened}
+              size="s"
+            />
+          </EuiToolTip>
+        </EventsTdContent>
+      </div>
+    </ActionsContainer>
+  );
+};
+
+PreviewActionsComponent.displayName = 'PreviewActionsComponent';
+
+export const PreviewActions = React.memo(PreviewActionsComponent);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/translations.ts
@@ -174,3 +174,30 @@ export const QUERY_PREVIEW_SEE_ALL_WARNINGS = i18n.translate(
     defaultMessage: 'See all warnings',
   }
 );
+
+export const ACTIONS = i18n.translate(
+  'xpack.securitySolution.detectionEngine.queryPreview.actions',
+  {
+    defaultMessage: 'Actions',
+  }
+);
+
+export const VIEW_DETAILS = i18n.translate(
+  'xpack.securitySolution.detectionEngine.queryPreview.viewDetailsAriaLabel',
+  {
+    defaultMessage: 'View details',
+  }
+);
+
+export const VIEW_DETAILS_FOR_ROW = ({
+  ariaRowindex,
+  columnValues,
+}: {
+  ariaRowindex: number;
+  columnValues: string;
+}) =>
+  i18n.translate('xpack.securitySolution.detectionEngine.queryPreview.viewDetailsForRowAriaLabel', {
+    values: { ariaRowindex, columnValues },
+    defaultMessage:
+      'View details for the alert or event in row {ariaRowindex}, with columns {columnValues}',
+  });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/index.tsx
@@ -70,6 +70,9 @@ const MyEuiPanel = styled(EuiPanel)<{
       display: none;
     }
   }
+  .euiAccordion__childWrapper {
+    transform: none; /* To circumvent an issue in Eui causing the fullscreen datagrid to break */
+  }
 `;
 
 MyEuiPanel.displayName = 'MyEuiPanel';

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/expandable_event.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/expandable_event.tsx
@@ -40,6 +40,7 @@ interface Props {
   timelineId: string;
   hostRisk: HostRisk | null;
   handleOnEventClosed: HandleOnEventClosed;
+  isReadOnly?: boolean;
 }
 
 interface ExpandableEventTitleProps {
@@ -109,6 +110,7 @@ export const ExpandableEvent = React.memo<Props>(
     hostRisk,
     rawEventData,
     handleOnEventClosed,
+    isReadOnly,
   }) => {
     if (!event.eventId) {
       return <EuiTextColor color="subdued">{i18n.EVENT_DETAILS_PLACEHOLDER}</EuiTextColor>;
@@ -133,6 +135,7 @@ export const ExpandableEvent = React.memo<Props>(
             timelineTabType={timelineTabType}
             hostRisk={hostRisk}
             handleOnEventClosed={handleOnEventClosed}
+            isReadOnly={isReadOnly}
           />
         </StyledEuiFlexItem>
       </StyledFlexGroup>

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
@@ -67,6 +67,7 @@ interface EventDetailsPanelProps {
   runtimeMappings: MappingRuntimeFields;
   tabType: TimelineTabs;
   timelineId: string;
+  isReadOnly?: boolean;
 }
 
 const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
@@ -80,6 +81,7 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
   runtimeMappings,
   tabType,
   timelineId,
+  isReadOnly,
 }) => {
   const [loading, detailsData, rawEventData, ecsData, refetchFlyoutData] = useTimelineEventsDetails(
     {
@@ -234,21 +236,24 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
             timelineTabType="flyout"
             hostRisk={hostRisk}
             handleOnEventClosed={handleOnEventClosed}
+            isReadOnly={isReadOnly}
           />
         )}
       </StyledEuiFlyoutBody>
 
-      <EventDetailsFooter
-        detailsData={detailsData}
-        detailsEcsData={ecsData}
-        expandedEvent={expandedEvent}
-        refetchFlyoutData={refetchFlyoutData}
-        handleOnEventClosed={handleOnEventClosed}
-        isHostIsolationPanelOpen={isHostIsolationPanelOpen}
-        loadingEventDetails={loading}
-        onAddIsolationStatusClick={showHostIsolationPanel}
-        timelineId={timelineId}
-      />
+      {!isReadOnly && (
+        <EventDetailsFooter
+          detailsData={detailsData}
+          detailsEcsData={ecsData}
+          expandedEvent={expandedEvent}
+          refetchFlyoutData={refetchFlyoutData}
+          handleOnEventClosed={handleOnEventClosed}
+          isHostIsolationPanelOpen={isHostIsolationPanelOpen}
+          loadingEventDetails={loading}
+          onAddIsolationStatusClick={showHostIsolationPanel}
+          timelineId={timelineId}
+        />
+      )}
     </CasesContext>
   ) : (
     <CasesContext owner={[APP_ID]} userCanCrud={casesPermissions?.crud ?? false}>
@@ -272,17 +277,19 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
         hostRisk={hostRisk}
         handleOnEventClosed={handleOnEventClosed}
       />
-      <EventDetailsFooter
-        detailsData={detailsData}
-        detailsEcsData={ecsData}
-        expandedEvent={expandedEvent}
-        handleOnEventClosed={handleOnEventClosed}
-        isHostIsolationPanelOpen={isHostIsolationPanelOpen}
-        loadingEventDetails={loading}
-        onAddIsolationStatusClick={showHostIsolationPanel}
-        refetchFlyoutData={refetchFlyoutData}
-        timelineId={timelineId}
-      />
+      {!isReadOnly && (
+        <EventDetailsFooter
+          detailsData={detailsData}
+          detailsEcsData={ecsData}
+          expandedEvent={expandedEvent}
+          handleOnEventClosed={handleOnEventClosed}
+          isHostIsolationPanelOpen={isHostIsolationPanelOpen}
+          loadingEventDetails={loading}
+          onAddIsolationStatusClick={showHostIsolationPanel}
+          refetchFlyoutData={refetchFlyoutData}
+          timelineId={timelineId}
+        />
+      )}
     </CasesContext>
   );
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/index.tsx
@@ -30,6 +30,7 @@ interface DetailsPanelProps {
   runtimeMappings: MappingRuntimeFields;
   tabType?: TimelineTabs;
   timelineId: string;
+  isReadOnly?: boolean;
 }
 
 /**
@@ -47,6 +48,7 @@ export const DetailsPanel = React.memo(
     runtimeMappings,
     tabType,
     timelineId,
+    isReadOnly,
   }: DetailsPanelProps) => {
     const dispatch = useDispatch();
     const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
@@ -90,6 +92,7 @@ export const DetailsPanel = React.memo(
           runtimeMappings={runtimeMappings}
           tabType={activeTab}
           timelineId={timelineId}
+          isReadOnly={isReadOnly}
         />
       );
     }


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/security-team/issues/3187

Adds tgrid-based alerts table to the rule preview results so users can get a more in depth look as to what their potential rule query is returning. This table is designated as read-only, and no actionable items appear as they normally would on the alerts table (open/close alerts, add an exception, etc.). It also includes a control column that allows the user to view the alert details flyout for individual alerts, again, in a read-only manner. 

- [x] Render table with same preview index results as the histogram
- [x] Add alert details flyout functionality 
- [x] Introduce a read-only flag to remove the actionable items 
- [x] Update/add relative tests

To be addressed in follow-up:

- Initial reset fields mentioned in [this comment](https://github.com/elastic/kibana/pull/127986#pullrequestreview-925240529)
- Adding more test coverage
- Extra gray ux padding when table is full


### Screenshots

![Screen Shot 2022-03-24 at 3 56 15 PM](https://user-images.githubusercontent.com/56367316/159999657-d9b92c13-f7e8-4c09-a091-5a4388a16a24.png)


![Screen Shot 2022-03-24 at 3 56 29 PM](https://user-images.githubusercontent.com/56367316/159999659-d409a349-6bf8-4a7b-9a08-2cd450d63208.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
