### PR TITLE
[App Search] Add missing doclink for Elasticsearch Index Selector

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -93,6 +93,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       crawlRules: `${APP_SEARCH_DOCS}crawl-web-content.html#crawl-web-content-manage-crawl-rules`,
       curations: `${APP_SEARCH_DOCS}curations-guide.html`,
       duplicateDocuments: `${APP_SEARCH_DOCS}web-crawler-reference.html#web-crawler-reference-content-deduplication`,
+      elasticsearchEngine: `${APP_SEARCH_DOCS}use-an-existing-elasticsearch-index.html`,
       entryPoints: `${APP_SEARCH_DOCS}crawl-web-content.html#crawl-web-content-manage-entry-points`,
       guide: `${APP_SEARCH_DOCS}index.html`,
       indexingDocuments: `${APP_SEARCH_DOCS}indexing-documents-guide.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -82,6 +82,7 @@ export interface DocLinks {
     readonly crawlRules: string;
     readonly curations: string;
     readonly duplicateDocuments: string;
+    readonly elasticsearchEngine: string;
     readonly entryPoints: string;
     readonly guide: string;
     readonly indexingDocuments: string;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation.tsx
@@ -33,6 +33,7 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
+import { docLinks } from '../../../shared/doc_links';
 import { parseQueryParams } from '../../../shared/query_params';
 import { ENGINES_TITLE } from '../engines';
 import { AppSearchPageTemplate } from '../layout';
@@ -212,7 +213,11 @@ export const EngineCreation: React.FC = () => {
                             </p>
                             <p>
                               <small>
-                                <EuiLink href="#" target="_blank">
+                                <EuiLink
+                                  href={docLinks.appSearchElasticsearchEngine}
+                                  target="_blank"
+                                  external
+                                >
                                   {i18n.translate(
                                     'xpack.enterpriseSearch.engineCreation.elasticsearchIndexedLink',
                                     {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -15,6 +15,7 @@ class DocLinks {
   public appSearchCrawlRules: string;
   public appSearchCurations: string;
   public appSearchDuplicateDocuments: string;
+  public appSearchElasticsearchEngine: string;
   public appSearchEntryPoints: string;
   public appSearchGuide: string;
   public appSearchIndexingDocs: string;
@@ -72,6 +73,7 @@ class DocLinks {
     this.appSearchCrawlRules = '';
     this.appSearchCurations = '';
     this.appSearchDuplicateDocuments = '';
+    this.appSearchElasticsearchEngine = '';
     this.appSearchEntryPoints = '';
     this.appSearchGuide = '';
     this.appSearchIndexingDocs = '';
@@ -130,6 +132,7 @@ class DocLinks {
     this.appSearchCrawlRules = docLinks.links.appSearch.crawlRules;
     this.appSearchCurations = docLinks.links.appSearch.curations;
     this.appSearchDuplicateDocuments = docLinks.links.appSearch.duplicateDocuments;
+    this.appSearchElasticsearchEngine = docLinks.links.appSearch.elasticsearchEngine;
     this.appSearchEntryPoints = docLinks.links.appSearch.entryPoints;
     this.appSearchGuide = docLinks.links.appSearch.guide;
     this.appSearchIndexingDocs = docLinks.links.appSearch.indexingDocuments;


### PR DESCRIPTION
Relates to https://github.com/elastic/enterprise-search-team/issues/1680
## Summary

Add missing link to documentation for Elasticsearch index selector

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
