### PR TITLE
[Lens] Remove unused and duplicated code for XY chart expression

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -124,5 +124,5 @@ pageLoadAssetSize:
   sessionView: 77750
   cloudSecurityPosture: 19109
   visTypeGauge: 24113
-  expressionXY: 41392
+  expressionXY: 26500
   eventAnnotation: 19334

--- a/src/plugins/chart_expressions/expression_xy/public/components/annotations.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/annotations.tsx
@@ -18,18 +18,12 @@ import {
   Position,
 } from '@elastic/charts';
 import moment from 'moment';
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiIconProps, EuiText } from '@elastic/eui';
-import classnames from 'classnames';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import type { EventAnnotationArgs } from '../../../../event_annotation/common';
 import type { FieldFormat } from '../../../../field_formats/common';
 import { defaultAnnotationColor } from '../../../../../../src/plugins/event_annotation/public';
-import type {
-  AnnotationLayerArgs,
-  AnnotationLayerConfigResult,
-  IconPosition,
-  YAxisMode,
-} from '../../common/types';
-import { annotationsIconSet, hasIcon, isNumericalString } from '../helpers';
+import type { AnnotationLayerArgs, AnnotationLayerConfigResult } from '../../common/types';
+import { AnnotationIcon, hasIcon, Marker, MarkerBody } from '../helpers';
 import { mapVerticalToHorizontalPlacement, LINES_MARKER_SIZE } from '../helpers';
 
 const getRoundedTimestamp = (timestamp: number, firstTimestamp?: number, minInterval?: number) => {
@@ -235,123 +229,3 @@ export const Annotations = ({
     </>
   );
 };
-
-export function MarkerBody({
-  label,
-  isHorizontal,
-}: {
-  label: string | undefined;
-  isHorizontal: boolean;
-}) {
-  if (!label) {
-    return null;
-  }
-  if (isHorizontal) {
-    return (
-      <div className="eui-textTruncate" style={{ maxWidth: LINES_MARKER_SIZE * 3 }}>
-        {label}
-      </div>
-    );
-  }
-  return (
-    <div
-      className="xyDecorationRotatedWrapper"
-      style={{
-        width: LINES_MARKER_SIZE,
-      }}
-    >
-      <div
-        className="eui-textTruncate xyDecorationRotatedWrapper__label"
-        style={{
-          maxWidth: LINES_MARKER_SIZE * 3,
-        }}
-      >
-        {label}
-      </div>
-    </div>
-  );
-}
-
-function NumberIcon({ number }: { number: number }) {
-  return (
-    <EuiFlexGroup
-      justifyContent="spaceAround"
-      className="xyAnnotationNumberIcon"
-      gutterSize="none"
-      alignItems="center"
-    >
-      <EuiText color="ghost" className="xyAnnotationNumberIcon__text">
-        {number < 10 ? number : `9+`}
-      </EuiText>
-    </EuiFlexGroup>
-  );
-}
-
-export const AnnotationIcon = ({
-  type,
-  rotateClassName = '',
-  isHorizontal,
-  renderedInChart,
-  ...rest
-}: {
-  type: string;
-  rotateClassName?: string;
-  isHorizontal?: boolean;
-  renderedInChart?: boolean;
-} & EuiIconProps) => {
-  if (isNumericalString(type)) {
-    return <NumberIcon number={Number(type)} />;
-  }
-  const iconConfig = annotationsIconSet.find((i) => i.value === type);
-  if (!iconConfig) {
-    return null;
-  }
-  return (
-    <EuiIcon
-      {...rest}
-      type={iconConfig.icon || type}
-      className={classnames(
-        { [rotateClassName]: iconConfig.shouldRotate },
-        {
-          lensAnnotationIconFill: renderedInChart && iconConfig.canFill,
-        }
-      )}
-    />
-  );
-};
-
-interface MarkerConfig {
-  axisMode?: YAxisMode;
-  icon?: string;
-  textVisibility?: boolean;
-  iconPosition?: IconPosition;
-}
-
-export function Marker({
-  config,
-  isHorizontal,
-  hasReducedPadding,
-  label,
-  rotateClassName,
-}: {
-  config: MarkerConfig;
-  isHorizontal: boolean;
-  hasReducedPadding: boolean;
-  label?: string;
-  rotateClassName?: string;
-}) {
-  if (hasIcon(config.icon)) {
-    return (
-      <AnnotationIcon type={config.icon} rotateClassName={rotateClassName} renderedInChart={true} />
-    );
-  }
-
-  // if there's some text, check whether to show it as marker, or just show some padding for the icon
-  if (config.textVisibility) {
-    if (hasReducedPadding) {
-      return <MarkerBody label={label} isHorizontal={isHorizontal} />;
-    }
-    return <EuiIcon type="empty" />;
-  }
-  return null;
-}

--- a/src/plugins/chart_expressions/expression_xy/public/components/reference_lines.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/reference_lines.tsx
@@ -10,15 +10,17 @@ import './reference_lines.scss';
 
 import React from 'react';
 import { groupBy } from 'lodash';
-import { EuiIcon } from '@elastic/eui';
 import { RectAnnotation, AnnotationDomainType, LineAnnotation, Position } from '@elastic/charts';
 import { euiLightVars } from '@kbn/ui-theme';
 import type { FieldFormat } from '../../../../field_formats/common';
 import type { IconPosition, ReferenceLineLayerArgs, YAxisMode } from '../../common/types';
 import type { LensMultiTable } from '../../common/types';
-import { hasIcon } from '../helpers';
-
-export const REFERENCE_LINE_MARKER_SIZE = 20;
+import {
+  LINES_MARKER_SIZE,
+  mapVerticalToHorizontalPlacement,
+  Marker,
+  MarkerBody,
+} from '../helpers';
 
 export const computeChartMargins = (
   referenceLinePaddings: Partial<Record<Position, number>>,
@@ -54,66 +56,24 @@ export const computeChartMargins = (
   return result;
 };
 
-// Note: it does not take into consideration whether the reference line is in view or not
-export const getReferenceLineRequiredPaddings = (
-  referenceLineLayers: ReferenceLineLayerArgs[],
-  axesMap: Record<'left' | 'right', unknown>
-) => {
-  // collect all paddings for the 4 axis: if any text is detected double it.
-  const paddings: Partial<Record<Position, number>> = {};
-  const icons: Partial<Record<Position, number>> = {};
-  referenceLineLayers.forEach((layer) => {
-    layer.yConfig?.forEach(({ axisMode, icon, iconPosition, textVisibility }) => {
-      if (axisMode && (hasIcon(icon) || textVisibility)) {
-        const placement = getBaseIconPlacement(iconPosition, axisMode, axesMap);
-        paddings[placement] = Math.max(
-          paddings[placement] || 0,
-          REFERENCE_LINE_MARKER_SIZE * (textVisibility ? 2 : 1) // double the padding size if there's text
-        );
-        icons[placement] = (icons[placement] || 0) + (hasIcon(icon) ? 1 : 0);
-      }
-    });
-  });
-  // post-process the padding based on the icon presence:
-  // if no icon is present for the placement, just reduce the padding
-  (Object.keys(paddings) as Position[]).forEach((placement) => {
-    if (!icons[placement]) {
-      paddings[placement] = REFERENCE_LINE_MARKER_SIZE;
-    }
-  });
-
-  return paddings;
-};
-
-function mapVerticalToHorizontalPlacement(placement: Position) {
-  switch (placement) {
-    case Position.Top:
-      return Position.Right;
-    case Position.Bottom:
-      return Position.Left;
-    case Position.Left:
-      return Position.Bottom;
-    case Position.Right:
-      return Position.Top;
-  }
-}
-
 // if there's just one axis, put it on the other one
 // otherwise use the same axis
 // this function assume the chart is vertical
-function getBaseIconPlacement(
+export function getBaseIconPlacement(
   iconPosition: IconPosition | undefined,
-  axisMode: YAxisMode | undefined,
-  axesMap: Record<string, unknown>
+  axesMap?: Record<string, unknown>,
+  axisMode?: YAxisMode
 ) {
   if (iconPosition === 'auto') {
     if (axisMode === 'bottom') {
       return Position.Top;
     }
-    if (axisMode === 'left') {
-      return axesMap.right ? Position.Left : Position.Right;
+    if (axesMap) {
+      if (axisMode === 'left') {
+        return axesMap.right ? Position.Left : Position.Right;
+      }
+      return axesMap.left ? Position.Right : Position.Left;
     }
-    return axesMap.left ? Position.Right : Position.Left;
   }
 
   if (iconPosition === 'left') {
@@ -126,65 +86,6 @@ function getBaseIconPlacement(
     return Position.Bottom;
   }
   return Position.Top;
-}
-
-function getMarkerBody(label: string | undefined, isHorizontal: boolean) {
-  if (!label) {
-    return;
-  }
-  if (isHorizontal) {
-    return (
-      <div className="eui-textTruncate" style={{ maxWidth: REFERENCE_LINE_MARKER_SIZE * 3 }}>
-        {label}
-      </div>
-    );
-  }
-  return (
-    <div
-      className="xyDecorationRotatedWrapper"
-      style={{
-        width: REFERENCE_LINE_MARKER_SIZE,
-      }}
-    >
-      <div
-        className="eui-textTruncate xyDecorationRotatedWrapper__label"
-        style={{
-          maxWidth: REFERENCE_LINE_MARKER_SIZE * 3,
-        }}
-      >
-        {label}
-      </div>
-    </div>
-  );
-}
-
-interface MarkerConfig {
-  axisMode?: YAxisMode;
-  icon?: string;
-  textVisibility?: boolean;
-}
-
-function getMarkerToShow(
-  markerConfig: MarkerConfig,
-  label: string | undefined,
-  isHorizontal: boolean,
-  hasReducedPadding: boolean
-) {
-  // show an icon if present
-  if (hasIcon(markerConfig.icon)) {
-    return <EuiIcon type={markerConfig.icon} />;
-  }
-  // if there's some text, check whether to show it as marker, or just show some padding for the icon
-  if (markerConfig.textVisibility) {
-    if (hasReducedPadding) {
-      return getMarkerBody(
-        label,
-        (!isHorizontal && markerConfig.axisMode === 'bottom') ||
-          (isHorizontal && markerConfig.axisMode !== 'bottom')
-      );
-    }
-    return <EuiIcon type="empty" />;
-  }
 }
 
 export interface ReferenceLineAnnotationsProps {
@@ -243,27 +144,34 @@ export const ReferenceLineAnnotations = ({
           // get the position for vertical chart
           const markerPositionVertical = getBaseIconPlacement(
             yConfig.iconPosition,
-            yConfig.axisMode,
-            axesMap
+            axesMap,
+            yConfig.axisMode
           );
           // the padding map is built for vertical chart
-          const hasReducedPadding =
-            paddingMap[markerPositionVertical] === REFERENCE_LINE_MARKER_SIZE;
+          const hasReducedPadding = paddingMap[markerPositionVertical] === LINES_MARKER_SIZE;
 
           const props = {
             groupId,
-            marker: getMarkerToShow(
-              yConfig,
-              columnToLabelMap[yConfig.forAccessor],
-              isHorizontal,
-              hasReducedPadding
+            marker: (
+              <Marker
+                config={yConfig}
+                label={columnToLabelMap[yConfig.forAccessor]}
+                isHorizontal={isHorizontal}
+                hasReducedPadding={hasReducedPadding}
+              />
             ),
-            markerBody: getMarkerBody(
-              yConfig.textVisibility && !hasReducedPadding
-                ? columnToLabelMap[yConfig.forAccessor]
-                : undefined,
-              (!isHorizontal && yConfig.axisMode === 'bottom') ||
-                (isHorizontal && yConfig.axisMode !== 'bottom')
+            markerBody: (
+              <MarkerBody
+                label={
+                  yConfig.textVisibility && !hasReducedPadding
+                    ? columnToLabelMap[yConfig.forAccessor]
+                    : undefined
+                }
+                isHorizontal={
+                  (!isHorizontal && yConfig.axisMode === 'bottom') ||
+                  (isHorizontal && yConfig.axisMode !== 'bottom')
+                }
+              />
             ),
             // rotate the position if required
             markerPosition: isHorizontal
@@ -272,17 +180,15 @@ export const ReferenceLineAnnotations = ({
           };
           const annotations = [];
 
-          const dashStyle =
-            yConfig.lineStyle === 'dashed'
-              ? [(yConfig.lineWidth || 1) * 3, yConfig.lineWidth || 1]
-              : yConfig.lineStyle === 'dotted'
-              ? [yConfig.lineWidth || 1, yConfig.lineWidth || 1]
-              : undefined;
-
           const sharedStyle = {
             strokeWidth: yConfig.lineWidth || 1,
             stroke: yConfig.color || defaultColor,
-            dash: dashStyle,
+            dash:
+              yConfig.lineStyle === 'dashed'
+                ? [(yConfig.lineWidth || 1) * 3, yConfig.lineWidth || 1]
+                : yConfig.lineStyle === 'dotted'
+                ? [yConfig.lineWidth || 1, yConfig.lineWidth || 1]
+                : undefined,
           };
 
           annotations.push(

--- a/src/plugins/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
@@ -11,14 +11,14 @@ import { I18nProvider } from '@kbn/i18n-react';
 import { ThemeServiceStart } from 'kibana/public';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { ChartsPluginStart, PaletteRegistry } from '../../../../charts/public';
+import type { ChartsPluginStart, PaletteRegistry } from '../../../../charts/public';
 import { EventAnnotationServiceType } from '../../../../event_annotation/public';
 import { ExpressionRenderDefinition } from '../../../../expressions';
 import { FormatFactory } from '../../../../field_formats/common';
 import { KibanaThemeProvider } from '../../../../kibana_react/public';
-import { XYChartProps } from '../../common';
-import { calculateMinInterval } from '../helpers';
-import { BrushEvent, FilterEvent } from '../types';
+import type { XYChartProps } from '../../common';
+import { calculateMinInterval } from '../helpers/interval';
+import type { BrushEvent, FilterEvent } from '../types';
 
 export type GetStartDepsFn = () => Promise<{
   formatFactory: FormatFactory;

--- a/src/plugins/chart_expressions/expression_xy/public/helpers/annotations.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/helpers/annotations.tsx
@@ -5,45 +5,16 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+import React from 'react';
 import { Position } from '@elastic/charts';
+import { EuiFlexGroup, EuiIcon, EuiIconProps, EuiText } from '@elastic/eui';
+import classnames from 'classnames';
 import type { IconPosition, YAxisMode, YConfig } from '../../common/types';
+import { getBaseIconPlacement } from '../components';
 import { hasIcon } from './icon';
+import { annotationsIconSet } from './annotations_icon_set';
 
 export const LINES_MARKER_SIZE = 20;
-
-export const computeChartMargins = (
-  referenceLinePaddings: Partial<Record<Position, number>>,
-  labelVisibility: Partial<Record<'x' | 'yLeft' | 'yRight', boolean>>,
-  titleVisibility: Partial<Record<'x' | 'yLeft' | 'yRight', boolean>>,
-  axesMap: Record<'left' | 'right', unknown>,
-  isHorizontal: boolean
-) => {
-  const result: Partial<Record<Position, number>> = {};
-  if (!labelVisibility?.x && !titleVisibility?.x && referenceLinePaddings.bottom) {
-    const placement = isHorizontal ? mapVerticalToHorizontalPlacement('bottom') : 'bottom';
-    result[placement] = referenceLinePaddings.bottom;
-  }
-  if (
-    referenceLinePaddings.left &&
-    (isHorizontal || (!labelVisibility?.yLeft && !titleVisibility?.yLeft))
-  ) {
-    const placement = isHorizontal ? mapVerticalToHorizontalPlacement('left') : 'left';
-    result[placement] = referenceLinePaddings.left;
-  }
-  if (
-    referenceLinePaddings.right &&
-    (isHorizontal || !axesMap.right || (!labelVisibility?.yRight && !titleVisibility?.yRight))
-  ) {
-    const placement = isHorizontal ? mapVerticalToHorizontalPlacement('right') : 'right';
-    result[placement] = referenceLinePaddings.right;
-  }
-  // there's no top axis, so just check if a margin has been computed
-  if (referenceLinePaddings.top) {
-    const placement = isHorizontal ? mapVerticalToHorizontalPlacement('top') : 'top';
-    result[placement] = referenceLinePaddings.top;
-  }
-  return result;
-};
 
 // Note: it does not take into consideration whether the reference line is in view or not
 
@@ -93,36 +64,124 @@ export function mapVerticalToHorizontalPlacement(placement: Position) {
   }
 }
 
-// if there's just one axis, put it on the other one
-// otherwise use the same axis
-// this function assume the chart is vertical
-export function getBaseIconPlacement(
-  iconPosition: IconPosition | undefined,
-  axesMap?: Record<string, unknown>,
-  axisMode?: YAxisMode
-) {
-  if (iconPosition === 'auto') {
-    if (axisMode === 'bottom') {
-      return Position.Top;
-    }
-    if (axesMap) {
-      if (axisMode === 'left') {
-        return axesMap.right ? Position.Left : Position.Right;
-      }
-      return axesMap.left ? Position.Right : Position.Left;
-    }
+export function MarkerBody({
+  label,
+  isHorizontal,
+}: {
+  label: string | undefined;
+  isHorizontal: boolean;
+}) {
+  if (!label) {
+    return null;
   }
-
-  if (iconPosition === 'left') {
-    return Position.Left;
+  if (isHorizontal) {
+    return (
+      <div className="eui-textTruncate" style={{ maxWidth: LINES_MARKER_SIZE * 3 }}>
+        {label}
+      </div>
+    );
   }
-  if (iconPosition === 'right') {
-    return Position.Right;
-  }
-  if (iconPosition === 'below') {
-    return Position.Bottom;
-  }
-  return Position.Top;
+  return (
+    <div
+      className="xyDecorationRotatedWrapper"
+      style={{
+        width: LINES_MARKER_SIZE,
+      }}
+    >
+      <div
+        className="eui-textTruncate xyDecorationRotatedWrapper__label"
+        style={{
+          maxWidth: LINES_MARKER_SIZE * 3,
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
 }
 
-export const isNumericalString = (value: string) => !isNaN(Number(value));
+function NumberIcon({ number }: { number: number }) {
+  return (
+    <EuiFlexGroup
+      justifyContent="spaceAround"
+      className="xyAnnotationNumberIcon"
+      gutterSize="none"
+      alignItems="center"
+    >
+      <EuiText color="ghost" className="xyAnnotationNumberIcon__text">
+        {number < 10 ? number : `9+`}
+      </EuiText>
+    </EuiFlexGroup>
+  );
+}
+
+const isNumericalString = (value: string) => !isNaN(Number(value));
+
+export const AnnotationIcon = ({
+  type,
+  rotateClassName = '',
+  isHorizontal,
+  renderedInChart,
+  ...rest
+}: {
+  type: string;
+  rotateClassName?: string;
+  isHorizontal?: boolean;
+  renderedInChart?: boolean;
+} & EuiIconProps) => {
+  if (isNumericalString(type)) {
+    return <NumberIcon number={Number(type)} />;
+  }
+  const iconConfig = annotationsIconSet.find((i) => i.value === type);
+  if (!iconConfig) {
+    return null;
+  }
+  return (
+    <EuiIcon
+      {...rest}
+      type={iconConfig.icon || type}
+      className={classnames(
+        { [rotateClassName]: iconConfig.shouldRotate },
+        {
+          lensAnnotationIconFill: renderedInChart && iconConfig.canFill,
+        }
+      )}
+    />
+  );
+};
+
+interface MarkerConfig {
+  axisMode?: YAxisMode;
+  icon?: string;
+  textVisibility?: boolean;
+  iconPosition?: IconPosition;
+}
+
+export function Marker({
+  config,
+  isHorizontal,
+  hasReducedPadding,
+  label,
+  rotateClassName,
+}: {
+  config: MarkerConfig;
+  isHorizontal: boolean;
+  hasReducedPadding: boolean;
+  label?: string;
+  rotateClassName?: string;
+}) {
+  if (hasIcon(config.icon)) {
+    return (
+      <AnnotationIcon type={config.icon} rotateClassName={rotateClassName} renderedInChart={true} />
+    );
+  }
+
+  // if there's some text, check whether to show it as marker, or just show some padding for the icon
+  if (config.textVisibility) {
+    if (hasReducedPadding) {
+      return <MarkerBody label={label} isHorizontal={isHorizontal} />;
+    }
+    return <EuiIcon type="empty" />;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- lowers the limit for page bundle load (we've imported the whole directory before async import instead of importing single method we needed) - down from ~41000 to ~24000
- removes duplicated code shared between referenced lines and annotations - the conflicts here were quite difficult to solve when merging moving the xy expression so I thought it's better to do it after. 

