### PR TITLE
Improve Short URL HTTP error semantics

### DIFF
--- a/src/plugins/share/server/url_service/error.ts
+++ b/src/plugins/share/server/url_service/error.ts
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 
-export * from './types';
-export * from './short_urls';
-export { registerUrlServiceRoutes } from './http/register_url_service_routes';
-export { registerUrlServiceSavedObjectType } from './saved_objects/register_url_service_saved_object_type';
-export * from './error';
+export class UrlServiceError extends Error {
+  constructor(message: string, public readonly code: string = '') {
+    super(message);
+  }
+}

--- a/src/plugins/share/server/url_service/error.ts
+++ b/src/plugins/share/server/url_service/error.ts
@@ -6,8 +6,10 @@
  * Side Public License, v 1.
  */
 
+export type UrlServiceErrorCode = 'SLUG_EXISTS' | 'NOT_FOUND' | '';
+
 export class UrlServiceError extends Error {
-  constructor(message: string, public readonly code: string = '') {
+  constructor(message: string, public readonly code: UrlServiceErrorCode = '') {
     super(message);
   }
 }

--- a/src/plugins/share/server/url_service/http/short_urls/register_create_route.ts
+++ b/src/plugins/share/server/url_service/http/short_urls/register_create_route.ts
@@ -42,9 +42,6 @@ export const registerCreateRoute = (router: IRouter, url: ServerUrlService) => {
       if (!locator) {
         return res.customError({
           statusCode: 409,
-          headers: {
-            'content-type': 'application/json',
-          },
           body: 'Locator not found.',
         });
       }
@@ -68,9 +65,6 @@ export const registerCreateRoute = (router: IRouter, url: ServerUrlService) => {
           if (error.code === 'SLUG_EXISTS') {
             return res.customError({
               statusCode: 409,
-              headers: {
-                'content-type': 'application/json',
-              },
               body: error.message,
             });
           }

--- a/src/plugins/share/server/url_service/http/short_urls/register_resolve_route.ts
+++ b/src/plugins/share/server/url_service/http/short_urls/register_resolve_route.ts
@@ -43,9 +43,6 @@ export const registerResolveRoute = (router: IRouter, url: ServerUrlService) => 
           if (error.code === 'NOT_FOUND') {
             return res.customError({
               statusCode: 404,
-              headers: {
-                'content-type': 'application/json',
-              },
               body: error.message,
             });
           }

--- a/src/plugins/share/server/url_service/short_urls/short_url_client.test.ts
+++ b/src/plugins/share/server/url_service/short_urls/short_url_client.test.ts
@@ -12,6 +12,7 @@ import { LegacyShortUrlLocatorDefinition } from '../../../common/url_service/loc
 import { MemoryShortUrlStorage } from './storage/memory_short_url_storage';
 import { SerializableRecord } from '@kbn/utility-types';
 import { SavedObjectReference } from 'kibana/server';
+import { UrlServiceError } from '../error';
 
 const setup = () => {
   const currentVersion = '1.2.3';
@@ -125,7 +126,7 @@ describe('ServerShortUrlClient', () => {
             url: '/app/test#foo/bar/baz',
           },
         })
-      ).rejects.toThrowError(new Error(`Slug "lala" already exists.`));
+      ).rejects.toThrowError(new UrlServiceError(`Slug "lala" already exists.`, 'SLUG_EXISTS'));
     });
 
     test('can automatically generate human-readable slug', async () => {

--- a/src/plugins/share/server/url_service/short_urls/short_url_client.ts
+++ b/src/plugins/share/server/url_service/short_urls/short_url_client.ts
@@ -18,6 +18,7 @@ import type {
   ShortUrlData,
   LocatorData,
 } from '../../../common/url_service';
+import { UrlServiceError } from '../error';
 import type { ShortUrlStorage } from './types';
 import { validateSlug } from './util';
 
@@ -74,7 +75,7 @@ export class ServerShortUrlClient implements IShortUrlClient {
     if (slug) {
       const isSlugTaken = await storage.exists(slug);
       if (isSlugTaken) {
-        throw new Error(`Slug "${slug}" already exists.`);
+        throw new UrlServiceError(`Slug "${slug}" already exists.`, 'SLUG_EXISTS');
       }
     }
 

--- a/src/plugins/share/server/url_service/short_urls/storage/saved_object_short_url_storage.ts
+++ b/src/plugins/share/server/url_service/short_urls/storage/saved_object_short_url_storage.ts
@@ -9,6 +9,7 @@
 import type { SerializableRecord } from '@kbn/utility-types';
 import { SavedObject, SavedObjectReference, SavedObjectsClientContract } from 'kibana/server';
 import { ShortUrlRecord } from '..';
+import { UrlServiceError } from '../..';
 import { LEGACY_SHORT_URL_LOCATOR_ID } from '../../../../common/url_service/locators/legacy_short_url_locator';
 import { ShortUrlData } from '../../../../common/url_service/short_urls/types';
 import { ShortUrlStorage } from '../types';
@@ -161,7 +162,7 @@ export class SavedObjectShortUrlStorage implements ShortUrlStorage {
     });
 
     if (result.saved_objects.length !== 1) {
-      throw new Error('not found');
+      throw new UrlServiceError('not found', 'NOT_FOUND');
     }
 
     const savedObject = result.saved_objects[0] as ShortUrlSavedObject;

--- a/test/api_integration/apis/short_url/create_short_url/main.ts
+++ b/test/api_integration/apis/short_url/create_short_url/main.ts
@@ -131,8 +131,8 @@ export default function ({ getService }: FtrProviderContext) {
           slug,
         });
 
-        expect(response1.status === 200).to.be(true);
-        expect(response2.status >= 400).to.be(true);
+        expect(response1.status).to.be(200);
+        expect(response2.status).to.be(409);
       });
     });
   });

--- a/test/api_integration/apis/short_url/get_short_url/main.ts
+++ b/test/api_integration/apis/short_url/get_short_url/main.ts
@@ -23,6 +23,12 @@ export default function ({ getService }: FtrProviderContext) {
       expect(response2.body).to.eql(response1.body);
     });
 
+    it('returns 404 error when short URL does not exist', async () => {
+      const response = await supertest.get('/api/short_url/NotExistingID');
+
+      expect(response.status).to.be(404);
+    });
+
     it('supports legacy short URLs', async () => {
       const id = 'abcdefghjabcdefghjabcdefghjabcdefghj';
       await supertest.post('/api/saved_objects/url/' + id).send({

--- a/test/api_integration/apis/short_url/resolve_short_url/main.ts
+++ b/test/api_integration/apis/short_url/resolve_short_url/main.ts
@@ -26,6 +26,12 @@ export default function ({ getService }: FtrProviderContext) {
       expect(response2.body).to.eql(response1.body);
     });
 
+    it('returns 404 error when short URL does not exist', async () => {
+      const response = await supertest.get('/api/short_url/_slug/not-existing-slug');
+
+      expect(response.status).to.be(404);
+    });
+
     it('can resolve a short URL by its slug, when slugs are similar', async () => {
       const rnd = Math.round(Math.random() * 1e6) + 1;
       const now = Date.now();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/126173

Improves error codes for Short URL HTTP API, makes them more "semantic".

- Returns `409 Conflict` error, when attempting to create a short URL with a slug that is already in use.
- Returns `404 Not Found` error, when resolving a non-existing short URL by slug. (It was already working when: (1) resolving a short URL by ID; or (2) or deleting a short URL by ID.)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
