### PR TITLE
[ML] Fixes anomaly detection get_filter endpoint when calling with an unknown ID

### DIFF
--- a/x-pack/test/api_integration/apis/ml/filters/create_filters.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/create_filters.ts
@@ -92,8 +92,7 @@ export default ({ getService }: FtrProviderContext) => {
     },
   ];
 
-  // Failing: See https://github.com/elastic/kibana/issues/126642
-  describe.skip('create_filters', function () {
+  describe('create_filters', function () {
     before(async () => {
       await ml.testResources.setKibanaTimeZoneToUTC();
     });

--- a/x-pack/test/api_integration/apis/ml/filters/get_filters.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/get_filters.ts
@@ -26,8 +26,7 @@ export default ({ getService }: FtrProviderContext) => {
     },
   ];
 
-  // FLAKY: https://github.com/elastic/kibana/issues/126870
-  describe.skip('get_filters', function () {
+  describe('get_filters', function () {
     before(async () => {
       await ml.testResources.setKibanaTimeZoneToUTC();
       for (const filter of validFilters) {

--- a/x-pack/test/api_integration/apis/ml/filters/update_filters.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/update_filters.ts
@@ -31,8 +31,7 @@ export default ({ getService }: FtrProviderContext) => {
     },
   ];
 
-  // FLAKY: https://github.com/elastic/kibana/issues/127678
-  describe.skip('update_filters', function () {
+  describe('update_filters', function () {
     const updateFilterRequestBody = {
       description: 'Updated filter #1',
       removeItems: items,


### PR DESCRIPTION
Sometimes the get filter endpoint will throw a `Maximum call stack size exceeded` error when calling it with an unknown ID. This is flaky and not always reproducible.

Removing the `getFilters` es client call from the `Promise.all` seems to fix the problem.

Relates to https://github.com/elastic/kibana/issues/126870 and https://github.com/elastic/kibana/issues/126642

Note, all of the functions in this file need rewriting. We should not be wrapping every error in a `Boom.badRequest`.
I'm leaving this incorrect behaviour in for now, so this PR focuses on the 500 fix and doesn't change the expected errors thrown from the endpoint.

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
