### PR TITLE
[DOCS] Adds GET case API docs

### DIFF
--- a/docs/api/cases.asciidoc
+++ b/docs/api/cases.asciidoc
@@ -14,7 +14,7 @@ these APIs:
 * <<cases-api-find-connectors>>
 * {security-guide}/cases-api-get-case-activity.html[Get all case activity]
 * {security-guide}/cases-api-get-all-case-comments.html[Get all case comments]
-* {security-guide}/cases-api-get-case.html[Get case]
+* <<cases-api-get-case>>
 * {security-guide}/cases-api-get-comment.html[Get comment]
 * {security-guide}/cases-get-connector.html[Get current connector]
 * {security-guide}/cases-api-get-reporters.html[Get reporters]

--- a/docs/api/cases.asciidoc
+++ b/docs/api/cases.asciidoc
@@ -34,5 +34,7 @@ include::cases/cases-api-delete-comments.asciidoc[leveloffset=+1]
 //FIND
 include::cases/cases-api-find-cases.asciidoc[leveloffset=+1]
 include::cases/cases-api-find-connectors.asciidoc[leveloffset=+1]
+//GET
+include::cases/cases-api-get-case.asciidoc[leveloffset=+1]
 //UPDATE
 include::cases/cases-api-update.asciidoc[leveloffset=+1]

--- a/docs/api/cases/cases-api-get-case.asciidoc
+++ b/docs/api/cases/cases-api-get-case.asciidoc
@@ -41,7 +41,7 @@ a specific set of applications. Valid values are: `cases`, `observability`,
 and `securitySolution`. If this parameter is omitted, the response contains all
 cases that the user has access to read.
 
-WARNING: The `includeComments` query parameter is deprecated and will be removed 
+ deprecated:[8.1.0]
 in a future release.
 
 ==== Response code
@@ -55,7 +55,7 @@ Returns case ID `a18b38a0-71b0-11ea-a0b2-c51ea50a58e2` without comments:
 
 [source,sh]
 --------------------------------------------------
-GET api/cases/a18b38a0-71b0-11ea-a0b2-c51ea50a58e2?includeComments=false
+GET api/cases/a18b38a0-71b0-11ea-a0b2-c51ea50a58e2
 --------------------------------------------------
 // KIBANA
 

--- a/docs/api/cases/cases-api-get-case.asciidoc
+++ b/docs/api/cases/cases-api-get-case.asciidoc
@@ -35,7 +35,7 @@ default space is used.
 (Optional, boolean) Determines whether case comments are returned. Defaults to 
 `true`.
 
-deprecated:[8.1.0]
+deprecated:[8.1.0, "The `includeComments` query parameter is deprecated and will be removed in a future release."]
 
 ==== Response code
 

--- a/docs/api/cases/cases-api-get-case.asciidoc
+++ b/docs/api/cases/cases-api-get-case.asciidoc
@@ -35,14 +35,7 @@ default space is used.
 (Optional, boolean) Determines whether case comments are returned. Defaults to 
 `true`.
 
-`owner`::
-(Optional, string or array of strings) A filter to limit the retrieved cases to
-a specific set of applications. Valid values are: `cases`, `observability`,
-and `securitySolution`. If this parameter is omitted, the response contains all
-cases that the user has access to read.
-
- deprecated:[8.1.0]
-in a future release.
+ deprecated:[8.0.0]
 
 ==== Response code
 

--- a/docs/api/cases/cases-api-get-case.asciidoc
+++ b/docs/api/cases/cases-api-get-case.asciidoc
@@ -35,7 +35,7 @@ default space is used.
 (Optional, boolean) Determines whether case comments are returned. Defaults to 
 `true`.
 
- deprecated:[8.0.0]
+deprecated:[8.1.0]
 
 ==== Response code
 

--- a/docs/api/cases/cases-api-get-case.asciidoc
+++ b/docs/api/cases/cases-api-get-case.asciidoc
@@ -32,9 +32,8 @@ default space is used.
 === Query parameters
 
 `includeComments`::
-deprecated:[8.1.0, "The `includeComments` query parameter is deprecated and will be removed in a future release."]
 (Optional, boolean) Determines whether case comments are returned. Defaults to 
-`true`.
+`true`. deprecated:[8.1.0, "The `includeComments` query parameter is deprecated and will be removed in a future release."]
 
 
 ==== Response code

