### PR TITLE
[Visualize] Migrate to dataViews service

### DIFF
--- a/src/plugins/visualizations/kibana.json
+++ b/src/plugins/visualizations/kibana.json
@@ -13,7 +13,8 @@
     "inspector",
     "savedObjects",
     "screenshotMode",
-    "presentationUtil"
+    "presentationUtil",
+    "dataViews"
   ],
   "optionalPlugins": ["home", "share", "usageCollection", "spaces", "savedObjectsTaggingOss"],
   "requiredBundles": ["kibanaUtils", "discover", "kibanaReact", "home"],

--- a/src/plugins/visualizations/public/embeddable/create_vis_embeddable_from_object.ts
+++ b/src/plugins/visualizations/public/embeddable/create_vis_embeddable_from_object.ts
@@ -24,7 +24,7 @@ import { getUISettings, getHttp, getTimeFilter, getCapabilities } from '../servi
 import { urlFor } from '../utils/saved_visualize_utils';
 import { VisualizeEmbeddableFactoryDeps } from './visualize_embeddable_factory';
 import { VISUALIZE_ENABLE_LABS_SETTING } from '../../common/constants';
-import { IndexPattern } from '../../../data/public';
+import type { DataView } from '../../../data_views/public';
 import { createVisualizeEmbeddableAsync } from './visualize_embeddable_async';
 
 export const createVisEmbeddableFromObject =
@@ -51,7 +51,7 @@ export const createVisEmbeddableFromObject =
         return new DisabledLabEmbeddable(vis.title, input);
       }
 
