### PR TITLE
[failed-test] Auto-label failed-test issues whenever possible

### DIFF
--- a/.github/workflows/label-failed-test.yml
+++ b/.github/workflows/label-failed-test.yml
@@ -1,0 +1,28 @@
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  issue_commented:
+    name: Skip failed test on comment
+    if: |
+      !github.event.issue.pull_request
+      && github.event.label.name == 'failed-test'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout kibana-operations
+        uses: actions/checkout@v2
+        with:
+          repository: 'elastic/kibana-operations'
+          ref: main
+          path: ./kibana-operations
+          token: ${{secrets.KIBANAMACHINE_TOKEN}}
+
+      - name: Label failed test issue
+        working-directory: ./kibana-operations/triage
+        env:
+          GITHUB_TOKEN: ${{secrets.KIBANAMACHINE_TOKEN}}
+        run: |
+          npm install
+          node failed-test-label ${{github.event.issue.number}} || true

--- a/.github/workflows/label-failed-test.yml
+++ b/.github/workflows/label-failed-test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   issue_commented:
-    name: Skip failed test on comment
+    name: Label failed test issue
     if: |
       !github.event.issue.pull_request
       && github.event.label.name == 'failed-test'


### PR DESCRIPTION
This action will use `CODEOWNERS`, the failed test path, and a list of teams' github labels etc to label `failed-test` automatically when possible. This is the same logic that our skip tool uses.