### PR TITLE
[maps] fix formatting in "import geospatial data"

### DIFF
--- a/docs/maps/import-geospatial-data.asciidoc
+++ b/docs/maps/import-geospatial-data.asciidoc
@@ -57,7 +57,7 @@ NOTE: GeoJSON feature coordinates must be in EPSG:4326 coordinate reference syst
 . Use the file chooser to select a GeoJSON file with the extension `.json` or `.geojson`.
 . Click *Import file*.
 
-discrete]
+[discrete]
 === Upload a shapefile
 
 *Upload file* indexes shapefile features in {es}, creating a document for each feature.


### PR DESCRIPTION
There is a formatting error in the current docs

<img width="600" alt="Screen Shot 2022-03-31 at 8 16 00 AM" src="https://user-images.githubusercontent.com/373691/161076635-911dae48-f614-471e-8560-0d5e44cdd6dd.png">
