### PR TITLE
[Security Solution][Investigations] - Add related cases to Flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -171,8 +171,7 @@ const EventDetailsComponent: React.FC<Props> = ({
                 />
                 <EuiSpacer size="l" />
                 <Reason eventId={id} data={data} />
-                <EuiSpacer size="m" />
-                <RelatedCases data={data} isAlert={isAlert} />
+                <RelatedCases eventId={id} />
                 <EuiHorizontalRule />
                 <AlertSummaryView
                   {...{

--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -41,6 +41,7 @@ import { Reason } from './reason';
 import { InvestigationGuideView } from './investigation_guide_view';
 import { Overview } from './overview';
 import { HostRisk } from '../../../risk_score/containers';
+import { RelatedCases } from './related_cases';
 
 type EventViewTab = EuiTabbedContentTab;
 
@@ -170,6 +171,8 @@ const EventDetailsComponent: React.FC<Props> = ({
                 />
                 <EuiSpacer size="l" />
                 <Reason eventId={id} data={data} />
+                <EuiSpacer size="m" />
+                <RelatedCases data={data} isAlert={isAlert} />
                 <EuiHorizontalRule />
                 <AlertSummaryView
                   {...{

--- a/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { TestProviders } from '../../mock';
+import { useKibana as mockUseKibana } from '../../lib/kibana/__mocks__';
+import { RelatedCases } from './related_cases';
+
+const mockedUseKibana = mockUseKibana();
+const mockGetRelatedCases = jest.fn();
+
+jest.mock('../../lib/kibana', () => {
+  const original = jest.requireActual('../../lib/kibana');
+
+  return {
+    ...original,
+    useKibana: () => ({
+      ...mockedUseKibana,
+      services: {
+        ...mockedUseKibana.services,
+        cases: {
+          api: {
+            getRelatedCases: mockGetRelatedCases,
+          },
+        },
+      },
+    }),
+  };
+});
+
+const testData = [
+  {
+    category: '_id',
+    field: '_id',
+    isObjectArray: false,
+    originalValue: ['1c84d9bff4884dabe6aa1bb15f08433463b848d9269e587078dc56669550d27a'],
+    values: ['1c84d9bff4884dabe6aa1bb15f08433463b848d9269e587078dc56669550d27a'],
+  },
+];
+
+describe('Related Cases', () => {
+  describe('When related cases are unable to be retrieved', () => {
+    test('should show 0 related cases when there are none', async () => {
+      mockGetRelatedCases.mockReturnValue([]);
+      act(() => {
+        render(
+          <TestProviders>
+            <RelatedCases data={testData} isAlert />
+          </TestProviders>
+        );
+      });
+
+      expect(await screen.findByText('0 cases.')).toBeInTheDocument();
+    });
+  });
+
+  describe('When 1 related case is retrieved', () => {
+    test('should show 1 related case', async () => {
+      mockGetRelatedCases.mockReturnValue([{ id: '789', title: 'Test Case' }]);
+      act(() => {
+        render(
+          <TestProviders>
+            <RelatedCases data={testData} isAlert />
+          </TestProviders>
+        );
+      });
+
+      expect(await screen.findByText('1 case:')).toBeInTheDocument();
+      expect(await screen.findByTestId('case-details-link')).toHaveTextContent('Test Case');
+    });
+  });
+
+  describe('When 2 related cases are retrieved', () => {
+    test('should show 2 related cases', async () => {
+      mockGetRelatedCases.mockReturnValue([
+        { id: '789', title: 'Test Case 1' },
+        { id: '456', title: 'Test Case 2' },
+      ]);
+      act(() => {
+        render(
+          <TestProviders>
+            <RelatedCases data={testData} isAlert />
+          </TestProviders>
+        );
+      });
+
+      expect(await screen.findByText('2 cases:')).toBeInTheDocument();
+      const cases = await screen.findAllByTestId('case-details-link');
+      expect(cases).toHaveLength(2);
+      expect(cases[0]).toHaveTextContent('Test Case 1');
+      expect(cases[1]).toHaveTextContent('Test Case 2');
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
@@ -42,7 +42,7 @@ export const RelatedCases: React.FC<Props> = React.memo(({ eventId }) => {
     } catch (error) {
       setHasError(true);
       toasts.addWarning(
-        i18n.translate('xpack.securitySolution.alertDetails.overview.relatedCasesFailure.title', {
+        i18n.translate('xpack.securitySolution.alertDetails.overview.relatedCasesFailure', {
           defaultMessage: 'Unable to load related cases: "{error}"',
           values: { error },
         })

--- a/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
+import { EuiFlexItem, EuiLoadingContent } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useKibana } from '../../../common/lib/kibana';
+import { TimelineEventsDetailsItem } from '../../../../common/search_strategy';
+import { getFieldValue } from '../../../detections/components/host_isolation/helpers';
+import { CaseDetailsLink } from '../links';
+
+interface Props {
+  data: TimelineEventsDetailsItem[];
+  isAlert: boolean;
+}
+
+type RelatedCaseList = Array<{ id: string; title: string }>;
+
+export const RelatedCases: React.FC<Props> = React.memo(({ data, isAlert }) => {
+  const {
+    services: { cases },
+  } = useKibana();
+
+  const alertId = useMemo(() => getFieldValue({ category: '_id', field: '_id' }, data), [data]);
+
+  const [relatedCases, setRelatedCases] = useState<RelatedCaseList>([]);
+  const [areCasesLoading, setAreCasesLoading] = useState(true);
+
+  const getRelatedCases = useCallback(async () => {
+    let relatedCaseList: RelatedCaseList = [];
+    try {
+      const relatedCasesResponse = await cases.api.getRelatedCases(alertId, {
+        owner: 'securitySolution',
+      });
+      if (Array.isArray(relatedCasesResponse)) {
+        relatedCaseList = relatedCasesResponse;
+      }
+    } catch {
+      // TODO: Show an error toaster here?
+    }
+    setRelatedCases(relatedCaseList);
+    setAreCasesLoading(false);
+  }, [alertId, cases.api]);
+
+  useEffect(() => {
+    if (alertId && isAlert) {
+      getRelatedCases();
+    }
+  }, [alertId, getRelatedCases, isAlert]);
+
+  return areCasesLoading ? (
+    <EuiLoadingContent lines={2} />
+  ) : (
+    <EuiFlexItem grow={false} style={{ flexDirection: 'row' }}>
+      <span>
+        <FormattedMessage
+          defaultMessage="This alert was found in"
+          id="xpack.securitySolution.alertDetails.overview.relatedCasesFound"
+        />{' '}
+        <strong>
+          <FormattedMessage
+            defaultMessage="{caseCount} {caseCount, plural, =0 {cases.} =1 {case:} other {cases:}}"
+            id="xpack.securitySolution.alertDetails.overview.relatedCasesCount"
+            values={{
+              caseCount: relatedCases.length,
+            }}
+          />
+        </strong>
+        {relatedCases.map(({ id, title }, index) =>
+          id && title ? (
+            <span key={id}>
+              {' '}
+              <CaseDetailsLink detailName={id} title={title}>
+                {title}
+              </CaseDetailsLink>
+              {relatedCases[index + 1] ? ',' : ''}
+            </span>
+          ) : (
+            <></>
+          )
+        )}
+      </span>
+    </EuiFlexItem>
+  );
+});
+
+RelatedCases.displayName = 'RelatedCases';

--- a/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
@@ -12,6 +12,7 @@ import { useKibana } from '../../../common/lib/kibana';
 import { TimelineEventsDetailsItem } from '../../../../common/search_strategy';
 import { getFieldValue } from '../../../detections/components/host_isolation/helpers';
 import { CaseDetailsLink } from '../links';
+import { APP_ID } from '../../../../common/constants';
 
 interface Props {
   data: TimelineEventsDetailsItem[];
@@ -33,12 +34,9 @@ export const RelatedCases: React.FC<Props> = React.memo(({ data, isAlert }) => {
   const getRelatedCases = useCallback(async () => {
     let relatedCaseList: RelatedCaseList = [];
     try {
-      const relatedCasesResponse = await cases.api.getRelatedCases(alertId, {
-        owner: 'securitySolution',
+      relatedCaseList = await cases.api.getRelatedCases(alertId, {
+        owner: APP_ID,
       });
-      if (Array.isArray(relatedCasesResponse)) {
-        relatedCaseList = relatedCasesResponse;
-      }
     } catch {
       // TODO: Show an error toaster here?
     }

--- a/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
@@ -34,9 +34,10 @@ export const RelatedCases: React.FC<Props> = React.memo(({ data, isAlert }) => {
   const getRelatedCases = useCallback(async () => {
     let relatedCaseList: RelatedCaseList = [];
     try {
-      relatedCaseList = await cases.api.getRelatedCases(alertId, {
-        owner: APP_ID,
-      });
+      relatedCaseList =
+        (await cases.api.getRelatedCases(alertId, {
+          owner: APP_ID,
+        })) ?? [];
     } catch {
       // TODO: Show an error toaster here?
     }
@@ -64,11 +65,11 @@ export const RelatedCases: React.FC<Props> = React.memo(({ data, isAlert }) => {
             defaultMessage="{caseCount} {caseCount, plural, =0 {cases.} =1 {case:} other {cases:}}"
             id="xpack.securitySolution.alertDetails.overview.relatedCasesCount"
             values={{
-              caseCount: relatedCases.length,
+              caseCount: relatedCases?.length ?? 0,
             }}
           />
         </strong>
-        {relatedCases.map(({ id, title }, index) =>
+        {relatedCases?.map(({ id, title }, index) =>
           id && title ? (
             <span key={id}>
               {' '}

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
@@ -21,6 +21,7 @@ export interface UseAddToCaseActions {
   ariaLabel?: string;
   ecsData?: Ecs;
   nonEcsData?: TimelineNonEcsData[];
+  onSuccess?: () => Promise<void>;
   timelineId: string;
 }
 
@@ -29,6 +30,7 @@ export const useAddToCaseActions = ({
   ariaLabel,
   ecsData,
   nonEcsData,
+  onSuccess,
   timelineId,
 }: UseAddToCaseActions) => {
   const { cases: casesUi } = useKibana().services;
@@ -52,11 +54,13 @@ export const useAddToCaseActions = ({
   const createCaseFlyout = casesUi.hooks.getUseCasesAddToNewCaseFlyout({
     attachments: caseAttachments,
     onClose: onMenuItemClick,
+    onSuccess,
   });
 
   const selectCaseModal = casesUi.hooks.getUseCasesAddToExistingCaseModal({
     attachments: caseAttachments,
     onClose: onMenuItemClick,
+    onRowClick: onSuccess,
   });
 
   const handleAddToNewCaseClick = useCallback(() => {

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.test.tsx
@@ -76,6 +76,7 @@ describe('take action dropdown', () => {
     onAddExceptionTypeClick: jest.fn(),
     onAddIsolationStatusClick: jest.fn(),
     refetch: jest.fn(),
+    refetchFlyoutData: jest.fn(),
     timelineId: TimelineId.active,
   };
 

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
@@ -23,6 +23,7 @@ import { isAlertFromEndpointAlert } from '../../../common/utils/endpoint_alert_c
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
 import { useAddToCaseActions } from '../alerts_table/timeline_actions/use_add_to_case_actions';
+
 interface ActionsData {
   alertStatus: Status;
   eventId: string;
@@ -42,6 +43,7 @@ export interface TakeActionDropdownProps {
   onAddExceptionTypeClick: (type: ExceptionListType) => void;
   onAddIsolationStatusClick: (action: 'isolateHost' | 'unisolateHost') => void;
   refetch: (() => void) | undefined;
+  refetchFlyoutData: () => Promise<void>;
   timelineId: string;
 }
 
@@ -57,6 +59,7 @@ export const TakeActionDropdown = React.memo(
     onAddExceptionTypeClick,
     onAddIsolationStatusClick,
     refetch,
+    refetchFlyoutData,
     timelineId,
   }: TakeActionDropdownProps) => {
     const tGridEnabled = useIsExperimentalFeatureEnabled('tGridEnabled');
@@ -184,6 +187,7 @@ export const TakeActionDropdown = React.memo(
       ecsData,
       nonEcsData: detailsData?.map((d) => ({ field: d.field, value: d.values })) ?? [],
       onMenuItemClick,
+      onSuccess: refetchFlyoutData,
       timelineId,
     });
 

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
@@ -556,6 +556,7 @@ Array [
           isHostIsolationPanelOpen={false}
           loadingEventDetails={true}
           onAddIsolationStatusClick={[Function]}
+          refetchFlyoutData={[Function]}
           timelineId="test"
         >
           <Memo()
@@ -573,6 +574,7 @@ Array [
             isHostIsolationPanelOpen={false}
             loadingEventDetails={true}
             onAddIsolationStatusClick={[Function]}
+            refetchFlyoutData={[Function]}
             timelineId="test"
             timelineQuery={
               Object {
@@ -844,6 +846,7 @@ Array [
         isHostIsolationPanelOpen={false}
         loadingEventDetails={true}
         onAddIsolationStatusClick={[Function]}
+        refetchFlyoutData={[Function]}
         timelineId="test"
       >
         <Memo()
@@ -861,6 +864,7 @@ Array [
           isHostIsolationPanelOpen={false}
           loadingEventDetails={true}
           onAddIsolationStatusClick={[Function]}
+          refetchFlyoutData={[Function]}
           timelineId="test"
           timelineQuery={
             Object {

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
@@ -259,6 +259,7 @@ exports[`Details Panel Component DetailsPanel:EventDetails: rendering it should 
       isHostIsolationPanelOpen={false}
       loadingEventDetails={true}
       onAddIsolationStatusClick={[Function]}
+      refetchFlyoutData={[Function]}
       timelineId="test"
     >
       <Memo()
@@ -276,6 +277,7 @@ exports[`Details Panel Component DetailsPanel:EventDetails: rendering it should 
         isHostIsolationPanelOpen={false}
         loadingEventDetails={true}
         onAddIsolationStatusClick={[Function]}
+        refetchFlyoutData={[Function]}
         timelineId="test"
         timelineQuery={
           Object {

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/footer.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/footer.test.tsx
@@ -101,6 +101,7 @@ const defaultProps = {
   onAddIsolationStatusClick: jest.fn(),
   expandedEvent: { eventId: ecsData._id, indexName: '' },
   detailsData: mockAlertDetailsDataWithIsObject,
+  refetchFlyoutData: jest.fn(),
 };
 
 describe('event details footer component', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/footer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/footer.tsx
@@ -34,6 +34,7 @@ interface EventDetailsFooterProps {
   loadingEventDetails: boolean;
   onAddIsolationStatusClick: (action: 'isolateHost' | 'unisolateHost') => void;
   timelineId: string;
+  refetchFlyoutData: () => Promise<void>;
 }
 
 interface AddExceptionModalWrapperData {
@@ -55,6 +56,7 @@ export const EventDetailsFooterComponent = React.memo(
     timelineId,
     globalQuery,
     timelineQuery,
+    refetchFlyoutData,
   }: EventDetailsFooterProps & PropsFromRedux) => {
     const ruleIndex = useMemo(
       () =>
@@ -122,6 +124,7 @@ export const EventDetailsFooterComponent = React.memo(
                   onAddEventFilterClick={onAddEventFilterClick}
                   onAddExceptionTypeClick={onAddExceptionTypeClick}
                   onAddIsolationStatusClick={onAddIsolationStatusClick}
+                  refetchFlyoutData={refetchFlyoutData}
                   refetch={refetchAll}
                   indexName={expandedEvent.indexName}
                   timelineId={timelineId}

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
@@ -280,6 +280,7 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
         isHostIsolationPanelOpen={isHostIsolationPanelOpen}
         loadingEventDetails={loading}
         onAddIsolationStatusClick={showHostIsolationPanel}
+        refetchFlyoutData={refetchFlyoutData}
         timelineId={timelineId}
       />
     </CasesContext>

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
@@ -81,14 +81,16 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
   tabType,
   timelineId,
 }) => {
-  const [loading, detailsData, rawEventData, ecsData] = useTimelineEventsDetails({
-    docValueFields,
-    entityType,
-    indexName: expandedEvent.indexName ?? '',
-    eventId: expandedEvent.eventId ?? '',
-    runtimeMappings,
-    skip: !expandedEvent.eventId,
-  });
+  const [loading, detailsData, rawEventData, ecsData, refetchFlyoutData] = useTimelineEventsDetails(
+    {
+      docValueFields,
+      entityType,
+      indexName: expandedEvent.indexName ?? '',
+      eventId: expandedEvent.eventId ?? '',
+      runtimeMappings,
+      skip: !expandedEvent.eventId,
+    }
+  );
 
   const [isHostIsolationPanelOpen, setIsHostIsolationPanel] = useState(false);
 
@@ -240,6 +242,7 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
         detailsData={detailsData}
         detailsEcsData={ecsData}
         expandedEvent={expandedEvent}
+        refetchFlyoutData={refetchFlyoutData}
         handleOnEventClosed={handleOnEventClosed}
         isHostIsolationPanelOpen={isHostIsolationPanelOpen}
         loadingEventDetails={loading}

--- a/x-pack/plugins/security_solution/public/timelines/containers/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/details/index.tsx
@@ -5,13 +5,12 @@
  * 2.0.
  */
 
-import { isEmpty, noop } from 'lodash/fp';
+import { isEmpty } from 'lodash/fp';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import deepEqual from 'fast-deep-equal';
 import { Subscription } from 'rxjs';
 
 import { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { inputsModel } from '../../../common/store';
 import { useKibana } from '../../../common/lib/kibana';
 import {
   DocValueFields,
@@ -51,10 +50,12 @@ export const useTimelineEventsDetails = ({
   boolean,
   EventsArgs['detailsData'],
   object | undefined,
-  EventsArgs['ecs']
+  EventsArgs['ecs'],
+  () => Promise<void>
 ] => {
+  const asyncNoop = () => Promise.resolve();
   const { data } = useKibana().services;
-  const refetch = useRef<inputsModel.Refetch>(noop);
+  const refetch = useRef<() => Promise<void>>(asyncNoop);
   const abortCtrl = useRef(new AbortController());
   const searchSubscription$ = useRef(new Subscription());
   const [loading, setLoading] = useState(false);
@@ -141,5 +142,5 @@ export const useTimelineEventsDetails = ({
     };
   }, [timelineDetailsRequest, timelineDetailsSearch]);
 
-  return [loading, timelineDetailsResponse, rawEventData, ecsData];
+  return [loading, timelineDetailsResponse, rawEventData, ecsData, refetch.current];
 };


### PR DESCRIPTION
## Summary

Thanks to the work by @cnasikas [here](https://github.com/elastic/kibana/pull/127065), we've been able to add the cases linked to a given alert in the related cases section of the alert flyout. This is a continuation of the prevalence work from @janmonschke here https://github.com/elastic/kibana/pull/127599. This particular feature will provide analysts the ability to track which alerts are actively being triaged or investigated in any existing case or cases.

~Currently, the list doesn't refresh when the alert is added to the case , we may need a callback to enable that functionality.~ Thanks @cnasikas, we were able to fix this :) 



https://user-images.githubusercontent.com/17211684/159004169-384ffe3d-b805-4488-a52a-49069dd74b0a.mov


**Screen Shots: **

**O Cases:**

<img width="846" alt="Screen Shot 2022-03-17 at 3 26 36 PM" src="https://user-images.githubusercontent.com/17211684/158917785-14256e88-d809-4c17-9941-d09f92941033.png">


**1 Case:**

<img width="852" alt="Screen Shot 2022-03-17 at 3 27 54 PM" src="https://user-images.githubusercontent.com/17211684/158917818-38aea55d-dc07-42bf-a80c-caffb9ca18a2.png">

**2 Cases:**

<img width="852" alt="Screen Shot 2022-03-17 at 3 26 13 PM" src="https://user-images.githubusercontent.com/17211684/158917858-cbf39b8c-0f50-48b6-b6e3-db83f6cd78e9.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios