### PR TITLE
[7.16] Update API keys docs to mention the option to explicitly enable API keys service even if TLS is not configured. (#128184)

### DIFF
--- a/docs/user/security/api-keys/index.asciidoc
+++ b/docs/user/security/api-keys/index.asciidoc
@@ -27,11 +27,7 @@ The {es} API key service is automatically enabled when you configure
 {ref}/configuring-tls.html#tls-http[TLS on the HTTP interface].
 This ensures that clients are unable to send API keys in clear-text.
 
-When HTTPS connections are not enabled between {kib} and {es},
-you cannot create or manage API keys, and you get an error message.
-For more information, see the
-{ref}/security-api-create-api-key.html[{es} API key documentation],
-or contact your system administrator.
+When TLS on the HTTP interface between {kib} and {es} isn't configured, you must {ref}/security-api-create-api-key.html#security-api-create-api-key-desc[enable the API key service explicitly]. Otherwise, you cannot create or manage API keys, and you will get an error message when trying to use API keys in {kib}.
 
 [float]
 [[api-keys-security-privileges]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `7.17` to `7.16`:
 - [Update API keys docs to mention the option to explicitly enable API keys service even if TLS is not configured. (#128184)](https://github.com/elastic/kibana/pull/128184)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)