### PR TITLE
[Session View] Fix for process event pagination.

### DIFF
--- a/x-pack/plugins/session_view/public/components/session_view/hooks.ts
+++ b/x-pack/plugins/session_view/public/components/session_view/hooks.ts
@@ -58,7 +58,7 @@ export const useFetchSessionViewProcessEvents = (
       getNextPageParam: (lastPage) => {
         if (lastPage.events.length === PROCESS_EVENTS_PER_PAGE) {
           return {
-            cursor: lastPage.events[lastPage.events.length - 1]['@timestamp'],
+            cursor: lastPage.events[lastPage.events.length - 1].process.start,
             forward: true,
           };
         }
@@ -66,7 +66,7 @@ export const useFetchSessionViewProcessEvents = (
       getPreviousPageParam: (firstPage) => {
         if (jumpToEvent && firstPage.events.length === PROCESS_EVENTS_PER_PAGE) {
           return {
-            cursor: firstPage.events[0]['@timestamp'],
+            cursor: firstPage.events[0].process.start,
             forward: false,
           };
         }

--- a/x-pack/plugins/session_view/server/routes/process_events_route.ts
+++ b/x-pack/plugins/session_view/server/routes/process_events_route.ts
@@ -57,7 +57,7 @@ export const doSearch = async (
         { 'process.start': forward ? 'asc' : 'desc' },
         { '@timestamp': forward ? 'asc' : 'desc' },
       ],
-      search_after: cursor ? [cursor] : undefined,
+      search_after: cursor ? [cursor, cursor] : undefined,
     },
   });
 


### PR DESCRIPTION
## Summary

Added the double sort in a previous PR, but forgot to update the search_after prop as well as updating the cursor client side to send up process.start instead of `@timestamp`

We need to sort by process.start first, so that all of a processes lifecycle events are loaded at the same time. Which avoids having to load the entirety of the session to get the 'end' event for the entry leader.