### PR TITLE
Field editor: Stabilize confirm dialog

### DIFF
--- a/test/functional/services/field_editor.ts
+++ b/test/functional/services/field_editor.ts
@@ -11,6 +11,7 @@ import { FtrService } from '../ftr_provider_context';
 export class FieldEditorService extends FtrService {
   private readonly browser = this.ctx.getService('browser');
   private readonly testSubjects = this.ctx.getService('testSubjects');
+  private readonly retry = this.ctx.getService('retry');
 
   public async setName(name: string, clearFirst = false, typeCharByChar = false) {
     await this.testSubjects.setValue('nameField > input', name, {
@@ -50,12 +51,16 @@ export class FieldEditorService extends FtrService {
   }
 
   public async confirmSave() {
-    await this.testSubjects.setValue('saveModalConfirmText', 'change');
-    await this.testSubjects.click('confirmModalConfirmButton');
+    await this.retry.try(async () => {
+      await this.testSubjects.setValue('saveModalConfirmText', 'change');
+      await this.testSubjects.clickWhenNotDisabled('confirmModalConfirmButton', { timeout: 1000 });
+    });
   }
 
   public async confirmDelete() {
-    await this.testSubjects.setValue('deleteModalConfirmText', 'remove');
-    await this.testSubjects.click('confirmModalConfirmButton');
+    await this.retry.try(async () => {
+      await this.testSubjects.setValue('deleteModalConfirmText', 'remove');
+      await this.testSubjects.clickWhenNotDisabled('confirmModalConfirmButton', { timeout: 1000 });
+    });
   }
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/128106

The test failure doesn't happen every time which means this is a stability issue rather than a difference with the cloud setup.

This PR stabilizes confirming the field changes by checking whether the button is enabled before trying to click it. 