### PR TITLE
[7.17] [Discover] Fix "encoded URL params in context page" cloud test permissions (#126470)

### DIFF
--- a/test/functional/apps/discover/_context_encoded_url_param.ts
+++ b/test/functional/apps/discover/_context_encoded_url_param.ts
@@ -12,30 +12,32 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataGrid = getService('dataGrid');
   const kibanaServer = getService('kibanaServer');
+  const security = getService('security');
   const PageObjects = getPageObjects(['common', 'discover', 'timePicker', 'settings', 'header']);
   const testSubjects = getService('testSubjects');
   const es = getService('es');
 
-  describe('context encoded id param', () => {
+  describe('encoded URL params in context page', () => {
     before(async function () {
+      await security.testUser.setRoles(['kibana_admin', 'context_encoded_param']);
       await PageObjects.common.navigateToApp('settings');
       await es.transport.request({
-        path: '/includes-plus-symbol-doc-id/_doc/1+1=2',
+        path: '/context-encoded-param/_doc/1+1=2',
         method: 'PUT',
         body: {
           username: 'Dmitry',
           '@timestamp': '2015-09-21T09:30:23',
         },
       });
-      await PageObjects.settings.createIndexPattern('includes-plus-symbol-doc-id');
+      await PageObjects.settings.createIndexPattern('context-encoded-param');
 
       await kibanaServer.uiSettings.update({ 'doc_table:legacy': false });
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await PageObjects.common.navigateToApp('discover');
     });
 
-    it('should navigate to context page correctly', async () => {
-      await PageObjects.discover.selectIndexPattern('includes-plus-symbol-doc-id');
+    it('should navigate correctly', async () => {
+      await PageObjects.discover.selectIndexPattern('context-encoded-param');
       await PageObjects.header.waitUntilLoadingHasFinished();
 
       // navigate to the context view

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -204,6 +204,21 @@ export default async function ({ readConfigFile }) {
           kibana: [],
         },
 
+        context_encoded_param: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['context-encoded-param'],
+                privileges: ['read', 'view_index_metadata', 'manage', 'create_index', 'index'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+
         kibana_sample_read: {
           elasticsearch: {
             cluster: [],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Discover] Fix "encoded URL params in context page" cloud test permissions (#126470)](https://github.com/elastic/kibana/pull/126470)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)