### PR TITLE
[Security solution] [Session view] Session view alerts bug fix

### DIFF
--- a/x-pack/plugins/session_view/public/components/detail_panel_alert_actions/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_alert_actions/index.tsx
@@ -41,7 +41,7 @@ export const DetailPanelAlertActions = ({
 
   const onJumpToAlert = useCallback(() => {
     const process = new ProcessImpl(event.process.entity_id);
-    process.addAlert(event);
+    process.addEvent(event);
 
     onProcessSelected(process);
     setPopover(false);

--- a/x-pack/plugins/session_view/public/components/session_view/hooks.ts
+++ b/x-pack/plugins/session_view/public/components/session_view/hooks.ts
@@ -147,6 +147,7 @@ export const useFetchAlertStatus = (
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,
+      cacheTime: 0,
     }
   );
 

--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -78,10 +78,12 @@ export const SessionView = ({
   );
 
   useEffect(() => {
-    if (fetchAlertStatus) {
+    if (newUpdatedAlertsStatus) {
       setUpdatedAlertsStatus({ ...newUpdatedAlertsStatus });
+      // clearing alertUuids fetched without triggering a re-render
+      fetchAlertStatus.shift();
     }
-  }, [fetchAlertStatus, newUpdatedAlertsStatus]);
+  }, [newUpdatedAlertsStatus, fetchAlertStatus]);
 
   const handleOnAlertDetailsClosed = useCallback((alertUuid: string) => {
     setFetchAlertStatus([alertUuid]);


### PR DESCRIPTION
- `onJumpToAlert` in `detail_panel_alert_actions` need to add to events for detail panel to properly render results
- fix a bug on alerts flyout call back does not update the same alert more than once in a row