### PR TITLE
[ML] Fixes new anomaly detection job from saved search with no query filter

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/utils/new_job_utils.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/utils/new_job_utils.ts
@@ -66,6 +66,20 @@ export function createSearchItems(
       }
       const filterQuery = buildQueryFromFilters(filters, indexPattern);
 
+      if (combinedQuery.bool === undefined) {
+        combinedQuery.bool = {};
+        // toElasticsearchQuery may add a single multi_match item to the
+        // root of its returned query, rather than putting it inside
+        // a bool.should
+        // in this case, move it to a bool.should
+        if (combinedQuery.multi_match !== undefined) {
+          combinedQuery.bool.should = {
+            multi_match: combinedQuery.multi_match,
+          };
+          delete combinedQuery.multi_match;
+        }
+      }
+
       if (Array.isArray(combinedQuery.bool.filter) === false) {
         combinedQuery.bool.filter =
           combinedQuery.bool.filter === undefined ? [] : [combinedQuery.bool.filter];


### PR DESCRIPTION
If a saved search consists of only a single keyword, the query object created by `toElasticsearchQuery` will not produce a `bool` object and instead will produce a single `multi_match`.
This change moves the `multi_match` into a `bool` to be compatible with the rest of then query building function.

Fixes https://github.com/elastic/kibana/issues/127266

To test using the farequote dataset.
Create a saved search which contains only `AAL`.
Create a saved search which contains `AAL or ACA`.
Create a saved search which contains `airline : AAL`.

It should be possible to use all three to create anomaly detection jobs in ML.
The charts in the new job wizard should accurately reflect the filtered data.

