### PR TITLE
[Workplace Search] Configured sources with multiple options now routes correctly when connecting

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
@@ -52,6 +52,7 @@ describe('AddSourceList', () => {
     dataLoading: false,
     newCustomSource: {},
     isOrganization: true,
+    externalConfigured: false,
   };
 
   beforeEach(() => {
@@ -70,6 +71,17 @@ describe('AddSourceList', () => {
     wrapper.find(ConfigurationIntro).prop('advanceStep')();
 
     expect(setAddSourceStep).toHaveBeenCalledWith(AddSourceSteps.SaveConfigStep);
+  });
+
+  it('renders default state correctly when there are multiple connector options, but all connectors have been configured', () => {
+    setMockValues({ ...mockValues, externalConfigured: true });
+    const sourceData = {
+      ...staticSourceData[0],
+      externalConnectorAvailable: true,
+      configured: true,
+    };
+    shallow(<AddSource sourceData={sourceData} />);
+    expect(initializeAddSource).toHaveBeenCalledWith(expect.objectContaining({ connect: true }));
   });
 
   it('renders default state correctly when there are multiple connector options', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -41,15 +41,25 @@ export const AddSource: React.FC<AddSourceProps> = (props) => {
   const { initializeAddSource, setAddSourceStep, saveSourceConfig, resetSourceState } =
     useActions(AddSourceLogic);
   const { addSourceCurrentStep, sourceConfigData, dataLoading } = useValues(AddSourceLogic);
-  const { name, categories, needsPermissions, accountContextOnly, privateSourcesEnabled } =
-    sourceConfigData;
-  const { serviceType, configuration, features, objTypes } = props.sourceData;
+  const {
+    name,
+    categories,
+    needsPermissions,
+    accountContextOnly,
+    privateSourcesEnabled,
+    configured,
+  } = sourceConfigData;
+  const { serviceType, configuration, features, objTypes, externalConnectorAvailable } =
+    props.sourceData;
   const addPath = getAddPath(serviceType);
   const { isOrganization } = useValues(AppLogic);
   const { externalConfigured } = useValues(SourcesLogic);
 
   useEffect(() => {
-    initializeAddSource(props);
+    // We can land on this page from a choice page for multiple types of connectors
+    // If that's the case we want to skip the intro and configuration, if the external & internal connector have already been configured
+    const goToConnect = externalConnectorAvailable && externalConfigured && configured;
+    initializeAddSource(goToConnect ? props : { ...props, connect: true });
     return resetSourceState;
   }, []);
 


### PR DESCRIPTION
This fixes a bug where if you had both an external connector and an internal SharePoint Online connector configured, the connect flow would route you to the intro instead of the connect step