### PR TITLE
[Unified Observability] Fix shadow for overview panels

### DIFF
--- a/x-pack/plugins/observability/public/components/app/section/index.tsx
+++ b/x-pack/plugins/observability/public/components/app/section/index.tsx
@@ -79,7 +79,7 @@ export function SectionContainer({
       >
         <>
           <EuiSpacer size="s" />
-          <EuiPanel hasShadow={true}>{hasError ? <ErrorPanel /> : <>{children}</>}</EuiPanel>
+          <EuiPanel hasBorder={true}>{hasError ? <ErrorPanel /> : <>{children}</>}</EuiPanel>
         </>
       </EuiAccordion>
     </EuiPanel>

--- a/x-pack/plugins/observability/public/components/app/section/index.tsx
+++ b/x-pack/plugins/observability/public/components/app/section/index.tsx
@@ -42,7 +42,7 @@ export function SectionContainer({
 }: Props) {
   const { http } = useKibana<ObservabilityAppServices>().services;
   return (
-    <EuiPanel hasShadow={true} color="subdued">
+    <EuiPanel color="subdued">
       <EuiAccordion
         initialIsOpen
         id={title}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/126766. Small fix for the panels' shadow.

**Before**
<img width="400" alt="Screenshot 2022-03-30 at 13 16 17" src="https://user-images.githubusercontent.com/2249229/160822441-0dedd761-521f-4adf-a4b8-a2f192e9bb7f.png">


**After**
<img width="400" alt="Screenshot 2022-03-30 at 13 07 30" src="https://user-images.githubusercontent.com/2249229/160822118-8ed86ccc-6257-47fa-979a-bbedbf259555.png">
<img width="400" alt="Screenshot 2022-03-30 at 13 13 10" src="https://user-images.githubusercontent.com/2249229/160822134-756ecfbd-26dc-42ac-89f7-6254a3f01283.png">
