### PR TITLE
[ML] Adds `throughput_last_minute` to the deployment stats 

### DIFF
--- a/x-pack/plugins/ml/common/types/trained_models.ts
+++ b/x-pack/plugins/ml/common/types/trained_models.ts
@@ -158,6 +158,7 @@ export interface TrainedModelDeploymentStatsResponse {
     last_access: number;
     number_of_pending_requests: number;
     start_time: number;
+    throughput_last_minute: number;
   }>;
 }
 

--- a/x-pack/plugins/ml/common/types/trained_models.ts
+++ b/x-pack/plugins/ml/common/types/trained_models.ts
@@ -190,6 +190,7 @@ export interface AllocatedModel {
     last_access?: number;
     number_of_pending_requests: number;
     start_time: number;
+    throughput_last_minute: number;
   };
 }
 

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
@@ -140,6 +140,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
                 'last_access',
                 'number_of_pending_requests',
                 'start_time',
+                'throughput_last_minute',
               ]),
               name: nodeName,
             } as AllocatedModel['node'],

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/expanded_row.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState, useMemo, useCallback } from 'react';
 import { omit, pick } from 'lodash';
 import {
   EuiBadge,
@@ -17,18 +17,19 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiTabbedContent,
-  EuiTitle,
   EuiTabbedContentTab,
+  EuiTitle,
 } from '@elastic/eui';
 import type { EuiDescriptionListProps } from '@elastic/eui/src/components/description_list/description_list';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { ModelItemFull } from './models_list';
-import { timeFormatter } from '../../../../common/util/date_utils';
 import { isDefined } from '../../../../common/types/guards';
 import { isPopulatedObject } from '../../../../common';
 import { ModelPipelines } from './pipelines';
 import { AllocatedModels } from '../nodes_overview/allocated_models';
 import type { AllocatedModel } from '../../../../common/types/trained_models';
+import { useFieldFormatter } from '../../contexts/kibana/use_field_formatter';
+import { FIELD_FORMAT_IDS } from '../../../../../../../src/plugins/field_formats/common';
 
 interface ExpandedRowProps {
   item: ModelItemFull;
@@ -47,47 +48,61 @@ const badgeFormatter = (items: string[]) => {
   );
 };
 
