### PR TITLE
[8.2] Move the control type tooltip to above the button (#128949)

### DIFF
--- a/src/plugins/controls/public/control_group/editor/control_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_editor.tsx
@@ -127,7 +127,7 @@ export const ControlEditor = ({
       );
 
       return tooltip ? (
-        <EuiToolTip content={tooltip} position="bottom">
+        <EuiToolTip content={tooltip} position="top">
           {menuPadItem}
         </EuiToolTip>
       ) : (


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Move the control type tooltip to above the button (#128949)](https://github.com/elastic/kibana/pull/128949)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)