### PR TITLE
[7.17] [ML] Functional tests - refactor response code checks (#127875)

### DIFF
--- a/x-pack/test/api_integration/apis/ml/annotations/create_annotations.ts
+++ b/x-pack/test/api_integration/apis/ml/annotations/create_annotations.ts
@@ -34,12 +34,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should successfully create annotations for anomaly job', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put('/api/ml/annotations/index')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(annotationRequestBody)
-        .expect(200);
+        .send(annotationRequestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
       const annotationId = body._id;
 
       const fetchedAnnotation = await ml.api.getAnnotationById(annotationId);
@@ -56,12 +56,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should successfully create annotation for user with ML read permissions', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put('/api/ml/annotations/index')
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(annotationRequestBody)
-        .expect(200);
+        .send(annotationRequestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       const annotationId = body._id;
       const fetchedAnnotation = await ml.api.getAnnotationById(annotationId);
@@ -76,12 +76,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should not allow to create annotation for unauthorized user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put('/api/ml/annotations/index')
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
-        .send(annotationRequestBody)
-        .expect(403);
+        .send(annotationRequestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/annotations/delete_annotations.ts
+++ b/x-pack/test/api_integration/apis/ml/annotations/delete_annotations.ts
@@ -41,11 +41,11 @@ export default ({ getService }: FtrProviderContext) => {
 
       const annotationIdToDelete = annotationsForJob[0]._id;
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/annotations/delete/${annotationIdToDelete}`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body._id).to.eql(annotationIdToDelete);
       expect(body.result).to.eql('deleted');
@@ -59,11 +59,11 @@ export default ({ getService }: FtrProviderContext) => {
 
       const annotationIdToDelete = annotationsForJob[0]._id;
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/annotations/delete/${annotationIdToDelete}`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body._id).to.eql(annotationIdToDelete);
       expect(body.result).to.eql('deleted');
@@ -77,11 +77,11 @@ export default ({ getService }: FtrProviderContext) => {
 
       const annotationIdToDelete = annotationsForJob[0]._id;
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/annotations/delete/${annotationIdToDelete}`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/annotations/get_annotations.ts
+++ b/x-pack/test/api_integration/apis/ml/annotations/get_annotations.ts
@@ -43,12 +43,12 @@ export default ({ getService }: FtrProviderContext) => {
         latestMs: Date.now(),
         maxAnnotations: 500,
       };
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/annotations')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(200);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.success).to.eql(true);
       expect(body.annotations).not.to.be(undefined);
@@ -68,12 +68,12 @@ export default ({ getService }: FtrProviderContext) => {
         latestMs: Date.now(),
         maxAnnotations: 500,
       };
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/annotations')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(200);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.success).to.eql(true);
       expect(body.annotations).not.to.be(undefined);
@@ -93,12 +93,13 @@ export default ({ getService }: FtrProviderContext) => {
         latestMs: Date.now(),
         maxAnnotations: 500,
       };
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/annotations')
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(200);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
+
       expect(body.success).to.eql(true);
       expect(body.annotations).not.to.be(undefined);
       jobIds.forEach((jobId, idx) => {
@@ -117,12 +118,12 @@ export default ({ getService }: FtrProviderContext) => {
         latestMs: Date.now(),
         maxAnnotations: 500,
       };
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/annotations')
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(403);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/annotations/update_annotations.ts
+++ b/x-pack/test/api_integration/apis/ml/annotations/update_annotations.ts
@@ -59,12 +59,12 @@ export default ({ getService }: FtrProviderContext) => {
         _id: originalAnnotation._id,
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put('/api/ml/annotations/index')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(annotationUpdateRequestBody)
-        .expect(200);
+        .send(annotationUpdateRequestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body._id).to.eql(originalAnnotation._id);
       expect(body.result).to.eql('updated');
@@ -90,12 +90,12 @@ export default ({ getService }: FtrProviderContext) => {
         _id: originalAnnotation._id,
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put('/api/ml/annotations/index')
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(annotationUpdateRequestBody)
-        .expect(200);
+        .send(annotationUpdateRequestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body._id).to.eql(originalAnnotation._id);
       expect(body.result).to.eql('updated');
@@ -121,12 +121,12 @@ export default ({ getService }: FtrProviderContext) => {
         _id: originalAnnotation._id,
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put('/api/ml/annotations/index')
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
-        .send(annotationUpdateRequestBody)
-        .expect(403);
+        .send(annotationUpdateRequestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');
@@ -150,12 +150,12 @@ export default ({ getService }: FtrProviderContext) => {
         detector_index: 2,
         _id: originalAnnotation._id,
       };
-      await supertest
+      const { body, status } = await supertest
         .put('/api/ml/annotations/index')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(annotationUpdateRequestBodyWithMissingFields)
-        .expect(200);
+        .send(annotationUpdateRequestBodyWithMissingFields);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       const updatedAnnotation = await ml.api.getAnnotationById(originalAnnotation._id);
       if (updatedAnnotation) {

--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/close_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/close_with_spaces.ts
@@ -21,14 +21,15 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace2 = 'space2';
 
   async function runRequest(jobId: string, expectedStatusCode: number, space?: string) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`${space ? `/s/${space}` : ''}/api/ml/anomaly_detectors/${jobId}/_close`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
+
     return body;
   }
 

--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/create.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/create.ts
@@ -110,12 +110,12 @@ export default ({ getService }: FtrProviderContext) => {
 
     for (const testData of testDataList) {
       it(`${testData.testTitle}`, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .put(`/api/ml/anomaly_detectors/${testData.jobId}`)
           .auth(testData.user, ml.securityCommon.getPasswordForUser(testData.user))
           .set(COMMON_REQUEST_HEADERS)
-          .send(testData.requestBody)
-          .expect(testData.expected.responseCode);
+          .send(testData.requestBody);
+        ml.api.assertResponseStatusCode(testData.expected.responseCode, status, body);
 
         if (body.error === undefined) {
           // Validate the important parts of the response.

--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/create_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/create_with_spaces.ts
@@ -37,15 +37,15 @@ export default ({ getService }: FtrProviderContext) => {
       const jobConfig = ml.commonConfig.getADFqSingleMetricJobConfig(jobIdSpace1);
 
       await ml.testExecution.logTestStep('should create job');
-      await supertest
+      const { body, status } = await supertest
         .put(`/s/${idSpace1}/api/ml/anomaly_detectors/${jobIdSpace1}`)
         .auth(
           USER.ML_POWERUSER_ALL_SPACES,
           ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send(jobConfig)
-        .expect(200);
+        .send(jobConfig);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       await ml.testExecution.logTestStep(`job should be in space '${idSpace1}' only`);
       await ml.api.assertJobSpaces(jobIdSpace1, 'anomaly-detector', [idSpace1]);

--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/delete_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/delete_with_spaces.ts
@@ -19,14 +19,15 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace2 = 'space2';
 
   async function runRequest(jobId: string, expectedStatusCode: number, space?: string) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .delete(`${space ? `/s/${space}` : ''}/api/ml/anomaly_detectors/${jobId}`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
+
     return body;
   }
 

--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/get.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/get.ts
@@ -71,11 +71,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('GetAnomalyDetectors', () => {
       it('should fetch all anomaly detector jobs', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/anomaly_detectors`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.count).to.eql(2);
         expect(body.jobs.length).to.eql(2);
@@ -84,11 +84,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should not allow to retrieve jobs for the user without required permissions', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/anomaly_detectors`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -97,11 +97,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('GetAnomalyDetectorsById', () => {
       it('should fetch single anomaly detector job by id', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/anomaly_detectors/${jobId}_1`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.count).to.eql(1);
         expect(body.jobs.length).to.eql(1);
@@ -109,11 +109,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should fetch anomaly detector jobs based on provided ids', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/anomaly_detectors/${jobId}_1,${jobId}_2`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.count).to.eql(2);
         expect(body.jobs.length).to.eql(2);
@@ -122,11 +122,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should not allow to retrieve a job for the user without required permissions', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/anomaly_detectors/${jobId}_1`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -135,11 +135,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('GetAnomalyDetectorsStats', () => {
       it('should fetch jobs stats', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/anomaly_detectors/_stats`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.count).to.eql(2);
         expect(body.jobs.length).to.eql(2);
@@ -155,11 +155,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should not allow to retrieve jobs stats for the user without required permissions', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/anomaly_detectors/_stats`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -168,11 +168,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('GetAnomalyDetectorsStatsById', () => {
       it('should fetch single job stats', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/anomaly_detectors/${jobId}_1/_stats`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.count).to.eql(1);
         expect(body.jobs.length).to.eql(1);
@@ -187,11 +187,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should fetch multiple jobs stats based on provided ids', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/anomaly_detectors/${jobId}_1,${jobId}_2/_stats`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.count).to.eql(2);
         expect(body.jobs.length).to.eql(2);
@@ -207,11 +207,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should not allow to retrieve a job stats for the user without required permissions', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/anomaly_detectors/${jobId}_1/_stats`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/get_stats_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/get_stats_with_spaces.ts
@@ -27,7 +27,7 @@ export default ({ getService }: FtrProviderContext) => {
     expectedStatusCode: number,
     space?: string
   ) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(
         `${space ? `/s/${space}` : ''}/api/ml/anomaly_detectors${
           jobOrGroup ? `/${jobOrGroup}` : ''
@@ -37,8 +37,8 @@ export default ({ getService }: FtrProviderContext) => {
         USER.ML_VIEWER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/get_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/get_with_spaces.ts
@@ -27,7 +27,7 @@ export default ({ getService }: FtrProviderContext) => {
     expectedStatusCode: number,
     space?: string
   ) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(
         `${space ? `/s/${space}` : ''}/api/ml/anomaly_detectors${
           jobOrGroup ? `/${jobOrGroup}` : ''
@@ -37,8 +37,8 @@ export default ({ getService }: FtrProviderContext) => {
         USER.ML_VIEWER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/open_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/open_with_spaces.ts
@@ -21,14 +21,15 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace2 = 'space2';
 
   async function runRequest(jobId: string, expectedStatusCode: number, space?: string) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`${space ? `/s/${space}` : ''}/api/ml/anomaly_detectors/${jobId}/_open`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
+
     return body;
   }
 

--- a/x-pack/test/api_integration/apis/ml/calendars/create_calendars.ts
+++ b/x-pack/test/api_integration/apis/ml/calendars/create_calendars.ts
@@ -38,12 +38,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should successfully create calendar by id', async () => {
-      await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/calendars`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(200);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       const results = await ml.api.getCalendar(requestBody.calendarId);
       const createdCalendar = results.body.calendars[0];
@@ -56,12 +56,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should not create new calendar for user without required permission', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/calendars`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(403);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');
@@ -69,12 +69,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should not create new calendar for unauthorized user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/calendars`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(403);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/calendars/delete_calendars.ts
+++ b/x-pack/test/api_integration/apis/ml/calendars/delete_calendars.ts
@@ -42,44 +42,44 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should delete calendar by id', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/calendars/${calendarId}`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.acknowledged).to.eql(true);
       await ml.api.waitForCalendarNotToExist(calendarId);
     });
 
     it('should not delete calendar for user without required permission', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/calendars/${calendarId}`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       await ml.api.waitForCalendarToExist(calendarId);
     });
 
     it('should not delete calendar for unauthorized user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/calendars/${calendarId}`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       await ml.api.waitForCalendarToExist(calendarId);
     });
 
     it('should return 404 if invalid calendarId', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/calendars/calendar_id_dne`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(404);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(404, status, body);
 
       expect(body.error).to.eql('Not Found');
     });

--- a/x-pack/test/api_integration/apis/ml/calendars/get_calendars.ts
+++ b/x-pack/test/api_integration/apis/ml/calendars/get_calendars.ts
@@ -46,11 +46,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should fetch all calendars', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/calendars`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body).to.have.length(testCalendars.length);
         expect(body[0].events).to.have.length(testEvents.length);
@@ -58,11 +58,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should fetch all calendars for user with view permission', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/calendars`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body).to.have.length(testCalendars.length);
         expect(body[0].events).to.have.length(testEvents.length);
@@ -70,11 +70,12 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should not fetch calendars for unauthorized user', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/calendars`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
+
         expect(body.error).to.eql('Forbidden');
       });
     });
@@ -97,11 +98,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should fetch calendar & associated events by id', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/calendars/${calendarId}`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.job_ids).to.eql(testCalendar.job_ids);
         expect(body.description).to.eql(testCalendar.description);
@@ -110,11 +111,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should fetch calendar & associated events by id for user with view permission', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/calendars/${calendarId}`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.job_ids).to.eql(testCalendar.job_ids);
         expect(body.description).to.eql(testCalendar.description);
@@ -123,22 +124,23 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should not fetch calendars for unauthorized user', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/calendars/${calendarId}`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
       });
     });
 
     it('should return 404 if invalid calendar id', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/calendars/calendar_id_dne`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(404);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(404, status, body);
+
       expect(body.error).to.eql('Not Found');
     });
   });

--- a/x-pack/test/api_integration/apis/ml/calendars/update_calendars.ts
+++ b/x-pack/test/api_integration/apis/ml/calendars/update_calendars.ts
@@ -50,12 +50,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should update calendar by id with new settings', async () => {
-      await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/calendars/${calendarId}`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(updateCalendarRequestBody)
-        .expect(200);
+        .send(updateCalendarRequestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       await ml.api.waitForCalendarToExist(calendarId);
 
@@ -75,30 +75,30 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should not allow to update calendar for user without required permission', async () => {
-      await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/calendars/${calendarId}`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(updateCalendarRequestBody)
-        .expect(403);
+        .send(updateCalendarRequestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
     });
 
     it('should not allow to update calendar for unauthorized user', async () => {
-      await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/calendars/${calendarId}`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
-        .send(updateCalendarRequestBody)
-        .expect(403);
+        .send(updateCalendarRequestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
     });
 
     it('should return error if invalid calendarId', async () => {
-      await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/calendars/calendar_id_dne`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(updateCalendarRequestBody)
-        .expect(404);
+        .send(updateCalendarRequestBody);
+      ml.api.assertResponseStatusCode(404, status, body);
     });
   });
 };

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/create_job.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/create_job.ts
@@ -91,12 +91,12 @@ export default ({ getService }: FtrProviderContext) => {
           const analyticsId = `${testConfig.jobId}`;
           const requestBody = testConfig.config;
 
-          const { body } = await supertest
+          const { body, status } = await supertest
             .put(`/api/ml/data_frame/analytics/${analyticsId}`)
             .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
             .set(COMMON_REQUEST_HEADERS)
-            .send(requestBody)
-            .expect(200);
+            .send(requestBody);
+          ml.api.assertResponseStatusCode(200, status, body);
 
           expect(body).not.to.be(undefined);
 
@@ -113,12 +113,12 @@ export default ({ getService }: FtrProviderContext) => {
         const analyticsId = `${testJobConfigs[0].jobId}`;
         const requestBody = testJobConfigs[0].config;
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .put(`/api/ml/data_frame/analytics/${analyticsId}`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(403);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -128,12 +128,12 @@ export default ({ getService }: FtrProviderContext) => {
         const analyticsId = `${testJobConfigs[0].jobId}`;
         const requestBody = testJobConfigs[0].config;
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .put(`/api/ml/data_frame/analytics/${analyticsId}`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(403);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/delete.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/delete.ts
@@ -77,11 +77,11 @@ export default ({ getService }: FtrProviderContext) => {
     describe('DeleteDataFrameAnalytics', () => {
       it('should delete analytics jobs by id', async () => {
         const analyticsId = `${jobId}_1`;
-        const { body } = await supertest
+        const { body, status } = await supertest
           .delete(`/api/ml/data_frame/analytics/${analyticsId}`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.analyticsJobDeleted.success).to.eql(true);
         await ml.api.waitForDataFrameAnalyticsJobNotToExist(analyticsId);
@@ -89,11 +89,11 @@ export default ({ getService }: FtrProviderContext) => {
 
       it('should not allow to retrieve analytics jobs for unauthorized user', async () => {
         const analyticsId = `${jobId}_2`;
-        const { body } = await supertest
+        const { body, status } = await supertest
           .delete(`/api/ml/data_frame/analytics/${analyticsId}`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -102,11 +102,11 @@ export default ({ getService }: FtrProviderContext) => {
 
       it('should not allow to retrieve analytics jobs for the user with only view permission', async () => {
         const analyticsId = `${jobId}_2`;
-        const { body } = await supertest
+        const { body, status } = await supertest
           .delete(`/api/ml/data_frame/analytics/${analyticsId}`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -115,11 +115,11 @@ export default ({ getService }: FtrProviderContext) => {
 
       it('should show 404 error if job does not exist or has already been deleted', async () => {
         const id = `${jobId}_invalid`;
-        const { body } = await supertest
+        const { body, status } = await supertest
           .delete(`/api/ml/data_frame/analytics/${id}`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(404);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(404, status, body);
 
         expect(body.error).to.eql('Not Found');
         expect(body.message).to.eql(`No known job with id '${id}'`);
@@ -139,12 +139,12 @@ export default ({ getService }: FtrProviderContext) => {
         });
 
         it('should delete job and destination index by id', async () => {
-          const { body } = await supertest
+          const { body, status } = await supertest
             .delete(`/api/ml/data_frame/analytics/${analyticsId}`)
             .query({ deleteDestIndex: true })
             .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-            .set(COMMON_REQUEST_HEADERS)
-            .expect(200);
+            .set(COMMON_REQUEST_HEADERS);
+          ml.api.assertResponseStatusCode(200, status, body);
 
           expect(body.analyticsJobDeleted.success).to.eql(true);
           expect(body.destIndexDeleted.success).to.eql(true);
@@ -168,12 +168,12 @@ export default ({ getService }: FtrProviderContext) => {
         });
 
         it('should delete job and index pattern by id', async () => {
-          const { body } = await supertest
+          const { body, status } = await supertest
             .delete(`/api/ml/data_frame/analytics/${analyticsId}`)
             .query({ deleteDestIndexPattern: true })
             .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-            .set(COMMON_REQUEST_HEADERS)
-            .expect(200);
+            .set(COMMON_REQUEST_HEADERS);
+          ml.api.assertResponseStatusCode(200, status, body);
 
           expect(body.analyticsJobDeleted.success).to.eql(true);
           expect(body.destIndexDeleted.success).to.eql(false);
@@ -200,12 +200,12 @@ export default ({ getService }: FtrProviderContext) => {
         });
 
         it('should delete job, target index, and index pattern by id', async () => {
-          const { body } = await supertest
+          const { body, status } = await supertest
             .delete(`/api/ml/data_frame/analytics/${analyticsId}`)
             .query({ deleteDestIndex: true, deleteDestIndexPattern: true })
             .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-            .set(COMMON_REQUEST_HEADERS)
-            .expect(200);
+            .set(COMMON_REQUEST_HEADERS);
+          ml.api.assertResponseStatusCode(200, status, body);
 
           expect(body.analyticsJobDeleted.success).to.eql(true);
           expect(body.destIndexDeleted.success).to.eql(true);

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/delete_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/delete_spaces.ts
@@ -22,14 +22,14 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace2 = 'space2';
 
   async function runRequest(jobId: string, space: string, expectedStatusCode: number) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .delete(`/s/${space}/api/ml/data_frame/analytics/${jobId}`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/evaluate.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/evaluate.ts
@@ -126,12 +126,12 @@ export default ({ getService }: FtrProviderContext) => {
     testJobConfigs.forEach((testConfig) => {
       describe(`EvaluateDataFrameAnalytics ${testConfig.jobType}`, async () => {
         it(`should evaluate ${testConfig.jobType} analytics job`, async () => {
-          const { body } = await supertest
+          const { body, status } = await supertest
             .post(`/api/ml/data_frame/_evaluate`)
             .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
             .set(COMMON_REQUEST_HEADERS)
-            .send(testConfig.eval)
-            .expect(200);
+            .send(testConfig.eval);
+          ml.api.assertResponseStatusCode(200, status, body);
 
           if (testConfig.jobType === 'classification') {
             const { classification } = body;
@@ -149,12 +149,12 @@ export default ({ getService }: FtrProviderContext) => {
         });
 
         it(`should evaluate ${testConfig.jobType} job for the user with only view permission`, async () => {
-          const { body } = await supertest
+          const { body, status } = await supertest
             .post(`/api/ml/data_frame/_evaluate`)
             .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
             .set(COMMON_REQUEST_HEADERS)
-            .send(testConfig.eval)
-            .expect(200);
+            .send(testConfig.eval);
+          ml.api.assertResponseStatusCode(200, status, body);
 
           if (testConfig.jobType === 'classification') {
             const { classification } = body;
@@ -172,12 +172,12 @@ export default ({ getService }: FtrProviderContext) => {
         });
 
         it(`should not allow unauthorized user to evaluate ${testConfig.jobType} job`, async () => {
-          const { body } = await supertest
+          const { body, status } = await supertest
             .post(`/api/ml/data_frame/_evaluate`)
             .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
             .set(COMMON_REQUEST_HEADERS)
-            .send(testConfig.eval)
-            .expect(403);
+            .send(testConfig.eval);
+          ml.api.assertResponseStatusCode(403, status, body);
 
           expect(body.error).to.eql('Forbidden');
           expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/explain.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/explain.ts
@@ -90,12 +90,12 @@ export default ({ getService }: FtrProviderContext) => {
     testJobConfigs.forEach((testConfig) => {
       describe(`ExplainDataFrameAnalytics ${testConfig.jobType}`, async () => {
         it(`should explain ${testConfig.jobType} analytics job`, async () => {
-          const { body } = await supertest
+          const { body, status } = await supertest
             .post(`/api/ml/data_frame/analytics/_explain`)
             .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
             .set(COMMON_REQUEST_HEADERS)
-            .send(testConfig.config)
-            .expect(200);
+            .send(testConfig.config);
+          ml.api.assertResponseStatusCode(200, status, body);
 
           expect(body).to.have.property('field_selection');
           // eslint-disable-next-line
@@ -111,24 +111,24 @@ export default ({ getService }: FtrProviderContext) => {
         });
 
         it(`should not allow user with only view permission to use explain endpoint for ${testConfig.jobType} job `, async () => {
-          const { body } = await supertest
+          const { body, status } = await supertest
             .post(`/api/ml/data_frame/analytics/_explain`)
             .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
             .set(COMMON_REQUEST_HEADERS)
-            .send(testConfig.config)
-            .expect(403);
+            .send(testConfig.config);
+          ml.api.assertResponseStatusCode(403, status, body);
 
           expect(body.error).to.eql('Forbidden');
           expect(body.message).to.eql('Forbidden');
         });
 
         it(`should not allow unauthorized user to use explain endpoint for ${testConfig.jobType} job`, async () => {
-          const { body } = await supertest
+          const { body, status } = await supertest
             .post(`/api/ml/data_frame/analytics/_explain`)
             .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
             .set(COMMON_REQUEST_HEADERS)
-            .send(testConfig.config)
-            .expect(403);
+            .send(testConfig.config);
+          ml.api.assertResponseStatusCode(403, status, body);
 
           expect(body.error).to.eql('Forbidden');
           expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/get.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/get.ts
@@ -94,11 +94,12 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('GetDataFrameAnalytics', () => {
       it('should fetch all analytics jobs', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
+
         expect(body.count).to.eql(2);
         expect(body.data_frame_analytics.length).to.eql(2);
         expect(body.data_frame_analytics[0].id).to.eql(`${jobId}_1`);
@@ -106,11 +107,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should not allow to retrieve analytics jobs for the user without required permissions', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -119,11 +120,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('GetDataFrameAnalyticsById', () => {
       it('should fetch single analytics job by id', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics/${jobId}_1`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.count).to.eql(1);
         expect(body.data_frame_analytics.length).to.eql(1);
@@ -131,11 +132,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should fetch analytics jobs based on provided ids', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics/${jobId}_1,${jobId}_2`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.count).to.eql(2);
         expect(body.data_frame_analytics.length).to.eql(2);
@@ -144,11 +145,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should not allow to retrieve a job for the user without required permissions', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics/${jobId}_1`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -157,11 +158,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('GetDataFrameAnalyticsStats', () => {
       it('should fetch analytics jobs stats', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics/_stats`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.count).to.eql(2);
         expect(body.data_frame_analytics.length).to.eql(2);
@@ -177,11 +178,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should not allow to retrieve jobs stats for the user without required permissions', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics/_stats`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -190,11 +191,12 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('GetDataFrameAnalyticsStatsById', () => {
       it('should fetch single analytics job stats by id', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics/${jobId}_1/_stats`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
+
         expect(body.count).to.eql(1);
         expect(body.data_frame_analytics.length).to.eql(1);
         expect(body.data_frame_analytics[0].id).to.eql(`${jobId}_1`);
@@ -208,11 +210,12 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should fetch multiple analytics jobs stats based on provided ids', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics/${jobId}_1,${jobId}_2/_stats`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
+
         expect(body.count).to.eql(2);
         expect(body.data_frame_analytics.length).to.eql(2);
         expect(body.data_frame_analytics[0].id).to.eql(`${jobId}_1`);
@@ -227,11 +230,12 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should not allow to retrieve a job stats for the user without required permissions', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics/${jobId}_1/_stats`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
+
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
       });
@@ -239,11 +243,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('GetDataFrameAnalyticsIdMap', () => {
       it('should return a map of objects leading up to analytics job id', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics/map/${jobId}_1`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body).to.have.keys('elements', 'details', 'error');
         // Index node, 2 job nodes (with same source index), and 2 edge nodes to connect them
@@ -260,11 +264,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should return empty results and an error message if the job does not exist', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/data_frame/analytics/map/${jobId}_fake`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.elements.length).to.eql(0);
         expect(body.details).to.eql({});

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/get_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/get_spaces.ts
@@ -29,7 +29,7 @@ export default ({ getService }: FtrProviderContext) => {
     requestStats: boolean,
     jobId?: string
   ) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(
         `/s/${space}/api/ml/data_frame/analytics${jobId ? `/${jobId}` : ''}${
           requestStats ? '/_stats' : ''
@@ -39,21 +39,21 @@ export default ({ getService }: FtrProviderContext) => {
         USER.ML_VIEWER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }
 
   async function runMapRequest(space: string, expectedStatusCode: number, jobId: string) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(`/s/${space}/api/ml/data_frame/analytics/map/${jobId}`)
       .auth(
         USER.ML_VIEWER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/start.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/start.ts
@@ -78,11 +78,11 @@ export default ({ getService }: FtrProviderContext) => {
       it('should start analytics job for specified id if job exists', async () => {
         const analyticsId = `${jobId}_0`;
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_start`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body).not.to.be(undefined);
         expect(body.acknowledged).to.be(true);
@@ -96,11 +96,11 @@ export default ({ getService }: FtrProviderContext) => {
         const id = `${jobId}_invalid`;
         const message = `No known job with id '${id}'`;
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${id}/_start`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(404);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(404, status, body);
 
         expect(body.error).to.eql('Not Found');
         expect(body.message).to.eql(message);
@@ -109,11 +109,11 @@ export default ({ getService }: FtrProviderContext) => {
       it('should not allow to start analytics job for unauthorized user', async () => {
         const analyticsId = `${jobId}_0`;
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_start`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -122,11 +122,11 @@ export default ({ getService }: FtrProviderContext) => {
       it('should not allow to start analytics job for user with view only permission', async () => {
         const analyticsId = `${jobId}_0`;
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_start`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/start_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/start_spaces.ts
@@ -26,14 +26,14 @@ export default ({ getService }: FtrProviderContext) => {
   const initialModelMemoryLimit = '17mb';
 
   async function runStartRequest(jobId: string, space: string, expectedStatusCode: number) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/s/${space}/api/ml/data_frame/analytics/${jobId}/_start`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/stop.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/stop.ts
@@ -40,11 +40,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('StopsDataFrameAnalyticsJob', () => {
       it('should stop analytics job for specified id when job exists', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_stop`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body).not.to.be(undefined);
         expect(body.stopped).to.be(true);
@@ -55,33 +55,33 @@ export default ({ getService }: FtrProviderContext) => {
         const id = `${jobId}_invalid`;
         const message = `No known job with id '${id}'`;
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${id}/_stop`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(404);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(404, status, body);
 
         expect(body.error).to.eql('Not Found');
         expect(body.message).to.eql(message);
       });
 
       it('should not allow to stop analytics job for unauthorized user', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_stop`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
       });
 
       it('should not allow to stop analytics job for user with view only permission', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_stop`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(403);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/stop_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/stop_spaces.ts
@@ -29,16 +29,15 @@ export default ({ getService }: FtrProviderContext) => {
     action: string,
     expectedStatusCode: number
   ) {
-    const resp = await supertest
+    const { body, status } = await supertest
       .post(`/s/${space}/api/ml/data_frame/analytics/${jobId}/${action}`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
       .set(COMMON_REQUEST_HEADERS);
-    const { body, status } = resp;
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
-    expect(status).to.be(expectedStatusCode);
     return body;
   }
 

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/update.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/update.ts
@@ -99,12 +99,12 @@ export default ({ getService }: FtrProviderContext) => {
           max_num_threads: 2,
         };
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_update`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(200);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body).not.to.be(undefined);
 
@@ -123,12 +123,12 @@ export default ({ getService }: FtrProviderContext) => {
           description: 'Edited description for job 1',
         };
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_update`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(200);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body).not.to.be(undefined);
 
@@ -147,12 +147,12 @@ export default ({ getService }: FtrProviderContext) => {
           allow_lazy_start: true,
         };
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_update`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(200);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body).not.to.be(undefined);
 
@@ -171,12 +171,12 @@ export default ({ getService }: FtrProviderContext) => {
           model_memory_limit: '61mb',
         };
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_update`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(200);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body).not.to.be(undefined);
 
@@ -195,12 +195,12 @@ export default ({ getService }: FtrProviderContext) => {
           max_num_threads: 2,
         };
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_update`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(200);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body).not.to.be(undefined);
 
@@ -218,12 +218,12 @@ export default ({ getService }: FtrProviderContext) => {
           description: 'Unauthorized',
         };
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_update`)
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(403);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -239,12 +239,12 @@ export default ({ getService }: FtrProviderContext) => {
           description: 'View only',
         };
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${analyticsId}/_update`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(403);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -261,12 +261,12 @@ export default ({ getService }: FtrProviderContext) => {
         const id = `${jobId}_invalid`;
         const message = `No known job with id '${id}'`;
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/ml/data_frame/analytics/${id}/_update`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(404);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(404, status, body);
 
         expect(body.error).to.eql('Not Found');
         expect(body.message).to.eql(message);

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/update_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/update_spaces.ts
@@ -31,15 +31,15 @@ export default ({ getService }: FtrProviderContext) => {
     expectedStatusCode: number,
     requestBody: unknown
   ) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/s/${space}/api/ml/data_frame/analytics/${jobId}/_update`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
       .set(COMMON_REQUEST_HEADERS)
-      .send(requestBody)
-      .expect(expectedStatusCode);
+      .send(requestBody);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/validate.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/validate.ts
@@ -90,12 +90,12 @@ export default ({ getService }: FtrProviderContext) => {
         it(`should validate ${testConfig.jobType} job for given config`, async () => {
           const requestBody = testConfig.config;
 
-          const { body } = await supertest
+          const { body, status } = await supertest
             .post('/api/ml/data_frame/analytics/validate')
             .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
             .set(COMMON_REQUEST_HEADERS)
-            .send(requestBody)
-            .expect(200);
+            .send(requestBody);
+          ml.api.assertResponseStatusCode(200, status, body);
 
           expect(body).not.to.be(undefined);
           expect(body.length).to.eql(testConfig.jobType === 'outlier_detection' ? 1 : 3);
@@ -106,12 +106,12 @@ export default ({ getService }: FtrProviderContext) => {
       it('should not allow analytics job validation for unauthorized user', async () => {
         const requestBody = testJobConfigs[0].config;
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post('/api/ml/data_frame/analytics/validate')
           .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(403);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');
@@ -120,12 +120,12 @@ export default ({ getService }: FtrProviderContext) => {
       it('should not allow analytics job validation for the user with only view permission', async () => {
         const requestBody = testJobConfigs[0].config;
 
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post('/api/ml/data_frame/analytics/validate')
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(403);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(403, status, body);
 
         expect(body.error).to.eql('Forbidden');
         expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/datafeeds/get_stats_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/datafeeds/get_stats_with_spaces.ts
@@ -26,7 +26,7 @@ export default ({ getService }: FtrProviderContext) => {
     expectedStatusCode: number,
     space?: string
   ) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(
         `${space ? `/s/${space}` : ''}/api/ml/datafeeds${datafeedId ? `/${datafeedId}` : ''}/_stats`
       )
@@ -34,8 +34,8 @@ export default ({ getService }: FtrProviderContext) => {
         USER.ML_VIEWER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/datafeeds/get_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/datafeeds/get_with_spaces.ts
@@ -26,14 +26,14 @@ export default ({ getService }: FtrProviderContext) => {
     expectedStatusCode: number,
     space?: string
   ) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(`${space ? `/s/${space}` : ''}/api/ml/datafeeds${datafeedId ? `/${datafeedId}` : ''}`)
       .auth(
         USER.ML_VIEWER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/fields_service/field_cardinality.ts
+++ b/x-pack/test/api_integration/apis/ml/fields_service/field_cardinality.ts
@@ -27,6 +27,7 @@ export default ({ getService }: FtrProviderContext) => {
         timeFieldName: 'order_date',
       },
       expected: {
+        statusCode: 200,
         responseBody: {
           'customer_first_name.keyword': 46,
           'customer_last_name.keyword': 183,
@@ -45,6 +46,7 @@ export default ({ getService }: FtrProviderContext) => {
         latestMs: 1560643199000, //  June 15, 2019 11:59:59 PM GMT
       },
       expected: {
+        statusCode: 200,
         responseBody: {
           'geoip.city_name': 10,
           'geoip.continent_name': 5,
@@ -64,6 +66,7 @@ export default ({ getService }: FtrProviderContext) => {
         latestMs: 1560643199000, //  June 15, 2019 11:59:59 PM GMT
       },
       expected: {
+        statusCode: 200,
         responseBody: {},
       },
     },
@@ -76,8 +79,8 @@ export default ({ getService }: FtrProviderContext) => {
         timeFieldName: 'order_date',
       },
       expected: {
+        statusCode: 404,
         responseBody: {
-          statusCode: 404,
           error: 'Not Found',
           message: 'index_not_found_exception',
         },
@@ -93,11 +96,12 @@ export default ({ getService }: FtrProviderContext) => {
 
     for (const testData of testDataList) {
       it(`${testData.testTitle}`, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post('/api/ml/fields_service/field_cardinality')
           .auth(testData.user, ml.securityCommon.getPasswordForUser(testData.user))
           .set(COMMON_REQUEST_HEADERS)
           .send(testData.requestBody);
+        ml.api.assertResponseStatusCode(testData.expected.statusCode, status, body);
 
         if (body.error === undefined) {
           expect(body).to.eql(testData.expected.responseBody);

--- a/x-pack/test/api_integration/apis/ml/fields_service/time_field_range.ts
+++ b/x-pack/test/api_integration/apis/ml/fields_service/time_field_range.ts
@@ -96,12 +96,12 @@ export default ({ getService }: FtrProviderContext) => {
 
     for (const testData of testDataList) {
       it(`${testData.testTitle}`, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post('/api/ml/fields_service/time_field_range')
           .auth(testData.user, ml.securityCommon.getPasswordForUser(testData.user))
           .set(COMMON_REQUEST_HEADERS)
-          .send(testData.requestBody)
-          .expect(testData.expected.responseCode);
+          .send(testData.requestBody);
+        ml.api.assertResponseStatusCode(testData.expected.responseCode, status, body);
 
         if (body.error === undefined) {
           expect(body).to.eql(testData.expected.responseBody);

--- a/x-pack/test/api_integration/apis/ml/filters/create_filters.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/create_filters.ts
@@ -107,12 +107,13 @@ export default ({ getService }: FtrProviderContext) => {
     for (const testData of testDataList) {
       const { testTitle, user, requestBody, expected } = testData;
       it(`${testTitle}`, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .put(`/api/ml/filters`)
           .auth(user, ml.securityCommon.getPasswordForUser(user))
           .set(COMMON_REQUEST_HEADERS)
-          .send(requestBody)
-          .expect(expected.responseCode);
+          .send(requestBody);
+        ml.api.assertResponseStatusCode(expected.responseCode, status, body);
+
         if (body.error === undefined) {
           // Validate the important parts of the response.
           const expectedResponse = testData.expected.responseBody;

--- a/x-pack/test/api_integration/apis/ml/filters/delete_filters.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/delete_filters.ts
@@ -49,11 +49,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     it(`should delete filter by id`, async () => {
       const { filterId } = validFilters[0];
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/filters/${filterId}`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.acknowledged).to.eql(true);
       await ml.api.waitForFilterToNotExist(filterId);
@@ -61,11 +61,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     it(`should not delete filter for user without required permission`, async () => {
       const { filterId } = validFilters[1];
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/filters/${filterId}`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       await ml.api.waitForFilterToExist(filterId);
@@ -73,22 +73,23 @@ export default ({ getService }: FtrProviderContext) => {
 
     it(`should not delete filter for unauthorized user`, async () => {
       const { filterId } = validFilters[2];
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/filters/${filterId}`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       await ml.api.waitForFilterToExist(filterId);
     });
 
     it(`should not allow user to delete filter if invalid filterId`, async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/filters/filter_id_dne`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(404);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(404, status, body);
+
       expect(body.error).to.eql('Not Found');
     });
   });

--- a/x-pack/test/api_integration/apis/ml/filters/get_filters.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/get_filters.ts
@@ -41,32 +41,34 @@ export default ({ getService }: FtrProviderContext) => {
         await ml.api.deleteFilter(filterId);
       }
     });
+
     it(`should fetch all filters`, async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/filters`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body).to.have.length(validFilters.length);
     });
 
     it(`should not allow to retrieve filters for user without required permission`, async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/filters`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
+
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');
     });
 
     it(`should not allow to retrieve filters for unauthorized user`, async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/filters`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');
@@ -74,11 +76,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     it(`should fetch single filter by id`, async () => {
       const { filterId, requestBody } = validFilters[0];
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/filters/${filterId}`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.filter_id).to.eql(filterId);
       expect(body.description).to.eql(requestBody.description);
@@ -86,11 +88,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it(`should return 400 if filterId does not exist`, async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/filters/filter_id_dne`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(400);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(400, status, body);
+
       expect(body.error).to.eql('Bad Request');
       expect(body.message).to.contain('resource_not_found_exception');
     });

--- a/x-pack/test/api_integration/apis/ml/filters/update_filters.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/update_filters.ts
@@ -54,12 +54,12 @@ export default ({ getService }: FtrProviderContext) => {
 
     it(`should update filter by id`, async () => {
       const { filterId } = validFilters[0];
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/filters/${filterId}`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(updateFilterRequestBody)
-        .expect(200);
+        .send(updateFilterRequestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.filter_id).to.eql(filterId);
       expect(body.description).to.eql(updateFilterRequestBody.description);
@@ -68,12 +68,12 @@ export default ({ getService }: FtrProviderContext) => {
 
     it(`should not allow to update filter for user without required permission`, async () => {
       const { filterId, requestBody: oldFilterRequest } = validFilters[1];
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/filters/${filterId}`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(updateFilterRequestBody)
-        .expect(403);
+        .send(updateFilterRequestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       // response should return not found
       expect(body.error).to.eql('Forbidden');
@@ -88,12 +88,12 @@ export default ({ getService }: FtrProviderContext) => {
 
     it(`should not allow to update filter for unauthorized user`, async () => {
       const { filterId, requestBody: oldFilterRequest } = validFilters[2];
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/filters/${filterId}`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
-        .send(updateFilterRequestBody)
-        .expect(403);
+        .send(updateFilterRequestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
 
@@ -105,12 +105,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it(`should return appropriate error if invalid filterId`, async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/filters/filter_id_dne`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(updateFilterRequestBody)
-        .expect(400);
+        .send(updateFilterRequestBody);
+      ml.api.assertResponseStatusCode(400, status, body);
 
       expect(body.message).to.contain('resource_not_found_exception');
     });

--- a/x-pack/test/api_integration/apis/ml/indices/field_caps.ts
+++ b/x-pack/test/api_integration/apis/ml/indices/field_caps.ts
@@ -20,12 +20,12 @@ export default ({ getService }: FtrProviderContext) => {
     index: string,
     fields?: string[]
   ): Promise<{ indices: string[]; fields: any }> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/api/ml/indices/field_caps`)
       .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
       .set(COMMON_REQUEST_HEADERS)
-      .send({ index, fields })
-      .expect(200);
+      .send({ index, fields });
+    ml.api.assertResponseStatusCode(200, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
@@ -29,11 +29,11 @@ export default ({ getService }: FtrProviderContext) => {
         await ml.api.createAnomalyDetectionJob(jobConfig);
       }
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/job_audit_messages/messages`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       notificationIndices = body.notificationIndices;
     });
@@ -45,25 +45,25 @@ export default ({ getService }: FtrProviderContext) => {
     it('should mark audit messages as cleared for provided job', async () => {
       const timestamp = Date.now();
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/job_audit_messages/clear_messages`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
         .send({
           jobId: 'test_get_job_audit_messages_1',
           notificationIndices,
-        })
-        .expect(200);
+        });
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.success).to.eql(true);
       expect(body.last_cleared).to.be.above(timestamp);
 
       await retry.tryForTime(5000, async () => {
-        const { body: getBody } = await supertest
+        const { body: getBody, status: getStatus } = await supertest
           .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, getStatus, getBody);
 
         expect(getBody.messages.length).to.eql(
           1,
@@ -81,45 +81,47 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should not mark audit messages as cleared for the user with ML read permissions', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/job_audit_messages/clear_messages`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
         .send({
           jobId: 'test_get_job_audit_messages_2',
           notificationIndices,
-        })
-        .expect(403);
+        });
+      ml.api.assertResponseStatusCode(403, status, body);
+
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');
 
-      const { body: getBody } = await supertest
+      const { body: getBody, status: getStatus } = await supertest
         .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_2`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, getStatus, getBody);
 
       expect(getBody.messages[0].cleared).to.not.eql(true);
     });
 
     it('should not mark audit messages as cleared for unauthorized user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/ml/job_audit_messages/clear_messages`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
         .send({
           jobId: 'test_get_job_audit_messages_2',
           notificationIndices,
-        })
-        .expect(403);
+        });
+      ml.api.assertResponseStatusCode(403, status, body);
+
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');
 
-      const { body: getBody } = await supertest
+      const { body: getBody, status: getStatus } = await supertest
         .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_2`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, getStatus, getBody);
 
       expect(getBody.messages[0].cleared).to.not.eql(true);
     });

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/get_job_audit_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/get_job_audit_messages.ts
@@ -34,11 +34,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     it('should fetch all audit messages', async () => {
       await retry.tryForTime(5000, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/job_audit_messages/messages`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.messages.length).to.eql(
           2,
@@ -68,11 +68,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     it('should fetch audit messages for specified job', async () => {
       await retry.tryForTime(5000, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
           .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.messages.length).to.eql(
           1,
@@ -90,11 +90,11 @@ export default ({ getService }: FtrProviderContext) => {
 
     it('should fetch audit messages for user with ML read permissions', async () => {
       await retry.tryForTime(5000, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
           .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        ml.api.assertResponseStatusCode(200, status, body);
 
         expect(body.messages.length).to.eql(
           1,
@@ -111,11 +111,11 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should not allow to fetch audit messages for unauthorized user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/job_validation/bucket_span_estimator.ts
+++ b/x-pack/test/api_integration/apis/ml/job_validation/bucket_span_estimator.ts
@@ -95,12 +95,12 @@ export default ({ getService }: FtrProviderContext) => {
     describe('with default settings', function () {
       for (const testData of testDataList) {
         it(`estimates the bucket span ${testData.testTitleSuffix}`, async () => {
-          const { body } = await supertest
+          const { body, status } = await supertest
             .post('/api/ml/validate/estimate_bucket_span')
             .auth(testData.user, ml.securityCommon.getPasswordForUser(testData.user))
             .set(COMMON_REQUEST_HEADERS)
-            .send(testData.requestBody)
-            .expect(testData.expected.responseCode);
+            .send(testData.requestBody);
+          ml.api.assertResponseStatusCode(testData.expected.responseCode, status, body);
 
           expect(body).to.eql(testData.expected.responseBody);
         });
@@ -109,28 +109,28 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('with transient search.max_buckets setting', function () {
       before(async () => {
-        await esSupertest
+        const { body, status } = await esSupertest
           .put('/_cluster/settings')
-          .send({ transient: { 'search.max_buckets': 9000 } })
-          .expect(200);
+          .send({ transient: { 'search.max_buckets': 9000 } });
+        ml.api.assertResponseStatusCode(200, status, body);
       });
 
       after(async () => {
-        await esSupertest
+        const { body, status } = await esSupertest
           .put('/_cluster/settings')
-          .send({ transient: { 'search.max_buckets': null } })
-          .expect(200);
+          .send({ transient: { 'search.max_buckets': null } });
+        ml.api.assertResponseStatusCode(200, status, body);
       });
 
       const testData = testDataList[0];
 
       it(`estimates the bucket span`, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post('/api/ml/validate/estimate_bucket_span')
           .auth(testData.user, ml.securityCommon.getPasswordForUser(testData.user))
           .set(COMMON_REQUEST_HEADERS)
-          .send(testData.requestBody)
-          .expect(testData.expected.responseCode);
+          .send(testData.requestBody);
+        ml.api.assertResponseStatusCode(testData.expected.responseCode, status, body);
 
         expect(body).to.eql(testData.expected.responseBody);
       });
@@ -138,28 +138,28 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('with persistent search.max_buckets setting', function () {
       before(async () => {
-        await esSupertest
+        const { body, status } = await esSupertest
           .put('/_cluster/settings')
-          .send({ persistent: { 'search.max_buckets': 9000 } })
-          .expect(200);
+          .send({ persistent: { 'search.max_buckets': 9000 } });
+        ml.api.assertResponseStatusCode(200, status, body);
       });
 
       after(async () => {
-        await esSupertest
+        const { body, status } = await esSupertest
           .put('/_cluster/settings')
-          .send({ persistent: { 'search.max_buckets': null } })
-          .expect(200);
+          .send({ persistent: { 'search.max_buckets': null } });
+        ml.api.assertResponseStatusCode(200, status, body);
       });
 
       const testData = testDataList[0];
 
       it(`estimates the bucket span`, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post('/api/ml/validate/estimate_bucket_span')
           .auth(testData.user, ml.securityCommon.getPasswordForUser(testData.user))
           .set(COMMON_REQUEST_HEADERS)
-          .send(testData.requestBody)
-          .expect(testData.expected.responseCode);
+          .send(testData.requestBody);
+        ml.api.assertResponseStatusCode(testData.expected.responseCode, status, body);
 
         expect(body).to.eql(testData.expected.responseBody);
       });

--- a/x-pack/test/api_integration/apis/ml/job_validation/calculate_model_memory_limit.ts
+++ b/x-pack/test/api_integration/apis/ml/job_validation/calculate_model_memory_limit.ts
@@ -151,12 +151,12 @@ export default ({ getService }: FtrProviderContext) => {
 
     for (const testData of testDataList) {
       it(`calculates the model memory limit ${testData.testTitleSuffix}`, async () => {
-        await supertest
+        const { body, status } = await supertest
           .post('/api/ml/validate/calculate_model_memory_limit')
           .auth(testData.user, ml.securityCommon.getPasswordForUser(testData.user))
           .set(COMMON_REQUEST_HEADERS)
-          .send(testData.requestBody)
-          .expect(testData.expected.responseCode);
+          .send(testData.requestBody);
+        ml.api.assertResponseStatusCode(testData.expected.responseCode, status, body);
 
         // More backend changes to the model memory calculation are planned.
         // This value check will be re-enabled when the final batch of updates is in.

--- a/x-pack/test/api_integration/apis/ml/job_validation/cardinality.ts
+++ b/x-pack/test/api_integration/apis/ml/job_validation/cardinality.ts
@@ -54,12 +54,12 @@ export default ({ getService }: FtrProviderContext) => {
         },
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/cardinality')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(200);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body).to.eql([{ id: 'success_cardinality' }]);
     });
@@ -91,12 +91,12 @@ export default ({ getService }: FtrProviderContext) => {
           query: { bool: { must: [{ match_all: {} }], filter: [], must_not: [] } },
         },
       };
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/cardinality')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(200);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       const expectedResponse = [
         {
@@ -143,12 +143,12 @@ export default ({ getService }: FtrProviderContext) => {
         },
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/cardinality')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(400);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(400, status, body);
 
       expect(body.error).to.eql('Bad Request');
       expect(body.message).to.eql(
@@ -183,12 +183,12 @@ export default ({ getService }: FtrProviderContext) => {
         },
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/cardinality')
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(403);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/job_validation/datafeed_preview_validation.ts
+++ b/x-pack/test/api_integration/apis/ml/job_validation/datafeed_preview_validation.ts
@@ -100,12 +100,12 @@ export default ({ getService }: FtrProviderContext) => {
     it(`should validate a job with documents`, async () => {
       const job = getBaseJobConfig();
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/datafeed_preview')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job })
-        .expect(200);
+        .send({ job });
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.valid).to.eql(true, `valid should be true, but got ${body.valid}`);
       expect(body.documentsFound).to.eql(
@@ -118,12 +118,12 @@ export default ({ getService }: FtrProviderContext) => {
       const job = getBaseJobConfig();
       job.analysis_config.detectors[0].field_name = 'no_such_field';
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/datafeed_preview')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job })
-        .expect(200);
+        .send({ job });
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.valid).to.eql(false, `valid should be false, but got ${body.valid}`);
       expect(body.documentsFound).to.eql(
@@ -136,12 +136,12 @@ export default ({ getService }: FtrProviderContext) => {
       const job = getBaseJobConfig();
       job.datafeed_config.indices = ['farequote_empty'];
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/datafeed_preview')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job })
-        .expect(200);
+        .send({ job });
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.valid).to.eql(true, `valid should be true, but got ${body.valid}`);
       expect(body.documentsFound).to.eql(
@@ -153,23 +153,23 @@ export default ({ getService }: FtrProviderContext) => {
     it(`should fail for viewer user`, async () => {
       const job = getBaseJobConfig();
 
-      await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/datafeed_preview')
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job })
-        .expect(403);
+        .send({ job });
+      ml.api.assertResponseStatusCode(403, status, body);
     });
 
     it(`should fail for unauthorized user`, async () => {
       const job = getBaseJobConfig();
 
-      await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/datafeed_preview')
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job })
-        .expect(403);
+        .send({ job });
+      ml.api.assertResponseStatusCode(403, status, body);
     });
   });
 };

--- a/x-pack/test/api_integration/apis/ml/job_validation/validate.ts
+++ b/x-pack/test/api_integration/apis/ml/job_validation/validate.ts
@@ -70,12 +70,12 @@ export default ({ getService }: FtrProviderContext) => {
         },
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/job')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(200);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body).to.eql(basicValidJobMessages);
     });
@@ -114,12 +114,12 @@ export default ({ getService }: FtrProviderContext) => {
         },
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/job')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(200);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body).to.eql(basicInvalidJobMessages);
     });
@@ -164,12 +164,12 @@ export default ({ getService }: FtrProviderContext) => {
         },
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/job')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(200);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       // The existance and value of maxModelMemoryLimit depends on ES settings
       // and may vary between test environments, e.g. cloud vs non-cloud,
@@ -231,12 +231,12 @@ export default ({ getService }: FtrProviderContext) => {
         },
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/job')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(400);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(400, status, body);
 
       expect(body.error).to.eql('Bad Request');
       expect(body.message).to.eql(
@@ -277,12 +277,12 @@ export default ({ getService }: FtrProviderContext) => {
         },
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/validate/job')
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(403);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/jobs/categorization_field_examples.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/categorization_field_examples.ts
@@ -292,12 +292,12 @@ export default ({ getService }: FtrProviderContext) => {
 
     for (const testData of testDataList) {
       it(testData.title, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post('/api/ml/jobs/categorization_field_examples')
           .auth(testData.user, ml.securityCommon.getPasswordForUser(testData.user))
           .set(COMMON_REQUEST_HEADERS)
-          .send(testData.requestBody)
-          .expect(testData.expected.responseCode);
+          .send(testData.requestBody);
+        ml.api.assertResponseStatusCode(testData.expected.responseCode, status, body);
 
         expect(body.overallValidStatus).to.eql(testData.expected.overallValidStatus);
         expect(body.sampleSize).to.eql(testData.expected.sampleSize);

--- a/x-pack/test/api_integration/apis/ml/jobs/close_jobs.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/close_jobs.ts
@@ -25,12 +25,12 @@ export default ({ getService }: FtrProviderContext) => {
     requestBody: object,
     expectedResponsecode: number
   ): Promise<any> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post('/api/ml/jobs/close_jobs')
       .auth(user, ml.securityCommon.getPasswordForUser(user))
       .set(COMMON_REQUEST_HEADERS)
-      .send(requestBody)
-      .expect(expectedResponsecode);
+      .send(requestBody);
+    ml.api.assertResponseStatusCode(expectedResponsecode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/close_jobs_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/close_jobs_spaces.ts
@@ -23,15 +23,15 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace2 = 'space2';
 
   async function runRequest(space: string, expectedStatusCode: number, jobIds?: string[]) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/s/${space}/api/ml/jobs/close_jobs`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
       .set(COMMON_REQUEST_HEADERS)
-      .send({ jobIds })
-      .expect(expectedStatusCode);
+      .send({ jobIds });
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/datafeed_preview.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/datafeed_preview.ts
@@ -65,12 +65,12 @@ export default ({ getService }: FtrProviderContext) => {
         runtime_mappings: {},
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/jobs/datafeed_preview')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job, datafeed })
-        .expect(200);
+        .send({ job, datafeed });
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.length).to.eql(1000, 'Response body total hits should be 1000');
       expect(typeof body[0]?.airline).to.eql('string', 'Response body airlines should be a string');
@@ -102,12 +102,12 @@ export default ({ getService }: FtrProviderContext) => {
         runtime_mappings: {},
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/jobs/datafeed_preview')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job, datafeed })
-        .expect(200);
+        .send({ job, datafeed });
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.length).to.eql(1000, 'Response body total hits should be 1000');
       expect(typeof body[0]?.airline).to.eql('string', 'Response body airlines should be a string');
@@ -144,12 +144,12 @@ export default ({ getService }: FtrProviderContext) => {
         },
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/jobs/datafeed_preview')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job, datafeed })
-        .expect(200);
+        .send({ job, datafeed });
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.length).to.eql(1000, 'Response body total hits should be 1000');
       expect(typeof body[0]?.airline).to.eql('string', 'Response body airlines should be a string');
@@ -189,12 +189,12 @@ export default ({ getService }: FtrProviderContext) => {
         },
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/ml/jobs/datafeed_preview')
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job, datafeed })
-        .expect(200);
+        .send({ job, datafeed });
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.length).to.eql(1000, 'Response body total hits should be 1000');
       expect(typeof body[0]?.airline).to.eql('string', 'Response body airlines should be a string');
@@ -224,12 +224,12 @@ export default ({ getService }: FtrProviderContext) => {
         runtime_mappings: {},
       };
 
-      await supertest
+      const { body, status } = await supertest
         .post('/api/ml/jobs/datafeed_preview')
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job, datafeed })
-        .expect(403);
+        .send({ job, datafeed });
+      ml.api.assertResponseStatusCode(403, status, body);
     });
 
     it(`should return not a datafeed preview for unauthorized user`, async () => {
@@ -249,12 +249,12 @@ export default ({ getService }: FtrProviderContext) => {
         runtime_mappings: {},
       };
 
-      await supertest
+      const { body, status } = await supertest
         .post('/api/ml/jobs/datafeed_preview')
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
-        .send({ job, datafeed })
-        .expect(403);
+        .send({ job, datafeed });
+      ml.api.assertResponseStatusCode(403, status, body);
     });
   });
 };

--- a/x-pack/test/api_integration/apis/ml/jobs/delete_jobs.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/delete_jobs.ts
@@ -68,12 +68,12 @@ export default ({ getService }: FtrProviderContext) => {
     requestBody: object,
     expectedResponsecode: number
   ): Promise<any> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post('/api/ml/jobs/delete_jobs')
       .auth(user, ml.securityCommon.getPasswordForUser(user))
       .set(COMMON_REQUEST_HEADERS)
-      .send(requestBody)
-      .expect(expectedResponsecode);
+      .send(requestBody);
+    ml.api.assertResponseStatusCode(expectedResponsecode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/delete_jobs_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/delete_jobs_spaces.ts
@@ -22,15 +22,15 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace2 = 'space2';
 
   async function runRequest(space: string, expectedStatusCode: number, jobIds?: string[]) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/s/${space}/api/ml/jobs/delete_jobs`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
       .set(COMMON_REQUEST_HEADERS)
-      .send({ jobIds })
-      .expect(expectedStatusCode);
+      .send({ jobIds });
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/force_start_datafeeds.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/force_start_datafeeds.ts
@@ -24,12 +24,12 @@ export default ({ getService }: FtrProviderContext) => {
     requestBody: object,
     expectedResponsecode: number
   ): Promise<Record<string, { started: boolean; error?: string }>> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post('/api/ml/jobs/force_start_datafeeds')
       .auth(user, ml.securityCommon.getPasswordForUser(user))
       .set(COMMON_REQUEST_HEADERS)
-      .send(requestBody)
-      .expect(expectedResponsecode);
+      .send(requestBody);
+    ml.api.assertResponseStatusCode(expectedResponsecode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/force_start_datafeeds_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/force_start_datafeeds_spaces.ts
@@ -34,15 +34,15 @@ export default ({ getService }: FtrProviderContext) => {
     start: number,
     end: number
   ): Promise<Record<string, { started: boolean; error?: string }>> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/s/${space}/api/ml/jobs/force_start_datafeeds`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
       .set(COMMON_REQUEST_HEADERS)
-      .send({ datafeedIds, start, end })
-      .expect(expectedStatusCode);
+      .send({ datafeedIds, start, end });
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/jobs_exist.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/jobs_exist.ts
@@ -70,12 +70,12 @@ export default ({ getService }: FtrProviderContext) => {
     requestBody: object,
     expectedResponsecode: number
   ): Promise<any> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post('/api/ml/jobs/jobs_exist')
       .auth(user, ml.securityCommon.getPasswordForUser(user))
       .set(COMMON_REQUEST_HEADERS)
-      .send(requestBody)
-      .expect(expectedResponsecode);
+      .send(requestBody);
+    ml.api.assertResponseStatusCode(expectedResponsecode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/jobs_exist_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/jobs_exist_spaces.ts
@@ -23,15 +23,15 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace2 = 'space2';
 
   async function runRequest(space: string, expectedStatusCode: number, jobIds?: string[]) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/s/${space}/api/ml/jobs/jobs_exist`)
       .auth(
         USER.ML_VIEWER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
       )
       .set(COMMON_REQUEST_HEADERS)
-      .send({ jobIds })
-      .expect(expectedStatusCode);
+      .send({ jobIds });
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/jobs_summary.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/jobs_summary.ts
@@ -173,12 +173,12 @@ export default ({ getService }: FtrProviderContext) => {
     requestBody: object,
     expectedResponsecode: number
   ): Promise<any> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post('/api/ml/jobs/jobs_summary')
       .auth(user, ml.securityCommon.getPasswordForUser(user))
       .set(COMMON_REQUEST_HEADERS)
-      .send(requestBody)
-      .expect(expectedResponsecode);
+      .send(requestBody);
+    ml.api.assertResponseStatusCode(expectedResponsecode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/jobs_summary_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/jobs_summary_spaces.ts
@@ -21,15 +21,15 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace2 = 'space2';
 
   async function runRequest(space: string, expectedStatusCode: number, jobIds?: string[]) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/s/${space}/api/ml/jobs/jobs_summary`)
       .auth(
         USER.ML_VIEWER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
       )
       .set(COMMON_REQUEST_HEADERS)
-      .send({ jobIds })
-      .expect(expectedStatusCode);
+      .send({ jobIds });
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/stop_datafeeds.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/stop_datafeeds.ts
@@ -24,12 +24,12 @@ export default ({ getService }: FtrProviderContext) => {
     requestBody: object,
     expectedResponsecode: number
   ): Promise<Record<string, { stopped: boolean; error?: string }>> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post('/api/ml/jobs/stop_datafeeds')
       .auth(user, ml.securityCommon.getPasswordForUser(user))
       .set(COMMON_REQUEST_HEADERS)
-      .send(requestBody)
-      .expect(expectedResponsecode);
+      .send(requestBody);
+    ml.api.assertResponseStatusCode(expectedResponsecode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/jobs/stop_datafeeds_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/stop_datafeeds_spaces.ts
@@ -30,15 +30,15 @@ export default ({ getService }: FtrProviderContext) => {
     expectedStatusCode: number,
     datafeedIds: string[]
   ): Promise<Record<string, { stopped: boolean; error?: string }>> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/s/${space}/api/ml/jobs/stop_datafeeds`)
       .auth(
         USER.ML_POWERUSER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER_ALL_SPACES)
       )
       .set(COMMON_REQUEST_HEADERS)
-      .send({ datafeedIds })
-      .expect(expectedStatusCode);
+      .send({ datafeedIds });
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/modules/get_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/get_module.ts
@@ -48,11 +48,11 @@ export default ({ getService }: FtrProviderContext) => {
   const ml = getService('ml');
 
   async function executeGetModuleRequest(module: string, user: USER, rspCode: number) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(`/api/ml/modules/get_module/${module}`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(rspCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(rspCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/modules/recognize_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/recognize_module.ts
@@ -205,11 +205,11 @@ export default ({ getService }: FtrProviderContext) => {
   ];
 
   async function executeRecognizeModuleRequest(indexPattern: string, user: USER, rspCode: number) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(`/api/ml/modules/recognize/${indexPattern}`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(rspCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(rspCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/modules/setup_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/setup_module.ts
@@ -1002,12 +1002,12 @@ export default ({ getService }: FtrProviderContext) => {
     rqBody: object,
     rspCode: number
   ) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/api/ml/modules/setup/${module}`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
       .set(COMMON_REQUEST_HEADERS)
-      .send(rqBody)
-      .expect(rspCode);
+      .send(rqBody);
+    ml.api.assertResponseStatusCode(rspCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/results/get_anomalies_table_data.ts
+++ b/x-pack/test/api_integration/apis/ml/results/get_anomalies_table_data.ts
@@ -72,12 +72,12 @@ export default ({ getService }: FtrProviderContext) => {
         maxRecords: 500,
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post(`/api/ml/results/anomalies_table_data`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(200);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.interval).to.eql('hour');
       expect(body.anomalies.length).to.eql(13);
@@ -97,12 +97,12 @@ export default ({ getService }: FtrProviderContext) => {
         maxRecords: 500,
       };
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post(`/api/ml/results/anomalies_table_data`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(400);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(400, status, body);
 
       expect(body.error).to.eql('Bad Request');
       expect(body.message).to.eql(
@@ -122,12 +122,12 @@ export default ({ getService }: FtrProviderContext) => {
         dateFormatTz: 'UTC',
         maxRecords: 500,
       };
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post(`/api/ml/results/anomalies_table_data`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
-        .send(requestBody)
-        .expect(403);
+        .send(requestBody);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/results/get_categorizer_stats.ts
+++ b/x-pack/test/api_integration/apis/ml/results/get_categorizer_stats.ts
@@ -65,11 +65,11 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should fetch all the categorizer stats for job id', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/results/${jobId}/categorizer_stats`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       body.forEach((doc: AnomalyCategorizerStatsDoc) => {
         expect(doc.job_id).to.eql(jobId);
@@ -80,11 +80,11 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should fetch categorizer stats for job id for user with view permission', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/results/${jobId}/categorizer_stats`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       body.forEach((doc: AnomalyCategorizerStatsDoc) => {
         expect(doc.job_id).to.eql(jobId);
@@ -95,23 +95,24 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should not fetch categorizer stats for job id for unauthorized user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/results/${jobId}/categorizer_stats`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.be('Forbidden');
       expect(body.message).to.be('Forbidden');
     });
 
     it('should fetch all the categorizer stats with per-partition value for job id', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/results/${jobId}/categorizer_stats`)
         .query({ partitionByValue: 'sample_web_logs' })
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
+
       body.forEach((doc: AnomalyCategorizerStatsDoc) => {
         expect(doc.job_id).to.eql(jobId);
         expect(doc.result_type).to.eql('categorizer_stats');
@@ -121,12 +122,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should fetch categorizer stats with per-partition value for user with view permission', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/results/${jobId}/categorizer_stats`)
         .query({ partitionByValue: 'sample_web_logs' })
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       body.forEach((doc: AnomalyCategorizerStatsDoc) => {
         expect(doc.job_id).to.eql(jobId);
@@ -137,12 +138,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should not fetch categorizer stats with per-partition value for unauthorized user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/results/${jobId}/categorizer_stats`)
         .query({ partitionByValue: 'sample_web_logs' })
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.be('Forbidden');
       expect(body.message).to.be('Forbidden');

--- a/x-pack/test/api_integration/apis/ml/results/get_stopped_partitions.ts
+++ b/x-pack/test/api_integration/apis/ml/results/get_stopped_partitions.ts
@@ -102,12 +102,13 @@ export default ({ getService }: FtrProviderContext) => {
 
     it('should fetch all the stopped partitions correctly', async () => {
       const { jobId } = testSetUps[0];
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post(`/api/ml/results/category_stopped_partitions`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .send({ jobIds: [jobId] })
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
+
       expect(body.jobs).to.not.be(undefined);
       expect(body.jobs[jobId]).to.be.an('array');
       expect(body.jobs[jobId].length).to.be.greaterThan(0);
@@ -115,24 +116,25 @@ export default ({ getService }: FtrProviderContext) => {
 
     it('should not return jobId in response if stopped_on_warn is false', async () => {
       const { jobId } = testSetUps[1];
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post(`/api/ml/results/category_stopped_partitions`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .send({ jobIds: [jobId] })
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
+
       expect(body.jobs).to.not.be(undefined);
       expect(body.jobs).to.not.have.property(jobId);
     });
 
     it('should fetch stopped partitions for user with view permission', async () => {
       const { jobId } = testSetUps[2];
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post(`/api/ml/results/category_stopped_partitions`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .send({ jobIds: [jobId] })
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.jobs).to.not.be(undefined);
       expect(body.jobs[jobId]).to.be.an('array');
@@ -142,24 +144,25 @@ export default ({ getService }: FtrProviderContext) => {
     it('should not fetch stopped partitions for unauthorized user', async () => {
       const { jobId } = testSetUps[3];
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post(`/api/ml/results/category_stopped_partitions`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .send({ jobIds: [jobId] })
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
 
       expect(body.error).to.be('Forbidden');
       expect(body.message).to.be('Forbidden');
     });
 
     it('should fetch stopped partitions for multiple job ids', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post(`/api/ml/results/category_stopped_partitions`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .send({ jobIds: testJobIds })
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
+
       expect(body.jobs).to.not.be(undefined);
       expect(body.jobs).to.not.have.property(testSetUps[1].jobId);
 
@@ -171,12 +174,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should return array of jobIds with stopped_partitions for multiple job ids when bucketed by job_id', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post(`/api/ml/results/category_stopped_partitions`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .send({ jobIds: testJobIds, fieldToBucket: 'job_id' })
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.jobs).to.not.be(undefined);
       body.jobs.forEach((currentJobId: string) => {

--- a/x-pack/test/api_integration/apis/ml/saved_objects/can_delete_job.ts
+++ b/x-pack/test/api_integration/apis/ml/saved_objects/can_delete_job.ts
@@ -29,12 +29,13 @@ export default ({ getService }: FtrProviderContext) => {
     expectedStatusCode: number,
     space?: string
   ) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`${space ? `/s/${space}` : ''}/api/ml/saved_objects/can_delete_job/${jobType}`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
       .set(COMMON_REQUEST_HEADERS)
-      .send({ jobIds })
-      .expect(expectedStatusCode);
+      .send({ jobIds });
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
+
     return body;
   }
 

--- a/x-pack/test/api_integration/apis/ml/saved_objects/initialize.ts
+++ b/x-pack/test/api_integration/apis/ml/saved_objects/initialize.ts
@@ -21,11 +21,11 @@ export default ({ getService }: FtrProviderContext) => {
   const dfaJobId = 'ihp_od';
 
   async function runRequest(user: USER, expectedStatusCode: number) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(`/api/ml/saved_objects/initialize`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/saved_objects/jobs_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/saved_objects/jobs_spaces.ts
@@ -24,11 +24,11 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace2 = 'space2';
 
   async function runRequest(expectedStatusCode: number, user: USER) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(`/api/ml/saved_objects/jobs_spaces`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/saved_objects/status.ts
+++ b/x-pack/test/api_integration/apis/ml/saved_objects/status.ts
@@ -26,14 +26,14 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace2 = 'space2';
 
   async function runRequest(expectedStatusCode: number) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(`/api/ml/saved_objects/status`)
       .auth(
         USER.ML_VIEWER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
       )
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/saved_objects/sync.ts
+++ b/x-pack/test/api_integration/apis/ml/saved_objects/sync.ts
@@ -24,22 +24,22 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace1 = 'space1';
 
   async function runSyncRequest(user: USER, expectedStatusCode: number) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(`/s/${idSpace1}/api/ml/saved_objects/sync`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(expectedStatusCode);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }
 
   async function runSyncCheckRequest(user: USER, jobType: JobType, expectedStatusCode: number) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/s/${idSpace1}/api/ml/saved_objects/sync_check`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
       .set(COMMON_REQUEST_HEADERS)
-      .send({ jobType })
-      .expect(expectedStatusCode);
+      .send({ jobType });
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/saved_objects/update_jobs_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/saved_objects/update_jobs_spaces.ts
@@ -33,12 +33,12 @@ export default ({ getService }: FtrProviderContext) => {
     expectedStatusCode: number,
     user: USER
   ) {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .post(`/api/ml/saved_objects/update_jobs_spaces`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
       .set(COMMON_REQUEST_HEADERS)
-      .send(requestBody)
-      .expect(expectedStatusCode);
+      .send(requestBody);
+    ml.api.assertResponseStatusCode(expectedStatusCode, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/system/capabilities.ts
+++ b/x-pack/test/api_integration/apis/ml/system/capabilities.ts
@@ -17,11 +17,11 @@ export default ({ getService }: FtrProviderContext) => {
   const ml = getService('ml');
 
   async function runRequest(user: USER): Promise<MlCapabilitiesResponse> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(`/api/ml/ml_capabilities`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(200);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(200, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/system/space_capabilities.ts
+++ b/x-pack/test/api_integration/apis/ml/system/space_capabilities.ts
@@ -21,11 +21,11 @@ export default ({ getService }: FtrProviderContext) => {
   const ml = getService('ml');
 
   async function runRequest(user: USER, space?: string): Promise<MlCapabilitiesResponse> {
-    const { body } = await supertest
+    const { body, status } = await supertest
       .get(`${space ? `/s/${space}` : ''}/api/ml/ml_capabilities`)
       .auth(user, ml.securityCommon.getPasswordForUser(user))
-      .set(COMMON_REQUEST_HEADERS)
-      .expect(200);
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(200, status, body);
 
     return body;
   }

--- a/x-pack/test/api_integration/apis/ml/trained_models/delete_model.ts
+++ b/x-pack/test/api_integration/apis/ml/trained_models/delete_model.ts
@@ -25,43 +25,43 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('deletes trained model by id', async () => {
-      const { body: deleteResponseBody } = await supertest
+      const { body: deleteResponseBody, status: deleteResponseStatus } = await supertest
         .delete(`/api/ml/trained_models/dfa_regression_model_n_0`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, deleteResponseStatus, deleteResponseBody);
 
       expect(deleteResponseBody).to.eql({ acknowledged: true });
 
       // verify that model is actually deleted
-      await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models/dfa_regression_model_n_0`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(404);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(404, status, body);
     });
 
     it('returns 404 if requested trained model does not exist', async () => {
-      await supertest
+      const { body, status } = await supertest
         .delete(`/api/ml/trained_models/not_existing_model`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(404);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(404, status, body);
     });
 
     it('does not allow to delete trained model if the user does not have required permissions', async () => {
-      await supertest
+      const { body: deleteResponseBody, status: deleteResponseStatus } = await supertest
         .delete(`/api/ml/trained_models/dfa_regression_model_n_1`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, deleteResponseStatus, deleteResponseBody);
 
       // verify that model has not been deleted
-      await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models/dfa_regression_model_n_1`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
     });
   });
 };

--- a/x-pack/test/api_integration/apis/ml/trained_models/get_model_pipelines.ts
+++ b/x-pack/test/api_integration/apis/ml/trained_models/get_model_pipelines.ts
@@ -29,11 +29,11 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('returns trained model pipelines by id', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models/dfa_regression_model_n_0/pipelines`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.length).to.eql(1);
       expect(body[0].model_id).to.eql('dfa_regression_model_n_0');
@@ -41,11 +41,11 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('returns an error in case user does not have required permission', async () => {
-      await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models/dfa_regression_model_n_0/pipelines`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
     });
   });
 };

--- a/x-pack/test/api_integration/apis/ml/trained_models/get_model_stats.ts
+++ b/x-pack/test/api_integration/apis/ml/trained_models/get_model_stats.ts
@@ -25,30 +25,30 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('returns trained model stats by id', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models/dfa_regression_model_n_0/_stats`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
 
       expect(body.count).to.eql(1);
       expect(body.trained_model_stats[0].model_id).to.eql('dfa_regression_model_n_0');
     });
 
     it('returns 404 if requested trained model does not exist', async () => {
-      await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models/not_existing_model/_stats`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(404);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(404, status, body);
     });
 
     it('returns an error for unauthorized user', async () => {
-      await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models/dfa_regression_model_n_0/_stats`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
     });
   });
 };

--- a/x-pack/test/api_integration/apis/ml/trained_models/get_models.ts
+++ b/x-pack/test/api_integration/apis/ml/trained_models/get_models.ts
@@ -35,11 +35,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('returns all trained models with associated pipelines including aliases', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models?with_pipelines=true`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
+
       // Created models + system model
       expect(body.length).to.eql(6);
 
@@ -48,11 +49,12 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('returns models without pipeline in case user does not have required permission', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models?with_pipelines=true`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
+
       // Created models + system model
       expect(body.length).to.eql(6);
       const sampleModel = body.find((v: any) => v.model_id === 'dfa_regression_model_n_0');
@@ -60,29 +62,30 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('returns trained model by id', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models/dfa_regression_model_n_1`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
+
       expect(body.length).to.eql(1);
       expect(body[0].model_id).to.eql('dfa_regression_model_n_1');
     });
 
     it('returns 404 if requested trained model does not exist', async () => {
-      await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models/not_existing_model`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(404);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(404, status, body);
     });
 
     it('returns an error for unauthorized user', async () => {
-      await supertest
+      const { body, status } = await supertest
         .get(`/api/ml/trained_models/dfa_regression_model_n_1`)
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(403);
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
     });
   });
 };

--- a/x-pack/test/api_integration/apis/transform/delete_transforms.ts
+++ b/x-pack/test/api_integration/apis/transform/delete_transforms.ts
@@ -54,15 +54,15 @@ export default ({ getService }: FtrProviderContext) => {
         const reqBody: DeleteTransformsRequestSchema = {
           transformsInfo: [{ id: transformId, state: TRANSFORM_STATE.STOPPED }],
         };
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/delete_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(body[transformId].transformDeleted.success).to.eql(true);
         expect(body[transformId].destIndexDeleted.success).to.eql(false);
@@ -75,15 +75,16 @@ export default ({ getService }: FtrProviderContext) => {
         const reqBody: DeleteTransformsRequestSchema = {
           transformsInfo: [{ id: transformId, state: TRANSFORM_STATE.STOPPED }],
         };
-        await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/delete_transforms`)
           .auth(
             USER.TRANSFORM_VIEWER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_VIEWER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(403);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(403, status, body);
+
         await transform.api.waitForTransformToExist(transformId);
         await transform.api.waitForIndicesToExist(destinationIndex);
       });
@@ -94,15 +95,16 @@ export default ({ getService }: FtrProviderContext) => {
         const reqBody: DeleteTransformsRequestSchema = {
           transformsInfo: [{ id: 'invalid_transform_id', state: TRANSFORM_STATE.STOPPED }],
         };
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/delete_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
+
         expect(body.invalid_transform_id.transformDeleted.success).to.eql(false);
         expect(body.invalid_transform_id.transformDeleted).to.have.property('error');
       });
@@ -131,15 +133,15 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should delete multiple transforms by transformIds', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/delete_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         await asyncForEach(
           reqBody.transformsInfo,
@@ -155,7 +157,7 @@ export default ({ getService }: FtrProviderContext) => {
 
       it('should delete multiple transforms by transformIds, even if one of the transformIds is invalid', async () => {
         const invalidTransformId = 'invalid_transform_id';
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/delete_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
@@ -168,8 +170,8 @@ export default ({ getService }: FtrProviderContext) => {
               ...reqBody.transformsInfo,
               { id: invalidTransformId, state: TRANSFORM_STATE.STOPPED },
             ],
-          })
-          .expect(200);
+          });
+        transform.api.assertResponseStatusCode(200, status, body);
 
         await asyncForEach(
           reqBody.transformsInfo,
@@ -205,15 +207,15 @@ export default ({ getService }: FtrProviderContext) => {
           transformsInfo: [{ id: transformId, state: TRANSFORM_STATE.STOPPED }],
           deleteDestIndex: true,
         };
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/delete_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(body[transformId].transformDeleted.success).to.eql(true);
         expect(body[transformId].destIndexDeleted.success).to.eql(true);
@@ -244,15 +246,15 @@ export default ({ getService }: FtrProviderContext) => {
           deleteDestIndex: false,
           deleteDestIndexPattern: true,
         };
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/delete_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(body[transformId].transformDeleted.success).to.eql(true);
         expect(body[transformId].destIndexDeleted.success).to.eql(false);
@@ -284,15 +286,15 @@ export default ({ getService }: FtrProviderContext) => {
           deleteDestIndex: true,
           deleteDestIndexPattern: true,
         };
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/delete_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(body[transformId].transformDeleted.success).to.eql(true);
         expect(body[transformId].destIndexDeleted.success).to.eql(true);

--- a/x-pack/test/api_integration/apis/transform/start_transforms.ts
+++ b/x-pack/test/api_integration/apis/transform/start_transforms.ts
@@ -48,15 +48,15 @@ export default ({ getService }: FtrProviderContext) => {
 
       it('should start the transform by transformId', async () => {
         const reqBody: StartTransformsRequestSchema = [{ id: transformId }];
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/start_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(body[transformId].success).to.eql(true);
         expect(typeof body[transformId].error).to.eql('undefined');
@@ -66,15 +66,15 @@ export default ({ getService }: FtrProviderContext) => {
 
       it('should return 200 with success:false for unauthorized user', async () => {
         const reqBody: StartTransformsRequestSchema = [{ id: transformId }];
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/start_transforms`)
           .auth(
             USER.TRANSFORM_VIEWER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_VIEWER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(body[transformId].success).to.eql(false);
         expect(typeof body[transformId].error).to.eql('object');
@@ -87,15 +87,15 @@ export default ({ getService }: FtrProviderContext) => {
     describe('single transform start with invalid transformId', function () {
       it('should return 200 with error in response if invalid transformId', async () => {
         const reqBody: StartTransformsRequestSchema = [{ id: 'invalid_transform_id' }];
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/start_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(body.invalid_transform_id.success).to.eql(false);
         expect(body.invalid_transform_id).to.have.property('error');
@@ -123,15 +123,15 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should start multiple transforms by transformIds', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/start_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         await asyncForEach(reqBody, async ({ id: transformId }: { id: string }, idx: number) => {
           expect(body[transformId].success).to.eql(true);
@@ -142,15 +142,15 @@ export default ({ getService }: FtrProviderContext) => {
 
       it('should start multiple transforms by transformIds, even if one of the transformIds is invalid', async () => {
         const invalidTransformId = 'invalid_transform_id';
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/start_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send([{ id: reqBody[0].id }, { id: invalidTransformId }, { id: reqBody[1].id }])
-          .expect(200);
+          .send([{ id: reqBody[0].id }, { id: invalidTransformId }, { id: reqBody[1].id }]);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         await asyncForEach(reqBody, async ({ id: transformId }: { id: string }, idx: number) => {
           expect(body[transformId].success).to.eql(true);

--- a/x-pack/test/api_integration/apis/transform/stop_transforms.ts
+++ b/x-pack/test/api_integration/apis/transform/stop_transforms.ts
@@ -66,15 +66,15 @@ export default ({ getService }: FtrProviderContext) => {
         const reqBody: StopTransformsRequestSchema = [
           { id: transformId, state: TRANSFORM_STATE.STARTED },
         ];
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/stop_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(isStopTransformsResponseSchema(body)).to.eql(true);
         expect(body[transformId].success).to.eql(true);
@@ -87,15 +87,15 @@ export default ({ getService }: FtrProviderContext) => {
         const reqBody: StopTransformsRequestSchema = [
           { id: transformId, state: TRANSFORM_STATE.STARTED },
         ];
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/stop_transforms`)
           .auth(
             USER.TRANSFORM_VIEWER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_VIEWER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(isStopTransformsResponseSchema(body)).to.eql(true);
         expect(body[transformId].success).to.eql(false);
@@ -111,15 +111,15 @@ export default ({ getService }: FtrProviderContext) => {
         const reqBody: StopTransformsRequestSchema = [
           { id: 'invalid_transform_id', state: TRANSFORM_STATE.STARTED },
         ];
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/stop_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(isStopTransformsResponseSchema(body)).to.eql(true);
         expect(body.invalid_transform_id.success).to.eql(false);
@@ -148,15 +148,15 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should stop multiple transforms by transformIds', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/stop_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send(reqBody)
-          .expect(200);
+          .send(reqBody);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(isStopTransformsResponseSchema(body)).to.eql(true);
 
@@ -169,7 +169,7 @@ export default ({ getService }: FtrProviderContext) => {
 
       it('should stop multiple transforms by transformIds, even if one of the transformIds is invalid', async () => {
         const invalidTransformId = 'invalid_transform_id';
-        const { body } = await supertest
+        const { body, status } = await supertest
           .post(`/api/transform/stop_transforms`)
           .auth(
             USER.TRANSFORM_POWERUSER,
@@ -180,8 +180,8 @@ export default ({ getService }: FtrProviderContext) => {
             { id: reqBody[0].id, state: reqBody[0].state },
             { id: invalidTransformId, state: TRANSFORM_STATE.STOPPED },
             { id: reqBody[1].id, state: reqBody[1].state },
-          ])
-          .expect(200);
+          ]);
+        transform.api.assertResponseStatusCode(200, status, body);
 
         expect(isStopTransformsResponseSchema(body)).to.eql(true);
 

--- a/x-pack/test/api_integration/apis/transform/transforms.ts
+++ b/x-pack/test/api_integration/apis/transform/transforms.ts
@@ -94,29 +94,29 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('/transforms', function () {
       it('should return a list of transforms for super-user', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get('/api/transform/transforms')
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send()
-          .expect(200);
+          .send();
+        transform.api.assertResponseStatusCode(200, status, body);
 
         assertTransformsResponseBody(body);
       });
 
       it('should return a list of transforms for transform view-only user', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/transform/transforms`)
           .auth(
             USER.TRANSFORM_VIEWER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_VIEWER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send()
-          .expect(200);
+          .send();
+        transform.api.assertResponseStatusCode(200, status, body);
 
         assertTransformsResponseBody(body);
       });
@@ -124,43 +124,43 @@ export default ({ getService }: FtrProviderContext) => {
 
     describe('/transforms/{transformId}', function () {
       it('should return a specific transform configuration for super-user', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get('/api/transform/transforms/transform-test-get-1')
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send()
-          .expect(200);
+          .send();
+        transform.api.assertResponseStatusCode(200, status, body);
 
         assertSingleTransformResponseBody(body);
       });
 
       it('should return a specific transform configuration transform view-only user', async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/transform/transforms/transform-test-get-1`)
           .auth(
             USER.TRANSFORM_VIEWER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_VIEWER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send()
-          .expect(200);
+          .send();
+        transform.api.assertResponseStatusCode(200, status, body);
 
         assertSingleTransformResponseBody(body);
       });
 
       it('should report 404 for a non-existing transform', async () => {
-        await supertest
+        const { body, status } = await supertest
           .get('/api/transform/transforms/the-non-existing-transform')
           .auth(
             USER.TRANSFORM_POWERUSER,
             transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
           )
           .set(COMMON_REQUEST_HEADERS)
-          .send()
-          .expect(404);
+          .send();
+        transform.api.assertResponseStatusCode(404, status, body);
       });
     });
   });

--- a/x-pack/test/api_integration/apis/transform/transforms_create.ts
+++ b/x-pack/test/api_integration/apis/transform/transforms_create.ts
@@ -30,7 +30,7 @@ export default ({ getService }: FtrProviderContext) => {
     it('should not allow pivot and latest configs in same transform', async () => {
       const transformId = 'test_transform_id';
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/transform/transforms/${transformId}`)
         .auth(
           USER.TRANSFORM_POWERUSER,
@@ -43,8 +43,8 @@ export default ({ getService }: FtrProviderContext) => {
             unique_key: ['country', 'gender'],
             sort: 'infected',
           },
-        })
-        .expect(400);
+        });
+      transform.api.assertResponseStatusCode(400, status, body);
 
       expect(body.message).to.eql('[request body]: pivot and latest are not allowed together');
     });
@@ -54,15 +54,15 @@ export default ({ getService }: FtrProviderContext) => {
 
       const { pivot, ...config } = generateTransformConfig(transformId);
 
-      const { body } = await supertest
+      const { body, status } = await supertest
         .put(`/api/transform/transforms/${transformId}`)
         .auth(
           USER.TRANSFORM_POWERUSER,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send(config)
-        .expect(400);
+        .send(config);
+      transform.api.assertResponseStatusCode(400, status, body);
 
       expect(body.message).to.eql(
         '[request body]: pivot or latest is required for transform configuration'

--- a/x-pack/test/api_integration/apis/transform/transforms_nodes.ts
+++ b/x-pack/test/api_integration/apis/transform/transforms_nodes.ts
@@ -32,43 +32,43 @@ export default ({ getService }: FtrProviderContext) => {
 
   describe('/api/transform/transforms/_nodes', function () {
     it('should return the number of available transform nodes for a power user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get('/api/transform/transforms/_nodes')
         .auth(
           USER.TRANSFORM_POWERUSER,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send()
-        .expect(200);
+        .send();
+      transform.api.assertResponseStatusCode(200, status, body);
 
       assertTransformsNodesResponseBody(body);
     });
 
     it('should return the number of available transform nodes for a viewer user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get('/api/transform/transforms/_nodes')
         .auth(
           USER.TRANSFORM_VIEWER,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_VIEWER)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send()
-        .expect(200);
+        .send();
+      transform.api.assertResponseStatusCode(200, status, body);
 
       assertTransformsNodesResponseBody(body);
     });
 
     it('should not return the number of available transform nodes for an unauthorized user', async () => {
-      await supertest
+      const { body, status } = await supertest
         .get('/api/transform/transforms/_nodes')
         .auth(
           USER.TRANSFORM_UNAUTHORIZED,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_UNAUTHORIZED)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send()
-        .expect(403);
+        .send();
+      transform.api.assertResponseStatusCode(403, status, body);
     });
   });
 };

--- a/x-pack/test/api_integration/apis/transform/transforms_preview.ts
+++ b/x-pack/test/api_integration/apis/transform/transforms_preview.ts
@@ -43,15 +43,15 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should return a transform preview', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post('/api/transform/transforms/_preview')
         .auth(
           USER.TRANSFORM_POWERUSER,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send(getTransformPreviewConfig())
-        .expect(200);
+        .send(getTransformPreviewConfig());
+      transform.api.assertResponseStatusCode(200, status, body);
 
       expect(body.preview).to.have.length(expected.apiTransformTransformsPreview.previewItemCount);
       expect(typeof body.generated_dest_index).to.eql(
@@ -60,7 +60,7 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should return a correct error for transform preview', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .post(`/api/transform/transforms/_preview`)
         .auth(
           USER.TRANSFORM_POWERUSER,
@@ -75,8 +75,8 @@ export default ({ getService }: FtrProviderContext) => {
               '@timestamp.value_count': { value_countt: { field: '@timestamp' } },
             },
           },
-        })
-        .expect(400);
+        });
+      transform.api.assertResponseStatusCode(400, status, body);
 
       expect(body.message).to.contain(
         '[parsing_exception] Unknown aggregation type [value_countt] did you mean [value_count]?, with line=1 & col=43'
@@ -84,15 +84,15 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should return 403 for transform view-only user', async () => {
-      await supertest
+      const { body, status } = await supertest
         .post(`/api/transform/transforms/_preview`)
         .auth(
           USER.TRANSFORM_VIEWER,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_VIEWER)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send(getTransformPreviewConfig())
-        .expect(403);
+        .send(getTransformPreviewConfig());
+      transform.api.assertResponseStatusCode(403, status, body);
     });
   });
 };

--- a/x-pack/test/api_integration/apis/transform/transforms_stats.ts
+++ b/x-pack/test/api_integration/apis/transform/transforms_stats.ts
@@ -73,29 +73,29 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should return a list of transforms statistics for super-user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get('/api/transform/transforms/_stats')
         .auth(
           USER.TRANSFORM_POWERUSER,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send()
-        .expect(200);
+        .send();
+      transform.api.assertResponseStatusCode(200, status, body);
 
       assertTransformsStatsResponseBody(body);
     });
 
     it('should return a list of transforms statistics view-only user', async () => {
-      const { body } = await supertest
+      const { body, status } = await supertest
         .get(`/api/transform/transforms/_stats`)
         .auth(
           USER.TRANSFORM_VIEWER,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_VIEWER)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send()
-        .expect(200);
+        .send();
+      transform.api.assertResponseStatusCode(200, status, body);
 
       assertTransformsStatsResponseBody(body);
     });

--- a/x-pack/test/api_integration/apis/transform/transforms_update.ts
+++ b/x-pack/test/api_integration/apis/transform/transforms_update.ts
@@ -70,15 +70,15 @@ export default ({ getService }: FtrProviderContext) => {
 
     it('should update a transform', async () => {
       // assert the original transform for comparison
-      const { body: transformOriginalBody } = await supertest
+      const { body: transformOriginalBody, status: transformOriginalStatus } = await supertest
         .get('/api/transform/transforms/transform-test-update-1')
         .auth(
           USER.TRANSFORM_POWERUSER,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send()
-        .expect(200);
+        .send();
+      transform.api.assertResponseStatusCode(200, transformOriginalStatus, transformOriginalBody);
 
       expect(transformOriginalBody.count).to.eql(expected.transformOriginalConfig.count);
       expect(transformOriginalBody.transforms).to.have.length(
@@ -92,15 +92,20 @@ export default ({ getService }: FtrProviderContext) => {
       expect(transformOriginalConfig.settings).to.eql({});
 
       // update the transform and assert the response
-      const { body: transformUpdateResponseBody } = await supertest
-        .post('/api/transform/transforms/transform-test-update-1/_update')
-        .auth(
-          USER.TRANSFORM_POWERUSER,
-          transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
-        )
-        .set(COMMON_REQUEST_HEADERS)
-        .send(getTransformUpdateConfig())
-        .expect(200);
+      const { body: transformUpdateResponseBody, status: transformUpdatedResponseStatus } =
+        await supertest
+          .post('/api/transform/transforms/transform-test-update-1/_update')
+          .auth(
+            USER.TRANSFORM_POWERUSER,
+            transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
+          )
+          .set(COMMON_REQUEST_HEADERS)
+          .send(getTransformUpdateConfig());
+      transform.api.assertResponseStatusCode(
+        200,
+        transformUpdatedResponseStatus,
+        transformUpdateResponseBody
+      );
 
       const expectedUpdateConfig = getTransformUpdateConfig();
       expect(transformUpdateResponseBody.id).to.eql(expected.transformOriginalConfig.id);
@@ -112,15 +117,15 @@ export default ({ getService }: FtrProviderContext) => {
       expect(transformUpdateResponseBody.settings).to.eql({});
 
       // assert the updated transform for comparison
-      const { body: transformUpdatedBody } = await supertest
+      const { body: transformUpdatedBody, status: transformUpdatedStatus } = await supertest
         .get('/api/transform/transforms/transform-test-update-1')
         .auth(
           USER.TRANSFORM_POWERUSER,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_POWERUSER)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send()
-        .expect(200);
+        .send();
+      transform.api.assertResponseStatusCode(200, transformUpdatedStatus, transformUpdatedBody);
 
       expect(transformUpdatedBody.count).to.eql(expected.transformOriginalConfig.count);
       expect(transformUpdatedBody.transforms).to.have.length(
@@ -138,15 +143,15 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should return 403 for transform view-only user', async () => {
-      await supertest
+      const { body, status } = await supertest
         .post('/api/transform/transforms/transform-test-update-1/_update')
         .auth(
           USER.TRANSFORM_VIEWER,
           transform.securityCommon.getPasswordForUser(USER.TRANSFORM_VIEWER)
         )
         .set(COMMON_REQUEST_HEADERS)
-        .send(getTransformUpdateConfig())
-        .expect(403);
+        .send(getTransformUpdateConfig());
+      transform.api.assertResponseStatusCode(403, status, body);
     });
   });
 };

--- a/x-pack/test/api_integration/services/ml.ts
+++ b/x-pack/test/api_integration/services/ml.ts
@@ -20,7 +20,7 @@ export function MachineLearningProvider(context: FtrProviderContext) {
   const commonConfig = MachineLearningCommonConfigsProvider(context);
   const securityCommon = MachineLearningSecurityCommonProvider(context);
   const testExecution = MachineLearningTestExecutionProvider(context);
-  const testResources = MachineLearningTestResourcesProvider(context);
+  const testResources = MachineLearningTestResourcesProvider(context, api);
 
   return {
     api,

--- a/x-pack/test/api_integration/services/transform.ts
+++ b/x-pack/test/api_integration/services/transform.ts
@@ -9,12 +9,14 @@ import { FtrProviderContext } from '../../functional/ftr_provider_context';
 
 import { TransformAPIProvider } from '../../functional/services/transform/api';
 import { TransformSecurityCommonProvider } from '../../functional/services/transform/security_common';
+import { MachineLearningAPIProvider } from '../../functional/services/ml/api';
 import { MachineLearningTestResourcesProvider } from '../../functional/services/ml/test_resources';
 
 export function TransformProvider(context: FtrProviderContext) {
   const api = TransformAPIProvider(context);
+  const mlApi = MachineLearningAPIProvider(context);
   const securityCommon = TransformSecurityCommonProvider(context);
-  const testResources = MachineLearningTestResourcesProvider(context);
+  const testResources = MachineLearningTestResourcesProvider(context, mlApi);
 
   return {
     api,

--- a/x-pack/test/functional/services/ml/api.ts
+++ b/x-pack/test/functional/services/ml/api.ts
@@ -19,13 +19,14 @@ import { DataFrameTaskStateType } from '../../../../plugins/ml/common/types/data
 import { DATA_FRAME_TASK_STATE } from '../../../../plugins/ml/common/constants/data_frame_analytics';
 import { Datafeed, Job } from '../../../../plugins/ml/common/types/anomaly_detection_jobs';
 import { JobType } from '../../../../plugins/ml/common/types/saved_objects';
-export type MlApi = ProvidedType<typeof MachineLearningAPIProvider>;
 import {
   ML_ANNOTATIONS_INDEX_ALIAS_READ,
   ML_ANNOTATIONS_INDEX_ALIAS_WRITE,
 } from '../../../../plugins/ml/common/constants/index_patterns';
 import { COMMON_REQUEST_HEADERS } from '../../../functional/services/ml/common_api';
 import { PutTrainedModelConfig } from '../../../../plugins/ml/common/types/trained_models';
+
+export type MlApi = ProvidedType<typeof MachineLearningAPIProvider>;
 
 type ModelType = 'regression' | 'classification';
 
@@ -38,6 +39,15 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
   const esDeleteAllIndices = getService('esDeleteAllIndices');
 
   return {
+    assertResponseStatusCode(expectedStatus: number, actualStatus: number, responseBody: object) {
+      expect(actualStatus).to.eql(
+        expectedStatus,
+        `Expected status code ${expectedStatus}, got ${actualStatus} with body '${JSON.stringify(
+          responseBody
+        )}'`
+      );
+    },
+
     async hasJobResults(jobId: string): Promise<boolean> {
       const { body } = await es.search({
         index: '.ml-anomalies-*',
@@ -184,10 +194,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async getADJobStats(jobId: string): Promise<any> {
       log.debug(`Fetching anomaly detection job stats for job ${jobId}...`);
-      const jobStats = await esSupertest
-        .get(`/_ml/anomaly_detectors/${jobId}/_stats`)
-        .expect(200)
-        .then((res: any) => res.body);
+      const { body: jobStats, status } = await esSupertest.get(
+        `/_ml/anomaly_detectors/${jobId}/_stats`
+      );
+      this.assertResponseStatusCode(200, status, jobStats);
 
       log.debug('> AD job stats fetched.');
       return jobStats;
@@ -210,10 +220,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async getDatafeedState(datafeedId: string): Promise<DATAFEED_STATE> {
       log.debug(`Fetching datafeed state for datafeed ${datafeedId}`);
-      const datafeedStats = await esSupertest
-        .get(`/_ml/datafeeds/${datafeedId}/_stats`)
-        .expect(200)
-        .then((res: any) => res.body);
+      const { body: datafeedStats, status } = await esSupertest.get(
+        `/_ml/datafeeds/${datafeedId}/_stats`
+      );
+      this.assertResponseStatusCode(200, status, datafeedStats);
 
       expect(datafeedStats.datafeeds).to.have.length(
         1,
@@ -245,10 +255,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async getDFAJobStats(analyticsId: string): Promise<any> {
       log.debug(`Fetching data frame analytics job stats for job ${analyticsId}...`);
-      const analyticsStats = await esSupertest
-        .get(`/_ml/data_frame/analytics/${analyticsId}/_stats`)
-        .expect(200)
-        .then((res: any) => res.body);
+      const { body: analyticsStats, status } = await esSupertest.get(
+        `/_ml/data_frame/analytics/${analyticsId}/_stats`
+      );
+      this.assertResponseStatusCode(200, status, analyticsStats);
 
       log.debug('> DFA job stats fetched.');
       return analyticsStats;
@@ -357,7 +367,9 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
     },
 
     async getCalendar(calendarId: string, expectedCode = 200) {
-      return await esSupertest.get(`/_ml/calendars/${calendarId}`).expect(expectedCode);
+      const response = await esSupertest.get(`/_ml/calendars/${calendarId}`);
+      this.assertResponseStatusCode(expectedCode, response.status, response.body);
+      return response;
     },
 
     async createCalendar(
@@ -365,7 +377,11 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       requestBody: Partial<Calendar> = { description: '', job_ids: [] }
     ) {
       log.debug(`Creating calendar with id '${calendarId}'...`);
-      await esSupertest.put(`/_ml/calendars/${calendarId}`).send(requestBody).expect(200);
+      const { body, status } = await esSupertest
+        .put(`/_ml/calendars/${calendarId}`)
+        .send(requestBody);
+      this.assertResponseStatusCode(200, status, body);
+
       await this.waitForCalendarToExist(calendarId);
       log.debug('> Calendar created.');
     },
@@ -400,13 +416,19 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async createCalendarEvents(calendarId: string, events: estypes.MlCalendarEvent[]) {
       log.debug(`Creating events for calendar with id '${calendarId}'...`);
-      await esSupertest.post(`/_ml/calendars/${calendarId}/events`).send({ events }).expect(200);
+      const { body, status } = await esSupertest
+        .post(`/_ml/calendars/${calendarId}/events`)
+        .send({ events });
+      this.assertResponseStatusCode(200, status, body);
+
       await this.waitForEventsToExistInCalendar(calendarId, events);
       log.debug('> Calendar events created.');
     },
 
     async getCalendarEvents(calendarId: string, expectedCode = 200) {
-      return await esSupertest.get(`/_ml/calendars/${calendarId}/events`).expect(expectedCode);
+      const response = await esSupertest.get(`/_ml/calendars/${calendarId}/events`);
+      this.assertResponseStatusCode(expectedCode, response.status, response.body);
+      return response;
     },
 
     assertAllEventsExistInCalendar: (
@@ -468,7 +490,9 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
     },
 
     async getAnomalyDetectionJob(jobId: string) {
-      return await esSupertest.get(`/_ml/anomaly_detectors/${jobId}`).expect(200);
+      const response = await esSupertest.get(`/_ml/anomaly_detectors/${jobId}`);
+      this.assertResponseStatusCode(200, response.status, response.body);
+      return response;
     },
 
     async adJobExist(jobId: string) {
@@ -493,7 +517,9 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async waitForAnomalyDetectionJobNotToExist(jobId: string, timeout: number = 5 * 1000) {
       await retry.waitForWithTimeout(`'${jobId}' to not exist`, timeout, async () => {
-        if (await esSupertest.get(`/_ml/anomaly_detectors/${jobId}`).expect(404)) {
+        const { status } = await esSupertest.get(`/_ml/anomaly_detectors/${jobId}`);
+
+        if (status === 404) {
           return true;
         } else {
           throw new Error(`expected anomaly detection job '${jobId}' not to exist`);
@@ -509,11 +535,11 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
         }...`
       );
 
-      await kbnSupertest
+      const { body, status } = await kbnSupertest
         .put(`${space ? `/s/${space}` : ''}/api/ml/anomaly_detectors/${jobId}`)
         .set(COMMON_REQUEST_HEADERS)
-        .send(jobConfig)
-        .expect(200);
+        .send(jobConfig);
+      this.assertResponseStatusCode(200, status, body);
 
       await this.waitForAnomalyDetectionJobToExist(jobId);
       log.debug('> AD job created.');
@@ -523,7 +549,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       const jobId = jobConfig.job_id;
       log.debug(`Creating anomaly detection job with id '${jobId}' via ES API...`);
 
-      await esSupertest.put(`/_ml/anomaly_detectors/${jobId}`).send(jobConfig).expect(200);
+      const { body, status } = await esSupertest
+        .put(`/_ml/anomaly_detectors/${jobId}`)
+        .send(jobConfig);
+      this.assertResponseStatusCode(200, status, body);
 
       await this.waitForAnomalyDetectionJobToExist(jobId);
       log.debug('> AD job created.');
@@ -542,18 +571,19 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
         await this.deleteDatafeedES(datafeedId);
       }
 
-      await esSupertest
+      const { body, status } = await esSupertest
         .delete(`/_ml/anomaly_detectors/${jobId}`)
-        .query({ force: true })
-        .expect(200);
+        .query({ force: true });
+      this.assertResponseStatusCode(200, status, body);
 
       await this.waitForAnomalyDetectionJobNotToExist(jobId);
       log.debug('> AD job deleted.');
     },
 
     async getDatafeed(datafeedId: string) {
-      return await esSupertest.get(`/_ml/datafeeds/${datafeedId}`).expect(200);
-      // return await kbnSupertest.get(`/api/ml/datafeeds/${datafeedId}`).expect(200);
+      const response = await esSupertest.get(`/_ml/datafeeds/${datafeedId}`);
+      this.assertResponseStatusCode(200, response.status, response.body);
+      return response;
     },
 
     async datafeedExist(datafeedId: string) {
@@ -590,11 +620,11 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       log.debug(
         `Creating datafeed with id '${datafeedId}' ${space ? `in space '${space}' ` : ''}...`
       );
-      await kbnSupertest
+      const { body, status } = await kbnSupertest
         .put(`${space ? `/s/${space}` : ''}/api/ml/datafeeds/${datafeedId}`)
         .set(COMMON_REQUEST_HEADERS)
-        .send(datafeedConfig)
-        .expect(200);
+        .send(datafeedConfig);
+      this.assertResponseStatusCode(200, status, body);
 
       await this.waitForDatafeedToExist(datafeedId);
       log.debug('> Datafeed created.');
@@ -603,7 +633,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
     async createDatafeedES(datafeedConfig: Datafeed) {
       const datafeedId = datafeedConfig.datafeed_id;
       log.debug(`Creating datafeed with id '${datafeedId}' via ES API ...`);
-      await esSupertest.put(`/_ml/datafeeds/${datafeedId}`).send(datafeedConfig).expect(200);
+      const { body, status } = await esSupertest
+        .put(`/_ml/datafeeds/${datafeedId}`)
+        .send(datafeedConfig);
+      this.assertResponseStatusCode(200, status, body);
 
       await this.waitForDatafeedToExist(datafeedId);
       log.debug('> Datafeed created.');
@@ -611,7 +644,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async deleteDatafeedES(datafeedId: string) {
       log.debug(`Deleting datafeed with id '${datafeedId}' ...`);
-      await esSupertest.delete(`/_ml/datafeeds/${datafeedId}`).query({ force: true }).expect(200);
+      const { body, status } = await esSupertest
+        .delete(`/_ml/datafeeds/${datafeedId}`)
+        .query({ force: true });
+      this.assertResponseStatusCode(200, status, body);
 
       await this.waitForDatafeedToNotExist(datafeedId);
       log.debug('> Datafeed deleted.');
@@ -619,12 +655,11 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async openAnomalyDetectionJob(jobId: string) {
       log.debug(`Opening anomaly detection job '${jobId}'...`);
-      const openResponse = await esSupertest
+      const { body: openResponse, status } = await esSupertest
         .post(`/_ml/anomaly_detectors/${jobId}/_open`)
         .send({ timeout: '10s' })
-        .set({ 'Content-Type': 'application/json' })
-        .expect(200)
-        .then((res: any) => res.body);
+        .set({ 'Content-Type': 'application/json' });
+      this.assertResponseStatusCode(200, status, openResponse);
 
       expect(openResponse)
         .to.have.property('opened')
@@ -634,12 +669,11 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async closeAnomalyDetectionJob(jobId: string) {
       log.debug(`Closing anomaly detection job '${jobId}'...`);
-      const closeResponse = await esSupertest
+      const { body: closeResponse, status } = await esSupertest
         .post(`/_ml/anomaly_detectors/${jobId}/_close`)
         .send({ timeout: '10s' })
-        .set({ 'Content-Type': 'application/json' })
-        .expect(200)
-        .then((res: any) => res.body);
+        .set({ 'Content-Type': 'application/json' });
+      this.assertResponseStatusCode(200, status, closeResponse);
 
       expect(closeResponse)
         .to.have.property('closed')
@@ -654,12 +688,11 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       log.debug(
         `Starting datafeed '${datafeedId}' with start: '${startConfig.start}', end: '${startConfig.end}'...`
       );
-      const startResponse = await esSupertest
+      const { body: startResponse, status } = await esSupertest
         .post(`/_ml/datafeeds/${datafeedId}/_start`)
         .send(startConfig)
-        .set({ 'Content-Type': 'application/json' })
-        .expect(200)
-        .then((res: any) => res.body);
+        .set({ 'Content-Type': 'application/json' });
+      this.assertResponseStatusCode(200, status, startResponse);
 
       expect(startResponse)
         .to.have.property('started')
@@ -669,11 +702,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async stopDatafeed(datafeedId: string) {
       log.debug(`Stopping datafeed '${datafeedId}'...`);
-      const stopResponse = await esSupertest
+      const { body: stopResponse, status } = await esSupertest
         .post(`/_ml/datafeeds/${datafeedId}/_stop`)
-        .set({ 'Content-Type': 'application/json' })
-        .expect(200)
-        .then((res: any) => res.body);
+        .set({ 'Content-Type': 'application/json' });
+      this.assertResponseStatusCode(200, status, stopResponse);
 
       expect(stopResponse)
         .to.have.property('stopped')
@@ -692,9 +724,9 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async getDataFrameAnalyticsJob(analyticsId: string, statusCode = 200) {
       log.debug(`Fetching data frame analytics job '${analyticsId}'...`);
-      const response = await esSupertest
-        .get(`/_ml/data_frame/analytics/${analyticsId}`)
-        .expect(statusCode);
+      const response = await esSupertest.get(`/_ml/data_frame/analytics/${analyticsId}`);
+      this.assertResponseStatusCode(statusCode, response.status, response.body);
+
       log.debug('> DFA job fetched.');
       return response;
     },
@@ -736,11 +768,11 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
           space ? `in space '${space}' ` : ''
         }...`
       );
-      await kbnSupertest
+      const { body, status } = await kbnSupertest
         .put(`${space ? `/s/${space}` : ''}/api/ml/data_frame/analytics/${analyticsId}`)
         .set(COMMON_REQUEST_HEADERS)
-        .send(analyticsConfig)
-        .expect(200);
+        .send(analyticsConfig);
+      this.assertResponseStatusCode(200, status, body);
 
       await this.waitForDataFrameAnalyticsJobToExist(analyticsId);
       log.debug('> DFA job created.');
@@ -749,11 +781,11 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
     async createDataFrameAnalyticsJobES(jobConfig: DataFrameAnalyticsConfig) {
       const { id: analyticsId, ...analyticsConfig } = jobConfig;
       log.debug(`Creating data frame analytic job with id '${analyticsId}' via ES API...`);
-      await esSupertest
+      const { body, status } = await esSupertest
         .put(`/_ml/data_frame/analytics/${analyticsId}`)
         .set(COMMON_REQUEST_HEADERS)
-        .send(analyticsConfig)
-        .expect(200);
+        .send(analyticsConfig);
+      this.assertResponseStatusCode(200, status, body);
 
       await this.waitForDataFrameAnalyticsJobToExist(analyticsId);
       log.debug('> DFA job created.');
@@ -767,10 +799,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
         return;
       }
 
-      await esSupertest
+      const { body, status } = await esSupertest
         .delete(`/_ml/data_frame/analytics/${analyticsId}`)
-        .query({ force: true })
-        .expect(200);
+        .query({ force: true });
+      this.assertResponseStatusCode(200, status, body);
 
       await this.waitForDataFrameAnalyticsJobNotToExist(analyticsId);
       log.debug('> DFA job deleted.');
@@ -806,12 +838,15 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
     },
 
     async getFilter(filterId: string, expectedCode = 200) {
-      return await esSupertest.get(`/_ml/filters/${filterId}`).expect(expectedCode);
+      const response = await esSupertest.get(`/_ml/filters/${filterId}`);
+      this.assertResponseStatusCode(expectedCode, response.status, response.body);
+      return response;
     },
 
     async createFilter(filterId: string, requestBody: object) {
       log.debug(`Creating filter with id '${filterId}'...`);
-      await esSupertest.put(`/_ml/filters/${filterId}`).send(requestBody).expect(200);
+      const { body, status } = await esSupertest.put(`/_ml/filters/${filterId}`).send(requestBody);
+      this.assertResponseStatusCode(200, status, body);
 
       await this.waitForFilterToExist(filterId, `expected filter '${filterId}' to be created`);
       log.debug('> Filter created.');
@@ -924,11 +959,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async runDFAJob(dfaId: string) {
       log.debug(`Starting data frame analytics job '${dfaId}'...`);
-      const startResponse = await esSupertest
+      const { body: startResponse, status } = await esSupertest
         .post(`/_ml/data_frame/analytics/${dfaId}/_start`)
-        .set({ 'Content-Type': 'application/json' })
-        .expect(200)
-        .then((res: any) => res.body);
+        .set({ 'Content-Type': 'application/json' });
+      this.assertResponseStatusCode(200, status, startResponse);
 
       expect(startResponse)
         .to.have.property('acknowledged')
@@ -950,20 +984,20 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       spacesToRemove: string[],
       space?: string
     ) {
-      const { body } = await kbnSupertest
+      const { body, status } = await kbnSupertest
         .post(`${space ? `/s/${space}` : ''}/api/ml/saved_objects/update_jobs_spaces`)
         .set(COMMON_REQUEST_HEADERS)
-        .send({ jobType, jobIds: [jobId], spacesToAdd, spacesToRemove })
-        .expect(200);
+        .send({ jobType, jobIds: [jobId], spacesToAdd, spacesToRemove });
+      this.assertResponseStatusCode(200, status, body);
 
       expect(body).to.eql({ [jobId]: { success: true } });
     },
 
     async assertJobSpaces(jobId: string, jobType: JobType, expectedSpaces: string[]) {
-      const { body } = await kbnSupertest
+      const { body, status } = await kbnSupertest
         .get('/api/ml/saved_objects/jobs_spaces')
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      this.assertResponseStatusCode(200, status, body);
 
       if (expectedSpaces.length > 0) {
         // Should list expected spaces correctly
@@ -981,11 +1015,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async createTrainedModel(modelId: string, body: PutTrainedModelConfig) {
       log.debug(`Creating trained model with id "${modelId}"`);
-      const model = await esSupertest
+      const { body: model, status } = await esSupertest
         .put(`/_ml/trained_models/${modelId}`)
-        .send(body)
-        .expect(200)
-        .then((res: any) => res.body);
+        .send(body);
+      this.assertResponseStatusCode(200, status, model);
 
       log.debug('> Trained model created');
       return model;
@@ -1043,9 +1076,11 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async createModelAlias(modelId: string, modelAlias: string) {
       log.debug(`Creating alias for model "${modelId}"`);
-      await esSupertest
-        .put(`/_ml/trained_models/${modelId}/model_aliases/${modelAlias}`)
-        .expect(200);
+      const { body, status } = await esSupertest.put(
+        `/_ml/trained_models/${modelId}/model_aliases/${modelAlias}`
+      );
+      this.assertResponseStatusCode(200, status, body);
+
       log.debug('> Model alias created');
     },
 
@@ -1055,7 +1090,7 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
      */
     async createIngestPipeline(modelId: string) {
       log.debug(`Creating ingest pipeline for trained model with id "${modelId}"`);
-      const ingestPipeline = await esSupertest
+      const { body: ingestPipeline, status } = await esSupertest
         .put(`/_ingest/pipeline/pipeline_${modelId}`)
         .send({
           processors: [
@@ -1065,9 +1100,8 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
               },
             },
           ],
-        })
-        .expect(200)
-        .then((res) => res.body);
+        });
+      this.assertResponseStatusCode(200, status, ingestPipeline);
 
       log.debug('> Ingest pipeline crated');
       return ingestPipeline;
@@ -1075,7 +1109,9 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async deleteIngestPipeline(modelId: string) {
       log.debug(`Deleting ingest pipeline for trained model with id "${modelId}"`);
-      await esSupertest.delete(`/_ingest/pipeline/pipeline_${modelId}`).expect(200);
+      const { body, status } = await esSupertest.delete(`/_ingest/pipeline/pipeline_${modelId}`);
+      this.assertResponseStatusCode(200, status, body);
+
       log.debug('> Ingest pipeline deleted');
     },
   };

--- a/x-pack/test/functional/services/ml/index.ts
+++ b/x-pack/test/functional/services/ml/index.ts
@@ -119,8 +119,8 @@ export function MachineLearningProvider(context: FtrProviderContext) {
     dataFrameAnalyticsTable
   );
   const testExecution = MachineLearningTestExecutionProvider(context);
-  const testResources = MachineLearningTestResourcesProvider(context);
-  const alerting = MachineLearningAlertingProvider(context, commonUI);
+  const testResources = MachineLearningTestResourcesProvider(context, api);
+  const alerting = MachineLearningAlertingProvider(context, api, commonUI);
   const swimLane = SwimLaneProvider(context);
   const trainedModels = TrainedModelsProvider(context, api, commonUI);
   const trainedModelsTable = TrainedModelsTableProvider(context);

--- a/x-pack/test/functional/services/ml/test_resources.ts
+++ b/x-pack/test/functional/services/ml/test_resources.ts
@@ -9,6 +9,7 @@ import expect from '@kbn/expect';
 import { ProvidedType } from '@kbn/test';
 import { savedSearches, dashboards } from './test_resources_data';
 import { COMMON_REQUEST_HEADERS } from './common_api';
+import { MlApi } from './api';
 import { FtrProviderContext } from '../../ftr_provider_context';
 import { JobType } from '../../../../plugins/ml/common/types/saved_objects';
 
@@ -23,7 +24,10 @@ export enum SavedObjectType {
 
 export type MlTestResourcesi = ProvidedType<typeof MachineLearningTestResourcesProvider>;
 
-export function MachineLearningTestResourcesProvider({ getService }: FtrProviderContext) {
+export function MachineLearningTestResourcesProvider(
+  { getService }: FtrProviderContext,
+  mlApi: MlApi
+) {
   const kibanaServer = getService('kibanaServer');
   const log = getService('log');
   const supertest = getService('supertest');
@@ -59,11 +63,10 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
       objectType: SavedObjectType
     ): Promise<string | undefined> {
       log.debug(`Searching for '${objectType}' with title '${title}'...`);
-      const findResponse = await supertest
+      const { body: findResponse, status } = await supertest
         .get(`/api/saved_objects/_find?type=${objectType}&per_page=10000`)
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200)
-        .then((res: any) => res.body);
+        .set(COMMON_REQUEST_HEADERS);
+      mlApi.assertResponseStatusCode(200, status, findResponse);
 
       for (const savedObject of findResponse.saved_objects) {
         const objectTitle = savedObject.attributes.title;
@@ -79,11 +82,10 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
       const savedObjectIds: string[] = [];
 
       log.debug(`Searching for '${objectType}' ...`);
-      const findResponse = await supertest
+      const { body: findResponse, status } = await supertest
         .get(`/api/saved_objects/_find?type=${objectType}&per_page=10000`)
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200)
-        .then((res: any) => res.body);
+        .set(COMMON_REQUEST_HEADERS);
+      mlApi.assertResponseStatusCode(200, status, findResponse);
 
       findResponse.saved_objects.forEach((element: any) => {
         savedObjectIds.push(element.id);
@@ -115,12 +117,11 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
         }`
       );
 
-      const createResponse = await supertest
+      const { body: createResponse, status } = await supertest
         .post(`/api/saved_objects/${SavedObjectType.INDEX_PATTERN}`)
         .set(COMMON_REQUEST_HEADERS)
-        .send({ attributes: { title, timeFieldName } })
-        .expect(200)
-        .then((res: any) => res.body);
+        .send({ attributes: { title, timeFieldName } });
+      mlApi.assertResponseStatusCode(200, status, createResponse);
 
       await this.assertIndexPatternExistByTitle(title);
 
@@ -131,12 +132,11 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
     async createBulkSavedObjects(body: object[]): Promise<string> {
       log.debug(`Creating bulk saved objects'`);
 
-      const createResponse = await supertest
+      const { body: createResponse, status } = await supertest
         .post(`/api/saved_objects/_bulk_create`)
         .set(COMMON_REQUEST_HEADERS)
-        .send(body)
-        .expect(200)
-        .then((res: any) => res.body);
+        .send(body);
+      mlApi.assertResponseStatusCode(200, status, createResponse);
 
       log.debug(` > Created bulk saved objects'`);
       return createResponse;
@@ -159,12 +159,11 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
     async createSavedSearch(title: string, body: object): Promise<string> {
       log.debug(`Creating saved search with title '${title}'`);
 
-      const createResponse = await supertest
+      const { body: createResponse, status } = await supertest
         .post(`/api/saved_objects/${SavedObjectType.SEARCH}`)
         .set(COMMON_REQUEST_HEADERS)
-        .send(body)
-        .expect(200)
-        .then((res: any) => res.body);
+        .send(body);
+      mlApi.assertResponseStatusCode(200, status, createResponse);
 
       await this.assertSavedSearchExistByTitle(title);
 
@@ -175,12 +174,11 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
     async createDashboard(title: string, body: object): Promise<string> {
       log.debug(`Creating dashboard with title '${title}'`);
 
-      const createResponse = await supertest
+      const { body: createResponse, status } = await supertest
         .post(`/api/saved_objects/${SavedObjectType.DASHBOARD}`)
         .set(COMMON_REQUEST_HEADERS)
-        .send(body)
-        .expect(200)
-        .then((res: any) => res.body);
+        .send(body);
+      mlApi.assertResponseStatusCode(200, status, createResponse);
 
       log.debug(` > Created with id '${createResponse.id}'`);
       return createResponse.id;
@@ -272,11 +270,11 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
         log.debug(`${objectType} with id '${id}' does not exists. Nothing to delete.`);
         return;
       } else {
-        await supertest
+        const { body, status } = await supertest
           .delete(`/api/saved_objects/${objectType}/${id}`)
           .set(COMMON_REQUEST_HEADERS)
-          .query({ force })
-          .expect(200);
+          .query({ force });
+        mlApi.assertResponseStatusCode(200, status, body);
 
         await this.assertSavedObjectNotExistsById(id, objectType);
 
@@ -465,7 +463,10 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
     async setupFleet() {
       log.debug(`Setting up Fleet`);
       await retry.tryForTime(2 * 60 * 1000, async () => {
-        await supertest.post(`/api/fleet/setup`).set(COMMON_REQUEST_HEADERS).expect(200);
+        const { body, status } = await supertest
+          .post(`/api/fleet/setup`)
+          .set(COMMON_REQUEST_HEADERS);
+        mlApi.assertResponseStatusCode(200, status, body);
       });
       log.debug(` > Setup done`);
     },
@@ -477,10 +478,10 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
       const packageWithVersion = `${packageName}-${version}`;
 
       await retry.tryForTime(30 * 1000, async () => {
-        await supertest
+        const { body, status } = await supertest
           .post(`/api/fleet/epm/packages/${packageWithVersion}`)
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        mlApi.assertResponseStatusCode(200, status, body);
       });
 
       log.debug(` > Installed`);
@@ -491,10 +492,10 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
       log.debug(`Removing Fleet package '${packageWithVersion}'`);
 
       await retry.tryForTime(30 * 1000, async () => {
-        await supertest
+        const { body, status } = await supertest
           .delete(`/api/fleet/epm/packages/${packageWithVersion}`)
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        mlApi.assertResponseStatusCode(200, status, body);
       });
 
       log.debug(` > Removed`);
@@ -505,10 +506,10 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
       let packageVersion = '';
 
       await retry.tryForTime(10 * 1000, async () => {
-        const { body } = await supertest
+        const { body, status } = await supertest
           .get(`/api/fleet/epm/packages?experimental=true`)
-          .set(COMMON_REQUEST_HEADERS)
-          .expect(200);
+          .set(COMMON_REQUEST_HEADERS);
+        mlApi.assertResponseStatusCode(200, status, body);
 
         packageVersion =
           body.response.find(
@@ -529,10 +530,10 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
     async installKibanaSampleData(sampleDataId: 'ecommerce' | 'flights' | 'logs') {
       log.debug(`Installing Kibana sample data '${sampleDataId}'`);
 
-      await supertest
+      const { body, status } = await supertest
         .post(`/api/sample_data/${sampleDataId}`)
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+        .set(COMMON_REQUEST_HEADERS);
+      mlApi.assertResponseStatusCode(200, status, body);
 
       log.debug(` > Installed`);
     },
@@ -540,10 +541,10 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
     async removeKibanaSampleData(sampleDataId: 'ecommerce' | 'flights' | 'logs') {
       log.debug(`Removing Kibana sample data '${sampleDataId}'`);
 
-      await supertest
+      const { body, status } = await supertest
         .delete(`/api/sample_data/${sampleDataId}`)
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(204); // No Content
+        .set(COMMON_REQUEST_HEADERS);
+      mlApi.assertResponseStatusCode(204, status, body);
 
       log.debug(` > Removed`);
     },

--- a/x-pack/test/functional/services/transform/index.ts
+++ b/x-pack/test/functional/services/transform/index.ts
@@ -19,10 +19,12 @@ import { TransformTableProvider } from './transform_table';
 import { TransformTestExecutionProvider } from './test_execution';
 import { TransformWizardProvider } from './wizard';
 
+import { MachineLearningAPIProvider } from '../ml/api';
 import { MachineLearningTestResourcesProvider } from '../ml/test_resources';
 
 export function TransformProvider(context: FtrProviderContext) {
   const api = TransformAPIProvider(context);
+  const mlApi = MachineLearningAPIProvider(context);
   const discover = TransformDiscoverProvider(context);
   const editFlyout = TransformEditFlyoutProvider(context);
   const management = TransformManagementProvider(context);
@@ -32,7 +34,7 @@ export function TransformProvider(context: FtrProviderContext) {
   const sourceSelection = TransformSourceSelectionProvider(context);
   const table = TransformTableProvider(context);
   const testExecution = TransformTestExecutionProvider(context);
-  const testResources = MachineLearningTestResourcesProvider(context);
+  const testResources = MachineLearningTestResourcesProvider(context, mlApi);
   const wizard = TransformWizardProvider(context);
 
   return {


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #127875

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
