### PR TITLE
[7.17] [APM] ensure rum_allow_origins setting only saves valid YAML strings (#128703) (#128707)

### DIFF
--- a/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import yaml from 'js-yaml';
 import {
   POLICY_ELASTIC_AGENT_ON_CLOUD,
   SUPPORTED_APM_PACKAGE_VERSION,
@@ -89,7 +89,11 @@ function getApmPackageInputVars(options: GetApmPackagePolicyDefinitionOptions) {
 
   const inputVars: Record<string, { type: string; value: any }> =
     apmServerConfigs.reduce((acc, { key, name, type, getValue }) => {
-      const value = (getValue ? getValue(options) : apmServerSchema[key]) ?? ''; // defaults to an empty string to be edited in Fleet UI
+      const apmServerSchemaValue = apmServerSchema[key];
+      const value =
+        (getValue
+          ? getValue(options, apmServerSchemaValue)
+          : apmServerSchemaValue) ?? ''; // defaults to an empty string to be edited in Fleet UI
       return {
         ...acc,
         [name]: { type, value },
@@ -103,7 +107,10 @@ export const apmConfigMapping: Record<
   {
     name: string;
     type: string;
-    getValue?: (options: GetApmPackagePolicyDefinitionOptions) => any;
+    getValue?: (
+      options: GetApmPackagePolicyDefinitionOptions,
+      value?: any
+    ) => any;
   }
 > = {
   'apm-server.host': {
@@ -126,6 +133,8 @@ export const apmConfigMapping: Record<
   'apm-server.rum.allow_origins': {
     name: 'rum_allow_origins',
     type: 'text',
+    getValue: (options, apmServerSchemaValue) =>
+      ensureValidMultiText(apmServerSchemaValue as string[]) ?? '',
   },
   'apm-server.rum.allow_headers': {
     name: 'rum_allow_headers',
@@ -252,3 +261,20 @@ export const apmConfigMapping: Record<
     type: 'integer',
   },
 };
+
+function ensureValidMultiText(textMultiValue: string[] | undefined) {
+  if (!textMultiValue) {
+    return undefined;
+  }
+  return textMultiValue.map(escapeInvalidYamlString);
+}
+function escapeInvalidYamlString(yamlString: string) {
+  try {
+    yaml.load(yamlString);
+  } catch (error) {
+    if (error instanceof yaml.YAMLException) {
+      return `"${yamlString}"`;
+    }
+  }
+  return yamlString;
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.1` to `7.17`:
 - [[APM] ensure rum_allow_origins setting only saves valid YAML strings (#128703) (#128707)](https://github.com/elastic/kibana/pull/128707)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)