-const formatterDictionary: Record<string, (value: any) => JSX.Element | string | undefined> = {
-  tags: badgeFormatter,
-  roles: badgeFormatter,
-  create_time: timeFormatter,
-  timestamp: timeFormatter,
-};
+export function useListItemsFormatter() {
+  const bytesFormatter = useFieldFormatter(FIELD_FORMAT_IDS.BYTES);
+  const dateFormatter = useFieldFormatter(FIELD_FORMAT_IDS.DATE);
 
-export function formatToListItems(
-  items: Record<string, unknown> | object
-): EuiDescriptionListProps['listItems'] {
-  return Object.entries(items)
-    .filter(([, value]) => isDefined(value))
-    .map(([title, value]) => {
-      if (title in formatterDictionary) {
-        return {
-          title,
-          description: formatterDictionary[title](value),
-        };
-      }
-      return {
-        title,
-        description:
-          typeof value === 'object' ? (
-            <EuiCodeBlock
-              language="json"
-              fontSize="s"
-              paddingSize="s"
-              overflowHeight={300}
-              isCopyable={false}
-            >
-              {JSON.stringify(value, null, 2)}
-            </EuiCodeBlock>
-          ) : (
-            value.toString()
-          ),
-      };
-    });
+  const formatterDictionary: Record<string, (value: any) => JSX.Element | string | undefined> =
+    useMemo(
+      () => ({
+        tags: badgeFormatter,
+        roles: badgeFormatter,
+        create_time: dateFormatter,
+        timestamp: dateFormatter,
+        model_size_bytes: bytesFormatter,
+        required_native_memory_bytes: bytesFormatter,
+      }),
+      []
+    );
+
+  return useCallback(
+    (items: Record<string, unknown> | object): EuiDescriptionListProps['listItems'] => {
+      return Object.entries(items)
+        .filter(([, value]) => isDefined(value))
+        .map(([title, value]) => {
+          if (title in formatterDictionary) {
+            return {
+              title,
+              description: formatterDictionary[title](value),
+            };
+          }
+          return {
+            title,
+            description:
+              typeof value === 'object' ? (
+                <EuiCodeBlock
+                  language="json"
+                  fontSize="s"
+                  paddingSize="s"
+                  overflowHeight={300}
+                  isCopyable={false}
+                >
+                  {JSON.stringify(value, null, 2)}
+                </EuiCodeBlock>
+              ) : (
+                value.toString()
+              ),
+          };
+        });
+    },
+    [formatterDictionary]
+  );
 }
 
 export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
   const [modelItems, setModelItems] = useState<AllocatedModel[]>([]);
+
+  const formatToListItems = useListItemsFormatter();
 
   const {
     inference_config: inferenceConfig,

--- a/x-pack/plugins/ml/public/application/trained_models/nodes_overview/allocated_models.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/nodes_overview/allocated_models.tsx
@@ -35,7 +35,7 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
       name: i18n.translate('xpack.ml.trainedModels.nodesList.modelsList.nodeNameHeader', {
         defaultMessage: 'Node name',
       }),
-      width: '200px',
+      width: '150px',
       sortable: true,
       truncateText: false,
       'data-test-subj': 'mlAllocatedModelsTableNodeName',
@@ -46,7 +46,7 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
       name: i18n.translate('xpack.ml.trainedModels.nodesList.modelsList.modelNameHeader', {
         defaultMessage: 'Name',
       }),
-      width: '300px',
+      width: '250px',
       sortable: true,
       truncateText: false,
       'data-test-subj': 'mlAllocatedModelsTableName',
@@ -63,13 +63,16 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
       },
     },
     {
-      field: 'state',
-      name: i18n.translate('xpack.ml.trainedModels.nodesList.modelsList.modelStateHeader', {
-        defaultMessage: 'State',
-      }),
+      field: 'node.throughput_last_minute',
+      name: i18n.translate(
+        'xpack.ml.trainedModels.nodesList.modelsList.throughputLastMinuteHeader',
+        {
+          defaultMessage: 'Throughput',
+        }
+      ),
       width: '100px',
       truncateText: false,
-      'data-test-subj': 'mlAllocatedModelsTableState',
+      'data-test-subj': 'mlAllocatedModelsTableThroughput',
     },
     {
       name: i18n.translate(
@@ -117,7 +120,7 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
       width: '200px',
       'data-test-subj': 'mlAllocatedModelsTableInferenceCount',
       render: (v: AllocatedModel) => {
-        return dateFormatter(v.node.last_access);
+        return v.node.last_access ? dateFormatter(v.node.last_access) : '-';
       },
     },
     {

--- a/x-pack/plugins/ml/public/application/trained_models/nodes_overview/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/nodes_overview/expanded_row.tsx
@@ -17,7 +17,7 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { cloneDeep } from 'lodash';
 import { NodeItem } from './nodes_list';
-import { formatToListItems } from '../models_management/expanded_row';
+import { useListItemsFormatter } from '../models_management/expanded_row';
 import { AllocatedModels } from './allocated_models';
 import { useFieldFormatter } from '../../contexts/kibana/use_field_formatter';
 import { FIELD_FORMAT_IDS } from '../../../../../../../src/plugins/field_formats/common';
@@ -28,6 +28,8 @@ interface ExpandedRowProps {
 
 export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
   const bytesFormatter = useFieldFormatter(FIELD_FORMAT_IDS.BYTES);
+
+  const formatToListItems = useListItemsFormatter();
 
   const {
     allocated_models: allocatedModels,

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -19019,7 +19019,6 @@
     "xpack.ml.trainedModels.nodesList.modelsList.modelRoutingStateHeader": "ルーティング状態",
     "xpack.ml.trainedModels.nodesList.modelsList.modelSizeHeader": "サイズ",
     "xpack.ml.trainedModels.nodesList.modelsList.modelStartTimeHeader": "開始時刻",
-    "xpack.ml.trainedModels.nodesList.modelsList.modelStateHeader": "ステータス",
     "xpack.ml.trainedModels.nodesList.modelsList.nodeNameHeader": "ノード名",
     "xpack.ml.trainedModels.nodesList.modelsMemoryUsage": "学習済みモデル",
     "xpack.ml.trainedModels.nodesList.nodeMemoryUsageHeader": "メモリー使用状況",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -19046,7 +19046,6 @@
     "xpack.ml.trainedModels.nodesList.modelsList.modelRoutingStateHeader": "路由状态",
     "xpack.ml.trainedModels.nodesList.modelsList.modelSizeHeader": "大小",
     "xpack.ml.trainedModels.nodesList.modelsList.modelStartTimeHeader": "开始时间",
-    "xpack.ml.trainedModels.nodesList.modelsList.modelStateHeader": "状态",
     "xpack.ml.trainedModels.nodesList.modelsList.nodeNameHeader": "节点名称",
     "xpack.ml.trainedModels.nodesList.modelsMemoryUsage": "已训练模型",
     "xpack.ml.trainedModels.nodesList.nodeMemoryUsageHeader": "内存使用",


### PR DESCRIPTION
## Summary

https://github.com/elastic/elasticsearch/pull/84628 added throughput stats for the Trained Models deployments. This PR replaces the `state` column with `throughput_last_minute` in the Deployment stats table.
 
Also, bytes formatting has been added to the Model size stats.

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/5236598/160394890-f5749242-4f93-4808-8ffd-ad3526e4931d.png">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios