### PR TITLE
[7.17] [Remote Clusters] Remove `axios` dependency in tests (#128590)

### DIFF
--- a/x-pack/plugins/remote_clusters/__jest__/client_integration/add/remote_clusters_add.helpers.tsx
+++ b/x-pack/plugins/remote_clusters/__jest__/client_integration/add/remote_clusters_add.helpers.tsx
@@ -5,38 +5,27 @@
  * 2.0.
  */
 
-import React from 'react';
 import { registerTestBed } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 
 import { RemoteClusterAdd } from '../../../public/application/sections';
 import { createRemoteClustersStore } from '../../../public/application/store';
 import { AppRouter, registerRouter } from '../../../public/application/services';
-import { createRemoteClustersActions } from '../helpers';
-import { AppContextProvider } from '../../../public/application/app_context';
+import { createRemoteClustersActions, WithAppDependencies } from '../helpers';
 
-const ComponentWithContext = ({ isCloudEnabled }: { isCloudEnabled: boolean }) => {
-  return (
-    <AppContextProvider context={{ isCloudEnabled, cloudBaseUrl: 'test.com' }}>
-      <RemoteClusterAdd />
-    </AppContextProvider>
+const testBedConfig = {
+  store: createRemoteClustersStore,
+  memoryRouter: {
+    onRouter: (router: AppRouter) => registerRouter(router),
+  },
+};
+
+export const setup = async (httpSetup: HttpSetup, overrides?: Record<string, unknown>) => {
+  const initTestBed = registerTestBed(
+    WithAppDependencies(RemoteClusterAdd, httpSetup, overrides),
+    testBedConfig
   );
-};
-
-const testBedConfig = ({ isCloudEnabled }: { isCloudEnabled: boolean }) => {
-  return {
-    store: createRemoteClustersStore,
-    memoryRouter: {
-      onRouter: (router: AppRouter) => registerRouter(router),
-    },
-    defaultProps: { isCloudEnabled },
-  };
-};
-
-const initTestBed = (isCloudEnabled: boolean) =>
-  registerTestBed(ComponentWithContext, testBedConfig({ isCloudEnabled }))();
-
-export const setup = async (isCloudEnabled = false) => {
-  const testBed = await initTestBed(isCloudEnabled);
+  const testBed = await initTestBed();
 
   return {
     ...testBed,

--- a/x-pack/plugins/remote_clusters/__jest__/client_integration/add/remote_clusters_add.test.ts
+++ b/x-pack/plugins/remote_clusters/__jest__/client_integration/add/remote_clusters_add.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { SinonFakeServer } from 'sinon';
 import { TestBed } from '@kbn/test/jest';
 import { act } from 'react-dom/test-utils';
 
@@ -17,20 +16,13 @@ const notInArray = (array: string[]) => (value: string) => array.indexOf(value) 
 
 let component: TestBed['component'];
 let actions: RemoteClustersActions;
-let server: SinonFakeServer;
 
 describe('Create Remote cluster', () => {
-  beforeAll(() => {
-    ({ server } = setupEnvironment());
-  });
-
-  afterAll(() => {
-    server.restore();
-  });
+  const { httpSetup } = setupEnvironment();
 
   beforeEach(async () => {
     await act(async () => {
-      ({ actions, component } = await setup());
+      ({ actions, component } = await setup(httpSetup));
     });
     component.update();
   });
@@ -95,7 +87,7 @@ describe('Create Remote cluster', () => {
     describe('on cloud', () => {
       beforeEach(async () => {
         await act(async () => {
-          ({ actions, component } = await setup(true));
+          ({ actions, component } = await setup(httpSetup, { isCloudEnabled: true }));
         });
 
         component.update();
@@ -153,7 +145,7 @@ describe('Create Remote cluster', () => {
     describe('proxy address', () => {
       beforeEach(async () => {
         await act(async () => {
-          ({ actions, component } = await setup());
+          ({ actions, component } = await setup(httpSetup));
         });
 
         component.update();
@@ -190,7 +182,7 @@ describe('Create Remote cluster', () => {
     describe('on prem', () => {
       beforeEach(async () => {
         await act(async () => {
-          ({ actions, component } = await setup());
+          ({ actions, component } = await setup(httpSetup));
         });
 
         component.update();
@@ -235,7 +227,7 @@ describe('Create Remote cluster', () => {
     describe('on cloud', () => {
       beforeEach(async () => {
         await act(async () => {
-          ({ actions, component } = await setup(true));
+          ({ actions, component } = await setup(httpSetup, { isCloudEnabled: true }));
         });
 
         component.update();

--- a/x-pack/plugins/remote_clusters/__jest__/client_integration/edit/remote_clusters_edit.helpers.tsx
+++ b/x-pack/plugins/remote_clusters/__jest__/client_integration/edit/remote_clusters_edit.helpers.tsx
@@ -6,13 +6,12 @@
  */
 
 import { registerTestBed, TestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 
-import React from 'react';
 import { RemoteClusterEdit } from '../../../public/application/sections';
 import { createRemoteClustersStore } from '../../../public/application/store';
 import { AppRouter, registerRouter } from '../../../public/application/services';
-import { createRemoteClustersActions } from '../helpers';
-import { AppContextProvider } from '../../../public/application/app_context';
+import { createRemoteClustersActions, WithAppDependencies } from '../helpers';
 
 export const REMOTE_CLUSTER_EDIT_NAME = 'new-york';
 
@@ -20,15 +19,6 @@ export const REMOTE_CLUSTER_EDIT = {
   name: REMOTE_CLUSTER_EDIT_NAME,
   seeds: ['localhost:9400'],
   skipUnavailable: true,
-};
-
-const ComponentWithContext = (props: { isCloudEnabled: boolean }) => {
-  const { isCloudEnabled, ...rest } = props;
-  return (
-    <AppContextProvider context={{ isCloudEnabled, cloudBaseUrl: 'test.com' }}>
-      <RemoteClusterEdit {...rest} />
-    </AppContextProvider>
-  );
 };
 
 const testBedConfig: TestBedConfig = {
@@ -43,11 +33,12 @@ const testBedConfig: TestBedConfig = {
   },
 };
 
-const initTestBed = (isCloudEnabled: boolean) =>
-  registerTestBed(ComponentWithContext, testBedConfig)({ isCloudEnabled });
-
-export const setup = async (isCloudEnabled = false) => {
-  const testBed = await initTestBed(isCloudEnabled);
+export const setup = async (httpSetup: HttpSetup, overrides?: Record<string, unknown>) => {
+  const initTestBed = registerTestBed(
+    WithAppDependencies(RemoteClusterEdit, httpSetup, overrides),
+    testBedConfig
+  );
+  const testBed = await initTestBed();
 
   return {
     ...testBed,

--- a/x-pack/plugins/remote_clusters/__jest__/client_integration/edit/remote_clusters_edit.test.tsx
+++ b/x-pack/plugins/remote_clusters/__jest__/client_integration/edit/remote_clusters_edit.test.tsx
@@ -20,18 +20,15 @@ import { Cluster } from '../../../common/lib';
 
 let component: TestBed['component'];
 let actions: RemoteClustersActions;
-const { server, httpRequestsMockHelpers } = setupEnvironment();
 
 describe('Edit Remote cluster', () => {
-  afterAll(() => {
-    server.restore();
-  });
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
 
   httpRequestsMockHelpers.setLoadRemoteClustersResponse([REMOTE_CLUSTER_EDIT]);
 
   beforeEach(async () => {
     await act(async () => {
-      ({ component, actions } = await setup());
+      ({ component, actions } = await setup(httpSetup));
     });
     component.update();
   });
@@ -54,7 +51,7 @@ describe('Edit Remote cluster', () => {
     let addRemoteClusterTestBed: TestBed;
 
     await act(async () => {
-      addRemoteClusterTestBed = await setupRemoteClustersAdd();
+      addRemoteClusterTestBed = await setupRemoteClustersAdd(httpSetup);
     });
 
     addRemoteClusterTestBed!.component.update();
@@ -90,7 +87,7 @@ describe('Edit Remote cluster', () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse([cluster]);
 
       await act(async () => {
-        ({ component, actions } = await setup(true));
+        ({ component, actions } = await setup(httpSetup, { isCloudEnabled: true }));
       });
       component.update();
 
@@ -108,7 +105,7 @@ describe('Edit Remote cluster', () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse([cluster]);
 
       await act(async () => {
-        ({ component, actions } = await setup(true));
+        ({ component, actions } = await setup(httpSetup, { isCloudEnabled: true }));
       });
       component.update();
 
@@ -128,7 +125,7 @@ describe('Edit Remote cluster', () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse([cluster]);
 
       await act(async () => {
-        ({ component, actions } = await setup(true));
+        ({ component, actions } = await setup(httpSetup, { isCloudEnabled: true }));
       });
       component.update();
 

--- a/x-pack/plugins/remote_clusters/__jest__/client_integration/helpers/index.ts
+++ b/x-pack/plugins/remote_clusters/__jest__/client_integration/helpers/index.ts
@@ -6,6 +6,6 @@
  */
 
 export { nextTick, getRandomString, findTestSubject } from '@kbn/test/jest';
-export { setupEnvironment } from './setup_environment';
+export { setupEnvironment, WithAppDependencies } from './setup_environment';
 export type { RemoteClustersActions } from './remote_clusters_actions';
 export { createRemoteClustersActions } from './remote_clusters_actions';

--- a/x-pack/plugins/remote_clusters/__jest__/client_integration/list/remote_clusters_list.helpers.js
+++ b/x-pack/plugins/remote_clusters/__jest__/client_integration/list/remote_clusters_list.helpers.js
@@ -9,6 +9,7 @@ import { act } from 'react-dom/test-utils';
 
 import { registerTestBed, findTestSubject } from '@kbn/test/jest';
 
+import { WithAppDependencies } from '../helpers';
 import { RemoteClusterList } from '../../../public/application/sections/remote_cluster_list';
 import { createRemoteClustersStore } from '../../../public/application/store';
 import { registerRouter } from '../../../public/application/services/routing';
@@ -20,10 +21,15 @@ const testBedConfig = {
   },
 };
 
-const initTestBed = registerTestBed(RemoteClusterList, testBedConfig);
+export const setup = async (httpSetup, overrides) => {
+  const initTestBed = registerTestBed(
+    // ESlint cannot figure out that the hoc should start with a capital leter.
+    // eslint-disable-next-line
+    WithAppDependencies(RemoteClusterList, httpSetup, overrides),
+    testBedConfig
+  );
+  const testBed = await initTestBed();
 
-export const setup = (props) => {
-  const testBed = initTestBed(props);
   const EUI_TABLE = 'remoteClusterListTable';
 
   // User actions

--- a/x-pack/plugins/remote_clusters/__jest__/client_integration/list/remote_clusters_list.test.js
+++ b/x-pack/plugins/remote_clusters/__jest__/client_integration/list/remote_clusters_list.test.js
@@ -31,7 +31,7 @@ jest.mock('@elastic/eui/lib/components/search_bar/search_box', () => {
 });
 
 describe('<RemoteClusterList />', () => {
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
 
   beforeAll(() => {
     jest.useFakeTimers();
@@ -39,7 +39,6 @@ describe('<RemoteClusterList />', () => {
 
   afterAll(() => {
     jest.useRealTimers();
-    server.restore();
   });
 
   httpRequestsMockHelpers.setLoadRemoteClustersResponse([]);
@@ -47,8 +46,8 @@ describe('<RemoteClusterList />', () => {
   describe('on component mount', () => {
     let exists;
 
-    beforeEach(() => {
-      ({ exists } = setup());
+    beforeEach(async () => {
+      ({ exists } = await setup(httpSetup));
     });
 
     test('should show a "loading remote clusters" indicator', () => {
@@ -62,7 +61,7 @@ describe('<RemoteClusterList />', () => {
 
     beforeEach(async () => {
       await act(async () => {
-        ({ exists, component } = setup());
+        ({ exists, component } = await setup(httpSetup));
       });
 
       component.update();
@@ -98,7 +97,7 @@ describe('<RemoteClusterList />', () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse(remoteClusters);
 
       await act(async () => {
-        ({ table, component, form } = setup());
+        ({ table, component, form } = await setup(httpSetup));
       });
 
       component.update();
@@ -154,7 +153,7 @@ describe('<RemoteClusterList />', () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse(remoteClusters);
 
       await act(async () => {
-        ({ table, actions, component, form } = setup());
+        ({ table, actions, component, form } = await setup(httpSetup));
       });
 
       component.update();
@@ -217,7 +216,7 @@ describe('<RemoteClusterList />', () => {
       httpRequestsMockHelpers.setLoadRemoteClustersResponse(remoteClusters);
 
       await act(async () => {
-        ({ component, find, exists, table, actions } = setup());
+        ({ component, find, exists, table, actions } = await setup(httpSetup));
       });
 
       component.update();
@@ -339,7 +338,7 @@ describe('<RemoteClusterList />', () => {
     describe('confirmation modal (delete remote cluster)', () => {
       test('should remove the remote cluster from the table after delete is successful', async () => {
         // Mock HTTP DELETE request
-        httpRequestsMockHelpers.setDeleteRemoteClusterResponse({
+        httpRequestsMockHelpers.setDeleteRemoteClusterResponse(remoteCluster1.name, {
           itemsDeleted: [remoteCluster1.name],
           errors: [],
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Remote Clusters] Remove `axios` dependency in tests (#128590)](https://github.com/elastic/kibana/pull/128590)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)