### PR TITLE
[ML] Data Frame Analytics: add analytics ID to url when using selector flyout

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/page.tsx
@@ -20,6 +20,7 @@ import { useMlKibana, useMlApiContext } from '../../../contexts/kibana';
 import { MlPageHeader } from '../../../components/page_header';
 import { AnalyticsIdSelector, AnalyticsSelectorIds } from '../components/analytics_selector';
 import { AnalyticsEmptyPrompt } from '../analytics_management/components/empty_prompt';
+import { useUrlState } from '../../../util/url_state';
 
 export const Page: FC<{
   jobId: string;
@@ -37,6 +38,8 @@ export const Page: FC<{
   const jobIdToUse = jobId ?? analyticsId?.job_id;
   const analysisTypeToUse = analysisType || analyticsId?.analysis_type;
 
+  const [ , setGlobalState] = useUrlState('_g');
+
   const checkJobsExist = async () => {
     try {
       const { count } = await getDataFrameAnalytics(undefined, undefined, 0);
@@ -50,6 +53,17 @@ export const Page: FC<{
   useEffect(function checkJobs() {
     checkJobsExist();
   }, []);
+
+  useEffect(function updateUrl() {
+    if (analyticsId !== undefined) {
+      setGlobalState({
+        ml: {
+          ...(analyticsId.analysis_type ? { analysisType: analyticsId. analysis_type } : {}),
+          ...(analyticsId.job_id ? { jobId: analyticsId.job_id } : {}),
+        },
+      });
+    }
+  }, [analyticsId?.job_id, analyticsId?.model_id]);
 
   const getEmptyState = () => {
     if (jobsExist === false) {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/page.tsx
@@ -38,7 +38,7 @@ export const Page: FC<{
   const jobIdToUse = jobId ?? analyticsId?.job_id;
   const analysisTypeToUse = analysisType || analyticsId?.analysis_type;
 
-  const [ , setGlobalState] = useUrlState('_g');
+  const [, setGlobalState] = useUrlState('_g');
 
   const checkJobsExist = async () => {
     try {
@@ -54,16 +54,19 @@ export const Page: FC<{
     checkJobsExist();
   }, []);
 
-  useEffect(function updateUrl() {
-    if (analyticsId !== undefined) {
-      setGlobalState({
-        ml: {
-          ...(analyticsId.analysis_type ? { analysisType: analyticsId. analysis_type } : {}),
-          ...(analyticsId.job_id ? { jobId: analyticsId.job_id } : {}),
-        },
-      });
-    }
-  }, [analyticsId?.job_id, analyticsId?.model_id]);
+  useEffect(
+    function updateUrl() {
+      if (analyticsId !== undefined) {
+        setGlobalState({
+          ml: {
+            ...(analyticsId.analysis_type ? { analysisType: analyticsId.analysis_type } : {}),
+            ...(analyticsId.job_id ? { jobId: analyticsId.job_id } : {}),
+          },
+        });
+      }
+    },
+    [analyticsId?.job_id, analyticsId?.model_id]
+  );
 
   const getEmptyState = () => {
     if (jobsExist === false) {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
@@ -190,11 +190,10 @@ export function AnalyticsIdSelector({ setAnalyticsId, jobsOnly = false }: Props)
 
   const selectionValue = {
     selectable: (item: TableItem) => {
-      const selectedId = selected?.job_id ?? selected?.model_id;
       const isDFA = isDataFrameAnalyticsConfigs(item);
       const itemId = isDFA ? item.id : item.model_id;
       const isBuiltInModel = isDFA ? false : item.tags.includes(BUILT_IN_MODEL_TAG);
-      return (selected === undefined || selectedId === itemId) && !isBuiltInModel;
+      return (selected === undefined || selected?.job_id === itemId || selected?.model_id === itemId) && !isBuiltInModel;
     },
     onSelectionChange: (selectedItem: TableItem[]) => {
       const item = selectedItem[0];

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
@@ -193,7 +193,10 @@ export function AnalyticsIdSelector({ setAnalyticsId, jobsOnly = false }: Props)
       const isDFA = isDataFrameAnalyticsConfigs(item);
       const itemId = isDFA ? item.id : item.model_id;
       const isBuiltInModel = isDFA ? false : item.tags.includes(BUILT_IN_MODEL_TAG);
-      return (selected === undefined || selected?.job_id === itemId || selected?.model_id === itemId) && !isBuiltInModel;
+      return (
+        (selected === undefined || selected?.job_id === itemId || selected?.model_id === itemId) &&
+        !isBuiltInModel
+      );
     },
     onSelectionChange: (selectedItem: TableItem[]) => {
       const item = selectedItem[0];

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
@@ -208,7 +208,7 @@ export function AnalyticsIdSelector({ setAnalyticsId, jobsOnly = false }: Props)
 
       setSelected({
         model_id: isDFA ? undefined : item.model_id,
-        job_id: isDFA ? item.id : undefined,
+        job_id: isDFA ? item.id : item.metadata?.analytics_config.id,
         analysis_type: analysisType,
       });
     },

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -22,7 +22,7 @@ import { AnalyticsIdSelector, AnalyticsSelectorIds } from '../components/analyti
 import { AnalyticsEmptyPrompt } from '../analytics_management/components/empty_prompt';
 
 export const Page: FC = () => {
-  const [globalState] = useUrlState('_g');
+  const [globalState, setGlobalState] = useUrlState('_g');
   const [isLoading, setIsLoading] = useState(false);
   const [jobsExist, setJobsExist] = useState(true);
   const { refresh } = useRefreshAnalyticsList({ isLoading: setIsLoading });
@@ -50,6 +50,17 @@ export const Page: FC = () => {
   useEffect(function checkJobs() {
     checkJobsExist();
   }, []);
+
+  useEffect(function updateUrl() {
+    if (analyticsId !== undefined) {
+      setGlobalState({
+        ml: {
+          ...(analyticsId.job_id && !analyticsId.model_id ? { jobId: analyticsId.job_id } : {}),
+          ...(analyticsId.model_id ? { modelId: analyticsId.model_id } : {}),
+        },
+      });
+    }
+  }, [analyticsId?.job_id, analyticsId?.model_id]);
 
   const getEmptyState = () => {
     if (jobsExist === false) {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -51,16 +51,19 @@ export const Page: FC = () => {
     checkJobsExist();
   }, []);
 
-  useEffect(function updateUrl() {
-    if (analyticsId !== undefined) {
-      setGlobalState({
-        ml: {
-          ...(analyticsId.job_id && !analyticsId.model_id ? { jobId: analyticsId.job_id } : {}),
-          ...(analyticsId.model_id ? { modelId: analyticsId.model_id } : {}),
-        },
-      });
-    }
-  }, [analyticsId?.job_id, analyticsId?.model_id]);
+  useEffect(
+    function updateUrl() {
+      if (analyticsId !== undefined) {
+        setGlobalState({
+          ml: {
+            ...(analyticsId.job_id && !analyticsId.model_id ? { jobId: analyticsId.job_id } : {}),
+            ...(analyticsId.model_id ? { modelId: analyticsId.model_id } : {}),
+          },
+        });
+      }
+    },
+    [analyticsId?.job_id, analyticsId?.model_id]
+  );
 
   const getEmptyState = () => {
     if (jobsExist === false) {


### PR DESCRIPTION
## Summary

When using the DFA job selector flyout - ensure url is updated with the selected analytics ID so that the url is shareable.
This PR also fixes the model id selection for the explorer.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))



