### PR TITLE
[Workplace Search] Add source skips config step correctly

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
@@ -81,7 +81,10 @@ describe('AddSourceList', () => {
       configured: true,
     };
     shallow(<AddSource sourceData={sourceData} />);
-    expect(initializeAddSource).toHaveBeenCalledWith(expect.objectContaining({ connect: true }));
+    expect(initializeAddSource).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ connect: true })
+    );
   });
 
   it('renders default state correctly when there are multiple connector options', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -59,9 +59,9 @@ export const AddSource: React.FC<AddSourceProps> = (props) => {
     // We can land on this page from a choice page for multiple types of connectors
     // If that's the case we want to skip the intro and configuration, if the external & internal connector have already been configured
     const goToConnect = externalConnectorAvailable && externalConfigured && configured;
-    initializeAddSource(goToConnect ? props : { ...props, connect: true });
+    initializeAddSource(goToConnect ? { ...props, connect: true } : props);
     return resetSourceState;
-  }, []);
+  }, [configured]);
 
   const goToConfigurationIntro = () => setAddSourceStep(AddSourceSteps.ConfigIntroStep);
   const goToSaveConfig = () => setAddSourceStep(AddSourceSteps.SaveConfigStep);


### PR DESCRIPTION
This fixes a logic error where we were always skipping the config for connectors, instead of only for connectors which have been configured.