### PR TITLE
[Security Solution][Detections] Adds a back button to the Tour UI on the Rule Management page

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -95,6 +95,20 @@ export const FEATURE_TOUR_TITLE = i18n.translate(
   }
 );
 
+export const FEATURE_TOUR_PREV_STEP_BUTTON = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.featureTour.prevStepButtonTitle',
+  {
+    defaultMessage: 'Go back',
+  }
+);
+
+export const FEATURE_TOUR_NEXT_STEP_BUTTON = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.featureTour.nextStepButtonTitle',
+  {
+    defaultMessage: 'Ok, got it',
+  }
+);
+
 export const FEATURE_TOUR_IN_MEMORY_TABLE_STEP = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.featureTour.inMemoryTableStepDescription',
   {
@@ -107,13 +121,6 @@ export const FEATURE_TOUR_IN_MEMORY_TABLE_STEP_TITLE = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.featureTour.inMemoryTableStepTitle',
   {
     defaultMessage: 'Step 1',
-  }
-);
-
-export const FEATURE_TOUR_IN_MEMORY_TABLE_STEP_NEXT = i18n.translate(
-  'xpack.securitySolution.detectionEngine.rules.allRules.featureTour.inMemoryTableStepNextButtonTitle',
-  {
-    defaultMessage: 'Ok, got it',
   }
 );
 


### PR DESCRIPTION
**Ticket:** https://github.com/elastic/kibana/issues/126084

## Summary

This PR adds a back button to each of the two Tour steps. Users will be able to freely navigate between the steps.

## Before

![](https://user-images.githubusercontent.com/92328789/152391079-57a12b97-a273-4852-95e6-222680d09464.png)

![](https://user-images.githubusercontent.com/92328789/152391090-87cd436a-eb74-4358-b699-53c3e79fdb48.png)

## After

![](https://puu.sh/IQoYO/d213b38e5d.png)

![](https://puu.sh/IQoYT/bd1c055be3.png)

