### PR TITLE
[Fleet] Fix Windows Expand-Archive command for agent install

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
@@ -66,7 +66,7 @@ tar xzvf elastic-agent-${kibanaVersion}-darwin-x86_64.tar.gz
 sudo ./elastic-agent install`;
 
     const STANDALONE_RUN_INSTRUCTIONS_WINDOWS = `wget https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${kibanaVersion}-windows-x86_64.zip -OutFile elastic-agent-${kibanaVersion}-windows-x86_64.zip
-Expand-Archive .\elastic-agent-${kibanaVersion}-windows-x86_64.zip
+Expand-Archive .\\elastic-agent-${kibanaVersion}-windows-x86_64.zip
 .\\elastic-agent.exe install`;
 
     const linuxDebCommand = `curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${kibanaVersion}-amd64.deb

--- a/x-pack/plugins/fleet/public/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/plugins/fleet/public/components/enrollment_instructions/manual/index.tsx
@@ -40,7 +40,7 @@ cd elastic-agent-${kibanaVersion}-darwin-x86_64
 sudo ./elastic-agent install ${enrollArgs}`;
 
   const windowsCommand = `wget https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${kibanaVersion}-windows-x86_64.zip -OutFile elastic-agent-${kibanaVersion}-windows-x86_64.zip
-Expand-Archive .\elastic-agent-${kibanaVersion}-windows-x86_64.zip
+Expand-Archive .\\elastic-agent-${kibanaVersion}-windows-x86_64.zip
 .\\elastic-agent.exe install ${enrollArgs}`;
 
   const linuxDebCommand = `curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${kibanaVersion}-amd64.deb


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/128250. 

We had a missing `\` to escape the `\` that appears in the Windows command for installing Agent.

![image](https://user-images.githubusercontent.com/6766512/160668020-e33a8844-37eb-417d-bb64-2bf96ad03076.png)
