### PR TITLE
[APM] Allow plugins to link to APM UI using locators

### DIFF
--- a/x-pack/plugins/apm/common/locator.test.ts
+++ b/x-pack/plugins/apm/common/locator.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { APMLocatorDefinition, APM_APP_LOCATOR } from './locator';
+
+describe('APMLocatorDefinition', () => {
+  test('locator has the right ID and app', async () => {
+    const locator = new APMLocatorDefinition();
+    const location = await locator.getLocation({});
+
+    expect(locator.id).toBe(APM_APP_LOCATOR);
+    expect(location).toMatchObject({
+      app: 'apm',
+    });
+  });
+
+  test('when serviceName is provided, returns path to the given service overiew page', async () => {
+    const locator = new APMLocatorDefinition();
+    const location = await locator.getLocation({
+      serviceName: 'example-app',
+    });
+
+    expect(location).toMatchObject({
+      path: '/services/example-app/overview',
+      state: {},
+    });
+  });
+
+  test('when both serviceName and serviceOverViewActiveTab are provided, returns path to the given service overiew page with the right tab selected', async () => {
+    const locator = new APMLocatorDefinition();
+    const location = await locator.getLocation({
+      serviceName: 'example-app',
+      serviceOverViewActiveTab: 'logs',
+    });
+
+    expect(location).toMatchObject({
+      path: '/services/example-app/logs',
+      state: {},
+    });
+  });
+
+  test('when serviceOverViewActiveTab is invalid, returns path to the given service overiew page', async () => {
+    const locator = new APMLocatorDefinition();
+    const location = await locator.getLocation({
+      serviceName: 'example-app',
+      // @ts-ignore
+      serviceOverViewActiveTab: 'invalidTab',
+    });
+
+    expect(location).toMatchObject({
+      path: '/services/example-app/overview',
+      state: {},
+    });
+  });
+});

--- a/x-pack/plugins/apm/common/locator.ts
+++ b/x-pack/plugins/apm/common/locator.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LocatorDefinition } from 'src/plugins/share/common';
+import type { SerializableRecord } from '@kbn/utility-types';
+import * as t from 'io-ts';
+import { isRight } from 'fp-ts/Either';
+
+const serviceOverViewTab = t.keyof({
+  transactions: null,
+  metrics: null,
+  logs: null,
+});
+
+export const APM_APP_LOCATOR = 'APM_LOCATOR';
+
+type ServiceOverViewTab = t.TypeOf<typeof serviceOverViewTab>;
+
+export interface ServiceViewLocatorParams extends SerializableRecord {
+  serviceName?: string;
+  serviceOverViewActiveTab?: ServiceOverViewTab;
+}
+
+export type APMLocatorParams = ServiceViewLocatorParams;
+
+export class APMLocatorDefinition
+  implements LocatorDefinition<APMLocatorParams>
+{
+  public readonly id = APM_APP_LOCATOR;
+
+  public readonly getLocation = async ({
+    serviceName,
+    serviceOverViewActiveTab,
+  }: APMLocatorParams) => {
+    let path;
+    if (
+      serviceName &&
+      serviceOverViewActiveTab &&
+      isRight(serviceOverViewTab.decode(serviceOverViewActiveTab))
+    ) {
+      path = `/services/${encodeURIComponent(serviceName)}/${encodeURIComponent(
+        serviceOverViewActiveTab
+      )}`;
+    } else if (serviceName) {
+      path = `/services/${encodeURIComponent(serviceName)}/overview`;
+    } else {
+      path = '/';
+    }
+
+    return {
+      app: 'apm',
+      path,
+      state: {},
+    };
+  };
+}

--- a/x-pack/plugins/apm/kibana.json
+++ b/x-pack/plugins/apm/kibana.json
@@ -16,7 +16,8 @@
     "licensing",
     "observability",
     "ruleRegistry",
-    "triggersActionsUi"
+    "triggersActionsUi",
+    "share"
   ],
   "optionalPlugins": [
     "actions",

--- a/x-pack/plugins/apm/public/plugin.ts
+++ b/x-pack/plugins/apm/public/plugin.ts
@@ -23,6 +23,7 @@ import type {
 } from '../../../../src/plugins/data/public';
 import type { EmbeddableStart } from '../../../../src/plugins/embeddable/public';
 import type { HomePublicPluginSetup } from '../../../../src/plugins/home/public';
+import type { SharePluginSetup } from '../../../../src/plugins/share/public';
 import { Start as InspectorPluginStart } from '../../../../src/plugins/inspector/public';
 import type {
   PluginSetupContract as AlertingPluginPublicSetup,
@@ -55,6 +56,7 @@ import { featureCatalogueEntry } from './feature_catalogue_entry';
 import type { SecurityPluginStart } from '../../security/public';
 import { SpacesPluginStart } from '../../spaces/public';
 import { enableServiceGroups } from '../../observability/public';
+import { APMLocatorDefinition } from '../common/locator';
 
 export type ApmPluginSetup = ReturnType<ApmPlugin['setup']>;
 
@@ -69,6 +71,7 @@ export interface ApmPluginSetupDeps {
   ml?: MlPluginSetup;
   observability: ObservabilityPublicSetup;
   triggersActionsUi: TriggersAndActionsUIPublicPluginSetup;
+  share: SharePluginSetup;
 }
 
 export interface ApmPluginStartDeps {
@@ -298,7 +301,13 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
 
     registerApmAlerts(observabilityRuleTypeRegistry);
 
-    return {};
+    const locator = plugins.share.url.locators.create(
+      new APMLocatorDefinition()
+    );
+
+    return {
+      locator,
+    };
   }
   public start(core: CoreStart, plugins: ApmPluginStartDeps) {
     const { fleet } = plugins;


### PR DESCRIPTION
This PR introduces `APMLocator` to the `APM plugin` setup to allow plugins to link to the different pages inside APM, specifically allowing `fleet datastreams` to link to the relevant service in APM which is needed for #91409.

For more context on how the locators API works in kibana Check [the doc](https://github.com/elastic/kibana/blob/8.1/src/plugins/share/common/url_service/locators/README.md).

#### Remarks:
* The `APMLocator` introduced in this PR only handles links to the service details overview and service details with a specific tab.
* A follow-up PR against `fleet plugin` that allows fleet UI to link to APM pages is on the way!.