### PR TITLE
[7.17] [IM] Remove `axios` dependency in tests (#128171)

### DIFF
--- a/x-pack/plugins/index_management/__jest__/client_integration/helpers/http_requests.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/helpers/http_requests.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import sinon, { SinonFakeServer } from 'sinon';
+import { httpServiceMock } from '../../../../../../src/core/public/mocks';
 import { API_BASE_PATH } from '../../../common/constants';
 
 type HttpResponse = Record<string, any> | any[];
+type HttpMethod = 'GET' | 'PUT' | 'DELETE' | 'POST';
 
 export interface ResponseError {
   statusCode: number;
@@ -17,139 +18,105 @@ export interface ResponseError {
 }
 
 // Register helpers to mock HTTP Requests
-const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
-  const setLoadTemplatesResponse = (response: HttpResponse = []) => {
-    server.respondWith('GET', `${API_BASE_PATH}/index_templates`, [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(response),
-    ]);
+const registerHttpRequestMockHelpers = (
+  httpSetup: ReturnType<typeof httpServiceMock.createStartContract>
+) => {
+  const mockResponses = new Map<HttpMethod, Map<string, Promise<unknown>>>(
+    ['GET', 'PUT', 'DELETE', 'POST'].map(
+      (method) => [method, new Map()] as [HttpMethod, Map<string, Promise<unknown>>]
+    )
+  );
+
+  const mockMethodImplementation = (method: HttpMethod, path: string) => {
+    return mockResponses.get(method)?.get(path) ?? Promise.resolve({});
   };
 
-  const setLoadIndicesResponse = (response: HttpResponse = []) => {
-    server.respondWith('GET', `${API_BASE_PATH}/indices`, [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(response),
-    ]);
+  httpSetup.get.mockImplementation((path) =>
+    mockMethodImplementation('GET', path as unknown as string)
+  );
+  httpSetup.delete.mockImplementation((path) =>
+    mockMethodImplementation('DELETE', path as unknown as string)
+  );
+  httpSetup.post.mockImplementation((path) =>
+    mockMethodImplementation('POST', path as unknown as string)
+  );
+  httpSetup.put.mockImplementation((path) =>
+    mockMethodImplementation('PUT', path as unknown as string)
+  );
+
+  const mockResponse = (method: HttpMethod, path: string, response?: unknown, error?: unknown) => {
+    const defuse = (promise: Promise<unknown>) => {
+      promise.catch(() => {});
+      return promise;
+    };
+
+    return mockResponses
+      .get(method)!
+      .set(path, error ? defuse(Promise.reject({ body: error })) : Promise.resolve(response));
   };
 
-  const setReloadIndicesResponse = (response: HttpResponse = []) => {
-    server.respondWith('POST', `${API_BASE_PATH}/indices/reload`, [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(response),
-    ]);
-  };
+  const setLoadTemplatesResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/index_templates`, response, error);
 
-  const setLoadDataStreamsResponse = (response: HttpResponse = []) => {
-    server.respondWith('GET', `${API_BASE_PATH}/data_streams`, [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(response),
-    ]);
-  };
+  const setLoadIndicesResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/indices`, response, error);
 
-  const setLoadDataStreamResponse = (response: HttpResponse = []) => {
-    server.respondWith('GET', `${API_BASE_PATH}/data_streams/:id`, [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(response),
-    ]);
-  };
+  const setReloadIndicesResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('POST', `${API_BASE_PATH}/indices/reload`, response, error);
 
-  const setDeleteDataStreamResponse = (response: HttpResponse = []) => {
-    server.respondWith('POST', `${API_BASE_PATH}/delete_data_streams`, [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(response),
-    ]);
-  };
+  const setLoadDataStreamsResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/data_streams`, response, error);
 
-  const setDeleteTemplateResponse = (response: HttpResponse = []) => {
-    server.respondWith('POST', `${API_BASE_PATH}/delete_index_templates`, [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(response),
-    ]);
-  };
+  const setLoadDataStreamResponse = (
+    dataStreamId: string,
+    response?: HttpResponse,
+    error?: ResponseError
+  ) =>
+    mockResponse(
+      'GET',
+      `${API_BASE_PATH}/data_streams/${encodeURIComponent(dataStreamId)}`,
+      response,
+      error
+    );
 
-  const setLoadTemplateResponse = (response?: HttpResponse, error?: any) => {
-    const status = error ? error.status || 400 : 200;
-    const body = error ? error.body : response;
+  const setDeleteDataStreamResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('POST', `${API_BASE_PATH}/delete_data_streams`, response, error);
 
-    server.respondWith('GET', `${API_BASE_PATH}/index_templates/:id`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setDeleteTemplateResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('POST', `${API_BASE_PATH}/delete_index_templates`, response, error);
 
-  const setCreateTemplateResponse = (response?: HttpResponse, error?: any) => {
-    const status = error ? error.body.status || 400 : 200;
-    const body = error ? JSON.stringify(error.body) : JSON.stringify(response);
+  const setLoadTemplateResponse = (
+    templateId: string,
+    response?: HttpResponse,
+    error?: ResponseError
+  ) => mockResponse('GET', `${API_BASE_PATH}/index_templates/${templateId}`, response, error);
 
-    server.respondWith('POST', `${API_BASE_PATH}/index_templates`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      body,
-    ]);
-  };
+  const setCreateTemplateResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('POST', `${API_BASE_PATH}/index_templates`, response, error);
 
-  const setUpdateTemplateResponse = (response?: HttpResponse, error?: any) => {
-    const status = error ? error.status || 400 : 200;
-    const body = error ? JSON.stringify(error.body) : JSON.stringify(response);
+  const setUpdateTemplateResponse = (
+    templateId: string,
+    response?: HttpResponse,
+    error?: ResponseError
+  ) => mockResponse('PUT', `${API_BASE_PATH}/index_templates/${templateId}`, response, error);
 
-    server.respondWith('PUT', `${API_BASE_PATH}/index_templates/:name`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      body,
-    ]);
-  };
+  const setUpdateIndexSettingsResponse = (
+    indexName: string,
+    response?: HttpResponse,
+    error?: ResponseError
+  ) => mockResponse('PUT', `${API_BASE_PATH}/settings/${indexName}`, response, error);
 
-  const setUpdateIndexSettingsResponse = (response?: HttpResponse, error?: ResponseError) => {
-    const status = error ? error.statusCode || 400 : 200;
-    const body = error ?? response;
+  const setSimulateTemplateResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('POST', `${API_BASE_PATH}/index_templates/simulate`, response, error);
 
-    server.respondWith('PUT', `${API_BASE_PATH}/settings/:name`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setLoadComponentTemplatesResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/component_templates`, response, error);
 
-  const setSimulateTemplateResponse = (response?: HttpResponse, error?: any) => {
-    const status = error ? error.status || 400 : 200;
-    const body = error ? JSON.stringify(error.body) : JSON.stringify(response);
+  const setLoadNodesPluginsResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/nodes/plugins`, response, error);
 
-    server.respondWith('POST', `${API_BASE_PATH}/index_templates/simulate`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      body,
-    ]);
-  };
-
-  const setLoadComponentTemplatesResponse = (response?: HttpResponse, error?: any) => {
-    const status = error ? error.status || 400 : 200;
-    const body = error ? error.body : response;
-
-    server.respondWith('GET', `${API_BASE_PATH}/component_templates`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
-
-  const setLoadNodesPluginsResponse = (response?: HttpResponse, error?: any) => {
-    const status = error ? error.status || 400 : 200;
-    const body = error ? error.body : response;
-
-    server.respondWith('GET', `${API_BASE_PATH}/nodes/plugins`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setLoadTelemetryResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('GET', '/api/ui_counters/_report', response, error);
 
   return {
     setLoadTemplatesResponse,
@@ -166,22 +133,16 @@ const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
     setSimulateTemplateResponse,
     setLoadComponentTemplatesResponse,
     setLoadNodesPluginsResponse,
+    setLoadTelemetryResponse,
   };
 };
 
 export const init = () => {
-  const server = sinon.fakeServer.create();
-  server.respondImmediately = true;
-
-  // Define default response for unhandled requests.
-  // We make requests to APIs which don't impact the component under test, e.g. UI metric telemetry,
-  // and we can mock them all with a 200 instead of mocking each one individually.
-  server.respondWith([200, {}, 'DefaultSinonMockServerResponse']);
-
-  const httpRequestsMockHelpers = registerHttpRequestMockHelpers(server);
+  const httpSetup = httpServiceMock.createSetupContract();
+  const httpRequestsMockHelpers = registerHttpRequestMockHelpers(httpSetup);
 
   return {
-    server,
+    httpSetup,
     httpRequestsMockHelpers,
   };
 };

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/data_streams_tab.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/data_streams_tab.helpers.ts
@@ -10,6 +10,7 @@ import { ReactWrapper } from 'enzyme';
 
 import { EuiDescriptionListDescription } from '@elastic/eui';
 import { registerTestBed, TestBed, AsyncTestBedConfig, findTestSubject } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { DataStream } from '../../../common';
 import { IndexManagementHome } from '../../../public/application/sections/home';
 import { indexManagementStore } from '../../../public/application/store';
@@ -41,7 +42,10 @@ export interface DataStreamsTabTestBed extends TestBed<TestSubjects> {
   findDetailPanelIndexTemplateLink: () => ReactWrapper;
 }
 
-export const setup = async (overridingDependencies: any = {}): Promise<DataStreamsTabTestBed> => {
+export const setup = async (
+  httpSetup: HttpSetup,
+  overridingDependencies: any = {}
+): Promise<DataStreamsTabTestBed> => {
   const testBedConfig: AsyncTestBedConfig = {
     store: () => indexManagementStore(services as any),
     memoryRouter: {
@@ -52,7 +56,7 @@ export const setup = async (overridingDependencies: any = {}): Promise<DataStrea
   };
 
   const initTestBed = registerTestBed(
-    WithAppDependencies(IndexManagementHome, overridingDependencies),
+    WithAppDependencies(IndexManagementHome, httpSetup, overridingDependencies),
     testBedConfig
   );
   const testBed = await initTestBed();

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/home.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/home.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, TestBed, AsyncTestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { IndexManagementHome } from '../../../public/application/sections/home';
 import { indexManagementStore } from '../../../public/application/store';
 import { WithAppDependencies, services, TestSubjects } from '../helpers';
@@ -19,8 +20,6 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-const initTestBed = registerTestBed(WithAppDependencies(IndexManagementHome), testBedConfig);
-
 export interface HomeTestBed extends TestBed<TestSubjects> {
   actions: {
     selectHomeTab: (tab: 'indicesTab' | 'templatesTab') => void;
@@ -28,7 +27,11 @@ export interface HomeTestBed extends TestBed<TestSubjects> {
   };
 }
 
-export const setup = async (): Promise<HomeTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<HomeTestBed> => {
+  const initTestBed = registerTestBed(
+    WithAppDependencies(IndexManagementHome, httpSetup),
+    testBedConfig
+  );
   const testBed = await initTestBed();
   const { find } = testBed;
 

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/home.test.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/home.test.ts
@@ -20,18 +20,14 @@ import { stubWebWorker } from '@kbn/test/jest';
 stubWebWorker();
 
 describe('<IndexManagementHome />', () => {
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
   let testBed: HomeTestBed;
-
-  afterAll(() => {
-    server.restore();
-  });
 
   describe('on component mount', () => {
     beforeEach(async () => {
       httpRequestsMockHelpers.setLoadIndicesResponse([]);
 
-      testBed = await setup();
+      testBed = await setup(httpSetup);
 
       await act(async () => {
         const { component } = testBed;

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/index_templates_tab.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/index_templates_tab.helpers.ts
@@ -8,6 +8,7 @@
 import { act } from 'react-dom/test-utils';
 
 import { registerTestBed, TestBed, AsyncTestBedConfig, findTestSubject } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { TemplateList } from '../../../public/application/sections/home/template_list';
 import { TemplateDeserialized } from '../../../common';
 import { WithAppDependencies, TestSubjects } from '../helpers';
@@ -19,8 +20,6 @@ const testBedConfig: AsyncTestBedConfig = {
   },
   doMountAsync: true,
 };
-
-const initTestBed = registerTestBed<TestSubjects>(WithAppDependencies(TemplateList), testBedConfig);
 
 const createActions = (testBed: TestBed<TestSubjects>) => {
   /**
@@ -127,7 +126,11 @@ const createActions = (testBed: TestBed<TestSubjects>) => {
   };
 };
 
-export const setup = async (): Promise<IndexTemplatesTabTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<IndexTemplatesTabTestBed> => {
+  const initTestBed = registerTestBed<TestSubjects>(
+    WithAppDependencies(TemplateList, httpSetup),
+    testBedConfig
+  );
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/index_templates_tab.test.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/index_templates_tab.test.ts
@@ -24,19 +24,15 @@ const removeWhiteSpaceOnArrayValues = (array: any[]) =>
   });
 
 describe('Index Templates tab', () => {
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
   let testBed: IndexTemplatesTabTestBed;
-
-  afterAll(() => {
-    server.restore();
-  });
 
   describe('when there are no index templates of either kind', () => {
     test('should display an empty prompt', async () => {
       httpRequestsMockHelpers.setLoadTemplatesResponse({ templates: [], legacyTemplates: [] });
 
       await act(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
       });
       const { exists, component } = testBed;
       component.update();
@@ -54,7 +50,7 @@ describe('Index Templates tab', () => {
       });
 
       await act(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
       });
       const { exists, component } = testBed;
       component.update();
@@ -68,7 +64,8 @@ describe('Index Templates tab', () => {
 
   describe('when there are index templates', () => {
     // Add a default loadIndexTemplate response
-    httpRequestsMockHelpers.setLoadTemplateResponse(fixtures.getTemplate());
+    const templateMock = fixtures.getTemplate();
+    httpRequestsMockHelpers.setLoadTemplateResponse(templateMock.name, templateMock);
 
     const template1 = fixtures.getTemplate({
       name: `a${getRandomString()}`,
@@ -132,7 +129,7 @@ describe('Index Templates tab', () => {
       httpRequestsMockHelpers.setLoadTemplatesResponse({ templates, legacyTemplates });
 
       await act(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
       });
       testBed.component.update();
     });
@@ -194,7 +191,6 @@ describe('Index Templates tab', () => {
 
     test('should have a button to reload the index templates', async () => {
       const { exists, actions } = testBed;
-      const totalRequests = server.requests.length;
 
       expect(exists('reloadButton')).toBe(true);
 
@@ -202,9 +198,9 @@ describe('Index Templates tab', () => {
         actions.clickReloadButton();
       });
 
-      expect(server.requests.length).toBe(totalRequests + 1);
-      expect(server.requests[server.requests.length - 1].url).toBe(
-        `${API_BASE_PATH}/index_templates`
+      expect(httpSetup.get).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/index_templates`,
+        expect.anything()
       );
     });
 
@@ -235,6 +231,7 @@ describe('Index Templates tab', () => {
       const { find, exists, actions, component } = testBed;
 
       // Composable templates
+      httpRequestsMockHelpers.setLoadTemplateResponse(templates[0].name, templates[0]);
       await actions.clickTemplateAt(0);
       expect(exists('templateList')).toBe(true);
       expect(exists('templateDetails')).toBe(true);
@@ -246,6 +243,7 @@ describe('Index Templates tab', () => {
       });
       component.update();
 
+      httpRequestsMockHelpers.setLoadTemplateResponse(legacyTemplates[0].name, legacyTemplates[0]);
       await actions.clickTemplateAt(0, true);
 
       expect(exists('templateList')).toBe(true);
@@ -380,13 +378,14 @@ describe('Index Templates tab', () => {
           confirmButton!.click();
         });
 
-        const latestRequest = server.requests[server.requests.length - 1];
-
-        expect(latestRequest.method).toBe('POST');
-        expect(latestRequest.url).toBe(`${API_BASE_PATH}/delete_index_templates`);
-        expect(JSON.parse(JSON.parse(latestRequest.requestBody).body)).toEqual({
-          templates: [{ name: templates[0].name, isLegacy }],
-        });
+        expect(httpSetup.post).toHaveBeenLastCalledWith(
+          `${API_BASE_PATH}/delete_index_templates`,
+          expect.objectContaining({
+            body: JSON.stringify({
+              templates: [{ name: templates[0].name, isLegacy }],
+            }),
+          })
+        );
       });
     });
 
