### PR TITLE
[7.17] chore(NA): run force-install automatically when .yarn-integrity file is missing (#128631)

### DIFF
--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -8910,9 +8910,10 @@ const BootstrapCommand = {
     const kibanaProjectPath = ((_projects$get = projects.get('kibana')) === null || _projects$get === void 0 ? void 0 : _projects$get.path) || '';
     const runOffline = (options === null || options === void 0 ? void 0 : options.offline) === true;
     const reporter = _kbn_dev_utils_ci_stats_reporter__WEBPACK_IMPORTED_MODULE_1__["CiStatsReporter"].fromEnv(_utils_log__WEBPACK_IMPORTED_MODULE_2__["log"]);
-    const timings = []; // Force install is set in case a flag `--force-install` is passed into kbn bootstrap
+    const timings = []; // Force install is set in case a flag is passed into yarn kbn bootstrap or if the `.yarn-integrity`
+    // file is not found which will be indicated by the return of yarnIntegrityFileExists.
 
-    const forceInstall = !!options && options['force-install'] === true; // Install bazel machinery tools if needed
+    const forceInstall = !!options && options['force-install'] === true || !(await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["yarnIntegrityFileExists"])(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(kibanaProjectPath, 'node_modules'))); // Install bazel machinery tools if needed
 
     await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["installBazelTools"])(rootPath); // Setup remote cache settings in .bazelrc.cache if needed
 
@@ -52574,6 +52575,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _yarn_integrity__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(526);
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "removeYarnIntegrityFileIfExists", function() { return _yarn_integrity__WEBPACK_IMPORTED_MODULE_3__["removeYarnIntegrityFileIfExists"]; });
 
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "yarnIntegrityFileExists", function() { return _yarn_integrity__WEBPACK_IMPORTED_MODULE_3__["yarnIntegrityFileExists"]; });
+
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -59006,6 +59009,7 @@ function observeReadable(readable) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "removeYarnIntegrityFileIfExists", function() { return removeYarnIntegrityFileIfExists; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "yarnIntegrityFileExists", function() { return yarnIntegrityFileExists; });
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(4);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(231);
@@ -59028,6 +59032,19 @@ async function removeYarnIntegrityFileIfExists(nodeModulesPath) {
     }
   } catch {// no-op
   }
+}
+async function yarnIntegrityFileExists(nodeModulesPath) {
+  try {
+    const nodeModulesRealPath = await Object(_fs__WEBPACK_IMPORTED_MODULE_1__["tryRealpath"])(nodeModulesPath);
+    const yarnIntegrityFilePath = Object(path__WEBPACK_IMPORTED_MODULE_0__["join"])(nodeModulesRealPath, '.yarn-integrity'); // check if the file already exists
+
+    if (await Object(_fs__WEBPACK_IMPORTED_MODULE_1__["isFile"])(yarnIntegrityFilePath)) {
+      return true;
+    }
+  } catch {// no-op
+  }
+
+  return false;
 }
 
 /***/ }),

--- a/packages/kbn-pm/src/commands/bootstrap.ts
+++ b/packages/kbn-pm/src/commands/bootstrap.ts
@@ -17,7 +17,12 @@ import { ICommand } from './';
 import { readYarnLock } from '../utils/yarn_lock';
 import { sortPackageJson } from '../utils/sort_package_json';
 import { validateDependencies } from '../utils/validate_dependencies';
-import { installBazelTools, removeYarnIntegrityFileIfExists, runBazel } from '../utils/bazel';
+import {
+  installBazelTools,
+  removeYarnIntegrityFileIfExists,
+  runBazel,
+  yarnIntegrityFileExists,
+} from '../utils/bazel';
 import { setupRemoteCache } from '../utils/bazel/setup_remote_cache';
 
 export const BootstrapCommand: ICommand = {
@@ -37,8 +42,11 @@ export const BootstrapCommand: ICommand = {
     const reporter = CiStatsReporter.fromEnv(log);
     const timings = [];
 
-    // Force install is set in case a flag `--force-install` is passed into kbn bootstrap
-    const forceInstall = !!options && options['force-install'] === true;
+    // Force install is set in case a flag is passed into yarn kbn bootstrap or if the `.yarn-integrity`
+    // file is not found which will be indicated by the return of yarnIntegrityFileExists.
+    const forceInstall =
+      (!!options && options['force-install'] === true) ||
+      !(await yarnIntegrityFileExists(resolve(kibanaProjectPath, 'node_modules')));
 
     // Install bazel machinery tools if needed
     await installBazelTools(rootPath);

--- a/packages/kbn-pm/src/utils/bazel/yarn_integrity.ts
+++ b/packages/kbn-pm/src/utils/bazel/yarn_integrity.ts
@@ -22,3 +22,19 @@ export async function removeYarnIntegrityFileIfExists(nodeModulesPath: string) {
     // no-op
   }
 }
+
+export async function yarnIntegrityFileExists(nodeModulesPath: string) {
+  try {
+    const nodeModulesRealPath = await tryRealpath(nodeModulesPath);
+    const yarnIntegrityFilePath = join(nodeModulesRealPath, '.yarn-integrity');
+
+    // check if the file already exists
+    if (await isFile(yarnIntegrityFilePath)) {
+      return true;
+    }
+  } catch {
+    // no-op
+  }
+
+  return false;
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [chore(NA): run force-install automatically when .yarn-integrity file is missing (#128631)](https://github.com/elastic/kibana/pull/128631)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)