### PR TITLE
[APM] Service groups: Minor UI polish changes

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_groups/service_group_save/group_details.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_groups/service_group_save/group_details.tsx
@@ -141,7 +141,7 @@ export function GroupDetails({
                 { defaultMessage: 'Description' }
               )}
               labelAppend={
-                <EuiText size="s" color="subdued">
+                <EuiText size="xs" color="subdued">
                   {i18n.translate(
                     'xpack.apm.serviceGroups.groupDetailsForm.description.optional',
                     { defaultMessage: 'Optional' }

--- a/x-pack/plugins/apm/public/components/routing/templates/service_group_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/service_group_template.tsx
@@ -69,9 +69,10 @@ export function ServiceGroupTemplate({
   const serviceGroupsPageTitle = (
     <EuiFlexGroup
       direction="row"
-      gutterSize="s"
+      gutterSize="m"
       alignItems="center"
       justifyContent="flexStart"
+      responsive={false}
     >
       <EuiFlexItem grow={false}>
         <EuiButtonIcon


### PR DESCRIPTION
## Summary

Some minor UI polish changes

- [x] Changed the guttersize of the page header title and service groups icon

**Before**
<img width="299" alt="CleanShot 2022-03-22 at 09 48 10@2x" src="https://user-images.githubusercontent.com/4104278/159442290-0a1117d2-ce2a-45b2-95a6-93b33e6b261c.png">

**After**
<img width="297" alt="CleanShot 2022-03-22 at 09 48 23@2x" src="https://user-images.githubusercontent.com/4104278/159442305-97e8f4ac-ce2d-4ce7-bf32-10d00b3c563a.png">

- [x] Changed the optional text size in the service group details modal form

**Before**

<img width="300" src="https://user-images.githubusercontent.com/4104278/159442508-fe981fbb-3008-4877-815e-5d03bbd036ff.png" />

**After**

<img width="300" src="https://user-images.githubusercontent.com/4104278/159442529-2af3bfa9-c230-43d5-b03b-8e2f1276f76e.png" />

