### PR TITLE
[Enterprise Search] Remove gated Content plugin

### DIFF
--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -26,7 +26,6 @@ import { SecurityPluginSetup, SecurityPluginStart } from '../../security/public'
 
 import {
   APP_SEARCH_PLUGIN,
-  ENTERPRISE_SEARCH_CONTENT_PLUGIN,
   ENTERPRISE_SEARCH_OVERVIEW_PLUGIN,
   WORKPLACE_SEARCH_PLUGIN,
 } from '../common/constants';
@@ -89,32 +88,6 @@ export class EnterpriseSearchPlugin implements Plugin {
         return renderApp(EnterpriseSearchOverview, kibanaDeps, pluginData);
       },
     });
-
-    /* We are gating the Content plugin to develpers only until release */
-    if (process.env.NODE_ENV === 'development') {
-      core.application.register({
-        id: ENTERPRISE_SEARCH_CONTENT_PLUGIN.ID,
-        title: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAV_TITLE,
-        euiIconType: ENTERPRISE_SEARCH_CONTENT_PLUGIN.LOGO,
-        appRoute: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL,
-        category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
-        mount: async (params: AppMountParameters) => {
-          const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
-          const { chrome, http } = kibanaDeps.core;
-          chrome.docTitle.change(ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME);
-
-          await this.getInitialData(http);
-          const pluginData = this.getPluginData();
-
-          const { renderApp } = await import('./applications');
-          const { EnterpriseSearchContent } = await import(
-            './applications/enterprise_search_content'
-          );
-
-          return renderApp(EnterpriseSearchContent, kibanaDeps, pluginData);
-        },
-      });
-    }
 
     core.application.register({
       id: APP_SEARCH_PLUGIN.ID,


### PR DESCRIPTION
## Summary

When we [added basic scaffolding](https://github.com/elastic/kibana/pull/127660) for the Content plugin, we added a gated plugin for development. This had unintended consequences on FTR in other apps. This PR reverts [this commit](https://github.com/elastic/kibana/pull/127660/commits/383467f5971705e15099e3f911a3281670dc173f).

Will reintroduce in 8.3 ungated. 

[Slack thread](https://elastic.slack.com/archives/C7LLL50CA/p1648588524137379) for context.