### PR TITLE
fix(NA): propagation of env vars on forced yarn installs

### DIFF
--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -8947,8 +8947,8 @@ const BootstrapCommand = {
       await time('force install dependencies', async () => {
         await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["runBazel"])(['run', '@nodejs//:yarn'], runOffline, {
           env: {
-            "SASS_BINARY_SITE": "https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-sass",
-            "RE2_DOWNLOAD_MIRROR": "https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2"
+            SASS_BINARY_SITE: 'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-sass',
+            RE2_DOWNLOAD_MIRROR: 'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2'
           }
         });
       });

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -8945,7 +8945,12 @@ const BootstrapCommand = {
 
     if (forceInstall) {
       await time('force install dependencies', async () => {
-        await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["runBazel"])(['run', '@nodejs//:yarn'], runOffline);
+        await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["runBazel"])(['run', '@nodejs//:yarn'], runOffline, {
+          env: {
+            "SASS_BINARY_SITE": "https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-sass",
+            "RE2_DOWNLOAD_MIRROR": "https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2"
+          }
+        });
       });
     } // build packages
 

--- a/packages/kbn-pm/src/commands/bootstrap.ts
+++ b/packages/kbn-pm/src/commands/bootstrap.ts
@@ -83,7 +83,14 @@ export const BootstrapCommand: ICommand = {
 
     if (forceInstall) {
       await time('force install dependencies', async () => {
-        await runBazel(['run', '@nodejs//:yarn'], runOffline);
+        await runBazel(['run', '@nodejs//:yarn'], runOffline, {
+          env: {
+            SASS_BINARY_SITE:
+              'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-sass',
+            RE2_DOWNLOAD_MIRROR:
+              'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2',
+          },
+        });
       });
     }
 


### PR DESCRIPTION
This PR fixes a problem we found on mac M1 related with the `macOS@12.3` upgrade which no longer have python by default which allowed us to find the env vars to download `node-sass` binary were not being correctly passed to `yarn forced installs` and resulted in trying to run `node-gyp` locally. 