### PR TITLE
[Lens] Migrate to dataViews service

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.test.tsx
@@ -24,7 +24,8 @@ import { I18nProvider } from '@kbn/i18n-react';
 import { SavedObjectSaveModal } from '../../../../../src/plugins/saved_objects/public';
 import { checkForDuplicateTitle } from '../persistence';
 import { createMemoryHistory } from 'history';
-import { FilterManager, IndexPattern, Query } from '../../../../../src/plugins/data/public';
+import { FilterManager, Query } from '../../../../../src/plugins/data/public';
+import type { DataView } from '../../../../../src/plugins/data_views/public';
 import { buildExistsFilter, FilterStateStore } from '@kbn/es-query';
 import type { FieldSpec } from '../../../../../src/plugins/data/common';
 import { TopNavMenuData } from '../../../../../src/plugins/navigation/public';
@@ -142,7 +143,7 @@ describe('Lens App', () => {
 
   it('updates global filters with store state', async () => {
     const services = makeDefaultServicesForApp();
-    const indexPattern = { id: 'index1' } as unknown as IndexPattern;
+    const indexPattern = { id: 'index1' } as unknown as DataView;
     const pinnedField = { name: 'pinnedField' } as unknown as FieldSpec;
     const pinnedFilter = buildExistsFilter(pinnedField, indexPattern);
     services.data.query.filterManager.getFilters = jest.fn().mockImplementation(() => {
@@ -341,11 +342,9 @@ describe('Lens App', () => {
   describe('TopNavMenu#showDatePicker', () => {
     it('shows date picker if any used index pattern isTimeBased', async () => {
       const customServices = makeDefaultServicesForApp();
-      customServices.data.indexPatterns.get = jest
+      customServices.dataViews.get = jest
         .fn()
-        .mockImplementation((id) =>
-          Promise.resolve({ id, isTimeBased: () => true } as IndexPattern)
-        );
+        .mockImplementation((id) => Promise.resolve({ id, isTimeBased: () => true } as DataView));
       const { services } = await mountWith({ services: customServices });
       expect(services.navigation.ui.TopNavMenu).toHaveBeenCalledWith(
         expect.objectContaining({ showDatePicker: true }),
@@ -354,11 +353,9 @@ describe('Lens App', () => {
     });
     it('shows date picker if active datasource isTimeBased', async () => {
       const customServices = makeDefaultServicesForApp();
-      customServices.data.indexPatterns.get = jest
+      customServices.dataViews.get = jest
         .fn()
-        .mockImplementation((id) =>
-          Promise.resolve({ id, isTimeBased: () => true } as IndexPattern)
-        );
+        .mockImplementation((id) => Promise.resolve({ id, isTimeBased: () => true } as DataView));
       const customProps = makeDefaultProps();
       customProps.datasourceMap.testDatasource.isTimeBased = () => true;
       const { services } = await mountWith({ props: customProps, services: customServices });
@@ -369,11 +366,9 @@ describe('Lens App', () => {
     });
     it('does not show date picker if index pattern nor active datasource is not time based', async () => {
       const customServices = makeDefaultServicesForApp();
-      customServices.data.indexPatterns.get = jest
+      customServices.dataViews.get = jest
         .fn()
-        .mockImplementation((id) =>
-          Promise.resolve({ id, isTimeBased: () => true } as IndexPattern)
-        );
+        .mockImplementation((id) => Promise.resolve({ id, isTimeBased: () => true } as DataView));
       const customProps = makeDefaultProps();
       customProps.datasourceMap.testDatasource.isTimeBased = () => false;
       const { services } = await mountWith({ props: customProps, services: customServices });
@@ -416,7 +411,7 @@ describe('Lens App', () => {
     });
     it('handles rejected index pattern', async () => {
       const customServices = makeDefaultServicesForApp();
-      customServices.data.indexPatterns.get = jest
+      customServices.dataViews.get = jest
         .fn()
         .mockImplementation((id) => Promise.reject({ reason: 'Could not locate that data view' }));
       const customProps = makeDefaultProps();
@@ -755,7 +750,7 @@ describe('Lens App', () => {
       });
 
       it('saves app filters and does not save pinned filters', async () => {
-        const indexPattern = { id: 'index1' } as unknown as IndexPattern;
+        const indexPattern = { id: 'index1' } as unknown as DataView;
         const field = { name: 'myfield' } as unknown as FieldSpec;
         const pinnedField = { name: 'pinnedField' } as unknown as FieldSpec;
         const unpinned = buildExistsFilter(field, indexPattern);
@@ -965,7 +960,7 @@ describe('Lens App', () => {
 
     it('updates the filters when the user changes them', async () => {
       const { instance, services, lensStore } = await mountWith({});
-      const indexPattern = { id: 'index1' } as unknown as IndexPattern;
+      const indexPattern = { id: 'index1' } as unknown as DataView;
       const field = { name: 'myfield' } as unknown as FieldSpec;
       expect(lensStore.getState()).toEqual({
         lens: expect.objectContaining({
@@ -1018,7 +1013,7 @@ describe('Lens App', () => {
           searchSessionId: `sessionId-3`,
         }),
       });
-      const indexPattern = { id: 'index1' } as unknown as IndexPattern;
+      const indexPattern = { id: 'index1' } as unknown as DataView;
       const field = { name: 'myfield' } as unknown as FieldSpec;
       act(() =>
         services.data.query.filterManager.setFilters([buildExistsFilter(field, indexPattern)])
@@ -1151,7 +1146,7 @@ describe('Lens App', () => {
           query: { query: 'new', language: 'lucene' },
         })
       );
-      const indexPattern = { id: 'index1' } as unknown as IndexPattern;
+      const indexPattern = { id: 'index1' } as unknown as DataView;
       const field = { name: 'myfield' } as unknown as FieldSpec;
       const pinnedField = { name: 'pinnedField' } as unknown as FieldSpec;
       const unpinned = buildExistsFilter(field, indexPattern);
@@ -1208,7 +1203,7 @@ describe('Lens App', () => {
           query: { query: 'new', language: 'lucene' },
         })
       );
-      const indexPattern = { id: 'index1' } as unknown as IndexPattern;
+      const indexPattern = { id: 'index1' } as unknown as DataView;
       const field = { name: 'myfield' } as unknown as FieldSpec;
       const pinnedField = { name: 'pinnedField' } as unknown as FieldSpec;
       const unpinned = buildExistsFilter(field, indexPattern);

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -207,6 +207,7 @@ export const LensTopNavMenu = ({
     attributeService,
     discover,
     dashboardFeatureFlag,
+    dataViews,
   } = useKibana<LensAppServices>().services;
 
   const dispatch = useLensDispatch();
@@ -260,7 +261,7 @@ export const LensTopNavMenu = ({
 
     // Update the cached index patterns if the user made a change to any of them
     if (hasIndexPatternsChanged) {
-      getIndexPatternsObjects(indexPatternIds, data.indexPatterns).then(
+      getIndexPatternsObjects(indexPatternIds, dataViews).then(
         ({ indexPatterns: indexPatternObjects, rejectedIds }) => {
           setIndexPatterns(indexPatternObjects);
           setRejectedIndexPatterns(rejectedIds);
@@ -273,7 +274,7 @@ export const LensTopNavMenu = ({
     rejectedIndexPatterns,
     datasourceMap,
     indexPatterns,
-    data.indexPatterns,
+    dataViews,
   ]);
 
   const { TopNavMenu } = navigation.ui;

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -18,7 +18,8 @@ import {
 import { downloadMultipleAs } from '../../../../../src/plugins/share/public';
 import { trackUiEvent } from '../lens_ui_telemetry';
 import { tableHasFormulas } from '../../../../../src/plugins/data/common';
-import { exporters, IndexPattern } from '../../../../../src/plugins/data/public';
+import { exporters } from '../../../../../src/plugins/data/public';
+import type { DataView } from '../../../../../src/plugins/data_views/public';
 import { useKibana } from '../../../../../src/plugins/kibana_react/public';
 import {
   setState,
@@ -216,7 +217,7 @@ export const LensTopNavMenu = ({
     [dispatch]
   );
 
-  const [indexPatterns, setIndexPatterns] = useState<IndexPattern[]>([]);
+  const [indexPatterns, setIndexPatterns] = useState<DataView[]>([]);
   const [rejectedIndexPatterns, setRejectedIndexPatterns] = useState<string[]>([]);
 
   const {

--- a/x-pack/plugins/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/mounter.tsx
@@ -93,6 +93,7 @@ export async function getLensServices(
         ? stateTransfer?.getAppNameFromId(embeddableEditorIncomingState.originatingApp)
         : undefined;
     },
+    dataViews: startDependencies.dataViews,
     // Temporarily required until the 'by value' paradigm is default.
     dashboardFeatureFlag: startDependencies.dashboard.dashboardFeatureFlagConfig,
     spaces,

--- a/x-pack/plugins/lens/public/app_plugin/types.ts
+++ b/x-pack/plugins/lens/public/app_plugin/types.ts
@@ -21,6 +21,7 @@ import type {
   SavedObjectsStart,
 } from '../../../../../src/core/public';
 import type { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
+import type { DataViewsPublicPluginStart } from '../../../../../src/plugins/data_views/public';
 import type { UsageCollectionStart } from '../../../../../src/plugins/usage_collection/public';
 import type { DashboardStart } from '../../../../../src/plugins/dashboard/public';
 import type { LensEmbeddableInput } from '../embeddable/embeddable';
@@ -121,6 +122,7 @@ export interface LensAppServices {
   overlays: OverlayStart;
   storage: IStorageWrapper;
   dashboard: DashboardStart;
+  dataViews: DataViewsPublicPluginStart;
   fieldFormats: FieldFormatsStart;
   data: DataPublicPluginStart;
   inspector: LensInspector;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
@@ -29,7 +29,7 @@ import { DragDrop, ChildDragDropProvider } from '../../../drag_drop';
 import { fromExpression } from '@kbn/interpreter';
 import { buildExistsFilter } from '@kbn/es-query';
 import { coreMock } from 'src/core/public/mocks';
-import { IndexPattern } from '../../../../../../../src/plugins/data/public';
+import { DataView } from '../../../../../../../src/plugins/data_views/public';
 import type { FieldSpec } from '../../../../../../../src/plugins/data/common';
 import { UiActionsStart } from '../../../../../../../src/plugins/ui_actions/public';
 import { uiActionsPluginMock } from '../../../../../../../src/plugins/ui_actions/public/mocks';
@@ -602,7 +602,7 @@ describe('workspace_panel', () => {
 
     expect(expressionRendererMock).toHaveBeenCalledTimes(2);
 
-    const indexPattern = { id: 'index1' } as unknown as IndexPattern;
+    const indexPattern = { id: 'index1' } as unknown as DataView;
     const field = { name: 'myfield' } as unknown as FieldSpec;
 
     act(() => {

--- a/x-pack/plugins/lens/public/embeddable/embeddable.test.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.test.tsx
@@ -17,7 +17,8 @@ import {
 import { ReactExpressionRendererProps } from 'src/plugins/expressions/public';
 import { spacesPluginMock } from '../../../spaces/public/mocks';
 import { Filter } from '@kbn/es-query';
-import { Query, TimeRange, IndexPatternsContract, FilterManager } from 'src/plugins/data/public';
+import { Query, TimeRange, FilterManager } from 'src/plugins/data/public';
+import type { DataViewsContract } from 'src/plugins/data_views/public';
 import { Document } from '../persistence';
 import { dataPluginMock } from '../../../../../src/plugins/data/public/mocks';
 import { VIS_EVENT_TO_TRIGGER } from '../../../../../src/plugins/visualizations/public/embeddable';
@@ -140,7 +141,7 @@ describe('embeddable', () => {
         attributeService,
         expressionRenderer,
         basePath,
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -186,7 +187,7 @@ describe('embeddable', () => {
         attributeService,
         expressionRenderer,
         basePath,
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         inspector: inspectorPluginMock.createStartContract(),
         capabilities: { canSaveDashboards: true, canSaveVisualizations: true },
         getTrigger,
@@ -231,7 +232,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -288,7 +289,7 @@ describe('embeddable', () => {
         inspector: inspectorPluginMock.createStartContract(),
         expressionRenderer,
         basePath,
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         spaces: spacesPluginStart,
         capabilities: {
           canSaveDashboards: true,
@@ -336,7 +337,7 @@ describe('embeddable', () => {
         inspector: inspectorPluginMock.createStartContract(),
         indexPatternService: {
           get: (id: string) => Promise.resolve({ id, isTimeBased: jest.fn(() => true) }),
-        } as unknown as IndexPatternsContract,
+        } as unknown as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -382,7 +383,7 @@ describe('embeddable', () => {
         inspector: inspectorPluginMock.createStartContract(),
         indexPatternService: {
           get: (id: string) => Promise.resolve({ id, isTimeBased: () => false }),
-        } as unknown as IndexPatternsContract,
+        } as unknown as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -424,7 +425,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -472,7 +473,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: { canSaveDashboards: true, canSaveVisualizations: true },
         getTrigger,
         visualizationMap: {},
@@ -521,7 +522,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -571,7 +572,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -628,7 +629,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -686,7 +687,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -745,7 +746,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: { get: jest.fn() } as unknown as IndexPatternsContract,
+        indexPatternService: { get: jest.fn() } as unknown as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -793,7 +794,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -841,7 +842,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -886,7 +887,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -946,7 +947,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -1025,7 +1026,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -1079,7 +1080,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -1130,7 +1131,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
@@ -1202,7 +1203,7 @@ describe('embeddable', () => {
         expressionRenderer,
         basePath,
         inspector: inspectorPluginMock.createStartContract(),
-        indexPatternService: {} as IndexPatternsContract,
+        indexPatternService: {} as DataViewsContract,
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -15,7 +15,6 @@ import {
   Query,
   TimefilterContract,
   TimeRange,
-  IndexPattern,
   FilterManager,
 } from 'src/plugins/data/public';
 import type { PaletteOutput } from 'src/plugins/charts/public';
@@ -58,7 +57,7 @@ import {
   Visualization,
 } from '../types';
 
-import { IndexPatternsContract } from '../../../../../src/plugins/data/public';
+import type { DataViewsContract, DataView } from '../../../../../src/plugins/data_views/public';
 import { getEditPath, DOC_TYPE, PLUGIN_ID } from '../../common';
 import type {
   IBasePath,
@@ -105,7 +104,7 @@ export type LensByReferenceInput = SavedObjectEmbeddableInput & LensBaseEmbeddab
 export type LensEmbeddableInput = LensByValueInput | LensByReferenceInput;
 
 export interface LensEmbeddableOutput extends EmbeddableOutput {
-  indexPatterns?: IndexPattern[];
+  indexPatterns?: DataView[];
 }
 
 export interface LensEmbeddableDeps {
@@ -115,7 +114,7 @@ export interface LensEmbeddableDeps {
   ) => Promise<{ ast: Ast | null; errors: ErrorMessage[] | undefined }>;
   injectFilterReferences: FilterManager['inject'];
   visualizationMap: VisualizationMap;
-  indexPatternService: IndexPatternsContract;
+  indexPatternService: DataViewsContract;
   expressionRenderer: ReactExpressionRendererType;
   timefilter: TimefilterContract;
   basePath: IBasePath;
@@ -308,7 +307,7 @@ export class Embeddable
   private maybeAddTimeRangeError(
     errors: ErrorMessage[] | undefined,
     input: LensEmbeddableInput,
-    indexPatterns: IndexPattern[]
+    indexPatterns: DataView[]
   ) {
     // if at least one indexPattern is time based, then the Lens embeddable requires the timeRange prop
     if (
@@ -610,8 +609,7 @@ export class Embeddable
     );
     const indexPatterns = responses
       .filter(
-        (response): response is PromiseFulfilledResult<IndexPattern> =>
-          response.status === 'fulfilled'
+        (response): response is PromiseFulfilledResult<DataView> => response.status === 'fulfilled'
       )
       .map(({ value }) => value);
 

--- a/x-pack/plugins/lens/public/embeddable/embeddable_factory.ts
+++ b/x-pack/plugins/lens/public/embeddable/embeddable_factory.ts
@@ -10,11 +10,8 @@ import { i18n } from '@kbn/i18n';
 import { RecursiveReadonly } from '@kbn/utility-types';
 import { Ast } from '@kbn/interpreter';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/public';
-import {
-  FilterManager,
-  IndexPatternsContract,
-  TimefilterContract,
-} from '../../../../../src/plugins/data/public';
+import { FilterManager, TimefilterContract } from '../../../../../src/plugins/data/public';
+import type { DataViewsContract } from '../../../../../src/plugins/data_views/public';
 import { ReactExpressionRendererType } from '../../../../../src/plugins/expressions/public';
 import {
   EmbeddableFactoryDefinition,
@@ -38,7 +35,7 @@ export interface LensEmbeddableStartServices {
   attributeService: LensAttributeService;
   capabilities: RecursiveReadonly<Capabilities>;
   expressionRenderer: ReactExpressionRendererType;
-  indexPatternService: IndexPatternsContract;
+  indexPatternService: DataViewsContract;
   uiActions?: UiActionsStart;
   usageCollection?: UsageCollectionSetup;
   documentToExpression: (

--- a/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.test.tsx
@@ -10,6 +10,7 @@ import { waitFor } from '@testing-library/react';
 import ReactDOM from 'react-dom';
 import { createMockedDragDropContext } from './mocks';
 import { dataPluginMock } from '../../../../../src/plugins/data/public/mocks';
+import { dataViewPluginMocks } from '../../../../../src/plugins/data_views/public/mocks';
 import { InnerIndexPatternDataPanel, IndexPatternDataPanel, MemoizedDataPanel } from './datapanel';
 import { FieldList } from './field_list';
 import { FieldItem } from './field_item';
@@ -259,6 +260,7 @@ describe('IndexPattern Data Panel', () => {
       indexPatternRefs: [],
       existingFields: {},
       data: dataPluginMock.createStartContract(),
+      dataViews: dataViewPluginMocks.createStartContract(),
       fieldFormats: fieldFormatsServiceMock.createStartContract(),
       indexPatternFieldEditor: indexPatternFieldEditorPluginMock.createStartContract(),
       onUpdateIndexPattern: jest.fn(),
@@ -857,7 +859,7 @@ describe('IndexPattern Data Panel', () => {
       });
       it('should call field editor plugin on clicking add button', async () => {
         const mockIndexPattern = {};
-        (props.data.indexPatterns.get as jest.Mock).mockImplementation(() =>
+        (props.dataViews.get as jest.Mock).mockImplementation(() =>
           Promise.resolve(mockIndexPattern)
         );
         const wrapper = mountWithIntl(<InnerIndexPatternDataPanel {...props} />);
@@ -895,7 +897,7 @@ describe('IndexPattern Data Panel', () => {
           ],
           metaFields: [],
         };
-        (props.data.indexPatterns.get as jest.Mock).mockImplementation(() =>
+        (props.dataViews.get as jest.Mock).mockImplementation(() =>
           Promise.resolve(mockIndexPattern)
         );
         const wrapper = mountWithIntl(<InnerIndexPatternDataPanel {...props} />);

--- a/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.tsx
@@ -45,9 +45,11 @@ import { Loader } from '../loader';
 import { getEsQueryConfig } from '../../../../../src/plugins/data/public';
 import { IndexPatternFieldEditorStart } from '../../../../../src/plugins/data_view_field_editor/public';
 import { VISUALIZE_GEO_FIELD_TRIGGER } from '../../../../../src/plugins/ui_actions/public';
+import type { DataViewsPublicPluginStart } from '../../../../../src/plugins/data_views/public';
 
 export type Props = Omit<DatasourceDataPanelProps<IndexPatternPrivateState>, 'core'> & {
   data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
   fieldFormats: FieldFormatsStart;
   changeIndexPattern: (
     id: string,
@@ -121,6 +123,7 @@ export function IndexPatternDataPanel({
   dragDropContext,
   core,
   data,
+  dataViews,
   fieldFormats,
   query,
   filters,
@@ -235,6 +238,7 @@ export function IndexPatternDataPanel({
           dragDropContext={dragDropContext}
           core={core}
           data={data}
+          dataViews={dataViews}
           fieldFormats={fieldFormats}
           charts={charts}
           indexPatternFieldEditor={indexPatternFieldEditor}
@@ -294,6 +298,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
   onUpdateIndexPattern,
   core,
   data,
+  dataViews,
   fieldFormats,
   indexPatternFieldEditor,
   existingFields,
@@ -303,6 +308,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
   uiActions,
 }: Omit<DatasourceDataPanelProps, 'state' | 'setState' | 'showNoDataPopover' | 'core'> & {
   data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
   fieldFormats: FieldFormatsStart;
   core: CoreStart;
   currentIndexPatternId: string;
@@ -506,21 +512,21 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
 
   const refreshFieldList = useCallback(async () => {
     const newlyMappedIndexPattern = await loadIndexPatterns({
-      indexPatternsService: data.indexPatterns,
+      indexPatternsService: dataViews,
       cache: {},
       patterns: [currentIndexPattern.id],
     });
     onUpdateIndexPattern(newlyMappedIndexPattern[currentIndexPattern.id]);
     // start a new session so all charts are refreshed
     data.search.session.start();
-  }, [data, currentIndexPattern, onUpdateIndexPattern]);
+  }, [data, dataViews, currentIndexPattern, onUpdateIndexPattern]);
 
   const editField = useMemo(
     () =>
       editPermission
         ? async (fieldName?: string, uiAction: 'edit' | 'add' = 'edit') => {
             trackUiEvent(`open_field_editor_${uiAction}`);
-            const indexPatternInstance = await data.indexPatterns.get(currentIndexPattern.id);
+            const indexPatternInstance = await dataViews.get(currentIndexPattern.id);
             closeFieldEditor.current = indexPatternFieldEditor.openEditor({
               ctx: {
                 dataView: indexPatternInstance,
@@ -533,7 +539,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
             });
           }
         : undefined,
-    [data, indexPatternFieldEditor, currentIndexPattern, editPermission, refreshFieldList]
+    [editPermission, dataViews, currentIndexPattern.id, indexPatternFieldEditor, refreshFieldList]
   );
 
   const removeField = useMemo(
@@ -541,7 +547,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
       editPermission
         ? async (fieldName: string) => {
             trackUiEvent('open_field_delete_modal');
-            const indexPatternInstance = await data.indexPatterns.get(currentIndexPattern.id);
+            const indexPatternInstance = await dataViews.get(currentIndexPattern.id);
             closeFieldEditor.current = indexPatternFieldEditor.openDeleteModal({
               ctx: {
                 dataView: indexPatternInstance,
@@ -554,13 +560,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
             });
           }
         : undefined,
-    [
-      currentIndexPattern.id,
-      data.indexPatterns,
-      editPermission,
-      indexPatternFieldEditor,
-      refreshFieldList,
-    ]
+    [currentIndexPattern.id, dataViews, editPermission, indexPatternFieldEditor, refreshFieldList]
   );
 
   const addField = useMemo(

--- a/x-pack/plugins/lens/public/indexpattern_datasource/index.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/index.ts
@@ -14,6 +14,7 @@ import type {
   DataPublicPluginSetup,
   DataPublicPluginStart,
 } from '../../../../../src/plugins/data/public';
+import type { DataViewsPublicPluginStart } from '../../../../../src/plugins/data_views/public';
 import type { EditorFrameSetup } from '../types';
 import type { UiActionsStart } from '../../../../../src/plugins/ui_actions/public';
 import type {
@@ -35,6 +36,7 @@ export interface IndexPatternDatasourceStartPlugins {
   data: DataPublicPluginStart;
   fieldFormats: FieldFormatsStart;
   dataViewFieldEditor: IndexPatternFieldEditorStart;
+  dataViews: DataViewsPublicPluginStart;
   uiActions: UiActionsStart;
 }
 
@@ -62,7 +64,7 @@ export class IndexPatternDatasource {
         fieldFormatsSetup.register([suffixFormatter]);
       }
 
-      const [coreStart, { dataViewFieldEditor, uiActions, data, fieldFormats }] =
+      const [coreStart, { dataViewFieldEditor, uiActions, data, fieldFormats, dataViews }] =
         await core.getStartServices();
 
       return getIndexPatternDatasource({
@@ -70,6 +72,7 @@ export class IndexPatternDatasource {
         fieldFormats,
         storage: new Storage(localStorage),
         data,
+        dataViews,
         charts,
         dataViewFieldEditor,
         uiActions,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
@@ -12,6 +12,7 @@ import { DatasourcePublicAPI, Datasource, FramePublicAPI, OperationDescriptor } 
 import { coreMock } from 'src/core/public/mocks';
 import { IndexPatternPersistedState, IndexPatternPrivateState } from './types';
 import { dataPluginMock } from '../../../../../src/plugins/data/public/mocks';
+import { dataViewPluginMocks } from '../../../../../src/plugins/data_views/public/mocks';
 import { Ast } from '@kbn/interpreter';
 import { chartPluginMock } from '../../../../../src/plugins/charts/public/mocks';
 import { getFieldByNameFactory } from './pure_helpers';
@@ -186,6 +187,7 @@ describe('IndexPattern Data Source', () => {
       storage: {} as IStorageWrapper,
       core: coreMock.createStart(),
       data: dataPluginMock.createStartContract(),
+      dataViews: dataViewPluginMocks.createStartContract(),
       fieldFormats: fieldFormatsServiceMock.createStartContract(),
       charts: chartPluginMock.createSetupContract(),
       dataViewFieldEditor: indexPatternFieldEditorPluginMock.createStartContract(),

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
@@ -13,6 +13,7 @@ import { i18n } from '@kbn/i18n';
 import type { IStorageWrapper } from 'src/plugins/kibana_utils/public';
 import type { FieldFormatsStart } from 'src/plugins/field_formats/public';
 import { isEqual } from 'lodash';
+import type { DataViewsPublicPluginStart } from '../../../../../src/plugins/data_views/public';
 import type { IndexPatternFieldEditorStart } from '../../../../../src/plugins/data_view_field_editor/public';
 import type {
   DatasourceDimensionEditorProps,
@@ -117,6 +118,7 @@ export function getIndexPatternDatasource({
   core,
   storage,
   data,
+  dataViews,
   fieldFormats,
   charts,
   dataViewFieldEditor,
@@ -125,6 +127,7 @@ export function getIndexPatternDatasource({
   core: CoreStart;
   storage: IStorageWrapper;
   data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
   fieldFormats: FieldFormatsStart;
   charts: ChartsPluginSetup;
   dataViewFieldEditor: IndexPatternFieldEditorStart;
@@ -138,7 +141,7 @@ export function getIndexPatternDatasource({
       }),
     });
 
-  const indexPatternsService = data.indexPatterns;
+  const indexPatternsService = dataViews;
 
   const handleChangeIndexPattern = (
     id: string,
@@ -260,6 +263,7 @@ export function getIndexPatternDatasource({
             <IndexPatternDataPanel
               changeIndexPattern={handleChangeIndexPattern}
               data={data}
+              dataViews={dataViews}
               fieldFormats={fieldFormats}
               charts={charts}
               indexPatternFieldEditor={dataViewFieldEditor}

--- a/x-pack/plugins/lens/public/indexpattern_datasource/loader.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/loader.test.ts
@@ -16,7 +16,7 @@ import {
   extractReferences,
   injectReferences,
 } from './loader';
-import { IndexPatternsContract } from '../../../../../src/plugins/data/public';
+import { DataViewsContract } from '../../../../../src/plugins/data_views/public';
 import { HttpFetchError } from '../../../../../src/core/public';
 import {
   IndexPatternPersistedState,
@@ -214,7 +214,7 @@ function mockIndexPatternsService() {
         },
       ];
     }),
-  } as unknown as Pick<IndexPatternsContract, 'get' | 'getIdsWithTitle'>;
+  } as unknown as Pick<DataViewsContract, 'get' | 'getIdsWithTitle'>;
 }
 
 describe('loader', () => {
@@ -228,7 +228,7 @@ describe('loader', () => {
             Promise.reject('mockIndexPatternService.get should not have been called')
           ),
           getIdsWithTitle: jest.fn(),
-        } as unknown as Pick<IndexPatternsContract, 'get' | 'getIdsWithTitle'>,
+        } as unknown as Pick<DataViewsContract, 'get' | 'getIdsWithTitle'>,
       });
 
       expect(cache).toEqual(sampleIndexPatterns);
@@ -301,7 +301,7 @@ describe('loader', () => {
             id: 'foo',
             title: 'Foo index',
           })),
-        } as unknown as Pick<IndexPatternsContract, 'get' | 'getIdsWithTitle'>,
+        } as unknown as Pick<DataViewsContract, 'get' | 'getIdsWithTitle'>,
       });
 
       expect(cache.foo.getFieldByName('bytes')!.aggregationRestrictions).toEqual({
@@ -357,7 +357,7 @@ describe('loader', () => {
             id: 'foo',
             title: 'Foo index',
           })),
-        } as unknown as Pick<IndexPatternsContract, 'get' | 'getIdsWithTitle'>,
+        } as unknown as Pick<DataViewsContract, 'get' | 'getIdsWithTitle'>,
       });
 
       expect(cache.foo.getFieldByName('timestamp')!.meta).toEqual(true);
@@ -695,7 +695,7 @@ describe('loader', () => {
               },
             ];
           }),
-        } as unknown as Pick<IndexPatternsContract, 'get' | 'getIdsWithTitle'>;
+        } as unknown as Pick<DataViewsContract, 'get' | 'getIdsWithTitle'>;
       }
       const savedState: IndexPatternPersistedState = {
         layers: {

--- a/x-pack/plugins/lens/public/mocks/services_mock.tsx
+++ b/x-pack/plugins/lens/public/mocks/services_mock.tsx
@@ -15,6 +15,9 @@ import { UI_SETTINGS } from '../../../../../src/plugins/data/public';
 import { inspectorPluginMock } from '../../../../../src/plugins/inspector/public/mocks';
 import { spacesPluginMock } from '../../../spaces/public/mocks';
 import { dashboardPluginMock } from '../../../../../src/plugins/dashboard/public/mocks';
+import { dataViewPluginMocks } from '../../../../../src/plugins/data_views/public/mocks';
+import { DataViewsPublicPluginStart } from '../../../../../src/plugins/data_views/public';
+
 import type {
   LensByValueInput,
   LensByReferenceInput,
@@ -78,6 +81,13 @@ export function makeDefaultServices(
     })
   );
 
+  const dataViewsMock = dataViewPluginMocks.createStartContract();
+  dataViewsMock.get.mockImplementation(
+    jest.fn((id) =>
+      Promise.resolve({ id, isTimeBased: () => true })
+    ) as unknown as DataViewsPublicPluginStart['get']
+  );
+
   const navigationStartMock = navigationPluginMock.createStartContract();
 
   jest.spyOn(navigationStartMock.ui.TopNavMenu.prototype, 'constructor').mockImplementation(() => {
@@ -136,6 +146,7 @@ export function makeDefaultServices(
       getUrlForApp: jest.fn((appId: string) => `/testbasepath/app/${appId}#/`),
     },
     data: mockDataPlugin(sessionIdSubject, sessionId),
+    dataViews: dataViewsMock,
     fieldFormats: fieldFormatsServiceMock.createStartContract(),
     storage: {
       get: jest.fn(),

--- a/x-pack/plugins/lens/public/plugin.ts
+++ b/x-pack/plugins/lens/public/plugin.ts
@@ -16,6 +16,7 @@ import type {
   DataPublicPluginSetup,
   DataPublicPluginStart,
 } from '../../../../src/plugins/data/public';
+import type { DataViewsPublicPluginStart } from '../../../../src/plugins/data_views/public';
 import type { EmbeddableSetup, EmbeddableStart } from '../../../../src/plugins/embeddable/public';
 import type { DashboardStart } from '../../../../src/plugins/dashboard/public';
 import type { SpacesPluginStart } from '../../spaces/public';
@@ -110,6 +111,7 @@ export interface LensPluginSetupDependencies {
 
 export interface LensPluginStartDependencies {
   data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
   fieldFormats: FieldFormatsStart;
   expressions: ExpressionsStart;
   navigation: NavigationPublicPluginStart;
@@ -262,7 +264,7 @@ export class LensPlugin {
         documentToExpression: this.editorFrameService!.documentToExpression,
         injectFilterReferences: data.query.filterManager.inject.bind(data.query.filterManager),
         visualizationMap,
-        indexPatternService: plugins.data.indexPatterns,
+        indexPatternService: plugins.dataViews,
         uiActions: plugins.uiActions,
         usageCollection,
         inspector: plugins.inspector,
@@ -292,7 +294,7 @@ export class LensPlugin {
     const ensureDefaultDataView = () => {
       // make sure a default index pattern exists
       // if not, the page will be redirected to management and visualize won't be rendered
-      startServices().plugins.data.indexPatterns.ensureDefaultDataView();
+      startServices().plugins.dataViews.ensureDefaultDataView();
     };
 
     core.application.register({

--- a/x-pack/plugins/lens/public/utils.ts
+++ b/x-pack/plugins/lens/public/utils.ts
@@ -8,13 +8,9 @@ import { uniq } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment-timezone';
 
-import type {
-  IndexPattern,
-  IndexPatternsContract,
-  TimefilterContract,
-} from 'src/plugins/data/public';
-import type { IUiSettingsClient } from 'kibana/public';
-import type { SavedObjectReference } from 'kibana/public';
+import type { TimefilterContract } from 'src/plugins/data/public';
+import type { IUiSettingsClient, SavedObjectReference } from 'kibana/public';
+import type { DataView, DataViewsContract } from '../../../../src/plugins/data_views/public';
 import type { Document } from './persistence/saved_object_store';
 import type {
   Datasource,
@@ -89,11 +85,11 @@ export function getIndexPatternsIds({
 
 export async function getIndexPatternsObjects(
   ids: string[],
-  indexPatternsService: IndexPatternsContract
-): Promise<{ indexPatterns: IndexPattern[]; rejectedIds: string[] }> {
+  indexPatternsService: DataViewsContract
+): Promise<{ indexPatterns: DataView[]; rejectedIds: string[] }> {
   const responses = await Promise.allSettled(ids.map((id) => indexPatternsService.get(id)));
   const fullfilled = responses.filter(
-    (response): response is PromiseFulfilledResult<IndexPattern> => response.status === 'fulfilled'
+    (response): response is PromiseFulfilledResult<DataView> => response.status === 'fulfilled'
   );
   const rejectedIds = responses
     .map((_response, i) => ids[i])

--- a/x-pack/plugins/lens/server/routes/existing_fields.test.ts
+++ b/x-pack/plugins/lens/server/routes/existing_fields.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { IndexPattern } from 'src/plugins/data/common';
+import { DataView } from 'src/plugins/data_views/common';
 import { legacyExistingFields, existingFields, Field, buildFieldList } from './existing_fields';
 
 describe('existingFields', () => {
@@ -143,7 +143,7 @@ describe('buildFieldList', () => {
   };
 
   it('supports scripted fields', () => {
-    const fields = buildFieldList(indexPattern as unknown as IndexPattern, []);
+    const fields = buildFieldList(indexPattern as unknown as DataView, []);
     expect(fields.find((f) => f.isScript)).toMatchObject({
       isScript: true,
       name: 'foo',
@@ -153,7 +153,7 @@ describe('buildFieldList', () => {
   });
 
   it('supports runtime fields', () => {
-    const fields = buildFieldList(indexPattern as unknown as IndexPattern, []);
+    const fields = buildFieldList(indexPattern as unknown as DataView, []);
     expect(fields.find((f) => f.runtimeField)).toMatchObject({
       name: 'runtime_foo',
       runtimeField: { type: 'long', script: { source: '2+2' } },
@@ -161,7 +161,7 @@ describe('buildFieldList', () => {
   });
 
   it('supports meta fields', () => {
-    const fields = buildFieldList(indexPattern as unknown as IndexPattern, ['_mymeta']);
+    const fields = buildFieldList(indexPattern as unknown as DataView, ['_mymeta']);
     expect(fields.find((f) => f.isMeta)).toMatchObject({
       isScript: false,
       isMeta: true,

--- a/x-pack/plugins/lens/server/routes/field_stats.ts
+++ b/x-pack/plugins/lens/server/routes/field_stats.ts
@@ -9,7 +9,7 @@ import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import DateMath from '@elastic/datemath';
 import { schema } from '@kbn/config-schema';
 import { CoreSetup } from 'src/core/server';
-import type { IndexPatternField } from 'src/plugins/data/common';
+import type { DataViewField } from 'src/plugins/data_views/common';
 import { SavedObjectNotFound } from '../../../../../src/plugins/kibana_utils/common';
 import { ESSearchResponse } from '../../../../../src/core/types/elasticsearch';
 import { FieldStatsResponse, BASE_API_URL } from '../../common';
@@ -42,10 +42,10 @@ export async function initFieldsRoute(setup: CoreSetup<PluginStartContract>) {
       const requestClient = context.core.elasticsearch.client.asCurrentUser;
       const { fromDate, toDate, fieldName, dslQuery, size } = req.body;
 
-      const [{ savedObjects, elasticsearch }, { data }] = await setup.getStartServices();
+      const [{ savedObjects, elasticsearch }, { dataViews }] = await setup.getStartServices();
       const savedObjectsClient = savedObjects.getScopedClient(req);
       const esClient = elasticsearch.client.asScoped(req).asCurrentUser;
-      const indexPatternsService = await data.indexPatterns.indexPatternsServiceFactory(
+      const indexPatternsService = await dataViews.dataViewsServiceFactory(
         savedObjectsClient,
         esClient
       );
@@ -141,7 +141,7 @@ export async function getNumberHistogram(
   aggSearchWithBody: (
     aggs: Record<string, estypes.AggregationsAggregationContainer>
   ) => Promise<unknown>,
-  field: IndexPatternField,
+  field: DataViewField,
   useTopHits = true
 ): Promise<FieldStatsResponse> {
   const fieldRef = getFieldRef(field);
@@ -250,7 +250,7 @@ export async function getNumberHistogram(
 
 export async function getStringSamples(
   aggSearchWithBody: (aggs: Record<string, estypes.AggregationsAggregationContainer>) => unknown,
-  field: IndexPatternField,
+  field: DataViewField,
   size = 10
 ): Promise<FieldStatsResponse> {
   const fieldRef = getFieldRef(field);
@@ -290,7 +290,7 @@ export async function getStringSamples(
 // This one is not sampled so that it returns the full date range
 export async function getDateHistogram(
   aggSearchWithBody: (aggs: Record<string, estypes.AggregationsAggregationContainer>) => unknown,
-  field: IndexPatternField,
+  field: DataViewField,
   range: { fromDate: string; toDate: string }
 ): Promise<FieldStatsResponse> {
   const fromDate = DateMath.parse(range.fromDate);
@@ -332,7 +332,7 @@ export async function getDateHistogram(
   };
 }
 
-function getFieldRef(field: IndexPatternField) {
+function getFieldRef(field: DataViewField) {
   return field.scripted
     ? {
         script: {

--- a/x-pack/plugins/lens/tsconfig.json
+++ b/x-pack/plugins/lens/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "../global_search/tsconfig.json"},
     { "path": "../saved_objects_tagging/tsconfig.json"},
     { "path": "../../../src/plugins/data/tsconfig.json"},
+    { "path": "../../../src/plugins/data_views/tsconfig.json"},
     { "path": "../../../src/plugins/data_view_field_editor/tsconfig.json"},
     { "path": "../../../src/plugins/charts/tsconfig.json"},
     { "path": "../../../src/plugins/expressions/tsconfig.json"},


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/124086
This PR is handling the Lens case. We don't want to use the indexpattern service (exposed by the data plugin) but the dataViews service. 
I have updated all lens files that were using the deprecated service and types (🤞 ).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios