### PR TITLE
[DOCS] Adds GET all case comments API docs

### DIFF
--- a/docs/api/cases.asciidoc
+++ b/docs/api/cases.asciidoc
@@ -13,7 +13,7 @@ these APIs:
 * {security-guide}/cases-api-find-cases-by-alert.html[Find cases by alert]
 * <<cases-api-find-connectors>>
 * {security-guide}/cases-api-get-case-activity.html[Get all case activity]
-* {security-guide}/cases-api-get-all-case-comments.html[Get all case comments]
+* <<cases-api-get-all-case-comments>>
 * {security-guide}/cases-api-get-case.html[Get case]
 * {security-guide}/cases-api-get-comment.html[Get comment]
 * {security-guide}/cases-get-connector.html[Get current connector]
@@ -34,5 +34,7 @@ include::cases/cases-api-delete-comments.asciidoc[leveloffset=+1]
 //FIND
 include::cases/cases-api-find-cases.asciidoc[leveloffset=+1]
 include::cases/cases-api-find-connectors.asciidoc[leveloffset=+1]
+//GET
+include::cases/cases-api-get-all-case-comments.asciidoc[leveloffset=+1]
 //UPDATE
 include::cases/cases-api-update.asciidoc[leveloffset=+1]

--- a/docs/api/cases/cases-api-get-all-case-comments.asciidoc
+++ b/docs/api/cases/cases-api-get-all-case-comments.asciidoc
@@ -1,0 +1,108 @@
+[[cases-api-get-all-case-comments]]
+== Get all case comments API
+++++
+<titleabbrev>Get all case comments</titleabbrev>
+++++
+
+Returns all comments for the specified case.
+
+=== Request
+
+`GET <kibana host>:<port>/api/cases/<case ID>/comments`
+
+`GET <kibana host>:<port>/s/<space_id>/api/cases/<case ID>/comments`
+
+=== Prerequisite
+
+You must have `read` privileges for the *Cases* feature in the *Management*,
+*{observability}*, or *Security* section of the
+<<kibana-feature-privileges,{kib} feature privileges>>, depending on the
+`owner` of the cases you're seeking.
+
+=== Path parameters
+
+`<case_id>`::
+(Required, string) An identifier for the case to retrieve. Use 
+<<cases-api-find-cases>> to retrieve case IDs.
+
+`<space_id>`::
+(Optional, string) An identifier for the space. If it is not specified, the
+default space is used.
+
+==== Response code
+
+`200`::
+   Indicates a successful call.
+
+==== Example
+
+Gets all comments for case ID `a18b38a0-71b0-11ea-a0b2-c51ea50a58e2`:
+
+[source,sh]
+--------------------------------------------------
+GET api/cases/a18b38a0-71b0-11ea-a0b2-c51ea50a58e2/comments
+--------------------------------------------------
+// KIBANA
+
+The API returns a JSON object with all the comments for the case. For example:
+
+[source,json]
+--------------------------------------------------
+[
+  {
+    "id": "c6f0dca0-71b3-11ea-a0b2-c51ea50a58e2",
+    "version": "WzEwNSwxXQ==",
+    "type": "user",
+    "comment": "That is nothing - Ethan Hunt answered a targeted social media campaign promoting phishy pension schemes to IMF operatives. Even worse, he likes baked beans.",
+    "created_at": "2020-03-29T11:52:33.889Z",
+    "created_by": {
+      "email": "moneypenny@hms.gov.uk",
+      "full_name": "Ms Moneypenny",
+      "username": "moneypenny"
+    },
+    "owner": "securitySolution",
+    "pushed_at": null,
+    "pushed_by": null,
+    "updated_at": "2020-03-29T12:14:32.997Z",
+    "updated_by": {
+      "email": "jbond@hms.gov.uk",
+      "full_name": "James Bond",
+      "username": "_007"
+    }
+  },
+  {
+    "id": "71ec1870-725b-11ea-a0b2-c51ea50a58e2",
+    "type": "user",
+    "version": "WzEyOCwxXQ==",
+    "comment": "Start operation bubblegum immediately! And chew fast!",
+    "created_at": "2020-03-30T07:52:46.702Z",
+    "created_by": {
+      "email": "classified@hms.oo.gov.uk",
+      "full_name": "Classified",
+      "username": "M"
+    },
+    "owner": "securitySolution",
+    "pushed_at": null,
+    "pushed_by": null,
+    "updated_at": null,
+    "updated_by": null
+  },
+  {
+    "type":"alert",
+    "alertId":"9241255e1e761ff068768671f6971bcbef869862b02188971036ed4ebba842f1",
+    "index":".siem-signals-siem-estc-dev-default-000028",
+    "version": "WyEzOCwxXQ==",
+    "created_at": "2020-03-31T07:52:46.702Z",
+    "created_by": {
+      "email": "classified@hms.oo.gov.uk",
+      "full_name": "Classified",
+      "username": "M"
+    },
+    "owner": "securitySolution",
+    "pushed_at": null,
+    "pushed_by": null,
+    "updated_at": null,
+    "updated_by": null
+  }
+]
+--------------------------------------------------


### PR DESCRIPTION
## Summary

Relates to #126956.

This PR copies the GET [all case comments API](https://www.elastic.co/guide/en/security/master/cases-api-overview.html) from the Security Guide to the Kibana Guide. It also formats the content to align with existing Kibana APIs.


### Preview

* [GET all case comments](https://kibana_128758.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-get-all-case-comments.html)