### PR TITLE
[8.1] [ResponseOps][task manager] log event loop delay for tasks when over configured limit (#126300)

### DIFF
--- a/docs/settings/task-manager-settings.asciidoc
+++ b/docs/settings/task-manager-settings.asciidoc
@@ -40,6 +40,11 @@ These non-persisted action tasks have a risk that they won't be run at all if th
 `xpack.task_manager.ephemeral_tasks.request_capacity`::
 Sets the size of the ephemeral queue defined above. Defaults to 10.
 
+`xpack.task_manager.event_loop_delay.monitor`::
+Enables event loop delay monitoring, which will log a warning when a task causes an event loop delay which exceeds the `warn_threshold` setting.  Defaults to true.
+
+`xpack.task_manager.event_loop_delay.warn_threshold`::
+Sets the amount of event loop delay during a task execution which will cause a warning to be logged. Defaults to 5000 milliseconds (5 seconds).
 
 [float]
 [[task-manager-health-settings]]

--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -376,6 +376,8 @@ kibana_vars=(
     xpack.task_manager.poll_interval
     xpack.task_manager.request_capacity
     xpack.task_manager.version_conflict_threshold
+    xpack.task_manager.event_loop_delay.monitor
+    xpack.task_manager.event_loop_delay.warn_threshold
     xpack.uptime.index
 )
 

--- a/x-pack/plugins/task_manager/server/config.test.ts
+++ b/x-pack/plugins/task_manager/server/config.test.ts
@@ -16,6 +16,10 @@ describe('config validation', () => {
           "enabled": false,
           "request_capacity": 10,
         },
+        "event_loop_delay": Object {
+          "monitor": true,
+          "warn_threshold": 5000,
+        },
         "max_attempts": 3,
         "max_poll_inactivity_cycles": 10,
         "max_workers": 10,
@@ -62,6 +66,10 @@ describe('config validation', () => {
           "enabled": false,
           "request_capacity": 10,
         },
+        "event_loop_delay": Object {
+          "monitor": true,
+          "warn_threshold": 5000,
+        },
         "max_attempts": 3,
         "max_poll_inactivity_cycles": 10,
         "max_workers": 10,
@@ -105,6 +113,10 @@ describe('config validation', () => {
         "ephemeral_tasks": Object {
           "enabled": false,
           "request_capacity": 10,
+        },
+        "event_loop_delay": Object {
+          "monitor": true,
+          "warn_threshold": 5000,
         },
         "max_attempts": 3,
         "max_poll_inactivity_cycles": 10,

--- a/x-pack/plugins/task_manager/server/config.ts
+++ b/x-pack/plugins/task_manager/server/config.ts
@@ -41,6 +41,14 @@ export const taskExecutionFailureThresholdSchema = schema.object(
   }
 );
 
+const eventLoopDelaySchema = schema.object({
+  monitor: schema.boolean({ defaultValue: true }),
+  warn_threshold: schema.number({
+    defaultValue: 5000,
+    min: 10,
+  }),
+});
+
 export const configSchema = schema.object(
   {
     /* The maximum number of times a task will be attempted before being abandoned as failed */
@@ -118,6 +126,7 @@ export const configSchema = schema.object(
         max: DEFAULT_MAX_EPHEMERAL_REQUEST_CAPACITY,
       }),
     }),
+    event_loop_delay: eventLoopDelaySchema,
     /* These are not designed to be used by most users. Please use caution when changing these */
     unsafe: schema.object({
       exclude_task_types: schema.arrayOf(schema.string(), { defaultValue: [] }),
@@ -138,3 +147,4 @@ export const configSchema = schema.object(
 
 export type TaskManagerConfig = TypeOf<typeof configSchema>;
 export type TaskExecutionFailureThreshold = TypeOf<typeof taskExecutionFailureThresholdSchema>;
+export type EventLoopDelayConfig = TypeOf<typeof eventLoopDelaySchema>;

--- a/x-pack/plugins/task_manager/server/ephemeral_task_lifecycle.test.ts
+++ b/x-pack/plugins/task_manager/server/ephemeral_task_lifecycle.test.ts
@@ -69,6 +69,10 @@ describe('EphemeralTaskLifecycle', () => {
         unsafe: {
           exclude_task_types: [],
         },
+        event_loop_delay: {
+          monitor: true,
+          warn_threshold: 5000,
+        },
         ...config,
       },
       elasticsearchAndSOAvailability$,

--- a/x-pack/plugins/task_manager/server/integration_tests/managed_configuration.test.ts
+++ b/x-pack/plugins/task_manager/server/integration_tests/managed_configuration.test.ts
@@ -57,6 +57,10 @@ describe.skip('managed configuration', () => {
       unsafe: {
         exclude_task_types: [],
       },
+      event_loop_delay: {
+        monitor: true,
+        warn_threshold: 5000,
+      },
     });
     logger = context.logger.get('taskManager');
 

--- a/x-pack/plugins/task_manager/server/monitoring/configuration_statistics.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/configuration_statistics.test.ts
@@ -40,6 +40,10 @@ describe('Configuration Statistics Aggregator', () => {
       unsafe: {
         exclude_task_types: [],
       },
+      event_loop_delay: {
+        monitor: true,
+        warn_threshold: 5000,
+      },
     };
 
     const managedConfig = {

--- a/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.test.ts
@@ -44,6 +44,10 @@ describe('createMonitoringStatsStream', () => {
     unsafe: {
       exclude_task_types: [],
     },
+    event_loop_delay: {
+      monitor: true,
+      warn_threshold: 5000,
+    },
   };
 
   it('returns the initial config used to configure Task Manager', async () => {

--- a/x-pack/plugins/task_manager/server/plugin.test.ts
+++ b/x-pack/plugins/task_manager/server/plugin.test.ts
@@ -43,6 +43,10 @@ describe('TaskManagerPlugin', () => {
         unsafe: {
           exclude_task_types: [],
         },
+        event_loop_delay: {
+          monitor: true,
+          warn_threshold: 5000,
+        },
       });
 
       pluginInitializerContext.env.instanceUuid = '';
@@ -83,6 +87,10 @@ describe('TaskManagerPlugin', () => {
         },
         unsafe: {
           exclude_task_types: [],
+        },
+        event_loop_delay: {
+          monitor: true,
+          warn_threshold: 5000,
         },
       });
 
@@ -153,6 +161,10 @@ describe('TaskManagerPlugin', () => {
         },
         unsafe: {
           exclude_task_types: ['*'],
+        },
+        event_loop_delay: {
+          monitor: true,
+          warn_threshold: 5000,
         },
       });
 

--- a/x-pack/plugins/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/plugins/task_manager/server/polling_lifecycle.test.ts
@@ -67,6 +67,10 @@ describe('TaskPollingLifecycle', () => {
       unsafe: {
         exclude_task_types: [],
       },
+      event_loop_delay: {
+        monitor: true,
+        warn_threshold: 5000,
+      },
     },
     taskStore: mockTaskStore,
     logger: taskManagerLogger,

--- a/x-pack/plugins/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/plugins/task_manager/server/polling_lifecycle.ts
@@ -90,6 +90,7 @@ export class TaskPollingLifecycle {
   private middleware: Middleware;
 
   private usageCounter?: UsageCounter;
+  private config: TaskManagerConfig;
 
   /**
    * Initializes the task manager, preventing any further addition of middleware,
@@ -115,6 +116,7 @@ export class TaskPollingLifecycle {
     this.store = taskStore;
     this.executionContext = executionContext;
     this.usageCounter = usageCounter;
+    this.config = config;
 
     const emitEvent = (event: TaskLifecycleEvent) => this.events$.next(event);
 
@@ -237,6 +239,7 @@ export class TaskPollingLifecycle {
       defaultMaxAttempts: this.taskClaiming.maxAttempts,
       executionContext: this.executionContext,
       usageCounter: this.usageCounter,
+      eventLoopDelayConfig: { ...this.config.event_loop_delay },
     });
   };
 

--- a/x-pack/plugins/task_manager/server/task_events.test.ts
+++ b/x-pack/plugins/task_manager/server/task_events.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { startTaskTimer, startTaskTimerWithEventLoopMonitoring } from './task_events';
+
+const DelayIterations = 4;
+const DelayMillis = 250;
+const DelayTotal = DelayIterations * DelayMillis;
+
+async function nonBlockingDelay(millis: number) {
+  await new Promise((resolve) => setTimeout(resolve, millis));
+}
+
+async function blockingDelay(millis: number) {
+  // get task in async queue
+  await nonBlockingDelay(0);
+
+  const end = Date.now() + millis;
+  // eslint-disable-next-line no-empty
+  while (Date.now() < end) {}
+}
+
+async function nonBlockingTask() {
+  for (let i = 0; i < DelayIterations; i++) {
+    await nonBlockingDelay(DelayMillis);
+  }
+}
+
+async function blockingTask() {
+  for (let i = 0; i < DelayIterations; i++) {
+    await blockingDelay(DelayMillis);
+  }
+}
+
+describe('task_events', () => {
+  test('startTaskTimer', async () => {
+    const stopTaskTimer = startTaskTimer();
+    await nonBlockingTask();
+    const result = stopTaskTimer();
+    expect(result.stop - result.start).not.toBeLessThan(DelayTotal);
+    expect(result.eventLoopBlockMs).toBe(undefined);
+  });
+
+  describe('startTaskTimerWithEventLoopMonitoring', () => {
+    test('non-blocking', async () => {
+      const stopTaskTimer = startTaskTimerWithEventLoopMonitoring({
+        monitor: true,
+        warn_threshold: 5000,
+      });
+      await nonBlockingTask();
+      const result = stopTaskTimer();
+      expect(result.stop - result.start).not.toBeLessThan(DelayTotal);
+      expect(result.eventLoopBlockMs).toBeLessThan(DelayMillis);
+    });
+
+    test('blocking', async () => {
+      const stopTaskTimer = startTaskTimerWithEventLoopMonitoring({
+        monitor: true,
+        warn_threshold: 5000,
+      });
+      await blockingTask();
+      const result = stopTaskTimer();
+      expect(result.stop - result.start).not.toBeLessThan(DelayTotal);
+      expect(result.eventLoopBlockMs).not.toBeLessThan(DelayMillis);
+    });
+
+    test('not monitoring', async () => {
+      const stopTaskTimer = startTaskTimerWithEventLoopMonitoring({
+        monitor: false,
+        warn_threshold: 5000,
+      });
+      await blockingTask();
+      const result = stopTaskTimer();
+      expect(result.stop - result.start).not.toBeLessThan(DelayTotal);
+      expect(result.eventLoopBlockMs).toBe(0);
+    });
+  });
+});

--- a/x-pack/plugins/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/plugins/task_manager/server/task_running/task_runner.test.ts
@@ -1528,7 +1528,11 @@ describe('TaskManagerRunner', () => {
   function withAnyTiming(taskRun: TaskRun) {
     return {
       ...taskRun,
-      timing: { start: expect.any(Number), stop: expect.any(Number) },
+      timing: {
+        start: expect.any(Number),
+        stop: expect.any(Number),
+        eventLoopBlockMs: expect.any(Number),
+      },
     };
   }
 
@@ -1590,6 +1594,10 @@ describe('TaskManagerRunner', () => {
       onTaskEvent: opts.onTaskEvent,
       executionContext,
       usageCounter,
+      eventLoopDelayConfig: {
+        monitor: true,
+        warn_threshold: 5000,
+      },
     });
 
     if (stage === TaskRunningStage.READY_TO_RUN) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[ResponseOps][task manager] log event loop delay for tasks when over configured limit (#126300)](https://github.com/elastic/kibana/pull/126300)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)