### PR TITLE
[ML] Combines annotations into one block if multiple annotations overlap

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/swimlane_annotation_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_annotation_container.tsx
@@ -153,7 +153,6 @@ export const SwimlaneAnnotationContainer: FC<SwimlaneAnnotationContainerProps> =
                 // @ts-ignore skipping header so it doesn't have other params
                 tooltipData.push({ skipHeader: true });
               }
-
               d.annotations.forEach((item) => {
                 let timespan = moment(item.timestamp).format('MMMM Do YYYY, HH:mm');
 
@@ -163,15 +162,36 @@ export const SwimlaneAnnotationContainer: FC<SwimlaneAnnotationContainerProps> =
                   )}`;
                 }
 
-                tooltipData.push({
-                  label: timespan,
-                  value: `${item.annotation}`,
-                  seriesIdentifier: {
-                    key: 'anomaly_timeline',
-                    specId: item._id ?? `${item.annotation}-${item.timestamp}-label`,
-                  },
-                  valueAccessor: 'annotation',
-                });
+                if (hasMergedAnnotations) {
+                  tooltipData.push({
+                    label: timespan,
+                    value: `${item.annotation}`,
+                    seriesIdentifier: {
+                      key: 'anomaly_timeline',
+                      specId: item._id ?? `${item.annotation}-${item.timestamp}-label`,
+                    },
+                    valueAccessor: 'annotation',
+                  });
+                } else {
+                  tooltipData.push(
+                    {
+                      label: `${item.annotation}`,
+                      seriesIdentifier: {
+                        key: 'anomaly_timeline',
+                        specId: item._id ?? `${item.annotation}-${item.timestamp}-label`,
+                      },
+                      valueAccessor: 'label',
+                    },
+                    {
+                      label: `${timespan}`,
+                      seriesIdentifier: {
+                        key: 'anomaly_timeline',
+                        specId: item._id ?? `${item.annotation}-${item.timestamp}-ts`,
+                      },
+                      valueAccessor: 'time',
+                    }
+                  );
+                }
 
                 if (
                   item.partition_field_name !== undefined &&

--- a/x-pack/plugins/ml/public/application/explorer/swimlane_annotation_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_annotation_container.tsx
@@ -9,8 +9,8 @@ import React, { FC, useEffect } from 'react';
 import d3 from 'd3';
 import { scaleTime } from 'd3-scale';
 import { i18n } from '@kbn/i18n';
-import { formatHumanReadableDateTimeSeconds } from '../../../common/util/date_utils';
-import { AnnotationsTable } from '../../../common/types/annotations';
+import moment from 'moment';
+import type { Annotation, AnnotationsTable } from '../../../common/types/annotations';
 import { ChartTooltipService } from '../components/chart_tooltip';
 import { useCurrentEuiTheme } from '../components/color_range_legend';
 
@@ -83,17 +83,54 @@ export const SwimlaneAnnotationContainer: FC<SwimlaneAnnotationContainerProps> =
         .style('fill', 'none')
         .style('stroke-width', 1);
 
+      // Merging overlapping annotations into bigger blocks
+      let mergedAnnotations: Array<{ start: number; end: number; annotations: Annotation[] }> = [];
+      const sortedAnnotationsData = [...annotationsData].sort((a, b) => a.timestamp - b.timestamp);
+
+      if (sortedAnnotationsData.length > 0) {
+        let lastEndTime =
+          sortedAnnotationsData[0].end_timestamp ?? sortedAnnotationsData[0].timestamp;
+
+        mergedAnnotations = [
+          {
+            start: sortedAnnotationsData[0].timestamp,
+            end: lastEndTime,
+            annotations: [sortedAnnotationsData[0]],
+          },
+        ];
+
+        for (let i = 1; i < sortedAnnotationsData.length; i++) {
+          if (sortedAnnotationsData[i].timestamp < lastEndTime) {
+            const itemToMerge = mergedAnnotations.pop();
+            if (itemToMerge) {
+              const newMergedItem = {
+                ...itemToMerge,
+                end: lastEndTime,
+                annotations: [...itemToMerge.annotations, sortedAnnotationsData[i]],
+              };
+              mergedAnnotations.push(newMergedItem);
+            }
+          } else {
+            lastEndTime =
+              sortedAnnotationsData[i].end_timestamp ?? sortedAnnotationsData[i].timestamp;
+
+            mergedAnnotations.push({
+              start: sortedAnnotationsData[i].timestamp,
+              end: lastEndTime,
+              annotations: [sortedAnnotationsData[i]],
+            });
+          }
+        }
+      }
+
       // Add annotation marker
-      annotationsData.forEach((d) => {
+      mergedAnnotations.forEach((d) => {
         const annotationWidth = Math.max(
-          d.end_timestamp
-            ? xScale(Math.min(d.end_timestamp, domain.max)) -
-                Math.max(xScale(d.timestamp), startingXPos)
-            : 0,
+          d.end ? xScale(Math.min(d.end, domain.max)) - Math.max(xScale(d.start), startingXPos) : 0,
           ANNOTATION_MIN_WIDTH
         );
 
-        const xPos = d.timestamp >= domain.min ? xScale(d.timestamp) : startingXPos;
+        const xPos = d.start >= domain.min ? xScale(d.start) : startingXPos;
         svg
           .append('rect')
           .classed('mlAnnotationRect', true)
@@ -103,42 +140,54 @@ export const SwimlaneAnnotationContainer: FC<SwimlaneAnnotationContainerProps> =
           .attr('height', ANNOTATION_CONTAINER_HEIGHT)
           .attr('width', annotationWidth)
           .on('mouseover', function () {
-            const startingTime = formatHumanReadableDateTimeSeconds(d.timestamp);
-            const endingTime =
-              d.end_timestamp !== undefined
-                ? formatHumanReadableDateTimeSeconds(d.end_timestamp)
-                : undefined;
+            const tooltipData: Array<{
+              label: string;
+              seriesIdentifier: { key: string; specId: string } | { key: string; specId: string };
+              valueAccessor: string;
+              skipHeader?: boolean;
+              value?: string;
+            }> = [];
+            if (Array.isArray(d.annotations)) {
+              const hasMergedAnnotations = d.annotations.length > 1;
+              if (hasMergedAnnotations) {
+                // @ts-ignore skipping header so it doesn't have other params
+                tooltipData.push({ skipHeader: true });
+              }
 
-            const timeLabel = endingTime ? `${startingTime} - ${endingTime}` : startingTime;
+              d.annotations.forEach((item) => {
+                let timespan = moment(item.timestamp).format('MMMM Do YYYY, HH:mm');
 
-            const tooltipData = [
-              {
-                label: `${d.annotation}`,
-                seriesIdentifier: {
-                  key: 'anomaly_timeline',
-                  specId: d._id ?? `${d.annotation}-${d.timestamp}-label`,
-                },
-                valueAccessor: 'label',
-              },
-              {
-                label: `${timeLabel}`,
-                seriesIdentifier: {
-                  key: 'anomaly_timeline',
-                  specId: d._id ?? `${d.annotation}-${d.timestamp}-ts`,
-                },
-                valueAccessor: 'time',
-              },
-            ];
-            if (d.partition_field_name !== undefined && d.partition_field_value !== undefined) {
-              tooltipData.push({
-                label: `${d.partition_field_name}: ${d.partition_field_value}`,
-                seriesIdentifier: {
-                  key: 'anomaly_timeline',
-                  specId: d._id
-                    ? `${d._id}-partition`
-                    : `${d.partition_field_name}-${d.partition_field_value}-label`,
-                },
-                valueAccessor: 'partition',
+                if (typeof item.end_timestamp !== 'undefined') {
+                  timespan += ` - ${moment(item.end_timestamp).format(
+                    hasMergedAnnotations ? 'HH:mm' : 'MMMM Do YYYY, HH:mm'
+                  )}`;
+                }
+
+                tooltipData.push({
+                  label: timespan,
+                  value: `${item.annotation}`,
+                  seriesIdentifier: {
+                    key: 'anomaly_timeline',
+                    specId: item._id ?? `${item.annotation}-${item.timestamp}-label`,
+                  },
+                  valueAccessor: 'annotation',
+                });
+
+                if (
+                  item.partition_field_name !== undefined &&
+                  item.partition_field_value !== undefined
+                ) {
+                  tooltipData.push({
+                    label: `${item.partition_field_name}: ${item.partition_field_value}`,
+                    seriesIdentifier: {
+                      key: 'anomaly_timeline',
+                      specId: item._id
+                        ? `${item._id}-partition`
+                        : `${item.partition_field_name}-${item.partition_field_value}-label`,
+                    },
+                    valueAccessor: 'partition',
+                  });
+                }
               });
             }
             // @ts-ignore we don't need all the fields for tooltip to show

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart.js
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart.js
@@ -979,7 +979,8 @@ class TimeseriesChartIntl extends Component {
       ? [...annotationData].sort((a, b) => a.timestamp - b.timestamp)
       : [];
 
-    // Merging overlapping annotations into bigger blocks
+    // Since there might be lots of annotations which is hard to view
+    // we should merge overlapping annotations into bigger annotation "blocks"
     let mergedAnnotations = [];
     if (focusAnnotationData.length > 0) {
       mergedAnnotations = [
@@ -991,16 +992,21 @@ class TimeseriesChartIntl extends Component {
       ];
       let lastEndTime = focusAnnotationData[0].end_timestamp;
 
+      // Since annotations/intervals are already sorted from earliest to latest
+      // we can keep checking if next annotation starts before the last merged end_timestamp
       for (let i = 1; i < focusAnnotationData.length; i++) {
         if (focusAnnotationData[i].timestamp < lastEndTime) {
+          // If it overlaps with last annotation block, update block with latest end_timestamp
           const itemToMerge = mergedAnnotations.pop();
           const newMergedItem = {
             ...itemToMerge,
             end: lastEndTime,
+            // and add to list of annotations for that block
             annotations: [...itemToMerge.annotations, focusAnnotationData[i]],
           };
           mergedAnnotations.push(newMergedItem);
         } else {
+          // If annotation does not overlap with previous block, add it as a new block
           mergedAnnotations.push({
             start: focusAnnotationData[i].timestamp,
             end: focusAnnotationData[i].end_timestamp,

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart.js
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart.js
@@ -1748,11 +1748,13 @@ class TimeseriesChartIntl extends Component {
           timespan += ` - ${moment(annotation.end_timestamp).format('HH:mm')}`;
         }
         tooltipData.push({
-          label: `${timespan}: ${annotation.annotation}`,
+          label: timespan,
+          value: `${annotation.annotation}`,
           seriesIdentifier: {
-            key: seriesKey,
+            key: 'anomaly_timeline',
+            specId: annotation._id ?? `${annotation.annotation}-${annotation.timestamp}-label`,
           },
-          valueAccessor: 'timespan',
+          valueAccessor: 'annotation',
         });
       });
     }

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart.js
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart.js
@@ -975,6 +975,50 @@ class TimeseriesChartIntl extends Component {
       this.props;
     const data = contextChartData;
 
+    const focusAnnotationData = Array.isArray(annotationData)
+      ? [...annotationData].sort((a, b) => a.timestamp - b.timestamp)
+      : [];
+
+    if (focusAnnotationData.length > 0) {
+      const stack = [
+        {
+          start: focusAnnotationData[0].timestamp,
+          end: focusAnnotationData[0].end_timestamp,
+          annotations: [focusAnnotationData[0]],
+        },
+      ];
+      let lastEndTime = focusAnnotationData[0].end_timestamp;
+
+      for (let i = 1; i < focusAnnotationData.length; i++) {
+        if (focusAnnotationData[i].timestamp < lastEndTime) {
+          console.log(
+            focusAnnotationData[i].annotation,
+            focusAnnotationData[i].timestamp,
+            'lastEndTime',
+            lastEndTime,
+            focusAnnotationData[i].timestamp < lastEndTime
+          );
+
+          const itemToMerge = stack.pop();
+          const newMergedItem = {
+            ...itemToMerge,
+            end: lastEndTime,
+            annotations: [...itemToMerge.annotations, focusAnnotationData[i]],
+          };
+          stack.push(newMergedItem);
+        } else {
+          stack.push({
+            start: focusAnnotationData[i].timestamp,
+            end: focusAnnotationData[i].end_timestamp,
+            annotations: [focusAnnotationData[i]],
+          });
+        }
+        lastEndTime = focusAnnotationData[i].end_timestamp;
+      }
+      console.log('stack', stack);
+    }
+    console.log('---annotationData', annotationData);
+
     const showFocusChartTooltip = this.showFocusChartTooltip.bind(this);
     const hideFocusChartTooltip = this.props.tooltipService.hide.bind(this.props.tooltipService);
 


### PR DESCRIPTION
## Summary

This PR is part of https://github.com/elastic/kibana/issues/69538. It combines annotations into one block if multiple of them overlap:

Before:
<img width="1531" alt="Screen Shot 2022-03-29 at 11 51 13" src="https://user-images.githubusercontent.com/43350163/160664527-9c45e528-1a50-4a04-955a-4c041446e1f9.png">


After:

<img width="1269" alt="Screen Shot 2022-03-29 at 12 57 46" src="https://user-images.githubusercontent.com/43350163/160675414-2dfb2505-9853-4b96-8dee-452928483aca.png">



Before:
<img width="1517" alt="Screen Shot 2022-03-29 at 10 31 41" src="https://user-images.githubusercontent.com/43350163/160664199-776756ab-f8f6-4238-90b7-65b9b86ef5dd.png">


After:
 
<img width="1531" alt="Screen Shot 2022-03-29 at 11 46 11" src="https://user-images.githubusercontent.com/43350163/160663997-293e015f-e653-4d58-8870-981e56d084f6.png">



https://user-images.githubusercontent.com/43350163/160675545-f957b9d1-cbee-495c-a05a-80a9ef8916ab.mov


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
