### PR TITLE
[7.17] [CCR] Remove `axios` dependency in tests (#128148)

### DIFF
--- a/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/auto_follow_pattern_add.test.js
+++ b/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/auto_follow_pattern_add.test.js
@@ -12,15 +12,10 @@ import { setupEnvironment, pageHelpers, nextTick, getRandomString } from './help
 const { setup } = pageHelpers.autoFollowPatternAdd;
 
 describe('Create Auto-follow pattern', () => {
-  let server;
   let httpRequestsMockHelpers;
 
   beforeAll(() => {
-    ({ server, httpRequestsMockHelpers } = setupEnvironment());
-  });
-
-  afterAll(() => {
-    server.restore();
+    ({ httpRequestsMockHelpers } = setupEnvironment());
   });
 
   beforeEach(() => {

--- a/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/auto_follow_pattern_edit.test.js
+++ b/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/auto_follow_pattern_edit.test.js
@@ -8,21 +8,16 @@
 import { AutoFollowPatternForm } from '../../app/components/auto_follow_pattern_form';
 import './mocks';
 import { setupEnvironment, pageHelpers, nextTick } from './helpers';
-import { AUTO_FOLLOW_PATTERN_EDIT } from './helpers/constants';
+import { AUTO_FOLLOW_PATTERN_EDIT, AUTO_FOLLOW_PATTERN_EDIT_NAME } from './helpers/constants';
 
 const { setup } = pageHelpers.autoFollowPatternEdit;
 const { setup: setupAutoFollowPatternAdd } = pageHelpers.autoFollowPatternAdd;
 
 describe('Edit Auto-follow pattern', () => {
-  let server;
   let httpRequestsMockHelpers;
 
   beforeAll(() => {
-    ({ server, httpRequestsMockHelpers } = setupEnvironment());
-  });
-
-  afterAll(() => {
-    server.restore();
+    ({ httpRequestsMockHelpers } = setupEnvironment());
   });
 
   describe('on component mount', () => {
@@ -36,7 +31,10 @@ describe('Edit Auto-follow pattern', () => {
 
     beforeEach(async () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse(remoteClusters);
-      httpRequestsMockHelpers.setGetAutoFollowPatternResponse(AUTO_FOLLOW_PATTERN_EDIT);
+      httpRequestsMockHelpers.setGetAutoFollowPatternResponse(
+        AUTO_FOLLOW_PATTERN_EDIT_NAME,
+        AUTO_FOLLOW_PATTERN_EDIT
+      );
       ({ component, find } = setup());
 
       await nextTick();
@@ -83,7 +81,10 @@ describe('Edit Auto-follow pattern', () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse([
         { name: 'cluster-2', seeds: ['localhost:123'], isConnected: false },
       ]);
-      httpRequestsMockHelpers.setGetAutoFollowPatternResponse(AUTO_FOLLOW_PATTERN_EDIT);
+      httpRequestsMockHelpers.setGetAutoFollowPatternResponse(
+        AUTO_FOLLOW_PATTERN_EDIT_NAME,
+        AUTO_FOLLOW_PATTERN_EDIT
+      );
       ({ component, find, exists, actions, form } = setup());
 
       await nextTick();

--- a/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/auto_follow_pattern_list.test.js
+++ b/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/auto_follow_pattern_list.test.js
@@ -12,15 +12,10 @@ import { setupEnvironment, pageHelpers, nextTick, delay, getRandomString } from 
 const { setup } = pageHelpers.autoFollowPatternList;
 
 describe('<AutoFollowPatternList />', () => {
-  let server;
   let httpRequestsMockHelpers;
 
   beforeAll(() => {
-    ({ server, httpRequestsMockHelpers } = setupEnvironment());
-  });
-
-  afterAll(() => {
-    server.restore();
+    ({ httpRequestsMockHelpers } = setupEnvironment());
   });
 
   beforeEach(() => {
@@ -213,7 +208,7 @@ describe('<AutoFollowPatternList />', () => {
         expect(rows.length).toBe(2);
 
         // We wil delete the *first* auto-follow pattern in the table
-        httpRequestsMockHelpers.setDeleteAutoFollowPatternResponse({
+        httpRequestsMockHelpers.setDeleteAutoFollowPatternResponse(autoFollowPattern1.name, {
           itemsDeleted: [autoFollowPattern1.name],
         });
 

--- a/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/follower_index_add.test.js
+++ b/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/follower_index_add.test.js
@@ -14,15 +14,13 @@ const { setup } = pageHelpers.followerIndexAdd;
 const { setup: setupAutoFollowPatternAdd } = pageHelpers.autoFollowPatternAdd;
 
 describe('Create Follower index', () => {
-  let server;
+  let httpSetup;
   let httpRequestsMockHelpers;
 
   beforeAll(() => {
-    ({ server, httpRequestsMockHelpers } = setupEnvironment());
-  });
-
-  afterAll(() => {
-    server.restore();
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   beforeEach(() => {
@@ -165,15 +163,12 @@ describe('Create Follower index', () => {
         test('should make a request to check if the index name is available in ES', async () => {
           httpRequestsMockHelpers.setGetClusterIndicesResponse([]);
 
-          // Keep track of the request count made until this point
-          const totalRequests = server.requests.length;
-
           form.setInputValue('followerIndexInput', 'index-name');
           await delay(550); // we need to wait as there is a debounce of 500ms on the http validation
 
-          expect(server.requests.length).toBe(totalRequests + 1);
-          expect(server.requests[server.requests.length - 1].url).toBe(
-            '/api/index_management/indices'
+          expect(httpSetup.get).toHaveBeenLastCalledWith(
+            `/api/index_management/indices`,
+            expect.anything()
           );
         });
 

--- a/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/follower_index_edit.test.js
+++ b/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/follower_index_edit.test.js
@@ -9,22 +9,20 @@ import { act } from 'react-dom/test-utils';
 import { API_BASE_PATH } from '../../../common/constants';
 import { FollowerIndexForm } from '../../app/components/follower_index_form/follower_index_form';
 import './mocks';
-import { FOLLOWER_INDEX_EDIT } from './helpers/constants';
+import { FOLLOWER_INDEX_EDIT, FOLLOWER_INDEX_EDIT_NAME } from './helpers/constants';
 import { setupEnvironment, pageHelpers, nextTick } from './helpers';
 
 const { setup } = pageHelpers.followerIndexEdit;
 const { setup: setupFollowerIndexAdd } = pageHelpers.followerIndexAdd;
 
 describe('Edit follower index', () => {
-  let server;
+  let httpSetup;
   let httpRequestsMockHelpers;
 
   beforeAll(() => {
-    ({ server, httpRequestsMockHelpers } = setupEnvironment());
-  });
-
-  afterAll(() => {
-    server.restore();
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   describe('on component mount', () => {
@@ -35,7 +33,10 @@ describe('Edit follower index', () => {
 
     beforeEach(async () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse(remoteClusters);
-      httpRequestsMockHelpers.setGetFollowerIndexResponse(FOLLOWER_INDEX_EDIT);
+      httpRequestsMockHelpers.setGetFollowerIndexResponse(
+        FOLLOWER_INDEX_EDIT_NAME,
+        FOLLOWER_INDEX_EDIT
+      );
       ({ component, find } = setup());
 
       await nextTick();
@@ -97,7 +98,10 @@ describe('Edit follower index', () => {
 
     beforeEach(async () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse(remoteClusters);
-      httpRequestsMockHelpers.setGetFollowerIndexResponse(FOLLOWER_INDEX_EDIT);
+      httpRequestsMockHelpers.setGetFollowerIndexResponse(
+        FOLLOWER_INDEX_EDIT_NAME,
+        FOLLOWER_INDEX_EDIT
+      );
 
       await act(async () => {
         testBed = await setup();
@@ -117,26 +121,23 @@ describe('Edit follower index', () => {
 
       await nextTick(); // Make sure the Request went through
 
-      const latestRequest = server.requests[server.requests.length - 1];
-      const requestBody = JSON.parse(JSON.parse(latestRequest.requestBody).body);
-
-      // Verify the API endpoint called: method, path and payload
-      expect(latestRequest.method).toBe('PUT');
-      expect(latestRequest.url).toBe(
-        `${API_BASE_PATH}/follower_indices/${FOLLOWER_INDEX_EDIT.name}`
+      expect(httpSetup.put).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/follower_indices/${FOLLOWER_INDEX_EDIT_NAME}`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            maxReadRequestOperationCount: 7845,
+            maxOutstandingReadRequests: 16,
+            maxReadRequestSize: '64mb',
+            maxWriteRequestOperationCount: 2456,
+            maxWriteRequestSize: '1048b',
+            maxOutstandingWriteRequests: 69,
+            maxWriteBufferCount: 123456,
+            maxWriteBufferSize: '256mb',
+            maxRetryDelay: '10s',
+            readPollTimeout: '2m',
+          }),
+        })
       );
-      expect(requestBody).toEqual({
-        maxReadRequestOperationCount: 7845,
-        maxOutstandingReadRequests: 16,
-        maxReadRequestSize: '64mb',
-        maxWriteRequestOperationCount: 2456,
-        maxWriteRequestSize: '1048b',
-        maxOutstandingWriteRequests: 69,
-        maxWriteBufferCount: 123456,
-        maxWriteBufferSize: '256mb',
-        maxRetryDelay: '10s',
-        readPollTimeout: '2m',
-      });
     });
   });
 
@@ -151,7 +152,10 @@ describe('Edit follower index', () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse([
         { name: 'new-york', seeds: ['localhost:123'], isConnected: false },
       ]);
-      httpRequestsMockHelpers.setGetFollowerIndexResponse(FOLLOWER_INDEX_EDIT);
+      httpRequestsMockHelpers.setGetFollowerIndexResponse(
+        FOLLOWER_INDEX_EDIT_NAME,
+        FOLLOWER_INDEX_EDIT
+      );
       ({ component, find, exists, actions, form } = setup());
 
       await nextTick();

--- a/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/follower_indices_list.test.js
+++ b/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/follower_indices_list.test.js
@@ -21,17 +21,15 @@ import { setupEnvironment, pageHelpers, getRandomString } from './helpers';
 const { setup } = pageHelpers.followerIndexList;
 
 describe('<FollowerIndicesList />', () => {
-  let server;
   let httpRequestsMockHelpers;
 
   beforeAll(() => {
     jest.useFakeTimers();
-    ({ server, httpRequestsMockHelpers } = setupEnvironment());
+    ({ httpRequestsMockHelpers } = setupEnvironment());
   });
 
   afterAll(() => {
     jest.useRealTimers();
-    server.restore();
   });
 
   beforeEach(() => {

--- a/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/helpers/http_requests.js
+++ b/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/helpers/http_requests.js
@@ -5,111 +5,63 @@
  * 2.0.
  */
 
-import { fakeServer } from 'sinon';
+import { httpServiceMock } from '../../../../../../../src/core/public/mocks';
+import { API_BASE_PATH } from '../../../../common/constants';
 
 // Register helpers to mock HTTP Requests
-const registerHttpRequestMockHelpers = (server) => {
-  const mockResponse = (defaultResponse, response) => [
-    200,
-    { 'Content-Type': 'application/json' },
-    JSON.stringify({ ...defaultResponse, ...response }),
-  ];
+const registerHttpRequestMockHelpers = (httpSetup) => {
+  const mockResponses = new Map(
+    ['GET', 'PUT', 'DELETE', 'POST'].map((method) => [method, new Map()])
+  );
 
-  const setLoadFollowerIndicesResponse = (response) => {
-    const defaultResponse = { indices: [] };
-
-    server.respondWith(
-      'GET',
-      '/api/cross_cluster_replication/follower_indices',
-      mockResponse(defaultResponse, response)
-    );
+  const mockMethodImplementation = (method, path) => {
+    return mockResponses.get(method)?.get(path) ?? Promise.resolve({});
   };
 
-  const setLoadAutoFollowPatternsResponse = (response) => {
-    const defaultResponse = { patterns: [] };
+  httpSetup.get.mockImplementation((path) => mockMethodImplementation('GET', path));
+  httpSetup.delete.mockImplementation((path) => mockMethodImplementation('DELETE', path));
+  httpSetup.post.mockImplementation((path) => mockMethodImplementation('POST', path));
+  httpSetup.put.mockImplementation((path) => mockMethodImplementation('PUT', path));
 
-    server.respondWith(
-      'GET',
-      '/api/cross_cluster_replication/auto_follow_patterns',
-      mockResponse(defaultResponse, response)
-    );
-  };
-
-  const setDeleteAutoFollowPatternResponse = (response) => {
-    const defaultResponse = { errors: [], itemsDeleted: [] };
-
-    server.respondWith(
-      'DELETE',
-      /\/api\/cross_cluster_replication\/auto_follow_patterns/,
-      mockResponse(defaultResponse, response)
-    );
-  };
-
-  const setAutoFollowStatsResponse = (response) => {
-    const defaultResponse = {
-      numberOfFailedFollowIndices: 0,
-      numberOfFailedRemoteClusterStateRequests: 0,
-      numberOfSuccessfulFollowIndices: 0,
-      recentAutoFollowErrors: [],
-      autoFollowedClusters: [
-        {
-          clusterName: 'new-york',
-          timeSinceLastCheckMillis: 13746,
-          lastSeenMetadataVersion: 22,
-        },
-      ],
+  const mockResponse = (method, path, response, error) => {
+    const defuse = (promise) => {
+      promise.catch(() => {});
+      return promise;
     };
 
-    server.respondWith(
-      'GET',
-      '/api/cross_cluster_replication/stats/auto_follow',
-      mockResponse(defaultResponse, response)
+    return mockResponses
+      .get(method)
+      .set(path, error ? defuse(Promise.reject({ body: error })) : Promise.resolve(response));
+  };
+
+  const setLoadFollowerIndicesResponse = (response = { indices: [] }, error) =>
+    mockResponse('GET', `${API_BASE_PATH}/follower_indices`, response, error);
+
+  const setLoadAutoFollowPatternsResponse = (response = { patterns: [] }, error) =>
+    mockResponse('GET', `${API_BASE_PATH}/auto_follow_patterns`, response, error);
+
+  const setDeleteAutoFollowPatternResponse = (autoFollowId, response, error) =>
+    mockResponse(
+      'DELETE',
+      `${API_BASE_PATH}/auto_follow_patterns/${autoFollowId}`,
+      response,
+      error
     );
-  };
 
-  const setLoadRemoteClustersResponse = (response = [], error) => {
-    if (error) {
-      server.respondWith('GET', '/api/remote_clusters', [
-        error.status || 400,
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(error.body),
-      ]);
-    } else {
-      server.respondWith('GET', '/api/remote_clusters', [
-        200,
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(response),
-      ]);
-    }
-  };
+  const setAutoFollowStatsResponse = (response, error) =>
+    mockResponse('GET', `${API_BASE_PATH}/stats/auto_follow`, response, error);
 
-  const setGetAutoFollowPatternResponse = (response) => {
-    const defaultResponse = {};
+  const setLoadRemoteClustersResponse = (response = [], error) =>
+    mockResponse('GET', '/api/remote_clusters', response, error);
 
-    server.respondWith(
-      'GET',
-      /\/api\/cross_cluster_replication\/auto_follow_patterns\/.+/,
-      mockResponse(defaultResponse, response)
-    );
-  };
+  const setGetAutoFollowPatternResponse = (patternId, response = {}, error) =>
+    mockResponse('GET', `${API_BASE_PATH}/auto_follow_patterns/${patternId}`, response, error);
 
-  const setGetClusterIndicesResponse = (response = []) => {
-    server.respondWith('GET', '/api/index_management/indices', [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(response),
-    ]);
-  };
+  const setGetClusterIndicesResponse = (response = [], error) =>
+    mockResponse('GET', '/api/index_management/indices', response, error);
 
-  const setGetFollowerIndexResponse = (response) => {
-    const defaultResponse = {};
-
-    server.respondWith(
-      'GET',
-      /\/api\/cross_cluster_replication\/follower_indices\/.+/,
-      mockResponse(defaultResponse, response)
-    );
-  };
+  const setGetFollowerIndexResponse = (patternId, response = {}, error) =>
+    mockResponse('GET', `${API_BASE_PATH}/follower_indices/${patternId}`, response, error);
 
   return {
     setLoadFollowerIndicesResponse,
@@ -124,15 +76,10 @@ const registerHttpRequestMockHelpers = (server) => {
 };
 
 export const init = () => {
-  const server = fakeServer.create();
-  server.respondImmediately = true;
-
-  // We make requests to APIs which don't impact the UX, e.g. UI metric telemetry,
-  // and we can mock them all with a 200 instead of mocking each one individually.
-  server.respondWith([200, {}, '']);
+  const httpSetup = httpServiceMock.createSetupContract();
 
   return {
-    server,
-    httpRequestsMockHelpers: registerHttpRequestMockHelpers(server),
+    httpSetup,
+    httpRequestsMockHelpers: registerHttpRequestMockHelpers(httpSetup),
   };
 };

--- a/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/helpers/setup_environment.js
+++ b/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/helpers/setup_environment.js
@@ -5,26 +5,16 @@
  * 2.0.
  */
 
-import axios from 'axios';
-import axiosXhrAdapter from 'axios/lib/adapters/xhr';
-
 import { docLinksServiceMock } from '../../../../../../../src/core/public/mocks';
-import { setHttpClient } from '../../../app/services/api';
 import { init as initDocumentation } from '../../../app/services/documentation_links';
 import { init as initHttpRequests } from './http_requests';
+import { setHttpClient } from '../../../app/services/api';
 
 export const setupEnvironment = () => {
-  // axios has a similar interface to HttpSetup, but we
-  // flatten out the response.
-  const client = axios.create({ adapter: axiosXhrAdapter });
-  client.interceptors.response.use(({ data }) => data);
-  setHttpClient(client);
+  const httpRequests = initHttpRequests();
+
+  setHttpClient(httpRequests.httpSetup);
   initDocumentation(docLinksServiceMock.createStartContract());
 
-  const { server, httpRequestsMockHelpers } = initHttpRequests();
-
-  return {
-    server,
-    httpRequestsMockHelpers,
-  };
+  return httpRequests;
 };

--- a/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/home.test.js
+++ b/x-pack/plugins/cross_cluster_replication/public/__jest__/client_integration/home.test.js
@@ -11,18 +11,13 @@ import { setupEnvironment, pageHelpers, nextTick } from './helpers';
 const { setup } = pageHelpers.home;
 
 describe('<CrossClusterReplicationHome />', () => {
-  let server;
   let httpRequestsMockHelpers;
   let find;
   let exists;
   let component;
 
   beforeAll(() => {
-    ({ server, httpRequestsMockHelpers } = setupEnvironment());
-  });
-
-  afterAll(() => {
-    server.restore();
+    ({ httpRequestsMockHelpers } = setupEnvironment());
   });
 
   beforeEach(() => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[CCR] Remove `axios` dependency in tests (#128148)](https://github.com/elastic/kibana/pull/128148)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)