### PR TITLE
[RAM] Follow up on _snooze api

### DIFF
--- a/x-pack/plugins/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/plugins/alerting/server/rules_client/rules_client.ts
@@ -1595,7 +1595,7 @@ export class RulesClient {
       await this.authorization.ensureAuthorized({
         ruleTypeId: attributes.alertTypeId,
         consumer: attributes.consumer,
-        operation: WriteOperations.MuteAll,
+        operation: WriteOperations.Snooze,
         entity: AlertingAuthorizationEntity.Rule,
       });
 
@@ -1693,6 +1693,7 @@ export class RulesClient {
     const updateAttributes = this.updateMeta({
       muteAll: true,
       mutedInstanceIds: [],
+      snoozeEndTime: null,
       updatedBy: await this.getUserName(),
       updatedAt: new Date().toISOString(),
     });
@@ -1755,6 +1756,7 @@ export class RulesClient {
     const updateAttributes = this.updateMeta({
       muteAll: false,
       mutedInstanceIds: [],
+      snoozeEndTime: null,
       updatedBy: await this.getUserName(),
       updatedAt: new Date().toISOString(),
     });

--- a/x-pack/plugins/alerting/server/rules_client/tests/mute_all.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/tests/mute_all.test.ts
@@ -82,6 +82,7 @@ describe('muteAll()', () => {
       {
         muteAll: true,
         mutedInstanceIds: [],
+        snoozeEndTime: null,
         updatedAt: '2019-02-12T21:01:22.479Z',
         updatedBy: 'elastic',
       },

--- a/x-pack/plugins/alerting/server/rules_client/tests/unmute_all.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/tests/unmute_all.test.ts
@@ -82,6 +82,7 @@ describe('unmuteAll()', () => {
       {
         muteAll: false,
         mutedInstanceIds: [],
+        snoozeEndTime: null,
         updatedAt: '2019-02-12T21:01:22.479Z',
         updatedBy: 'elastic',
       },

--- a/x-pack/plugins/security/server/authorization/privileges/feature_privilege_builder/alerting.test.ts
+++ b/x-pack/plugins/security/server/authorization/privileges/feature_privilege_builder/alerting.test.ts
@@ -209,24 +209,25 @@ describe(`feature_privilege_builder`, () => {
         });
 
         expect(alertingFeaturePrivileges.getActions(privilege, feature)).toMatchInlineSnapshot(`
-            Array [
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/get",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getRuleState",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getAlertSummary",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getExecutionLog",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/find",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/create",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/delete",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/update",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/updateApiKey",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/enable",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/disable",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAll",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAll",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAlert",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAlert",
-            ]
-          `);
+          Array [
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/get",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getRuleState",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getAlertSummary",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getExecutionLog",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/find",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/create",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/delete",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/update",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/updateApiKey",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/enable",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/disable",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAll",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAll",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAlert",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAlert",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/snooze",
+          ]
+        `);
       });
 
       test('grants `all` privileges to alerts under feature consumer', () => {
@@ -303,27 +304,28 @@ describe(`feature_privilege_builder`, () => {
         });
 
         expect(alertingFeaturePrivileges.getActions(privilege, feature)).toMatchInlineSnapshot(`
-            Array [
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/get",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getRuleState",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getAlertSummary",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getExecutionLog",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/find",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/create",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/delete",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/update",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/updateApiKey",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/enable",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/disable",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAll",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAll",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAlert",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAlert",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/alert/get",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/alert/find",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/alert/update",
-            ]
-          `);
+          Array [
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/get",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getRuleState",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getAlertSummary",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getExecutionLog",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/find",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/create",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/delete",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/update",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/updateApiKey",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/enable",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/disable",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAll",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAll",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAlert",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAlert",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/snooze",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/alert/get",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/alert/find",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/alert/update",
+          ]
+        `);
       });
 
       test('grants both `all` and `read` to rules privileges under feature consumer', () => {
@@ -357,29 +359,30 @@ describe(`feature_privilege_builder`, () => {
         });
 
         expect(alertingFeaturePrivileges.getActions(privilege, feature)).toMatchInlineSnapshot(`
-            Array [
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/get",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getRuleState",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getAlertSummary",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getExecutionLog",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/find",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/create",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/delete",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/update",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/updateApiKey",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/enable",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/disable",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAll",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAll",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAlert",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAlert",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/get",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getRuleState",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getAlertSummary",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getExecutionLog",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/find",
-            ]
-          `);
+          Array [
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/get",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getRuleState",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getAlertSummary",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getExecutionLog",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/find",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/create",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/delete",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/update",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/updateApiKey",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/enable",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/disable",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAll",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAll",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAlert",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAlert",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/snooze",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/get",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getRuleState",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getAlertSummary",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getExecutionLog",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/find",
+          ]
+        `);
       });
 
       test('grants both `all` and `read` to alerts privileges under feature consumer', () => {
@@ -458,34 +461,35 @@ describe(`feature_privilege_builder`, () => {
         });
 
         expect(alertingFeaturePrivileges.getActions(privilege, feature)).toMatchInlineSnapshot(`
-            Array [
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/get",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getRuleState",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getAlertSummary",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getExecutionLog",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/find",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/create",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/delete",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/update",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/updateApiKey",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/enable",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/disable",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAll",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAll",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAlert",
-              "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAlert",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/get",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getRuleState",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getAlertSummary",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getExecutionLog",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/find",
-              "alerting:1.0.0-zeta1:another-alert-type/my-feature/alert/get",
-              "alerting:1.0.0-zeta1:another-alert-type/my-feature/alert/find",
-              "alerting:1.0.0-zeta1:another-alert-type/my-feature/alert/update",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/alert/get",
-              "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/alert/find",
-            ]
-          `);
+          Array [
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/get",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getRuleState",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getAlertSummary",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/getExecutionLog",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/find",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/create",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/delete",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/update",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/updateApiKey",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/enable",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/disable",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAll",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAll",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/muteAlert",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/unmuteAlert",
+            "alerting:1.0.0-zeta1:alert-type/my-feature/rule/snooze",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/get",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getRuleState",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getAlertSummary",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/getExecutionLog",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/rule/find",
+            "alerting:1.0.0-zeta1:another-alert-type/my-feature/alert/get",
+            "alerting:1.0.0-zeta1:another-alert-type/my-feature/alert/find",
+            "alerting:1.0.0-zeta1:another-alert-type/my-feature/alert/update",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/alert/get",
+            "alerting:1.0.0-zeta1:readonly-alert-type/my-feature/alert/find",
+          ]
+        `);
       });
     });
   });

