### PR TITLE
[7.17] chore(NA): upgrade ibazel into v0.16.2 with M1 binaries (#127934)

### DIFF
--- a/package.json
+++ b/package.json
@@ -438,7 +438,7 @@
     "@babel/register": "^7.16.0",
     "@babel/traverse": "^7.16.3",
     "@babel/types": "^7.16.0",
-    "@bazel/ibazel": "^0.15.10",
+    "@bazel/ibazel": "^0.16.2",
     "@bazel/typescript": "^3.8.0",
     "@cypress/snapshot": "^2.1.7",
     "@cypress/webpack-preprocessor": "^5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,10 +1312,10 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.1.tgz#371ba8be66d556812dc7fb169ebc3c08378f69d4"
   integrity sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==
 
-"@bazel/ibazel@^0.15.10":
-  version "0.15.10"
-  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.15.10.tgz#cf0cff1aec6d8e7bb23e1fc618d09fbd39b7a13f"
-  integrity sha512-0v+OwCQ6fsGFa50r6MXWbUkSGuWOoZ22K4pMSdtWiL5LKFIE4kfmMmtQS+M7/ICNwk2EIYob+NRreyi/DGUz5A==
+"@bazel/ibazel@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.16.2.tgz#05dd7f06659759fda30f87b15534f1e42f1201bb"
+  integrity sha512-KgqAWMH0emL6f3xH6nqyTryoBMqlJ627LBIe9PT1PRRQPz2FtHib3FIHJPukp1slzF3hJYZvdiVwgPnHbaSOOA==
 
 "@bazel/typescript@^3.8.0":
   version "3.8.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [chore(NA): upgrade ibazel into v0.16.2 with M1 binaries (#127934)](https://github.com/elastic/kibana/pull/127934)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)