### PR TITLE
[Fleet] added missing package field mappings

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -157,6 +157,27 @@ describe('EPM template', () => {
     expect(mappings).toEqual(longWithIndexFalseMapping);
   });
 
+  it('tests processing keyword field with doc_values false', () => {
+    const keywordWithIndexFalseYml = `
+- name: keywordIndexFalse
+  type: keyword
+  doc_values: false
+`;
+    const keywordWithIndexFalseMapping = {
+      properties: {
+        keywordIndexFalse: {
+          ignore_above: 1024,
+          type: 'keyword',
+          doc_values: false,
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(keywordWithIndexFalseYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(keywordWithIndexFalseMapping);
+  });
+
   it('tests processing text field with multi fields', () => {
     const textWithMultiFieldsLiteralYml = `
 - name: textWithMultiFields
@@ -376,6 +397,34 @@ describe('EPM template', () => {
     const processedFields = processFields(fields);
     const mappings = generateMappings(processedFields);
     expect(mappings).toEqual(keywordWithMultiFieldsMapping);
+  });
+
+  it('tests processing wildcard field with multi fields with match_only_text type', () => {
+    const wildcardWithMultiFieldsLiteralYml = `
+- name: wildcardWithMultiFields
+  type: wildcard
+  multi_fields:
+    - name: text
+      type: match_only_text
+`;
+
+    const wildcardWithMultiFieldsMapping = {
+      properties: {
+        wildcardWithMultiFields: {
+          ignore_above: 1024,
+          type: 'wildcard',
+          fields: {
+            text: {
+              type: 'match_only_text',
+            },
+          },
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(wildcardWithMultiFieldsLiteralYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(wildcardWithMultiFieldsMapping);
   });
 
   it('tests processing object field with no other attributes', () => {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -244,9 +244,8 @@ function generateMultiFields(fields: Fields): MultiFields {
           multiFields[f.name] = { ...generateKeywordMapping(f), type: f.type };
           break;
         case 'long':
-          multiFields[f.name] = { type: f.type };
-          break;
         case 'double':
+        case 'match_only_text':
           multiFields[f.name] = { type: f.type };
           break;
       }
@@ -302,7 +301,7 @@ function getDefaultProperties(field: Field): Properties {
   if (field.index !== undefined) {
     properties.index = field.index;
   }
-  if (field.doc_values) {
+  if (field.doc_values !== undefined) {
     properties.doc_values = field.doc_values;
   }
   if (field.copy_to) {


### PR DESCRIPTION
## Summary

Added field mappings for:
- `doc_values`: false value
- `multi_fields`: match_only_text type

Original issue: https://github.com/elastic/elastic-package/issues/678

Related discussion: https://github.com/elastic/elastic-package/pull/752#issuecomment-1076477443


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
