### PR TITLE
[Stack Monitoring] fix sorting by node status on nodes listing page

### DIFF
--- a/x-pack/plugins/monitoring/server/lib/elasticsearch/nodes/get_nodes/get_paginated_nodes.ts
+++ b/x-pack/plugins/monitoring/server/lib/elasticsearch/nodes/get_nodes/get_paginated_nodes.ts
@@ -51,7 +51,14 @@ export async function getPaginatedNodes(
     nodesShardCount,
   }: {
     clusterStats: {
-      cluster_state: { nodes: Record<string, Node> };
+      cluster_state?: { nodes: Record<string, Node> };
+      elasticsearch?: {
+        cluster: {
+          stats: {
+            state: { nodes: Record<string, Node> };
+          };
+        };
+      };
     };
     nodesShardCount: { nodes: Record<string, { shardCount: number }> };
   }
@@ -61,7 +68,8 @@ export async function getPaginatedNodes(
   const nodes: Node[] = await getNodeIds(req, { clusterUuid }, size);
 
   // Add `isOnline` and shards from the cluster state and shard stats
-  const clusterState = clusterStats?.cluster_state ?? { nodes: {} };
+  const clusterState = clusterStats?.cluster_state ??
+    clusterStats?.elasticsearch?.cluster.stats.state ?? { nodes: {} };
   for (const node of nodes) {
     node.isOnline = !isUndefined(clusterState?.nodes[node.uuid]);
     node.shardCount = nodesShardCount?.nodes[node.uuid]?.shardCount ?? 0;

--- a/x-pack/plugins/monitoring/server/lib/elasticsearch/nodes/get_nodes/get_paginated_nodes.ts
+++ b/x-pack/plugins/monitoring/server/lib/elasticsearch/nodes/get_nodes/get_paginated_nodes.ts
@@ -63,10 +63,12 @@ export async function getPaginatedNodes(
   const nodes: Node[] = await getNodeIds(req, { clusterUuid }, size);
 
   // Add `isOnline` and shards from the cluster state and shard stats
-  const clusterState = clusterStats?.cluster_state ??
-    clusterStats?.elasticsearch?.cluster?.stats?.state ?? { nodes: {} };
+  const clusterStateNodes =
+    clusterStats?.cluster_state?.nodes ??
+    clusterStats?.elasticsearch?.cluster?.stats?.state?.nodes ??
+    {};
   for (const node of nodes) {
-    node.isOnline = !isUndefined(clusterState?.nodes && clusterState?.nodes[node.uuid]);
+    node.isOnline = !isUndefined(clusterStateNodes && clusterStateNodes[node.uuid]);
     node.shardCount = nodesShardCount?.nodes[node.uuid]?.shardCount ?? 0;
   }
 

--- a/x-pack/plugins/monitoring/server/lib/elasticsearch/nodes/get_nodes/get_paginated_nodes.ts
+++ b/x-pack/plugins/monitoring/server/lib/elasticsearch/nodes/get_nodes/get_paginated_nodes.ts
@@ -14,6 +14,7 @@ import { sortNodes } from './sort_nodes';
 import { paginate } from '../../../pagination/paginate';
 import { getMetrics } from '../../../details/get_metrics';
 import { LegacyRequest } from '../../../../types';
+import { ElasticsearchModifiedSource } from '../../../../../common/types/es';
 
 /**
  * This function performs an optimization around the node listing tables in the UI. To avoid
@@ -52,13 +53,7 @@ export async function getPaginatedNodes(
   }: {
     clusterStats: {
       cluster_state?: { nodes: Record<string, Node> };
-      elasticsearch?: {
-        cluster: {
-          stats: {
-            state: { nodes: Record<string, Node> };
-          };
-        };
-      };
+      elasticsearch?: ElasticsearchModifiedSource['elasticsearch'];
     };
     nodesShardCount: { nodes: Record<string, { shardCount: number }> };
   }
@@ -69,9 +64,9 @@ export async function getPaginatedNodes(
 
   // Add `isOnline` and shards from the cluster state and shard stats
   const clusterState = clusterStats?.cluster_state ??
-    clusterStats?.elasticsearch?.cluster.stats.state ?? { nodes: {} };
+    clusterStats?.elasticsearch?.cluster?.stats?.state ?? { nodes: {} };
   for (const node of nodes) {
-    node.isOnline = !isUndefined(clusterState?.nodes[node.uuid]);
+    node.isOnline = !isUndefined(clusterState?.nodes && clusterState?.nodes[node.uuid]);
     node.shardCount = nodesShardCount?.nodes[node.uuid]?.shardCount ?? 0;
   }
 

--- a/x-pack/test/functional/apps/monitoring/elasticsearch/nodes_mb.js
+++ b/x-pack/test/functional/apps/monitoring/elasticsearch/nodes_mb.js
@@ -189,19 +189,21 @@ export default function ({ getService, getPageObjects }) {
         });
       });
 
-      // this is actually broken, see https://github.com/elastic/kibana/issues/122338
-      it.skip('should sort by status', async () => {
-        const sortedStatusesAscending = ['Status: Offline', 'Status: Online', 'Status: Online'];
-        const sortedStatusesDescending = [...sortedStatusesAscending].reverse();
-
+      it('should sort by status', async () => {
         await nodesList.clickStatusCol();
-        await retry.try(async () => {
-          expect(await nodesList.getNodeStatuses()).to.eql(sortedStatusesDescending);
-        });
-
         await nodesList.clickStatusCol();
+
+        // retry in case the table hasn't had time to re-render
         await retry.try(async () => {
-          expect(await nodesList.getNodeStatuses()).to.eql(sortedStatusesAscending);
+          const nodesAll = await nodesList.getNodesAll();
+          const tableData = [
+            { status: 'Status: Online' },
+            { status: 'Status: Online' },
+            { status: 'Status: Offline' },
+          ];
+          nodesAll.forEach((obj, node) => {
+            expect(nodesAll[node].status).to.be(tableData[node].status);
+          });
         });
       });
 


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/122338

Sorting nodes by status was broken in 8.0 using standalone metricbeat because the code that determines status was not updated to use the ECS path.

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/311