### PR TITLE
[Workplace Search] Add feedback link to pages with external source

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
@@ -134,7 +134,23 @@ describe('AddSourceList', () => {
       addSourceCurrentStep: AddSourceSteps.ConfigCompletedStep,
     });
     const wrapper = shallow(<AddSource sourceData={staticSourceData[1]} />);
+    expect(wrapper.find(ConfigCompleted).prop('showFeedbackLink')).toEqual(false);
     wrapper.find(ConfigCompleted).prop('advanceStep')();
+
+    expect(navigateToUrl).toHaveBeenCalledWith('/sources/add/confluence_cloud/connect');
+    expect(setAddSourceStep).toHaveBeenCalledWith(AddSourceSteps.ConnectInstanceStep);
+  });
+
+  it('renders Config Completed step with feedback for external connectors', () => {
+    setMockValues({
+      ...mockValues,
+      sourceConfigData: { ...sourceConfigData, serviceType: 'external' },
+      addSourceCurrentStep: AddSourceSteps.ConfigCompletedStep,
+    });
+    const wrapper = shallow(
+      <AddSource sourceData={{ ...staticSourceData[1], serviceType: 'external' }} />
+    );
+    expect(wrapper.find(ConfigCompleted).prop('showFeedbackLink')).toEqual(true);
 
     expect(navigateToUrl).toHaveBeenCalledWith('/sources/add/confluence_cloud/connect');
     expect(setAddSourceStep).toHaveBeenCalledWith(AddSourceSteps.ConnectInstanceStep);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -109,6 +109,7 @@ export const AddSource: React.FC<AddSourceProps> = (props) => {
           advanceStep={goToConnectInstance}
           privateSourcesEnabled={privateSourcesEnabled}
           header={header}
+          showFeedbackLink={serviceType === 'external'}
         />
       )}
       {addSourceCurrentStep === AddSourceSteps.ConnectInstanceStep && (

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_completed.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_completed.test.tsx
@@ -9,6 +9,8 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
+import { EuiCallOut } from '@elastic/eui';
+
 import { ConfigCompleted } from './config_completed';
 
 describe('ConfigCompleted', () => {
@@ -26,6 +28,7 @@ describe('ConfigCompleted', () => {
 
     expect(wrapper.find('[data-test-subj="OrgCanConnectMessage"]')).toHaveLength(1);
     expect(wrapper.find('[data-test-subj="PersonalConnectLinkMessage"]')).toHaveLength(0);
+    expect(wrapper.find(EuiCallOut)).toHaveLength(0);
   });
 
   it('renders account context', () => {
@@ -44,5 +47,9 @@ describe('ConfigCompleted', () => {
     );
 
     expect(wrapper.find('[data-test-subj="PrivateDisabledMessage"]')).toHaveLength(1);
+  });
+  it('renders feedback callout when set', () => {
+    const wrapper = shallow(<ConfigCompleted {...{ ...props, showFeedbackLink: true }} />);
+    expect(wrapper.find(EuiCallOut)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_completed.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_completed.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import {
   EuiButton,
+  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
@@ -37,6 +38,7 @@ interface ConfigCompletedProps {
   accountContextOnly?: boolean;
   privateSourcesEnabled: boolean;
   advanceStep(): void;
+  showFeedbackLink?: boolean;
 }
 
 export const ConfigCompleted: React.FC<ConfigCompletedProps> = ({
@@ -45,6 +47,7 @@ export const ConfigCompleted: React.FC<ConfigCompletedProps> = ({
   accountContextOnly,
   header,
   privateSourcesEnabled,
+  showFeedbackLink,
 }) => (
   <>
     {header}
@@ -166,5 +169,31 @@ export const ConfigCompleted: React.FC<ConfigCompletedProps> = ({
         )}
       </EuiFlexGroup>
     </EuiPanel>
+    {showFeedbackLink && (
+      <>
+        <EuiSpacer />
+        <EuiFlexGroup justifyContent="center">
+          <EuiFlexItem grow={false}>
+            <EuiCallOut
+              size="s"
+              color="primary"
+              iconType="email"
+              title={
+                <EuiLink href="https://www.elastic.co/kibana/feedback" external>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.workplaceSearch.contentSource.addSource.configCompleted.feedbackCallOutText',
+                    {
+                      defaultMessage:
+                        'Have feedback about deploying a {name} Connector Package? Let us know.',
+                      values: { name },
+                    }
+                  )}
+                </EuiLink>
+              }
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </>
+    )}
   </>
 );

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.test.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiConfirmModal, EuiEmptyPrompt, EuiPanel, EuiTable } from '@elastic/eui';
+import { EuiCallOut, EuiConfirmModal, EuiEmptyPrompt, EuiPanel, EuiTable } from '@elastic/eui';
 
 import { ComponentLoader } from '../../../components/shared/component_loader';
 
@@ -119,6 +119,22 @@ describe('Overview', () => {
     const wrapper = shallow(<Overview />);
 
     expect(wrapper.find('[data-test-subj="DocumentPermissionsDisabled"]')).toHaveLength(1);
+  });
+
+  it('renders feedback callout for external sources', () => {
+    setMockValues({
+      ...mockValues,
+      contentSource: {
+        ...fullContentSources[1],
+        serviceTypeSupportsPermissions: true,
+        custom: false,
+        serviceType: 'external',
+      },
+    });
+
+    const wrapper = shallow(<Overview />);
+
+    expect(wrapper.find(EuiCallOut)).toHaveLength(1);
   });
 
   it('handles confirmModal submission', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -29,7 +29,9 @@ import {
   EuiText,
   EuiTextColor,
   EuiTitle,
+  EuiCallOut,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { CANCEL_BUTTON_LABEL, START_BUTTON_LABEL } from '../../../../shared/constants';
@@ -107,6 +109,8 @@ export const Overview: React.FC = () => {
     hasPermissions,
     isFederatedSource,
     isIndexedSource,
+    serviceType,
+    name,
   } = contentSource;
 
   const [isSyncing, setIsSyncing] = useState(false);
@@ -582,6 +586,32 @@ export const Overview: React.FC = () => {
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
+      {serviceType === 'external' && (
+        <>
+          <EuiSpacer />
+          <EuiFlexGroup justifyContent="center">
+            <EuiFlexItem grow={false}>
+              <EuiCallOut
+                size="s"
+                color="primary"
+                iconType="email"
+                title={
+                  <EuiLink href="https://www.elastic.co/kibana/feedback" external>
+                    {i18n.translate(
+                      'xpack.enterpriseSearch.workplaceSearch.sources.feedbackCallOutText',
+                      {
+                        defaultMessage:
+                          'Have feedback about deploying a {name} Connector Package? Let us know.',
+                        values: { name },
+                      }
+                    )}
+                  </EuiLink>
+                }
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
+      )}
     </SourceLayout>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/source_config.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/source_config.test.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiConfirmModal } from '@elastic/eui';
+import { EuiCallOut, EuiConfirmModal } from '@elastic/eui';
 
 import { SaveConfig } from '../../content_sources/components/add_source/save_config';
 
@@ -40,6 +40,7 @@ describe('SourceConfig', () => {
     saveConfig.prop('onDeleteConfig')!();
 
     expect(wrapper.find(EuiConfirmModal)).toHaveLength(1);
+    expect(wrapper.find(EuiCallOut)).toHaveLength(0);
   });
 
   it('renders a breadcrumb fallback while data is loading', () => {
@@ -83,5 +84,12 @@ describe('SourceConfig', () => {
     wrapper.find(EuiConfirmModal).prop('onCancel')!({} as any);
 
     expect(wrapper.find(EuiConfirmModal)).toHaveLength(0);
+  });
+
+  it('shows feedback link for external sources', () => {
+    const wrapper = shallow(
+      <SourceConfig sourceData={{ ...staticSourceData[1], serviceType: 'external' }} />
+    );
+    expect(wrapper.find(EuiCallOut)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/source_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/source_config.tsx
@@ -9,7 +9,14 @@ import React, { useEffect, useState } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiConfirmModal } from '@elastic/eui';
+import {
+  EuiCallOut,
+  EuiConfirmModal,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiSpacer,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { WorkplaceSearchPageTemplate } from '../../../components/layout';
@@ -76,6 +83,32 @@ export const SourceConfig: React.FC<SourceConfigProps> = ({ sourceData }) => {
             }
           )}
         </EuiConfirmModal>
+      )}
+      {serviceType === 'external' && (
+        <>
+          <EuiSpacer />
+          <EuiFlexGroup justifyContent="center">
+            <EuiFlexItem grow={false}>
+              <EuiCallOut
+                size="s"
+                color="primary"
+                iconType="email"
+                title={
+                  <EuiLink href="https://www.elastic.co/kibana/feedback" external>
+                    {i18n.translate(
+                      'xpack.enterpriseSearch.workplaceSearch.settings.feedbackCallOutText',
+                      {
+                        defaultMessage:
+                          'Have feedback about deploying a {name} Connector Package? Let us know.',
+                        values: { name },
+                      }
+                    )}
+                  </EuiLink>
+                }
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
       )}
     </WorkplaceSearchPageTemplate>
   );


### PR DESCRIPTION
## Summary
Adding a feedback link to guide users to the Kibana feedback form in case they have something to say on our new external connectors.
<img width="1191" alt="Screenshot 2022-03-22 at 14 55 36" src="https://user-images.githubusercontent.com/94373878/159529703-0b03f5ab-f0e8-4cea-a6e2-75b7009d5dcf.png">
<img width="1360" alt="Screenshot 2022-03-22 at 14 53 53" src="https://user-images.githubusercontent.com/94373878/159529717-2353f31e-58ce-4834-8924-895ad23a2bba.png">
<img width="1427" alt="Screenshot 2022-03-22 at 17 39 24" src="https://user-images.githubusercontent.com/94373878/159530294-64ec8e1f-547a-46b7-9529-5b3a0eb742f6.png">

