### PR TITLE
[Visualize] Enable Save&Return button for canvas when dashboard permissions are off

### DIFF
--- a/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.test.tsx
+++ b/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.test.tsx
@@ -148,13 +148,77 @@ describe('getTopNavConfig', () => {
         },
         Object {
           "description": "Finish editing visualization and return to the last app",
-          "disableButton": true,
+          "disableButton": false,
           "emphasize": true,
           "iconType": "checkInCircleFilled",
           "id": "saveAndReturn",
           "label": "Save and return",
           "run": [Function],
           "testId": "visualizesaveAndReturnButton",
+          "tooltip": [Function],
+        },
+      ]
+    `);
+  });
+  test('returns correct links if the originating app is undefined', () => {
+    const vis = {
+      savedVis: {
+        id: 'test',
+        sharingSavedObjectProps: {
+          outcome: 'conflict',
+          aliasTargetId: 'alias_id',
+        },
+      },
+      vis: {
+        type: {
+          title: 'TSVB',
+        },
+      },
+    } as VisualizeEditorVisInstance;
+    const topNavLinks = getTopNavConfig(
+      {
+        hasUnsavedChanges: false,
+        setHasUnsavedChanges: jest.fn(),
+        hasUnappliedChanges: false,
+        onOpenInspector: jest.fn(),
+        originatingApp: undefined,
+        setOriginatingApp: jest.fn(),
+        visInstance: vis,
+        stateContainer,
+        visualizationIdFromUrl: undefined,
+        stateTransfer: createEmbeddableStateTransferMock(),
+      } as unknown as TopNavConfigParams,
+      services as unknown as VisualizeServices
+    );
+
+    expect(topNavLinks).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "description": "Open Inspector for visualization",
+          "disableButton": [Function],
+          "id": "inspector",
+          "label": "inspect",
+          "run": undefined,
+          "testId": "openInspectorButton",
+          "tooltip": [Function],
+        },
+        Object {
+          "description": "Share Visualization",
+          "disableButton": false,
+          "id": "share",
+          "label": "share",
+          "run": [Function],
+          "testId": "shareTopNavButton",
+        },
+        Object {
+          "description": "Save Visualization",
+          "disableButton": false,
+          "emphasize": true,
+          "iconType": "save",
+          "id": "save",
+          "label": "Save",
+          "run": [Function],
+          "testId": "visualizeSaveButton",
           "tooltip": [Function],
         },
       ]

--- a/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.test.tsx
+++ b/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.test.tsx
@@ -81,6 +81,85 @@ describe('getTopNavConfig', () => {
     },
     share,
   };
+  test('returns correct links if the save visualize capabilities are set to false', () => {
+    const vis = {
+      savedVis: {
+        id: 'test',
+        sharingSavedObjectProps: {
+          outcome: 'conflict',
+          aliasTargetId: 'alias_id',
+        },
+      },
+      vis: {
+        type: {
+          title: 'TSVB',
+        },
+      },
+    } as VisualizeEditorVisInstance;
+    const novizSaveServices = {
+      ...services,
+      visualizeCapabilities: {
+        save: false,
+      },
+    };
+    const topNavLinks = getTopNavConfig(
+      {
+        hasUnsavedChanges: false,
+        setHasUnsavedChanges: jest.fn(),
+        hasUnappliedChanges: false,
+        onOpenInspector: jest.fn(),
+        originatingApp: 'dashboards',
+        setOriginatingApp: jest.fn(),
+        visInstance: vis,
+        stateContainer,
+        visualizationIdFromUrl: undefined,
+        stateTransfer: createEmbeddableStateTransferMock(),
+      } as unknown as TopNavConfigParams,
+      novizSaveServices as unknown as VisualizeServices
+    );
+
+    expect(topNavLinks).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "description": "Open Inspector for visualization",
+          "disableButton": [Function],
+          "id": "inspector",
+          "label": "inspect",
+          "run": undefined,
+          "testId": "openInspectorButton",
+          "tooltip": [Function],
+        },
+        Object {
+          "description": "Share Visualization",
+          "disableButton": false,
+          "id": "share",
+          "label": "share",
+          "run": [Function],
+          "testId": "shareTopNavButton",
+        },
+        Object {
+          "description": "Return to the last app without saving changes",
+          "emphasize": false,
+          "id": "cancel",
+          "label": "Cancel",
+          "run": [Function],
+          "testId": "visualizeCancelAndReturnButton",
+          "tooltip": [Function],
+        },
+        Object {
+          "description": "Finish editing visualization and return to the last app",
+          "disableButton": true,
+          "emphasize": true,
+          "iconType": "checkInCircleFilled",
+          "id": "saveAndReturn",
+          "label": "Save and return",
+          "run": [Function],
+          "testId": "visualizesaveAndReturnButton",
+          "tooltip": [Function],
+        },
+      ]
+    `);
+  });
   test('returns correct links for by reference visualization', () => {
     const vis = {
       savedVis: {

--- a/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
@@ -627,7 +627,7 @@ export const getTopNavConfig = (
               }
             ),
             testId: 'visualizesaveAndReturnButton',
-            disableButton: hasUnappliedChanges || !dashboardCapabilities.showWriteControls,
+            disableButton: hasUnappliedChanges || !visualizeCapabilities.save,
             tooltip() {
               if (hasUnappliedChanges) {
                 return i18n.translate(

--- a/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
@@ -627,7 +627,7 @@ export const getTopNavConfig = (
               }
             ),
             testId: 'visualizesaveAndReturnButton',
-            disableButton: hasUnappliedChanges || !visualizeCapabilities.save,
+            disableButton: hasUnappliedChanges,
             tooltip() {
               if (hasUnappliedChanges) {
                 return i18n.translate(


### PR DESCRIPTION
## Summary

This PR fixes a permission problem on Visualize editor when the dashboard capailities are off. When the user doesn't have dashboard permissions but have canvas permissions then the user is able to add a by ref or by value visualization in canvas but can't save it and return to canvas.

This change allows the saving to happen correctly as nowit doesn't depend on the dashboard capabilities.
I checked it and now it behaves exactly as Lens in the following scenarios:
- User with no viz save permissions but full dashboard ones
- User with no dashboard permissions but full visualize ones
- User with no canvas permissions but full all the others

<img width="1323" alt="image" src="https://user-images.githubusercontent.com/17003240/159246853-7e3d005a-fe7d-4a28-882b-161a59a615ce.png">

###  How to test
- Create new user which doesn't have access to dashboards
- Go to canvas 
- Add a new visualization (TSVB or vega or agg-based)
- Edit this
- Check that the user can save and return to canvas

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios