### PR TITLE
[APM] ensure rum_allow_origins setting only saves valid YAML strings

### DIFF
--- a/x-pack/plugins/apm/server/routes/fleet/create_cloud_apm_package_policy.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/create_cloud_apm_package_policy.ts
@@ -23,6 +23,7 @@ import {
 import { getApmPackagePolicyDefinition } from './get_apm_package_policy_definition';
 import { Setup } from '../../lib/helpers/setup_request';
 import { mergePackagePolicyWithApm } from './merge_package_policy_with_apm';
+import { ELASTIC_CLOUD_APM_AGENT_POLICY_ID } from '../../../common/fleet';
 
 export async function createCloudApmPackgePolicy({
   cloudPluginSetup,
@@ -65,7 +66,7 @@ export async function createCloudApmPackgePolicy({
     savedObjectsClient,
     esClient,
     mergedAPMPackagePolicy,
-    { force: true, bumpRevision: true }
+    { id: ELASTIC_CLOUD_APM_AGENT_POLICY_ID, force: true, bumpRevision: true }
   );
   logger.info(`Fleet migration on Cloud - apmPackagePolicy create end`);
   return apmPackagePolicy;


### PR DESCRIPTION
Closes #128703.

Ensures that the text values set in the `rum_allow_origins` setting (`apm-server.rum.allow_origins`) will be checked if they are valid YAML strings and then wrapped in quotes if not. This fixes the bug https://github.com/elastic/kibana/issues/121934 (in the short term) that would fail when the user attempts to migrate from classic indices / standalong APM server to a fleet-managed APM server agent policy. The fix validates and updates the settings values only when a user attempts the migration.

![Screen Shot 2022-03-28 at 9 23 09 PM](https://user-images.githubusercontent.com/1967266/160513848-71e9c438-52d8-40aa-ab61-92548186e33d.png)
![Screen Shot 2022-03-28 at 9 22 59 PM](https://user-images.githubusercontent.com/1967266/160513870-923ccd76-0fef-4d7b-8fc4-b63cd8f70af0.png)
