### PR TITLE
[SecuritySolution] Update toast content on attaching visualization to case

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/translations.ts
@@ -39,6 +39,13 @@ export const ADD_TO_EXISTING_CASE = i18n.translate(
   }
 );
 
+export const ADD_TO_CASE_SUCCESS = i18n.translate(
+  'xpack.securitySolution.visualizationActions.addToCaseSuccessContent',
+  {
+    defaultMessage: 'Successfully added visualization to the case',
+  }
+);
+
 export const SOURCE_CHART_LABEL = i18n.translate(
   'xpack.securitySolution.visualizationActions.uniqueIps.sourceChartLabel',
   {

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_existing_case.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_existing_case.test.tsx
@@ -50,6 +50,7 @@ describe('', () => {
         },
       ],
       onClose: mockOnAddToCaseClicked,
+      toastContent: 'Successfully added visualization to the case',
     });
     expect(result.current.disabled).toEqual(false);
   });

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_existing_case.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_existing_case.tsx
@@ -9,6 +9,7 @@ import { CommentType } from '../../../../../cases/common';
 
 import { APP_ID } from '../../../../common/constants';
 import { useKibana } from '../../lib/kibana/kibana_react';
+import { ADD_TO_CASE_SUCCESS } from './translations';
 
 import { LensAttributes } from './types';
 
@@ -42,6 +43,7 @@ export const useAddToExistingCase = ({
   const selectCaseModal = cases.hooks.getUseCasesAddToExistingCaseModal({
     attachments,
     onClose: onAddToCaseClicked,
+    toastContent: ADD_TO_CASE_SUCCESS,
   });
 
   const onAddToExistingCaseClicked = useCallback(() => {

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_new_case.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_new_case.test.tsx
@@ -47,6 +47,7 @@ describe('', () => {
           type,
         },
       ],
+      toastContent: 'Successfully added visualization to the case',
     });
     expect(result.current.disabled).toEqual(false);
   });

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_new_case.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_new_case.tsx
@@ -10,6 +10,7 @@ import { CommentType } from '../../../../../cases/common';
 
 import { APP_ID } from '../../../../common/constants';
 import { useKibana } from '../../lib/kibana/kibana_react';
+import { ADD_TO_CASE_SUCCESS } from './translations';
 
 import { LensAttributes } from './types';
 
@@ -44,6 +45,7 @@ export const useAddToNewCase = ({
 
   const createCaseFlyout = cases.hooks.getUseCasesAddToNewCaseFlyout({
     attachments,
+    toastContent: ADD_TO_CASE_SUCCESS,
   });
 
   const onAddToNewCaseClicked = useCallback(() => {


### PR DESCRIPTION
## Summary
issue: https://github.com/elastic/kibana/issues/127956



Before:

Steps to reproduce

1. Go to Security Solution > Hosts, click on the ... menu on a chart
2. Select add to new case or add to existing case
3. Fill up the form and observe the wording on the toast
4. It says an **alert** has been added instead of a **visualization** has been added.

<img src="https://user-images.githubusercontent.com/6295984/158789135-d2ed6a1e-a145-433b-bfff-04b128d37e33.gif" />

After:

The Success toast says: `Successfully added visualization to the case`



https://user-images.githubusercontent.com/6295984/160372002-4223b867-9cb1-4b2f-865c-a39984ec564e.mp4


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

