### PR TITLE
[Cloud Posture] use explicit side nav links

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/page_template.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/page_template.tsx
@@ -45,7 +45,11 @@ export const getSideNavItems = (
 const DEFAULT_PROPS: KibanaPageTemplateProps = {
   solutionNav: {
     name: CLOUD_SECURITY_POSTURE,
-    items: getSideNavItems(allNavigationItems),
+    items: getSideNavItems({
+      dashboard: allNavigationItems.dashboard,
+      findings: allNavigationItems.findings,
+      benchmark: allNavigationItems.benchmarks,
+    }),
   },
   restrictWidth: false,
 };


### PR DESCRIPTION
this PR makes the sidebar menu navigation items array explicit, allowing us to specify which routes don't go there.

(also removing the `rules` page from the side nav menu)