--- a/x-pack/plugins/security/server/authorization/privileges/feature_privilege_builder/alerting.ts
+++ b/x-pack/plugins/security/server/authorization/privileges/feature_privilege_builder/alerting.ts
@@ -32,6 +32,7 @@ const writeOperations: Record<AlertingEntity, string[]> = {
     'unmuteAll',
     'muteAlert',
     'unmuteAlert',
+    'snooze',
   ],
   alert: ['update'],
 };

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/mute_all.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/mute_all.ts
@@ -99,7 +99,7 @@ export default function createMuteAlertTests({ getService }: FtrProviderContext)
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(true);
-              expect(updatedAlert.snooze_end_time).to.eql(null);
+              expect(updatedAlert.snooze_end_time).to.eql(undefined);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -156,7 +156,7 @@ export default function createMuteAlertTests({ getService }: FtrProviderContext)
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(true);
-              expect(updatedAlert.snooze_end_time).to.eql(null);
+              expect(updatedAlert.snooze_end_time).to.eql(undefined);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -224,7 +224,7 @@ export default function createMuteAlertTests({ getService }: FtrProviderContext)
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(true);
-              expect(updatedAlert.snooze_end_time).to.eql(null);
+              expect(updatedAlert.snooze_end_time).to.eql(undefined);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -292,7 +292,7 @@ export default function createMuteAlertTests({ getService }: FtrProviderContext)
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(true);
-              expect(updatedAlert.snooze_end_time).to.eql(null);
+              expect(updatedAlert.snooze_end_time).to.eql(undefined);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/mute_all.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/mute_all.ts
@@ -99,6 +99,7 @@ export default function createMuteAlertTests({ getService }: FtrProviderContext)
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(true);
+              expect(updatedAlert.snooze_end_time).to.eql(null);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -155,6 +156,7 @@ export default function createMuteAlertTests({ getService }: FtrProviderContext)
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(true);
+              expect(updatedAlert.snooze_end_time).to.eql(null);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -222,6 +224,7 @@ export default function createMuteAlertTests({ getService }: FtrProviderContext)
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(true);
+              expect(updatedAlert.snooze_end_time).to.eql(null);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -289,6 +292,7 @@ export default function createMuteAlertTests({ getService }: FtrProviderContext)
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(true);
+              expect(updatedAlert.snooze_end_time).to.eql(null);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/snooze.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/snooze.ts
@@ -77,7 +77,7 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
               expect(response.body).to.eql({
                 error: 'Forbidden',
                 message: getConsumerUnauthorizedErrorMessage(
-                  'muteAll',
+                  'snooze',
                   'test.noop',
                   'alertsFixture'
                 ),
@@ -145,7 +145,7 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
               expect(response.body).to.eql({
                 error: 'Forbidden',
                 message: getConsumerUnauthorizedErrorMessage(
-                  'muteAll',
+                  'snooze',
                   'test.restricted-noop',
                   'alertsRestrictedFixture'
                 ),
@@ -202,7 +202,7 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
               expect(response.body).to.eql({
                 error: 'Forbidden',
                 message: getConsumerUnauthorizedErrorMessage(
-                  'muteAll',
+                  'snooze',
                   'test.unrestricted-noop',
                   'alertsFixture'
                 ),
@@ -215,7 +215,7 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
               expect(response.body).to.eql({
                 error: 'Forbidden',
                 message: getProducerUnauthorizedErrorMessage(
-                  'muteAll',
+                  'snooze',
                   'test.unrestricted-noop',
                   'alertsRestrictedFixture'
                 ),
@@ -271,7 +271,7 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
               expect(response.body).to.eql({
                 error: 'Forbidden',
                 message: getConsumerUnauthorizedErrorMessage(
-                  'muteAll',
+                  'snooze',
                   'test.restricted-noop',
                   'alerts'
                 ),
@@ -285,7 +285,7 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
               expect(response.body).to.eql({
                 error: 'Forbidden',
                 message: getProducerUnauthorizedErrorMessage(
-                  'muteAll',
+                  'snooze',
                   'test.restricted-noop',
                   'alertsRestrictedFixture'
                 ),
@@ -358,7 +358,7 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
               expect(response.body).to.eql({
                 error: 'Forbidden',
                 message: getConsumerUnauthorizedErrorMessage(
-                  'muteAll',
+                  'snooze',
                   'test.noop',
                   'alertsFixture'
                 ),

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/unmute_all.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/unmute_all.ts
@@ -104,6 +104,7 @@ export default function createUnmuteAlertTests({ getService }: FtrProviderContex
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(false);
+              expect(updatedAlert.snooze_end_time).to.eql(null);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -165,6 +166,7 @@ export default function createUnmuteAlertTests({ getService }: FtrProviderContex
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(false);
+              expect(updatedAlert.snooze_end_time).to.eql(null);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -237,6 +239,7 @@ export default function createUnmuteAlertTests({ getService }: FtrProviderContex
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(false);
+              expect(updatedAlert.snooze_end_time).to.eql(null);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -309,6 +312,7 @@ export default function createUnmuteAlertTests({ getService }: FtrProviderContex
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(false);
+              expect(updatedAlert.snooze_end_time).to.eql(null);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/unmute_all.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/unmute_all.ts
@@ -104,7 +104,7 @@ export default function createUnmuteAlertTests({ getService }: FtrProviderContex
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(false);
-              expect(updatedAlert.snooze_end_time).to.eql(null);
+              expect(updatedAlert.snooze_end_time).to.eql(undefined);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -166,7 +166,7 @@ export default function createUnmuteAlertTests({ getService }: FtrProviderContex
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(false);
-              expect(updatedAlert.snooze_end_time).to.eql(null);
+              expect(updatedAlert.snooze_end_time).to.eql(undefined);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -239,7 +239,7 @@ export default function createUnmuteAlertTests({ getService }: FtrProviderContex
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(false);
-              expect(updatedAlert.snooze_end_time).to.eql(null);
+              expect(updatedAlert.snooze_end_time).to.eql(undefined);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,
@@ -312,7 +312,7 @@ export default function createUnmuteAlertTests({ getService }: FtrProviderContex
                 .auth(user.username, user.password)
                 .expect(200);
               expect(updatedAlert.mute_all).to.eql(false);
-              expect(updatedAlert.snooze_end_time).to.eql(null);
+              expect(updatedAlert.snooze_end_time).to.eql(undefined);
               // Ensure AAD isn't broken
               await checkAAD({
                 supertest,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/mute_all.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/mute_all.ts
@@ -41,7 +41,7 @@ export default function createMuteTests({ getService }: FtrProviderContext) {
         .set('kbn-xsrf', 'foo')
         .expect(200);
       expect(updatedAlert.mute_all).to.eql(true);
-
+      expect(updatedAlert.snooze_end_time).to.eql(null);
       // Ensure AAD isn't broken
       await checkAAD({
         supertest: supertestWithoutAuth,
@@ -70,6 +70,7 @@ export default function createMuteTests({ getService }: FtrProviderContext) {
           .set('kbn-xsrf', 'foo')
           .expect(200);
         expect(updatedAlert.mute_all).to.eql(true);
+        expect(updatedAlert.snooze_end_time).to.eql(null);
 
         // Ensure AAD isn't broken
         await checkAAD({

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/mute_all.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/mute_all.ts
@@ -41,7 +41,7 @@ export default function createMuteTests({ getService }: FtrProviderContext) {
         .set('kbn-xsrf', 'foo')
         .expect(200);
       expect(updatedAlert.mute_all).to.eql(true);
-      expect(updatedAlert.snooze_end_time).to.eql(null);
+      expect(updatedAlert.snooze_end_time).to.eql(undefined);
       // Ensure AAD isn't broken
       await checkAAD({
         supertest: supertestWithoutAuth,
@@ -70,7 +70,7 @@ export default function createMuteTests({ getService }: FtrProviderContext) {
           .set('kbn-xsrf', 'foo')
           .expect(200);
         expect(updatedAlert.mute_all).to.eql(true);
-        expect(updatedAlert.snooze_end_time).to.eql(null);
+        expect(updatedAlert.snooze_end_time).to.eql(undefined);
 
         // Ensure AAD isn't broken
         await checkAAD({

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/unmute_all.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/unmute_all.ts
@@ -42,7 +42,7 @@ export default function createUnmuteTests({ getService }: FtrProviderContext) {
         .set('kbn-xsrf', 'foo')
         .expect(200);
       expect(updatedAlert.mute_all).to.eql(false);
-      expect(updatedAlert.snooze_end_time).to.eql(null);
+      expect(updatedAlert.snooze_end_time).to.eql(undefined);
 
       // Ensure AAD isn't broken
       await checkAAD({
@@ -76,7 +76,7 @@ export default function createUnmuteTests({ getService }: FtrProviderContext) {
           .set('kbn-xsrf', 'foo')
           .expect(200);
         expect(updatedAlert.mute_all).to.eql(false);
-        expect(updatedAlert.snooze_end_time).to.eql(null);
+        expect(updatedAlert.snooze_end_time).to.eql(undefined);
 
         // Ensure AAD isn't broken
         await checkAAD({

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/unmute_all.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/unmute_all.ts
@@ -42,6 +42,7 @@ export default function createUnmuteTests({ getService }: FtrProviderContext) {
         .set('kbn-xsrf', 'foo')
         .expect(200);
       expect(updatedAlert.mute_all).to.eql(false);
+      expect(updatedAlert.snooze_end_time).to.eql(null);
 
       // Ensure AAD isn't broken
       await checkAAD({
@@ -75,6 +76,7 @@ export default function createUnmuteTests({ getService }: FtrProviderContext) {
           .set('kbn-xsrf', 'foo')
           .expect(200);
         expect(updatedAlert.mute_all).to.eql(false);
+        expect(updatedAlert.snooze_end_time).to.eql(null);
 
         // Ensure AAD isn't broken
         await checkAAD({


### PR DESCRIPTION
## Summary

- Make sure to add the write operation for snooze
- set `snoozeEndTime` to null when mute or unMute API is used to not allow this two values to conflict

Follow up https://github.com/elastic/kibana/pull/127081
### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
