### PR TITLE
[Fleet] Display permissions tooltip on Add Integration button in Agent Policy view

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
@@ -24,8 +24,18 @@ import {
 import { INTEGRATIONS_PLUGIN_ID } from '../../../../../../../../common';
 import { pagePathGetters } from '../../../../../../../constants';
 import type { AgentPolicy, InMemoryPackagePolicy, PackagePolicy } from '../../../../../types';
-import { PackageIcon, PackagePolicyActionsMenu } from '../../../../../components';
-import { useAuthz, useLink, usePackageInstallations, useStartServices } from '../../../../../hooks';
+import {
+  EuiButtonWithTooltip,
+  PackageIcon,
+  PackagePolicyActionsMenu,
+} from '../../../../../components';
+import {
+  useAuthz,
+  useLink,
+  usePackageInstallations,
+  usePermissionCheck,
+  useStartServices,
+} from '../../../../../hooks';
 import { pkgKeyFromPackageInfo } from '../../../../../services';
 
 interface Props {
@@ -54,6 +64,10 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
   const canReadIntegrationPolicies = useAuthz().integrations.readIntegrationPolicies;
   const { updatableIntegrations } = usePackageInstallations();
   const { getHref } = useLink();
+
+  const permissionCheck = usePermissionCheck();
+  const missingSecurityConfiguration =
+    !permissionCheck.data?.success && permissionCheck.data?.error === 'MISSING_SECURITY';
 
   // With the package policies provided on input, generate the list of package policies
   // used in the InMemoryTable (flattens some values for search) as well as
@@ -265,7 +279,7 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
         toolsRight: agentPolicy.is_managed
           ? []
           : [
-              <EuiButton
+              <EuiButtonWithTooltip
                 key="addPackagePolicyButton"
                 fill
                 isDisabled={!canWriteIntegrationPolicies}
@@ -277,12 +291,29 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
                   });
                 }}
                 data-test-subj="addPackagePolicyButton"
+                tooltip={
+                  !canWriteIntegrationPolicies
+                    ? {
+                        content: missingSecurityConfiguration ? (
+                          <FormattedMessage
+                            id="xpack.fleet.epm.addPackagePolicyButtonSecurityRequiredTooltip"
+                            defaultMessage="To add Elastic Agent Integrations, you must have security enabled and have the All privilege for Fleet. Contact your administrator."
+                          />
+                        ) : (
+                          <FormattedMessage
+                            id="xpack.fleet.epm.addPackagePolicyButtonPrivilegesRequiredTooltip"
+                            defaultMessage="Elastic Agent Integrations require the All privilege for Fleet and All privilege for Integrations. Contact your administrator."
+                          />
+                        ),
+                      }
+                    : undefined
+                }
               >
                 <FormattedMessage
                   id="xpack.fleet.policyDetails.addPackagePolicyButtonText"
                   defaultMessage="Add integration"
                 />
-              </EuiButton>,
+              </EuiButtonWithTooltip>,
             ],
         box: {
           incremental: true,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -47,7 +47,7 @@ import {
   useBreadcrumbs as useIntegrationsBreadcrumbs,
   useGetOnePackagePolicy,
 } from '../../../../integrations/hooks';
-import { Loading, Error, ExtensionWrapper } from '../../../components';
+import { Loading, Error, ExtensionWrapper, EuiButtonWithTooltip } from '../../../components';
 import { ConfirmDeployAgentPolicyModal } from '../components';
 import { CreatePackagePolicyPageLayout } from '../create_package_policy_page/components';
 import type { PackagePolicyValidationResults } from '../create_package_policy_page/services';
@@ -64,7 +64,6 @@ import type {
 } from '../../../../../../common/types/rest_spec';
 import type { PackagePolicyEditExtensionComponentProps } from '../../../types';
 import { pkgKeyFromPackageInfo } from '../../../services';
-import { EuiButtonWithTooltip } from '../../../../integrations/sections/epm/screens/detail';
 
 import { fixApmDurationVars, hasUpgradeAvailable } from './utils';
 

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -8,11 +8,9 @@ import type { ReactEventHandler } from 'react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Redirect, Route, Switch, useLocation, useParams, useHistory } from 'react-router-dom';
 import styled from 'styled-components';
-import type { EuiToolTipProps } from '@elastic/eui';
 import {
   EuiBadge,
   EuiBetaBadge,
-  EuiButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiDescriptionList,
@@ -22,7 +20,6 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiText,
-  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -52,7 +49,7 @@ import type {
   PackageInfo,
 } from '../../../../types';
 import { InstallStatus } from '../../../../types';
-import { Error, Loading } from '../../../../components';
+import { Error, EuiButtonWithTooltip, Loading } from '../../../../components';
 import type { WithHeaderLayoutProps } from '../../../../layouts';
 import { WithHeaderLayout } from '../../../../layouts';
 import { RELEASE_BADGE_DESCRIPTION, RELEASE_BADGE_LABEL } from '../../components/release_badge';
@@ -639,17 +636,3 @@ export function Detail() {
     </WithHeaderLayout>
   );
 }
-
-type EuiButtonPropsFull = Parameters<typeof EuiButton>[0];
-
-export const EuiButtonWithTooltip: React.FC<
-  EuiButtonPropsFull & { tooltip?: Partial<EuiToolTipProps> }
-> = ({ tooltip: tooltipProps, ...buttonProps }) => {
-  return tooltipProps ? (
-    <EuiToolTip {...tooltipProps}>
-      <EuiButton {...buttonProps} />
-    </EuiToolTip>
-  ) : (
-    <EuiButton {...buttonProps} />
-  );
-};

--- a/x-pack/plugins/fleet/public/components/eui_button_with_tooltip.tsx
+++ b/x-pack/plugins/fleet/public/components/eui_button_with_tooltip.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { EuiToolTipProps } from '@elastic/eui';
+import { EuiToolTip } from '@elastic/eui';
+import { EuiButton } from '@elastic/eui';
+
+type EuiButtonPropsFull = Parameters<typeof EuiButton>[0];
+
+export const EuiButtonWithTooltip: React.FC<
+  EuiButtonPropsFull & { tooltip?: Partial<EuiToolTipProps> }
+> = ({ tooltip: tooltipProps, ...buttonProps }) => {
+  return tooltipProps ? (
+    <EuiToolTip {...tooltipProps}>
+      <EuiButton {...buttonProps} />
+    </EuiToolTip>
+  ) : (
+    <EuiButton {...buttonProps} />
+  );
+};

--- a/x-pack/plugins/fleet/public/components/index.ts
+++ b/x-pack/plugins/fleet/public/components/index.ts
@@ -20,5 +20,6 @@ export { DangerEuiContextMenuItem } from './danger_eui_context_menu_item';
 export { PackagePolicyDeleteProvider } from './package_policy_delete_provider';
 export { PackagePolicyActionsMenu } from './package_policy_actions_menu';
 export { AddAgentHelpPopover } from './add_agent_help_popover';
+export { EuiButtonWithTooltip } from './eui_button_with_tooltip';
 export * from './link_and_revision';
 export * from './agent_enrollment_flyout';


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/126139. 

- Display same tooltip on Agent Policy "Add Integration" button as we do on integration installation button
- Move `EuiButtonWithTooltip` component to the `public/components` directory since it's shared between the Fleet and Integrations apps

![image](https://user-images.githubusercontent.com/6766512/160677028-f60c8c81-ea79-42bb-9e78-17cfdae8e0e3.png)



