### PR TITLE
fix(NA): use a single step for yarn kbn bootstrap

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -15,7 +15,7 @@ if ! yarn kbn bootstrap; then
   rm -rf node_modules
 
   echo "--- yarn install and bootstrap, attempt 2"
-  yarn kbn bootstrap
+  yarn kbn bootstrap --force-install
 fi
 
 if [[ "$DISABLE_BOOTSTRAP_VALIDATION" != "true" ]]; then

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -8921,11 +8921,10 @@ const BootstrapCommand = {
           ms: Date.now() - start
         });
       }
-    }; // Force install is set in case a flag is passed into yarn kbn bootstrap or if the `.yarn-integrity`
-    // file is not found which will be indicated by the return of yarnIntegrityFileExists.
+    }; // Force install is set in case a flag is passed into yarn kbn bootstrap
 
 
-    const forceInstall = !!options && options['force-install'] === true || !(await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["yarnIntegrityFileExists"])(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(kibanaProjectPath, 'node_modules'))); // Install bazel machinery tools if needed
+    const forceInstall = !!options && options['force-install'] === true; // Install bazel machinery tools if needed
 
     await Object(_utils_bazel__WEBPACK_IMPORTED_MODULE_9__["installBazelTools"])(rootPath); // Setup remote cache settings in .bazelrc.cache if needed
 
@@ -52669,8 +52668,6 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _yarn_integrity__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(527);
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "removeYarnIntegrityFileIfExists", function() { return _yarn_integrity__WEBPACK_IMPORTED_MODULE_3__["removeYarnIntegrityFileIfExists"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "yarnIntegrityFileExists", function() { return _yarn_integrity__WEBPACK_IMPORTED_MODULE_3__["yarnIntegrityFileExists"]; });
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -59103,7 +59100,6 @@ function observeReadable(readable) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "removeYarnIntegrityFileIfExists", function() { return removeYarnIntegrityFileIfExists; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "yarnIntegrityFileExists", function() { return yarnIntegrityFileExists; });
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(4);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(231);
@@ -59126,19 +59122,6 @@ async function removeYarnIntegrityFileIfExists(nodeModulesPath) {
     }
   } catch {// no-op
   }
