### PR TITLE
[Fleet] Update elastic_agent bundled package 1.3.1

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -19,7 +19,7 @@
   },
   {
     "name": "elastic_agent",
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   {
     "name": "endpoint",

--- a/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
@@ -24,7 +24,7 @@ export function useDockerRegistry() {
 
   let dockerProcess: ChildProcess | undefined;
   async function startDockerRegistryServer() {
-    const dockerImage = `docker.elastic.co/package-registry/distribution@sha256:b3dfc6a11ff7dce82ba8689ea9eeb54e353c6b4bfd2d28127b20ef72fd8883e9`;
+    const dockerImage = `docker.elastic.co/package-registry/distribution@sha256:536fcac0b66de593bd21851fd3553892a28e6e838e191ee25818acb4a23ecc7f`;
 
     const args = ['run', '--rm', '-p', `${packageRegistryPort}:8080`, dockerImage];
 

--- a/x-pack/test/fleet_api_integration/config.ts
+++ b/x-pack/test/fleet_api_integration/config.ts
@@ -15,7 +15,7 @@ import { defineDockerServersConfig } from '@kbn/test';
 // example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
 // It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry.
 export const dockerImage =
-  'docker.elastic.co/package-registry/distribution@sha256:b3dfc6a11ff7dce82ba8689ea9eeb54e353c6b4bfd2d28127b20ef72fd8883e9';
+  'docker.elastic.co/package-registry/distribution@sha256:536fcac0b66de593bd21851fd3553892a28e6e838e191ee25818acb4a23ecc7f';
 
 export const BUNDLED_PACKAGE_DIR = '/tmp/fleet_bundled_packages';
 

--- a/x-pack/test/functional/config.js
+++ b/x-pack/test/functional/config.js
@@ -15,7 +15,7 @@ import { pageObjects } from './page_objects';
 // example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
 // It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry.
 export const dockerImage =
-  'docker.elastic.co/package-registry/distribution@sha256:b3dfc6a11ff7dce82ba8689ea9eeb54e353c6b4bfd2d28127b20ef72fd8883e9';
+  'docker.elastic.co/package-registry/distribution@sha256:536fcac0b66de593bd21851fd3553892a28e6e838e191ee25818acb4a23ecc7f';
 
 // the default export of config files must be a config provider
 // that returns an object with the projects config values

--- a/x-pack/test/functional_synthetics/config.js
+++ b/x-pack/test/functional_synthetics/config.js
@@ -17,7 +17,7 @@ import { pageObjects } from './page_objects';
 // example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
 // It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry that updates Synthetics.
 export const dockerImage =
-  'docker.elastic.co/package-registry/distribution@sha256:b3dfc6a11ff7dce82ba8689ea9eeb54e353c6b4bfd2d28127b20ef72fd8883e9';
+  'docker.elastic.co/package-registry/distribution@sha256:536fcac0b66de593bd21851fd3553892a28e6e838e191ee25818acb4a23ecc7f';
 
 // the default export of config files must be a config provider
 // that returns an object with the projects config values


### PR DESCRIPTION
## Summary

Updates our bundled package version for `elastic_agent` package to fix `ecs.version` field, see https://github.com/elastic/integrations/pull/2844 for details