### PR TITLE
[8.1] [Discover] Improve doc viewer source tab performance by limiting height (#127439)

### DIFF
--- a/src/plugins/discover/public/services/doc_views/components/doc_viewer_source/get_height.test.tsx
+++ b/src/plugins/discover/public/services/doc_views/components/doc_viewer_source/get_height.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { monaco } from '@kbn/monaco';
+import { getHeight } from './get_height';
+
+describe('getHeight', () => {
+  window.innerHeight = 500;
+  const getMonacoMock = (lineCount: number) => {
+    return {
+      getDomNode: jest.fn(() => {
+        return {
+          getBoundingClientRect: jest.fn(() => {
+            return {
+              top: 200,
+            };
+          }),
+        };
+      }),
+      getOption: jest.fn(() => 10),
+      getModel: jest.fn(() => ({ getLineCount: jest.fn(() => lineCount) })),
+      getTopForLineNumber: jest.fn((line) => line * 10),
+    } as unknown as monaco.editor.IStandaloneCodeEditor;
+  };
+  test('when using document explorer, returning the available height in the flyout', () => {
+    const monacoMock = getMonacoMock(500);
+
+    const height = getHeight(monacoMock, true);
+    expect(height).toBe(275);
+  });
+
+  test('when using classic table, its displayed inline without scrolling', () => {
+    const monacoMock = getMonacoMock(100);
+
+    const height = getHeight(monacoMock, false);
+    expect(height).toBe(1020);
+  });
+
+  test('when using classic table, limited height > 500 lines to allow scrolling', () => {
+    const monacoMock = getMonacoMock(1000);
+
+    const height = getHeight(monacoMock, false);
+    expect(height).toBe(5020);
+  });
+});

--- a/src/plugins/discover/public/services/doc_views/components/doc_viewer_source/get_height.tsx
+++ b/src/plugins/discover/public/services/doc_views/components/doc_viewer_source/get_height.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { monaco } from '@kbn/monaco';
+import { MARGIN_BOTTOM, MAX_LINES_CLASSIC_TABLE } from './source';
+
+export function getHeight(editor: monaco.editor.IStandaloneCodeEditor, useDocExplorer: boolean) {
+  const editorElement = editor?.getDomNode();
+  if (!editorElement) {
+    return 0;
+  }
+
+  let result;
+  if (useDocExplorer) {
+    // assign a good height filling the available space of the document flyout
+    const position = editorElement.getBoundingClientRect();
+    result = window.innerHeight - position.top - MARGIN_BOTTOM;
+  } else {
+    // takes care of the classic table, display a maximum of 500 lines
+    // why not display it all? Due to performance issues when the browser needs to render it all
+    const lineHeight = editor.getOption(monaco.editor.EditorOption.lineHeight);
+    const lineCount = editor.getModel()?.getLineCount() || 1;
+    const displayedLineCount =
+      lineCount > MAX_LINES_CLASSIC_TABLE ? MAX_LINES_CLASSIC_TABLE : lineCount;
+    result = editor.getTopForLineNumber(displayedLineCount + 1) + lineHeight;
+  }
+  return result > 0 ? result : 0;
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Discover] Improve doc viewer source tab performance by limiting height (#127439)](https://github.com/elastic/kibana/pull/127439)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)