### PR TITLE
[App Search] Fix sorting options for elasticsearch index based engines

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
@@ -9,7 +9,12 @@ import { Schema } from '../../../../shared/schema/types';
 
 import { Fields } from './types';
 
-export const buildSearchUIConfig = (apiConnector: object, schema: Schema, fields: Fields) => {
+export const buildSearchUIConfig = (
+  apiConnector: object,
+  schema: Schema,
+  fields: Fields,
+  initialState = { sortDirection: 'desc', sortField: 'id' }
+) => {
   const facets = fields.filterFields.reduce(
     (facetsConfig, fieldName) => ({
       ...facetsConfig,
@@ -22,10 +27,7 @@ export const buildSearchUIConfig = (apiConnector: object, schema: Schema, fields
     alwaysSearchOnInitialLoad: true,
     apiConnector,
     trackUrlState: false,
-    initialState: {
-      sortDirection: 'desc',
-      sortField: 'id',
-    },
+    initialState,
     searchQuery: {
       disjunctiveFacets: fields.filterFields,
       facets,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
@@ -31,7 +31,7 @@ import { SearchExperienceContent } from './search_experience_content';
 import { Fields, SortOption } from './types';
 import { SearchBoxView, SortingView, MultiCheckboxFacetsView } from './views';
 
-const RECENTLY_UPLOADED = i18n.translate(
+const DOCUMENT_ID = i18n.translate(
   'xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.documentId',
   {
     defaultMessage: 'Document ID',
@@ -45,12 +45,12 @@ const RELEVANCE = i18n.translate(
 
 const DEFAULT_SORT_OPTIONS: SortOption[] = [
   {
-    name: DESCENDING(RECENTLY_UPLOADED),
+    name: DESCENDING(DOCUMENT_ID),
     value: 'id',
     direction: 'desc',
   },
   {
-    name: ASCENDING(RECENTLY_UPLOADED),
+    name: ASCENDING(DOCUMENT_ID),
     value: 'id',
     direction: 'asc',
   },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
@@ -32,11 +32,17 @@ import { Fields, SortOption } from './types';
 import { SearchBoxView, SortingView, MultiCheckboxFacetsView } from './views';
 
 const RECENTLY_UPLOADED = i18n.translate(
-  'xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.recentlyUploaded',
+  'xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.documentId',
   {
-    defaultMessage: 'Recently Uploaded',
+    defaultMessage: 'Document ID',
   }
 );
+
+const RELEVANCE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.relevance',
+  { defaultMessage: 'Relevance' }
+);
+
 const DEFAULT_SORT_OPTIONS: SortOption[] = [
   {
     name: DESCENDING(RECENTLY_UPLOADED),
@@ -47,6 +53,14 @@ const DEFAULT_SORT_OPTIONS: SortOption[] = [
     name: ASCENDING(RECENTLY_UPLOADED),
     value: 'id',
     direction: 'asc',
+  },
+];
+
+const RELEVANCE_SORT_OPTIONS: SortOption[] = [
+  {
+    name: RELEVANCE,
+    value: '_score',
+    direction: 'desc',
   },
 ];
 
@@ -66,8 +80,10 @@ export const SearchExperience: React.FC = () => {
       sortFields: [],
     }
   );
+  const sortOptions =
+    engine.type === 'elasticsearch' ? RELEVANCE_SORT_OPTIONS : DEFAULT_SORT_OPTIONS;
 
-  const sortingOptions = buildSortOptions(fields, DEFAULT_SORT_OPTIONS);
+  const sortingOptions = buildSortOptions(fields, sortOptions);
 
   const connector = new AppSearchAPIConnector({
     cacheResponses: false,
@@ -78,7 +94,17 @@ export const SearchExperience: React.FC = () => {
     },
   });
 
-  const searchProviderConfig = buildSearchUIConfig(connector, engine.schema || {}, fields);
+  const initialState = {
+    sortField: engine.type === 'elasticsearch' ? '_score' : 'id',
+    sortDirection: 'desc',
+  };
+
+  const searchProviderConfig = buildSearchUIConfig(
+    connector,
+    engine.schema || {},
+    fields,
+    initialState
+  );
 
   return (
     <div className="documentsSearchExperience">

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
@@ -12,6 +12,7 @@ export enum EngineTypes {
   default = 'default',
   indexed = 'indexed',
   meta = 'meta',
+  elasticsearch = 'elasticsearch',
 }
 export interface Engine {
   name: string;

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -8730,7 +8730,6 @@
     "xpack.enterpriseSearch.appSearch.documents.search.sortBy.ariaLabel": "Trier les résultats par",
     "xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.ascendingDropDownOptionLabel": "{fieldName} (croiss.)",
     "xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.descendingDropDownOptionLabel": "{fieldName} (décroiss.)",
-    "xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.recentlyUploaded": "Récemment chargé",
     "xpack.enterpriseSearch.appSearch.documents.title": "Documents",
     "xpack.enterpriseSearch.appSearch.editorRoleTypeDescription": "Les éditeurs peuvent gérer les paramètres de recherche.",
     "xpack.enterpriseSearch.appSearch.emptyState.createFirstEngineCta": "Créer un moteur",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -10280,7 +10280,6 @@
     "xpack.enterpriseSearch.appSearch.documents.search.sortBy.ariaLabel": "結果の並べ替え条件",
     "xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.ascendingDropDownOptionLabel": "{fieldName}（昇順）",
     "xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.descendingDropDownOptionLabel": "{fieldName}（降順）",
-    "xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.recentlyUploaded": "最近アップロードされたドキュメント",
     "xpack.enterpriseSearch.appSearch.documents.title": "ドキュメント",
     "xpack.enterpriseSearch.appSearch.editorRoleTypeDescription": "エディターは検索設定を管理できます。",
     "xpack.enterpriseSearch.appSearch.emptyState.createFirstEngineCta": "エンジンを作成",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -10301,7 +10301,6 @@
     "xpack.enterpriseSearch.appSearch.documents.search.sortBy.ariaLabel": "结果排序方式",
     "xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.ascendingDropDownOptionLabel": "{fieldName}（升序）",
     "xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.descendingDropDownOptionLabel": "{fieldName}（降序）",
-    "xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.recentlyUploaded": "最近上传",
     "xpack.enterpriseSearch.appSearch.documents.title": "文档",
     "xpack.enterpriseSearch.appSearch.editorRoleTypeDescription": "编辑人员可以管理搜索设置。",
     "xpack.enterpriseSearch.appSearch.emptyState.createFirstEngineCta": "创建引擎",


### PR DESCRIPTION
Fixes https://github.com/elastic/enterprise-search-team/issues/1655


![Screenshot 2022-03-23 at 16 07 37](https://user-images.githubusercontent.com/1410658/159731178-9e3c84fc-6779-4861-a508-5319227c20fc.png)
## Summary

Fixes broken documents page due to sorting options on Elasticsearch index based engines.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
