### PR TITLE
[DO NOT MERGE] Replace EuiIcon with EuiImage to speed up rendering

### DIFF
--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_agents/agent_instructions_accordion.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_agents/agent_instructions_accordion.tsx
@@ -46,7 +46,7 @@ function AccordionButtonContent({
   return (
     <EuiFlexGroup justifyContent="flexStart" alignItems="center">
       <EuiFlexItem grow={false}>
-        <AgentIcon size="xl" agentName={agentName} />
+        <AgentIcon size={32} agentName={agentName} />
       </EuiFlexItem>
       <EuiFlexItem grow={1}>
         <EuiFlexGroup direction="column" gutterSize="none">

--- a/x-pack/plugins/apm/public/components/shared/agent_icon/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/agent_icon/index.tsx
@@ -6,20 +6,20 @@
  */
 
 import React from 'react';
-import { EuiIcon, EuiIconProps } from '@elastic/eui';
+import { EuiImage, EuiIcon, EuiImageProps } from '@elastic/eui';
 import { AgentName } from '../../../../typings/es_schemas/ui/fields/agent';
 import { getAgentIcon } from './get_agent_icon';
 import { useTheme } from '../../../hooks/use_theme';
 
 interface Props {
   agentName?: AgentName;
-  size?: EuiIconProps['size'];
+  size?: EuiImageProps['size'];
 }
 
 export function AgentIcon(props: Props) {
-  const { agentName, size = 'l' } = props;
+  const { agentName, size = 24 } = props;
   const theme = useTheme();
   const icon = getAgentIcon(agentName, theme.darkMode);
 
-  return <EuiIcon type={icon} size={size} title={agentName} />;
+  return <EuiImage src={icon} size={size} alt={`${agentName} icon`} />;
 }


### PR DESCRIPTION
## Summary
part of https://github.com/elastic/kibana/issues/126153 


It turns out that the `EuiIcon` slows down the rendering of the table. I replaced the component with `EuiImage` and the UI should remain unchanged apart from the rendering time.  

As for the `EuiIcon`, I'm not sure yet what causes the issue. I opened a ticket to [EUI](https://github.com/elastic/eui/issues/5741) 



### Before (with EuiIcon)  


https://user-images.githubusercontent.com/3369346/159706115-3be26ae9-79ba-42bf-a264-18e71af24f03.mov



### After (with EuiImage)

https://user-images.githubusercontent.com/3369346/159706132-0af756ef-e15e-47fc-bd58-0a57b4f8be8d.mov

 