### PR TITLE
Add loading state to the SparkPlot

### DIFF
--- a/x-pack/plugins/apm/public/components/app/error_group_overview/error_group_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/error_group_list/index.tsx
@@ -212,7 +212,7 @@ function ErrorGroupList({
           return (
             <SparkPlot
               color={currentPeriodColor}
-              seriesLoading={detailedStatisticsLoading}
+              isLoading={detailedStatisticsLoading}
               series={currentPeriodTimeseries}
               valueLabel={i18n.translate(
                 'xpack.apm.serviceOveriew.errorsTableOccurrences',

--- a/x-pack/plugins/apm/public/components/app/error_group_overview/error_group_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/error_group_list/index.tsx
@@ -59,6 +59,7 @@ type ErrorGroupDetailedStatistics =
 interface Props {
   mainStatistics: ErrorGroupItem[];
   serviceName: string;
+  detailedStatisticsLoading: boolean;
   detailedStatistics: ErrorGroupDetailedStatistics;
   comparisonEnabled?: boolean;
 }
@@ -66,6 +67,7 @@ interface Props {
 function ErrorGroupList({
   mainStatistics,
   serviceName,
+  detailedStatisticsLoading,
   detailedStatistics,
   comparisonEnabled,
 }: Props) {
@@ -210,6 +212,7 @@ function ErrorGroupList({
           return (
             <SparkPlot
               color={currentPeriodColor}
+              seriesLoading={detailedStatisticsLoading}
               series={currentPeriodTimeseries}
               valueLabel={i18n.translate(
                 'xpack.apm.serviceOveriew.errorsTableOccurrences',
@@ -229,7 +232,13 @@ function ErrorGroupList({
         },
       },
     ] as Array<ITableColumn<ErrorGroupItem>>;
-  }, [serviceName, query, detailedStatistics, comparisonEnabled]);
+  }, [
+    serviceName,
+    query,
+    detailedStatistics,
+    comparisonEnabled,
+    detailedStatisticsLoading,
+  ]);
 
   return (
     <ManagedTable

--- a/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
@@ -192,7 +192,7 @@ export function ErrorGroupOverview() {
             serviceName={serviceName}
             detailedStatisticsLoading={
               errorGroupDetailedStatisticsStatus === FETCH_STATUS.LOADING ||
-              FETCH_STATUS.NOT_INITIATED
+              errorGroupDetailedStatisticsStatus === FETCH_STATUS.NOT_INITIATED
             }
             detailedStatistics={errorGroupDetailedStatistics}
             comparisonEnabled={comparisonEnabled}

--- a/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
@@ -19,7 +19,7 @@ import { useApmServiceContext } from '../../../context/apm_service/use_apm_servi
 import { ChartPointerEventContextProvider } from '../../../context/chart_pointer_event/chart_pointer_event_context';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useErrorGroupDistributionFetcher } from '../../../hooks/use_error_group_distribution_fetcher';
-import { useFetcher } from '../../../hooks/use_fetcher';
+import { useFetcher, FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { useTimeRange } from '../../../hooks/use_time_range';
 import { APIReturnType } from '../../../services/rest/create_call_apm_api';
 import { FailedTransactionRateChart } from '../../shared/charts/failed_transaction_rate_chart';
@@ -115,6 +115,7 @@ export function ErrorGroupOverview() {
 
   const {
     data: errorGroupDetailedStatistics = INITIAL_STATE_DETAILED_STATISTICS,
+    status: errorGroupDetailedStatisticsStatus,
   } = useFetcher(
     (callApmApi) => {
       if (requestId && errorGroupMainStatistics.length && start && end) {
@@ -189,6 +190,9 @@ export function ErrorGroupOverview() {
           <ErrorGroupList
             mainStatistics={errorGroupMainStatistics}
             serviceName={serviceName}
+            detailedStatisticsLoading={
+              errorGroupDetailedStatisticsStatus === FETCH_STATUS.LOADING
+            }
             detailedStatistics={errorGroupDetailedStatistics}
             comparisonEnabled={comparisonEnabled}
           />

--- a/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
@@ -191,7 +191,8 @@ export function ErrorGroupOverview() {
             mainStatistics={errorGroupMainStatistics}
             serviceName={serviceName}
             detailedStatisticsLoading={
-              errorGroupDetailedStatisticsStatus === FETCH_STATUS.LOADING
+              errorGroupDetailedStatisticsStatus === FETCH_STATUS.LOADING ||
+              FETCH_STATUS.NOT_INITIATED
             }
             detailedStatistics={errorGroupDetailedStatistics}
             comparisonEnabled={comparisonEnabled}

--- a/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
@@ -191,6 +191,10 @@ export function ServiceInventory() {
             isLoading={isLoading}
             isFailure={isFailure}
             items={items}
+            comparisonDataLoading={
+              comparisonFetch.status === FETCH_STATUS.LOADING ||
+              comparisonFetch.status === FETCH_STATUS.NOT_INITIATED
+            }
             comparisonData={comparisonFetch?.data}
             noItemsMessage={noItemsMessage}
           />

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
@@ -164,7 +164,7 @@ export function getServiceColumns({
         );
         return (
           <ListMetric
-            seriesLoading={comparisonDataLoading}
+            isLoading={comparisonDataLoading}
             series={comparisonData?.currentPeriod[serviceName]?.latency}
             comparisonSeries={
               comparisonData?.previousPeriod[serviceName]?.latency
@@ -192,7 +192,7 @@ export function getServiceColumns({
 
         return (
           <ListMetric
-            seriesLoading={comparisonDataLoading}
+            isLoading={comparisonDataLoading}
             series={comparisonData?.currentPeriod[serviceName]?.throughput}
             comparisonSeries={
               comparisonData?.previousPeriod[serviceName]?.throughput
@@ -220,7 +220,7 @@ export function getServiceColumns({
         );
         return (
           <ListMetric
-            seriesLoading={comparisonDataLoading}
+            isLoading={comparisonDataLoading}
             series={
               comparisonData?.currentPeriod[serviceName]?.transactionErrorRate
             }

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
@@ -64,6 +64,7 @@ const SERVICE_HEALTH_STATUS_ORDER = [
 export function getServiceColumns({
   query,
   showTransactionTypeColumn,
+  comparisonDataLoading,
   comparisonData,
   breakpoints,
   showHealthStatusColumn,
@@ -71,6 +72,7 @@ export function getServiceColumns({
   query: TypeOf<ApmRoutes, '/services'>['query'];
   showTransactionTypeColumn: boolean;
   showHealthStatusColumn: boolean;
+  comparisonDataLoading: boolean;
   breakpoints: Breakpoints;
   comparisonData?: ServicesDetailedStatisticsAPIResponse;
 }): Array<ITableColumn<ServiceListItem>> {
@@ -162,6 +164,7 @@ export function getServiceColumns({
         );
         return (
           <ListMetric
+            seriesLoading={comparisonDataLoading}
             series={comparisonData?.currentPeriod[serviceName]?.latency}
             comparisonSeries={
               comparisonData?.previousPeriod[serviceName]?.latency
@@ -189,6 +192,7 @@ export function getServiceColumns({
 
         return (
           <ListMetric
+            seriesLoading={comparisonDataLoading}
             series={comparisonData?.currentPeriod[serviceName]?.throughput}
             comparisonSeries={
               comparisonData?.previousPeriod[serviceName]?.throughput
@@ -216,6 +220,7 @@ export function getServiceColumns({
         );
         return (
           <ListMetric
+            seriesLoading={comparisonDataLoading}
             series={
               comparisonData?.currentPeriod[serviceName]?.transactionErrorRate
             }
@@ -236,6 +241,7 @@ export function getServiceColumns({
 
 interface Props {
   items: ServiceListItem[];
+  comparisonDataLoading: boolean;
   comparisonData?: ServicesDetailedStatisticsAPIResponse;
   noItemsMessage?: React.ReactNode;
   isLoading: boolean;
@@ -245,6 +251,7 @@ interface Props {
 export function ServiceList({
   items,
   noItemsMessage,
+  comparisonDataLoading,
   comparisonData,
   isLoading,
   isFailure,
@@ -270,6 +277,7 @@ export function ServiceList({
       getServiceColumns({
         query,
         showTransactionTypeColumn,
+        comparisonDataLoading,
         comparisonData,
         breakpoints,
         showHealthStatusColumn: displayHealthStatus,
@@ -277,6 +285,7 @@ export function ServiceList({
     [
       query,
       showTransactionTypeColumn,
+      comparisonDataLoading,
       comparisonData,
       breakpoints,
       displayHealthStatus,

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/service_list.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/service_list.test.tsx
@@ -97,7 +97,7 @@ describe('ServiceList', () => {
             color="green"
             comparisonSeriesColor="black"
             hideSeries={false}
-            seriesLoading={false}
+            isLoading={false}
             valueLabel="0 ms"
           />
         `);
@@ -125,7 +125,7 @@ describe('ServiceList', () => {
             color="green"
             comparisonSeriesColor="black"
             hideSeries={true}
-            seriesLoading={false}
+            isLoading={false}
             valueLabel="0 ms"
           />
         `);
@@ -161,7 +161,7 @@ describe('ServiceList', () => {
               color="green"
               comparisonSeriesColor="black"
               hideSeries={false}
-              seriesLoading={false}
+              isLoading={false}
               valueLabel="0 ms"
             />
           `);
@@ -199,7 +199,7 @@ describe('ServiceList', () => {
               color="green"
               comparisonSeriesColor="black"
               hideSeries={false}
-              seriesLoading={false}
+              isLoading={false}
               valueLabel="0 ms"
             />
           `);

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/service_list.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/service_list.test.tsx
@@ -69,6 +69,7 @@ describe('ServiceList', () => {
     describe('when small', () => {
       it('shows environment, transaction type and sparklines', () => {
         const renderedColumns = getServiceColumns({
+          comparisonDataLoading: false,
           showHealthStatusColumn: true,
           query,
           showTransactionTypeColumn: true,
@@ -96,6 +97,7 @@ describe('ServiceList', () => {
             color="green"
             comparisonSeriesColor="black"
             hideSeries={false}
+            seriesLoading={false}
             valueLabel="0 ms"
           />
         `);
@@ -105,6 +107,7 @@ describe('ServiceList', () => {
     describe('when Large', () => {
       it('hides environment, transaction type and sparklines', () => {
         const renderedColumns = getServiceColumns({
+          comparisonDataLoading: false,
           showHealthStatusColumn: true,
           query,
           showTransactionTypeColumn: true,
@@ -122,6 +125,7 @@ describe('ServiceList', () => {
             color="green"
             comparisonSeriesColor="black"
             hideSeries={true}
+            seriesLoading={false}
             valueLabel="0 ms"
           />
         `);
@@ -130,6 +134,7 @@ describe('ServiceList', () => {
       describe('when XL', () => {
         it('hides transaction type', () => {
           const renderedColumns = getServiceColumns({
+            comparisonDataLoading: false,
             showHealthStatusColumn: true,
             query,
             showTransactionTypeColumn: true,
@@ -156,6 +161,7 @@ describe('ServiceList', () => {
               color="green"
               comparisonSeriesColor="black"
               hideSeries={false}
+              seriesLoading={false}
               valueLabel="0 ms"
             />
           `);
@@ -165,6 +171,7 @@ describe('ServiceList', () => {
       describe('when XXL', () => {
         it('hides transaction type', () => {
           const renderedColumns = getServiceColumns({
+            comparisonDataLoading: false,
             showHealthStatusColumn: true,
             query,
             showTransactionTypeColumn: true,
@@ -192,6 +199,7 @@ describe('ServiceList', () => {
               color="green"
               comparisonSeriesColor="black"
               hideSeries={false}
+              seriesLoading={false}
               valueLabel="0 ms"
             />
           `);
@@ -203,6 +211,7 @@ describe('ServiceList', () => {
   describe('without ML data', () => {
     it('hides healthStatus column', () => {
       const renderedColumns = getServiceColumns({
+        comparisonDataLoading: false,
         showHealthStatusColumn: false,
         query,
         showTransactionTypeColumn: true,
@@ -219,6 +228,7 @@ describe('ServiceList', () => {
   describe('with ML data', () => {
     it('shows healthStatus column', () => {
       const renderedColumns = getServiceColumns({
+        comparisonDataLoading: false,
         showHealthStatusColumn: true,
         query,
         showTransactionTypeColumn: true,

--- a/x-pack/plugins/apm/public/components/app/service_map/popover/stats_list.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/popover/stats_list.tsx
@@ -198,6 +198,7 @@ export function StatsList({ data, isLoading }: StatsListProps) {
                 <EuiFlexItem grow={false}>
                   {timeseries ? (
                     <SparkPlot
+                      seriesLoading={isLoading}
                       series={timeseries}
                       color={color}
                       valueLabel={valueLabel}

--- a/x-pack/plugins/apm/public/components/app/service_map/popover/stats_list.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/popover/stats_list.tsx
@@ -198,7 +198,7 @@ export function StatsList({ data, isLoading }: StatsListProps) {
                 <EuiFlexItem grow={false}>
                   {timeseries ? (
                     <SparkPlot
-                      seriesLoading={isLoading}
+                      isLoading={isLoading}
                       series={timeseries}
                       color={color}
                       valueLabel={valueLabel}

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/get_columns.tsx
@@ -35,11 +35,13 @@ type ErrorGroupDetailedStatistics =
 
 export function getColumns({
   serviceName,
+  errorGroupDetailedStatisticsLoading,
   errorGroupDetailedStatistics,
   comparisonEnabled,
   query,
 }: {
   serviceName: string;
+  errorGroupDetailedStatisticsLoading: boolean;
   errorGroupDetailedStatistics: ErrorGroupDetailedStatistics;
   comparisonEnabled?: boolean;
   query: TypeOf<ApmRoutes, '/services/{serviceName}/errors'>['query'];
@@ -129,6 +131,7 @@ export function getColumns({
         return (
           <SparkPlot
             color={currentPeriodColor}
+            seriesLoading={errorGroupDetailedStatisticsLoading}
             series={currentPeriodTimeseries}
             valueLabel={i18n.translate(
               'xpack.apm.serviceOveriew.errorsTableOccurrences',

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/get_columns.tsx
@@ -131,7 +131,7 @@ export function getColumns({
         return (
           <SparkPlot
             color={currentPeriodColor}
-            seriesLoading={errorGroupDetailedStatisticsLoading}
+            isLoading={errorGroupDetailedStatisticsLoading}
             series={currentPeriodTimeseries}
             valueLabel={i18n.translate(
               'xpack.apm.serviceOveriew.errorsTableOccurrences',

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
@@ -145,6 +145,7 @@ export function ServiceOverviewErrorsTable({ serviceName }: Props) {
 
   const {
     data: errorGroupDetailedStatistics = INITIAL_STATE_DETAILED_STATISTICS,
+    status: errorGroupDetailedStatisticsStatus,
   } = useFetcher(
     (callApmApi) => {
       if (requestId && items.length && start && end) {
@@ -176,8 +177,12 @@ export function ServiceOverviewErrorsTable({ serviceName }: Props) {
     { preservePreviousData: false }
   );
 
+  const errorGroupDetailedStatisticsLoading =
+    errorGroupDetailedStatisticsStatus === FETCH_STATUS.LOADING;
+
   const columns = getColumns({
     serviceName,
+    errorGroupDetailedStatisticsLoading,
     errorGroupDetailedStatistics,
     comparisonEnabled,
     query,

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
@@ -172,50 +172,52 @@ export function ServiceOverviewInstancesChartAndTable({
     direction
   ).slice(pageIndex * PAGE_SIZE, (pageIndex + 1) * PAGE_SIZE);
 
-  const { data: detailedStatsData = INITIAL_STATE_DETAILED_STATISTICS } =
-    useFetcher(
-      (callApmApi) => {
-        if (
-          !start ||
-          !end ||
-          !transactionType ||
-          !latencyAggregationType ||
-          !currentPeriodItemsCount
-        ) {
-          return;
-        }
+  const {
+    data: detailedStatsData = INITIAL_STATE_DETAILED_STATISTICS,
+    status: detailedStatsStatus,
+  } = useFetcher(
+    (callApmApi) => {
+      if (
+        !start ||
+        !end ||
+        !transactionType ||
+        !latencyAggregationType ||
+        !currentPeriodItemsCount
+      ) {
+        return;
+      }
 
-        return callApmApi(
-          'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
-          {
-            params: {
-              path: {
-                serviceName,
-              },
-              query: {
-                environment,
-                kuery,
-                latencyAggregationType:
-                  latencyAggregationType as LatencyAggregationType,
-                start,
-                end,
-                numBuckets: 20,
-                transactionType,
-                serviceNodeIds: JSON.stringify(
-                  currentPeriodOrderedItems.map((item) => item.serviceNodeName)
-                ),
-                comparisonStart,
-                comparisonEnd,
-              },
+      return callApmApi(
+        'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
+        {
+          params: {
+            path: {
+              serviceName,
             },
-          }
-        );
-      },
-      // only fetches detailed statistics when requestId is invalidated by main statistics api call
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [requestId],
-      { preservePreviousData: false }
-    );
+            query: {
+              environment,
+              kuery,
+              latencyAggregationType:
+                latencyAggregationType as LatencyAggregationType,
+              start,
+              end,
+              numBuckets: 20,
+              transactionType,
+              serviceNodeIds: JSON.stringify(
+                currentPeriodOrderedItems.map((item) => item.serviceNodeName)
+              ),
+              comparisonStart,
+              comparisonEnd,
+            },
+          },
+        }
+      );
+    },
+    // only fetches detailed statistics when requestId is invalidated by main statistics api call
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [requestId],
+    { preservePreviousData: false }
+  );
 
   return (
     <>
@@ -233,6 +235,7 @@ export function ServiceOverviewInstancesChartAndTable({
             mainStatsItems={currentPeriodOrderedItems}
             mainStatsStatus={mainStatsStatus}
             mainStatsItemCount={currentPeriodItemsCount}
+            detailedStatsLoading={detailedStatsStatus === FETCH_STATUS.LOADING}
             detailedStatsData={detailedStatsData}
             serviceName={serviceName}
             tableOptions={tableOptions}

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
@@ -235,7 +235,10 @@ export function ServiceOverviewInstancesChartAndTable({
             mainStatsItems={currentPeriodOrderedItems}
             mainStatsStatus={mainStatsStatus}
             mainStatsItemCount={currentPeriodItemsCount}
-            detailedStatsLoading={detailedStatsStatus === FETCH_STATUS.LOADING}
+            detailedStatsLoading={
+              detailedStatsStatus === FETCH_STATUS.LOADING ||
+              detailedStatsStatus === FETCH_STATUS.NOT_INITIATED
+            }
             detailedStatsData={detailedStatsData}
             serviceName={serviceName}
             tableOptions={tableOptions}

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
@@ -48,6 +48,7 @@ export function getColumns({
   kuery,
   agentName,
   latencyAggregationType,
+  detailedStatsLoading,
   detailedStatsData,
   comparisonEnabled,
   toggleRowDetails,
@@ -60,6 +61,7 @@ export function getColumns({
   kuery: string;
   agentName?: string;
   latencyAggregationType?: LatencyAggregationType;
+  detailedStatsLoading: boolean;
   detailedStatsData?: ServiceInstanceDetailedStatistics;
   comparisonEnabled?: boolean;
   toggleRowDetails: (selectedServiceNodeName: string) => void;
@@ -125,6 +127,7 @@ export function getColumns({
             color={currentPeriodColor}
             valueLabel={asMillisecondDuration(latency)}
             hideSeries={!shouldShowSparkPlots}
+            seriesLoading={detailedStatsLoading}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined
@@ -158,6 +161,7 @@ export function getColumns({
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
             valueLabel={asTransactionRate(throughput)}
+            seriesLoading={detailedStatsLoading}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined
@@ -191,6 +195,7 @@ export function getColumns({
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
             valueLabel={asPercent(errorRate, 1)}
+            seriesLoading={detailedStatsLoading}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined
@@ -224,6 +229,7 @@ export function getColumns({
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
             valueLabel={asPercent(cpuUsage, 1)}
+            seriesLoading={detailedStatsLoading}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined
@@ -257,6 +263,7 @@ export function getColumns({
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
             valueLabel={asPercent(memoryUsage, 1)}
+            seriesLoading={detailedStatsLoading}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
@@ -127,7 +127,7 @@ export function getColumns({
             color={currentPeriodColor}
             valueLabel={asMillisecondDuration(latency)}
             hideSeries={!shouldShowSparkPlots}
-            seriesLoading={detailedStatsLoading}
+            isLoading={detailedStatsLoading}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined
@@ -161,7 +161,7 @@ export function getColumns({
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
             valueLabel={asTransactionRate(throughput)}
-            seriesLoading={detailedStatsLoading}
+            isLoading={detailedStatsLoading}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined
@@ -195,7 +195,7 @@ export function getColumns({
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
             valueLabel={asPercent(errorRate, 1)}
-            seriesLoading={detailedStatsLoading}
+            isLoading={detailedStatsLoading}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined
@@ -229,7 +229,7 @@ export function getColumns({
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
             valueLabel={asPercent(cpuUsage, 1)}
-            seriesLoading={detailedStatsLoading}
+            isLoading={detailedStatsLoading}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined
@@ -263,7 +263,7 @@ export function getColumns({
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
             valueLabel={asPercent(memoryUsage, 1)}
-            seriesLoading={detailedStatsLoading}
+            isLoading={detailedStatsLoading}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
@@ -53,6 +53,7 @@ interface Props {
     page?: { index: number };
     sort?: { field: string; direction: SortDirection };
   }) => void;
+  detailedStatsLoading: boolean;
   detailedStatsData?: ServiceInstanceDetailedStatistics;
   isLoading: boolean;
   isNotInitiated: boolean;
@@ -64,6 +65,7 @@ export function ServiceOverviewInstancesTable({
   mainStatsStatus: status,
   tableOptions,
   onChangeTableOptions,
+  detailedStatsLoading,
   detailedStatsData: detailedStatsData,
   isLoading,
   isNotInitiated,
@@ -124,6 +126,7 @@ export function ServiceOverviewInstancesTable({
     serviceName,
     kuery,
     latencyAggregationType: latencyAggregationType as LatencyAggregationType,
+    detailedStatsLoading,
     detailedStatsData,
     comparisonEnabled,
     toggleRowDetails,

--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -37,7 +37,7 @@ const flexGroupStyle = { overflow: 'hidden' };
 
 export function SparkPlot({
   color,
-  seriesLoading,
+  isLoading,
   series,
   comparisonSeries = [],
   valueLabel,
@@ -45,7 +45,7 @@ export function SparkPlot({
   comparisonSeriesColor,
 }: {
   color: string;
-  seriesLoading: boolean;
+  isLoading: boolean;
   series?: Coordinate[] | null;
   valueLabel: React.ReactNode;
   compact?: boolean;
@@ -66,7 +66,7 @@ export function SparkPlot({
       <EuiFlexItem grow={false}>
         <SparkPlotItem
           color={color}
-          seriesLoading={seriesLoading}
+          isLoading={isLoading}
           series={series}
           comparisonSeries={comparisonSeries}
           comparisonSeriesColor={comparisonSeriesColor}
@@ -79,14 +79,14 @@ export function SparkPlot({
 
 function SparkPlotItem({
   color,
-  seriesLoading,
+  isLoading,
   series,
   comparisonSeries,
   comparisonSeriesColor,
   compact,
 }: {
   color: string;
-  seriesLoading: boolean;
+  isLoading: boolean;
   series?: Coordinate[] | null;
   compact?: boolean;
   comparisonSeries?: Coordinate[];
@@ -115,7 +115,7 @@ function SparkPlotItem({
 
   const Sparkline = hasComparisonSeries ? LineSeries : AreaSeries;
 
-  if (seriesLoading) {
+  if (isLoading) {
     return (
       <div
         style={{

--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -14,7 +14,12 @@ import {
   ScaleType,
   Settings,
 } from '@elastic/charts';
-import { EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLoadingChart,
+} from '@elastic/eui';
 import React from 'react';
 import { useChartTheme } from '../../../../../../observability/public';
 import { Coordinate } from '../../../../../typings/timeseries';
@@ -32,6 +37,7 @@ const flexGroupStyle = { overflow: 'hidden' };
 
 export function SparkPlot({
   color,
+  seriesLoading,
   series,
   comparisonSeries = [],
   valueLabel,
@@ -39,8 +45,49 @@ export function SparkPlot({
   comparisonSeriesColor,
 }: {
   color: string;
+  seriesLoading: boolean;
   series?: Coordinate[] | null;
   valueLabel: React.ReactNode;
+  compact?: boolean;
+  comparisonSeries?: Coordinate[];
+  comparisonSeriesColor: string;
+}) {
+  return (
+    <EuiFlexGroup
+      justifyContent="flexEnd"
+      gutterSize="xs"
+      responsive={false}
+      alignItems="flexEnd"
+      style={flexGroupStyle}
+    >
+      <EuiFlexItem grow={false} style={{ whiteSpace: 'nowrap' }}>
+        {valueLabel}
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <SparkPlotItem
+          color={color}
+          seriesLoading={seriesLoading}
+          series={series}
+          comparisonSeries={comparisonSeries}
+          comparisonSeriesColor={comparisonSeriesColor}
+          compact={compact}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}
+
+function SparkPlotItem({
+  color,
+  seriesLoading,
+  series,
+  comparisonSeries,
+  comparisonSeriesColor,
+  compact,
+}: {
+  color: string;
+  seriesLoading: boolean;
+  series?: Coordinate[] | null;
   compact?: boolean;
   comparisonSeries?: Coordinate[];
   comparisonSeriesColor: string;
@@ -68,61 +115,65 @@ export function SparkPlot({
 
   const Sparkline = hasComparisonSeries ? LineSeries : AreaSeries;
 
-  return (
-    <EuiFlexGroup
-      justifyContent="flexEnd"
-      gutterSize="xs"
-      responsive={false}
-      alignItems="flexEnd"
-      style={flexGroupStyle}
-    >
-      <EuiFlexItem grow={false} style={{ whiteSpace: 'nowrap' }}>
-        {valueLabel}
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        {hasValidTimeseries(series) ? (
-          <Chart size={chartSize}>
-            <Settings
-              theme={[sparkplotChartTheme, ...defaultChartTheme]}
-              showLegend={false}
-              tooltip="none"
-            />
-            <Sparkline
-              id="Sparkline"
-              xScaleType={ScaleType.Time}
-              yScaleType={ScaleType.Linear}
-              xAccessor={'x'}
-              yAccessors={['y']}
-              data={series}
-              color={color}
-              curve={CurveType.CURVE_MONOTONE_X}
-            />
-            {hasComparisonSeries && (
-              <AreaSeries
-                id="comparisonSeries"
-                xScaleType={ScaleType.Time}
-                yScaleType={ScaleType.Linear}
-                xAccessor={'x'}
-                yAccessors={['y']}
-                data={comparisonSeries}
-                color={comparisonSeriesColor}
-                curve={CurveType.CURVE_MONOTONE_X}
-              />
-            )}
-          </Chart>
-        ) : (
-          <div
-            style={{
-              ...chartSize,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <EuiIcon type="visLine" color={theme.eui.euiColorMediumShade} />
-          </div>
+  if (seriesLoading) {
+    return (
+      <div
+        style={{
+          ...chartSize,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <EuiLoadingChart mono />
+      </div>
+    );
+  }
+
+  if (hasValidTimeseries(series)) {
+    return (
+      <Chart size={chartSize}>
+        <Settings
+          theme={[sparkplotChartTheme, ...defaultChartTheme]}
+          showLegend={false}
+          tooltip="none"
+        />
+        <Sparkline
+          id="Sparkline"
+          xScaleType={ScaleType.Time}
+          yScaleType={ScaleType.Linear}
+          xAccessor={'x'}
+          yAccessors={['y']}
+          data={series}
+          color={color}
+          curve={CurveType.CURVE_MONOTONE_X}
+        />
+        {hasComparisonSeries && (
+          <AreaSeries
+            id="comparisonSeries"
+            xScaleType={ScaleType.Time}
+            yScaleType={ScaleType.Linear}
+            xAccessor={'x'}
+            yAccessors={['y']}
+            data={comparisonSeries}
+            color={comparisonSeriesColor}
+            curve={CurveType.CURVE_MONOTONE_X}
+          />
         )}
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      </Chart>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        ...chartSize,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <EuiIcon type="visLine" color={theme.eui.euiColorMediumShade} />
+    </div>
   );
 }

--- a/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -95,7 +95,10 @@ export function DependenciesTable(props: Props) {
             compact
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
-            seriesLoading={status === FETCH_STATUS.LOADING}
+            seriesLoading={
+              status === FETCH_STATUS.LOADING ||
+              status === FETCH_STATUS.NOT_INITIATED
+            }
             series={currentStats.latency.timeseries}
             comparisonSeries={previousStats?.latency.timeseries}
             valueLabel={asMillisecondDuration(currentStats.latency.value)}
@@ -121,7 +124,10 @@ export function DependenciesTable(props: Props) {
             compact
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
-            seriesLoading={status === FETCH_STATUS.LOADING}
+            seriesLoading={
+              status === FETCH_STATUS.LOADING ||
+              status === FETCH_STATUS.NOT_INITIATED
+            }
             series={currentStats.throughput.timeseries}
             comparisonSeries={previousStats?.throughput.timeseries}
             valueLabel={asTransactionRate(currentStats.throughput.value)}
@@ -147,7 +153,10 @@ export function DependenciesTable(props: Props) {
             compact
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
-            seriesLoading={status === FETCH_STATUS.LOADING}
+            seriesLoading={
+              status === FETCH_STATUS.LOADING ||
+              status === FETCH_STATUS.NOT_INITIATED
+            }
             series={currentStats.errorRate.timeseries}
             comparisonSeries={previousStats?.errorRate.timeseries}
             valueLabel={asPercent(currentStats.errorRate.value, 1)}

--- a/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -95,7 +95,7 @@ export function DependenciesTable(props: Props) {
             compact
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
-            seriesLoading={
+            isLoading={
               status === FETCH_STATUS.LOADING ||
               status === FETCH_STATUS.NOT_INITIATED
             }
@@ -124,7 +124,7 @@ export function DependenciesTable(props: Props) {
             compact
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
-            seriesLoading={
+            isLoading={
               status === FETCH_STATUS.LOADING ||
               status === FETCH_STATUS.NOT_INITIATED
             }
@@ -153,7 +153,7 @@ export function DependenciesTable(props: Props) {
             compact
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
-            seriesLoading={
+            isLoading={
               status === FETCH_STATUS.LOADING ||
               status === FETCH_STATUS.NOT_INITIATED
             }

--- a/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -95,6 +95,7 @@ export function DependenciesTable(props: Props) {
             compact
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
+            seriesLoading={status === FETCH_STATUS.LOADING}
             series={currentStats.latency.timeseries}
             comparisonSeries={previousStats?.latency.timeseries}
             valueLabel={asMillisecondDuration(currentStats.latency.value)}
@@ -120,6 +121,7 @@ export function DependenciesTable(props: Props) {
             compact
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
+            seriesLoading={status === FETCH_STATUS.LOADING}
             series={currentStats.throughput.timeseries}
             comparisonSeries={previousStats?.throughput.timeseries}
             valueLabel={asTransactionRate(currentStats.throughput.value)}
@@ -145,6 +147,7 @@ export function DependenciesTable(props: Props) {
             compact
             color={currentPeriodColor}
             hideSeries={!shouldShowSparkPlots}
+            seriesLoading={status === FETCH_STATUS.LOADING}
             series={currentStats.errorRate.timeseries}
             comparisonSeries={previousStats?.errorRate.timeseries}
             valueLabel={asPercent(currentStats.errorRate.value, 1)}

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
@@ -102,7 +102,7 @@ export function getColumns({
             color={currentPeriodColor}
             compact
             hideSeries={!shouldShowSparkPlots}
-            seriesLoading={transactionGroupDetailedStatisticsLoading}
+            isLoading={transactionGroupDetailedStatisticsLoading}
             series={currentTimeseries}
             comparisonSeries={
               comparisonEnabled ? previousTimeseries : undefined
@@ -137,7 +137,7 @@ export function getColumns({
             color={currentPeriodColor}
             compact
             hideSeries={!shouldShowSparkPlots}
-            seriesLoading={transactionGroupDetailedStatisticsLoading}
+            isLoading={transactionGroupDetailedStatisticsLoading}
             series={currentTimeseries}
             comparisonSeries={
               comparisonEnabled ? previousTimeseries : undefined
@@ -171,7 +171,7 @@ export function getColumns({
             color={currentPeriodColor}
             compact
             hideSeries={!shouldShowSparkPlots}
-            seriesLoading={transactionGroupDetailedStatisticsLoading}
+            isLoading={transactionGroupDetailedStatisticsLoading}
             series={currentTimeseries}
             comparisonSeries={
               comparisonEnabled ? previousTimeseries : undefined

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
@@ -40,6 +40,7 @@ type TransactionGroupDetailedStatistics =
 export function getColumns({
   serviceName,
   latencyAggregationType,
+  transactionGroupDetailedStatisticsLoading,
   transactionGroupDetailedStatistics,
   comparisonEnabled,
   shouldShowSparkPlots = true,
@@ -47,6 +48,7 @@ export function getColumns({
 }: {
   serviceName: string;
   latencyAggregationType?: LatencyAggregationType;
+  transactionGroupDetailedStatisticsLoading: boolean;
   transactionGroupDetailedStatistics?: TransactionGroupDetailedStatistics;
   comparisonEnabled?: boolean;
   shouldShowSparkPlots?: boolean;
@@ -100,6 +102,7 @@ export function getColumns({
             color={currentPeriodColor}
             compact
             hideSeries={!shouldShowSparkPlots}
+            seriesLoading={transactionGroupDetailedStatisticsLoading}
             series={currentTimeseries}
             comparisonSeries={
               comparisonEnabled ? previousTimeseries : undefined
@@ -134,6 +137,7 @@ export function getColumns({
             color={currentPeriodColor}
             compact
             hideSeries={!shouldShowSparkPlots}
+            seriesLoading={transactionGroupDetailedStatisticsLoading}
             series={currentTimeseries}
             comparisonSeries={
               comparisonEnabled ? previousTimeseries : undefined
@@ -167,6 +171,7 @@ export function getColumns({
             color={currentPeriodColor}
             compact
             hideSeries={!shouldShowSparkPlots}
+            seriesLoading={transactionGroupDetailedStatisticsLoading}
             series={currentTimeseries}
             comparisonSeries={
               comparisonEnabled ? previousTimeseries : undefined

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
@@ -182,7 +182,10 @@ export function TransactionsTable({
     },
   } = data;
 
-  const { data: transactionGroupDetailedStatistics } = useFetcher(
+  const {
+    data: transactionGroupDetailedStatistics,
+    status: transactionGroupDetailedStatisticsStatus,
+  } = useFetcher(
     (callApmApi) => {
       if (
         transactionGroupsTotalItems &&
@@ -225,6 +228,8 @@ export function TransactionsTable({
   const columns = getColumns({
     serviceName,
     latencyAggregationType: latencyAggregationType as LatencyAggregationType,
+    transactionGroupDetailedStatisticsLoading:
+      transactionGroupDetailedStatisticsStatus === FETCH_STATUS.LOADING,
     transactionGroupDetailedStatistics,
     comparisonEnabled,
     shouldShowSparkPlots,

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
@@ -229,7 +229,8 @@ export function TransactionsTable({
     serviceName,
     latencyAggregationType: latencyAggregationType as LatencyAggregationType,
     transactionGroupDetailedStatisticsLoading:
-      transactionGroupDetailedStatisticsStatus === FETCH_STATUS.LOADING,
+      transactionGroupDetailedStatisticsStatus === FETCH_STATUS.LOADING ||
+      transactionGroupDetailedStatisticsStatus === FETCH_STATUS.NOT_INITIATED,
     transactionGroupDetailedStatistics,
     comparisonEnabled,
     shouldShowSparkPlots,


### PR DESCRIPTION
## Summary

Add `<EuiLoadingChart mono />` when SparkPlots are loading.

### Service inventory
https://user-images.githubusercontent.com/5831975/159464873-e9ee7f46-8c42-4dd9-b34c-47c0d9b26a65.mov

### Service overview
https://user-images.githubusercontent.com/5831975/159464887-7bdf3cd8-a2e5-45c9-96c3-63527d3c091b.mov

Closes https://github.com/elastic/kibana/issues/108522