### PR TITLE
Event log and Alerts tab in rule summary

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/alert_muted_switch.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/alert_muted_switch.tsx
@@ -8,7 +8,7 @@
 import React, { useState } from 'react';
 import { EuiSwitch, EuiLoadingSpinner } from '@elastic/eui';
 
-import { AlertListItem } from './rule';
+import { AlertListItem } from './types';
 
 interface ComponentOpts {
   alert: AlertListItem;

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_alert_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_alert_list.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useCallback } from 'react';
+import moment, { Duration } from 'moment';
+import { padStart } from 'lodash';
+import { EuiHealth, EuiBasicTable, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { RIGHT_ALIGNMENT } from '@elastic/eui/lib/services';
+import { Pagination } from '../../../../types';
+import { AlertListItemStatus, AlertListItem } from './types';
+import { AlertMutedSwitch } from './alert_muted_switch';
+
+const durationAsString = (duration: Duration): string => {
+  return [duration.hours(), duration.minutes(), duration.seconds()]
+    .map((value) => padStart(`${value}`, 2, '0'))
+    .join(':');
+};
+
+const alertsTableColumns = (
+  onMuteAction: (alert: AlertListItem) => Promise<void>,
+  readOnly: boolean
+) => [
+  {
+    field: 'alert',
+    name: i18n.translate('xpack.triggersActionsUI.sections.ruleDetails.alertsList.columns.Alert', {
+      defaultMessage: 'Alert',
+    }),
+    sortable: false,
+    truncateText: true,
+    width: '45%',
+    'data-test-subj': 'alertsTableCell-alert',
+    render: (value: string) => {
+      return (
+        <EuiToolTip anchorClassName={'eui-textTruncate'} content={value}>
+          <span>{value}</span>
+        </EuiToolTip>
+      );
+    },
+  },
+  {
+    field: 'status',
+    name: i18n.translate('xpack.triggersActionsUI.sections.ruleDetails.alertsList.columns.status', {
+      defaultMessage: 'Status',
+    }),
+    width: '15%',
+    render: (value: AlertListItemStatus) => {
+      return (
+        <EuiHealth color={value.healthColor} className="alertsList__health">
+          {value.label}
+          {value.actionGroup ? ` (${value.actionGroup})` : ``}
+        </EuiHealth>
+      );
+    },
+    sortable: false,
+    'data-test-subj': 'alertsTableCell-status',
+  },
+  {
+    field: 'start',
+    width: '190px',
+    render: (value: Date | undefined) => {
+      return value ? moment(value).format('D MMM YYYY @ HH:mm:ss') : '';
+    },
+    name: i18n.translate('xpack.triggersActionsUI.sections.ruleDetails.alertsList.columns.start', {
+      defaultMessage: 'Start',
+    }),
+    sortable: false,
+    'data-test-subj': 'alertsTableCell-start',
+  },
+  {
+    field: 'duration',
+    render: (value: number) => {
+      return value ? durationAsString(moment.duration(value)) : '';
+    },
+    name: i18n.translate(
+      'xpack.triggersActionsUI.sections.ruleDetails.alertsList.columns.duration',
+      { defaultMessage: 'Duration' }
+    ),
+    sortable: false,
+    width: '80px',
+    'data-test-subj': 'alertsTableCell-duration',
+  },
+  {
+    field: '',
+    align: RIGHT_ALIGNMENT,
+    width: '60px',
+    name: i18n.translate('xpack.triggersActionsUI.sections.ruleDetails.alertsList.columns.mute', {
+      defaultMessage: 'Mute',
+    }),
+    render: (alert: AlertListItem) => {
+      return (
+        <AlertMutedSwitch
+          disabled={readOnly}
+          onMuteAction={async () => await onMuteAction(alert)}
+          alert={alert}
+        />
+      );
+    },
+    sortable: false,
+    'data-test-subj': 'alertsTableCell-actions',
+  },
+];
+
+interface RuleAlertListProps {
+  items: AlertListItem[];
+  pagination: Pagination;
+  paginationItemCount: number;
+  readOnly: boolean;
+  onMuteAction: (alert: AlertListItem) => Promise<void>;
+  onPaginate: (pagination: Pagination) => void;
+}
+
+const getRowProps = () => ({
+  'data-test-subj': 'alert-row',
+});
+
+const getCellProps = () => ({
+  'data-test-subj': 'cell',
+});
+
+export const RuleAlertList = (props: RuleAlertListProps) => {
+  const { items, pagination, paginationItemCount, readOnly, onMuteAction, onPaginate } = props;
+
+  const paginationOptions = useMemo(() => {
+    return {
+      pageIndex: pagination.index,
+      pageSize: pagination.size,
+      totalItemCount: paginationItemCount,
+    };
+  }, [pagination, paginationItemCount]);
+
+  const onChange = useCallback(
+    ({ page: changedPage }: { page: Pagination }) => {
+      onPaginate(changedPage);
+    },
+    [onPaginate]
+  );
+
+  return (
+    <EuiBasicTable<AlertListItem>
+      items={items}
+      pagination={paginationOptions}
+      onChange={onChange}
+      rowProps={getRowProps}
+      cellProps={getCellProps}
+      columns={alertsTableColumns(onMuteAction, readOnly)}
+      data-test-subj="alertsList"
+      tableLayout="fixed"
+      className="alertsList"
+    />
+  );
+};

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list.tsx
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+export const RuleEventLogList = () => {
+  return <div data-test-subj="ruleEventLogList">To be implemented</div>;
+};
+
+RuleEventLogList.displayName = 'RuleEventLogList';

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface AlertListItemStatus {
+  label: string;
+  healthColor: string;
+  actionGroup?: string;
+}
+
+export interface AlertListItem {
+  alert: string;
+  status: AlertListItemStatus;
+  start?: Date;
+  duration: number;
+  isMuted: boolean;
+  sortPriority: number;
+}

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/details.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/details.ts
@@ -550,6 +550,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         // Get action groups
         const { actionGroups } = alwaysFiringAlertType;
 
+        // If the tab exists, click on the alert list
+        await pageObjects.triggersActionsUI.maybeClickOnAlertTab();
+
         // Verify content
         await testSubjects.existOrFail('alertsList');
 
@@ -648,6 +651,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         // refresh to see rule
         await browser.refresh();
 
+        // If the tab exists, click on the alert list
+        await pageObjects.triggersActionsUI.maybeClickOnAlertTab();
+
         const alertsList: any[] = await pageObjects.ruleDetailsUI.getAlertsList();
         expect(alertsList.filter((a) => a.alert === 'eu/east')).to.eql([
           {
@@ -660,6 +666,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       it('allows the user to mute a specific alert', async () => {
+        // If the tab exists, click on the alert list
+        await pageObjects.triggersActionsUI.maybeClickOnAlertTab();
+
         // Verify content
         await testSubjects.existOrFail('alertsList');
 
@@ -674,6 +683,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       it('allows the user to unmute a specific alert', async () => {
+        // If the tab exists, click on the alert list
+        await pageObjects.triggersActionsUI.maybeClickOnAlertTab();
+
         // Verify content
         await testSubjects.existOrFail('alertsList');
 
@@ -694,6 +706,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       it('allows the user unmute an inactive alert', async () => {
+        // If the tab exists, click on the alert list
+        await pageObjects.triggersActionsUI.maybeClickOnAlertTab();
+
         log.debug(`Ensuring eu/east is muted`);
         await pageObjects.ruleDetailsUI.ensureAlertMuteState('eu/east', true);
 
@@ -747,6 +762,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
       const PAGE_SIZE = 10;
       it('renders the first page', async () => {
+        // If the tab exists, click on the alert list
+        await pageObjects.triggersActionsUI.maybeClickOnAlertTab();
+
         // Verify content
         await testSubjects.existOrFail('alertsList');
 
@@ -760,6 +778,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       it('navigates to the next page', async () => {
+        // If the tab exists, click on the alert list
+        await pageObjects.triggersActionsUI.maybeClickOnAlertTab();
+
         // Verify content
         await testSubjects.existOrFail('alertsList');
 

--- a/x-pack/test/functional_with_es_ssl/page_objects/triggers_actions_ui_page.ts
+++ b/x-pack/test/functional_with_es_ssl/page_objects/triggers_actions_ui_page.ts
@@ -141,6 +141,12 @@ export function TriggersActionsPageProvider({ getService }: FtrProviderContext) 
       await this.searchAlerts(name);
       await find.clickDisplayedByCssSelector(`[data-test-subj="rulesList"] [title="${name}"]`);
     },
+    async maybeClickOnAlertTab() {
+      if (await testSubjects.exists('ruleDetailsTabbedContent')) {
+        const alertTab = await testSubjects.find('ruleAlertListTab');
+        await alertTab.click();
+      }
+    },
     async changeTabs(tab: 'rulesTab' | 'connectorsTab') {
       await testSubjects.click(tab);
     },


### PR DESCRIPTION
## Summary

Resolves the following issue: https://github.com/elastic/kibana/issues/126845

Change the rule summary page to include the execution history/log tab. The execution history is a stub and the this new tabbed content is hidden behind a feature flag (`rulesListDatagrid`).

This PR also moves the alert list to its own component so it can be composed with the execution history list later on.

![execution_log_tab](https://user-images.githubusercontent.com/74562234/159313010-d564bddd-0cc0-443a-94ae-faceb66d7841.png)