### PR TITLE
[App Search] Filter Elasticsearch index based engines from meta engine creation

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.test.ts
@@ -104,6 +104,7 @@ describe('MetaEngineCreationLogic', () => {
   describe('listeners', () => {
     describe('fetchIndexedEngineNames', () => {
       beforeEach(() => {
+        mount();
         jest.clearAllMocks();
       });
 
@@ -118,6 +119,22 @@ describe('MetaEngineCreationLogic', () => {
         jest.spyOn(MetaEngineCreationLogic.actions, 'setIndexedEngineNames');
         http.get.mockReturnValueOnce(
           Promise.resolve({ results: [{ name: 'foo' }], meta: { page: { total_pages: 1 } } })
+        );
+        MetaEngineCreationLogic.actions.fetchIndexedEngineNames();
+        await nextTick();
+        expect(MetaEngineCreationLogic.actions.setIndexedEngineNames).toHaveBeenCalledWith(['foo']);
+      });
+
+      it('filters out elasticsearch type engines', async () => {
+        jest.spyOn(MetaEngineCreationLogic.actions, 'setIndexedEngineNames');
+        http.get.mockReturnValueOnce(
+          Promise.resolve({
+            results: [
+              { name: 'foo', type: 'default' },
+              { name: 'elasticsearch-engine', type: 'elasticsearch' },
+            ],
+            meta: { page: { total_pages: 1 } },
+          })
         );
         MetaEngineCreationLogic.actions.fetchIndexedEngineNames();
         await nextTick();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.ts
@@ -16,7 +16,7 @@ import { HttpLogic } from '../../../shared/http';
 import { KibanaLogic } from '../../../shared/kibana';
 import { ENGINE_PATH } from '../../routes';
 import { formatApiName } from '../../utils/format_api_name';
-import { EngineDetails } from '../engine/types';
+import { EngineDetails, EngineTypes } from '../engine/types';
 
 import { META_ENGINE_CREATION_SUCCESS_MESSAGE } from './constants';
 
@@ -100,7 +100,9 @@ export const MetaEngineCreationLogic = kea<
       }
 
       if (response) {
-        const engineNames = response.results.map((result) => result.name);
+        const engineNames = response.results
+          .filter(({ type }) => type !== EngineTypes.elasticsearch)
+          .map((result) => result.name);
         actions.setIndexedEngineNames([...values.indexedEngineNames, ...engineNames]);
 
         if (page < response.meta.page.total_pages) {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.test.ts
@@ -109,6 +109,24 @@ describe('SourceEnginesLogic', () => {
           selectableEngineNames: ['source-engine-1', 'source-engine-2'],
         });
       });
+
+      it('sets indexedEngines filters out elasticsearch type engines', () => {
+        mount();
+
+        SourceEnginesLogic.actions.setIndexedEngines([
+          { name: 'source-engine-1' },
+          { name: 'source-engine-2' },
+          { name: 'source-engine-elasticsearch', type: 'elasticsearch' },
+        ] as EngineDetails[]);
+
+        expect(SourceEnginesLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          indexedEngines: [{ name: 'source-engine-1' }, { name: 'source-engine-2' }],
+          // Selectors
+          indexedEngineNames: ['source-engine-1', 'source-engine-2'],
+          selectableEngineNames: ['source-engine-1', 'source-engine-2'],
+        });
+      });
     });
 
     describe('onSourceEnginesFetch', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.ts
@@ -11,7 +11,7 @@ import { flashAPIErrors, flashSuccessToast } from '../../../shared/flash_message
 import { HttpLogic } from '../../../shared/http';
 import { recursivelyFetchEngines } from '../../utils/recursively_fetch_engines';
 import { EngineLogic } from '../engine';
-import { EngineDetails } from '../engine/types';
+import { EngineDetails, EngineTypes } from '../engine/types';
 
 import { ADD_SOURCE_ENGINES_SUCCESS_MESSAGE, REMOVE_SOURCE_ENGINE_SUCCESS_MESSAGE } from './i18n';
 
@@ -88,7 +88,8 @@ export const SourceEnginesLogic = kea<
     indexedEngines: [
       [],
       {
-        setIndexedEngines: (_, { indexedEngines }) => indexedEngines,
+        setIndexedEngines: (_, { indexedEngines }) =>
+          indexedEngines.filter(({ type }) => type !== EngineTypes.elasticsearch),
       },
     ],
     selectedEngineNamesToAdd: [


### PR DESCRIPTION
Fixes https://github.com/elastic/enterprise-search-team/issues/1686
## Summary

This filters out Elasticsearch indices based engines to show up on the meta engine creation views.

https://user-images.githubusercontent.com/1410658/159942607-a0817cad-b576-4c8c-b542-ff2ed14e5634.mov


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
