### PR TITLE
Update reporting timeout

### DIFF
--- a/x-pack/test/upgrade/config.ts
+++ b/x-pack/test/upgrade/config.ts
@@ -35,6 +35,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       reportName: 'Upgrade Tests',
     },
 
+    timeouts: {
+      kibanaReportCompletion: 120000,
+    },
+
     security: {
       disableTestUser: true,
     },


### PR DESCRIPTION
The default cloud timeout is 120 seconds in the UI, so we should match that timeout when waiting for the job to finish in the API, the default currently is 60 seconds.  This should fix timeout errors I am seeing, but we still have socket hang up issues happening that need to be addressed. 

```
18:53:43              │ debg Waiting up to 60000ms for job /api/reporting/jobs/download/l13xc6wo000z680082981ymp finished...
18:53:43              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:44              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:44              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:45              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:46              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:46              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:47              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:48              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:48              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:49              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:50              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:50              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:51              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:52              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:52              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:53              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:54              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:54              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:55              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:56              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:56              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:57              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:58              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:58              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:53:59              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:00              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:00              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:01              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:02              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:02              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:03              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:04              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:04              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:05              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:06              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:06              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:07              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:08              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:08              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:09              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:10              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:10              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:11              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:12              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:13              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:13              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:14              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:15              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:15              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:16              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:16              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:17              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:18              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:19              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:19              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:20              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:20              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:21              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:22              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:22              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:23              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:24              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:24              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:25              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:26              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:26              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:27              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:28              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:28              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:29              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:30              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:30              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:31              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:32              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:32              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:33              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:34              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:34              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:35              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:36              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:36              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:37              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:38              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:38              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:39              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:40              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:41              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:42              │ debg Report at path /api/reporting/jobs/download/l13xc6wo000z680082981ymp is pending
18:54:43              │ info Taking screenshot "/var/lib/jenkins/workspace/elastic+estf-cloud-upgrade-tests/JOB/upgradeTest1k/TASK/kibana_upgrade_tests/node/ess-testing/ci/upgrade/kibana/build/kibana/x-pack/test/functional/screenshots/failure/upgrade reporting smoke tests generate report space default name ecommerce type pdf_optimize.png"
18:54:43              │ info Current URL is: https://5fdff6c878034ac485994fccb68309ae.us-east-1.aws.staging.foundit.no:9243/app/dashboards#/view/722b74f0-b882-11e8-a6d9-e546fe2bba5f?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))
18:54:43              │ info Saving page source to: /var/lib/jenkins/workspace/elastic+estf-cloud-upgrade-tests/JOB/upgradeTest1k/TASK/kibana_upgrade_tests/node/ess-testing/ci/upgrade/kibana/build/kibana/x-pack/test/functional/failure_debug/html/upgrade reporting smoke tests generate report space default name ecommerce type pdf_optimize.html
18:54:43              └- ✖ fail: upgrade reporting smoke tests generate report space default name ecommerce type pdf_optimize
18:54:43              │      Error: timed out waiting for job /api/reporting/jobs/download/l13xc6wo000z680082981ymp finished
```