--- a/docs/api/cases/cases-api-get-case.asciidoc
+++ b/docs/api/cases/cases-api-get-case.asciidoc
@@ -1,0 +1,108 @@
+[[cases-api-get-case]]
+== Get case API
+++++
+<titleabbrev>Get case</titleabbrev>
+++++
+
+Returns a specified case.
+
+=== Request
+
+`GET <kibana host>:<port>/api/cases/<case ID>`
+
+`GET <kibana host>:<port>/s/<space_id>/api/cases/<case ID>`
+
+=== Prerequisite
+
+You must have `read` privileges for the *Cases* feature in the *Management*,
+*{observability}*, or *Security* section of the
+<<kibana-feature-privileges,{kib} feature privileges>>, depending on the
+`owner` of the cases you're seeking.
+
+=== Path parameters
+
+`<case_id>`::
+(Required, string) An identifier for the case to retrieve. Use 
+<<cases-api-find-cases>> to retrieve case IDs.
+
+`<space_id>`::
+(Optional, string) An identifier for the space. If it is not specified, the
+default space is used.
+
+=== Query parameters
+
+`includeComments`::
+(Optional, boolean) Determines whether case comments are returned. Defaults to 
+`true`.
+
+`owner`::
+(Optional, string or array of strings) A filter to limit the retrieved cases to
+a specific set of applications. Valid values are: `cases`, `observability`,
+and `securitySolution`. If this parameter is omitted, the response contains all
+cases that the user has access to read.
+
+WARNING: The `includeComments` query parameter is deprecated and will be removed 
+in a future release.
+
+==== Response code
+
+`200`::
+   Indicates a successful call.
+
+==== Example
+
+Returns case ID `a18b38a0-71b0-11ea-a0b2-c51ea50a58e2` without comments:
+
+[source,sh]
+--------------------------------------------------
+GET api/cases/a18b38a0-71b0-11ea-a0b2-c51ea50a58e2?includeComments=false
+--------------------------------------------------
+// KIBANA
+
+The API returns a JSON object with the retrieved case. For example:
+
+[source,json]
+--------------------------------------------------
+{
+  "id": "a18b38a0-71b0-11ea-a0b2-c51ea50a58e2",
+  "version": "Wzk4LDFd",
+  "comments": [],
+  "totalComment": 0,
+  "closed_at": null,
+  "closed_by": null,
+  "created_at": "2020-03-29T11:30:02.658Z",
+  "created_by": {
+    "email": "ahunley@imf.usa.gov",
+    "full_name": "Alan Hunley",
+    "username": "ahunley"
+  },
+  "external_service": null,
+  "updated_at": "2020-03-29T12:01:50.244Z",
+  "updated_by": {
+    "full_name": "Classified",
+    "email": "classified@hms.oo.gov.uk",
+    "username": "M"
+  },
+  "description": "James Bond clicked on a highly suspicious email banner advertising cheap holidays for underpaid civil servants. Operation bubblegum is active. Repeat - operation bubblegum is now active!",
+  "title": "This case will self-destruct in 5 seconds",
+  "status": "open",
+  "connector": {
+    "id": "131d4448-abe0-4789-939d-8ef60680b498",
+    "name": "My connector",
+    "type": ".jira",
+    "fields": {
+      "issueType": "10006",
+      "priority": "High",
+    }
+  },
+  "settings": {
+    "syncAlerts": true
+  },
+  "owner": "securitySolution",
+  "tags": [
+    "phishing",
+    "social engineering",
+    "bubblegum"
+  ]
+}
+--------------------------------------------------

--- a/docs/api/cases/cases-api-get-case.asciidoc
+++ b/docs/api/cases/cases-api-get-case.asciidoc
@@ -32,10 +32,10 @@ default space is used.
 === Query parameters
 
 `includeComments`::
+deprecated:[8.1.0, "The `includeComments` query parameter is deprecated and will be removed in a future release."]
 (Optional, boolean) Determines whether case comments are returned. Defaults to 
 `true`.
 
-deprecated:[8.1.0, "The `includeComments` query parameter is deprecated and will be removed in a future release."]
 
 ==== Response code
 


### PR DESCRIPTION
## Summary

Relates to #126956.

This PR copies the GET [case API](https://www.elastic.co/guide/en/security/master/cases-api-overview.html) from the Security Guide to the Kibana Guide. It also formats the content to align with existing Kibana APIs.


### Preview

* [GET case](https://kibana_128606.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-get-case.html)