### PR TITLE
[8.2] [ML][Maps] Anomaly Detection: ensure maps link only created when geo type chart (#128945)

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
@@ -198,20 +198,21 @@ function ExplorerChartContainer({
 
   useEffect(
     function getMapsPluginLink() {
-      if (!series) return;
       let isCancelled = false;
-      const generateLink = async () => {
-        if (!isCancelled) {
+      if (series && getChartType(series) === CHART_TYPE.GEO_MAP) {
+        const generateLink = async () => {
           try {
             const mapsLink = await getMapsLink();
-            setMapsLink(mapsLink?.path);
+            if (!isCancelled) {
+              setMapsLink(mapsLink?.path);
+            }
           } catch (error) {
             console.error(error);
             setMapsLink('');
           }
-        }
-      };
-      generateLink().catch(console.error);
+        };
+        generateLink().catch(console.error);
+      }
       return () => {
         isCancelled = true;
       };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[ML][Maps] Anomaly Detection: ensure maps link only created when geo type chart (#128945)](https://github.com/elastic/kibana/pull/128945)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)