### PR TITLE
[cft] Reuse elasticsearch snapshot on upgrade

### DIFF
--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -75,7 +75,6 @@ if [ -z "${CLOUD_DEPLOYMENT_ID}" ]; then
 else
 ecctl deployment show "$CLOUD_DEPLOYMENT_ID" --generate-update-payload | jq '
   .resources.kibana[0].plan.kibana.docker_image = "'$CLOUD_IMAGE'" |
-  .resources.elasticsearch[0].plan.elasticsearch.docker_image = "'$ELASTICSEARCH_CLOUD_IMAGE'" |
   (.. | select(.version? != null).version) = "'$VERSION'"
   ' > /tmp/deploy.json
   ecctl deployment update "$CLOUD_DEPLOYMENT_ID" --track --output json --file /tmp/deploy.json &> "$JSON_FILE"


### PR DESCRIPTION
Same-version elasticsearch snapshot upgrades have been causing deployments
to become unhealthy.  For now, lets reuse the original snapshot while we
look for a workaround.