### PR TITLE
[Fleet] Disabling Create enrollment token button when no policy is selected

### DIFF
--- a/x-pack/plugins/fleet/public/components/new_enrollment_key_modal.tsx
+++ b/x-pack/plugins/fleet/public/components/new_enrollment_key_modal.tsx
@@ -149,6 +149,7 @@ export const NewEnrollmentTokenModal: React.FunctionComponent<Props> = ({
       confirmButtonText={i18n.translate('xpack.fleet.newEnrollmentKey.submitButton', {
         defaultMessage: 'Create enrollment token',
       })}
+      confirmButtonDisabled={!form.policyIdInput.value}
     >
       {body}
     </EuiConfirmModal>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/128599

Disabling Create enrollment token button when no policy is selected.

<img width="427" alt="image" src="https://user-images.githubusercontent.com/90178898/160782440-bedcbd13-f2f2-4a19-98fd-7d361e3b983a.png">