-}
-async function yarnIntegrityFileExists(nodeModulesPath) {
-  try {
-    const nodeModulesRealPath = await Object(_fs__WEBPACK_IMPORTED_MODULE_1__["tryRealpath"])(nodeModulesPath);
-    const yarnIntegrityFilePath = Object(path__WEBPACK_IMPORTED_MODULE_0__["join"])(nodeModulesRealPath, '.yarn-integrity'); // check if the file already exists
-
-    if (await Object(_fs__WEBPACK_IMPORTED_MODULE_1__["isFile"])(yarnIntegrityFilePath)) {
-      return true;
-    }
-  } catch {// no-op
-  }
-
-  return false;
 }
 
 /***/ }),

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -52893,6 +52893,7 @@ async function runBazelCommandWithRunner(bazelCommandRunner, bazelArgs, offline 
   try {
     await bazelProc;
   } catch {
+    _log__WEBPACK_IMPORTED_MODULE_5__["log"].error('HINT: when experiencing problems with node_modules try `yarn kbn bootstrap --force-install` or `yarn kbn reset` as last resort.');
     throw new _errors__WEBPACK_IMPORTED_MODULE_6__["CliError"](`The bazel command that was running failed to complete.`);
   }
 

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -52893,7 +52893,7 @@ async function runBazelCommandWithRunner(bazelCommandRunner, bazelArgs, offline 
   try {
     await bazelProc;
   } catch {
-    _log__WEBPACK_IMPORTED_MODULE_5__["log"].error('HINT: when experiencing problems with node_modules try `yarn kbn bootstrap --force-install` or `yarn kbn reset` as last resort.');
+    _log__WEBPACK_IMPORTED_MODULE_5__["log"].error('HINT: If experiencing problems with node_modules try `yarn kbn bootstrap --force-install` or as last resort `yarn kbn reset && yarn kbn bootstrap`');
     throw new _errors__WEBPACK_IMPORTED_MODULE_6__["CliError"](`The bazel command that was running failed to complete.`);
   }
 

--- a/packages/kbn-pm/src/commands/bootstrap.ts
+++ b/packages/kbn-pm/src/commands/bootstrap.ts
@@ -17,12 +17,7 @@ import { ICommand } from './';
 import { readYarnLock } from '../utils/yarn_lock';
 import { sortPackageJson } from '../utils/sort_package_json';
 import { validateDependencies } from '../utils/validate_dependencies';
-import {
-  installBazelTools,
-  removeYarnIntegrityFileIfExists,
-  runBazel,
-  yarnIntegrityFileExists,
-} from '../utils/bazel';
+import { installBazelTools, removeYarnIntegrityFileIfExists, runBazel } from '../utils/bazel';
 import { setupRemoteCache } from '../utils/bazel/setup_remote_cache';
 
 export const BootstrapCommand: ICommand = {
@@ -54,11 +49,8 @@ export const BootstrapCommand: ICommand = {
       }
     };
 
-    // Force install is set in case a flag is passed into yarn kbn bootstrap or if the `.yarn-integrity`
-    // file is not found which will be indicated by the return of yarnIntegrityFileExists.
-    const forceInstall =
-      (!!options && options['force-install'] === true) ||
-      !(await yarnIntegrityFileExists(resolve(kibanaProjectPath, 'node_modules')));
+    // Force install is set in case a flag is passed into yarn kbn bootstrap
+    const forceInstall = !!options && options['force-install'] === true;
 
     // Install bazel machinery tools if needed
     await installBazelTools(rootPath);

--- a/packages/kbn-pm/src/utils/bazel/run.ts
+++ b/packages/kbn-pm/src/utils/bazel/run.ts
@@ -52,6 +52,9 @@ async function runBazelCommandWithRunner(
   try {
     await bazelProc;
   } catch {
+    log.error(
+      'HINT: when experiencing problems with node_modules try `yarn kbn bootstrap --force-install` or `yarn kbn reset` as last resort.'
+    );
     throw new CliError(`The bazel command that was running failed to complete.`);
   }
   await bazelLogs$.toPromise();

--- a/packages/kbn-pm/src/utils/bazel/run.ts
+++ b/packages/kbn-pm/src/utils/bazel/run.ts
@@ -53,7 +53,7 @@ async function runBazelCommandWithRunner(
     await bazelProc;
   } catch {
     log.error(
-      'HINT: when experiencing problems with node_modules try `yarn kbn bootstrap --force-install` or `yarn kbn reset` as last resort.'
+      'HINT: If experiencing problems with node_modules try `yarn kbn bootstrap --force-install` or as last resort `yarn kbn reset && yarn kbn bootstrap`'
     );
     throw new CliError(`The bazel command that was running failed to complete.`);
   }

--- a/packages/kbn-pm/src/utils/bazel/yarn_integrity.ts
+++ b/packages/kbn-pm/src/utils/bazel/yarn_integrity.ts
@@ -22,19 +22,3 @@ export async function removeYarnIntegrityFileIfExists(nodeModulesPath: string) {
     // no-op
   }
 }
-
-export async function yarnIntegrityFileExists(nodeModulesPath: string) {
-  try {
-    const nodeModulesRealPath = await tryRealpath(nodeModulesPath);
-    const yarnIntegrityFilePath = join(nodeModulesRealPath, '.yarn-integrity');
-
-    // check if the file already exists
-    if (await isFile(yarnIntegrityFilePath)) {
-      return true;
-    }
-  } catch {
-    // no-op
-  }
-
-  return false;
-}


### PR DESCRIPTION
Follow up of https://github.com/elastic/kibana/pull/114048 and https://github.com/elastic/kibana/pull/128631

In the previous PRs and after a small fix to get CI green a double yarn step was reintroduced for the majority of the use cases. In that follow up I'm completing the needed work to get back to a single yarn step and also with a different solution to not hurt CI bootstrap retries.