-      let indexPatterns: IndexPattern[] = [];
+      let indexPatterns: DataView[] = [];
 
       if (vis.type.getUsedIndexPattern) {
         indexPatterns = await vis.type.getUsedIndexPattern(vis.params);

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -16,12 +16,8 @@ import { Filter, onlyDisabledFiltersChanged } from '@kbn/es-query';
 import type { SavedObjectAttributes, KibanaExecutionContext } from 'kibana/public';
 import { KibanaThemeProvider } from '../../../kibana_react/public';
 import { VISUALIZE_EMBEDDABLE_TYPE } from './constants';
-import {
-  IndexPattern,
-  TimeRange,
-  Query,
-  TimefilterContract,
-} from '../../../../plugins/data/public';
+import { TimeRange, Query, TimefilterContract } from '../../../../plugins/data/public';
+import type { DataView } from '../../../../plugins/data_views/public';
 import {
   EmbeddableInput,
   EmbeddableOutput,
@@ -51,7 +47,7 @@ const getKeys = <T extends {}>(o: T): Array<keyof T> => Object.keys(o) as Array<
 
 export interface VisualizeEmbeddableConfiguration {
   vis: Vis;
-  indexPatterns?: IndexPattern[];
+  indexPatterns?: DataView[];
   editPath: string;
   editUrl: string;
   capabilities: { visualizeSave: boolean; dashboardSave: boolean };
@@ -74,7 +70,7 @@ export interface VisualizeOutput extends EmbeddableOutput {
   editPath: string;
   editApp: string;
   editUrl: string;
-  indexPatterns?: IndexPattern[];
+  indexPatterns?: DataView[];
   visTypeName: string;
 }
 

--- a/src/plugins/visualizations/public/mocks.ts
+++ b/src/plugins/visualizations/public/mocks.ts
@@ -15,6 +15,7 @@ import { coreMock, applicationServiceMock } from '../../../core/public/mocks';
 import { embeddablePluginMock } from '../../../plugins/embeddable/public/mocks';
 import { expressionsPluginMock } from '../../../plugins/expressions/public/mocks';
 import { dataPluginMock } from '../../../plugins/data/public/mocks';
+import { dataViewPluginMocks } from '../../../plugins/data_views/public/mocks';
 import { usageCollectionPluginMock } from '../../../plugins/usage_collection/public/mocks';
 import { uiActionsPluginMock } from '../../../plugins/ui_actions/public/mocks';
 import { inspectorPluginMock } from '../../../plugins/inspector/public/mocks';
@@ -56,6 +57,7 @@ const createInstance = async () => {
   const doStart = () =>
     plugin.start(coreMock.createStart(), {
       data: dataPluginMock.createStartContract(),
+      dataViews: dataViewPluginMocks.createStartContract(),
       expressions: expressionsPluginMock.createStartContract(),
       inspector: inspectorPluginMock.createStartContract(),
       uiActions: uiActionsPluginMock.createStartContract(),

--- a/src/plugins/visualizations/public/plugin.ts
+++ b/src/plugins/visualizations/public/plugin.ts
@@ -79,6 +79,7 @@ import type {
   Start as InspectorStart,
 } from '../../../plugins/inspector/public';
 import type { DataPublicPluginSetup, DataPublicPluginStart } from '../../../plugins/data/public';
+import type { DataViewsPublicPluginStart } from '../../../plugins/data_views/public';
 import type { ExpressionsSetup, ExpressionsStart } from '../../expressions/public';
 import type { EmbeddableSetup, EmbeddableStart } from '../../embeddable/public';
 import type { SavedObjectTaggingOssPluginStart } from '../../saved_objects_tagging_oss/public';
@@ -117,6 +118,7 @@ export interface VisualizationsSetupDeps {
 
 export interface VisualizationsStartDeps {
   data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
   expressions: ExpressionsStart;
   embeddable: EmbeddableStart;
   inspector: InspectorStart;
@@ -237,10 +239,10 @@ export class VisualizationsPlugin
         };
 
         // make sure the index pattern list is up to date
-        pluginsStart.data.indexPatterns.clearCache();
+        pluginsStart.dataViews.clearCache();
         // make sure a default index pattern exists
         // if not, the page will be redirected to management and visualize won't be rendered
-        await pluginsStart.data.indexPatterns.ensureDefaultDataView();
+        await pluginsStart.dataViews.ensureDefaultDataView();
 
         appMounted();
 
@@ -268,6 +270,7 @@ export class VisualizationsPlugin
           pluginInitializerContext: this.initializerContext,
           chrome: coreStart.chrome,
           data: pluginsStart.data,
+          dataViews: pluginsStart.dataViews,
           localStorage: new Storage(localStorage),
           navigation: pluginsStart.navigation,
           share: pluginsStart.share,

--- a/src/plugins/visualizations/public/utils/saved_visualization_references/controls_references.ts
+++ b/src/plugins/visualizations/public/utils/saved_visualization_references/controls_references.ts
@@ -8,7 +8,7 @@
 
 import { SavedObjectReference } from '../../../../../core/types';
 import { VisParams } from '../../../common';
-import { INDEX_PATTERN_SAVED_OBJECT_TYPE } from '../../../../data/common';
+import { DATA_VIEW_SAVED_OBJECT_TYPE } from '../../../../data_views/common';
 
 const isControlsVis = (visType: string) => visType === 'input_control_vis';
 
@@ -26,7 +26,7 @@ export const extractControlsReferences = (
       control.indexPatternRefName = `${prefix}_${i}_index_pattern`;
       references.push({
         name: control.indexPatternRefName,
-        type: INDEX_PATTERN_SAVED_OBJECT_TYPE,
+        type: DATA_VIEW_SAVED_OBJECT_TYPE,
         id: control.indexPattern,
       });
       delete control.indexPattern;

--- a/src/plugins/visualizations/public/utils/saved_visualization_references/timeseries_references.ts
+++ b/src/plugins/visualizations/public/utils/saved_visualization_references/timeseries_references.ts
@@ -8,7 +8,7 @@
 
 import { SavedObjectReference } from '../../../../../core/types';
 import { VisParams } from '../../../common';
-import { INDEX_PATTERN_SAVED_OBJECT_TYPE } from '../../../../data/common';
+import { DATA_VIEW_SAVED_OBJECT_TYPE } from '../../../../data_views/common';
 
 /** @internal **/
 const REF_NAME_POSTFIX = '_ref_name';
@@ -49,7 +49,7 @@ export const extractTimeSeriesReferences = (
         object[key + REF_NAME_POSTFIX] = name;
         references.push({
           name,
-          type: INDEX_PATTERN_SAVED_OBJECT_TYPE,
+          type: DATA_VIEW_SAVED_OBJECT_TYPE,
           id: object[key].id,
         });
         delete object[key];

--- a/src/plugins/visualizations/public/vis.ts
+++ b/src/plugins/visualizations/public/vis.ts
@@ -22,7 +22,8 @@ import { i18n } from '@kbn/i18n';
 
 import { PersistedState } from './persisted_state';
 import { getTypes, getAggs, getSearch, getSavedObjects, getSpaces } from './services';
-import { IAggConfigs, IndexPattern, ISearchSource, AggConfigSerialized } from '../../data/public';
+import { IAggConfigs, ISearchSource, AggConfigSerialized } from '../../data/public';
+import type { DataView } from '../../data_views/public';
 import { BaseVisType } from './vis_types';
 import { SerializedVis, SerializedVisData, VisParams } from '../common/types';
 
@@ -33,7 +34,7 @@ export type { SerializedVis, SerializedVisData };
 export interface VisData {
   ast?: string;
   aggs?: IAggConfigs;
-  indexPattern?: IndexPattern;
+  indexPattern?: DataView;
   searchSource?: ISearchSource;
   savedSearchId?: string;
 }

--- a/src/plugins/visualizations/public/vis_types/types.ts
+++ b/src/plugins/visualizations/public/vis_types/types.ts
@@ -9,13 +9,8 @@
 import type { IconType } from '@elastic/eui';
 import type { ReactNode } from 'react';
 import type { Adapters } from 'src/plugins/inspector';
-import type {
-  IndexPattern,
-  AggGroupNames,
-  AggParam,
-  AggGroupName,
-  Query,
-} from '../../../data/public';
+import type { AggGroupNames, AggParam, AggGroupName, Query } from '../../../data/public';
+import type { DataView } from '../../../data_views/public';
 import { PaletteOutput } from '../../../charts/public';
 import type { Vis, VisEditorOptionsProps, VisParams, VisToExpressionAst } from '../types';
 import { VisGroups } from './vis_groups_enum';
@@ -181,7 +176,7 @@ export interface VisTypeDefinition<TVisParams> {
    * Some visualizations are created without SearchSource and may change the used indexes during the visualization configuration.
    * Using this method we can rewrite the standard mechanism for getting used indexes
    */
-  readonly getUsedIndexPattern?: (visParams: VisParams) => IndexPattern[] | Promise<IndexPattern[]>;
+  readonly getUsedIndexPattern?: (visParams: VisParams) => DataView[] | Promise<DataView[]>;
 
   readonly isAccessible?: boolean;
   /**

--- a/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
@@ -20,7 +20,7 @@ import {
 } from '../types';
 import { VISUALIZE_APP_NAME } from '../../../common/constants';
 import { getTopNavConfig } from '../utils';
-import type { IndexPattern } from '../../../../data/public';
+import type { DataView } from '../../../../data_views/public';
 import type { NavigateToLensContext } from '../../../../visualizations/public';
 
 const LOCAL_STORAGE_EDIT_IN_LENS_BADGE = 'EDIT_IN_LENS_BADGE_VISIBLE';
@@ -151,7 +151,7 @@ const TopNav = ({
     hideLensBadge,
     hideTryInLensBadge,
   ]);
-  const [indexPatterns, setIndexPatterns] = useState<IndexPattern[]>(
+  const [indexPatterns, setIndexPatterns] = useState<DataView[]>(
     vis.data.indexPattern ? [vis.data.indexPattern] : []
   );
   const showDatePicker = () => {
@@ -210,13 +210,13 @@ const TopNav = ({
 
   useEffect(() => {
     const asyncSetIndexPattern = async () => {
-      let indexes: IndexPattern[] | undefined;
+      let indexes: DataView[] | undefined;
 
       if (vis.type.getUsedIndexPattern) {
         indexes = await vis.type.getUsedIndexPattern(vis.params);
       }
       if (!indexes || !indexes.length) {
-        const defaultIndex = await services.data.indexPatterns.getDefault();
+        const defaultIndex = await services.dataViews.getDefault();
         if (defaultIndex) {
           indexes = [defaultIndex];
         }
@@ -229,7 +229,7 @@ const TopNav = ({
     if (!vis.data.indexPattern) {
       asyncSetIndexPattern();
     }
-  }, [vis.params, vis.type, services.data.indexPatterns, vis.data.indexPattern]);
+  }, [vis.params, vis.type, vis.data.indexPattern, services.dataViews]);
 
   useEffect(() => {
     const autoRefreshFetchSub = services.data.query.timefilter.timefilter

--- a/src/plugins/visualizations/public/visualize_app/types.ts
+++ b/src/plugins/visualizations/public/visualize_app/types.ts
@@ -37,6 +37,7 @@ import type {
 import type { NavigationPublicPluginStart as NavigationStart } from 'src/plugins/navigation/public';
 import type { Filter } from '@kbn/es-query';
 import type { Query, DataPublicPluginStart, TimeRange } from 'src/plugins/data/public';
+import type { DataViewsPublicPluginStart } from 'src/plugins/data_views/public';
 import type { SharePluginStart } from 'src/plugins/share/public';
 import type { SavedObjectsStart } from 'src/plugins/saved_objects/public';
 import type { EmbeddableStart, EmbeddableStateTransfer } from 'src/plugins/embeddable/public';
@@ -89,6 +90,7 @@ export interface VisualizeServices extends CoreStart {
   pluginInitializerContext: PluginInitializerContext;
   chrome: ChromeStart;
   data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
   localStorage: Storage;
   navigation: NavigationStart;
   toastNotifications: ToastsStart;

--- a/src/plugins/visualizations/server/migrations/visualization_saved_object_migrations.ts
+++ b/src/plugins/visualizations/server/migrations/visualization_saved_object_migrations.ts
@@ -11,11 +11,8 @@ import type { SavedObjectMigrationFn, SavedObjectMigrationMap } from 'kibana/ser
 import { mergeSavedObjectMigrationMaps } from '../../../../core/server';
 import { MigrateFunctionsObject, MigrateFunction } from '../../../kibana_utils/common';
 
-import {
-  DEFAULT_QUERY_LANGUAGE,
-  INDEX_PATTERN_SAVED_OBJECT_TYPE,
-  SerializedSearchSourceFields,
-} from '../../../data/common';
+import { DEFAULT_QUERY_LANGUAGE, SerializedSearchSourceFields } from '../../../data/common';
+import { DATA_VIEW_SAVED_OBJECT_TYPE } from '../../../data_views/common';
 import {
   commonAddSupportOfDualIndexSelectionModeInTSVB,
   commonHideTSVBLastValueIndicator,
@@ -47,7 +44,7 @@ const migrateIndexPattern: SavedObjectMigrationFn<any, any> = (doc) => {
     searchSource.indexRefName = 'kibanaSavedObjectMeta.searchSourceJSON.index';
     doc.references.push({
       name: searchSource.indexRefName,
-      type: INDEX_PATTERN_SAVED_OBJECT_TYPE,
+      type: DATA_VIEW_SAVED_OBJECT_TYPE,
       id: searchSource.index,
     });
     delete searchSource.index;
@@ -60,7 +57,7 @@ const migrateIndexPattern: SavedObjectMigrationFn<any, any> = (doc) => {
       filterRow.meta.indexRefName = `kibanaSavedObjectMeta.searchSourceJSON.filter[${i}].meta.index`;
       doc.references.push({
         name: filterRow.meta.indexRefName,
-        type: INDEX_PATTERN_SAVED_OBJECT_TYPE,
+        type: DATA_VIEW_SAVED_OBJECT_TYPE,
         id: filterRow.meta.index,
       });
       delete filterRow.meta.index;
@@ -658,7 +655,7 @@ const migrateControls: SavedObjectMigrationFn<any, any> = (doc) => {
         control.indexPatternRefName = `control_${i}_index_pattern`;
         doc.references.push({
           name: control.indexPatternRefName,
-          type: INDEX_PATTERN_SAVED_OBJECT_TYPE,
+          type: DATA_VIEW_SAVED_OBJECT_TYPE,
           id: control.indexPattern,
         });
         delete control.indexPattern;
@@ -1103,7 +1100,7 @@ export const replaceIndexPatternReference: SavedObjectMigrationFn<any, any> = (d
   references: Array.isArray(doc.references)
     ? doc.references.map((reference) => {
         if (reference.type === 'index_pattern') {
-          reference.type = INDEX_PATTERN_SAVED_OBJECT_TYPE;
+          reference.type = DATA_VIEW_SAVED_OBJECT_TYPE;
         }
         return reference;
       })

--- a/src/plugins/visualizations/tsconfig.json
+++ b/src/plugins/visualizations/tsconfig.json
@@ -15,6 +15,7 @@
   "references": [
     { "path": "../../core/tsconfig.json" },
     { "path": "../data/tsconfig.json" },
+    { "path": "../data_views/tsconfig.json" },
     { "path": "../expressions/tsconfig.json" },
     { "path": "../ui_actions/tsconfig.json" },
     { "path": "../embeddable/tsconfig.json" },


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/124086
This PR is handling the Visualize editor case. I have updated all deprecated types and methods to import from the data_views plugin.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios