### PR TITLE
[ci/ftr] add missing break statement

### DIFF
--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -186,6 +186,8 @@ for (const testSuite of testSuites) {
         concurrency_group: UUID,
         concurrency_method: 'eager',
       });
+      break;
+
     case 'cypress':
       const CYPRESS_SUITE = CI_GROUP;
       const group = groups.find((group) => group.key.includes(CYPRESS_SUITE));


### PR DESCRIPTION
There's a missing break statement causing extra groups to be started when trying to run the x-pack accessibility tests in the flaky test runner.