### PR TITLE
[Stack Monitoring] Add docs for Enterprise Search log collection

### DIFF
--- a/x-pack/plugins/monitoring/dev_docs/reference/data_collection_modes.md
+++ b/x-pack/plugins/monitoring/dev_docs/reference/data_collection_modes.md
@@ -138,8 +138,7 @@ ElasticsearchModule-->|/_bulk|Pipeline
 ```
 
 Beats and Enterprise Search don't have filebeat modules, but the logs can be ingested using basic JSON filebeat configurations.
-
-See (internal) https://github.com/elastic/enterprise-search-team/issues/1532 for updates on Enterprise Search filebeat modules and configurations.
+[Enterprise Search Filebeat reference configuration](https://github.com/elastic/ent-search-monitoring/blob/main/filebeat/filebeat.yml)
 
 ## Unified collection
 


### PR DESCRIPTION
Depends on https://github.com/elastic/ent-search-monitoring/pull/7