### PR TITLE
[ci] bump memory for webpack bundle reports 

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -173,6 +173,6 @@ steps:
   - command: .buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
     label: 'Build Webpack Bundle Analyzer reports'
     agents:
-      queue: n2-2
+      queue: n2-4
     key: webpack_bundle_analyzer
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -173,6 +173,6 @@ steps:
   - command: .buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
     label: 'Build Webpack Bundle Analyzer reports'
     agents:
-      queue: n2-4
+      queue: c2-4
     key: webpack_bundle_analyzer
     timeout_in_minutes: 60


### PR DESCRIPTION
We're seeing intermittent out of memory errors when building platform
plugins for the webpack bundle analyzer job.  This instance is comparatively undersized with other jobs that
build platform plugins.  This resizes the instance to add more memory.
The higher core count will be utilized by the build plugin task and
decrease build time.