### PR TITLE
[8.1] [APM] Service overview only shows top 5 transaction groups (#128287)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
@@ -81,6 +81,7 @@ export function TransactionOverview() {
           kuery={kuery}
           start={start}
           end={end}
+          saveTableOptionsToUrl
         />
       </EuiPanel>
     </>

--- a/x-pack/plugins/apm/public/components/routing/service_detail/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/service_detail/index.tsx
@@ -8,7 +8,7 @@ import * as t from 'io-ts';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { Outlet } from '@kbn/typed-react-router-config';
-import { toBooleanRt } from '@kbn/io-ts-utils';
+import { toBooleanRt, toNumberRt } from '@kbn/io-ts-utils';
 import { comparisonTypeRt } from '../../../../common/runtime_types/comparison_type_rt';
 import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
 import { environmentRt } from '../../../../common/environment_rt';
@@ -95,17 +95,27 @@ export const serviceDetail = {
       },
     },
     children: {
-      '/services/{serviceName}/overview': page({
-        element: <ServiceOverview />,
-        tab: 'overview',
-        title: i18n.translate('xpack.apm.views.overview.title', {
-          defaultMessage: 'Overview',
+      '/services/{serviceName}/overview': {
+        ...page({
+          element: <ServiceOverview />,
+          tab: 'overview',
+          title: i18n.translate('xpack.apm.views.overview.title', {
+            defaultMessage: 'Overview',
+          }),
+          searchBarOptions: {
+            showTransactionTypeSelector: true,
+            showTimeComparison: true,
+          },
         }),
-        searchBarOptions: {
-          showTransactionTypeSelector: true,
-          showTimeComparison: true,
-        },
-      }),
+        params: t.partial({
+          query: t.partial({
+            page: toNumberRt,
+            pageSize: toNumberRt,
+            sortField: t.string,
+            sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
+          }),
+        }),
+      },
       '/services/{serviceName}/transactions': {
         ...page({
           tab: 'transactions',
@@ -117,6 +127,14 @@ export const serviceDetail = {
             showTransactionTypeSelector: true,
             showTimeComparison: true,
           },
+        }),
+        params: t.partial({
+          query: t.partial({
+            page: toNumberRt,
+            pageSize: toNumberRt,
+            sortField: t.string,
+            sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
+          }),
         }),
         children: {
           '/services/{serviceName}/transactions/view': {
@@ -163,10 +181,10 @@ export const serviceDetail = {
         }),
         params: t.partial({
           query: t.partial({
-            sortDirection: t.string,
+            page: toNumberRt,
+            pageSize: toNumberRt,
             sortField: t.string,
-            pageSize: t.string,
-            page: t.string,
+            sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
           }),
         }),
         children: {

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, RIGHT_ALIGNMENT } from '@elastic/eui';
+import {
+  EuiBasicTableColumn,
+  EuiFlexGroup,
+  EuiFlexItem,
+  RIGHT_ALIGNMENT,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { ValuesType } from 'utility-types';
@@ -17,16 +22,15 @@ import {
   asTransactionRate,
 } from '../../../../common/utils/formatters';
 import { APIReturnType } from '../../../services/rest/create_call_apm_api';
-import { ImpactBar } from '../impact_bar';
-import { TransactionDetailLink } from '../links/apm/transaction_detail_link';
-import { ListMetric } from '../list_metric';
-import { ITableColumn } from '../managed_table';
-import { TruncateWithTooltip } from '../truncate_with_tooltip';
-import { getLatencyColumnLabel } from './get_latency_column_label';
 import {
   ChartType,
   getTimeSeriesColor,
 } from '../charts/helper/get_timeseries_color';
+import { ImpactBar } from '../impact_bar';
+import { TransactionDetailLink } from '../links/apm/transaction_detail_link';
+import { ListMetric } from '../list_metric';
+import { TruncateWithTooltip } from '../truncate_with_tooltip';
+import { getLatencyColumnLabel } from './get_latency_column_label';
 
 type TransactionGroupMainStatistics =
   APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/groups/main_statistics'>;
@@ -51,7 +55,7 @@ export function getColumns({
   comparisonEnabled?: boolean;
   shouldShowSparkPlots?: boolean;
   comparisonType?: TimeRangeComparisonType;
-}): Array<ITableColumn<ServiceTransactionGroupItem>> {
+}): Array<EuiBasicTableColumn<ServiceTransactionGroupItem>> {
   return [
     {
       field: 'name',

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
@@ -5,17 +5,22 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { orderBy } from 'lodash';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import uuid from 'uuid';
 import { EuiCallOut } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiCode } from '@elastic/eui';
+import { useHistory } from 'react-router-dom';
 import { APIReturnType } from '../../../services/rest/create_call_apm_api';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
-import { useLegacyUrlParams } from '../../../context/url_params_context/use_url_params';
 import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
 import { TransactionOverviewLink } from '../links/apm/transaction_overview_link';
 import { getTimeRangeComparison } from '../time_comparison/get_time_range_comparison';
@@ -23,7 +28,8 @@ import { OverviewTableContainer } from '../overview_table_container';
 import { getColumns } from './get_columns';
 import { ElasticDocsLink } from '../links/elastic_docs_link';
 import { useBreakpoints } from '../../../hooks/use_breakpoints';
-import { ManagedTable } from '../managed_table';
+import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
+import { fromQuery, toQuery } from '../links/url_helpers';
 
 type ApiResponse =
   APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/groups/main_statistics'>;
@@ -63,6 +69,7 @@ interface Props {
   kuery: string;
   start: string;
   end: string;
+  saveTableOptionsToUrl?: boolean;
 }
 
 export function TransactionsTable({
@@ -76,29 +83,45 @@ export function TransactionsTable({
   kuery,
   start,
   end,
+  saveTableOptionsToUrl = false,
 }: Props) {
-  const [tableOptions] = useState<{
-    pageIndex: number;
-    sort: {
-      direction: SortDirection;
-      field: SortField;
-    };
+  const history = useHistory();
+
+  const {
+    query: {
+      comparisonEnabled,
+      comparisonType,
+      latencyAggregationType,
+      page: urlPage = 0,
+      pageSize: urlPageSize = numberOfTransactionsPerPage,
+      sortField: urlSortField = 'impact',
+      sortDirection: urlSortDirection = 'desc',
+    },
+  } = useAnyOfApmParams(
+    '/services/{serviceName}/transactions',
+    '/services/{serviceName}/overview'
+  );
+
+  const [tableOptions, setTableOptions] = useState<{
+    page: { index: number; size: number };
+    sort: { direction: SortDirection; field: SortField };
   }>({
-    pageIndex: 0,
-    sort: DEFAULT_SORT,
+    page: { index: urlPage, size: urlPageSize },
+    sort: {
+      field: urlSortField as SortField,
+      direction: urlSortDirection as SortDirection,
+    },
   });
 
   // SparkPlots should be hidden if we're in two-column view and size XL (1200px)
   const { isXl } = useBreakpoints();
   const shouldShowSparkPlots = isSingleColumn || !isXl;
 
-  const { pageIndex, sort } = tableOptions;
+  const { page, sort } = tableOptions;
   const { direction, field } = sort;
+  const { index, size } = page;
 
   const { transactionType, serviceName } = useApmServiceContext();
-  const {
-    urlParams: { latencyAggregationType, comparisonType, comparisonEnabled },
-  } = useLegacyUrlParams();
 
   const { comparisonStart, comparisonEnd } = getTimeRangeComparison({
     start,
@@ -132,10 +155,7 @@ export function TransactionsTable({
           response.transactionGroups,
           field,
           direction
-        ).slice(
-          pageIndex * numberOfTransactionsPerPage,
-          (pageIndex + 1) * numberOfTransactionsPerPage
-        );
+        ).slice(index * size, (index + 1) * size);
 
         return {
           // Everytime the main statistics is refetched, updates the requestId making the detailed API to be refetched.
@@ -157,7 +177,8 @@ export function TransactionsTable({
       end,
       transactionType,
       latencyAggregationType,
-      pageIndex,
+      index,
+      size,
       direction,
       field,
       // not used, but needed to trigger an update when comparisonType is changed either manually by user or when time range is changed
@@ -227,6 +248,21 @@ export function TransactionsTable({
 
   const isLoading = status === FETCH_STATUS.LOADING;
   const isNotInitiated = status === FETCH_STATUS.NOT_INITIATED;
+
+  const pagination = useMemo(
+    () => ({
+      pageIndex: index,
+      pageSize: size,
+      totalItemCount: transactionGroupsTotalItems,
+      showPerPageOptions: !hidePerPageOptions,
+    }),
+    [index, size, transactionGroupsTotalItems, hidePerPageOptions]
+  );
+
+  const sorting = useMemo(
+    () => ({ sort: { field, direction } }),
+    [field, direction]
+  );
 
   return (
     <EuiFlexGroup
@@ -306,24 +342,49 @@ export function TransactionsTable({
               transactionGroupsTotalItems === 0 && isNotInitiated
             }
           >
-            <ManagedTable
-              isLoading={isLoading}
-              error={status === FETCH_STATUS.FAILURE}
-              columns={columns}
-              items={transactionGroups}
-              initialSortField="impact"
-              initialSortDirection="desc"
-              initialPageSize={numberOfTransactionsPerPage}
-              noItemsMessage={
-                isLoading
-                  ? i18n.translate('xpack.apm.transactionsTable.loading', {
-                      defaultMessage: 'Loading...',
+            <EuiBasicTable
+              loading={isLoading}
+              error={
+                status === FETCH_STATUS.FAILURE
+                  ? i18n.translate('xpack.apm.transactionsTable.errorMessage', {
+                      defaultMessage: 'Failed to fetch',
                     })
-                  : i18n.translate('xpack.apm.transactionsTable.noResults', {
-                      defaultMessage: 'No transaction groups found',
-                    })
+                  : ''
               }
-              hidePerPageOptions={hidePerPageOptions}
+              items={transactionGroups}
+              columns={columns}
+              pagination={pagination}
+              sorting={sorting}
+              onChange={(newTableOptions: {
+                page?: { index: number; size: number };
+                sort?: { field: string; direction: SortDirection };
+              }) => {
+                setTableOptions({
+                  page: {
+                    index: newTableOptions.page?.index ?? 0,
+                    size:
+                      newTableOptions.page?.size ?? numberOfTransactionsPerPage,
+                  },
+                  sort: newTableOptions.sort
+                    ? {
+                        field: newTableOptions.sort.field as SortField,
+                        direction: newTableOptions.sort.direction,
+                      }
+                    : DEFAULT_SORT,
+                });
+                if (saveTableOptionsToUrl) {
+                  history.push({
+                    ...history.location,
+                    search: fromQuery({
+                      ...toQuery(history.location.search),
+                      page: newTableOptions.page?.index,
+                      pageSize: newTableOptions.page?.size,
+                      sortField: newTableOptions.sort?.field,
+                      sortDirection: newTableOptions.sort?.direction,
+                    }),
+                  });
+                }
+              }}
             />
           </OverviewTableContainer>
         </EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
@@ -29,6 +29,7 @@ import { getColumns } from './get_columns';
 import { ElasticDocsLink } from '../links/elastic_docs_link';
 import { useBreakpoints } from '../../../hooks/use_breakpoints';
 import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
+import { useLegacyUrlParams } from '../../../context/url_params_context/use_url_params';
 import { fromQuery, toQuery } from '../links/url_helpers';
 
 type ApiResponse =
@@ -89,9 +90,6 @@ export function TransactionsTable({
 
   const {
     query: {
-      comparisonEnabled,
-      comparisonType,
-      latencyAggregationType,
       page: urlPage = 0,
       pageSize: urlPageSize = numberOfTransactionsPerPage,
       sortField: urlSortField = 'impact',
@@ -101,6 +99,10 @@ export function TransactionsTable({
     '/services/{serviceName}/transactions',
     '/services/{serviceName}/overview'
   );
+
+  const {
+    urlParams: { latencyAggregationType, comparisonType, comparisonEnabled },
+  } = useLegacyUrlParams();
 
   const [tableOptions, setTableOptions] = useState<{
     page: { index: number; size: number };
@@ -254,7 +256,7 @@ export function TransactionsTable({
       pageIndex: index,
       pageSize: size,
       totalItemCount: transactionGroupsTotalItems,
-      showPerPageOptions: !hidePerPageOptions,
+      hidePerPageOptions,
     }),
     [index, size, transactionGroupsTotalItems, hidePerPageOptions]
   );

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -7853,8 +7853,6 @@
     "xpack.apm.transactionsTable.cardinalityWarning.docsLink": "詳細はドキュメントをご覧ください",
     "xpack.apm.transactionsTable.cardinalityWarning.title": "このビューには、報告されたトランザクションのサブセットが表示されます。",
     "xpack.apm.transactionsTable.linkText": "トランザクションを表示",
-    "xpack.apm.transactionsTable.loading": "読み込み中...",
-    "xpack.apm.transactionsTable.noResults": "トランザクショングループが見つかりません",
     "xpack.apm.transactionsTable.title": "トランザクション",
     "xpack.apm.transactionTypesSelectCustomOptionText": "新しいトランザクションタイプとして\\{searchValue\\}を追加",
     "xpack.apm.transactionTypesSelectPlaceholder": "トランザクションタイプを選択",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -7871,8 +7871,6 @@
     "xpack.apm.transactionsTable.cardinalityWarning.docsLink": "在文档中了解详情",
     "xpack.apm.transactionsTable.cardinalityWarning.title": "此视图显示已报告事务的子集。",
     "xpack.apm.transactionsTable.linkText": "查看事务",
-    "xpack.apm.transactionsTable.loading": "正在加载……",
-    "xpack.apm.transactionsTable.noResults": "未找到事务组",
     "xpack.apm.transactionsTable.title": "事务",
     "xpack.apm.transactionTypesSelectCustomOptionText": "将 \\{searchValue\\} 添加为新事务类型",
     "xpack.apm.transactionTypesSelectPlaceholder": "选择事务类型",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[APM] Service overview only shows top 5 transaction groups (#128287)](https://github.com/elastic/kibana/pull/128287)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)