### PR TITLE
[APM] Set metadata tab as default in span details flyout

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/index.tsx
@@ -21,6 +21,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { Fragment } from 'react';
+import { isEmpty } from 'lodash';
 import { CompositeSpanDurationSummaryItem } from '../../../../../../shared/summary/composite_span_duration_summary_item';
 import { euiStyled } from '../../../../../../../../../../../src/plugins/kibana_react/common';
 import { Span } from '../../../../../../../../typings/es_schemas/ui/span';
@@ -217,24 +218,6 @@ export function SpanFlyout({
           <EuiTabbedContent
             tabs={[
               {
-                id: 'stack-trace',
-                name: i18n.translate(
-                  'xpack.apm.transactionDetails.spanFlyout.stackTraceTabLabel',
-                  {
-                    defaultMessage: 'Stack Trace',
-                  }
-                ),
-                content: (
-                  <Fragment>
-                    <EuiSpacer size="l" />
-                    <Stacktrace
-                      stackframes={stackframes}
-                      codeLanguage={codeLanguage}
-                    />
-                  </Fragment>
-                ),
-              },
-              {
                 id: 'metadata',
                 name: i18n.translate(
                   'xpack.apm.propertiesTable.tabs.metadataLabel',
@@ -249,6 +232,28 @@ export function SpanFlyout({
                   </Fragment>
                 ),
               },
+              ...(!isEmpty(stackframes)
+                ? [
+                    {
+                      id: 'stack-trace',
+                      name: i18n.translate(
+                        'xpack.apm.transactionDetails.spanFlyout.stackTraceTabLabel',
+                        {
+                          defaultMessage: 'Stack Trace',
+                        }
+                      ),
+                      content: (
+                        <Fragment>
+                          <EuiSpacer size="l" />
+                          <Stacktrace
+                            stackframes={stackframes}
+                            codeLanguage={codeLanguage}
+                          />
+                        </Fragment>
+                      ),
+                    },
+                  ]
+                : []),
             ]}
           />
         </EuiFlyoutBody>


### PR DESCRIPTION
## Summary
- Set `Metadata` tab as default in span details flyout
- Display `Stack Trace` tab only if `span.stacktrace` is not empty.

https://user-images.githubusercontent.com/5831975/160386681-e34c3c60-2517-47ca-8693-7fe8258745b4.mov

Closes https://github.com/elastic/kibana/issues/68757