### PR TITLE
[7.17] [APM] Fixes setting APM fleet migration policy id with correct API param (#128494) (#128706)

### DIFF
--- a/x-pack/plugins/apm/common/fleet.ts
+++ b/x-pack/plugins/apm/common/fleet.ts
@@ -8,3 +8,5 @@
 export const POLICY_ELASTIC_AGENT_ON_CLOUD = 'policy-elastic-agent-on-cloud';
 
 export const SUPPORTED_APM_PACKAGE_VERSION = '7.16.0';
+
+export const ELASTIC_CLOUD_APM_AGENT_POLICY_ID = 'elastic-cloud-apm';

--- a/x-pack/plugins/apm/server/lib/fleet/create_cloud_apm_package_policy.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/create_cloud_apm_package_policy.ts
@@ -22,6 +22,7 @@ import {
 import { getApmPackagePolicyDefinition } from './get_apm_package_policy_definition';
 import { Setup } from '../helpers/setup_request';
 import { mergePackagePolicyWithApm } from './merge_package_policy_with_apm';
+import { ELASTIC_CLOUD_APM_AGENT_POLICY_ID } from '../../../common/fleet';
 
 export async function createCloudApmPackgePolicy({
   cloudPluginSetup,
@@ -60,7 +61,7 @@ export async function createCloudApmPackgePolicy({
     savedObjectsClient,
     esClient,
     mergedAPMPackagePolicy,
-    { force: true, bumpRevision: true }
+    { id: ELASTIC_CLOUD_APM_AGENT_POLICY_ID, force: true, bumpRevision: true }
   );
   logger.info(`Fleet migration on Cloud - apmPackagePolicy create end`);
   return apmPackagePolicy;


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.1` to `7.17`:
 - [[APM] Fixes setting APM fleet migration policy id with correct API param (#128494) (#128706)](https://github.com/elastic/kibana/pull/128706)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)