### PR TITLE
[Lens] Cleanup the SO from the unused indexpattern-datasource-currentindexpattern reference

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
@@ -294,7 +294,6 @@ describe('IndexPattern Data Source', () => {
           },
         },
         savedObjectReferences: [
-          { name: 'indexpattern-datasource-current-indexpattern', type: 'index-pattern', id: '1' },
           { name: 'indexpattern-datasource-layer-first', type: 'index-pattern', id: '1' },
         ],
       });
@@ -2705,14 +2704,7 @@ describe('IndexPattern Data Source', () => {
       },
     };
 
-    const currentIndexPatternReference = {
-      id: 'some-id',
-      name: 'indexpattern-datasource-current-indexpattern',
-      type: 'index-pattern',
-    };
-
     const references1: SavedObjectReference[] = [
-      currentIndexPatternReference,
       {
         id: 'some-id',
         name: 'indexpattern-datasource-layer-8bd66b66-aba3-49fb-9ff2-4bf83f2be08e',
@@ -2721,7 +2713,6 @@ describe('IndexPattern Data Source', () => {
     ];
 
     const references2: SavedObjectReference[] = [
-      currentIndexPatternReference,
       {
         id: 'some-DIFFERENT-id',
         name: 'indexpattern-datasource-layer-8bd66b66-aba3-49fb-9ff2-4bf83f2be08e',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/loader.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/loader.test.ts
@@ -589,7 +589,6 @@ describe('loader', () => {
       const state = await loadInitialState({
         persistedState: savedState,
         references: [
-          { name: 'indexpattern-datasource-current-indexpattern', id: '2', type: 'index-pattern' },
           { name: 'indexpattern-datasource-layer-layerb', id: '2', type: 'index-pattern' },
           { name: 'another-reference', id: 'c', type: 'index-pattern' },
         ],
@@ -640,7 +639,6 @@ describe('loader', () => {
       const state = await loadInitialState({
         persistedState: savedState,
         references: [
-          { name: 'indexpattern-datasource-current-indexpattern', id: '2', type: 'index-pattern' },
           { name: 'indexpattern-datasource-layer-layerb', id: '2', type: 'index-pattern' },
           { name: 'another-reference', id: 'c', type: 'index-pattern' },
         ],
@@ -727,11 +725,6 @@ describe('loader', () => {
       const state = await loadInitialState({
         persistedState: savedState,
         references: [
-          {
-            name: 'indexpattern-datasource-current-indexpattern',
-            id: 'conflictId',
-            type: 'index-pattern',
-          },
           { name: 'indexpattern-datasource-layer-layerb', id: 'conflictId', type: 'index-pattern' },
         ],
         indexPatternsService: mockIndexPatternsServiceWithConflict(),
@@ -800,11 +793,6 @@ describe('loader', () => {
       expect(savedObjectReferences).toMatchInlineSnapshot(`
         Array [
           Object {
-            "id": "b",
-            "name": "indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern",
-          },
-          Object {
             "id": "id-index-pattern-a",
             "name": "indexpattern-datasource-layer-a",
             "type": "index-pattern",
@@ -821,13 +809,6 @@ describe('loader', () => {
     it('should restore layers', () => {
       const { savedObjectReferences, state: persistedState } = extractReferences(state);
       expect(injectReferences(persistedState, savedObjectReferences).layers).toEqual(state.layers);
-    });
-
-    it('should restore current index pattern', () => {
-      const { savedObjectReferences, state: persistedState } = extractReferences(state);
-      expect(injectReferences(persistedState, savedObjectReferences).currentIndexPatternId).toEqual(
-        state.currentIndexPatternId
-      );
     });
   });
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/loader.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/loader.ts
@@ -165,18 +165,12 @@ const setLastUsedIndexPatternId = (storage: IStorageWrapper, value: string) => {
   writeToStorage(storage, 'indexPatternId', value);
 };
 
-const CURRENT_PATTERN_REFERENCE_NAME = 'indexpattern-datasource-current-indexpattern';
 function getLayerReferenceName(layerId: string) {
   return `indexpattern-datasource-layer-${layerId}`;
 }
 
-export function extractReferences({ currentIndexPatternId, layers }: IndexPatternPrivateState) {
+export function extractReferences({ layers }: IndexPatternPrivateState) {
   const savedObjectReferences: SavedObjectReference[] = [];
-  savedObjectReferences.push({
-    type: 'index-pattern',
-    id: currentIndexPatternId,
-    name: CURRENT_PATTERN_REFERENCE_NAME,
-  });
   const persistableLayers: Record<string, Omit<IndexPatternLayer, 'indexPatternId'>> = {};
   Object.entries(layers).forEach(([layerId, { indexPatternId, ...persistableLayer }]) => {
     savedObjectReferences.push({
@@ -201,8 +195,6 @@ export function injectReferences(
     };
   });
   return {
-    currentIndexPatternId: references.find(({ name }) => name === CURRENT_PATTERN_REFERENCE_NAME)!
-      .id,
     layers,
   };
 }
@@ -246,13 +238,7 @@ export async function loadInitialState({
   const usedPatterns = (
     initialContext
       ? indexPatternIds
-      : uniq(
-          state
-            ? Object.values(state.layers)
-                .map((l) => l.indexPatternId)
-                .concat(state.currentIndexPatternId)
-            : [fallbackId]
-        )
+      : uniq(state ? Object.values(state.layers).map((l) => l.indexPatternId) : [fallbackId])
   )
     // take out the undefined from the list
     .filter(Boolean);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/122918

This PR clean up the Lens SO from the unused reference: `indexpattern-datasource-currentindexpattern reference`

This was used in prior versions for storing the dataview that the user has selected in the dropdown. But this does't work anymore. If you save for example a lens viz  with a different dataview for one layer and another one selected on the dropdown, when you open the viz, the dropdown has populated the dataview of the first layer.

This means that this reference is not used anywhere anymore. I have removed it from the references. You can see that now this information is not stored on the SO.

The old lens visualizations should work as before.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios