### PR TITLE
Change error text to new version

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
+++ b/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
@@ -44,7 +44,7 @@ export default ({ getPageObjects, getService }) => {
           await retry.try(async () => {
             const executionFailureResultCallout = await testSubjects.find('executionFailureResult');
             expect(await executionFailureResultCallout.getVisibleText()).to.be(
-              'Test failed to run\nThe following error was found:\nerror sending email\nDetails:\nMail command failed: 550 5.7.1 Relaying denied'
+              'Test failed to run\nThe following error was found:\nerror sending email\nDetails:\nCan\'t send mail - all recipients were rejected: 550 5.7.1 Relaying denied'
             );
           });
           expect(true).to.be(true);

--- a/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
+++ b/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
@@ -44,7 +44,7 @@ export default ({ getPageObjects, getService }) => {
           await retry.try(async () => {
             const executionFailureResultCallout = await testSubjects.find('executionFailureResult');
             expect(await executionFailureResultCallout.getVisibleText()).to.be(
-              'Test failed to run\nThe following error was found:\nerror sending email\nDetails:\nCan\'t send mail - all recipients were rejected: 550 5.7.1 Relaying denied'
+              "Test·failed·to·run\nThe·following·error·was·found:\nerror·sending·email\nDetails:\nCan't·send·mail·-·all·recipients·were·rejected:·550·5.7.1·Relaying·denied"
             );
           });
           expect(true).to.be(true);

--- a/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
+++ b/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
@@ -44,7 +44,7 @@ export default ({ getPageObjects, getService }) => {
           await retry.try(async () => {
             const executionFailureResultCallout = await testSubjects.find('executionFailureResult');
             expect(await executionFailureResultCallout.getVisibleText()).to.be(
-              "Test·failed·to·run\nThe·following·error·was·found:\nerror·sending·email\nDetails:\nCan't·send·mail·-·all·recipients·were·rejected:·550·5.7.1·Relaying·denied"
+              "Test failed to run\nThe following error was found:\nerror sending email\nDetails:\nCan't send mail - all recipients were rejected: 550 5.7.1 Relaying denied"
             );
           });
           expect(true).to.be(true);


### PR DESCRIPTION
Looks like we have a new text being returned from the email sending service while doing our email connector tests in Alerting. 
This PR changes the one set in the test to the new version