### PR TITLE
[Security Solution] Enhance field filtering function (filterBrowserFieldsByFieldName)

### DIFF
--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/helpers.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/helpers.test.tsx
@@ -172,14 +172,11 @@ describe('helpers', () => {
     });
 
     test("it returns the expected fields/categories when the substring is '.' and the browser fields are large", () => {
-      const start = Date.now();
-      const result = filterBrowserFieldsByFieldName({
-        browserFields: largeBrowserFields,
-        substring: '.',
-      });
-      console.log(`This took: ${Date.now() - start}ms.`);
       expect(
-        result
+        filterBrowserFieldsByFieldName({
+          browserFields: largeBrowserFields,
+          substring: '.',
+        })
       ).toMatchSnapshot();
     });
 

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/helpers.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/helpers.test.tsx
@@ -15,6 +15,7 @@ import {
 } from './helpers';
 import { BrowserFields } from '../../../../../common/search_strategy';
 import { ColumnHeaderOptions } from '../../../../../common';
+import largeBrowserFields from './large_browser_fields_for_testing_filter_browser_fields_by_field_name.json';
 
 describe('helpers', () => {
   describe('categoryHasFields', () => {
@@ -168,6 +169,18 @@ describe('helpers', () => {
           substring: '',
         })
       ).toEqual(mockBrowserFields);
+    });
+
+    test("it returns the expected fields/categories when the substring is '.' and the browser fields are large", () => {
+      const start = Date.now();
+      const result = filterBrowserFieldsByFieldName({
+        browserFields: largeBrowserFields,
+        substring: '.',
+      });
+      console.log(`This took: ${Date.now() - start}ms.`);
+      expect(
+        result
+      ).toMatchSnapshot();
     });
 
     test('it returns (only) non-empty categories, where each category contains only the fields matching the substring', () => {


### PR DESCRIPTION
## Summary

Note: [there is an 8.1 version of this PR.](https://github.com/elastic/kibana/pull/128690) I created this PR so that `main` would match 8.1. It's sort of like a reverse backport :) a front-port.

Customers who upgrade to 8.1.1 are experiencing severe performance problems using the Security Solution. One reason is that we have client side code that filters field mappings, in memory, based on a substring match. The code works fine when run on a small number of field mappings, but it can cause issues if there are many field mappings. Furthermore, the filtering function is running more often than needed. It may run 4-9 times (or maybe more?) when loading the alerts page.

In order to fix this, I rewrote the filtering function against the 8.1 branch and did some performance benchmarking. Upon trying to open this PR up, I realized that the function has already been significantly improved in `main`. 

We should be sure to backport the new version of the function (or the one in `main`) into the 8.1 branch before the 8.1.1 release.

### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix


| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| The function doesn't work as expected | Low, we have tests, and a similar version is already in `main` | Unknown | |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
