### PR TITLE
[CI] Build TS refs before API docs

### DIFF
--- a/.buildkite/scripts/steps/build_api_docs.sh
+++ b/.buildkite/scripts/steps/build_api_docs.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+export BUILD_TS_REFS_DISABLE=false
+
 .buildkite/scripts/bootstrap.sh
 
 echo "--- Build API Docs"

--- a/.buildkite/scripts/steps/build_api_docs.sh
+++ b/.buildkite/scripts/steps/build_api_docs.sh
@@ -2,9 +2,13 @@
 
 set -euo pipefail
 
-export BUILD_TS_REFS_DISABLE=false
-
 .buildkite/scripts/bootstrap.sh
+
+echo "--- Build TS Refs"
+node scripts/build_ts_refs \
+  --clean \
+  --no-cache \
+  --force
 
 echo "--- Build API Docs"
 node --max-old-space-size=12000 scripts/build_api_docs


### PR DESCRIPTION
It looks like building API docs requires TS refs to be built first, at least for all of the metrics to be consistent between PRs and the `on merge` pipeline.

We aren't currently sure if building TS refs is causing things to be double-counted, or if not building TS refs is causing things to be missing, but we should at least make it match `on merge` for now.