### PR TITLE
[Security Solution] [Investigations] [Tech Debt] `StatefulEventsViewer`: remove `deepEqual` checks and replace `connect` + `mapStateToProps` with `useSelector`

### DIFF
--- a/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
@@ -72,8 +72,8 @@ export const expandFirstAlert = () => {
 
   cy.get(EXPAND_ALERT_BTN)
     .first()
-    .pipe(($el) => $el.trigger('click'))
-    .should('exist');
+    .should('exist')
+    .pipe(($el) => $el.trigger('click'));
 };
 
 export const viewThreatIntelTab = () => cy.get(THREAT_INTEL_TAB).click();

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -6,20 +6,20 @@
  */
 
 import React, { useRef, useCallback, useMemo, useEffect } from 'react';
-import { connect, ConnectedProps, useDispatch } from 'react-redux';
-import deepEqual from 'fast-deep-equal';
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import type { Filter } from '@kbn/es-query';
-import { inputsModel, inputsSelectors, State } from '../../store';
+import { inputsModel, State } from '../../store';
 import { inputsActions } from '../../store/actions';
 import { ControlColumnProps, RowRenderer, TimelineId } from '../../../../common/types/timeline';
 import { APP_ID, APP_UI_ID } from '../../../../common/constants';
-import { timelineSelectors, timelineActions } from '../../../timelines/store/timeline';
-import type { SubsetTimelineModel, TimelineModel } from '../../../timelines/store/timeline/model';
+import { timelineActions } from '../../../timelines/store/timeline';
+import type { SubsetTimelineModel } from '../../../timelines/store/timeline/model';
 import { Status } from '../../../../common/detection_engine/schemas/common/schemas';
 import { InspectButtonContainer } from '../inspect';
 import { useGlobalFullScreen } from '../../containers/use_full_screen';
 import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
+import { eventsViewerSelector } from './selectors';
 import { SourcererScopeName } from '../../store/sourcerer/model';
 import { useSourcererDataView } from '../../containers/sourcerer';
 import type { EntityType } from '../../../../../timelines/common';
@@ -43,7 +43,7 @@ const FullScreenContainer = styled.div<{ $isFullScreen: boolean }>`
   width: 100%;
 `;
 
