### PR TITLE
[Controls] Move control type tooltip

### DIFF
--- a/src/plugins/controls/public/control_group/editor/control_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_editor.tsx
@@ -127,7 +127,7 @@ export const ControlEditor = ({
       );
 
       return tooltip ? (
-        <EuiToolTip content={tooltip} position="bottom">
+        <EuiToolTip content={tooltip} position="top">
           {menuPadItem}
         </EuiToolTip>
       ) : (


### PR DESCRIPTION
## Summary

Before this change, the tooltip for each control type was linked to the **bottom** of the button - however, this positioning got in the way of the data view selection:

![OldTooltip](https://user-images.githubusercontent.com/8698078/160888364-cf31e720-555b-4646-a199-602b24680097.gif)

Now, the position was moved to **above** the bottom, so nothing important gets covered:

![NewTooltip](https://user-images.githubusercontent.com/8698078/160888863-c0690ca4-6bb2-44f5-af1e-d51f517052df.gif)

### Checklist
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)