### PR TITLE
[ML] Fixes data frame analytics map saved object sync warning

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/page.tsx
@@ -64,11 +64,7 @@ export const Page: FC = () => {
 
       <NodeAvailableWarning />
 
-      <SavedObjectsWarning
-        mlSavedObjectType="data-frame-analytics"
-        onCloseFlyout={refresh}
-        forceRefresh={isLoading}
-      />
+      <SavedObjectsWarning onCloseFlyout={refresh} forceRefresh={isLoading} />
       <UpgradeWarning />
 
       {selectedTabId === 'map' && (mapJobId || mapModelId) && (

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
@@ -184,8 +184,8 @@ export function AnalyticsIdSelector({ setAnalyticsId, jobsOnly = false }: Props)
   }, [selected?.model_id, selected?.job_id]);
 
   const pagination = {
-    initialPageSize: 5,
-    pageSizeOptions: [3, 5, 8],
+    initialPageSize: 20,
+    pageSizeOptions: [5, 10, 20, 50],
   };
 
   const selectionValue = {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/job_map.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/job_map.tsx
@@ -41,9 +41,10 @@ ${theme.euiColorLightShade}`,
 interface Props {
   analyticsId?: string;
   modelId?: string;
+  forceRefresh?: boolean;
 }
 
-export const JobMap: FC<Props> = ({ analyticsId, modelId }) => {
+export const JobMap: FC<Props> = ({ analyticsId, modelId, forceRefresh }) => {
   // itemsDeleted will reset to false when Controls component calls updateElements to remove nodes deleted from map
   const [itemsDeleted, setItemsDeleted] = useState<boolean>(false);
   const [resetCyToggle, setResetCyToggle] = useState<boolean>(false);
@@ -110,6 +111,12 @@ export const JobMap: FC<Props> = ({ analyticsId, modelId }) => {
   useEffect(() => {
     fetchAndSetElementsWrapper({ analyticsId, modelId });
   }, [analyticsId, modelId]);
+
+  useEffect(() => {
+    if (forceRefresh === true) {
+      fetchAndSetElementsWrapper({ analyticsId, modelId });
+    }
+  }, [forceRefresh]);
 
   useEffect(() => {
     if (message !== undefined) {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -125,17 +125,14 @@ export const Page: FC = () => {
 
       <NodeAvailableWarning />
 
-      <SavedObjectsWarning
-        mlSavedObjectType="data-frame-analytics"
-        onCloseFlyout={refresh}
-        forceRefresh={isLoading}
-      />
+      <SavedObjectsWarning onCloseFlyout={refresh} />
       <UpgradeWarning />
 
       {mapJobId || mapModelId || analyticsId ? (
         <JobMap
           analyticsId={mapJobId || analyticsId?.job_id}
           modelId={mapModelId || analyticsId?.model_id}
+          forceRefresh={isLoading}
         />
       ) : (
         getEmptyState()

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/jobs_list_view/jobs_list_view.js
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/jobs_list_view/jobs_list_view.js
@@ -474,7 +474,6 @@ export class JobsListView extends Component {
         <JobsAwaitingNodeWarning jobCount={jobsAwaitingNodeCount} />
 
         <SavedObjectsWarning
-          jobType="anomaly-detector"
           onCloseFlyout={this.onRefreshClick}
           forceRefresh={loading || isRefreshing}
         />

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/models_list.tsx
@@ -729,11 +729,7 @@ export const ModelsList: FC<Props> = ({
     <>
       {isManagementTable ? null : (
         <>
-          <SavedObjectsWarning
-            mlSavedObjectType="trained-model"
-            onCloseFlyout={fetchModelsData}
-            forceRefresh={isLoading}
-          />
+          <SavedObjectsWarning onCloseFlyout={fetchModelsData} forceRefresh={isLoading} />
         </>
       )}
       <EuiFlexGroup justifyContent="spaceBetween">


### PR DESCRIPTION
Fixes the saved object sync warning that should shown on the Analytics Map page.
Fixes https://github.com/elastic/kibana/issues/128517

![image](https://user-images.githubusercontent.com/22172091/160809374-d44a9a3a-53ba-4133-9785-6ce528a27627.png)

Also changes every warning check to look for all types of saved objects, not just the ones applicable to the current page.
I.e. Previously the Anomaly Detection jobs like would only show the sync warning if only AD jobs needed syncing. Now it will show the warning if DFA jobs or trained models need syncing.
