### PR TITLE
[reporting/upgrade/tests] rewrite waitForJobToFinish to handle errors

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/lib/config/schema.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/config/schema.ts
@@ -114,6 +114,7 @@ export const schema = Joi.object()
         try: Joi.number().default(120000),
         waitFor: Joi.number().default(20000),
         esRequestTimeout: Joi.number().default(30000),
+        kibanaReportCompletion: Joi.number().default(60_000),
         kibanaStabilize: Joi.number().default(15000),
         navigateStatusPageCheck: Joi.number().default(250),
 
@@ -166,7 +167,9 @@ export const schema = Joi.object()
 
     mochaReporter: Joi.object()
       .keys({
-        captureLogOutput: Joi.boolean().default(!!process.env.CI),
+        captureLogOutput: Joi.boolean().default(
+          !!process.env.CI && !process.env.DISABLE_CI_LOG_OUTPUT_CAPTURE
+        ),
         sendToCiStats: Joi.boolean().default(!!process.env.CI),
       })
       .default(),

--- a/x-pack/test/upgrade/apps/reporting/reporting_smoke_tests.ts
+++ b/x-pack/test/upgrade/apps/reporting/reporting_smoke_tests.ts
@@ -89,11 +89,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             const postUrl = await find.byXPath(`//button[descendant::*[text()='Copy POST URL']]`);
             await postUrl.click();
             const url = await browser.getClipboardValue();
-            await reportingAPI.expectAllJobsToFinishSuccessfully(
-              await Promise.all([
-                reportingAPI.postJob(parse(url).pathname + '?' + parse(url).query),
-              ])
-            );
+            await reportingAPI.expectAllJobsToFinishSuccessfully([
+              await reportingAPI.postJob(parse(url).pathname + '?' + parse(url).query),
+            ]);
             usage = (await usageAPI.getUsageStats()) as UsageStats;
             reportingAPI.expectCompletedReportCount(usage, completedReportCount + 1);
           });

--- a/x-pack/test/upgrade/reporting_services.ts
+++ b/x-pack/test/upgrade/reporting_services.ts
@@ -47,33 +47,34 @@ export function ReportingAPIProvider({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const esSupertest = getService('esSupertest');
   const retry = getService('retry');
+  const config = getService('config');
 
   return {
-    async waitForJobToFinish(downloadReportPath: string) {
-      log.debug(`Waiting for job to finish: ${downloadReportPath}`);
-      const JOB_IS_PENDING_CODE = 503;
-
-      const statusCode = await new Promise((resolve) => {
-        const intervalId = setInterval(async () => {
-          const response = (await supertest
+    async waitForJobToFinish(downloadReportPath: string, options?: { timeout?: number }) {
+      await retry.waitForWithTimeout(
+        `job ${downloadReportPath} finished`,
+        options?.timeout ?? config.get('timeouts.kibanaReportCompletion'),
+        async () => {
+          const response = await supertest
             .get(downloadReportPath)
             .responseType('blob')
-            .set('kbn-xsrf', 'xxx')) as any;
-          if (response.statusCode === 503) {
-            log.debug(`Report at path ${downloadReportPath} is pending`);
-          } else if (response.statusCode === 200) {
-            log.debug(`Report at path ${downloadReportPath} is complete`);
-          } else {
-            log.debug(`Report at path ${downloadReportPath} returned code ${response.statusCode}`);
-          }
-          if (response.statusCode !== JOB_IS_PENDING_CODE) {
-            clearInterval(intervalId);
-            resolve(response.statusCode);
-          }
-        }, 1500);
-      });
+            .set('kbn-xsrf', 'xxx');
 
-      expect(statusCode).to.be(200);
+          if (response.status === 503) {
+            log.debug(`Report at path ${downloadReportPath} is pending`);
+            return false;
+          }
+
+          log.debug(`Report at path ${downloadReportPath} returned code ${response.status}`);
+
+          if (response.status === 200) {
+            log.debug(`Report at path ${downloadReportPath} is complete`);
+            return true;
+          }
+
+          throw new Error(`unexpected status code ${response.status}`);
+        }
+      );
     },
 
     async expectAllJobsToFinishSuccessfully(jobPaths: string[]) {


### PR DESCRIPTION
The current implementation of `reportingApi.waitForJobToFinish()` does not handle errors, which I think is the cause of the unhandled promise rejection errors being seen in the ESTF tests right now. This rewrite utilizes the `retry.waitFor()` function rather than re-implementing polling. `retry.waitFor()` handles errors and keeps trying, which should at least give us a better idea of what's breaking and allow test reports to be written. Additionally, this adds support for the `DISABLE_CI_LOG_OUTPUT_CAPTURE` environment variable, which when set, will disable `debug` log capture and instead write the logs to stdout.