### PR TITLE
[Actionable Observability] Bug: Rules summary on the Alerts view is not showing the count of rules

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/aggregate.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/aggregate.ts
@@ -14,12 +14,14 @@ const rewriteBodyRes: RewriteRequestCase<RuleAggregations> = ({
   rule_execution_status: ruleExecutionStatus,
   rule_enabled_status: ruleEnabledStatus,
   rule_muted_status: ruleMutedStatus,
+  rule_snoozed_status: ruleSnoozedStatus,
   ...rest
 }: any) => ({
   ...rest,
   ruleExecutionStatus,
   ruleEnabledStatus,
   ruleMutedStatus,
+  ruleSnoozedStatus,
 });
 
 export async function loadRuleAggregations({
@@ -47,5 +49,6 @@ export async function loadRuleAggregations({
       },
     }
   );
+
   return rewriteBodyRes(res);
 }

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/aggregate.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/aggregate.ts
@@ -49,6 +49,5 @@ export async function loadRuleAggregations({
       },
     }
   );
-
   return rewriteBodyRes(res);
 }


### PR DESCRIPTION
## Summary

It fixes #128900, by renaming the var `rule_snoozed_status` from snake case to camel case `ruleSnoozedStatus` like the other variables rule status vars, so alert_page will be able to read it [here](https://github.com/elastic/kibana/blob/main/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx#L118)

