### PR TITLE
[7.17] [Ingest Pipelines] Remove `axios` dependency in tests (#128467)

### DIFF
--- a/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/http_requests.ts
+++ b/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/http_requests.ts
@@ -5,52 +5,70 @@
  * 2.0.
  */
 
-import sinon, { SinonFakeServer } from 'sinon';
-
+import { httpServiceMock } from '../../../../../../src/core/public/mocks';
 import { API_BASE_PATH } from '../../../common/constants';
 
+type HttpMethod = 'GET' | 'PUT' | 'DELETE' | 'POST';
+export interface ResponseError {
+  statusCode: number;
+  message: string | Error;
+  attributes?: Record<string, any>;
+}
+
 // Register helpers to mock HTTP Requests
-const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
-  const setLoadPipelinesResponse = (response?: any[], error?: any) => {
-    const status = error ? error.status || 400 : 200;
-    const body = error ? error.body : response;
+const registerHttpRequestMockHelpers = (
+  httpSetup: ReturnType<typeof httpServiceMock.createStartContract>
+) => {
+  const mockResponses = new Map<HttpMethod, Map<string, Promise<unknown>>>(
+    ['GET', 'PUT', 'DELETE', 'POST'].map(
+      (method) => [method, new Map()] as [HttpMethod, Map<string, Promise<unknown>>]
+    )
+  );
 
-    server.respondWith('GET', API_BASE_PATH, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
+  const mockMethodImplementation = (method: HttpMethod, path: string) =>
+    mockResponses.get(method)?.get(path) ?? Promise.resolve({});
+
+  httpSetup.get.mockImplementation((path) =>
+    mockMethodImplementation('GET', path as unknown as string)
+  );
+  httpSetup.delete.mockImplementation((path) =>
+    mockMethodImplementation('DELETE', path as unknown as string)
+  );
+  httpSetup.post.mockImplementation((path) =>
+    mockMethodImplementation('POST', path as unknown as string)
+  );
+  httpSetup.put.mockImplementation((path) =>
+    mockMethodImplementation('PUT', path as unknown as string)
+  );
+
+  const mockResponse = (method: HttpMethod, path: string, response?: unknown, error?: unknown) => {
+    const defuse = (promise: Promise<unknown>) => {
+      promise.catch(() => {});
+      return promise;
+    };
+
+    return mockResponses
+      .get(method)!
+      .set(path, error ? defuse(Promise.reject({ body: error })) : Promise.resolve(response));
   };
 
-  const setLoadPipelineResponse = (response?: {}, error?: any) => {
-    const status = error ? error.status || 400 : 200;
-    const body = error ? error.body : response;
+  const setLoadPipelinesResponse = (response?: object[], error?: ResponseError) =>
+    mockResponse('GET', API_BASE_PATH, response, error);
 
-    server.respondWith('GET', `${API_BASE_PATH}/:name`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(body),
-    ]);
-  };
+  const setLoadPipelineResponse = (
+    pipelineName: string,
+    response?: object,
+    error?: ResponseError
+  ) => mockResponse('GET', `${API_BASE_PATH}/${pipelineName}`, response, error);
 
-  const setDeletePipelineResponse = (response?: object) => {
-    server.respondWith('DELETE', `${API_BASE_PATH}/:name`, [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(response),
-    ]);
-  };
+  const setDeletePipelineResponse = (
+    pipelineName: string,
+    response?: object,
+    error?: ResponseError
+  ) => mockResponse('DELETE', `${API_BASE_PATH}/${pipelineName}`, response, error);
 
-  const setCreatePipelineResponse = (response?: object, error?: any) => {
-    const status = error ? error.status || 400 : 200;
-    const body = error ? JSON.stringify(error.body) : JSON.stringify(response);
-
-    server.respondWith('POST', API_BASE_PATH, [
-      status,
-      { 'Content-Type': 'application/json' },
-      body,
-    ]);
-  };
+  const setCreatePipelineResponse = (response?: object, error?: ResponseError) =>
+    mockResponse('POST', API_BASE_PATH, response, error);
 
   return {
     setLoadPipelinesResponse,
@@ -61,18 +79,11 @@ const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
 };
 
 export const init = () => {
-  const server = sinon.fakeServer.create();
-  server.respondImmediately = true;
-
-  // Define default response for unhandled requests.
-  // We make requests to APIs which don't impact the component under test, e.g. UI metric telemetry,
-  // and we can mock them all with a 200 instead of mocking each one individually.
-  server.respondWith([200, {}, 'DefaultMockedResponse']);
-
-  const httpRequestsMockHelpers = registerHttpRequestMockHelpers(server);
+  const httpSetup = httpServiceMock.createSetupContract();
+  const httpRequestsMockHelpers = registerHttpRequestMockHelpers(httpSetup);
 
   return {
-    server,
+    httpSetup,
     httpRequestsMockHelpers,
   };
 };

--- a/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/pipelines_clone.helpers.ts
+++ b/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/pipelines_clone.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, AsyncTestBedConfig, TestBed } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { PipelinesClone } from '../../../public/application/sections/pipelines_clone';
 import { getFormActions, PipelineFormTestSubjects } from './pipeline_form.helpers';
 import { WithAppDependencies } from './setup_environment';
@@ -36,9 +37,11 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-const initTestBed = registerTestBed(WithAppDependencies(PipelinesClone), testBedConfig);
-
-export const setup = async (): Promise<PipelinesCloneTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<PipelinesCloneTestBed> => {
+  const initTestBed = registerTestBed(
+    WithAppDependencies(PipelinesClone, httpSetup),
+    testBedConfig
+  );
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/pipelines_create.helpers.ts
+++ b/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/pipelines_create.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, AsyncTestBedConfig, TestBed } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { PipelinesCreate } from '../../../public/application/sections/pipelines_create';
 import { getFormActions, PipelineFormTestSubjects } from './pipeline_form.helpers';
 import { WithAppDependencies } from './setup_environment';
@@ -23,9 +24,11 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-const initTestBed = registerTestBed(WithAppDependencies(PipelinesCreate), testBedConfig);
-
-export const setup = async (): Promise<PipelinesCreateTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<PipelinesCreateTestBed> => {
+  const initTestBed = registerTestBed(
+    WithAppDependencies(PipelinesCreate, httpSetup),
+    testBedConfig
+  );
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/pipelines_edit.helpers.ts
+++ b/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/pipelines_edit.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, AsyncTestBedConfig, TestBed } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { PipelinesEdit } from '../../../public/application/sections/pipelines_edit';
 import { getFormActions, PipelineFormTestSubjects } from './pipeline_form.helpers';
 import { WithAppDependencies } from './setup_environment';
@@ -36,9 +37,8 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-const initTestBed = registerTestBed(WithAppDependencies(PipelinesEdit), testBedConfig);
-
-export const setup = async (): Promise<PipelinesEditTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<PipelinesEditTestBed> => {
+  const initTestBed = registerTestBed(WithAppDependencies(PipelinesEdit, httpSetup), testBedConfig);
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/pipelines_list.helpers.ts
+++ b/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/pipelines_list.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { act } from 'react-dom/test-utils';
+import { HttpSetup } from 'src/core/public';
 
 import { registerTestBed, TestBed, AsyncTestBedConfig, findTestSubject } from '@kbn/test/jest';
 import { PipelinesList } from '../../../public/application/sections/pipelines_list';
@@ -19,8 +20,6 @@ const testBedConfig: AsyncTestBedConfig = {
   },
   doMountAsync: true,
 };
-
-const initTestBed = registerTestBed(WithAppDependencies(PipelinesList), testBedConfig);
 
 export type PipelineListTestBed = TestBed<PipelineListTestSubjects> & {
   actions: ReturnType<typeof createActions>;
@@ -84,7 +83,8 @@ const createActions = (testBed: TestBed) => {
   };
 };
 
-export const setup = async (): Promise<PipelineListTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<PipelineListTestBed> => {
+  const initTestBed = registerTestBed(WithAppDependencies(PipelinesList, httpSetup), testBedConfig);
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/setup_environment.tsx
+++ b/x-pack/plugins/ingest_pipelines/__jest__/client_integration/helpers/setup_environment.tsx
@@ -6,8 +6,6 @@
  */
 
 import React from 'react';
-import axios from 'axios';
-import axiosXhrAdapter from 'axios/lib/adapters/xhr';
 import { LocationDescriptorObject } from 'history';
 import { HttpSetup } from 'kibana/public';
 
@@ -29,8 +27,6 @@ import {
 
 import { init as initHttpRequests } from './http_requests';
 
-const mockHttpClient = axios.create({ adapter: axiosXhrAdapter });
-
 const history = scopedHistoryMock.create();
 history.createHref.mockImplementation((location: LocationDescriptorObject) => {
   return `${location.pathname}?${location.search}`;
@@ -51,22 +47,19 @@ const appServices = {
 };
 
 export const setupEnvironment = () => {
-  uiMetricService.setup(usageCollectionPluginMock.createSetupContract());
-  apiService.setup(mockHttpClient as unknown as HttpSetup, uiMetricService);
   documentationService.setup(docLinksServiceMock.createStartContract());
   breadcrumbService.setup(() => {});
 
-  const { server, httpRequestsMockHelpers } = initHttpRequests();
-
-  return {
-    server,
-    httpRequestsMockHelpers,
-  };
+  return initHttpRequests();
 };
 
-export const WithAppDependencies = (Comp: any) => (props: any) =>
-  (
+export const WithAppDependencies = (Comp: any, httpSetup: HttpSetup) => (props: any) => {
+  uiMetricService.setup(usageCollectionPluginMock.createSetupContract());
+  apiService.setup(httpSetup, uiMetricService);
+
+  return (
     <KibanaContextProvider services={appServices}>
       <Comp {...props} />
     </KibanaContextProvider>
   );
+};

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/__jest__/pipeline_processors_editor.helpers.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/__jest__/pipeline_processors_editor.helpers.tsx
@@ -178,7 +178,7 @@ const createActions = (testBed: TestBed<TestSubject>) => {
 };
 
 export const setup = async (props: Props): Promise<SetupResult> => {
-  const testBed = await testBedSetup(props);
+  const testBed = testBedSetup(props);
   return {
     ...testBed,
     actions: createActions(testBed),

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/processor.helpers.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/processor.helpers.tsx
@@ -104,7 +104,7 @@ const createActions = (testBed: TestBed<TestSubject>) => {
 };
 
 export const setup = async (props: Props): Promise<SetupResult> => {
-  const testBed = await testBedSetup(props);
+  const testBed = testBedSetup(props);
   return {
     ...testBed,
     actions: createActions(testBed),
@@ -119,10 +119,9 @@ export const setupEnvironment = () => {
   // @ts-ignore
   apiService.setup(mockHttpClient, uiMetricService);
 
-  const { server, httpRequestsMockHelpers } = initHttpRequests();
+  const { httpRequestsMockHelpers } = initHttpRequests();
 
   return {
-    server,
     httpRequestsMockHelpers,
   };
 };

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/__jest__/test_pipeline.helpers.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/__jest__/test_pipeline.helpers.tsx
@@ -7,11 +7,10 @@
 
 import { act } from 'react-dom/test-utils';
 import React from 'react';
-import axios from 'axios';
-import axiosXhrAdapter from 'axios/lib/adapters/xhr';
 
 /* eslint-disable-next-line @kbn/eslint/no-restricted-paths */
 import { usageCollectionPluginMock } from 'src/plugins/usage_collection/public/mocks';
+import { HttpSetup } from 'src/core/public';
 
 import { registerTestBed, TestBed } from '@kbn/test/jest';
 import { stubWebWorker } from '@kbn/test/jest';
@@ -62,6 +61,7 @@ const testBedSetup = registerTestBed<TestSubject>(
 );
 
 export interface SetupResult extends TestBed<TestSubject> {
+  httpSetup: HttpSetup;
   actions: ReturnType<typeof createActions>;
 }
 
@@ -189,29 +189,22 @@ const createActions = (testBed: TestBed<TestSubject>) => {
   };
 };
 
-export const setup = async (props: Props): Promise<SetupResult> => {
-  const testBed = await testBedSetup(props);
+export const setup = async (httpSetup: HttpSetup, props: Props): Promise<SetupResult> => {
+  // Initialize mock services
+  uiMetricService.setup(usageCollectionPluginMock.createSetupContract());
+  // @ts-ignore
+  apiService.setup(httpSetup, uiMetricService);
+
+  const testBed = testBedSetup(props);
+
   return {
     ...testBed,
+    httpSetup,
     actions: createActions(testBed),
   };
 };
 
-const mockHttpClient = axios.create({ adapter: axiosXhrAdapter });
-
-export const setupEnvironment = () => {
-  // Initialize mock services
-  uiMetricService.setup(usageCollectionPluginMock.createSetupContract());
-  // @ts-ignore
-  apiService.setup(mockHttpClient, uiMetricService);
-
-  const { server, httpRequestsMockHelpers } = initHttpRequests();
-
-  return {
-    server,
-    httpRequestsMockHelpers,
-  };
-};
+export const setupEnvironment = initHttpRequests;
 
 type TestSubject =
   | 'addDocumentsButton'

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/__jest__/test_pipeline.test.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/__jest__/test_pipeline.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Pipeline } from '../../../../../common/types';
+import { API_BASE_PATH } from '../../../../../common/constants';
 
 import { VerboseTestOutput, Document } from '../types';
 import { setup, SetupResult, setupEnvironment } from './test_pipeline.helpers';
@@ -21,7 +22,7 @@ describe('Test pipeline', () => {
   let onUpdate: jest.Mock;
   let testBed: SetupResult;
 
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
 
   // This is a hack
   // We need to provide the processor id in the mocked output;
@@ -49,13 +50,12 @@ describe('Test pipeline', () => {
   });
 
   afterAll(() => {
-    server.restore();
     jest.useRealTimers();
   });
 
   beforeEach(async () => {
     onUpdate = jest.fn();
-    testBed = await setup({
+    testBed = await setup(httpSetup, {
       value: {
         ...PROCESSORS,
       },
@@ -87,8 +87,9 @@ describe('Test pipeline', () => {
       await actions.clickRunPipelineButton();
 
       // Verify request
-      const latestRequest = server.requests[server.requests.length - 1];
-      const requestBody: ReqBody = JSON.parse(JSON.parse(latestRequest.requestBody).body);
+      const latestRequest: any = httpSetup.post.mock.calls.pop() || [];
+      const requestBody: ReqBody = JSON.parse(latestRequest[1]?.body);
+
       const {
         documents: reqDocuments,
         verbose: reqVerbose,
@@ -114,23 +115,26 @@ describe('Test pipeline', () => {
       expect(exists('outputTabContent')).toBe(true);
 
       // Click reload button and verify request
-      const totalRequests = server.requests.length;
       await actions.clickRefreshOutputButton();
       // There will be two requests made to the simulate API
       // the second request will have verbose enabled to update the processor results
-      expect(server.requests.length).toBe(totalRequests + 2);
-      expect(server.requests[server.requests.length - 2].url).toBe(
-        '/api/ingest_pipelines/simulate'
+      expect(httpSetup.post).toHaveBeenNthCalledWith(
+        1,
+        `${API_BASE_PATH}/simulate`,
+        expect.anything()
       );
-      expect(server.requests[server.requests.length - 1].url).toBe(
-        '/api/ingest_pipelines/simulate'
+      expect(httpSetup.post).toHaveBeenNthCalledWith(
+        2,
+        `${API_BASE_PATH}/simulate`,
+        expect.anything()
       );
 
       // Click verbose toggle and verify request
       await actions.toggleVerboseSwitch();
-      expect(server.requests.length).toBe(totalRequests + 3);
-      expect(server.requests[server.requests.length - 1].url).toBe(
-        '/api/ingest_pipelines/simulate'
+      // There will be one request made to the simulate API
+      expect(httpSetup.post).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}/simulate`,
+        expect.anything()
       );
     });
 
@@ -163,12 +167,12 @@ describe('Test pipeline', () => {
       const { actions, find, exists } = testBed;
 
       const error = {
-        status: 500,
+        statusCode: 500,
         error: 'Internal server error',
         message: 'Internal server error',
       };
 
-      httpRequestsMockHelpers.setSimulatePipelineResponse(undefined, { body: error });
+      httpRequestsMockHelpers.setSimulatePipelineResponse(undefined, error);
 
       // Open flyout
       actions.clickAddDocumentsButton();
@@ -201,7 +205,7 @@ describe('Test pipeline', () => {
 
         const { _index: index, _id: documentId } = DOCUMENTS[0];
 
-        httpRequestsMockHelpers.setFetchDocumentsResponse(DOCUMENTS[0]);
+        httpRequestsMockHelpers.setFetchDocumentsResponse(index, documentId, DOCUMENTS[0]);
 
         // Open flyout
         actions.clickAddDocumentsButton();
@@ -220,9 +224,10 @@ describe('Test pipeline', () => {
         await actions.clickAddDocumentButton();
 
         // Verify request
-        const latestRequest = server.requests[server.requests.length - 1];
-        expect(latestRequest.status).toEqual(200);
-        expect(latestRequest.url).toEqual(`/api/ingest_pipelines/documents/${index}/${documentId}`);
+        expect(httpSetup.get).toHaveBeenLastCalledWith(
+          `${API_BASE_PATH}/documents/${index}/${documentId}`,
+          expect.anything()
+        );
         // Verify success callout
         expect(exists('addDocumentSuccess')).toBe(true);
       });
@@ -236,12 +241,17 @@ describe('Test pipeline', () => {
         };
 
         const error = {
-          status: 404,
+          statusCode: 404,
           error: 'Not found',
           message: '[index_not_found_exception] no such index',
         };
 
-        httpRequestsMockHelpers.setFetchDocumentsResponse(undefined, { body: error });
+        httpRequestsMockHelpers.setFetchDocumentsResponse(
+          nonExistentDoc.index,
+          nonExistentDoc.id,
+          undefined,
+          error
+        );
 
         // Open flyout
         actions.clickAddDocumentsButton();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Ingest Pipelines] Remove `axios` dependency in tests (#128467)](https://github.com/elastic/kibana/pull/128467)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)