### PR TITLE
[DOCS] Delete cases and comments APIs

### DIFF
--- a/docs/api/cases.asciidoc
+++ b/docs/api/cases.asciidoc
@@ -6,9 +6,8 @@ these APIs:
 
 * {security-guide}/cases-api-add-comment.html[Add comment]
 * <<cases-api-create>>
-* {security-guide}/cases-api-delete-case.html[Delete case]
-* {security-guide}/cases-api-delete-all-comments.html[Delete all comments]
-* {security-guide}/cases-api-delete-comment.html[Delete comment]
+* <<cases-api-delete-cases>>
+* <<cases-api-delete-comments>>
 * {security-guide}/cases-api-find-alert.html[Find all alerts attached to a case]
 * <<cases-api-find-cases>>
 * {security-guide}/cases-api-find-cases-by-alert.html[Find cases by alert]
@@ -29,6 +28,9 @@ these APIs:
 
 //CREATE
 include::cases/cases-api-create.asciidoc[leveloffset=+1]
+//DELETE
+include::cases/cases-api-delete-cases.asciidoc[leveloffset=+1]
+include::cases/cases-api-delete-comments.asciidoc[leveloffset=+1]
 //FIND
 include::cases/cases-api-find-cases.asciidoc[leveloffset=+1]
 include::cases/cases-api-find-connectors.asciidoc[leveloffset=+1]

--- a/docs/api/cases/cases-api-delete-cases.asciidoc
+++ b/docs/api/cases/cases-api-delete-cases.asciidoc
@@ -1,0 +1,52 @@
+[[cases-api-delete-cases]]
+== Delete cases API
+++++
+<titleabbrev>Delete cases</titleabbrev>
+++++
+
+Deletes one or more cases.
+
+=== Request
+
+`DELETE <kibana host>:<port>/api/cases?ids=["<case ID1>","<case ID2>"]`
+
+`DELETE <kibana host>:<port>/s/<space_id>/api/cases?ids=["<case ID1>","<case ID2>"]`
+
+=== Prerequisite
+
+You must have `all` privileges for the *Cases* feature in the *Management*,
+*{observability}*, or *Security* section of the
+<<kibana-feature-privileges,{kib} feature privileges>>, depending on the
+`owner` of the cases you're deleting.
+
+=== Path parameters
+
+`<space_id>`::
+(Optional, string) An identifier for the space. If it is not specified, the
+default space is used.
+
+=== Query parameters
+
+`ids`::
+(Required, string) The cases that you want to remove. To retrieve case IDs, use
+<<cases-api-find-cases>>.
++
+NOTE: All non-ASCII characters must be URL encoded.
+
+==== Response code
+
+`204`::
+   Indicates a successful call.
+
+=== Example
+
+Delete cases with these IDs:
+
+* `2e3a54f0-6754-11ea-a1c2-e3a8bc9f7aca`
+* `40b9a450-66a0-11ea-be1b-2bd3fef48984`
+
+[source,console]
+--------------------------------------------------
+DELETE api/cases?ids=%5B%222e3a54f0-6754-11ea-a1c2-e3a8bc9f7aca%22%2C%2240b9a450-66a0-11ea-be1b-2bd3fef48984%22%5D
+--------------------------------------------------
+// KIBANA

--- a/docs/api/cases/cases-api-delete-comments.asciidoc
+++ b/docs/api/cases/cases-api-delete-comments.asciidoc
@@ -1,0 +1,63 @@
+[[cases-api-delete-comments]]
+== Delete comments from case API
+++++
+<titleabbrev>Delete comments</titleabbrev>
+++++
+
+Deletes one or all comments from a case.
+
+=== Request
+
+`DELETE <kibana host>:<port>/api/cases/<case_id>/comments`
+
+`DELETE <kibana host>:<port>/api/cases/<case_id>/comments/<comment_id>`
+
+`DELETE <kibana host>:<port>/s/<space_id>/api/cases/<case_id>/comments`
+
+`DELETE <kibana host>:<port>/s/<space_id>/api/cases/<case_id>/comments/<comment_id>`
+
+=== Prerequisite
+
+You must have `all` privileges for the *Cases* feature in the *Management*,
+*{observability}*, or *Security* section of the
+<<kibana-feature-privileges,{kib} feature privileges>>, depending on the
+`owner` of the cases you're updating.
+
+=== Path parameters
+
+`<case_id>`::
+(Required, string) The identifier for the case. To retrieve case IDs, use
+<<cases-api-find-cases>>.
+
+`<comment_id>`::
+(Optional, string) The identifier for the comment.
+//To retrieve comment IDs, use <<cases-api-get-all-case-comments>>. 
+If it is not specified, all comments are deleted.
+
+<space_id>::
+(Optional, string) An identifier for the space. If it is not specified, the
+default space is used.
+
+=== Response code
+
+`204`::
+   Indicates a successful call.
+
+=== Example
+
+Delete all comments from case ID `9c235210-6834-11ea-a78c-6ffb38a34414`:
+
+[source,console]
+--------------------------------------------------
+DELETE api/cases/a18b38a0-71b0-11ea-a0b2-c51ea50a58e2/comments
+--------------------------------------------------
+// KIBANA
+
+Delete comment ID `71ec1870-725b-11ea-a0b2-c51ea50a58e2` from case ID
+`a18b38a0-71b0-11ea-a0b2-c51ea50a58e2`:
+
+[source,sh]
+--------------------------------------------------
+DELETE api/cases/a18b38a0-71b0-11ea-a0b2-c51ea50a58e2/comments/71ec1870-725b-11ea-a0b2-c51ea50a58e2
+--------------------------------------------------
+// KIBANA


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/126956

This PR copies the "delete" subset of [cases APIs](https://www.elastic.co/guide/en/security/master/cases-api-overview.html) from the Security Guide to the Kibana Guide. It also formats the content to align with existing Kibana APIs.

NOTE: Though [delete all comments](https://www.elastic.co/guide/en/security/master/cases-api-delete-all-comments.html) and [delete comment](https://www.elastic.co/guide/en/security/master/cases-api-delete-comment.html) APIs are documented separately in the Security Guide, I've combined them into a single page in the Kibana Guide.

### Preview

* https://kibana_128329.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-delete-cases.html
* https://kibana_128329.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-delete-comments.html