-export interface OwnProps {
+export interface Props {
   defaultCellActions?: TGridCellAction[];
   defaultModel: SubsetTimelineModel;
   end: string;
@@ -64,51 +64,52 @@ export interface OwnProps {
   unit?: (n: number) => string;
 }
 
-type Props = OwnProps & PropsFromRedux;
-
 /**
  * The stateful events viewer component is the highest level component that is utilized across the security_solution pages layer where
  * timeline is used BESIDES the flyout. The flyout makes use of the `EventsViewer` component which is a subcomponent here
  * NOTE: As of writting, it is not used in the Case_View component
  */
 const StatefulEventsViewerComponent: React.FC<Props> = ({
-  createTimeline,
-  columns,
-  defaultColumns,
-  dataProviders,
   defaultCellActions,
-  deletedEventIds,
-  deleteEventQuery,
+  defaultModel,
   end,
   entityType,
-  excludedRowRendererIds,
-  filters,
-  globalQuery,
   id,
-  isLive,
-  itemsPerPage,
-  itemsPerPageOptions,
-  kqlMode,
   leadingControlColumns,
   pageFilters,
   currentFilter,
   onRuleChange,
-  query,
   renderCellValue,
   rowRenderers,
   start,
   scopeId,
-  showCheckboxes,
-  sort,
-  timelineQuery,
   utilityBar,
   additionalFilters,
-  // If truthy, the graph viewer (Resolver) is showing
-  graphEventId,
   hasAlertsCrud = false,
   unit,
 }) => {
   const dispatch = useDispatch();
+  const {
+    filters,
+    input,
+    query,
+    globalQueries,
+    timelineQuery,
+    timeline: {
+      columns,
+      dataProviders,
+      defaultColumns,
+      deletedEventIds,
+      excludedRowRendererIds,
+      graphEventId, // If truthy, the graph viewer (Resolver) is showing
+      itemsPerPage,
+      itemsPerPageOptions,
+      kqlMode,
+      showCheckboxes,
+      sort,
+    } = defaultModel,
+  } = useSelector((state: State) => eventsViewerSelector(state, id));
+
   const { timelines: timelinesUi, cases } = useKibana().services;
   const {
     browserFields,
@@ -128,8 +129,8 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
   const editorActionsRef = useRef<FieldEditorActions>(null);
 
   useEffect(() => {
-    if (createTimeline != null) {
-      createTimeline({
+    dispatch(
+      timelineActions.createTimeline({
         columns,
         dataViewId: selectedDataViewId,
         defaultColumns,
@@ -139,10 +140,11 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
         itemsPerPage,
         showCheckboxes,
         sort,
-      });
-    }
+      })
+    );
+
     return () => {
-      deleteEventQuery({ id, inputId: 'global' });
+      dispatch(inputsActions.deleteOneQuery({ id, inputId: 'global' }));
       if (editorActionsRef.current) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
         editorActionsRef.current.closeEditor();
@@ -172,9 +174,9 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
     if (id === TimelineId.active) {
       refetchQuery([timelineQuery]);
     } else {
-      refetchQuery(globalQuery);
+      refetchQuery(globalQueries);
     }
-  }, [id, timelineQuery, globalQuery]);
+  }, [id, timelineQuery, globalQueries]);
   const bulkActions = useMemo(() => ({ onAlertStatusActionSuccess }), [onAlertStatusActionSuccess]);
 
   const fieldBrowserOptions = useFieldBrowserOptions({
@@ -185,6 +187,7 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
 
   const casesPermissions = useGetUserCasesPermissions();
   const CasesContext = cases.ui.getCasesContext();
+  const isLive = input.policy.kind === 'interval';
 
   return (
     <>
@@ -249,93 +252,4 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
   );
 };
 
-const makeMapStateToProps = () => {
-  const getInputsTimeline = inputsSelectors.getTimelineSelector();
-  const getGlobalQuerySelector = inputsSelectors.globalQuerySelector();
-  const getGlobalFiltersQuerySelector = inputsSelectors.globalFiltersQuerySelector();
-  const getTimeline = timelineSelectors.getTimelineByIdSelector();
-  const getGlobalQueries = inputsSelectors.globalQuery();
-  const getTimelineQuery = inputsSelectors.timelineQueryByIdSelector();
-  const mapStateToProps = (state: State, { id, defaultModel }: OwnProps) => {
-    const input: inputsModel.InputsRange = getInputsTimeline(state);
-    const timeline: TimelineModel = getTimeline(state, id) ?? defaultModel;
-    const {
-      columns,
-      defaultColumns,
-      dataProviders,
-      deletedEventIds,
-      excludedRowRendererIds,
-      graphEventId,
-      itemsPerPage,
-      itemsPerPageOptions,
-      kqlMode,
-      sort,
-      showCheckboxes,
-    } = timeline;
-
-    return {
-      columns,
-      defaultColumns,
-      dataProviders,
-      deletedEventIds,
-      excludedRowRendererIds,
-      filters: getGlobalFiltersQuerySelector(state),
-      id,
-      isLive: input.policy.kind === 'interval',
-      itemsPerPage,
-      itemsPerPageOptions,
-      kqlMode,
-      query: getGlobalQuerySelector(state),
-      sort,
-      showCheckboxes,
-      // Used to determine whether the footer should show (since it is hidden if the graph is showing.)
-      // `getTimeline` actually returns `TimelineModel | undefined`
-      graphEventId,
-      globalQuery: getGlobalQueries(state),
-      timelineQuery: getTimelineQuery(state, id),
-    };
-  };
-  return mapStateToProps;
-};
-
-const mapDispatchToProps = {
-  createTimeline: timelineActions.createTimeline,
-  deleteEventQuery: inputsActions.deleteOneQuery,
-};
-
-const connector = connect(makeMapStateToProps, mapDispatchToProps);
-
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export const StatefulEventsViewer = connector(
-  React.memo(
-    StatefulEventsViewerComponent,
-    // eslint-disable-next-line complexity
-    (prevProps, nextProps) =>
-      prevProps.id === nextProps.id &&
-      prevProps.scopeId === nextProps.scopeId &&
-      deepEqual(prevProps.columns, nextProps.columns) &&
-      deepEqual(prevProps.dataProviders, nextProps.dataProviders) &&
-      prevProps.defaultCellActions === nextProps.defaultCellActions &&
-      deepEqual(prevProps.excludedRowRendererIds, nextProps.excludedRowRendererIds) &&
-      prevProps.deletedEventIds === nextProps.deletedEventIds &&
-      prevProps.end === nextProps.end &&
-      deepEqual(prevProps.filters, nextProps.filters) &&
-      prevProps.isLive === nextProps.isLive &&
-      prevProps.itemsPerPage === nextProps.itemsPerPage &&
-      deepEqual(prevProps.itemsPerPageOptions, nextProps.itemsPerPageOptions) &&
-      prevProps.kqlMode === nextProps.kqlMode &&
-      prevProps.leadingControlColumns === nextProps.leadingControlColumns &&
-      deepEqual(prevProps.query, nextProps.query) &&
-      prevProps.renderCellValue === nextProps.renderCellValue &&
-      prevProps.rowRenderers === nextProps.rowRenderers &&
-      deepEqual(prevProps.sort, nextProps.sort) &&
-      prevProps.start === nextProps.start &&
-      deepEqual(prevProps.pageFilters, nextProps.pageFilters) &&
-      prevProps.showCheckboxes === nextProps.showCheckboxes &&
-      prevProps.start === nextProps.start &&
-      prevProps.utilityBar === nextProps.utilityBar &&
-      prevProps.additionalFilters === nextProps.additionalFilters &&
-      prevProps.graphEventId === nextProps.graphEventId
-  )
-);
+export const StatefulEventsViewer = React.memo(StatefulEventsViewerComponent);

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/selectors/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/selectors/index.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockState } from './mock_state';
+
+import { eventsViewerSelector } from '.';
+
+describe('selectors', () => {
+  describe('eventsViewerSelector', () => {
+    it('returns the expected results', () => {
+      const id = 'detections-page';
+
+      expect(eventsViewerSelector(mockState, id)).toEqual({
+        filters: mockState.inputs.global.filters,
+        input: mockState.inputs.timeline,
+        query: mockState.inputs.global.query,
+        globalQueries: mockState.inputs.global.queries,
+        timelineQuery: mockState.inputs.timeline.queries[0],
+        timeline: mockState.timeline.timelineById[id],
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/selectors/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/selectors/index.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createSelector } from 'reselect';
+
+import {
+  getTimelineSelector,
+  globalFiltersQuerySelector,
+  globalQuery,
+  globalQuerySelector,
+  timelineQueryByIdSelector,
+} from '../../../store/inputs/selectors';
+import { getTimelineByIdSelector } from '../../../../timelines/store/timeline/selectors';
+
+/**
+ * This selector is invoked with two arguments:
+ * @param state - the state of the store as defined by State in common/store/types.ts
+ * @param id - a timeline id e.g. `detections-page`
+ *
+ * Example:
+ *  `useSelector((state: State) => eventsViewerSelector(state, id))`
+ */
+export const eventsViewerSelector = createSelector(
+  globalFiltersQuerySelector(),
+  getTimelineSelector(),
+  globalQuerySelector(),
+  globalQuery(),
+  timelineQueryByIdSelector(),
+  getTimelineByIdSelector(),
+  (filters, input, query, globalQueries, timelineQuery, timeline) => ({
+    /** an array representing filters added to the search bar */
+    filters,
+    /** an object containing the timerange set in the global date picker, and other page level state */
+    input,
+    /** a serialized representation of the KQL / Lucence query in the search bar */
+    query,
+    /** an array of objects with metadata and actions related to queries on the page */
+    globalQueries,
+    /** an object with metadata and actions related to the table query */
+    timelineQuery,
+    /** a specific timeline from the state's timelineById collection, or undefined */
+    timeline,
+  })
+);

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/selectors/mock_state.ts
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/selectors/mock_state.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { set } from '@elastic/safer-lodash-set';
+import { pipe } from 'lodash/fp';
+
+import { mockGlobalState } from '../../../mock';
+
+const filters = [
+  {
+    meta: {
+      alias: null,
+      negate: false,
+      disabled: false,
+      type: 'phrase',
+      key: 'kibana.alert.severity',
+      params: { query: 'low' },
+    },
+    $state: { store: 'appState' },
+    query: { match_phrase: { 'kibana.alert.severity': { query: 'low' } } },
+  },
+];
+
+const input = {
+  timerange: {
+    kind: 'relative',
+    fromStr: 'now/d',
+    toStr: 'now/d',
+    from: '2022-03-17T06:00:00.000Z',
+    to: '2022-03-18T05:59:59.999Z',
+  },
+  queries: [
+    {
+      id: 'timeline-1-eql',
+      inspect: { dsl: [], response: [] },
+      isInspected: false,
+      loading: false,
+      selectedInspectIndex: 0,
+    },
+  ],
+  policy: { kind: 'manual', duration: 300000 },
+  linkTo: ['global'],
+  query: { query: '', language: 'kuery' },
+  filters: [],
+  fullScreen: false,
+};
+
+const query = { query: 'host.ip: *', language: 'kuery' };
+
+const globalQueries = [
+  {
+    id: 'detections-page',
+    inspect: {
+      dsl: ['{\n  "allow_no_indices": ...}'],
+    },
+    isInspected: false,
+    loading: false,
+    selectedInspectIndex: 0,
+  },
+  {
+    id: 'detections-alerts-count-3e92347c-7e0c-44dc-a13d-fbe71706a0f0',
+    inspect: {
+      dsl: ['{\n  "index": [\n ...}'],
+      response: ['{\n  "took": 3,\n  ...}'],
+    },
+    isInspected: false,
+    loading: false,
+    selectedInspectIndex: 0,
+  },
+  {
+    id: 'detections-histogram-a9c910ff-bcc9-48f2-9224-fad55cd5fd31',
+    inspect: {
+      dsl: ['{\n  "index": [\n ...}'],
+      response: ['{\n  "took": 4,\n ...}'],
+    },
+    isInspected: false,
+    loading: false,
+    selectedInspectIndex: 0,
+  },
+];
+
+const timelineQueries = [
+  {
+    id: 'detections-page',
+    inspect: {
+      dsl: ['{\n  "allow_no_indices": ...}'],
+    },
+    isInspected: false,
+    loading: false,
+    selectedInspectIndex: 0,
+  },
+];
+
+const timeline = {
+  id: 'detections-page',
+  columns: [
+    { columnHeaderType: 'not-filtered', id: '@timestamp', initialWidth: 200 },
+    {
+      columnHeaderType: 'not-filtered',
+      displayAsText: 'Rule',
+      id: 'kibana.alert.rule.name',
+      initialWidth: 180,
+      linkField: 'kibana.alert.rule.uuid',
+    },
+    {
+      columnHeaderType: 'not-filtered',
+      displayAsText: 'Severity',
+      id: 'kibana.alert.severity',
+      initialWidth: 105,
+    },
+    {
+      columnHeaderType: 'not-filtered',
+      displayAsText: 'Risk Score',
+      id: 'kibana.alert.risk_score',
+      initialWidth: 100,
+    },
+    {
+      columnHeaderType: 'not-filtered',
+      displayAsText: 'Reason',
+      id: 'kibana.alert.reason',
+      initialWidth: 450,
+    },
+    { columnHeaderType: 'not-filtered', id: 'host.name' },
+    { columnHeaderType: 'not-filtered', id: 'user.name' },
+    { columnHeaderType: 'not-filtered', id: 'process.name' },
+    { columnHeaderType: 'not-filtered', id: 'file.name' },
+    { columnHeaderType: 'not-filtered', id: 'source.ip' },
+    { columnHeaderType: 'not-filtered', id: 'destination.ip' },
+  ],
+  defaultColumns: [
+    { columnHeaderType: 'not-filtered', id: '@timestamp', initialWidth: 200 },
+    {
+      columnHeaderType: 'not-filtered',
+      displayAsText: 'Rule',
+      id: 'kibana.alert.rule.name',
+      initialWidth: 180,
+      linkField: 'kibana.alert.rule.uuid',
+    },
+    {
+      columnHeaderType: 'not-filtered',
+      displayAsText: 'Severity',
+      id: 'kibana.alert.severity',
+      initialWidth: 105,
+    },
+    {
+      columnHeaderType: 'not-filtered',
+      displayAsText: 'Risk Score',
+      id: 'kibana.alert.risk_score',
+      initialWidth: 100,
+    },
+    {
+      columnHeaderType: 'not-filtered',
+      displayAsText: 'Reason',
+      id: 'kibana.alert.reason',
+      initialWidth: 450,
+    },
+    { columnHeaderType: 'not-filtered', id: 'host.name' },
+    { columnHeaderType: 'not-filtered', id: 'user.name' },
+    { columnHeaderType: 'not-filtered', id: 'process.name' },
+    { columnHeaderType: 'not-filtered', id: 'file.name' },
+    { columnHeaderType: 'not-filtered', id: 'source.ip' },
+    { columnHeaderType: 'not-filtered', id: 'destination.ip' },
+  ],
+  dataViewId: 'security-solution-default',
+  dateRange: { start: '2022-03-17T06:00:00.000Z', end: '2022-03-18T05:59:59.999Z' },
+  deletedEventIds: [],
+  excludedRowRendererIds: [
+    'alerts',
+    'auditd',
+    'auditd_file',
+    'library',
+    'netflow',
+    'plain',
+    'registry',
+    'suricata',
+    'system',
+    'system_dns',
+    'system_endgame_process',
+    'system_file',
+    'system_fim',
+    'system_security_event',
+    'system_socket',
+    'threat_match',
+    'zeek',
+  ],
+  expandedDetail: {},
+  filters: [],
+  kqlQuery: { filterQuery: null },
+  indexNames: ['.alerts-security.alerts-default'],
+  isSelectAllChecked: false,
+  itemsPerPage: 25,
+  itemsPerPageOptions: [10, 25, 50, 100],
+  loadingEventIds: [],
+  selectedEventIds: {},
+  showCheckboxes: true,
+  sort: [{ columnId: '@timestamp', columnType: 'date', sortDirection: 'desc' }],
+  savedObjectId: null,
+  version: null,
+  footerText: 'alerts',
+  title: '',
+  initialized: true,
+  activeTab: 'query',
+  prevActiveTab: 'query',
+  dataProviders: [],
+  description: '',
+  eqlOptions: {
+    eventCategoryField: 'event.category',
+    tiebreakerField: '',
+    timestampField: '@timestamp',
+    query: '',
+    size: 100,
+  },
+  eventType: 'all',
+  eventIdToNoteIds: {},
+  highlightedDropAndProviderId: '',
+  historyIds: [],
+  isFavorite: false,
+  isLive: false,
+  isSaving: false,
+  kqlMode: 'filter',
+  timelineType: 'default',
+  templateTimelineId: null,
+  templateTimelineVersion: null,
+  noteIds: [],
+  pinnedEventIds: {},
+  pinnedEventsSaveObject: {},
+  show: false,
+  status: 'draft',
+  updated: 1647542283361,
+  documentType: '',
+  isLoading: false,
+  queryFields: [],
+  selectAll: false,
+};
+
+export const mockState = pipe(
+  (state) => set(state, 'inputs.global.filters', filters),
+  (state) => set(state, 'inputs.timeline', input),
+  (state) => set(state, 'inputs.global.query', query),
+  (state) => set(state, 'inputs.global.queries', globalQueries),
+  (state) => set(state, 'inputs.timeline.queries', timelineQueries),
+  (state) => set(state, 'timeline.timelineById.detections-page', timeline)
+)(mockGlobalState);

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -306,14 +306,23 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
     ]
   );
 
-  const additionalFiltersComponent = (
-    <AditionalFiltersAction
-      areEventsLoading={loadingEventIds.length > 0}
-      onShowBuildingBlockAlertsChanged={onShowBuildingBlockAlertsChanged}
-      showBuildingBlockAlerts={showBuildingBlockAlerts}
-      onShowOnlyThreatIndicatorAlertsChanged={onShowOnlyThreatIndicatorAlertsChanged}
-      showOnlyThreatIndicatorAlerts={showOnlyThreatIndicatorAlerts}
-    />
+  const additionalFiltersComponent = useMemo(
+    () => (
+      <AditionalFiltersAction
+        areEventsLoading={loadingEventIds.length > 0}
+        onShowBuildingBlockAlertsChanged={onShowBuildingBlockAlertsChanged}
+        showBuildingBlockAlerts={showBuildingBlockAlerts}
+        onShowOnlyThreatIndicatorAlertsChanged={onShowOnlyThreatIndicatorAlertsChanged}
+        showOnlyThreatIndicatorAlerts={showOnlyThreatIndicatorAlerts}
+      />
+    ),
+    [
+      loadingEventIds.length,
+      onShowBuildingBlockAlertsChanged,
+      onShowOnlyThreatIndicatorAlertsChanged,
+      showBuildingBlockAlerts,
+      showOnlyThreatIndicatorAlerts,
+    ]
   );
 
   const defaultFiltersMemo = useMemo(() => {


### PR DESCRIPTION
## [Security Solution] [Investigations] [Tech Debt] `StatefulEventsViewer`: remove `deepEqual` checks and replace `connect` + `mapStateToProps` with `useSelector`

This tech debt PR updates the `StatefulEventsViewer` component to:

- Remove `deepEqual` checks, as detailed in <https://github.com/elastic/kibana/issues/124151>
- Replace the usage of legacy Redux APIs `connect` and `mapStateToProps` with `useSelector`, as detailed in <https://github.com/elastic/kibana/issues/124146>

### Methodology

Before making changes, the Alerts page, which uses the `StatefulEventsViewer` was profiled with the `Record why each component rendered wile profiling` setting in the React dev tools Profiler, shown in the screenshot below:

![record_why_each_component_rendered](https://user-images.githubusercontent.com/4459398/158903740-8122e2d3-11a6-4927-916a-f895717835ae.png)

_Above: The `Record why each component rendered wile profiling` setting in the React dev tools Profiler_

After the page fully loaded, the profiler was started before clicking the `Refresh` button, and stopped after the page completed the refresh.

With a baseline of performance established, the code was refactored to:

- Remove the custom equality check passed to `React.memo`, and all the calls to `deepEqual` it contained
- Remove `mapStateToProps`, which contained multiple invocations of selectors created by [reselect](https://github.com/reduxjs/reselect)'s [createSelector](https://github.com/reduxjs/reselect#createselectorinputselectors--inputselectors-resultfunc-selectoroptions) API
- Using [reselect](https://github.com/reduxjs/reselect)'s [createSelector](https://github.com/reduxjs/reselect#createselectorinputselectors--inputselectors-resultfunc-selectoroptions) API, combine those multiple selectors into a single selector:

```ts
export const eventsViewerSelector = createSelector(
  globalFiltersQuerySelector(),
  getTimelineSelector(),
  globalQuerySelector(),
  globalQuery(),
  timelineQueryByIdSelector(),
  getTimelineByIdSelector(),
  (filters, input, query, globalQueries, timelineQuery, timeline) => ({
    /** an array representing filters added to the search bar */
    filters,
    /** an object containing the timerange set in the global date picker, and other page level state */
    input,
    /** a serialized representation of the KQL / Lucence query in the search bar */
    query,
    /** an array of objects with metadata and actions related to queries on the page */
    globalQueries,
    /** an object with metadata and actions related to the table query */
    timelineQuery,
    /** a specific timeline from the state's timelineById collection, or undefined */
    timeline,
  })
);
```

- Replace the usage of `connect` with a single invocation of `useSelector`, which is provided the new `eventsViewerSelector` selector:

```ts
  const {
    filters,
    input,
    // ...
  } = useSelector((state: State) => eventsViewerSelector(state, id));
```

- A unit test was created for the new `eventsViewerSelector`, using mock Redux state from the Alerts page

- After making the changes above, the Alerts page was profiled again to verify `StatefulEventsViewer` re-renders as expected, per the screenshot below:

![testing_methodology](https://user-images.githubusercontent.com/4459398/158907345-2ec974ec-c733-4eaa-8ad6-da53a9d6a21b.png)

_Above: In the profiler, each `Why did this render?` entry for the `StatefulEventsViewer` was examined after the changes_
