### PR TITLE
[ML] Fixes outlier detection results exploration color legend display.

### DIFF
--- a/x-pack/plugins/ml/public/application/components/data_grid/common.ts
+++ b/x-pack/plugins/ml/public/application/components/data_grid/common.ts
@@ -7,7 +7,7 @@
 
 import moment from 'moment-timezone';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { EuiDataGridCellValueElementProps, EuiDataGridStyle } from '@elastic/eui';
 
@@ -372,16 +372,9 @@ export const useRenderCellValue = (
 
       const cellValue = getCellValue(columnId);
 
-      // React by default doesn't allow us to use a hook in a callback.
-      // However, this one will be passed on to EuiDataGrid and its docs
-      // recommend wrapping `setCellProps` in a `useEffect()` hook
-      // so we're ignoring the linting rule here.
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      useEffect(() => {
-        if (typeof cellPropsCallback === 'function') {
-          cellPropsCallback(columnId, cellValue, fullItem, setCellProps);
-        }
-      }, [columnId, cellValue]);
+      if (typeof cellPropsCallback === 'function') {
+        cellPropsCallback(columnId, cellValue, fullItem, setCellProps);
+      }
 
       if (typeof cellValue === 'object' && cellValue !== null) {
         return JSON.stringify(cellValue);

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/common/get_index_data.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/common/get_index_data.ts
@@ -72,8 +72,11 @@ export const getIndexData = async (
         );
         setTableItems(
           resp.hits.hits.map((d) =>
-            getProcessedFields(d.fields ?? {}, (key: string) =>
-              key.startsWith(`${jobConfig.dest.results_field}.feature_importance`)
+            getProcessedFields(
+              d.fields ?? {},
+              (key: string) =>
+                key.startsWith(`${jobConfig.dest.results_field}.feature_importance`) ||
+                key.startsWith(`${jobConfig.dest.results_field}.feature_influence`)
             )
           )
         );

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/common.test.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/common.test.ts
@@ -7,28 +7,51 @@
 
 import { DataFrameAnalyticsConfig } from '../../../../common';
 
-import { getOutlierScoreFieldName } from './common';
+import { getFeatureCount, getOutlierScoreFieldName } from './common';
 
 describe('Data Frame Analytics: <Exploration /> common utils', () => {
-  test('getOutlierScoreFieldName()', () => {
-    const jobConfig: DataFrameAnalyticsConfig = {
-      id: 'the-id',
-      analysis: { outlier_detection: {} },
-      dest: {
-        index: 'the-dest-index',
-        results_field: 'the-results-field',
-      },
-      source: {
-        index: 'the-source-index',
-      },
-      analyzed_fields: { includes: [], excludes: [] },
-      model_memory_limit: '50mb',
-      create_time: 1234,
-      version: '1.0.0',
-    };
+  describe('getOutlierScoreFieldName()', () => {
+    it('returns the outlier_score field name based on the job config.', () => {
+      const jobConfig: DataFrameAnalyticsConfig = {
+        id: 'the-id',
+        analysis: { outlier_detection: {} },
+        dest: {
+          index: 'the-dest-index',
+          results_field: 'the-results-field',
+        },
+        source: {
+          index: 'the-source-index',
+        },
+        analyzed_fields: { includes: [], excludes: [] },
+        model_memory_limit: '50mb',
+        create_time: 1234,
+        version: '1.0.0',
+      };
 
-    const outlierScoreFieldName = getOutlierScoreFieldName(jobConfig);
+      const outlierScoreFieldName = getOutlierScoreFieldName(jobConfig);
 
-    expect(outlierScoreFieldName).toMatch('the-results-field.outlier_score');
+      expect(outlierScoreFieldName).toMatch('the-results-field.outlier_score');
+    });
+  });
+
+  describe('getFeatureCount()', () => {
+    it('returns 0 features with no table items.', () => {
+      expect(getFeatureCount('ml')).toBe(0);
+    });
+    it('returns 0 features with table items with no feature influencer info', () => {
+      expect(getFeatureCount('ml', [{}])).toBe(0);
+    });
+    it('returns number of features with table items with feature influencer info', () => {
+      expect(
+        getFeatureCount('ml', [
+          {
+            'ml.feature_influence': [
+              { feature_name: ['the-feature-name-1'], influence: [0.1] },
+              { feature_name: ['the-feature-name-2'], influence: [0.2] },
+            ],
+          },
+        ])
+      ).toBe(2);
+    });
   });
 });

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/common.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/common.ts
@@ -14,15 +14,10 @@ export const getOutlierScoreFieldName = (jobConfig: DataFrameAnalyticsConfig) =>
   `${jobConfig.dest.results_field}.${OUTLIER_SCORE}`;
 
 export const getFeatureCount = (resultsField: string, tableItems: DataGridItem[] = []) => {
-  if (tableItems.length === 0) {
-    return 0;
-  }
-
-  const fullItem = tableItems[0];
-
-  if (Array.isArray(fullItem[`${resultsField}.${FEATURE_INFLUENCE}`])) {
-    return fullItem[`${resultsField}.${FEATURE_INFLUENCE}`].length;
-  }
-
-  return 0;
+  return tableItems.reduce((featureCount, fullItem) => {
+    if (Array.isArray(fullItem[`${resultsField}.${FEATURE_INFLUENCE}`])) {
+      return Math.max(featureCount, fullItem[`${resultsField}.${FEATURE_INFLUENCE}`].length);
+    }
+    return featureCount;
+  }, 0);
 };

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/outlier_exploration.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/outlier_exploration.tsx
@@ -70,7 +70,7 @@ export const OutlierExploration: FC<ExplorationProps> = React.memo(({ jobId }) =
   const featureCount = getFeatureCount(resultsField, tableItems);
   const colorRange = useColorRange(COLOR_RANGE.BLUE, COLOR_RANGE_SCALE.INFLUENCER, featureCount);
 
-  // Show the color range only if feature influence is enabled and there's more than 0 features.
+  // Show the color range only if feature influence is enabled.
   const showColorRange =
     isOutlierAnalysis(jobConfig?.analysis) &&
     jobConfig?.analysis.outlier_detection.compute_feature_influence === true;

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/outlier_exploration.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/outlier_exploration.tsx
@@ -66,16 +66,14 @@ export const OutlierExploration: FC<ExplorationProps> = React.memo(({ jobId }) =
 
   const { columnsWithCharts, tableItems } = outlierData;
 
-  const featureCount = getFeatureCount(jobConfig?.dest?.results_field || '', tableItems);
+  const resultsField = jobConfig?.dest.results_field ?? '';
+  const featureCount = getFeatureCount(resultsField, tableItems);
   const colorRange = useColorRange(COLOR_RANGE.BLUE, COLOR_RANGE_SCALE.INFLUENCER, featureCount);
 
   // Show the color range only if feature influence is enabled and there's more than 0 features.
   const showColorRange =
-    featureCount > 0 &&
     isOutlierAnalysis(jobConfig?.analysis) &&
     jobConfig?.analysis.outlier_detection.compute_feature_influence === true;
-
-  const resultsField = jobConfig?.dest.results_field ?? '';
 
   // Identify if the results index has a legacy feature influence format.
   // If feature influence was enabled for the legacy job we'll show a callout


### PR DESCRIPTION
## Summary

Fixes #127119.

Fixes the display of the color legend for the outlier results table. The check to display the legend was based on just checking if the first row on display had feature influence information. However, depending on the jobs results, not every row might be populated with feature influence information. This PR fixes it by displaying the color legend in any case when feature influence calculation is enabled and calculating the necessary `featureCount` value by looking at all available rows instead of just the first row.  Unit tests have been added for the `getFeatureCount()` function.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
