### PR TITLE
[Security Solution] Update user page deep links

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -79,7 +79,6 @@ export const DEFAULT_THREAT_MATCH_QUERY = '@timestamp >= "now-30d/d"' as const;
 export enum SecurityPageName {
   administration = 'administration',
   alerts = 'alerts',
-  authentications = 'authentications',
   /*
    * Warning: Computed values are not permitted in an enum with string valued members
    * The 3 following Cases page names must match `CasesDeepLinkId` in x-pack/plugins/cases/public/common/navigation.ts
@@ -92,7 +91,6 @@ export enum SecurityPageName {
   detectionAndResponse = 'detection_response',
   endpoints = 'endpoints',
   eventFilters = 'event_filters',
-  events = 'events',
   exceptions = 'exceptions',
   explore = 'explore',
   hostIsolationExceptions = 'host_isolation_exceptions',
@@ -100,6 +98,8 @@ export enum SecurityPageName {
   hostsAnomalies = 'hosts-anomalies',
   hostsExternalAlerts = 'hosts-external_alerts',
   hostsRisk = 'hosts-risk',
+  hostsEvents = 'hosts-events',
+  hostsAuthentications = 'hosts-authentications',
   investigate = 'investigate',
   landing = 'get_started',
   network = 'network',
@@ -116,9 +116,12 @@ export enum SecurityPageName {
   trustedApps = 'trusted_apps',
   uncommonProcesses = 'uncommon_processes',
   users = 'users',
+  usersAuthentications = 'users-authentications',
   usersAnomalies = 'users-anomalies',
   usersRisk = 'users-risk',
   sessions = 'sessions',
+  usersEvents = 'users-events',
+  usersExternalAlerts = 'users-external_alerts',
 }
 
 export const TIMELINES_PATH = '/timelines' as const;

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.test.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.test.ts
@@ -154,6 +154,14 @@ describe('deepLinks', () => {
       expect(findDeepLink(SecurityPageName.users, deepLinks)).toBeTruthy();
     });
 
+    it('should NOT return host authentications when enableExperimental.usersEnabled === true', () => {
+      const deepLinks = getDeepLinks({
+        ...mockGlobalState.app.enableExperimental,
+        usersEnabled: true,
+      });
+      expect(findDeepLink(SecurityPageName.hostsAuthentications, deepLinks)).toBeFalsy();
+    });
+
     it('should return NO detection & Response link when enableExperimental.detectionResponseEnabled === false', () => {
       const deepLinks = getDeepLinks(mockGlobalState.app.enableExperimental);
       expect(findDeepLink(SecurityPageName.detectionAndResponse, deepLinks)).toBeFalsy();

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -68,7 +68,14 @@ type Feature = typeof FEATURE[keyof typeof FEATURE];
 type SecuritySolutionDeepLink = AppDeepLink & {
   isPremium?: boolean;
   features?: Feature[];
+  /**
+   * Displays deep link when feature flag is enabled.
+   */
   experimentalKey?: keyof ExperimentalFeatures;
+  /**
+   * Hides deep link when feature flag is enabled.
+   */
+  hideWhenExperimentalKey?: keyof ExperimentalFeatures;
   deepLinks?: SecuritySolutionDeepLink[];
 };
 
