### PR TITLE
[ML][Maps] Adds link to maps in charts section of Anomaly Explorer

### DIFF
--- a/x-pack/plugins/maps/common/index.ts
+++ b/x-pack/plugins/maps/common/index.ts
@@ -7,6 +7,7 @@
 
 export {
   AGG_TYPE,
+  APP_ID,
   COLOR_MAP_TYPE,
   ES_GEO_FIELD_TYPE,
   FIELD_ORIGIN,

--- a/x-pack/plugins/maps/public/index.ts
+++ b/x-pack/plugins/maps/public/index.ts
@@ -17,7 +17,7 @@ export const plugin: PluginInitializer<MapsPluginSetup, MapsPluginStart> = (
   return new MapsPlugin(initContext);
 };
 
-export { APP_ID, MAP_SAVED_OBJECT_TYPE } from '../common/constants';
+export { MAP_SAVED_OBJECT_TYPE } from '../common/constants';
 export { MAPS_APP_LOCATOR } from './locators';
 export type { PreIndexedShape } from '../common/elasticsearch_util';
 

--- a/x-pack/plugins/maps/public/index.ts
+++ b/x-pack/plugins/maps/public/index.ts
@@ -17,7 +17,8 @@ export const plugin: PluginInitializer<MapsPluginSetup, MapsPluginStart> = (
   return new MapsPlugin(initContext);
 };
 
-export { MAP_SAVED_OBJECT_TYPE } from '../common/constants';
+export { APP_ID, MAP_SAVED_OBJECT_TYPE } from '../common/constants';
+export { MAPS_APP_LOCATOR } from './locators';
 export type { PreIndexedShape } from '../common/elasticsearch_util';
 
 export { GEOJSON_FEATURE_ID_PROPERTY_NAME } from './classes/layers/vector_layer/geojson_vector_layer/assign_feature_ids';

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
@@ -7,6 +7,7 @@
 import './_index.scss';
 
 import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { escapeKuery } from '@kbn/es-query';
 
 import {
   EuiButtonEmpty,
@@ -65,6 +66,17 @@ const openInMapsPluginMessage = i18n.translate('xpack.ml.explorer.charts.openInM
   defaultMessage: 'Open in Maps',
 });
 
+export function getEntitiesQuery(series) {
+  const queryString = series.entityFields
+    ?.map(({ fieldName, fieldValue }) => `${escapeKuery(fieldName)}:${escapeKuery(fieldValue)}`)
+    .join(' or ');
+  const query = {
+    language: SEARCH_QUERY_LANGUAGE.KUERY,
+    query: queryString,
+  };
+  return { query, queryString };
+}
+
 // create a somewhat unique ID
 // from charts metadata for React's key attribute
 function getChartId(series) {
@@ -101,14 +113,7 @@ function ExplorerChartContainer({
   } = useMlKibana();
 
   const getMapsLink = useCallback(async () => {
-    const queryString = series.entityFields
-      ?.map(({ fieldName, fieldValue }) => `${fieldName}:${fieldValue}`)
-      .join(' or ');
-    const query = {
-      language: SEARCH_QUERY_LANGUAGE.KUERY,
-      query: queryString,
-    };
-
+    const { queryString, query } = getEntitiesQuery(series);
     const initialLayers = [];
     const typicalStyle = {
       type: 'VECTOR',

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
@@ -37,6 +37,7 @@ import { ML_JOB_AGGREGATION } from '../../../../common/constants/aggregation_typ
 import { AnomalySource } from '../../../maps/anomaly_source';
 import { CUSTOM_COLOR_RAMP } from '../../../maps/anomaly_layer_wizard_factory';
 import { LAYER_TYPE } from '../../../../../maps/common';
+import { APP_ID as MAPS_APP_ID, MAPS_APP_LOCATOR } from '../../../../../maps/public';
 import { ExplorerChartsErrorCallOuts } from './explorer_charts_error_callouts';
 import { addItemToRecentlyAccessed } from '../../util/recently_accessed';
 import { EmbeddedMapComponentWrapper } from './explorer_chart_embedded_map';
@@ -99,58 +100,29 @@ function ExplorerChartContainer({
   } = useMlKibana();
 
   const getMapsLink = useCallback(async () => {
-    const initialLayers = [
-      {
-        id: htmlIdGenerator()(),
-        type: LAYER_TYPE.GEOJSON_VECTOR,
-        sourceDescriptor: AnomalySource.createDescriptor({
-          jobId: series.jobId,
-          typicalActual: ML_ANOMALY_LAYERS.ACTUAL,
-        }),
-        style: {
-          type: 'VECTOR',
-          properties: {
-            fillColor: CUSTOM_COLOR_RAMP,
-            lineColor: CUSTOM_COLOR_RAMP,
+    const initialLayers = [];
+    for (const layer in ML_ANOMALY_LAYERS) {
+      if (ML_ANOMALY_LAYERS.hasOwnProperty(layer)) {
+        initialLayers.push({
+          id: htmlIdGenerator()(),
+          type: LAYER_TYPE.GEOJSON_VECTOR,
+          sourceDescriptor: AnomalySource.createDescriptor({
+            jobId: series.jobId,
+            typicalActual: ML_ANOMALY_LAYERS[layer],
+          }),
+          style: {
+            type: 'VECTOR',
+            properties: {
+              fillColor: CUSTOM_COLOR_RAMP,
+              lineColor: CUSTOM_COLOR_RAMP,
+            },
+            isTimeAware: false,
           },
-          isTimeAware: false,
-        },
-      },
-      {
-        id: htmlIdGenerator()(),
-        type: LAYER_TYPE.GEOJSON_VECTOR,
-        sourceDescriptor: AnomalySource.createDescriptor({
-          jobId: series.jobId,
-          typicalActual: ML_ANOMALY_LAYERS.TYPICAL,
-        }),
-        style: {
-          type: 'VECTOR',
-          properties: {
-            fillColor: CUSTOM_COLOR_RAMP,
-            lineColor: CUSTOM_COLOR_RAMP,
-          },
-          isTimeAware: false,
-        },
-      },
-      {
-        id: htmlIdGenerator()(),
-        type: LAYER_TYPE.GEOJSON_VECTOR,
-        sourceDescriptor: AnomalySource.createDescriptor({
-          jobId: series.jobId,
-          typicalActual: ML_ANOMALY_LAYERS.TYPICAL_TO_ACTUAL,
-        }),
-        style: {
-          type: 'VECTOR',
-          properties: {
-            fillColor: CUSTOM_COLOR_RAMP,
-            lineColor: CUSTOM_COLOR_RAMP,
-          },
-          isTimeAware: false,
-        },
-      },
-    ];
+        });
+      }
+    }
 
-    const locator = share.url.locators.get('MAPS_APP_LOCATOR');
+    const locator = share.url.locators.get(MAPS_APP_LOCATOR);
     const location = await locator.getLocation({
       initialLayers: initialLayers,
       timeRange: data.query.timefilter.timefilter.getTime(),
@@ -300,7 +272,7 @@ function ExplorerChartContainer({
                   iconType="logoMaps"
                   size="xs"
                   onClick={async () => {
-                    await navigateToApp('maps', { path: mapsLink });
+                    await navigateToApp(MAPS_APP_ID, { path: mapsLink });
                   }}
                 >
                   <FormattedMessage

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
@@ -36,8 +36,8 @@ import { useMlKibana } from '../../contexts/kibana';
 import { ML_JOB_AGGREGATION } from '../../../../common/constants/aggregation_types';
 import { AnomalySource } from '../../../maps/anomaly_source';
 import { CUSTOM_COLOR_RAMP } from '../../../maps/anomaly_layer_wizard_factory';
-import { LAYER_TYPE } from '../../../../../maps/common';
-import { APP_ID as MAPS_APP_ID, MAPS_APP_LOCATOR } from '../../../../../maps/public';
+import { LAYER_TYPE, APP_ID as MAPS_APP_ID } from '../../../../../maps/common';
+import { MAPS_APP_LOCATOR } from '../../../../../maps/public';
 import { ExplorerChartsErrorCallOuts } from './explorer_charts_error_callouts';
 import { addItemToRecentlyAccessed } from '../../util/recently_accessed';
 import { EmbeddedMapComponentWrapper } from './explorer_chart_embedded_map';
@@ -101,6 +101,45 @@ function ExplorerChartContainer({
 
   const getMapsLink = useCallback(async () => {
     const initialLayers = [];
+    const typicalStyle = {
+      type: 'VECTOR',
+      properties: {
+        fillColor: {
+          type: 'STATIC',
+          options: {
+            color: '#98A2B2',
+          },
+        },
+        lineColor: {
+          type: 'STATIC',
+          options: {
+            color: '#fff',
+          },
+        },
+        lineWidth: {
+          type: 'STATIC',
+          options: {
+            size: 2,
+          },
+        },
+        iconSize: {
+          type: 'STATIC',
+          options: {
+            size: 6,
+          },
+        },
+      },
+    };
+
+    const style = {
+      type: 'VECTOR',
+      properties: {
+        fillColor: CUSTOM_COLOR_RAMP,
+        lineColor: CUSTOM_COLOR_RAMP,
+      },
+      isTimeAware: false,
+    };
+
     for (const layer in ML_ANOMALY_LAYERS) {
       if (ML_ANOMALY_LAYERS.hasOwnProperty(layer)) {
         initialLayers.push({
@@ -110,14 +149,7 @@ function ExplorerChartContainer({
             jobId: series.jobId,
             typicalActual: ML_ANOMALY_LAYERS[layer],
           }),
-          style: {
-            type: 'VECTOR',
-            properties: {
-              fillColor: CUSTOM_COLOR_RAMP,
-              lineColor: CUSTOM_COLOR_RAMP,
-            },
-            isTimeAware: false,
-          },
+          style: ML_ANOMALY_LAYERS[layer] === ML_ANOMALY_LAYERS.TYPICAL ? typicalStyle : style,
         });
       }
     }

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
@@ -15,6 +15,7 @@ import {
   EuiFlexItem,
   EuiIconTip,
   EuiToolTip,
+  htmlIdGenerator
 } from '@elastic/eui';
 
 import {
@@ -31,7 +32,11 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { MlTooltipComponent } from '../../components/chart_tooltip';
 import { withKibana } from '../../../../../../../src/plugins/kibana_react/public';
+import { useMlKibana } from '../../contexts/kibana';
 import { ML_JOB_AGGREGATION } from '../../../../common/constants/aggregation_types';
+import { AnomalySource } from '../../../maps/anomaly_source';
+import { CUSTOM_COLOR_RAMP } from '../../../maps/anomaly_layer_wizard_factory';
+import { LAYER_TYPE } from '../../../../../maps/common';
 import { ExplorerChartsErrorCallOuts } from './explorer_charts_error_callouts';
 import { addItemToRecentlyAccessed } from '../../util/recently_accessed';
 import { EmbeddedMapComponentWrapper } from './explorer_chart_embedded_map';
@@ -53,6 +58,10 @@ const textViewButton = i18n.translate(
 const mapsPluginMessage = i18n.translate('xpack.ml.explorer.charts.mapsPluginMissingMessage', {
   defaultMessage: 'maps or embeddable start plugin not found',
 });
+const openInMapsPluginMessage = i18n.translate('xpack.ml.explorer.charts.openInMapsPluginMessage', {
+  defaultMessage: 'Open in Maps',
+});
+
 
 // create a somewhat unique ID
 // from charts metadata for React's key attribute
@@ -79,6 +88,72 @@ function ExplorerChartContainer({
   chartsService,
 }) {
   const [explorerSeriesLink, setExplorerSeriesLink] = useState('');
+  const [mapsLink, setMapsLink] = useState('');
+
+  const {
+    services: { data, share,
+    application: { navigateToApp }, },
+  } = useMlKibana();
+
+  // TODO: pull in layer name constant and wrap in useCallback if poss
+  const getMapsLink = async () => {
+    const initialLayers = [{
+        id: htmlIdGenerator()(),
+        type: LAYER_TYPE.GEOJSON_VECTOR,
+        sourceDescriptor: AnomalySource.createDescriptor({
+          jobId: series.jobId,
+          typicalActual: 'actual',
+        }),
+        style: {
+          type: 'VECTOR',
+          properties: {
+            fillColor: CUSTOM_COLOR_RAMP,
+            lineColor: CUSTOM_COLOR_RAMP,
+          },
+          isTimeAware: false,
+        },
+      },
+      {
+        id: htmlIdGenerator()(),
+        type: LAYER_TYPE.GEOJSON_VECTOR,
+        sourceDescriptor: AnomalySource.createDescriptor({
+          jobId: series.jobId,
+          typicalActual: 'typical',
+        }),
+        style: {
+          type: 'VECTOR',
+          properties: {
+            fillColor: CUSTOM_COLOR_RAMP,
+            lineColor: CUSTOM_COLOR_RAMP,
+          },
+          isTimeAware: false,
+        },
+      },
+      {
+        id: htmlIdGenerator()(),
+        type: LAYER_TYPE.GEOJSON_VECTOR,
+        sourceDescriptor: AnomalySource.createDescriptor({
+          jobId: series.jobId,
+          typicalActual: 'typical to actual',
+        }),
+        style: {
+          type: 'VECTOR',
+          properties: {
+            fillColor: CUSTOM_COLOR_RAMP,
+            lineColor: CUSTOM_COLOR_RAMP,
+          },
+          isTimeAware: false,
+        },
+      }];
+
+    const locator = share.url.locators.get('MAPS_APP_LOCATOR');
+    const location = await locator.getLocation({
+      initialLayers: initialLayers,
+      timeRange: data.query.timefilter.timefilter.getTime(),
+    });
+
+    return location;
+  };
 
   useEffect(() => {
     let isCancelled = false;
@@ -97,6 +172,26 @@ function ExplorerChartContainer({
       isCancelled = true;
     };
   }, [mlLocator, series]);
+
+  useEffect(function getMapsPluginLink() {
+    if (!series) return;
+    let isCancelled = false;   
+    const generateLink = async () => {
+      if (!isCancelled) {
+        try {
+          const mapsLink = await getMapsLink();
+          setMapsLink(mapsLink?.path); 
+        } catch (error) {
+          console.error(error);
+          setMapsLink('');
+        }
+      }
+    };
+    generateLink().catch(console.error);;
+    return () => {
+      isCancelled = true;
+    };
+  }, [series]);
 
   const chartRef = useRef(null);
 
@@ -191,6 +286,20 @@ function ExplorerChartContainer({
                 </EuiButtonEmpty>
               </EuiToolTip>
             )}
+            {chartType === CHART_TYPE.GEO_MAP && mapsLink ? (
+              <EuiToolTip position="top" content={openInMapsPluginMessage}>
+                <EuiButtonEmpty
+                  iconSide="right"
+                  iconType="logoMaps"
+                  size="xs"
+                  onClick={async () => {
+                    await navigateToApp('maps', { path: mapsLink });
+                  }}
+                >
+                  <FormattedMessage id="xpack.ml.explorer.charts.viewInMapsLabel" defaultMessage="View" />
+                </EuiButtonEmpty>
+              </EuiToolTip>
+            ) : null}
           </div>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
@@ -28,6 +28,7 @@ import { ExplorerChartSingleMetric } from './explorer_chart_single_metric';
 import { ExplorerChartLabel } from './components/explorer_chart_label';
 
 import { CHART_TYPE } from '../explorer_constants';
+import { SEARCH_QUERY_LANGUAGE } from '../../../../common/constants/search';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { MlTooltipComponent } from '../../components/chart_tooltip';
@@ -100,6 +101,14 @@ function ExplorerChartContainer({
   } = useMlKibana();
 
   const getMapsLink = useCallback(async () => {
+    const queryString = series.entityFields
+      ?.map(({ fieldName, fieldValue }) => `${fieldName}:${fieldValue}`)
+      .join(' or ');
+    const query = {
+      language: SEARCH_QUERY_LANGUAGE.KUERY,
+      query: queryString,
+    };
+
     const initialLayers = [];
     const typicalStyle = {
       type: 'VECTOR',
@@ -158,6 +167,7 @@ function ExplorerChartContainer({
     const location = await locator.getLocation({
       initialLayers: initialLayers,
       timeRange: data.query.timefilter.timefilter.getTime(),
+      ...(queryString !== undefined ? { query } : {}),
     });
 
     return location;

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.test.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.test.js
@@ -11,7 +11,7 @@ import { mount, shallow } from 'enzyme';
 import { I18nProvider } from '@kbn/i18n-react';
 
 import { getDefaultChartsData } from './explorer_charts_container_service';
-import { ExplorerChartsContainer } from './explorer_charts_container';
+import { ExplorerChartsContainer, getEntitiesQuery } from './explorer_charts_container';
 
 import { chartData } from './__mocks__/mock_chart_data';
 import seriesConfig from './__mocks__/mock_series_config_filebeat.json';
@@ -157,5 +157,70 @@ describe('ExplorerChartsContainer', () => {
 
     // Check if the additional y-axis information for rare charts is part of the chart
     expect(wrapper.html().search(rareChartUniqueString)).toBeGreaterThan(0);
+  });
+
+  describe('getEntitiesQuery', () => {
+    test('no entity fields', () => {
+      const series = {};
+      const expected = {
+        query: { language: 'kuery', query: undefined },
+        queryString: undefined,
+      };
+      const actual = getEntitiesQuery(series);
+      expect(actual).toMatchObject(expected);
+    });
+
+    test('with entity field', () => {
+      const series = {
+        entityFields: [{ fieldName: 'testFieldName', fieldValue: 'testFieldValue' }],
+      };
+      const expected = {
+        query: { language: 'kuery', query: 'testFieldName:testFieldValue' },
+        queryString: 'testFieldName:testFieldValue',
+      };
+      const actual = getEntitiesQuery(series);
+      expect(actual).toMatchObject(expected);
+    });
+
+    test('with multiple entity fields', () => {
+      const series = {
+        entityFields: [
+          { fieldName: 'testFieldName1', fieldValue: 'testFieldValue1' },
+          { fieldName: 'testFieldName2', fieldValue: 'testFieldValue2' },
+        ],
+      };
+      const expected = {
+        query: {
+          language: 'kuery',
+          query: 'testFieldName1:testFieldValue1 or testFieldName2:testFieldValue2',
+        },
+        queryString: 'testFieldName1:testFieldValue1 or testFieldName2:testFieldValue2',
+      };
+      const actual = getEntitiesQuery(series);
+      expect(actual).toMatchObject(expected);
+    });
+
+    test('with entity field with special characters', () => {
+      const series = {
+        entityFields: [
+          {
+            fieldName: 'agent.keyword',
+            fieldValue:
+              'Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24',
+          },
+        ],
+      };
+      const expected = {
+        query: {
+          language: 'kuery',
+          query:
+            'agent.keyword:Mozilla/5.0 \\(X11; Linux i686\\) AppleWebKit/534.24 \\(KHTML, like Gecko\\) Chrome/11.0.696.50 Safari/534.24',
+        },
+        queryString:
+          'agent.keyword:Mozilla/5.0 \\(X11; Linux i686\\) AppleWebKit/534.24 \\(KHTML, like Gecko\\) Chrome/11.0.696.50 Safari/534.24',
+      };
+      const actual = getEntitiesQuery(series);
+      expect(actual).toMatchObject(expected);
+    });
   });
 });

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.test.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.test.js
@@ -45,10 +45,12 @@ jest.mock('../../contexts/kibana', () => ({
           url: {
             locators: {
               get: jest.fn(() => {
-                  return { getLocation: jest.fn(() => { path: '/#maps' }) };
-                })
-            }
-          }
+                return {
+                  getLocation: jest.fn(() => ({ path: '/#maps' })),
+                };
+              }),
+            },
+          },
         },
         data: {
           query: {
@@ -62,7 +64,7 @@ jest.mock('../../contexts/kibana', () => ({
           },
         },
         application: {
-          navigateToApp: jest.fn()
+          navigateToApp: jest.fn(),
         },
       },
     };

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.test.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.test.js
@@ -37,6 +37,38 @@ jest.mock('../../../../../../../src/plugins/kibana_react/public', () => ({
   },
 }));
 
+jest.mock('../../contexts/kibana', () => ({
+  useMlKibana: () => {
+    return {
+      services: {
+        share: {
+          url: {
+            locators: {
+              get: jest.fn(() => {
+                  return { getLocation: jest.fn(() => { path: '/#maps' }) };
+                })
+            }
+          }
+        },
+        data: {
+          query: {
+            timefilter: {
+              timefilter: {
+                getTime: jest.fn(() => {
+                  return { from: '', to: '' };
+                }),
+              },
+            },
+          },
+        },
+        application: {
+          navigateToApp: jest.fn()
+        },
+      },
+    };
+  },
+}));
+
 const getUtilityProps = () => {
   const mlUrlGenerator = {
     createUrl: jest.fn(),

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
@@ -26,7 +26,7 @@ import type { MlPluginStart, MlStartDependencies } from '../plugin';
 import type { MlApiServices } from '../application/services/ml_api_service';
 
 export const ML_ANOMALY = 'ML_ANOMALIES';
-const CUSTOM_COLOR_RAMP = {
+export const CUSTOM_COLOR_RAMP = {
   type: STYLE_TYPE.DYNAMIC,
   options: {
     customColorRamp: SEVERITY_COLOR_RAMP,

--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -149,9 +149,7 @@ export class AnomalySource implements IVectorSource {
 
   getSourceStatus(sourceDataRequest?: DataRequest): SourceStatus {
     const featureCollection = sourceDataRequest ? sourceDataRequest.getData() : null;
-    const meta = sourceDataRequest
-      ? (sourceDataRequest.getMeta())
-      : null;
+    const meta = sourceDataRequest ? sourceDataRequest.getMeta() : null;
     if (!featureCollection || !meta) {
       return {
         tooltipContent: null,
@@ -232,9 +230,7 @@ export class AnomalySource implements IVectorSource {
   }
 
   getSourceTooltipContent(sourceDataRequest?: DataRequest): SourceStatus {
-    const meta = sourceDataRequest
-      ? (sourceDataRequest.getMeta())
-      : null;
+    const meta = sourceDataRequest ? sourceDataRequest.getMeta() : null;
     return {
       tooltipContent: i18n.translate('xpack.ml.maps.sourceTooltip', {
         defaultMessage: 'Shows anomalies',


### PR DESCRIPTION
## Summary

Related meta issue: https://github.com/elastic/kibana/issues/123492

This PR adds a link in the anomaly explorer embedded maps to the Maps plugin for displaying the anomalies for that job id.

<img width="779" alt="image" src="https://user-images.githubusercontent.com/6446462/160502867-acb27f7d-5a22-4b9b-847f-df797013dc3c.png">

Links to:

<img width="1191" alt="image" src="https://user-images.githubusercontent.com/6446462/160502890-60c4c894-4e4b-4d8e-9960-d005c12b7b45.png">



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))


