### PR TITLE
Sort content sources and connectors by display name

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/index.ts
@@ -13,3 +13,4 @@ export { readUploadedFileAsText } from './read_uploaded_file_as_text';
 export { handlePrivateKeyUpload } from './handle_private_key_upload';
 export { hasMultipleConnectorOptions } from './has_multiple_connector_options';
 export { isNotNullish } from './is_not_nullish';
+export { sortByName } from './sort_by_name';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/sort_by_name.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/sort_by_name.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { sortByName } from './sort_by_name';
+
+describe('sortByName', () => {
+  it('should sort by name', () => {
+    const unsorted = [
+      {
+        name: 'aba',
+      },
+      {
+        name: 'aaa',
+      },
+      {
+        name: 'constant',
+      },
+      {
+        name: 'beta',
+      },
+    ];
+    const sorted = [
+      {
+        name: 'aaa',
+      },
+      {
+        name: 'aba',
+      },
+      {
+        name: 'beta',
+      },
+      {
+        name: 'constant',
+      },
+    ];
+    expect(sortByName(unsorted)).toEqual(sorted);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/sort_by_name.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/sort_by_name.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+interface WithName {
+  name: string;
+}
+
+export function sortByName<T extends WithName>(nameItems: T[]): T[] {
+  return [...nameItems].sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
@@ -20,6 +20,7 @@ import { AppLogic } from '../../app_logic';
 import { ORG_UPDATED_MESSAGE, OAUTH_APP_UPDATED_MESSAGE } from '../../constants';
 import { ORG_SETTINGS_CONNECTORS_PATH } from '../../routes';
 import { Connector } from '../../types';
+import { sortByName } from '../../utils';
 
 interface IOauthApplication {
   name: string;
@@ -118,8 +119,7 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
     connectors: [
       [],
       {
-        onInitializeConnectors: (_, connectors) =>
-          connectors.sort((a, b) => a.name.localeCompare(b.name)),
+        onInitializeConnectors: (_, connectors) => sortByName(connectors),
       },
     ],
     orgNameInputValue: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
@@ -118,7 +118,8 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
     connectors: [
       [],
       {
-        onInitializeConnectors: (_, connectors) => connectors,
+        onInitializeConnectors: (_, connectors) =>
+          connectors.sort((a, b) => a.name.localeCompare(b.name)),
       },
     ],
     orgNameInputValue: [


### PR DESCRIPTION
This sorts connectors by display name instead of serviceType.