### PR TITLE
Update charts renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,8 @@
       "matchPackageNames": ["@elastic/charts"],
       "reviewers": ["team:datavis"],
       "matchBaseBranches": ["main"],
-      "labels": ["release_note:skip", "auto-backport", "Team:DataVis", "v8.1.0", "v7.17.0"],
+      "labels": ["release_note:skip", "auto-backport", "Team:DataVis"],
+      "prCreation": "immediate",
       "draftPR": true,
       "enabled": true
     },


### PR DESCRIPTION
## Summary

- removes versioning label, too hard to keep up with it
- overrides the `prCreation` option to `immediate` as we are facing stuck PRs

Since this line below was added we have not had consistent PRs created by renovate bot.

https://github.com/elastic/kibana/blob/dd8176186985a8c3cc3f8cb0dc80b3c2437271e8/renovate.json#L22

Though the renovate docs for the [`prCreation`](https://docs.renovatebot.com/configuration-options/#prcreation) option states the `'not-pending'` value waits for passed or failed statuses, it seems to be an issue with our status checks that never enables the PR creation. Thus requiring us to force the PR every time.

![image](https://user-images.githubusercontent.com/19007109/160840863-87408697-82d3-4247-9af4-e3ab828bedea.png)
