### PR TITLE
[7.17] Fixed API Key Tests  (#127236)

### DIFF
--- a/x-pack/test/functional/apps/api_keys/api_keys_helpers.ts
+++ b/x-pack/test/functional/apps/api_keys/api_keys_helpers.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Client } from '@elastic/elasticsearch';
+import { ToolingLog } from '@kbn/dev-utils';
+
+export default async function clearAllApiKeys(esClient: Client, logger: ToolingLog) {
+  const existingKeys = await esClient.security.queryApiKeys();
+  if (existingKeys.count > 0) {
+    await Promise.all(
+      existingKeys.api_keys.map(async (key) => {
+        esClient.security.invalidateApiKey({ ids: [key.id] });
+      })
+    );
+  } else {
+    logger.debug('No API keys to delete.');
+  }
+}

--- a/x-pack/test/functional/apps/api_keys/home_page.ts
+++ b/x-pack/test/functional/apps/api_keys/home_page.ts
@@ -6,9 +6,11 @@
  */
 
 import expect from '@kbn/expect';
+import clearAllApiKeys from './api_keys_helpers';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
+  const es = getService('es');
   const pageObjects = getPageObjects(['common', 'apiKeys']);
   const log = getService('log');
   const security = getService('security');
@@ -18,6 +20,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
   describe('Home page', function () {
     before(async () => {
+      await clearAllApiKeys(es, log);
       await security.testUser.setRoles(['kibana_admin']);
       await pageObjects.common.navigateToApp('apiKeys');
     });
@@ -39,13 +42,16 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
     describe('creates API key', function () {
       before(async () => {
-        await security.testUser.setRoles(['kibana_admin']);
-        await security.testUser.setRoles(['test_api_keys']);
+        await security.testUser.setRoles(['kibana_admin', 'test_api_keys']);
         await pageObjects.common.navigateToApp('apiKeys');
       });
 
       afterEach(async () => {
         await pageObjects.apiKeys.deleteAllApiKeyOneByOne();
+      });
+
+      after(async () => {
+        await clearAllApiKeys(es, log);
       });
 
       it('when submitting form, close dialog and displays new api key', async () => {
@@ -92,8 +98,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
     describe('deletes API key(s)', function () {
       before(async () => {
-        await security.testUser.setRoles(['kibana_admin']);
-        await security.testUser.setRoles(['test_api_keys']);
+        await security.testUser.setRoles(['kibana_admin', 'test_api_keys']);
         await pageObjects.common.navigateToApp('apiKeys');
       });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fixed API Key Tests  (#127236)](https://github.com/elastic/kibana/pull/127236)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)