### PR TITLE
[type-summarizer] enable @kbn/analytics, @kbn/apm-config-loader and @kbn/apm-utils

### DIFF
--- a/packages/kbn-analytics/BUILD.bazel
+++ b/packages/kbn-analytics/BUILD.bazel
@@ -23,11 +23,13 @@ NPM_MODULE_EXTRA_FILES = [
 ]
 
 RUNTIME_DEPS = [
+  "@npm//moment",
   "@npm//moment-timezone",
   "@npm//tslib",
 ]
 
 TYPES_DEPS = [
+  "@npm//moment",
   "@npm//@types/moment-timezone",
   "@npm//@types/node",
 ]
@@ -70,6 +72,7 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
+  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",

--- a/packages/kbn-analytics/tsconfig.json
+++ b/packages/kbn-analytics/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "./target_types",

--- a/packages/kbn-apm-config-loader/BUILD.bazel
+++ b/packages/kbn-apm-config-loader/BUILD.bazel
@@ -65,6 +65,7 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
+  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",

--- a/packages/kbn-apm-config-loader/tsconfig.json
+++ b/packages/kbn-apm-config-loader/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "./target_types",
     "rootDir": "./src",

--- a/packages/kbn-apm-utils/BUILD.bazel
+++ b/packages/kbn-apm-utils/BUILD.bazel
@@ -50,6 +50,7 @@ ts_project(
   srcs = SRCS,
   deps = TYPES_DEPS,
   declaration = True,
+  declaration_map = True,
   emit_declaration_only = True,
   out_dir = "target_types",
   root_dir = "src",

--- a/packages/kbn-apm-utils/tsconfig.json
+++ b/packages/kbn-apm-utils/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
     "rootDir": "src",

--- a/packages/kbn-type-summarizer/src/lib/bazel_cli_config.ts
+++ b/packages/kbn-type-summarizer/src/lib/bazel_cli_config.ts
@@ -21,6 +21,7 @@ const TYPE_SUMMARIZER_PACKAGES = [
   '@kbn/alerts',
   '@kbn/analytics',
   '@kbn/apm-config-loader',
+  '@kbn/apm-utils',
 ];
 
 type TypeSummarizerType = 'api-extractor' | 'type-summarizer';

--- a/packages/kbn-type-summarizer/src/lib/bazel_cli_config.ts
+++ b/packages/kbn-type-summarizer/src/lib/bazel_cli_config.ts
@@ -20,6 +20,7 @@ const TYPE_SUMMARIZER_PACKAGES = [
   '@kbn/ace',
   '@kbn/alerts',
   '@kbn/analytics',
+  '@kbn/apm-config-loader',
 ];
 
 type TypeSummarizerType = 'api-extractor' | 'type-summarizer';

--- a/packages/kbn-type-summarizer/src/lib/bazel_cli_config.ts
+++ b/packages/kbn-type-summarizer/src/lib/bazel_cli_config.ts
@@ -19,6 +19,7 @@ const TYPE_SUMMARIZER_PACKAGES = [
   '@kbn/mapbox-gl',
   '@kbn/ace',
   '@kbn/alerts',
+  '@kbn/analytics',
 ];
 
 type TypeSummarizerType = 'api-extractor' | 'type-summarizer';


### PR DESCRIPTION
Builds on top of https://github.com/elastic/kibana/pull/128200

Updates the `@kbn/analytics`, `@kbn/apm-config-loader` and `@kbn/apm-utils` packages to build sourceMaps for their `@types/*` packages so that "Go to definition" calls work:

![2022-03-21 12 50 37](https://user-images.githubusercontent.com/1329312/159352723-cecc0b6e-6d01-4e4e-ad65-bc28ba0c8e7f.gif)