@@ -186,11 +193,12 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         order: 9002,
         deepLinks: [
           {
-            id: SecurityPageName.authentications,
+            id: SecurityPageName.hostsAuthentications,
             title: i18n.translate('xpack.securitySolution.search.hosts.authentications', {
               defaultMessage: 'Authentications',
             }),
             path: `${HOSTS_PATH}/authentications`,
+            hideWhenExperimentalKey: 'usersEnabled',
           },
           {
             id: SecurityPageName.uncommonProcesses,
@@ -200,7 +208,7 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
             path: `${HOSTS_PATH}/uncommonProcesses`,
           },
           {
-            id: SecurityPageName.events,
+            id: SecurityPageName.hostsEvents,
             title: i18n.translate('xpack.securitySolution.search.hosts.events', {
               defaultMessage: 'Events',
             }),
@@ -294,6 +302,13 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         order: 9004,
         deepLinks: [
           {
+            id: SecurityPageName.usersAuthentications,
+            title: i18n.translate('xpack.securitySolution.search.users.authentications', {
+              defaultMessage: 'Authentications',
+            }),
+            path: `${USERS_PATH}/authentications`,
+          },
+          {
             id: SecurityPageName.usersAnomalies,
             title: i18n.translate('xpack.securitySolution.search.users.anomalies', {
               defaultMessage: 'Anomalies',
@@ -307,7 +322,21 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
               defaultMessage: 'Risk',
             }),
             path: `${USERS_PATH}/userRisk`,
-            isPremium: true,
+            experimentalKey: 'riskyUsersEnabled',
+          },
+          {
+            id: SecurityPageName.usersEvents,
+            title: i18n.translate('xpack.securitySolution.search.users.events', {
+              defaultMessage: 'Events',
+            }),
+            path: `${USERS_PATH}/events`,
+          },
+          {
+            id: SecurityPageName.usersExternalAlerts,
+            title: i18n.translate('xpack.securitySolution.search.users.externalAlerts', {
+              defaultMessage: 'External Alerts',
+            }),
+            path: `${USERS_PATH}/externalAlerts`,
           },
         ],
       },
@@ -428,13 +457,21 @@ export function getDeepLinks(
 ): AppDeepLink[] {
   const filterDeepLinks = (securityDeepLinks: SecuritySolutionDeepLink[]): AppDeepLink[] =>
     securityDeepLinks.reduce(
-      (deepLinks: AppDeepLink[], { isPremium, features, experimentalKey, ...deepLink }) => {
+      (
+        deepLinks: AppDeepLink[],
+        { isPremium, features, experimentalKey, hideWhenExperimentalKey, ...deepLink }
+      ) => {
         if (licenseType && isPremium && !isPremiumLicense(licenseType)) {
           return deepLinks;
         }
         if (experimentalKey && !enableExperimental[experimentalKey]) {
           return deepLinks;
         }
+
+        if (hideWhenExperimentalKey && enableExperimental[hideWhenExperimentalKey]) {
+          return deepLinks;
+        }
+
         if (capabilities != null && !hasFeaturesCapability(features, capabilities)) {
           return deepLinks;
         }

--- a/x-pack/plugins/security_solution/public/users/components/all_users/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/all_users/index.tsx
@@ -58,6 +58,44 @@ const rowItems: ItemsPerRow[] = [
   },
 ];
 
+const getUsersColumns = (): UsersTableColumns => [
+  {
+    field: 'name',
+    name: i18n.USER_NAME,
+    truncateText: false,
+    sortable: true,
+    mobileOptions: { show: true },
+    render: (name) =>
+      getRowItemDraggables({
+        rowItems: [name],
+        attrName: 'user.name',
+        idPrefix: `users-table-${name}-name`,
+        render: (item) => <UserDetailsLink userName={item} />,
+      }),
+  },
+  {
+    field: 'lastSeen',
+    name: i18n.LAST_SEEN,
+    sortable: true,
+    truncateText: false,
+    mobileOptions: { show: true },
+    render: (lastSeen) => <FormattedRelativePreferenceDate value={lastSeen} />,
+  },
+  {
+    field: 'domain',
+    name: i18n.DOMAIN,
+    sortable: false,
+    truncateText: false,
+    mobileOptions: { show: true },
+    render: (domain) =>
+      getRowItemDraggables({
+        rowItems: [domain],
+        attrName: 'user.domain',
+        idPrefix: `users-table-${domain}-domain`,
+      }),
+  },
+];
+
 const UsersTableComponent: React.FC<UsersTableProps> = ({
   users,
   totalCount,
@@ -146,41 +184,3 @@ const UsersTableComponent: React.FC<UsersTableProps> = ({
 UsersTableComponent.displayName = 'UsersTableComponent';
 
 export const UsersTable = React.memo(UsersTableComponent);
-
-const getUsersColumns = (): UsersTableColumns => [
-  {
-    field: 'name',
-    name: i18n.USER_NAME,
-    truncateText: false,
-    sortable: true,
-    mobileOptions: { show: true },
-    render: (name) =>
-      getRowItemDraggables({
-        rowItems: [name],
-        attrName: 'user.name',
-        idPrefix: `users-table-${name}-name`,
-        render: (item) => <UserDetailsLink userName={item} />,
-      }),
-  },
-  {
-    field: 'lastSeen',
-    name: i18n.LAST_SEEN,
-    sortable: true,
-    truncateText: false,
-    mobileOptions: { show: true },
-    render: (lastSeen) => <FormattedRelativePreferenceDate value={lastSeen} />,
-  },
-  {
-    field: 'domain',
-    name: i18n.DOMAIN,
-    sortable: false,
-    truncateText: false,
-    mobileOptions: { show: true },
-    render: (domain) =>
-      getRowItemDraggables({
-        rowItems: [domain],
-        attrName: 'user.domain',
-        idPrefix: `users-table-${domain}-domain`,
-      }),
-  },
-];

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/all/query.all_users.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/all/query.all_users.dsl.ts
@@ -37,8 +37,6 @@ export const buildUsersQuery = ({
     },
   ];
 
-  const agg = { user_count: { cardinality: { field: 'user.name' } } };
-
   const dslQuery = {
     allow_no_indices: true,
     index: defaultIndex,
@@ -47,7 +45,7 @@ export const buildUsersQuery = ({
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),
       aggregations: {
-        ...agg,
+        user_count: { cardinality: { field: 'user.name' } },
         user_data: {
           terms: { size: querySize, field: 'user.name', order: getQueryOrder(sort) },
           aggs: {


### PR DESCRIPTION
issues: https://github.com/elastic/kibana/issues/128604  https://github.com/elastic/kibana/issues/128616

## Summary

Update user page deep-links to reflect the latest changes.
* It hides the host authentication deep link when `usersEnabled` FF is enabled
* It shows Users 'External Alerts' deep link when `usersEnabled` FF is enabled
* It shows Users 'Events' deep link when `usersEnabled` FF is enabled
* It shows Users 'Authentication' deep link when `usersEnabled` FF is enabled

It also fixes some code style issues from https://github.com/elastic/kibana/pull/128375


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

