### PR TITLE
[7.17] fix(NA): propagation of env vars on forced yarn installs (#128021)

### DIFF
--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -8933,7 +8933,12 @@ const BootstrapCommand = {
 
     if (forceInstall) {
       const forceInstallStartTime = Date.now();
-      await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["runBazel"])(['run', '@nodejs//:yarn'], runOffline);
+      await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["runBazel"])(['run', '@nodejs//:yarn'], runOffline, {
+        env: {
+          SASS_BINARY_SITE: 'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-sass',
+          RE2_DOWNLOAD_MIRROR: 'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2'
+        }
+      });
       timings.push({
         id: 'force install dependencies',
         ms: Date.now() - forceInstallStartTime

--- a/packages/kbn-pm/src/commands/bootstrap.ts
+++ b/packages/kbn-pm/src/commands/bootstrap.ts
@@ -71,7 +71,14 @@ export const BootstrapCommand: ICommand = {
 
     if (forceInstall) {
       const forceInstallStartTime = Date.now();
-      await runBazel(['run', '@nodejs//:yarn'], runOffline);
+      await runBazel(['run', '@nodejs//:yarn'], runOffline, {
+        env: {
+          SASS_BINARY_SITE:
+            'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-sass',
+          RE2_DOWNLOAD_MIRROR:
+            'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2',
+        },
+      });
       timings.push({
         id: 'force install dependencies',
         ms: Date.now() - forceInstallStartTime,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [fix(NA): propagation of env vars on forced yarn installs (#128021)](https://github.com/elastic/kibana/pull/128021)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)