### PR TITLE
[APM] Fixes setting APM fleet migration policy id with correct API param

### DIFF
--- a/x-pack/plugins/apm/server/routes/fleet/create_cloud_apm_package_policy.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/create_cloud_apm_package_policy.ts
@@ -22,6 +22,7 @@ import {
 import { getApmPackagePolicyDefinition } from './get_apm_package_policy_definition';
 import { Setup } from '../../lib/helpers/setup_request';
 import { mergePackagePolicyWithApm } from './merge_package_policy_with_apm';
+import { ELASTIC_CLOUD_APM_AGENT_POLICY_ID } from '../../../common/fleet';
 
 export async function createCloudApmPackgePolicy({
   cloudPluginSetup,
@@ -64,7 +65,7 @@ export async function createCloudApmPackgePolicy({
     savedObjectsClient,
     esClient,
     mergedAPMPackagePolicy,
-    { force: true, bumpRevision: true }
+    { id: ELASTIC_CLOUD_APM_AGENT_POLICY_ID, force: true, bumpRevision: true }
   );
   logger.info(`Fleet migration on Cloud - apmPackagePolicy create end`);
   return apmPackagePolicy;

--- a/x-pack/plugins/apm/server/routes/fleet/get_apm_package_policy_definition.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/get_apm_package_policy_definition.ts
@@ -9,7 +9,6 @@ import {
   isPrereleaseVersion,
   POLICY_ELASTIC_AGENT_ON_CLOUD,
   SUPPORTED_APM_PACKAGE_VERSION,
-  ELASTIC_CLOUD_APM_AGENT_POLICY_ID,
 } from '../../../common/fleet';
 import {
   APMPluginSetupDependencies,
@@ -30,7 +29,6 @@ export async function getApmPackagePolicyDefinition(
     options;
 
   return {
-    id: ELASTIC_CLOUD_APM_AGENT_POLICY_ID,
     name: 'Elastic APM',
     namespace: 'default',
     enabled: true,


### PR DESCRIPTION
Fixes #128494.

Preview PR (https://github.com/elastic/kibana/pull/128496) used the incorrect API param.