### PR TITLE
[7.16] [Stack Monitoring] add monitoring.ui.elasticsearch.serviceAccountToken to docs (#128488)

### DIFF
--- a/docs/settings/monitoring-settings.asciidoc
+++ b/docs/settings/monitoring-settings.asciidoc
@@ -78,6 +78,9 @@ For more information, see
   +
   If not set, {kib} uses the value of the <<elasticsearch-user-passwd, `elasticsearch.password`>> setting.
 
+| `monitoring.ui.elasticsearch.serviceAccountToken`
+  | Specifies a {ref}/security-api-create-service-token.html[service account token] for the {es} cluster where your monitoring data is stored when using `monitoring.ui.elasticsearch.hosts`.  This setting is an alternative to using `monitoring.ui.elasticsearch.username` and `monitoring.ui.elasticsearch.password`.
+
 | `monitoring.ui.elasticsearch.pingTimeout`
   | Specifies the time in milliseconds to wait for {es} to respond to internal
   health checks. By default, it matches the <<elasticsearch-pingTimeout, `elasticsearch.pingTimeout`>> setting,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.16`:
 - [[Stack Monitoring] add monitoring.ui.elasticsearch.serviceAccountToken to docs (#128488)](https://github.com/elastic/kibana/pull/128488)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)