### PR TITLE
[ML] Fix PDF and PNG export with ML embeddables 

### DIFF
--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/anomaly_charts_embeddable.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/anomaly_charts_embeddable.tsx
@@ -114,6 +114,7 @@ export class AnomalyChartsEmbeddable extends Embeddable<
                 refresh={this.reload$.asObservable()}
                 onInputChange={this.updateInput.bind(this)}
                 onOutputChange={this.updateOutput.bind(this)}
+                renderCompleteDispatcher={this.renderComplete}
               />
             </Suspense>
           </KibanaContextProvider>

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/anomaly_charts_embeddable.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/anomaly_charts_embeddable.tsx
@@ -94,6 +94,21 @@ export class AnomalyChartsEmbeddable extends Embeddable<
     }
   }
 
+  public onLoading() {
+    this.renderComplete.dispatchInProgress();
+    this.updateOutput({ loading: true, error: undefined });
+  }
+
+  public onError(error: Error) {
+    this.renderComplete.dispatchError();
+    this.updateOutput({ loading: false, error: { name: error.name, message: error.message } });
+  }
+
+  public onRenderComplete() {
+    this.renderComplete.dispatchComplete();
+    this.updateOutput({ loading: false, error: undefined });
+  }
+
   public render(node: HTMLElement) {
     super.render(node);
     this.node = node;
@@ -114,7 +129,9 @@ export class AnomalyChartsEmbeddable extends Embeddable<
                 refresh={this.reload$.asObservable()}
                 onInputChange={this.updateInput.bind(this)}
                 onOutputChange={this.updateOutput.bind(this)}
-                renderCompleteDispatcher={this.renderComplete}
+                onRenderComplete={this.onRenderComplete.bind(this)}
+                onLoading={this.onLoading.bind(this)}
+                onError={this.onError.bind(this)}
               />
             </Suspense>
           </KibanaContextProvider>

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/anomaly_charts_embeddable.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/anomaly_charts_embeddable.tsx
@@ -113,6 +113,9 @@ export class AnomalyChartsEmbeddable extends Embeddable<
     super.render(node);
     this.node = node;
 
+    // required for the export feature to work
+    this.node.setAttribute('data-shared-item', '');
+
     const I18nContext = this.services[0].i18n.Context;
     const theme$ = this.services[0].theme.theme$;
 

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.test.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.test.tsx
@@ -49,6 +49,9 @@ describe('EmbeddableAnomalyChartsContainer', () => {
 
   const onInputChange = jest.fn();
   const onOutputChange = jest.fn();
+  const onRenderComplete = jest.fn();
+  const onLoading = jest.fn();
+  const onError = jest.fn();
 
   const mockedInput = {
     viewMode: 'view',
@@ -145,6 +148,9 @@ describe('EmbeddableAnomalyChartsContainer', () => {
         refresh={refresh}
         onInputChange={onInputChange}
         onOutputChange={onOutputChange}
+        onLoading={onLoading}
+        onRenderComplete={onRenderComplete}
+        onError={onError}
       />,
       defaultOptions
     );
@@ -172,6 +178,9 @@ describe('EmbeddableAnomalyChartsContainer', () => {
         refresh={refresh}
         onInputChange={onInputChange}
         onOutputChange={onOutputChange}
+        onLoading={onLoading}
+        onRenderComplete={onRenderComplete}
+        onError={onError}
       />,
       defaultOptions
     );

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.tsx
@@ -27,7 +27,6 @@ import { UI_SETTINGS } from '../../../../../../src/plugins/data/common';
 import { TimeBuckets } from '../../application/util/time_buckets';
 import { EXPLORER_ENTITY_FIELD_SELECTION_TRIGGER } from '../../ui_actions/triggers';
 import { MlLocatorParams } from '../../../common/types/locator';
-import type { RenderCompleteDispatcher } from '../../../../../../src/plugins/kibana_utils/public';
 
 const RESIZE_THROTTLE_TIME_MS = 500;
 
@@ -39,7 +38,9 @@ export interface EmbeddableAnomalyChartsContainerProps {
   refresh: Observable<any>;
   onInputChange: (input: Partial<AnomalyChartsEmbeddableInput>) => void;
   onOutputChange: (output: Partial<AnomalyChartsEmbeddableOutput>) => void;
-  renderCompleteDispatcher: RenderCompleteDispatcher;
+  onRenderComplete: () => void;
+  onLoading: () => void;
+  onError: (error: Error) => void;
 }
 
 export const EmbeddableAnomalyChartsContainer: FC<EmbeddableAnomalyChartsContainerProps> = ({
@@ -50,7 +51,9 @@ export const EmbeddableAnomalyChartsContainer: FC<EmbeddableAnomalyChartsContain
   refresh,
   onInputChange,
   onOutputChange,
-  renderCompleteDispatcher,
+  onRenderComplete,
+  onError,
+  onLoading,
 }) => {
   const [chartWidth, setChartWidth] = useState<number>(0);
   const [severity, setSeverity] = useState(
@@ -98,7 +101,7 @@ export const EmbeddableAnomalyChartsContainer: FC<EmbeddableAnomalyChartsContain
     services,
     chartWidth,
     severity.val,
-    renderCompleteDispatcher
+    { onRenderComplete, onError, onLoading }
   );
   const resizeHandler = useCallback(
     throttle((e: { width: number; height: number }) => {

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.tsx
@@ -27,6 +27,7 @@ import { UI_SETTINGS } from '../../../../../../src/plugins/data/common';
 import { TimeBuckets } from '../../application/util/time_buckets';
 import { EXPLORER_ENTITY_FIELD_SELECTION_TRIGGER } from '../../ui_actions/triggers';
 import { MlLocatorParams } from '../../../common/types/locator';
+import type { RenderCompleteDispatcher } from '../../../../../../src/plugins/kibana_utils/public';
 
 const RESIZE_THROTTLE_TIME_MS = 500;
 
@@ -38,6 +39,7 @@ export interface EmbeddableAnomalyChartsContainerProps {
   refresh: Observable<any>;
   onInputChange: (input: Partial<AnomalyChartsEmbeddableInput>) => void;
   onOutputChange: (output: Partial<AnomalyChartsEmbeddableOutput>) => void;
+  renderCompleteDispatcher: RenderCompleteDispatcher;
 }
 
 export const EmbeddableAnomalyChartsContainer: FC<EmbeddableAnomalyChartsContainerProps> = ({
@@ -48,6 +50,7 @@ export const EmbeddableAnomalyChartsContainer: FC<EmbeddableAnomalyChartsContain
   refresh,
   onInputChange,
   onOutputChange,
+  renderCompleteDispatcher,
 }) => {
   const [chartWidth, setChartWidth] = useState<number>(0);
   const [severity, setSeverity] = useState(
@@ -94,7 +97,8 @@ export const EmbeddableAnomalyChartsContainer: FC<EmbeddableAnomalyChartsContain
     refresh,
     services,
     chartWidth,
-    severity.val
+    severity.val,
+    renderCompleteDispatcher
   );
   const resizeHandler = useCallback(
     throttle((e: { width: number; height: number }) => {

--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable.tsx
@@ -56,6 +56,18 @@ export class AnomalySwimlaneEmbeddable extends Embeddable<
     );
   }
 
+  public onLoading() {
+    this.renderComplete.dispatchInProgress();
+  }
+
+  public onError() {
+    this.renderComplete.dispatchError();
+  }
+
+  public onRenderComplete() {
+    this.renderComplete.dispatchComplete();
+  }
+
   public render(node: HTMLElement) {
     super.render(node);
     this.node = node;
@@ -76,6 +88,9 @@ export class AnomalySwimlaneEmbeddable extends Embeddable<
                 refresh={this.reload$.asObservable()}
                 onInputChange={this.updateInput.bind(this)}
                 onOutputChange={this.updateOutput.bind(this)}
+                onRenderComplete={this.onRenderComplete.bind(this)}
+                onLoading={this.onLoading.bind(this)}
+                onError={this.onError.bind(this)}
               />
             </Suspense>
           </KibanaContextProvider>

--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable.tsx
@@ -75,6 +75,9 @@ export class AnomalySwimlaneEmbeddable extends Embeddable<
     super.render(node);
     this.node = node;
 
+    // required for the export feature to work
+    this.node.setAttribute('data-shared-item', '');
+
     const I18nContext = this.services[0].i18n.Context;
     const theme$ = this.services[0].theme.theme$;
 

--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable.tsx
@@ -58,14 +58,17 @@ export class AnomalySwimlaneEmbeddable extends Embeddable<
 
   public onLoading() {
     this.renderComplete.dispatchInProgress();
+    this.updateOutput({ loading: true, error: undefined });
   }
 
-  public onError() {
+  public onError(error: Error) {
     this.renderComplete.dispatchError();
+    this.updateOutput({ loading: false, error: { name: error.name, message: error.message } });
   }
 
   public onRenderComplete() {
     this.renderComplete.dispatchComplete();
+    this.updateOutput({ loading: false, error: undefined });
   }
 
   public render(node: HTMLElement) {

--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/embeddable_swim_lane_container.test.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/embeddable_swim_lane_container.test.tsx
@@ -48,6 +48,9 @@ describe('ExplorerSwimlaneContainer', () => {
 
   const onInputChange = jest.fn();
   const onOutputChange = jest.fn();
+  const onRenderComplete = jest.fn();
+  const onLoading = jest.fn();
+  const onError = jest.fn();
 
   beforeEach(() => {
     embeddableContext = { id: 'test-id' } as AnomalySwimlaneEmbeddable;
@@ -102,6 +105,9 @@ describe('ExplorerSwimlaneContainer', () => {
         refresh={refresh}
         onInputChange={onInputChange}
         onOutputChange={onOutputChange}
+        onLoading={onLoading}
+        onRenderComplete={onRenderComplete}
+        onError={onError}
       />,
       defaultOptions
     );
@@ -141,6 +147,9 @@ describe('ExplorerSwimlaneContainer', () => {
         refresh={refresh}
         onInputChange={onInputChange}
         onOutputChange={onOutputChange}
+        onLoading={onLoading}
+        onRenderComplete={onRenderComplete}
+        onError={onError}
       />,
       defaultOptions
     );

--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/embeddable_swim_lane_container.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/embeddable_swim_lane_container.tsx
@@ -37,7 +37,7 @@ export interface ExplorerSwimlaneContainerProps {
   onOutputChange: (output: Partial<AnomalySwimlaneEmbeddableOutput>) => void;
   onRenderComplete: () => void;
   onLoading: () => void;
-  onError: () => void;
+  onError: (error: Error) => void;
 }
 
 export const EmbeddableSwimLaneContainer: FC<ExplorerSwimlaneContainerProps> = ({

--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/embeddable_swim_lane_container.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/embeddable_swim_lane_container.tsx
@@ -35,6 +35,9 @@ export interface ExplorerSwimlaneContainerProps {
   refresh: Observable<any>;
   onInputChange: (input: Partial<AnomalySwimlaneEmbeddableInput>) => void;
   onOutputChange: (output: Partial<AnomalySwimlaneEmbeddableOutput>) => void;
+  onRenderComplete: () => void;
+  onLoading: () => void;
+  onError: () => void;
 }
 
 export const EmbeddableSwimLaneContainer: FC<ExplorerSwimlaneContainerProps> = ({
@@ -45,6 +48,9 @@ export const EmbeddableSwimLaneContainer: FC<ExplorerSwimlaneContainerProps> = (
   refresh,
   onInputChange,
   onOutputChange,
+  onRenderComplete,
+  onLoading,
+  onError,
 }) => {
   const [chartWidth, setChartWidth] = useState<number>(0);
 
@@ -61,7 +67,8 @@ export const EmbeddableSwimLaneContainer: FC<ExplorerSwimlaneContainerProps> = (
       refresh,
       services,
       chartWidth,
-      fromPage
+      fromPage,
+      { onRenderComplete, onError, onLoading }
     );
 
   useEffect(() => {

--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/swimlane_input_resolver.test.ts
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/swimlane_input_resolver.test.ts
@@ -19,6 +19,12 @@ describe('useSwimlaneInputResolver', () => {
   let services: [CoreStart, MlStartDependencies, AnomalySwimlaneServices];
   let onInputChange: jest.Mock;
 
+  const renderCallbacks = {
+    onRenderComplete: jest.fn(),
+    onLoading: jest.fn(),
+    onError: jest.fn(),
+  };
+
   beforeEach(() => {
     jest.useFakeTimers();
 
@@ -78,6 +84,7 @@ describe('useSwimlaneInputResolver', () => {
     ];
     onInputChange = jest.fn();
   });
+
   afterEach(() => {
     jest.useRealTimers();
     jest.clearAllMocks();
@@ -91,7 +98,8 @@ describe('useSwimlaneInputResolver', () => {
         refresh,
         services,
         1000,
-        1
+        1,
+        renderCallbacks
       )
     );
 
@@ -105,6 +113,9 @@ describe('useSwimlaneInputResolver', () => {
 
     expect(services[2].anomalyDetectorService.getJobs$).toHaveBeenCalledTimes(1);
     expect(services[2].anomalyTimelineService.loadOverallData).toHaveBeenCalledTimes(1);
+
+    expect(renderCallbacks.onLoading).toHaveBeenCalledTimes(1);
+    expect(renderCallbacks.onRenderComplete).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       embeddableInput.next({
@@ -121,6 +132,9 @@ describe('useSwimlaneInputResolver', () => {
     expect(services[2].anomalyDetectorService.getJobs$).toHaveBeenCalledTimes(2);
     expect(services[2].anomalyTimelineService.loadOverallData).toHaveBeenCalledTimes(2);
 
+    expect(renderCallbacks.onLoading).toHaveBeenCalledTimes(2);
+    expect(renderCallbacks.onRenderComplete).toHaveBeenCalledTimes(2);
+
     await act(async () => {
       embeddableInput.next({
         id: 'test-swimlane-embeddable',
@@ -135,6 +149,9 @@ describe('useSwimlaneInputResolver', () => {
 
     expect(services[2].anomalyDetectorService.getJobs$).toHaveBeenCalledTimes(2);
     expect(services[2].anomalyTimelineService.loadOverallData).toHaveBeenCalledTimes(3);
+
+    expect(renderCallbacks.onLoading).toHaveBeenCalledTimes(3);
+    expect(renderCallbacks.onRenderComplete).toHaveBeenCalledTimes(3);
   });
 
   test('should not complete the observable on error', async () => {
@@ -145,7 +162,8 @@ describe('useSwimlaneInputResolver', () => {
         refresh,
         services,
         1000,
-        1
+        1,
+        renderCallbacks
       )
     );
 
@@ -160,5 +178,7 @@ describe('useSwimlaneInputResolver', () => {
     });
 
     expect(result.current[6]?.message).toBe('Invalid job');
+
+    expect(renderCallbacks.onError).toHaveBeenCalledTimes(1);
   });
 });

--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/swimlane_input_resolver.ts
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/swimlane_input_resolver.ts
@@ -53,7 +53,7 @@ export function useSwimlaneInputResolver(
   renderCallbacks: {
     onRenderComplete: () => void;
     onLoading: () => void;
-    onError: () => void;
+    onError: (error: Error) => void;
   }
 ): [
   string | undefined,
@@ -237,7 +237,7 @@ export function useSwimlaneInputResolver(
 
   useEffect(() => {
     if (error) {
-      renderCallbacks.onError();
+      renderCallbacks.onError(error);
     }
   }, [error]);
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/128479

Fixes generation of the PNG and PDF reports when ML embeddables are presented on the dashboard. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


