### PR TITLE
Update status when summary is updated

### DIFF
--- a/src/core/server/status/plugins_status.ts
+++ b/src/core/server/status/plugins_status.ts
@@ -14,7 +14,7 @@ import {
   timeoutWith,
   startWith,
 } from 'rxjs/operators';
-import { sortBy } from 'lodash';
+import { sortBy, isEqual } from 'lodash';
 import { isDeepStrictEqual } from 'util';
 
 import { type PluginName } from '../plugins';
@@ -330,16 +330,12 @@ export class PluginsStatusService {
    * @param {ServiceStatus} reportedStatus The newly reported status for that plugin
    */
   private updatePluginReportedStatus(plugin: PluginName, reportedStatus: ServiceStatus): void {
-    const previousReportedLevel = this.pluginData[plugin].reportedStatus?.level;
-    const previousReportedSummary = this.pluginData[plugin].reportedStatus?.summary;
+    const previousReportedStatus = this.pluginData[plugin].reportedStatus;
 
     this.pluginData[plugin].reportedStatus = reportedStatus;
     this.pluginStatus[plugin] = reportedStatus;
 
-    if (
-      reportedStatus.level !== previousReportedLevel ||
-      reportedStatus.summary !== previousReportedSummary
-    ) {
+    if (!isEqual(previousReportedStatus, reportedStatus)) {
       this.updatePluginsStatuses([plugin]);
     }
   }

--- a/src/core/server/status/plugins_status.ts
+++ b/src/core/server/status/plugins_status.ts
@@ -331,11 +331,15 @@ export class PluginsStatusService {
    */
   private updatePluginReportedStatus(plugin: PluginName, reportedStatus: ServiceStatus): void {
     const previousReportedLevel = this.pluginData[plugin].reportedStatus?.level;
+    const previousReportedSummary = this.pluginData[plugin].reportedStatus?.summary;
 
     this.pluginData[plugin].reportedStatus = reportedStatus;
     this.pluginStatus[plugin] = reportedStatus;
 
-    if (reportedStatus.level !== previousReportedLevel) {
+    if (
+      reportedStatus.level !== previousReportedLevel ||
+      reportedStatus.summary !== previousReportedSummary
+    ) {
       this.updatePluginsStatuses([plugin]);
     }
   }


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/127075 

In https://github.com/elastic/kibana/pull/128324 the status feature was rewritten causing status to not be updated if the level do not change, Fleet update the status `summary` without updating the level.

That PR fix that regression, should we compare the whole status and previous status if other fields are updated? 