### PR TITLE
[Workplace Search] Submit `base_service_type` field when creating a pre-configured custom source

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source_logic.test.ts
@@ -150,6 +150,31 @@ describe('AddCustomSourceLogic', () => {
           expect(setButtonNotLoadingSpy).toHaveBeenCalled();
         });
 
+        it('submits a base service type for pre-configured sources', () => {
+          mount(
+            {
+              customSourceNameValue: MOCK_NAME,
+            },
+            {
+              ...MOCK_PROPS,
+              sourceData: {
+                ...CUSTOM_SOURCE_DATA_ITEM,
+                serviceType: 'sharepoint-server',
+              },
+            }
+          );
+
+          AddCustomSourceLogic.actions.createContentSource();
+
+          expect(http.post).toHaveBeenCalledWith('/internal/workplace_search/org/create_source', {
+            body: JSON.stringify({
+              service_type: 'custom',
+              name: MOCK_NAME,
+              base_service_type: 'sharepoint-server',
+            }),
+          });
+        });
+
         itShowsServerErrorAsFlashMessage(http.post, () => {
           AddCustomSourceLogic.actions.createContentSource();
         });
@@ -169,6 +194,34 @@ describe('AddCustomSourceLogic', () => {
             '/internal/workplace_search/account/create_source',
             {
               body: JSON.stringify({ service_type: 'custom', name: MOCK_NAME }),
+            }
+          );
+        });
+
+        it('submits a base service type for pre-configured sources', () => {
+          mount(
+            {
+              customSourceNameValue: MOCK_NAME,
+            },
+            {
+              ...MOCK_PROPS,
+              sourceData: {
+                ...CUSTOM_SOURCE_DATA_ITEM,
+                serviceType: 'sharepoint-server',
+              },
+            }
+          );
+
+          AddCustomSourceLogic.actions.createContentSource();
+
+          expect(http.post).toHaveBeenCalledWith(
+            '/internal/workplace_search/account/create_source',
+            {
+              body: JSON.stringify({
+                service_type: 'custom',
+                name: MOCK_NAME,
+                base_service_type: 'sharepoint-server',
+              }),
             }
           );
         });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source_logic.ts
@@ -80,7 +80,7 @@ export const AddCustomSourceLogic = kea<
     ],
     sourceData: [props.sourceData],
   }),
-  listeners: ({ actions, values }) => ({
+  listeners: ({ actions, values, props }) => ({
     createContentSource: async () => {
       clearFlashMessages();
       const { isOrganization } = AppLogic.values;
@@ -90,14 +90,18 @@ export const AddCustomSourceLogic = kea<
 
       const { customSourceNameValue } = values;
 
-      const params = {
+      const params: Record<string, string> = {
         service_type: 'custom',
         name: customSourceNameValue,
       };
 
+      if (props.sourceData.serviceType !== 'custom') {
+        params.base_service_type = props.sourceData.serviceType;
+      }
+
       try {
         const response = await HttpLogic.values.http.post<CustomSource>(route, {
-          body: JSON.stringify({ ...params }),
+          body: JSON.stringify(params),
         });
         actions.setNewCustomSource(response);
       } catch (e) {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source_logic.ts
@@ -90,14 +90,20 @@ export const AddCustomSourceLogic = kea<
 
       const { customSourceNameValue } = values;
 
-      const params: Record<string, string> = {
+      const baseParams = {
         service_type: 'custom',
         name: customSourceNameValue,
       };
 
-      if (props.sourceData.serviceType !== 'custom') {
-        params.base_service_type = props.sourceData.serviceType;
-      }
+      // pre-configured custom sources have a serviceType reflecting their target service
+      // we submit this as `base_service_type` to keep track of
+      const params =
+        props.sourceData.serviceType === 'custom'
+          ? baseParams
+          : {
+              ...baseParams,
+              base_service_type: props.sourceData.serviceType,
+            };
 
       try {
         const response = await HttpLogic.values.http.post<CustomSource>(route, {

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -206,6 +206,7 @@ export function registerAccountCreateSourceRoute({
       validate: {
         body: schema.object({
           service_type: schema.string(),
+          base_service_type: schema.maybe(schema.string()),
           name: schema.maybe(schema.string()),
           login: schema.maybe(schema.string()),
           password: schema.maybe(schema.string()),
@@ -566,6 +567,7 @@ export function registerOrgCreateSourceRoute({
       validate: {
         body: schema.object({
           service_type: schema.string(),
+          base_service_type: schema.maybe(schema.string()),
           name: schema.maybe(schema.string()),
           login: schema.maybe(schema.string()),
           password: schema.maybe(schema.string()),


### PR DESCRIPTION
## Summary

This will used by Kibana UX in other views to conditional display relevant content to the user.

### QA

You'll need to be running branch `chenhui/add-custom-service-type` of `elastic/ent-search` to test this.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios