### PR TITLE
define configuration to expose to the browser

### DIFF
--- a/x-pack/plugins/monitoring/server/index.ts
+++ b/x-pack/plugins/monitoring/server/index.ts
@@ -20,7 +20,15 @@ export const config: PluginConfigDescriptor<TypeOf<typeof configSchema>> = {
   schema: configSchema,
   deprecations,
   exposeToBrowser: {
-    ui: true,
+    ui: {
+      enabled: true,
+      min_interval_seconds: true,
+      show_license_expiration: true,
+      container: true,
+      ccs: {
+        enabled: true,
+      },
+    },
     kibana: true,
   },
 };


### PR DESCRIPTION
## Summary

Closes #123269

Define a nested configuration to the `exposeToBrowser` option to restrict the shared settings to the strict minimum.
