### PR TITLE
[Lens] Fixed terms multifields flakiness

### DIFF
--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -596,7 +596,13 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       const lastIndex = (
         await find.allByCssSelector('[data-test-subj^="indexPattern-dimension-field"]')
       ).length;
-      await testSubjects.click('indexPattern-terms-add-field');
+      await retry.waitFor('check for field combobox existance', async () => {
+        await testSubjects.click('indexPattern-terms-add-field');
+        const comboboxExists = await testSubjects.exists(
+          `indexPattern-dimension-field-${lastIndex}`
+        );
+        return comboboxExists === true;
+      });
       // count the number of defined terms
       const target = await testSubjects.find(`indexPattern-dimension-field-${lastIndex}`);
       // await comboBox.openOptionsList(target);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/128791

This PR adds a retry on the flaky test. It seems that the add field button is not clicked. What I did was to wait until the combobox appears.

![image](https://user-images.githubusercontent.com/17003240/160790340-b1cf2ada-1361-44b9-9bc9-0a234d8e8e99.png)

Note: The `await testSubjects.click('indexPattern-terms-add-field');` is also used on the `addTermToAgg` function but it is already under a retry so maybe this is the reason that this specific part is not flaky.

### Runners
I tested it on our FTs runner (50 times) https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/348. I could run it more but I think that this must be specifically flaky to cloud instances.
I also run it on the cloud (60 times)
https://internal-ci.elastic.co/job/elastic+estf-cloud-kibana-flaky-test-runner/355/
https://internal-ci.elastic.co/job/elastic+estf-cloud-kibana-flaky-test-runner/356/

There was a failure on the last run but not on this test. I dont think that it is related to our code. Something went wrong with this run https://internal-ci.elastic.co/job/elastic+estf-cloud-kibana-flaky-test-runner/356/JOB=flakyRun1,TASK=saas_run_kibana_tests,node=ess-testing/testReport/junit/Chrome%20X-Pack%20UI%20Functional%20Tests19/x-pack_test_functional_apps_lens/lens_app__after_all__hook_in__lens_app_/ ()

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios