### PR TITLE
[type-summarizer] handle enums, extended interfaces, and export-type'd types

### DIFF
--- a/packages/kbn-type-summarizer/src/lib/export_collector/collector_results.ts
+++ b/packages/kbn-type-summarizer/src/lib/export_collector/collector_results.ts
@@ -41,10 +41,11 @@ export class CollectorResults {
 
   addImportFromNodeModules(
     exportInfo: ExportInfo | undefined,
-    symbol: DecSymbol,
+    sourceSymbol: DecSymbol,
+    importSymbol: DecSymbol,
     moduleId: string
   ) {
-    const imp = ImportedSymbol.fromSymbol(symbol, moduleId);
+    const imp = ImportedSymbol.fromSymbol(sourceSymbol, importSymbol, moduleId);
     imp.exportInfo ||= exportInfo;
     this.importedSymbols.add(imp);
   }

--- a/packages/kbn-type-summarizer/src/lib/export_collector/imported_symbol.ts
+++ b/packages/kbn-type-summarizer/src/lib/export_collector/imported_symbol.ts
@@ -13,17 +13,17 @@ import { ExportInfo } from '../export_info';
 const cache = new WeakMap<DecSymbol, ImportedSymbol>();
 
 export class ImportedSymbol {
-  static fromSymbol(symbol: DecSymbol, moduleId: string) {
-    const cached = cache.get(symbol);
+  static fromSymbol(source: DecSymbol, importSymbol: DecSymbol, moduleId: string) {
+    const cached = cache.get(source);
     if (cached) {
       return cached;
     }
 
-    if (symbol.declarations.length !== 1) {
+    if (importSymbol.declarations.length !== 1) {
       throw new Error('expected import symbol to have exactly one declaration');
     }
 
-    const dec = symbol.declarations[0];
+    const dec = importSymbol.declarations[0];
     if (
       !ts.isImportClause(dec) &&
       !ts.isExportSpecifier(dec) &&
@@ -41,18 +41,18 @@ export class ImportedSymbol {
     }
 
     const imp = ts.isImportClause(dec)
-      ? new ImportedSymbol(symbol, 'default', dec.name.text, dec.isTypeOnly, moduleId)
+      ? new ImportedSymbol(importSymbol, 'default', dec.name.text, dec.isTypeOnly, moduleId)
       : ts.isNamespaceImport(dec)
-      ? new ImportedSymbol(symbol, '*', dec.name.text, dec.parent.isTypeOnly, moduleId)
+      ? new ImportedSymbol(importSymbol, '*', dec.name.text, dec.parent.isTypeOnly, moduleId)
       : new ImportedSymbol(
-          symbol,
+          importSymbol,
           dec.name.text,
           dec.propertyName?.text,
           dec.isTypeOnly || dec.parent.parent.isTypeOnly,
           moduleId
         );
 
-    cache.set(symbol, imp);
+    cache.set(source, imp);
     return imp;
   }
 

--- a/packages/kbn-type-summarizer/src/lib/printer.ts
+++ b/packages/kbn-type-summarizer/src/lib/printer.ts
@@ -124,6 +124,10 @@ export class Printer {
       return 'interface';
     }
 
+    if (node.kind === ts.SyntaxKind.EnumDeclaration) {
+      return 'enum';
+    }
+
     if (ts.isVariableDeclaration(node)) {
       return this.getVariableDeclarationType(node);
     }
@@ -131,9 +135,15 @@ export class Printer {
 
   private printModifiers(exportInfo: ExportInfo | undefined, node: ts.Declaration) {
     const flags = ts.getCombinedModifierFlags(node);
+    const keyword = this.getDeclarationKeyword(node);
     const modifiers: string[] = [];
     if (exportInfo) {
-      modifiers.push(exportInfo.type);
+      // always use `export` for explicit types
+      if (keyword) {
+        modifiers.push('export');
+      } else {
+        modifiers.push(exportInfo.type);
+      }
     }
     if (flags & ts.ModifierFlags.Default) {
       modifiers.push('default');
@@ -160,7 +170,6 @@ export class Printer {
       modifiers.push('async');
     }
 
-    const keyword = this.getDeclarationKeyword(node);
     if (keyword) {
       modifiers.push(keyword);
     }
@@ -292,7 +301,10 @@ export class Printer {
       case ts.SyntaxKind.BigIntLiteral:
       case ts.SyntaxKind.NumericLiteral:
       case ts.SyntaxKind.StringKeyword:
-        return [this.printNode(node)];
+      case ts.SyntaxKind.EnumDeclaration:
+      case ts.SyntaxKind.TypeReference:
+      case ts.SyntaxKind.IntersectionType:
+        return [node.getFullText().trim()];
     }
 
     if (ts.isFunctionDeclaration(node)) {
@@ -335,6 +347,7 @@ export class Printer {
         this.printModifiers(exportInfo, node),
         this.getMappedSourceNode(node.name),
         ...(node.type ? [': ', this.printNode(node.type)] : []),
+        ...(node.initializer ? [' = ', this.printNode(node.initializer)] : []),
         ';\n',
       ];
     }
@@ -362,6 +375,9 @@ export class Printer {
         this.printModifiers(exportInfo, node),
         node.name ? this.getMappedSourceNode(node.name) : [],
         this.printTypeParameters(node),
+        node.heritageClauses
+          ? ` ${node.heritageClauses.map((c) => c.getFullText().trim()).join(' ')}`
+          : [],
         ' {\n',
         node.members.flatMap((m) => {
           const memberText = m.getText();

--- a/packages/kbn-type-summarizer/src/lib/printer.ts
+++ b/packages/kbn-type-summarizer/src/lib/printer.ts
@@ -145,6 +145,9 @@ export class Printer {
         modifiers.push(exportInfo.type);
       }
     }
+    if ((keyword === 'var' || keyword === 'const') && !exportInfo) {
+      modifiers.push('declare');
+    }
     if (flags & ts.ModifierFlags.Default) {
       modifiers.push('default');
     }
@@ -301,10 +304,13 @@ export class Printer {
       case ts.SyntaxKind.BigIntLiteral:
       case ts.SyntaxKind.NumericLiteral:
       case ts.SyntaxKind.StringKeyword:
-      case ts.SyntaxKind.EnumDeclaration:
       case ts.SyntaxKind.TypeReference:
       case ts.SyntaxKind.IntersectionType:
         return [node.getFullText().trim()];
+    }
+
+    if (ts.isEnumDeclaration(node)) {
+      return [node.getFullText().trim() + '\n'];
     }
 
     if (ts.isFunctionDeclaration(node)) {

--- a/packages/kbn-type-summarizer/src/lib/ts_nodes.ts
+++ b/packages/kbn-type-summarizer/src/lib/ts_nodes.ts
@@ -13,7 +13,8 @@ export type ValueNode =
   | ts.FunctionDeclaration
   | ts.TypeAliasDeclaration
   | ts.VariableDeclaration
-  | ts.InterfaceDeclaration;
+  | ts.InterfaceDeclaration
+  | ts.EnumDeclaration;
 
 export function isExportedValueNode(node: ts.Node): node is ValueNode {
   return (
@@ -21,7 +22,8 @@ export function isExportedValueNode(node: ts.Node): node is ValueNode {
     node.kind === ts.SyntaxKind.FunctionDeclaration ||
     node.kind === ts.SyntaxKind.TypeAliasDeclaration ||
     node.kind === ts.SyntaxKind.VariableDeclaration ||
-    node.kind === ts.SyntaxKind.InterfaceDeclaration
+    node.kind === ts.SyntaxKind.InterfaceDeclaration ||
+    node.kind === ts.SyntaxKind.EnumDeclaration
   );
 }
 export function assertExportedValueNode(node: ts.Node): asserts node is ValueNode {

--- a/packages/kbn-type-summarizer/src/tests/integration_helpers.ts
+++ b/packages/kbn-type-summarizer/src/tests/integration_helpers.ts
@@ -152,6 +152,15 @@ class MockCli {
     // convert the source files to .d.ts files
     this.buildDts();
 
+    // copy .d.ts files from source to dist
+    for (const [rel, content] of Object.entries(this.mockFiles)) {
+      if (rel.endsWith('.d.ts')) {
+        const path = Path.resolve(this.dtsOutputDir, rel);
+        await Fsp.mkdir(Path.dirname(path), { recursive: true });
+        await Fsp.writeFile(path, dedent(content));
+      }
+    }
+
     // summarize the .d.ts files into the output dir
     await summarizePackage(log, {
       dtsDir: normalizePath(this.dtsOutputDir),
@@ -159,7 +168,7 @@ class MockCli {
       outputDir: normalizePath(this.outputDir),
       repoRelativePackageDir: 'src',
       tsconfigPath: normalizePath(this.tsconfigPath),
-      strictPrinting: false,
+      strictPrinting: true,
     });
 
     // return the results

--- a/packages/kbn-type-summarizer/src/tests/integration_tests/class.test.ts
+++ b/packages/kbn-type-summarizer/src/tests/integration_tests/class.test.ts
@@ -75,3 +75,64 @@ it('prints basic class correctly', async () => {
     "
   `);
 });
+
+it('prints heritage clauses', async () => {
+  const output = await run(`
+    class Foo {
+      foo() {
+        return 'foo'
+      }
+    }
+
+    interface Named {
+      name: string
+    }
+
+    interface Aged {
+      age: number
+    }
+
+    export class Bar extends Foo implements Named, Aged {
+      name = 'bar'
+      age = 123
+
+      bar() {
+        return this.name
+      }
+    }
+  `);
+
+  expect(output.code).toMatchInlineSnapshot(`
+    "class Foo {
+      foo(): string;
+    }
+    interface Named {
+        name: string;
+    }
+    interface Aged {
+        age: number;
+    }
+    export class Bar extends Foo implements Named, Aged {
+      name: string;
+      age: number;
+      bar(): string;
+    }
+    //# sourceMappingURL=index.d.ts.map"
+  `);
+  expect(output.map).toMatchInlineSnapshot(`
+    Object {
+      "file": "index.d.ts",
+      "mappings": "MAAM,G;EACJ,G;;UAKQ,K;;;UAIA,I;;;aAIG,G;EACX,I;EACA,G;EAEA,G",
+      "names": Array [],
+      "sourceRoot": "../../../src",
+      "sources": Array [
+        "index.ts",
+      ],
+      "version": 3,
+    }
+  `);
+  expect(output.logs).toMatchInlineSnapshot(`
+    "debug loaded sourcemaps for [ 'packages/kbn-type-summarizer/__tmp__/dist_dts/index.d.ts' ]
+    "
+  `);
+});

--- a/packages/kbn-type-summarizer/src/tests/integration_tests/enum.test.ts
+++ b/packages/kbn-type-summarizer/src/tests/integration_tests/enum.test.ts
@@ -8,60 +8,64 @@
 
 import { run } from '../integration_helpers';
 
-it('prints the whole interface, including comments', async () => {
+it('prints the whole enum, including comments', async () => {
   const result = await run(`
     /**
-     * This is an interface
+     * This is an enum
      */
-    export interface Foo<Bar> {
+    export enum Foo {
       /**
-       * method
+       * some comment
        */
-      name(): string
-
+      x,
       /**
-       * hello
+       * some other comment
        */
-      close(): Promise<void>
+      y,
+      /**
+       * some final comment
+       */
+      z = 1,
     }
   `);
 
   expect(result.code).toMatchInlineSnapshot(`
     "/**
-     * This is an interface
+     * This is an enum
      */
-    export interface Foo<Bar> {
+    export declare enum Foo {
         /**
-         * method
+         * some comment
          */
-        name(): string;
+        x = 0,
         /**
-         * hello
+         * some other comment
          */
-        close(): Promise<void>;
+        y = 1,
+        /**
+         * some final comment
+         */
+        z = 1
     }
     //# sourceMappingURL=index.d.ts.map"
   `);
   expect(result.map).toMatchInlineSnapshot(`
     Object {
       "file": "index.d.ts",
-      "mappings": ";;;iBAGiB,G",
+      "mappings": "",
       "names": Array [],
       "sourceRoot": "../../../src",
-      "sources": Array [
-        "index.ts",
-      ],
+      "sources": Array [],
       "version": 3,
     }
   `);
   expect(result.logs).toMatchInlineSnapshot(`
     "debug loaded sourcemaps for [ 'packages/kbn-type-summarizer/__tmp__/dist_dts/index.d.ts' ]
-    debug Ignoring 5 global declarations for \\"Promise\\"
     "
   `);
 });
 
-it(`handles export-type'd interfaces`, async () => {
+it(`handles export-type'd enums`, async () => {
   const result = await run(
     `
       export type { Foo } from './foo'
@@ -69,8 +73,10 @@ it(`handles export-type'd interfaces`, async () => {
     {
       otherFiles: {
         ['foo.ts']: `
-          export interface Foo {
-            name: string
+          export enum Foo {
+            x = 1,
+            y = 2,
+            z = 3,
           }
         `,
       },
@@ -78,20 +84,20 @@ it(`handles export-type'd interfaces`, async () => {
   );
 
   expect(result.code).toMatchInlineSnapshot(`
-    "export interface Foo {
-        name: string;
+    "export declare enum Foo {
+        x = 1,
+        y = 2,
+        z = 3
     }
     //# sourceMappingURL=index.d.ts.map"
   `);
   expect(result.map).toMatchInlineSnapshot(`
     Object {
       "file": "index.d.ts",
-      "mappings": "iBAAiB,G",
+      "mappings": "",
       "names": Array [],
       "sourceRoot": "../../../src",
-      "sources": Array [
-        "foo.ts",
-      ],
+      "sources": Array [],
       "version": 3,
     }
   `);

--- a/packages/kbn-type-summarizer/src/tests/integration_tests/literals.test.ts
+++ b/packages/kbn-type-summarizer/src/tests/integration_tests/literals.test.ts
@@ -11,16 +11,20 @@ import { run } from '../integration_helpers';
 it('prints literal number types', async () => {
   const output = await run(`
     export const NUM = 3;
+    const NUM2 = 4;
+    export type PoN = Promise<typeof NUM2>;
   `);
 
   expect(output.code).toMatchInlineSnapshot(`
     "export const NUM = 3;
+    declare const NUM2 = 4;
+    export type PoN = Promise<typeof NUM2>
     //# sourceMappingURL=index.d.ts.map"
   `);
   expect(output.map).toMatchInlineSnapshot(`
     Object {
       "file": "index.d.ts",
-      "mappings": "aAAa,G",
+      "mappings": "aAAa,G;cACP,I;YACM,G",
       "names": Array [],
       "sourceRoot": "../../../src",
       "sources": Array [
@@ -31,6 +35,7 @@ it('prints literal number types', async () => {
   `);
   expect(output.logs).toMatchInlineSnapshot(`
     "debug loaded sourcemaps for [ 'packages/kbn-type-summarizer/__tmp__/dist_dts/index.d.ts' ]
+    debug Ignoring 5 global declarations for \\"Promise\\"
     "
   `);
 });

--- a/packages/kbn-type-summarizer/src/tests/integration_tests/literals.test.ts
+++ b/packages/kbn-type-summarizer/src/tests/integration_tests/literals.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { run } from '../integration_helpers';
+
+it('prints literal number types', async () => {
+  const output = await run(`
+    export const NUM = 3;
+  `);
+
+  expect(output.code).toMatchInlineSnapshot(`
+    "export const NUM = 3;
+    //# sourceMappingURL=index.d.ts.map"
+  `);
+  expect(output.map).toMatchInlineSnapshot(`
+    Object {
+      "file": "index.d.ts",
+      "mappings": "aAAa,G",
+      "names": Array [],
+      "sourceRoot": "../../../src",
+      "sources": Array [
+        "index.ts",
+      ],
+      "version": 3,
+    }
+  `);
+  expect(output.logs).toMatchInlineSnapshot(`
+    "debug loaded sourcemaps for [ 'packages/kbn-type-summarizer/__tmp__/dist_dts/index.d.ts' ]
+    "
+  `);
+});

--- a/packages/kbn-type-summarizer/src/tests/integration_tests/type_alias.test.ts
+++ b/packages/kbn-type-summarizer/src/tests/integration_tests/type_alias.test.ts
@@ -40,3 +40,42 @@ it('prints basic type alias', async () => {
     "
   `);
 });
+
+it(`prints export type'd type alias`, async () => {
+  const output = await run(
+    `
+      export type { Name } from './name'
+    `,
+    {
+      otherFiles: {
+        ['name.ts']: `
+          export type Name = 'foo';
+        `,
+      },
+    }
+  );
+
+  expect(output.code).toMatchInlineSnapshot(`
+    "export type Name = 'foo'
+    //# sourceMappingURL=index.d.ts.map"
+  `);
+  expect(output.map).toMatchInlineSnapshot(`
+    Object {
+      "file": "index.d.ts",
+      "mappings": "YAAY,I",
+      "names": Array [],
+      "sourceRoot": "../../../src",
+      "sources": Array [
+        "name.ts",
+      ],
+      "version": 3,
+    }
+  `);
+  expect(output.logs).toMatchInlineSnapshot(`
+    "debug loaded sourcemaps for [
+      'packages/kbn-type-summarizer/__tmp__/dist_dts/index.d.ts',
+      'packages/kbn-type-summarizer/__tmp__/dist_dts/name.d.ts'
+    ]
+    "
+  `);
+});


### PR DESCRIPTION
Improves the `@kbn/type-summarizer` by adding support for:

1. `enum` types can now be printed properly
2. `interface` types which exist in multiple locations within node modules are now supported, this is necessary for type like `Moment` which is defined in one location and extended in several others. When resolving the location of the type TS responds with the location of all extensions along with the initial declaration.
3. `export type`-ing explicit types, like `interface`. This previously would have printed `export type interface ...` which is invalid, especially for type aliases which would print `export type type = ...`
4. deduplicate import statements for the same underlying value from a node_module
5. print class heritage clauses, like `extends` and `implements`

Finally, the tests were fixed to run the type-summarizer in strict mode, which requires support for printing a few other basic types like `TypeReference` and `IntersectionType` nodes.