### PR TITLE
chore(NA): run force-install automatically when .yarn-integrity file don't exist

### DIFF
--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -8921,10 +8921,11 @@ const BootstrapCommand = {
           ms: Date.now() - start
         });
       }
-    }; // Force install is set in case a flag `--force-install` is passed into kbn bootstrap
+    }; // Force install is set in case a flag is passed into yarn kbn bootstrap or if the `.yarn-integrity`
+    // file is not found which will be indicated by the return of yarnIntegrityFileExists.
 
 
-    const forceInstall = !!options && options['force-install'] === true; // Install bazel machinery tools if needed
+    const forceInstall = !!options && options['force-install'] === true || !(await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["yarnIntegrityFileExists"])(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(kibanaProjectPath, 'node_modules'))); // Install bazel machinery tools if needed
 
     await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["installBazelTools"])(rootPath); // Setup remote cache settings in .bazelrc.cache if needed
 
@@ -52668,6 +52669,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _yarn_integrity__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(527);
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "removeYarnIntegrityFileIfExists", function() { return _yarn_integrity__WEBPACK_IMPORTED_MODULE_3__["removeYarnIntegrityFileIfExists"]; });
 
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "yarnIntegrityFileExists", function() { return _yarn_integrity__WEBPACK_IMPORTED_MODULE_3__["yarnIntegrityFileExists"]; });
+
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -59100,6 +59103,7 @@ function observeReadable(readable) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "removeYarnIntegrityFileIfExists", function() { return removeYarnIntegrityFileIfExists; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "yarnIntegrityFileExists", function() { return yarnIntegrityFileExists; });
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(4);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(231);
@@ -59122,6 +59126,19 @@ async function removeYarnIntegrityFileIfExists(nodeModulesPath) {
     }
   } catch {// no-op
   }
+}
+async function yarnIntegrityFileExists(nodeModulesPath) {
+  try {
+    const nodeModulesRealPath = await Object(_fs__WEBPACK_IMPORTED_MODULE_1__["tryRealpath"])(nodeModulesPath);
+    const yarnIntegrityFilePath = Object(path__WEBPACK_IMPORTED_MODULE_0__["join"])(nodeModulesRealPath, '.yarn-integrity'); // check if the file already exists
+
+    if (await Object(_fs__WEBPACK_IMPORTED_MODULE_1__["isFile"])(yarnIntegrityFilePath)) {
+      return true;
+    }
+  } catch {// no-op
+  }
+
+  return false;
 }
 
 /***/ }),

--- a/packages/kbn-pm/src/commands/bootstrap.ts
+++ b/packages/kbn-pm/src/commands/bootstrap.ts
@@ -17,7 +17,12 @@ import { ICommand } from './';
 import { readYarnLock } from '../utils/yarn_lock';
 import { sortPackageJson } from '../utils/sort_package_json';
 import { validateDependencies } from '../utils/validate_dependencies';
-import { installBazelTools, removeYarnIntegrityFileIfExists, runBazel } from '../utils/bazel';
+import {
+  installBazelTools,
+  removeYarnIntegrityFileIfExists,
+  runBazel,
+  yarnIntegrityFileExists,
+} from '../utils/bazel';
 import { setupRemoteCache } from '../utils/bazel/setup_remote_cache';
 
 export const BootstrapCommand: ICommand = {
@@ -49,8 +54,11 @@ export const BootstrapCommand: ICommand = {
       }
     };
 
-    // Force install is set in case a flag `--force-install` is passed into kbn bootstrap
-    const forceInstall = !!options && options['force-install'] === true;
+    // Force install is set in case a flag is passed into yarn kbn bootstrap or if the `.yarn-integrity`
+    // file is not found which will be indicated by the return of yarnIntegrityFileExists.
+    const forceInstall =
+      (!!options && options['force-install'] === true) ||
+      !(await yarnIntegrityFileExists(resolve(kibanaProjectPath, 'node_modules')));
 
     // Install bazel machinery tools if needed
     await installBazelTools(rootPath);

--- a/packages/kbn-pm/src/utils/bazel/yarn_integrity.ts
+++ b/packages/kbn-pm/src/utils/bazel/yarn_integrity.ts
@@ -22,3 +22,19 @@ export async function removeYarnIntegrityFileIfExists(nodeModulesPath: string) {
     // no-op
   }
 }
+
+export async function yarnIntegrityFileExists(nodeModulesPath: string) {
+  try {
+    const nodeModulesRealPath = await tryRealpath(nodeModulesPath);
+    const yarnIntegrityFilePath = join(nodeModulesRealPath, '.yarn-integrity');
+
+    // check if the file already exists
+    if (await isFile(yarnIntegrityFilePath)) {
+      return true;
+    }
+  } catch {
+    // no-op
+  }
+
+  return false;
+}


### PR DESCRIPTION
After the merge of https://github.com/elastic/kibana/pull/114048 which setups a new integration of Bazel with yarn our bazel `macOS` pipelines are red. In order to fix those I'm adding a feature to detect if the `.yarn-integrity` is missing and in that case auto setup the `forceInstall` when running bootstrap. 