### PR TITLE
[ci-stats-reporter] prevent `Request body larger than maxBodyLength limit` error

### DIFF
--- a/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
+++ b/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
@@ -312,6 +312,10 @@ export class CiStatsReporter {
           data: body,
           params: query,
           adapter: httpAdapter,
+
+          // if it can be serialized into a string, send it
+          maxBodyLength: Infinity,
+          maxContentLength: Infinity,
         });
 
         return resp.data;

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -9304,7 +9304,10 @@ class CiStatsReporter {
           headers,
           data: body,
           params: query,
-          adapter: _http.default
+          adapter: _http.default,
+          // if it can be serialized into a string, send it
+          maxBodyLength: Infinity,
+          maxContentLength: Infinity
         });
         return resp.data;
       } catch (error) {


### PR DESCRIPTION
We're seeing reports of intermittent `Request body larger than maxBodyLength limit` errors when reporting test groups to ci-stats. It seems there must be an error in Axios that causes some unknown default limit to be applied, this should take care of that and allow any amount of data that can be serialized into a string to be sent to ci-stats.