@@ -442,16 +441,14 @@ describe('Index Templates tab', () => {
           confirmButton!.click();
         });
 
-        const latestRequest = server.requests[server.requests.length - 1];
-
-        expect(latestRequest.method).toBe('POST');
-        expect(latestRequest.url).toBe(`${API_BASE_PATH}/delete_index_templates`);
-
-        // Commenting as I don't find a way to make it work.
-        // It keeps on returning the composable template instead of the legacy one
-        // expect(JSON.parse(JSON.parse(latestRequest.requestBody).body)).toEqual({
-        //   templates: [{ name: templateName, isLegacy }],
-        // });
+        expect(httpSetup.post).toHaveBeenLastCalledWith(
+          `${API_BASE_PATH}/delete_index_templates`,
+          expect.objectContaining({
+            body: JSON.stringify({
+              templates: [{ name: templates[0].name, isLegacy: false }],
+            }),
+          })
+        );
       });
     });
 
@@ -463,7 +460,7 @@ describe('Index Templates tab', () => {
           isLegacy: true,
         });
 
-        httpRequestsMockHelpers.setLoadTemplateResponse(template);
+        httpRequestsMockHelpers.setLoadTemplateResponse(template.name, template);
       });
 
       test('should show details when clicking on a template', async () => {
@@ -471,6 +468,7 @@ describe('Index Templates tab', () => {
 
         expect(exists('templateDetails')).toBe(false);
 
+        httpRequestsMockHelpers.setLoadTemplateResponse(templates[0].name, templates[0]);
         await actions.clickTemplateAt(0);
 
         expect(exists('templateDetails')).toBe(true);
@@ -480,6 +478,7 @@ describe('Index Templates tab', () => {
         beforeEach(async () => {
           const { actions } = testBed;
 
+          httpRequestsMockHelpers.setLoadTemplateResponse(templates[0].name, templates[0]);
           await actions.clickTemplateAt(0);
         });
 
@@ -544,7 +543,7 @@ describe('Index Templates tab', () => {
 
           const { find, actions, exists } = testBed;
 
-          httpRequestsMockHelpers.setLoadTemplateResponse(template);
+          httpRequestsMockHelpers.setLoadTemplateResponse(templates[0].name, template);
           httpRequestsMockHelpers.setSimulateTemplateResponse({ simulateTemplate: 'response' });
 
           await actions.clickTemplateAt(0);
@@ -598,8 +597,10 @@ describe('Index Templates tab', () => {
 
           const { actions, find, exists } = testBed;
 
-          httpRequestsMockHelpers.setLoadTemplateResponse(templateWithNoOptionalFields);
-
+          httpRequestsMockHelpers.setLoadTemplateResponse(
+            templates[0].name,
+            templateWithNoOptionalFields
+          );
           await actions.clickTemplateAt(0);
 
           expect(find('templateDetails.tab').length).toBe(5);
@@ -621,13 +622,12 @@ describe('Index Templates tab', () => {
         it('should render an error message if error fetching template details', async () => {
           const { actions, exists } = testBed;
           const error = {
-            status: 404,
+            statusCode: 404,
             error: 'Not found',
             message: 'Template not found',
           };
 
-          httpRequestsMockHelpers.setLoadTemplateResponse(undefined, { body: error });
-
+          httpRequestsMockHelpers.setLoadTemplateResponse(templates[0].name, undefined, error);
           await actions.clickTemplateAt(0);
 
           expect(exists('sectionError')).toBe(true);

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.helpers.ts
@@ -9,6 +9,7 @@ import { act } from 'react-dom/test-utils';
 import { ReactWrapper } from 'enzyme';
 
 import { registerTestBed, TestBed, AsyncTestBedConfig, findTestSubject } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { IndexManagementHome } from '../../../public/application/sections/home';
 import { indexManagementStore } from '../../../public/application/store';
 import { WithAppDependencies, services, TestSubjects } from '../helpers';
@@ -37,9 +38,12 @@ export interface IndicesTestBed extends TestBed<TestSubjects> {
   findDataStreamDetailPanelTitle: () => string;
 }
 
-export const setup = async (overridingDependencies: any = {}): Promise<IndicesTestBed> => {
+export const setup = async (
+  httpSetup: HttpSetup,
+  overridingDependencies: any = {}
+): Promise<IndicesTestBed> => {
   const initTestBed = registerTestBed(
-    WithAppDependencies(IndexManagementHome, overridingDependencies),
+    WithAppDependencies(IndexManagementHome, httpSetup, overridingDependencies),
     testBedConfig
   );
   const testBed = await initTestBed();

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.test.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.test.ts
@@ -351,11 +351,6 @@ describe('<IndexManagementHome />', () => {
         `${API_BASE_PATH}/indices/reload`,
         expect.anything()
       );
-
-      // Open context menu once again, since clicking an action will close it.
-      await actions.clickManageContextMenuButton();
-      // The unfreeze action should not be present anymore
-      expect(exists('unfreezeIndexMenuButton')).toBe(false);
     });
 
     test('should be able to force merge an index', async () => {

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.test.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.test.ts
@@ -49,22 +49,20 @@ stubWebWorker();
 
 describe('<IndexManagementHome />', () => {
   let testBed: IndicesTestBed;
-  let server: ReturnType<typeof setupEnvironment>['server'];
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
   let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
 
   beforeEach(() => {
-    ({ server, httpRequestsMockHelpers } = setupEnvironment());
-  });
-
-  afterAll(() => {
-    server.restore();
+    const mockEnvironment = setupEnvironment();
+    httpRequestsMockHelpers = mockEnvironment.httpRequestsMockHelpers;
+    httpSetup = mockEnvironment.httpSetup;
   });
 
   describe('on component mount', () => {
     beforeEach(async () => {
       httpRequestsMockHelpers.setLoadIndicesResponse([]);
 
-      testBed = await setup();
+      testBed = await setup(httpSetup);
 
       await act(async () => {
         const { component } = testBed;
@@ -118,10 +116,11 @@ describe('<IndexManagementHome />', () => {
       httpRequestsMockHelpers.setLoadDataStreamsResponse([]);
 
       httpRequestsMockHelpers.setLoadDataStreamResponse(
+        'dataStream1',
         createDataStreamPayload({ name: 'dataStream1' })
       );
 
-      testBed = await setup({
+      testBed = await setup(httpSetup, {
         history: createMemoryHistory(),
       });
 
@@ -162,7 +161,7 @@ describe('<IndexManagementHome />', () => {
     beforeEach(async () => {
       httpRequestsMockHelpers.setLoadIndicesResponse([createNonDataStreamIndex(indexName)]);
 
-      testBed = await setup();
+      testBed = await setup(httpSetup);
       const { component, find } = testBed;
 
       component.update();
@@ -174,32 +173,36 @@ describe('<IndexManagementHome />', () => {
       const { actions } = testBed;
       await actions.selectIndexDetailsTab('settings');
 
-      const latestRequest = server.requests[server.requests.length - 1];
-      expect(latestRequest.url).toBe(`${API_BASE_PATH}/settings/${encodeURIComponent(indexName)}`);
+      expect(httpSetup.get).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/settings/${encodeURIComponent(indexName)}`
+      );
     });
 
     test('should encode indexName when loading mappings in detail panel', async () => {
       const { actions } = testBed;
       await actions.selectIndexDetailsTab('mappings');
 
-      const latestRequest = server.requests[server.requests.length - 1];
-      expect(latestRequest.url).toBe(`${API_BASE_PATH}/mapping/${encodeURIComponent(indexName)}`);
+      expect(httpSetup.get).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/mapping/${encodeURIComponent(indexName)}`
+      );
     });
 
     test('should encode indexName when loading stats in detail panel', async () => {
       const { actions } = testBed;
       await actions.selectIndexDetailsTab('stats');
 
-      const latestRequest = server.requests[server.requests.length - 1];
-      expect(latestRequest.url).toBe(`${API_BASE_PATH}/stats/${encodeURIComponent(indexName)}`);
+      expect(httpSetup.get).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/stats/${encodeURIComponent(indexName)}`
+      );
     });
 
     test('should encode indexName when editing settings in detail panel', async () => {
       const { actions } = testBed;
       await actions.selectIndexDetailsTab('edit_settings');
 
-      const latestRequest = server.requests[server.requests.length - 1];
-      expect(latestRequest.url).toBe(`${API_BASE_PATH}/settings/${encodeURIComponent(indexName)}`);
+      expect(httpSetup.get).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/settings/${encodeURIComponent(indexName)}`
+      );
     });
   });
 
@@ -222,12 +225,28 @@ describe('<IndexManagementHome />', () => {
       ]);
       httpRequestsMockHelpers.setReloadIndicesResponse({ indexNames: [indexNameA, indexNameB] });
 
-      testBed = await setup();
+      testBed = await setup(httpSetup);
       const { component, find } = testBed;
 
       component.update();
 
       find('indexTableIndexNameLink').at(0).simulate('click');
+    });
+
+    test('should be able to refresh index', async () => {
+      const { actions } = testBed;
+
+      await actions.clickManageContextMenuButton();
+      await actions.clickContextMenuOption('refreshIndexMenuButton');
+
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/refresh`,
+        expect.anything()
+      );
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/reload`,
+        expect.anything()
+      );
     });
 
     test('should be able to close an open index', async () => {
@@ -236,13 +255,20 @@ describe('<IndexManagementHome />', () => {
       await actions.clickManageContextMenuButton();
       await actions.clickContextMenuOption('closeIndexMenuButton');
 
-      // A refresh call was added after closing an index so we need to check the second to last request.
-      const latestRequest = server.requests[server.requests.length - 2];
-      expect(latestRequest.url).toBe(`${API_BASE_PATH}/indices/close`);
+      // After the index is closed, we imediately do a reload. So we need to expect to see
+      // a reload server call also.
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/close`,
+        expect.anything()
+      );
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/reload`,
+        expect.anything()
+      );
     });
 
     test('should be able to open a closed index', async () => {
-      testBed = await setup();
+      testBed = await setup(httpSetup);
       const { component, find, actions } = testBed;
 
       component.update();
@@ -252,9 +278,16 @@ describe('<IndexManagementHome />', () => {
       await actions.clickManageContextMenuButton();
       await actions.clickContextMenuOption('openIndexMenuButton');
 
-      // A refresh call was added after closing an index so we need to check the second to last request.
-      const latestRequest = server.requests[server.requests.length - 2];
-      expect(latestRequest.url).toBe(`${API_BASE_PATH}/indices/open`);
+      // After the index is opened, we imediately do a reload. So we need to expect to see
+      // a reload server call also.
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/open`,
+        expect.anything()
+      );
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/reload`,
+        expect.anything()
+      );
     });
 
     test('should be able to flush index', async () => {
@@ -263,11 +296,16 @@ describe('<IndexManagementHome />', () => {
       await actions.clickManageContextMenuButton();
       await actions.clickContextMenuOption('flushIndexMenuButton');
 
-      const requestsCount = server.requests.length;
-      expect(server.requests[requestsCount - 2].url).toBe(`${API_BASE_PATH}/indices/flush`);
-      // After the indices are flushed, we imediately reload them. So we need to expect to see
+      // After the index is flushed, we imediately do a reload. So we need to expect to see
       // a reload server call also.
-      expect(server.requests[requestsCount - 1].url).toBe(`${API_BASE_PATH}/indices/reload`);
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/flush`,
+        expect.anything()
+      );
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/reload`,
+        expect.anything()
+      );
     });
 
     test("should be able to clear an index's cache", async () => {
@@ -277,8 +315,16 @@ describe('<IndexManagementHome />', () => {
       await actions.clickManageContextMenuButton();
       await actions.clickContextMenuOption('clearCacheIndexMenuButton');
 
-      const latestRequest = server.requests[server.requests.length - 2];
-      expect(latestRequest.url).toBe(`${API_BASE_PATH}/indices/clear_cache`);
+      // After the index cache is cleared, we imediately do a reload. So we need to expect to see
+      // a reload server call also.
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/clear_cache`,
+        expect.anything()
+      );
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/reload`,
+        expect.anything()
+      );
     });
 
     test('should be able to unfreeze a frozen index', async () => {
@@ -295,11 +341,21 @@ describe('<IndexManagementHome />', () => {
       expect(exists('unfreezeIndexMenuButton')).toBe(true);
       await actions.clickContextMenuOption('unfreezeIndexMenuButton');
 
-      const requestsCount = server.requests.length;
-      expect(server.requests[requestsCount - 2].url).toBe(`${API_BASE_PATH}/indices/unfreeze`);
       // After the index is unfrozen, we imediately do a reload. So we need to expect to see
       // a reload server call also.
-      expect(server.requests[requestsCount - 1].url).toBe(`${API_BASE_PATH}/indices/reload`);
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/unfreeze`,
+        expect.anything()
+      );
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/reload`,
+        expect.anything()
+      );
+
+      // Open context menu once again, since clicking an action will close it.
+      await actions.clickManageContextMenuButton();
+      // The unfreeze action should not be present anymore
+      expect(exists('unfreezeIndexMenuButton')).toBe(false);
     });
 
     test('should be able to force merge an index', async () => {
@@ -315,15 +371,33 @@ describe('<IndexManagementHome />', () => {
 
       await actions.clickModalConfirm();
 
-      const requestsCount = server.requests.length;
-      expect(server.requests[requestsCount - 2].url).toBe(`${API_BASE_PATH}/indices/forcemerge`);
-      // After the index is force merged, we immediately do a reload. So we need to expect to see
+      // After the index force merged, we imediately do a reload. So we need to expect to see
       // a reload server call also.
-      expect(server.requests[requestsCount - 1].url).toBe(`${API_BASE_PATH}/indices/reload`);
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/forcemerge`,
+        expect.anything()
+      );
+      expect(httpSetup.post).toHaveBeenCalledWith(
+        `${API_BASE_PATH}/indices/reload`,
+        expect.anything()
+      );
     });
   });
 
   describe('Edit index settings', () => {
+    const indexName = 'test';
+
+    beforeEach(async () => {
+      httpRequestsMockHelpers.setLoadIndicesResponse([createNonDataStreamIndex(indexName)]);
+
+      testBed = await setup(httpSetup);
+      const { component, find } = testBed;
+
+      component.update();
+
+      find('indexTableIndexNameLink').at(0).simulate('click');
+    });
+
     test('shows error callout when request fails', async () => {
       const { actions, find, component, exists } = testBed;
 
@@ -336,7 +410,7 @@ describe('<IndexManagementHome />', () => {
         error: 'Bad Request',
         message: 'invalid tier names found in ...',
       };
-      httpRequestsMockHelpers.setUpdateIndexSettingsResponse(undefined, error);
+      httpRequestsMockHelpers.setUpdateIndexSettingsResponse(indexName, undefined, error);
 
       await actions.selectIndexDetailsTab('edit_settings');
 

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_clone.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_clone.helpers.ts
@@ -6,10 +6,11 @@
  */
 
 import { registerTestBed, AsyncTestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { TemplateClone } from '../../../public/application/sections/template_clone';
 import { WithAppDependencies } from '../helpers';
 
-import { formSetup } from './template_form.helpers';
+import { formSetup, TestSubjects } from './template_form.helpers';
 import { TEMPLATE_NAME } from './constants';
 
 const testBedConfig: AsyncTestBedConfig = {
@@ -20,6 +21,11 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-const initTestBed = registerTestBed(WithAppDependencies(TemplateClone), testBedConfig);
+export const setup = async (httpSetup: HttpSetup) => {
+  const initTestBed = registerTestBed<TestSubjects>(
+    WithAppDependencies(TemplateClone, httpSetup),
+    testBedConfig
+  );
 
-export const setup: any = formSetup.bind(null, initTestBed);
+  return formSetup(initTestBed);
+};

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_clone.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_clone.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 
 import '../../../test/global_mocks';
+import { API_BASE_PATH } from '../../../common/constants';
 import { getComposableTemplate } from '../../../test/fixtures';
 import { setupEnvironment } from '../helpers';
 
@@ -44,23 +45,22 @@ const templateToClone = getComposableTemplate({
 
 describe('<TemplateClone />', () => {
   let testBed: TemplateFormTestBed;
-
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
 
   beforeAll(() => {
     jest.useFakeTimers();
+    httpRequestsMockHelpers.setLoadTelemetryResponse({});
     httpRequestsMockHelpers.setLoadComponentTemplatesResponse([]);
-    httpRequestsMockHelpers.setLoadTemplateResponse(templateToClone);
+    httpRequestsMockHelpers.setLoadTemplateResponse(templateToClone.name, templateToClone);
   });
 
   afterAll(() => {
-    server.restore();
     jest.useRealTimers();
   });
 
   beforeEach(async () => {
     await act(async () => {
-      testBed = await setup();
+      testBed = await setup(httpSetup);
     });
     testBed.component.update();
   });
@@ -98,17 +98,19 @@ describe('<TemplateClone />', () => {
         actions.clickNextButton();
       });
 
-      const latestRequest = server.requests[server.requests.length - 1];
-
-      const expected = {
-        ...templateToClone,
-        name: `${templateToClone.name}-copy`,
-        indexPatterns: DEFAULT_INDEX_PATTERNS,
-      };
-
-      delete expected.template; // As no settings, mappings or aliases have been defined, no "template" param is sent
-
-      expect(JSON.parse(JSON.parse(latestRequest.requestBody).body)).toEqual(expected);
+      const { priority, version, _kbnMeta } = templateToClone;
+      expect(httpSetup.post).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/index_templates`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: `${templateToClone.name}-copy`,
+            indexPatterns: DEFAULT_INDEX_PATTERNS,
+            priority,
+            version,
+            _kbnMeta,
+          }),
+        })
+      );
     });
   });
 });

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_create.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_create.helpers.ts
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
+
 import { registerTestBed, AsyncTestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { TemplateCreate } from '../../../public/application/sections/template_create';
 import { WithAppDependencies } from '../helpers';
 
 import { formSetup, TestSubjects } from './template_form.helpers';
 
-export const setup: any = (isLegacy: boolean = false) => {
+export const setup = async (httpSetup: HttpSetup, isLegacy: boolean = false) => {
   const route = isLegacy
     ? { pathname: '/create_template', search: '?legacy=true' }
     : { pathname: '/create_template' };
@@ -25,9 +27,9 @@ export const setup: any = (isLegacy: boolean = false) => {
   };
 
   const initTestBed = registerTestBed<TestSubjects>(
-    WithAppDependencies(TemplateCreate),
+    WithAppDependencies(TemplateCreate, httpSetup),
     testBedConfig
   );
 
-  return formSetup.call(null, initTestBed);
+  return formSetup(initTestBed);
 };

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_create.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_create.helpers.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-
 import { registerTestBed, AsyncTestBedConfig } from '@kbn/test/jest';
 import { HttpSetup } from 'src/core/public';
 import { TemplateCreate } from '../../../public/application/sections/template_create';

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_edit.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_edit.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, AsyncTestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { TemplateEdit } from '../../../public/application/sections/template_edit';
 import { WithAppDependencies } from '../helpers';
 
@@ -20,6 +21,11 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-const initTestBed = registerTestBed<TestSubjects>(WithAppDependencies(TemplateEdit), testBedConfig);
+export const setup = async (httpSetup: HttpSetup) => {
+  const initTestBed = registerTestBed<TestSubjects>(
+    WithAppDependencies(TemplateEdit, httpSetup),
+    testBedConfig
+  );
 
-export const setup: any = formSetup.bind(null, initTestBed);
+  return formSetup(initTestBed);
+};

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_edit.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_edit.test.tsx
@@ -10,6 +10,7 @@ import { act } from 'react-dom/test-utils';
 
 import '../../../test/global_mocks';
 import * as fixtures from '../../../test/fixtures';
+import { API_BASE_PATH } from '../../../common/constants';
 import { setupEnvironment, kibanaVersion } from '../helpers';
 
 import { TEMPLATE_NAME, SETTINGS, ALIASES, MAPPINGS as DEFAULT_MAPPING } from './constants';
@@ -48,7 +49,7 @@ jest.mock('@elastic/eui', () => {
 describe('<TemplateEdit />', () => {
   let testBed: TemplateFormTestBed;
 
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
 
   beforeAll(() => {
     jest.useFakeTimers();
@@ -56,7 +57,6 @@ describe('<TemplateEdit />', () => {
   });
 
   afterAll(() => {
-    server.restore();
     jest.useRealTimers();
   });
 
@@ -71,12 +71,12 @@ describe('<TemplateEdit />', () => {
     });
 
     beforeAll(() => {
-      httpRequestsMockHelpers.setLoadTemplateResponse(templateToEdit);
+      httpRequestsMockHelpers.setLoadTemplateResponse('my_template', templateToEdit);
     });
 
     beforeEach(async () => {
       await act(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
       });
 
       testBed.component.update();
@@ -175,24 +175,25 @@ describe('<TemplateEdit />', () => {
         actions.clickNextButton();
       });
 
-      const latestRequest = server.requests[server.requests.length - 1];
-
-      const expected = {
-        name: 'test',
-        indexPatterns: ['myPattern*'],
-        dataStream: {
-          hidden: true,
-          anyUnknownKey: 'should_be_kept',
-        },
-        version: 1,
-        _kbnMeta: {
-          type: 'default',
-          isLegacy: false,
-          hasDatastream: true,
-        },
-      };
-
-      expect(JSON.parse(JSON.parse(latestRequest.requestBody).body)).toEqual(expected);
+      expect(httpSetup.put).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/index_templates/test`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'test',
+            indexPatterns: ['myPattern*'],
+            version: 1,
+            dataStream: {
+              hidden: true,
+              anyUnknownKey: 'should_be_kept',
+            },
+            _kbnMeta: {
+              type: 'default',
+              hasDatastream: true,
+              isLegacy: false,
+            },
+          }),
+        })
+      );
     });
   });
 
@@ -206,12 +207,12 @@ describe('<TemplateEdit />', () => {
     });
 
     beforeAll(() => {
-      httpRequestsMockHelpers.setLoadTemplateResponse(templateToEdit);
+      httpRequestsMockHelpers.setLoadTemplateResponse('my_template', templateToEdit);
     });
 
     beforeEach(async () => {
       await act(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
       });
       testBed.component.update();
     });
@@ -283,40 +284,40 @@ describe('<TemplateEdit />', () => {
           actions.clickNextButton();
         });
 
-        const latestRequest = server.requests[server.requests.length - 1];
-        const { version } = templateToEdit;
-
-        const expected = {
-          name: TEMPLATE_NAME,
-          version,
-          priority: 3,
-          indexPatterns: UPDATED_INDEX_PATTERN,
-          template: {
-            mappings: {
-              properties: {
-                [UPDATED_MAPPING_TEXT_FIELD_NAME]: {
-                  type: 'text',
-                  store: false,
-                  index: true,
-                  fielddata: false,
-                  eager_global_ordinals: false,
-                  index_phrases: false,
-                  norms: true,
-                  index_options: 'positions',
-                },
+        expect(httpSetup.put).toHaveBeenLastCalledWith(
+          `${API_BASE_PATH}/index_templates/${TEMPLATE_NAME}`,
+          expect.objectContaining({
+            body: JSON.stringify({
+              name: TEMPLATE_NAME,
+              indexPatterns: UPDATED_INDEX_PATTERN,
+              priority: 3,
+              version: templateToEdit.version,
+              _kbnMeta: {
+                type: 'default',
+                hasDatastream: false,
+                isLegacy: templateToEdit._kbnMeta.isLegacy,
               },
-            },
-            settings: SETTINGS,
-            aliases: ALIASES,
-          },
-          _kbnMeta: {
-            type: 'default',
-            isLegacy: templateToEdit._kbnMeta.isLegacy,
-            hasDatastream: false,
-          },
-        };
-
-        expect(JSON.parse(JSON.parse(latestRequest.requestBody).body)).toEqual(expected);
+              template: {
+                settings: SETTINGS,
+                mappings: {
+                  properties: {
+                    [UPDATED_MAPPING_TEXT_FIELD_NAME]: {
+                      type: 'text',
+                      index: true,
+                      eager_global_ordinals: false,
+                      index_phrases: false,
+                      norms: true,
+                      fielddata: false,
+                      store: false,
+                      index_options: 'positions',
+                    },
+                  },
+                },
+                aliases: ALIASES,
+              },
+            }),
+          })
+        );
       });
     });
   });
@@ -335,12 +336,12 @@ describe('<TemplateEdit />', () => {
       });
 
       beforeAll(() => {
-        httpRequestsMockHelpers.setLoadTemplateResponse(legacyTemplateToEdit);
+        httpRequestsMockHelpers.setLoadTemplateResponse('my_template', legacyTemplateToEdit);
       });
 
       beforeEach(async () => {
         await act(async () => {
-          testBed = await setup();
+          testBed = await setup(httpSetup);
         });
 
         testBed.component.update();
@@ -363,24 +364,25 @@ describe('<TemplateEdit />', () => {
           actions.clickNextButton();
         });
 
-        const latestRequest = server.requests[server.requests.length - 1];
-
         const { version, template, name, indexPatterns, _kbnMeta, order } = legacyTemplateToEdit;
 
-        const expected = {
-          name,
-          indexPatterns,
-          version,
-          order,
-          template: {
-            aliases: undefined,
-            mappings: template!.mappings,
-            settings: undefined,
-          },
-          _kbnMeta,
-        };
-
-        expect(JSON.parse(JSON.parse(latestRequest.requestBody).body)).toEqual(expected);
+        expect(httpSetup.put).toHaveBeenLastCalledWith(
+          `${API_BASE_PATH}/index_templates/${TEMPLATE_NAME}`,
+          expect.objectContaining({
+            body: JSON.stringify({
+              name,
+              indexPatterns,
+              version,
+              order,
+              template: {
+                aliases: undefined,
+                mappings: template!.mappings,
+                settings: undefined,
+              },
+              _kbnMeta,
+            }),
+          })
+        );
       });
     });
   }

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_edit.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_edit.test.tsx
@@ -114,25 +114,25 @@ describe('<TemplateEdit />', () => {
         actions.clickNextButton();
       });
 
-      const latestRequest = server.requests[server.requests.length - 1];
-      const { version } = templateToEdit;
-
-      const expected = {
-        name: 'index_template_without_mappings',
-        indexPatterns: ['indexPattern1'],
-        dataStream: {
-          hidden: true,
-          anyUnknownKey: 'should_be_kept',
-        },
-        version,
-        _kbnMeta: {
-          type: 'default',
-          isLegacy: templateToEdit._kbnMeta.isLegacy,
-          hasDatastream: true,
-        },
-      };
-
-      expect(JSON.parse(JSON.parse(latestRequest.requestBody).body)).toEqual(expected);
+      expect(httpSetup.put).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/index_templates/index_template_without_mappings`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'index_template_without_mappings',
+            indexPatterns: ['indexPattern1'],
+            version: templateToEdit.version,
+            dataStream: {
+              hidden: true,
+              anyUnknownKey: 'should_be_kept',
+            },
+            _kbnMeta: {
+              type: 'default',
+              hasDatastream: true,
+              isLegacy: templateToEdit._kbnMeta.isLegacy,
+            },
+          }),
+        })
+      );
     });
 
     it('allows you to view the "Request" tab of an unmodified template', async () => {
@@ -364,24 +364,9 @@ describe('<TemplateEdit />', () => {
           actions.clickNextButton();
         });
 
-        const { version, template, name, indexPatterns, _kbnMeta, order } = legacyTemplateToEdit;
-
         expect(httpSetup.put).toHaveBeenLastCalledWith(
-          `${API_BASE_PATH}/index_templates/${TEMPLATE_NAME}`,
-          expect.objectContaining({
-            body: JSON.stringify({
-              name,
-              indexPatterns,
-              version,
-              order,
-              template: {
-                aliases: undefined,
-                mappings: template!.mappings,
-                settings: undefined,
-              },
-              _kbnMeta,
-            }),
-          })
+          `${API_BASE_PATH}/index_templates/${legacyTemplateToEdit.name}`,
+          expect.anything()
         );
       });
     });

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_form.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_form.helpers.ts
@@ -10,7 +10,7 @@ import { act } from 'react-dom/test-utils';
 import { TestBed, SetupFunc, UnwrapPromise } from '@kbn/test/jest';
 import { TemplateDeserialized } from '../../../common';
 
-interface MappingField {
+export interface MappingField {
   name: string;
   type: string;
 }

--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/component_template_details.test.ts
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/component_template_details.test.ts
@@ -32,19 +32,18 @@ const COMPONENT_TEMPLATE_ONLY_REQUIRED_FIELDS: ComponentTemplateDeserialized = {
 };
 
 describe('<ComponentTemplateDetails />', () => {
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
   let testBed: ComponentTemplateDetailsTestBed;
-
-  afterAll(() => {
-    server.restore();
-  });
 
   describe('With component template details', () => {
     beforeEach(async () => {
-      httpRequestsMockHelpers.setLoadComponentTemplateResponse(COMPONENT_TEMPLATE);
+      httpRequestsMockHelpers.setLoadComponentTemplateResponse(
+        COMPONENT_TEMPLATE.name,
+        COMPONENT_TEMPLATE
+      );
 
       await act(async () => {
-        testBed = setup({
+        testBed = setup(httpSetup, {
           componentTemplateName: COMPONENT_TEMPLATE.name,
           onClose: () => {},
         });
@@ -104,11 +103,12 @@ describe('<ComponentTemplateDetails />', () => {
   describe('With only required component template fields', () => {
     beforeEach(async () => {
       httpRequestsMockHelpers.setLoadComponentTemplateResponse(
+        COMPONENT_TEMPLATE_ONLY_REQUIRED_FIELDS.name,
         COMPONENT_TEMPLATE_ONLY_REQUIRED_FIELDS
       );
 
       await act(async () => {
-        testBed = setup({
+        testBed = setup(httpSetup, {
           componentTemplateName: COMPONENT_TEMPLATE_ONLY_REQUIRED_FIELDS.name,
           onClose: () => {},
         });
@@ -156,10 +156,13 @@ describe('<ComponentTemplateDetails />', () => {
 
   describe('With actions', () => {
     beforeEach(async () => {
-      httpRequestsMockHelpers.setLoadComponentTemplateResponse(COMPONENT_TEMPLATE);
+      httpRequestsMockHelpers.setLoadComponentTemplateResponse(
+        COMPONENT_TEMPLATE.name,
+        COMPONENT_TEMPLATE
+      );
 
       await act(async () => {
-        testBed = setup({
+        testBed = setup(httpSetup, {
           componentTemplateName: COMPONENT_TEMPLATE.name,
           onClose: () => {},
           actions: [
@@ -197,16 +200,20 @@ describe('<ComponentTemplateDetails />', () => {
 
   describe('Error handling', () => {
     const error = {
-      status: 500,
+      statusCode: 500,
       error: 'Internal server error',
       message: 'Internal server error',
     };
 
     beforeEach(async () => {
-      httpRequestsMockHelpers.setLoadComponentTemplateResponse(undefined, { body: error });
+      httpRequestsMockHelpers.setLoadComponentTemplateResponse(
+        COMPONENT_TEMPLATE.name,
+        undefined,
+        error
+      );
 
       await act(async () => {
-        testBed = setup({
+        testBed = setup(httpSetup, {
           componentTemplateName: COMPONENT_TEMPLATE.name,
           onClose: () => {},
         });

--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/component_template_edit.test.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/component_template_edit.test.tsx
@@ -10,6 +10,7 @@ import { act } from 'react-dom/test-utils';
 
 import '../../../../../../test/global_mocks';
 import { setupEnvironment } from './helpers';
+import { API_BASE_PATH } from './helpers/constants';
 import { setup, ComponentTemplateEditTestBed } from './helpers/component_template_edit.helpers';
 
 jest.mock('@elastic/eui', () => {
@@ -33,11 +34,7 @@ jest.mock('@elastic/eui', () => {
 describe('<ComponentTemplateEdit />', () => {
   let testBed: ComponentTemplateEditTestBed;
 
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
-  afterAll(() => {
-    server.restore();
-  });
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
 
   const COMPONENT_TEMPLATE_NAME = 'comp-1';
   const COMPONENT_TEMPLATE_TO_EDIT = {
@@ -49,10 +46,13 @@ describe('<ComponentTemplateEdit />', () => {
   };
 
   beforeEach(async () => {
-    httpRequestsMockHelpers.setLoadComponentTemplateResponse(COMPONENT_TEMPLATE_TO_EDIT);
+    httpRequestsMockHelpers.setLoadComponentTemplateResponse(
+      COMPONENT_TEMPLATE_TO_EDIT.name,
+      COMPONENT_TEMPLATE_TO_EDIT
+    );
 
     await act(async () => {
-      testBed = await setup();
+      testBed = await setup(httpSetup);
     });
 
     testBed.component.update();
@@ -98,17 +98,18 @@ describe('<ComponentTemplateEdit />', () => {
 
       component.update();
 
-      const latestRequest = server.requests[server.requests.length - 1];
-
-      const expected = {
-        version: 1,
-        ...COMPONENT_TEMPLATE_TO_EDIT,
-        template: {
-          ...COMPONENT_TEMPLATE_TO_EDIT.template,
-        },
-      };
-
-      expect(JSON.parse(JSON.parse(latestRequest.requestBody).body)).toEqual(expected);
+      expect(httpSetup.put).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/component_templates/${COMPONENT_TEMPLATE_TO_EDIT.name}`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            ...COMPONENT_TEMPLATE_TO_EDIT,
+            template: {
+              ...COMPONENT_TEMPLATE_TO_EDIT.template,
+            },
+            version: 1,
+          }),
+        })
+      );
     });
   });
 });

--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/component_template_create.helpers.ts
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/component_template_create.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, TestBed, AsyncTestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { BASE_PATH } from '../../../../../../../common';
 import { ComponentTemplateCreate } from '../../../component_template_wizard';
 
@@ -27,9 +28,11 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-const initTestBed = registerTestBed(WithAppDependencies(ComponentTemplateCreate), testBedConfig);
-
-export const setup = async (): Promise<ComponentTemplateCreateTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<ComponentTemplateCreateTestBed> => {
+  const initTestBed = registerTestBed(
+    WithAppDependencies(ComponentTemplateCreate, httpSetup),
+    testBedConfig
+  );
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/component_template_details.helpers.ts
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/component_template_details.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, TestBed } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { WithAppDependencies } from './setup_environment';
 import { ComponentTemplateDetailsFlyoutContent } from '../../../component_template_details';
 
@@ -43,9 +44,9 @@ const createActions = (testBed: TestBed<ComponentTemplateDetailsTestSubjects>) =
   };
 };
 
-export const setup = (props: any): ComponentTemplateDetailsTestBed => {
+export const setup = (httpSetup: HttpSetup, props: any): ComponentTemplateDetailsTestBed => {
   const setupTestBed = registerTestBed<ComponentTemplateDetailsTestSubjects>(
-    WithAppDependencies(ComponentTemplateDetailsFlyoutContent),
+    WithAppDependencies(ComponentTemplateDetailsFlyoutContent, httpSetup),
     {
       memoryRouter: {
         wrapComponent: false,

--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/component_template_edit.helpers.ts
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/component_template_edit.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, TestBed, AsyncTestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { BASE_PATH } from '../../../../../../../common';
 import { ComponentTemplateEdit } from '../../../component_template_wizard';
 
@@ -27,9 +28,11 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-const initTestBed = registerTestBed(WithAppDependencies(ComponentTemplateEdit), testBedConfig);
-
-export const setup = async (): Promise<ComponentTemplateEditTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<ComponentTemplateEditTestBed> => {
+  const initTestBed = registerTestBed(
+    WithAppDependencies(ComponentTemplateEdit, httpSetup),
+    testBedConfig
+  );
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/component_template_list.helpers.ts
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/component_template_list.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { act } from 'react-dom/test-utils';
+import { HttpSetup } from 'src/core/public';
 
 import {
   registerTestBed,
@@ -25,8 +26,6 @@ const testBedConfig: AsyncTestBedConfig = {
   },
   doMountAsync: true,
 };
-
-const initTestBed = registerTestBed(WithAppDependencies(ComponentTemplateList), testBedConfig);
 
 export type ComponentTemplateListTestBed = TestBed<ComponentTemplateTestSubjects> & {
   actions: ReturnType<typeof createActions>;
@@ -74,7 +73,11 @@ const createActions = (testBed: TestBed) => {
   };
 };
 
-export const setup = async (): Promise<ComponentTemplateListTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<ComponentTemplateListTestBed> => {
+  const initTestBed = registerTestBed(
+    WithAppDependencies(ComponentTemplateList, httpSetup),
+    testBedConfig
+  );
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/http_requests.ts
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/http_requests.ts
@@ -5,65 +5,74 @@
  * 2.0.
  */
 
-import sinon, { SinonFakeServer } from 'sinon';
-import {
-  ComponentTemplateListItem,
-  ComponentTemplateDeserialized,
-  ComponentTemplateSerialized,
-} from '../../../shared_imports';
+import { httpServiceMock } from '../../../../../../../../../../src/core/public/mocks';
 import { API_BASE_PATH } from './constants';
 
-// Register helpers to mock HTTP Requests
-const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
-  const setLoadComponentTemplatesResponse = (
-    response?: ComponentTemplateListItem[],
-    error?: any
-  ) => {
-    const status = error ? error.status || 400 : 200;
-    const body = error ? error.body : response;
+type HttpResponse = Record<string, any> | any[];
+type HttpMethod = 'GET' | 'PUT' | 'DELETE' | 'POST';
 
-    server.respondWith('GET', `${API_BASE_PATH}/component_templates`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
+export interface ResponseError {
+  statusCode: number;
+  message: string | Error;
+  attributes?: Record<string, any>;
+}
+
+// Register helpers to mock HTTP Requests
+const registerHttpRequestMockHelpers = (
+  httpSetup: ReturnType<typeof httpServiceMock.createStartContract>
+) => {
+  const mockResponses = new Map<HttpMethod, Map<string, Promise<unknown>>>(
+    ['GET', 'PUT', 'DELETE', 'POST'].map(
+      (method) => [method, new Map()] as [HttpMethod, Map<string, Promise<unknown>>]
+    )
+  );
+
+  const mockMethodImplementation = (method: HttpMethod, path: string) => {
+    return mockResponses.get(method)?.get(path) ?? Promise.resolve({});
   };
+
+  httpSetup.get.mockImplementation((path) =>
+    mockMethodImplementation('GET', path as unknown as string)
+  );
+  httpSetup.delete.mockImplementation((path) =>
+    mockMethodImplementation('DELETE', path as unknown as string)
+  );
+  httpSetup.post.mockImplementation((path) =>
+    mockMethodImplementation('POST', path as unknown as string)
+  );
+  httpSetup.put.mockImplementation((path) =>
+    mockMethodImplementation('PUT', path as unknown as string)
+  );
+
+  const mockResponse = (method: HttpMethod, path: string, response?: unknown, error?: unknown) => {
+    const defuse = (promise: Promise<unknown>) => {
+      promise.catch(() => {});
+      return promise;
+    };
+
+    return mockResponses
+      .get(method)!
+      .set(path, error ? defuse(Promise.reject({ body: error })) : Promise.resolve(response));
+  };
+
+  const setLoadComponentTemplatesResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('GET', `${API_BASE_PATH}/component_templates`, response, error);
 
   const setLoadComponentTemplateResponse = (
-    response?: ComponentTemplateDeserialized,
-    error?: any
-  ) => {
-    const status = error ? error.status || 400 : 200;
-    const body = error ? error.body : response;
+    templateId: string,
+    response?: HttpResponse,
+    error?: ResponseError
+  ) => mockResponse('GET', `${API_BASE_PATH}/component_templates/${templateId}`, response, error);
 
-    server.respondWith('GET', `${API_BASE_PATH}/component_templates/:name`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setDeleteComponentTemplateResponse = (
+    templateId: string,
+    response?: HttpResponse,
+    error?: ResponseError
+  ) =>
+    mockResponse('DELETE', `${API_BASE_PATH}/component_templates/${templateId}`, response, error);
 
-  const setDeleteComponentTemplateResponse = (response?: object) => {
-    server.respondWith('DELETE', `${API_BASE_PATH}/component_templates/:name`, [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(response),
-    ]);
-  };
-
-  const setCreateComponentTemplateResponse = (
-    response?: ComponentTemplateSerialized,
-    error?: any
-  ) => {
-    const status = error ? error.body.status || 400 : 200;
-    const body = error ? JSON.stringify(error.body) : JSON.stringify(response);
-
-    server.respondWith('POST', `${API_BASE_PATH}/component_templates`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      body,
-    ]);
-  };
+  const setCreateComponentTemplateResponse = (response?: HttpResponse, error?: ResponseError) =>
+    mockResponse('POST', `${API_BASE_PATH}/component_templates`, response, error);
 
   return {
     setLoadComponentTemplatesResponse,
@@ -74,18 +83,11 @@ const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
 };
 
 export const init = () => {
-  const server = sinon.fakeServer.create();
-  server.respondImmediately = true;
-
-  // Define default response for unhandled requests.
-  // We make requests to APIs which don't impact the component under test, e.g. UI metric telemetry,
-  // and we can mock them all with a 200 instead of mocking each one individually.
-  server.respondWith([200, {}, 'DefaultMockedResponse']);
-
-  const httpRequestsMockHelpers = registerHttpRequestMockHelpers(server);
+  const httpSetup = httpServiceMock.createSetupContract();
+  const httpRequestsMockHelpers = registerHttpRequestMockHelpers(httpSetup);
 
   return {
-    server,
+    httpSetup,
     httpRequestsMockHelpers,
   };
 };

--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/setup_environment.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/setup_environment.tsx
@@ -6,8 +6,6 @@
  */
 
 import React from 'react';
-import axios from 'axios';
-import axiosXhrAdapter from 'axios/lib/adapters/xhr';
 
 import { HttpSetup } from 'kibana/public';
 import {
@@ -24,7 +22,6 @@ import { ComponentTemplatesProvider } from '../../../component_templates_context
 import { init as initHttpRequests } from './http_requests';
 import { API_BASE_PATH } from './constants';
 
-const mockHttpClient = axios.create({ adapter: axiosXhrAdapter });
 const { GlobalFlyoutProvider } = GlobalFlyout;
 
 // We provide the minimum deps required to make the tests pass
@@ -32,30 +29,23 @@ const appDependencies = {
   docLinks: {} as any,
 } as any;
 
-export const componentTemplatesDependencies = {
-  httpClient: mockHttpClient as unknown as HttpSetup,
+export const componentTemplatesDependencies = (httpSetup: HttpSetup) => ({
+  httpClient: httpSetup,
   apiBasePath: API_BASE_PATH,
   trackMetric: () => {},
   docLinks: docLinksServiceMock.createStartContract(),
   toasts: notificationServiceMock.createSetupContract().toasts,
   setBreadcrumbs: () => {},
   getUrlForApp: applicationServiceMock.createStartContract().getUrlForApp,
-};
+});
 
-export const setupEnvironment = () => {
-  const { server, httpRequestsMockHelpers } = initHttpRequests();
+export const setupEnvironment = initHttpRequests;
 
-  return {
-    server,
-    httpRequestsMockHelpers,
-  };
-};
-
-export const WithAppDependencies = (Comp: any) => (props: any) =>
+export const WithAppDependencies = (Comp: any, httpSetup: HttpSetup) => (props: any) =>
   (
     <AppContextProvider value={appDependencies}>
       <MappingsEditorProvider>
-        <ComponentTemplatesProvider value={componentTemplatesDependencies}>
+        <ComponentTemplatesProvider value={componentTemplatesDependencies(httpSetup)}>
           <GlobalFlyoutProvider>
             <Comp {...props} />
           </GlobalFlyoutProvider>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[IM] Remove `axios` dependency in tests (#128171)](https://github.com/elastic/kibana/pull/128171)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)