### PR TITLE
[Dashboard][Controls] Options List Presave Transform Bug

### DIFF
--- a/src/plugins/controls/public/control_types/options_list/options_list_embeddable_factory.tsx
+++ b/src/plugins/controls/public/control_types/options_list/options_list_embeddable_factory.tsx
@@ -37,8 +37,8 @@ export class OptionsListEmbeddableFactory
   ) => {
     if (
       embeddable &&
-      (!deepEqual(newInput.fieldName, embeddable.getInput().fieldName) ||
-        !deepEqual(newInput.dataViewId, embeddable.getInput().dataViewId))
+      ((newInput.fieldName && !deepEqual(newInput.fieldName, embeddable.getInput().fieldName)) ||
+        (newInput.dataViewId && !deepEqual(newInput.dataViewId, embeddable.getInput().dataViewId)))
     ) {
       // if the field name or data view id has changed in this editing session, selected options are invalid, so reset them.
       newInput.selectedOptions = [];


### PR DESCRIPTION
## Summary

This PR Fixes a small issue where changing anything in the options list editor would deselect all the selections. Now it properly only deselects the selections when the fieldName or the dataViewId changes.
