### PR TITLE
[Security Solution] update blocklist fields to use file prefix

### DIFF
--- a/packages/kbn-securitysolution-utils/src/path_validations/index.ts
+++ b/packages/kbn-securitysolution-utils/src/path_validations/index.ts
@@ -22,6 +22,20 @@ export const enum ConditionEntryField {
   SIGNER = 'process.Ext.code_signature',
 }
 
+export const enum EntryFieldType {
+  HASH = '.hash.',
+  EXECUTABLE = '.executable.caseless',
+  PATH = '.path',
+  SIGNER = '.Ext.code_signature',
+}
+
+export type TrustedAppConditionEntryField =
+  | 'process.hash.*'
+  | 'process.executable.caseless'
+  | 'process.Ext.code_signature';
+export type BlocklistConditionEntryField = 'file.hash.*' | 'file.path' | 'file.Ext.code_signature';
+export type AllConditionEntryFields = TrustedAppConditionEntryField | BlocklistConditionEntryField;
+
 export const enum OperatingSystem {
   LINUX = 'linux',
   MAC = 'macos',
@@ -91,7 +105,7 @@ export const isPathValid = ({
   value,
 }: {
   os: OperatingSystem;
-  field: ConditionEntryField | 'file.path.text';
+  field: AllConditionEntryFields | 'file.path.text';
   type: EntryTypes;
   value: string;
 }): boolean => {

--- a/x-pack/plugins/security_solution/common/endpoint/types/exception_list_items.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/exception_list_items.ts
@@ -5,17 +5,14 @@
  * 2.0.
  */
 
-import { ConditionEntryField, EntryTypes } from '@kbn/securitysolution-utils';
+import { AllConditionEntryFields, EntryTypes } from '@kbn/securitysolution-utils';
 
 export type ConditionEntriesMap<T> = {
-  [K in ConditionEntryField]?: T;
+  [K in AllConditionEntryFields]?: T;
 };
 
-export interface ConditionEntry<
-  F extends ConditionEntryField = ConditionEntryField,
-  T extends EntryTypes = EntryTypes
-> {
-  field: F;
+export interface ConditionEntry<T extends EntryTypes = EntryTypes> {
+  field: AllConditionEntryFields;
   type: T;
   operator: 'included';
   value: string | string[];

--- a/x-pack/plugins/security_solution/public/management/pages/blocklist/translations.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/blocklist/translations.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { ConditionEntryField } from '@kbn/securitysolution-utils';
+import { BlocklistConditionEntryField } from '@kbn/securitysolution-utils';
 
 export const DETAILS_HEADER = i18n.translate('xpack.securitySolution.blocklists.details.header', {
   defaultMessage: 'Details',
@@ -69,29 +69,27 @@ export const VALUE_LABEL_HELPER = i18n.translate(
   }
 );
 
-export const CONDITION_FIELD_TITLE: { [K in ConditionEntryField]: string } = {
-  [ConditionEntryField.HASH]: i18n.translate('xpack.securitySolution.blocklists.entry.field.hash', {
+export const CONDITION_FIELD_TITLE: { [K in BlocklistConditionEntryField]: string } = {
+  'file.hash.*': i18n.translate('xpack.securitySolution.blocklists.entry.field.hash', {
     defaultMessage: 'Hash',
   }),
-  [ConditionEntryField.PATH]: i18n.translate('xpack.securitySolution.blocklists.entry.field.path', {
+  'file.path': i18n.translate('xpack.securitySolution.blocklists.entry.field.path', {
     defaultMessage: 'Path',
   }),
-  [ConditionEntryField.SIGNER]: i18n.translate(
+  'file.Ext.code_signature': i18n.translate(
     'xpack.securitySolution.blocklists.entry.field.signature',
     { defaultMessage: 'Signature' }
   ),
 };
 
-export const CONDITION_FIELD_DESCRIPTION: { [K in ConditionEntryField]: string } = {
-  [ConditionEntryField.HASH]: i18n.translate(
-    'xpack.securitySolution.blocklists.entry.field.description.hash',
-    { defaultMessage: 'md5, sha1, or sha256' }
-  ),
-  [ConditionEntryField.PATH]: i18n.translate(
-    'xpack.securitySolution.blocklists.entry.field.description.path',
-    { defaultMessage: 'The full path of the application' }
-  ),
-  [ConditionEntryField.SIGNER]: i18n.translate(
+export const CONDITION_FIELD_DESCRIPTION: { [K in BlocklistConditionEntryField]: string } = {
+  'file.hash.*': i18n.translate('xpack.securitySolution.blocklists.entry.field.description.hash', {
+    defaultMessage: 'md5, sha1, or sha256',
+  }),
+  'file.path': i18n.translate('xpack.securitySolution.blocklists.entry.field.description.path', {
+    defaultMessage: 'The full path of the application',
+  }),
+  'file.Ext.code_signature': i18n.translate(
     'xpack.securitySolution.blocklists.entry.field.description.signature',
     { defaultMessage: 'The signer of the application' }
   ),

--- a/x-pack/plugins/security_solution/public/management/pages/blocklist/view/components/blocklist_form.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/blocklist/view/components/blocklist_form.tsx
@@ -26,7 +26,7 @@ import {
 } from '@elastic/eui';
 import {
   OperatingSystem,
-  ConditionEntryField,
+  BlocklistConditionEntryField,
   isPathValid,
   hasSimpleExecutableName,
 } from '@kbn/securitysolution-utils';
@@ -67,7 +67,7 @@ import { isArtifactGlobal } from '../../../../../../common/endpoint/service/arti
 import type { PolicyData } from '../../../../../../common/endpoint/types';
 
 interface BlocklistEntry {
-  field: ConditionEntryField;
+  field: BlocklistConditionEntryField;
   operator: 'included';
   type: 'match_any';
   value: string[];
@@ -82,7 +82,7 @@ function createValidationMessage(message: string): React.ReactNode {
   return <div>{message}</div>;
 }
 
-function getDropdownDisplay(field: ConditionEntryField): React.ReactNode {
+function getDropdownDisplay(field: BlocklistConditionEntryField): React.ReactNode {
   return (
     <>
       {CONDITION_FIELD_TITLE[field]}
@@ -118,7 +118,7 @@ export const BlockListForm = memo(
     const blocklistEntry = useMemo((): BlocklistEntry => {
       if (!item.entries.length) {
         return {
-          field: ConditionEntryField.HASH,
+          field: 'file.hash.*',
           operator: 'included',
           type: 'match_any',
           value: [],
@@ -148,20 +148,19 @@ export const BlockListForm = memo(
       []
     );
 
-    const fieldOptions: Array<EuiSuperSelectOption<ConditionEntryField>> = useMemo(() => {
-      const selectableFields: Array<EuiSuperSelectOption<ConditionEntryField>> = [
-        ConditionEntryField.HASH,
-        ConditionEntryField.PATH,
-      ].map((field) => ({
+    const fieldOptions: Array<EuiSuperSelectOption<BlocklistConditionEntryField>> = useMemo(() => {
+      const selectableFields: Array<EuiSuperSelectOption<BlocklistConditionEntryField>> = (
+        ['file.hash.*', 'file.path'] as BlocklistConditionEntryField[]
+      ).map((field) => ({
         value: field,
         inputDisplay: CONDITION_FIELD_TITLE[field],
         dropdownDisplay: getDropdownDisplay(field),
       }));
       if (selectedOs === OperatingSystem.WINDOWS) {
         selectableFields.push({
-          value: ConditionEntryField.SIGNER,
-          inputDisplay: CONDITION_FIELD_TITLE[ConditionEntryField.SIGNER],
-          dropdownDisplay: getDropdownDisplay(ConditionEntryField.SIGNER),
+          value: 'file.Ext.code_signature',
+          inputDisplay: CONDITION_FIELD_TITLE['file.Ext.code_signature'],
+          dropdownDisplay: getDropdownDisplay('file.Ext.code_signature'),
         });
       }
 
@@ -183,7 +182,7 @@ export const BlockListForm = memo(
     const validateValues = useCallback((nextItem: ArtifactFormComponentProps['item']) => {
       const os = ((nextItem.os_types ?? [])[0] as OperatingSystem) ?? OperatingSystem.WINDOWS;
       const {
-        field = ConditionEntryField.HASH,
+        field = 'file.hash.*',
         type = 'match_any',
         value: values = [],
       } = (nextItem.entries[0] ?? {}) as BlocklistEntry;
@@ -203,20 +202,20 @@ export const BlockListForm = memo(
       }
 
       // error if invalid hash
-      if (field === ConditionEntryField.HASH && values.some((value) => !isValidHash(value))) {
+      if (field === 'file.hash.*' && values.some((value) => !isValidHash(value))) {
         newValueErrors.push(createValidationMessage(ERRORS.INVALID_HASH));
       }
 
       const isInvalidPath = values.some((value) => !isPathValid({ os, field, type, value }));
 
       // warn if invalid path
-      if (field !== ConditionEntryField.HASH && isInvalidPath) {
+      if (field !== 'file.hash.*' && isInvalidPath) {
         newValueWarnings.push(createValidationMessage(ERRORS.INVALID_PATH));
       }
 
       // warn if wildcard
       if (
-        field !== ConditionEntryField.HASH &&
+        field !== 'file.hash.*' &&
         !isInvalidPath &&
         values.some((value) => !hasSimpleExecutableName({ os, type, value }))
       ) {
@@ -275,9 +274,8 @@ export const BlockListForm = memo(
             {
               ...blocklistEntry,
               field:
-                os !== OperatingSystem.WINDOWS &&
-                blocklistEntry.field === ConditionEntryField.SIGNER
-                  ? ConditionEntryField.HASH
+                os !== OperatingSystem.WINDOWS && blocklistEntry.field === 'file.Ext.code_signature'
+                  ? 'file.hash.*'
                   : blocklistEntry.field,
             },
           ],
@@ -293,7 +291,7 @@ export const BlockListForm = memo(
     );
 
     const handleOnFieldChange = useCallback(
-      (field: ConditionEntryField) => {
+      (field: BlocklistConditionEntryField) => {
         const nextItem = {
           ...item,
           entries: [{ ...blocklistEntry, field }],


### PR DESCRIPTION
## Summary

Fixes blocklist creation. We were using `process` prefix for entry fields but should be using `file` prefix. Purposely left trusted apps as untouched as possible since we have another ticket to move it to the common list types.