### PR TITLE
[8.2] Update dependency @elastic/charts to v45.1.1 (main) (#128870)

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@elastic/apm-rum": "^5.10.2",
     "@elastic/apm-rum-react": "^1.3.4",
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
-    "@elastic/charts": "45.0.1",
+    "@elastic/charts": "45.1.1",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.2.0-canary.1",
     "@elastic/ems-client": "8.2.0",

--- a/src/plugins/chart_expressions/expression_gauge/public/components/__snapshots__/gauge_component.test.tsx.snap
+++ b/src/plugins/chart_expressions/expression_gauge/public/components/__snapshots__/gauge_component.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`GaugeComponent renders the chart 1`] = `
       ]
     }
   />
-  <Component
+  <Goal
     actual={3}
     bandFillColor={[Function]}
     bands={

--- a/x-pack/plugins/uptime/public/components/common/charts/__snapshots__/donut_chart.test.tsx.snap
+++ b/x-pack/plugins/uptime/public/components/common/charts/__snapshots__/donut_chart.test.tsx.snap
@@ -234,6 +234,11 @@ exports[`DonutChart component passes correct props without errors for valid prop
               },
             },
             "goal": Object {
+              "arcBoxSamplePitch": 0.08726646259971647,
+              "barThicknessMinSizeRatio": 0.1,
+              "baselineArcThickness": 32,
+              "baselineBarThickness": 32,
+              "capturePad": 16,
               "majorCenterLabel": Object {
                 "fill": "black",
                 "fontFamily": "sans-serif",
@@ -244,7 +249,13 @@ exports[`DonutChart component passes correct props without errors for valid prop
                 "fontFamily": "sans-serif",
                 "fontStyle": "normal",
               },
+              "marginRatio": 0.05,
+              "maxBulletSize": 500,
+              "maxCentralFontSize": 38,
+              "maxCircularSize": 360,
               "maxFontSize": 64,
+              "maxLabelFontSize": 32,
+              "maxTickFontSize": 24,
               "minFontSize": 8,
               "minorCenterLabel": Object {
                 "fill": "black",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1442,10 +1442,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@45.0.1":
-  version "45.0.1"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-45.0.1.tgz#02362d6345641788f878c99d9943b91923fbb221"
-  integrity sha512-CrMStOCZzTSO4SxU5FTL75JgG5AshFILVtWqiq2r7+cwwo9oekEPoUuBzqKFCfHkt/yeq1sTdEK19oZsQ0He6w==
+"@elastic/charts@45.1.1":
+  version "45.1.1"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-45.1.1.tgz#d65b51ee296138a7e6b3d954fcf9fa41ba379492"
+  integrity sha512-gVk8ZbCBh8fUKxM6Rd61qwhSCgt1zU0wt3y3ZMUe+MdaTFG9I+0SceYrltJR+bf0ycK0wb1yg+WEw0LoN8bEIg==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"
@@ -6562,11 +6562,6 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/raf@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@types/raf/-/raf-3.4.0.tgz#2b72cbd55405e071f1c4d29992638e022b20acc2"
-  integrity sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==
-
 "@types/rbush@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/rbush/-/rbush-3.0.0.tgz#b6887d99b159e87ae23cd14eceff34f139842aa6"
@@ -9742,20 +9737,6 @@ canvg@^3.0.9:
     stackblur-canvas "^2.0.0"
     svg-pathdata "^6.0.3"
 
-canvg@^3.0.9:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/canvg/-/canvg-3.0.9.tgz#9ba095f158b94b97ca2c9c1c40785b11dc08df6d"
-  integrity sha512-rDXcnRPuz4QHoCilMeoTxql+fvGqNAxp+qV/KHD8rOiJSAfVjFclbdUNHD2Uqfthr+VMg17bD2bVuk6F07oLGw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@types/raf" "^3.4.0"
-    core-js "^3.8.3"
-    raf "^3.4.1"
-    regenerator-runtime "^0.13.7"
-    rgbcolor "^1.0.1"
-    stackblur-canvas "^2.0.0"
-    svg-pathdata "^6.0.3"
-
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -10848,11 +10829,6 @@ core-js@^3.0.4, core-js@^3.21.1, core-js@^3.6.5, core-js@^3.8.2, core-js@^3.8.3:
   version "3.21.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.21.1.tgz#f2e0ddc1fc43da6f904706e8e955bc19d06a0d94"
   integrity sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==
-
-core-js@^3.8.3:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.1.tgz#f6f173cae23e73a7d88fa23b6e9da329276c6641"
-  integrity sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==
 
 core-util-is@1.0.2, core-util-is@^1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Update dependency @elastic/charts to v45.1.1 (main) (#128870)](https://github.com/elastic/kibana/pull/128870)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)