### PR TITLE
[TSVB] Fixes steps behavior to happen at the change point

### DIFF
--- a/src/plugins/vis_types/timeseries/public/application/visualizations/views/timeseries/utils/__snapshots__/series_styles.test.js.snap
+++ b/src/plugins/vis_types/timeseries/public/application/visualizations/views/timeseries/utils/__snapshots__/series_styles.test.js.snap
@@ -20,7 +20,7 @@ Object {
       "visible": true,
     },
   },
-  "curve": 6,
+  "curve": 7,
 }
 `;
 

--- a/src/plugins/vis_types/timeseries/public/application/visualizations/views/timeseries/utils/series_styles.js
+++ b/src/plugins/vis_types/timeseries/public/application/visualizations/views/timeseries/utils/series_styles.js
@@ -29,7 +29,7 @@ export const getAreaStyles = ({ points, lines, color }) => ({
       visible: points.lineWidth > 0 && Boolean(points.show),
     },
   },
-  curve: lines.steps ? CurveType.CURVE_STEP : CurveType.LINEAR,
+  curve: lines.steps ? CurveType.CURVE_STEP_AFTER : CurveType.LINEAR,
 });
 
 export const getBarStyles = ({ show = true, lineWidth = 0, fill = 1 }, color) => ({


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/128651

TSVB gives the users the ability to display their series with the steps curve (instead of the linear one)

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/17003240/160610832-c6821a00-3632-47e6-878e-104de234c0dd.png">

We were using the `CURVE_STEP ` option of the ECs that renders the steps between two data points and not at the point that the change happens. By using the `CURVE_STEP_AFTER` this is fixed.

I am using the following example:
Here is a percentiles aggregation on the AvgTicketPrice of the flights demo dataset. You can see that the annotations are being displayed at the middle.

<img width="1715" alt="image" src="https://user-images.githubusercontent.com/17003240/160611290-1a19813e-2fe8-4052-bad2-dbc7e64b489d.png">

Changing the curve type results in a better result. Now the steps happen at the change point making the chart more readable.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/17003240/160611552-106985ca-0ca5-4613-acac-8f90bcc4456f.png">


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios