### PR TITLE
[DOCS] Removes tag from 7.17.2 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -76,8 +76,6 @@ Review important information about the {kib} 7.17.x releases.
 [[release-notes-7.17.2]]
 == {kib} 7.17.2
 
-coming::[7.17.2]
-
 Review the following information about the 7.17.2 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes coming tag from the 7.17.2 release notes.