### PR TITLE
[data view mgmt] reload data view after changing space settings, check for 'all spaces' when showing delete confirm

### DIFF
--- a/src/plugins/data_view_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/data_view_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -112,7 +112,7 @@ export const EditIndexPattern = withRouter(
       }
 
       const warning =
-        indexPattern.namespaces.length > 1 ? (
+        indexPattern.namespaces.length > 1 || indexPattern.namespaces.includes('*') ? (
           <FormattedMessage
             id="indexPatternManagement.editDataView.deleteWarning"
             defaultMessage="When you delete {dataViewName}, you remove it from every space it is shared in. You can't undo this action."

--- a/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -161,7 +161,10 @@ export const IndexPatternTable = ({
             spaceIds={dataView.namespaces || []}
             id={dataView.id}
             title={dataView.title}
-            refresh={loadDataViews}
+            refresh={() => {
+              dataViews.clearCache(dataView.id);
+              loadDataViews();
+            }}
           />
         ) : (
           <></>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/128088 (has directions to reproduce)

Reload data view after changing space settings, check for 'all spaces' when showing delete confirm.