### PR TITLE
[Fleet] Fix logstash config ssl_verification_mode

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/logstash_instructions/helpers.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/logstash_instructions/helpers.tsx
@@ -17,7 +17,7 @@ export function getLogstashPipeline(apiKey?: string) {
     ssl_certificate_authorities => ["<ca_path>"]
     ssl_certificate => "<server_cert_path>"
     ssl_key => "<server_cert_key>"
-    ssl_verification_mode => "force-peer"
+    ssl_verify_mode => "force_peer"
   }
 }
 


### PR DESCRIPTION
## Summary

Make the logstash config valid by fixing a bad named config option `ssl_verification_mode` => `ssl_verify_mode`