### PR TITLE
[8.2] [Dashboard] [Controls] Fix mobile view of toolbar and controls callout (#128771)

### DIFF
--- a/src/plugins/controls/public/control_group/control_group.scss
+++ b/src/plugins/controls/public/control_group/control_group.scss
@@ -7,36 +7,9 @@ $controlMinWidth: $euiSize * 14;
   min-height: $euiSize * 4;
 }
 
-.controlsWrapper {
-  &--empty {
-    display: flex;
-    @include euiBreakpoint('m', 'l', 'xl') {
-      .addControlButton {
-        text-align: center;
-      }
-      .emptyStateText {
-        padding-left: $euiSize * 2;
-      }
-      height: $euiSize * 4;
-      overflow: hidden;
-    }
-    @include euiBreakpoint('xs', 's') {
-      .addControlButton {
-        text-align: center;
-      }
-      .emptyStateText {
-        text-align: center;
-      }
-      .controlsIllustration__container {
-        margin-bottom: 0 !important;
-      }
-    }
-  }
-
-  &--twoLine {
-    .groupEditActions {
-      padding-top: $euiSize;
-    }
+.controlsWrapper--twoLine {
+  .groupEditActions {
+    padding-top: $euiSize;
   }
 }
 
@@ -75,7 +48,8 @@ $controlMinWidth: $euiSize * 14;
     @include euiFontSizeXS;
   }
 
-  .controlFrame__formControlLayout, .controlFrame__draggable {
+  .controlFrame__formControlLayout,
+  .controlFrame__draggable {
     .controlFrame__dragHandle {
       cursor: grabbing;
     }
@@ -105,7 +79,7 @@ $controlMinWidth: $euiSize * 14;
   .controlFrame__formControlLayout {
     width: 100%;
     min-width: $controlMinWidth;
-    transition:background-color .1s, color .1s;
+    transition: background-color .1s, color .1s;
 
     &Label {
       @include euiTextTruncate;
@@ -163,7 +137,6 @@ $controlMinWidth: $euiSize * 14;
   &--insertBefore {
     .controlFrame__formControlLayout:after {
       left: -$euiSizeXS - 1;
-
     }
   }
 
@@ -184,7 +157,7 @@ $controlMinWidth: $euiSize * 14;
     position: absolute;
 
     &--oneLine {
-      right:$euiSizeXS;
+      right: $euiSizeXS;
       top: -$euiSizeL;
       padding: $euiSizeXS;
       border-radius: $euiBorderRadius;
@@ -193,14 +166,14 @@ $controlMinWidth: $euiSize * 14;
     }
 
     &--twoLine {
-      right:$euiSizeXS;
+      right: $euiSizeXS;
       top: -$euiSizeXS;
     }
   }
 
   &:hover {
     .controlFrameFloatingActions {
-      transition:visibility .1s, opacity .1s;
+      transition: visibility .1s, opacity .1s;
       visibility: visible;
       opacity: 1;
     }

--- a/src/plugins/controls/public/controls_callout/controls_callout.scss
+++ b/src/plugins/controls/public/controls_callout/controls_callout.scss
@@ -1,0 +1,36 @@
+@include euiBreakpoint('xs', 's') {
+  .controlsIllustration {
+    display: none;
+  }
+}
+
+.controlsWrapper {
+  &--empty {
+    display: flex;
+    overflow: hidden;
+    margin: 0 $euiSizeS 0 $euiSizeS;
+
+    .addControlButton {
+      text-align: center;
+    }
+
+    @include euiBreakpoint('m', 'l', 'xl') {
+      height: $euiSize * 4;
+
+      .emptyStateText {
+        padding-left: $euiSize * 2;
+      }
+    }
+    @include euiBreakpoint('xs', 's') {
+      min-height: $euiSize * 4;
+
+      .emptyStateText {
+        padding-left: 0;
+        text-align: center;
+      }
+      .controlsIllustration__container {
+        margin-bottom: 0 !important;
+      }
+    }
+  }
+}

--- a/src/plugins/controls/public/controls_callout/controls_callout.tsx
+++ b/src/plugins/controls/public/controls_callout/controls_callout.tsx
@@ -9,8 +9,8 @@
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiButtonEmpty, EuiPanel } from '@elastic/eui';
 import React from 'react';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
-import classNames from 'classnames';
 
+import './controls_callout.scss';
 import { ControlGroupStrings } from '../control_group/control_group_strings';
 import { ControlsIllustration } from './controls_illustration';
 
@@ -32,15 +32,10 @@ export const ControlsCallout = ({ getCreateControlButton }: CalloutProps) => {
   if (controlsCalloutDismissed) return null;
 
   return (
-    <EuiPanel
-      borderRadius="m"
-      color="plain"
-      paddingSize={'s'}
-      className={classNames('controlsWrapper--empty', 'dshDashboardViewport-controls')}
-    >
+    <EuiPanel borderRadius="m" color="plain" paddingSize={'s'} className="controlsWrapper--empty">
       <EuiFlexGroup alignItems="center" gutterSize="xs" data-test-subj="controls-empty">
         <EuiFlexItem grow={1} className="controlsIllustration__container">
-          <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
             <EuiFlexItem grow={false}>
               <ControlsIllustration />
             </EuiFlexItem>
@@ -49,13 +44,15 @@ export const ControlsCallout = ({ getCreateControlButton }: CalloutProps) => {
                 <p>{ControlGroupStrings.emptyState.getCallToAction()}</p>
               </EuiText>
             </EuiFlexItem>
-            {getCreateControlButton ? (
-              <EuiFlexItem grow={false}>{getCreateControlButton()}</EuiFlexItem>
-            ) : null}
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty size="s" onClick={dismissControls}>
-                {ControlGroupStrings.emptyState.getDismissButton()}
-              </EuiButtonEmpty>
+              <EuiFlexGroup justifyContent="spaceAround" responsive={false} gutterSize="xs">
+                {getCreateControlButton && <EuiFlexItem>{getCreateControlButton()}</EuiFlexItem>}
+                <EuiFlexItem>
+                  <EuiButtonEmpty size="s" onClick={dismissControls}>
+                    {ControlGroupStrings.emptyState.getDismissButton()}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              </EuiFlexGroup>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/src/plugins/controls/public/controls_callout/controls_illustration.scss
+++ b/src/plugins/controls/public/controls_callout/controls_illustration.scss
@@ -1,6 +1,0 @@
-@include euiBreakpoint('xs', 's') {
-  .controlsIllustration {
-    width: $euiSize * 6;
-    height: $euiSize * 6;
-  }
-}

--- a/src/plugins/controls/public/controls_callout/controls_illustration.tsx
+++ b/src/plugins/controls/public/controls_callout/controls_illustration.tsx
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import './controls_illustration.scss';
 import React from 'react';
 
 export const ControlsIllustration = () => (

--- a/src/plugins/presentation_util/public/components/solution_toolbar/solution_toolbar.tsx
+++ b/src/plugins/presentation_util/public/components/solution_toolbar/solution_toolbar.tsx
@@ -53,7 +53,7 @@ export const SolutionToolbar = ({ isDarkModeEnabled, children }: Props) => {
     >
       <EuiFlexItem grow={false}>{primaryActionButton}</EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiFlexGroup responsive={false} alignItems="center" gutterSize="xs">
+        <EuiFlexGroup wrap={true} responsive={false} alignItems="center" gutterSize="xs">
           {quickButtonGroup ? <EuiFlexItem grow={false}>{quickButtonGroup}</EuiFlexItem> : null}
           {extra}
         </EuiFlexGroup>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Dashboard] [Controls] Fix mobile view of toolbar and controls callout (#128771)](https://github.com/elastic/kibana/pull/128771)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)