### PR TITLE
[Workplace Search] Show external connector URL and API key on source settings page

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_config_fields/source_config_fields.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_config_fields/source_config_fields.test.tsx
@@ -12,7 +12,7 @@ import { shallow } from 'enzyme';
 import { ApiKey } from '../api_key';
 import { CredentialItem } from '../credential_item';
 
-import { SourceConfigFields } from './';
+import { SourceConfigFields } from './source_config_fields';
 
 describe('SourceConfigFields', () => {
   it('renders empty with no items', () => {
@@ -31,11 +31,14 @@ describe('SourceConfigFields', () => {
         publicKey="abc"
         consumerKey="def"
         baseUrl="ghi"
+        externalConnectorUrl="url"
+        externalConnectorApiKey="apiKey"
       />
     );
 
     expect(wrapper.find(ApiKey)).toHaveLength(0);
-    expect(wrapper.find(CredentialItem)).toHaveLength(3);
+    expect(wrapper.find(CredentialItem)).toHaveLength(4);
+    expect(wrapper.find('[data-test-subj="external-connector-url-input"]')).toHaveLength(1);
   });
 
   it('shows API keys', () => {
@@ -50,5 +53,23 @@ describe('SourceConfigFields', () => {
     );
 
     expect(wrapper.find(ApiKey)).toHaveLength(2);
+  });
+
+  it('handles select all button click', () => {
+    const wrapper = shallow(<SourceConfigFields externalConnectorUrl="url" />);
+    const simulatedEvent = {
+      button: 0,
+      target: { getAttribute: () => '_self' },
+      currentTarget: { select: jest.fn() },
+      preventDefault: jest.fn(),
+    };
+
+    const input = wrapper
+      .find('[data-test-subj="external-connector-url-input"]')
+      .dive()
+      .find('input');
+    input.simulate('click', simulatedEvent);
+
+    expect(simulatedEvent.currentTarget.select).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_config_fields/source_config_fields.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_config_fields/source_config_fields.test.tsx
@@ -31,7 +31,7 @@ describe('SourceConfigFields', () => {
         publicKey="abc"
         consumerKey="def"
         baseUrl="ghi"
-        externalConnectorUrl="url"
+        externalConnectorUrl="https://url.com"
         externalConnectorApiKey="apiKey"
       />
     );

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_config_fields/source_config_fields.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_config_fields/source_config_fields.tsx
@@ -7,7 +7,15 @@
 
 import React from 'react';
 
-import { EuiSpacer } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiCopy,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
 
 import {
   PUBLIC_KEY_LABEL,
@@ -15,6 +23,10 @@ import {
   BASE_URL_LABEL,
   CLIENT_ID_LABEL,
   CLIENT_SECRET_LABEL,
+  EXTERNAL_CONNECTOR_API_KEY_LABEL,
+  EXTERNAL_CONNECTOR_URL_LABEL,
+  COPIED_TOOLTIP,
+  COPY_TOOLTIP,
 } from '../../../constants';
 import { ApiKey } from '../api_key';
 import { CredentialItem } from '../credential_item';
@@ -26,6 +38,8 @@ interface SourceConfigFieldsProps {
   publicKey?: string;
   consumerKey?: string;
   baseUrl?: string;
+  externalConnectorUrl?: string;
+  externalConnectorApiKey?: string;
 }
 
 export const SourceConfigFields: React.FC<SourceConfigFieldsProps> = ({
@@ -35,9 +49,16 @@ export const SourceConfigFields: React.FC<SourceConfigFieldsProps> = ({
   publicKey,
   consumerKey,
   baseUrl,
+  externalConnectorApiKey,
+  externalConnectorUrl,
 }) => {
   const credentialItem = (label: string, item?: string) =>
-    item && <CredentialItem label={label} value={item} testSubj={label} hideCopy />;
+    item && (
+      <>
+        <EuiSpacer size="s" />
+        <CredentialItem label={label} value={item} testSubj={label} hideCopy />
+      </>
+    );
 
   const keyElement = (
     <>
@@ -60,10 +81,51 @@ export const SourceConfigFields: React.FC<SourceConfigFieldsProps> = ({
     <>
       {isOauth1 && keyElement}
       {!isOauth1 && credentialItem(CLIENT_ID_LABEL, clientId)}
-      <EuiSpacer size="s" />
       {!isOauth1 && credentialItem(CLIENT_SECRET_LABEL, clientSecret)}
-      <EuiSpacer size="s" />
       {credentialItem(BASE_URL_LABEL, baseUrl)}
+      {credentialItem(EXTERNAL_CONNECTOR_API_KEY_LABEL, externalConnectorApiKey)}
+      {externalConnectorUrl && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiFlexGroup alignItems="center" gutterSize="none" responsive={false}>
+            <EuiFlexItem grow={1}>
+              <EuiText size="s">
+                <strong>{EXTERNAL_CONNECTOR_URL_LABEL}</strong>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={2}>
+              <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiCopy
+                    beforeMessage={COPY_TOOLTIP}
+                    afterMessage={COPIED_TOOLTIP}
+                    textToCopy={externalConnectorUrl}
+                  >
+                    {(copy) => (
+                      <EuiButtonIcon
+                        aria-label={COPY_TOOLTIP}
+                        onClick={copy}
+                        iconType="copy"
+                        color="primary"
+                      />
+                    )}
+                  </EuiCopy>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiFieldText
+                    readOnly
+                    placeholder="https://URL"
+                    data-test-subj="external-connector-url-input"
+                    value={externalConnectorUrl}
+                    compressed
+                    onClick={(e: React.MouseEvent<HTMLInputElement>) => e.currentTarget.select()}
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
+      )}
     </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -481,6 +481,20 @@ export const BASE_URL_LABEL = i18n.translate(
   }
 );
 
+export const EXTERNAL_CONNECTOR_URL_LABEL = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.externalConnectorUrl.label',
+  {
+    defaultMessage: 'Connector URL',
+  }
+);
+
+export const EXTERNAL_CONNECTOR_API_KEY_LABEL = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.externalConnectorApiKey.label',
+  {
+    defaultMessage: 'Connector API key',
+  }
+);
+
 export const CLIENT_ID_LABEL = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.clientId.label',
   {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/external_connector_form_fields.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/external_connector_form_fields.tsx
@@ -54,7 +54,7 @@ export const ExternalConnectorFormFields: React.FC = () => {
         label={i18n.translate(
           'xpack.enterpriseSearch.workplaceSearch.contentSource.addSource.externalConnectorConfig.urlLabel',
           {
-            defaultMessage: 'URL',
+            defaultMessage: 'Connector URL',
           }
         )}
         isInvalid={!urlValid}
@@ -92,7 +92,7 @@ export const ExternalConnectorFormFields: React.FC = () => {
         label={i18n.translate(
           'xpack.enterpriseSearch.workplaceSearch.contentSource.addSource.externalConnectorConfig.apiKeyLabel',
           {
-            defaultMessage: 'API key',
+            defaultMessage: 'Connector API key',
           }
         )}
       >

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
@@ -105,7 +105,15 @@ export const SourceSettings: React.FC = () => {
   const showOauthConfig = !isGithubApp && isOrganization && !isEmpty(configuredFields);
   const showGithubAppConfig = isGithubApp;
 
-  const { clientId, clientSecret, publicKey, consumerKey, baseUrl } = configuredFields || {};
+  const {
+    clientId,
+    clientSecret,
+    publicKey,
+    consumerKey,
+    baseUrl,
+    externalConnectorUrl,
+    externalConnectorApiKey,
+  } = configuredFields || {};
 
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value);
 
@@ -190,6 +198,8 @@ export const SourceSettings: React.FC = () => {
             publicKey={publicKey}
             consumerKey={consumerKey}
             baseUrl={baseUrl}
+            externalConnectorUrl={externalConnectorUrl}
+            externalConnectorApiKey={externalConnectorApiKey}
           />
           <EuiFormRow>
             <EuiButtonEmptyTo to={editPath as string} flush="left">


### PR DESCRIPTION
## Summary

This shows the external connector URL and API key on the source settings page, if available.

<img width="1378" alt="Screenshot 2022-03-21 at 15 37 59" src="https://user-images.githubusercontent.com/94373878/159284538-0475251a-d441-4ec3-8323-da5f40542d88.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

