### PR TITLE
Fix visualize drag and drop layout jump

### DIFF
--- a/src/plugins/vis_default_editor/public/components/__snapshots__/agg_group.test.tsx.snap
+++ b/src/plugins/vis_default_editor/public/components/__snapshots__/agg_group.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`DefaultEditorAgg component should init with the default set of props 1`
       size="s"
     />
     <eui-droppable
+      className="visEditorSidebar__collapsible--marginBottom"
       droppableId="agg_group_dnd_metrics"
     >
       <EuiDraggable

--- a/src/plugins/vis_default_editor/public/components/agg_group.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_group.tsx
@@ -145,7 +145,10 @@ function DefaultEditorAggGroup({
             <EuiSpacer size="s" />
           </>
         )}
-        <EuiDroppable droppableId={`agg_group_dnd_${groupName}`}>
+        <EuiDroppable
+          droppableId={`agg_group_dnd_${groupName}`}
+          className="visEditorSidebar__collapsible--marginBottom"
+        >
           <>
             {group.map((agg: IAggConfig, index: number) => (
               <EuiDraggable


### PR DESCRIPTION
The distance between the last draggable item and the "add" button was defined by the margin bottom of the last draggable item itself. As this element becomes `position:absolute` as soon as the user picks it up, it caused a layout jump which sometimes confused the drag and drop logic.

This PR adds the margin bottom to the dnd container which stabilizes the layout.

old (look at the "Buckets" heading to see the jump)
![drag_old](https://user-images.githubusercontent.com/1508364/161035327-df34d715-3e0f-41e0-a913-b33271b4df3c.gif)

new (no jump)
![drag_new](https://user-images.githubusercontent.com/1508364/161035362-8b7b4e4a-b11d-4534-9564-14a4656d9ded.gif)


@chandlerprall @stratoula I wasn't able to reproduce the drag release in either version but it seems like you were able to, could you check whether this PR takes care of it? Even if it doesn't I think it's worth merging as it looks much better this way.