### PR TITLE
[type-summarizer] summarize @kbn/alerts types with source-maps

### DIFF
--- a/packages/kbn-alerts/BUILD.bazel
+++ b/packages/kbn-alerts/BUILD.bazel
@@ -73,6 +73,7 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
+  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",

--- a/packages/kbn-alerts/tsconfig.json
+++ b/packages/kbn-alerts/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",

--- a/packages/kbn-type-summarizer/src/lib/bazel_cli_config.ts
+++ b/packages/kbn-type-summarizer/src/lib/bazel_cli_config.ts
@@ -18,6 +18,7 @@ const TYPE_SUMMARIZER_PACKAGES = [
   '@kbn/generate',
   '@kbn/mapbox-gl',
   '@kbn/ace',
+  '@kbn/alerts',
 ];
 
 type TypeSummarizerType = 'api-extractor' | 'type-summarizer';


### PR DESCRIPTION
This PR just enables the `@kbn/alerts` package in the `@kbn/type-summarizer`, a new experimental type summarizer which supports sourceMaps. I was able to validate that the types produced for this package are correct, but unable to find any usage of this package so wondering if this PR should be updated to just remove the `@kbn/alerts` package...