### PR TITLE
[7.17] [Rule Registry] Switch to _source for updating documents instead of Fields API (#118245)

### DIFF
--- a/x-pack/plugins/rule_registry/server/rule_data_client/types.ts
+++ b/x-pack/plugins/rule_registry/server/rule_data_client/types.ts
@@ -10,7 +10,7 @@ import { BulkRequest, BulkResponse } from '@elastic/elasticsearch/api/types';
 
 import { ESSearchRequest, ESSearchResponse } from 'src/core/types/elasticsearch';
 import { FieldDescriptor } from 'src/plugins/data/server';
-import { TechnicalRuleDataFieldName } from '../../common/technical_rule_data_field_names';
+import { ParsedTechnicalFields } from '../../common/parse_technical_fields';
 
 export interface IRuleDataClient {
   indexName: string;
@@ -23,9 +23,7 @@ export interface IRuleDataClient {
 export interface IRuleDataReader {
   search<TSearchRequest extends ESSearchRequest>(
     request: TSearchRequest
-  ): Promise<
-    ESSearchResponse<Partial<Record<TechnicalRuleDataFieldName, unknown[]>>, TSearchRequest>
-  >;
+  ): Promise<ESSearchResponse<Partial<ParsedTechnicalFields>, TSearchRequest>>;
 
   getDynamicIndexPattern(target?: string): Promise<{
     title: string;

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.test.ts
@@ -126,7 +126,7 @@ describe('createLifecycleExecutor', () => {
       hits: {
         hits: [
           {
-            fields: {
+            _source: {
               '@timestamp': '',
               [ALERT_INSTANCE_ID]: 'TEST_ALERT_0',
               [ALERT_UUID]: 'ALERT_0_UUID',
@@ -143,7 +143,7 @@ describe('createLifecycleExecutor', () => {
             },
           },
           {
-            fields: {
+            _source: {
               '@timestamp': '',
               [ALERT_INSTANCE_ID]: 'TEST_ALERT_1',
               [ALERT_UUID]: 'ALERT_1_UUID',
@@ -246,7 +246,7 @@ describe('createLifecycleExecutor', () => {
       hits: {
         hits: [
           {
-            fields: {
+            _source: {
               '@timestamp': '',
               [ALERT_INSTANCE_ID]: 'TEST_ALERT_0',
               [ALERT_UUID]: 'ALERT_0_UUID',
@@ -262,7 +262,7 @@ describe('createLifecycleExecutor', () => {
             },
           },
           {
-            fields: {
+            _source: {
               '@timestamp': '',
               [ALERT_INSTANCE_ID]: 'TEST_ALERT_1',
               [ALERT_UUID]: 'ALERT_1_UUID',

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
@@ -18,7 +18,7 @@ import {
   AlertTypeParams,
   AlertTypeState,
 } from '../../../alerting/server';
-import { ParsedTechnicalFields, parseTechnicalFields } from '../../common/parse_technical_fields';
+import { ParsedTechnicalFields } from '../../common/parse_technical_fields';
 import {
   ALERT_DURATION,
   ALERT_END,
@@ -216,8 +216,6 @@ export const createLifecycleExecutor =
           collapse: {
             field: ALERT_UUID,
           },
-          _source: false,
-          fields: [{ field: '*', include_unmapped: true }],
           sort: {
             [TIMESTAMP]: 'desc' as const,
           },
@@ -226,13 +224,13 @@ export const createLifecycleExecutor =
       });
 
       hits.hits.forEach((hit) => {
-        const fields = parseTechnicalFields(hit.fields);
-        const indexName = hit._index;
-        const alertId = fields[ALERT_INSTANCE_ID];
-        trackedAlertsDataMap[alertId] = {
-          indexName,
-          fields,
-        };
+        const alertId = hit._source[ALERT_INSTANCE_ID];
+        if (alertId) {
+          trackedAlertsDataMap[alertId] = {
+            indexName: hit._index,
+            fields: hit._source,
+          };
+        }
       });
     }
 

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
@@ -14,7 +14,7 @@ import {
   ALERT_UUID,
 } from '@kbn/rule-data-utils';
 import { loggerMock } from '@kbn/logging/mocks';
-import { castArray, omit, mapValues } from 'lodash';
+import { castArray, omit } from 'lodash';
 import { RuleDataClient } from '../rule_data_client';
 import { createRuleDataClientMock } from '../rule_data_client/rule_data_client.mock';
 import { createLifecycleRuleTypeFactory } from './create_lifecycle_rule_type_factory';
@@ -272,13 +272,9 @@ describe('createLifecycleRuleTypeFactory', () => {
             (doc: any) => !('index' in doc) && doc['service.name'] === 'opbeans-node'
           ) as Record<string, any>;
 
-        const stored = mapValues(lastOpbeansNodeDoc, (val) => {
-          return castArray(val);
-        });
-
         helpers.ruleDataClientMock.getReader().search.mockResolvedValueOnce({
           hits: {
-            hits: [{ fields: stored } as any],
+            hits: [{ _source: lastOpbeansNodeDoc } as any],
             total: {
               value: 1,
               relation: 'eq',
@@ -356,13 +352,9 @@ describe('createLifecycleRuleTypeFactory', () => {
             (doc: any) => !('index' in doc) && doc['service.name'] === 'opbeans-node'
           ) as Record<string, any>;
 
-        const stored = mapValues(lastOpbeansNodeDoc, (val) => {
-          return castArray(val);
-        });
-
         helpers.ruleDataClientMock.getReader().search.mockResolvedValueOnce({
           hits: {
-            hits: [{ fields: stored } as any],
+            hits: [{ _source: lastOpbeansNodeDoc } as any],
             total: {
               value: 1,
               relation: 'eq',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Rule Registry] Switch to _source for updating documents instead of Fields API (#118245)](https://github.com/elastic/kibana/pull/118245)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)