### PR TITLE
[DOCS] Removes coming tag from 8.1.1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -25,8 +25,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.1.1]]
 == {kib} 8.1.1
 
-coming::[8.1.1]
-
 Review the following information about the {kib} 8.1.1 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes coming tag from 8.1.1 release notes.
