### PR TITLE
[generate/package] include react type for web packages

### DIFF
--- a/packages/kbn-generate/templates/package/BUILD.bazel.ejs
+++ b/packages/kbn-generate/templates/package/BUILD.bazel.ejs
@@ -8,6 +8,9 @@ PKG_REQUIRE_NAME = <%- json(pkg.name) %>
 SOURCE_FILES = glob(
   [
     "src/**/*.ts",
+  <%_ if (pkg.web) { _%>
+    "src/**/*.tsx",
+  <%_ } _%>
   ],
   exclude = [
     "**/*.test.*",
@@ -36,6 +39,9 @@ NPM_MODULE_EXTRA_FILES = [
 #    "@npm//name-of-package"
 #    eg. "@npm//lodash"
 RUNTIME_DEPS = [
+<%_ if (pkg.web) { _%>
+  "@npm//react"
+<%_ } _%>
 ]
 
 # In this array place dependencies necessary to build the types, which will include the
@@ -50,6 +56,9 @@ RUNTIME_DEPS = [
 TYPES_DEPS = [
   "@npm//@types/node",
   "@npm//@types/jest",
+<%_ if (pkg.web) { _%>
+  "@npm//react"
+<%_ } _%>
 ]
 
 jsts_transpiler(

--- a/packages/kbn-generate/templates/package/BUILD.bazel.ejs
+++ b/packages/kbn-generate/templates/package/BUILD.bazel.ejs
@@ -57,7 +57,7 @@ TYPES_DEPS = [
   "@npm//@types/node",
   "@npm//@types/jest",
 <%_ if (pkg.web) { _%>
-  "@npm//react"
+  "@npm//@types/react"
 <%_ } _%>
 ]
 

--- a/packages/kbn-generate/templates/package/tsconfig.json.ejs
+++ b/packages/kbn-generate/templates/package/tsconfig.json.ejs
@@ -7,8 +7,14 @@
     "rootDir": "src",
     "stripInternal": false,
     "types": [
+    <%_ if (pkg.web) { _%>
+      "jest",
+      "node",
+      "react"
+    <%_ } else { _%>
       "jest",
       "node"
+    <%_ } _%>
     ]
   },
   "include": [


### PR DESCRIPTION
Packages targeting the web will regularly include React components, which in some usage patterns requires the `"react"` global types to function, specifically:

```ts
import React from 'react'

export function SomeComponent() {
  return <div />
}
```

A module like this produces the following type:
```ts
export function SomeComponent(): JSX.Element; 
```

This is perfectly valid, but requires the `JSX` global produced by the `@types/react` package, but since there isn't any direct reference to the `@types/react` package in the types TS doesn't include the reference in the `.d.ts` output. This cause problems for consumers of the types as they can't resolve the `JSX` namespace unless `@types/react` is imported somewhere else. To prevent this from being a problem for contributors I think we should just include the react types by default for web packages.