### PR TITLE
Security Solution: enhance getAggregatableFields perf

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/__snapshots__/hooks.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/__snapshots__/hooks.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getAggregatableFields 1`] = `Array []`;

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.test.tsx
@@ -7,13 +7,22 @@
 
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
-import { useInspectButton, UseInspectButtonParams, useStackByFields } from './hooks';
+import {
+  getAggregatableFields,
+  useInspectButton,
+  UseInspectButtonParams,
+  useStackByFields,
+} from './hooks';
 import { mockBrowserFields } from '../../../../common/containers/source/mock';
 import { TestProviders } from '../../../../common/mock';
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
   return { ...actual, useLocation: jest.fn().mockReturnValue({ pathname: '' }) };
+});
+
+test('getAggregatableFields', () => {
+  expect(getAggregatableFields(mockBrowserFields)).toMatchSnapshot();
 });
 
 describe('hooks', () => {

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.ts
@@ -55,17 +55,16 @@ export const useInspectButton = ({
   }, [setQuery, loading, response, request, refetch, uniqueQueryId, deleteQuery]);
 };
 
-function getAggregatableFields(fields: { [fieldName: string]: Partial<BrowserField> }) {
-  return Object.entries(fields).reduce<EuiComboBoxOptionOption[]>(
-    (filteredOptions: EuiComboBoxOptionOption[], [key, field]) => {
-      if (field.aggregatable === true) {
-        return [...filteredOptions, { label: key, value: key }];
-      } else {
-        return filteredOptions;
-      }
-    },
-    []
-  );
+export function getAggregatableFields(fields: {
+  [fieldName: string]: Partial<BrowserField>;
+}): EuiComboBoxOptionOption[] {
+  const result = [];
+  for (const [key, field] of Object.entries(fields)) {
+    if (field.aggregatable === true) {
+      result.push({ label: key, value: key });
+    }
+  }
+  return result;
 }
 
 export const useStackByFields = () => {


### PR DESCRIPTION
The `getAggregatableFields` function is used to determine which fields can be passed to a stacked visualization. When there are many fields, this function can run long. This commit reimplements the function so that it run faster and uses less memory.

### Before

[Chrome dev tools performance profile](https://gist.githubusercontent.com/oatkiller/981b502e34d8875f0d7cdf8426ed9b91/raw/0c8722f55c4fde1d9d265e44657456a9d7fa23f7/before_aggregatable_fix.json)

The function ran for 1549ms 
<img width="483" alt="image" src="https://user-images.githubusercontent.com/35559/160701269-1672466d-1862-4324-acf1-c82c980aab78.png">


https://user-images.githubusercontent.com/35559/160701295-6cc39d94-5214-4052-bf00-bd796de1c16c.mov


### After

[Chrome dev tools performance profile](https://gist.githubusercontent.com/oatkiller/981b502e34d8875f0d7cdf8426ed9b91/raw/0c8722f55c4fde1d9d265e44657456a9d7fa23f7/after_aggregatable_fix.json)

The function ran for 42ms 
<img width="437" alt="image" src="https://user-images.githubusercontent.com/35559/160701426-b528e937-cfaa-4cf0-90aa-0196fe16a2f2.png">


https://user-images.githubusercontent.com/35559/160701441-338303f9-5840-4871-a11f-f174d48febce.mov

### The mappings i used to perf test
https://gist.githubusercontent.com/oatkiller/981b502e34d8875f0d7cdf8426ed9b91/raw/4bba981fded73e5bf3c9f4216b8211d5314e9ce9/huge_index_mapping.txt

If you run that in dev tools **BEFORE** you go to the security app for the first time (on a fresh kibana) then your default dataview will have 14k fields.

Otherwise just run that anyways and then create and use a new dataview :)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
