### PR TITLE
Mark `elasticsearch.serviceAccountToken` setting as GA

### DIFF
--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -282,7 +282,7 @@ on the {kib} index at startup. {kib} users still need to authenticate with
 {es}, which is proxied through the {kib} server.
 
 |[[elasticsearch-service-account-token]] `elasticsearch.serviceAccountToken:`
- | beta[]. If your {es} is protected with basic authentication, this token provides the credentials
+ | If your {es} is protected with basic authentication, this token provides the credentials
 that the {kib} server uses to perform maintenance on the {kib} index at startup. This setting
 is an alternative to `elasticsearch.username` and `elasticsearch.password`.
 


### PR DESCRIPTION
See also: https://github.com/elastic/kibana/issues/124576#issuecomment-1076738652

> We initially marked this setting as beta in our docs when we added this setting in 7.15 via #102121, here was our reasoning at the time: _**Note** I am marking this as `beta` in the docs because the underlying ES APIs are marked as `beta`. This gives us the necessary flexibility to make a breaking change if required (although I do not expect any at this time)_
> 
> It looks like the API is [marked as beta in the 7.13 docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/security-api-get-service-accounts.html), but it is [not marked as beta in the 7.14 docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.14/security-api-get-service-accounts.html).
> 
> I will submit a PR to update our docs accordingly.