### PR TITLE
[Fleet] Mark logstash output as BETA

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
@@ -45,7 +45,7 @@ export interface EditOutputFlyoutProps {
 
 const OUTPUT_TYPE_OPTIONS = [
   { value: 'elasticsearch', text: 'Elasticsearch' },
-  { value: 'logstash', text: 'Logstash' },
+  { value: 'logstash', text: 'Logstash (BETA)' },
 ];
 
 export const EditOutputFlyout: React.FunctionComponent<EditOutputFlyoutProps> = ({
@@ -129,6 +129,23 @@ export const EditOutputFlyout: React.FunctionComponent<EditOutputFlyoutProps> = 
                 id="xpack.fleet.settings.editOutputFlyout.typeInputLabel"
                 defaultMessage="Type"
               />
+            }
+            helpText={
+              isLogstashOutput && (
+                <FormattedMessage
+                  id="xpack.fleet.editOutputFlyout.logstashTypeOutputBetaHelpText"
+                  defaultMessage="Logstash output is in BETA, Please help by reporting any bugs. {learnMoreLink}."
+                  values={{
+                    learnMoreLink: (
+                      <EuiLink href={docLinks.links.fleet.guide} external>
+                        {i18n.translate('xpack.fleet.editOutputFlyout.learnMoreLink', {
+                          defaultMessage: 'Learn more',
+                        })}
+                      </EuiLink>
+                    ),
+                  }}
+                />
+              )
             }
           >
             <EuiSelect


### PR DESCRIPTION
## Summary

Resolve #128524

Indicate that the logstash output is a BETA feature.

## UI changes

<img width="690" alt="Screen Shot 2022-03-28 at 9 24 41 AM" src="https://user-images.githubusercontent.com/1336873/160408093-da10b667-b32e-48d4-a418-22260585db17.png">
<img width="392" alt="Screen Shot 2022-03-28 at 9 24 26 AM" src="https://user-images.githubusercontent.com/1336873/160408096-1e955247-4875-4fff-b6c4-2ecf2c1d5e30.png">
