### PR TITLE
[8.2] [Dashboard][Controls] Control Removal Fixes (#128699)

### DIFF
--- a/src/plugins/controls/public/control_group/embeddable/control_group_chaining_system.ts
+++ b/src/plugins/controls/public/control_group/embeddable/control_group_chaining_system.ts
@@ -67,7 +67,7 @@ export const ControlGroupChainingSystems: {
       const nextOrder = childOrder.IdsToOrder[childOutputChangedId] + 1;
       if (nextOrder >= childOrder.idsInOrder.length) return;
       setTimeout(
-        () => getChild(childOrder.idsInOrder[nextOrder]).refreshInputFromParent(),
+        () => getChild(childOrder.idsInOrder[nextOrder])?.refreshInputFromParent(),
         1 // run on next tick
       );
     },

--- a/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
+++ b/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
@@ -296,6 +296,19 @@ export class ControlGroupContainer extends Container<
     } as ControlPanelState<TEmbeddableInput>;
   }
 
+  protected onRemoveEmbeddable(idToRemove: string) {
+    const newPanels = super.onRemoveEmbeddable(idToRemove) as ControlsPanels;
+    const removedOrder = this.childOrderCache.IdsToOrder[idToRemove];
+    for (let i = removedOrder + 1; i < this.childOrderCache.idsInOrder.length; i++) {
+      const currentOrder = newPanels[this.childOrderCache.idsInOrder[i]].order;
+      newPanels[this.childOrderCache.idsInOrder[i]] = {
+        ...newPanels[this.childOrderCache.idsInOrder[i]],
+        order: currentOrder - 1,
+      };
+    }
+    return newPanels;
+  }
+
   protected getInheritedInput(id: string): ControlInput {
     const { filters, query, ignoreParentSettings, timeRange, chainingSystem } = this.getInput();
 

--- a/src/plugins/dashboard/public/application/lib/dashboard_control_group.ts
+++ b/src/plugins/dashboard/public/application/lib/dashboard_control_group.ts
@@ -9,7 +9,7 @@
 import { Subscription } from 'rxjs';
 import deepEqual from 'fast-deep-equal';
 import { compareFilters, COMPARE_ALL_OPTIONS, type Filter } from '@kbn/es-query';
-import { distinctUntilChanged, distinctUntilKeyChanged } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, distinctUntilKeyChanged } from 'rxjs/operators';
 
 import { pick } from 'lodash';
 import { DashboardContainer, DashboardContainerControlGroupInput } from '..';
@@ -118,7 +118,7 @@ export const syncDashboardControlGroup = async ({
   subscriptions.add(
     dashboardContainer
       .getInput$()
-      .pipe(distinctUntilKeyChanged('controlGroupInput'))
+      .pipe(debounceTime(10), distinctUntilKeyChanged('controlGroupInput'))
       .subscribe(() => {
         if (!isControlGroupInputEqual()) {
           if (!dashboardContainer.getInput().controlGroupInput) {

--- a/src/plugins/embeddable/public/lib/containers/container.ts
+++ b/src/plugins/embeddable/public/lib/containers/container.ts
@@ -135,9 +135,19 @@ export abstract class Container<
   public removeEmbeddable(embeddableId: string) {
     // Just a shortcut for removing the panel from input state, all internal state will get cleaned up naturally
     // by the listener.
+    const panels = this.onRemoveEmbeddable(embeddableId);
+    this.updateInput({ panels } as Partial<TContainerInput>);
+  }
+
+  /**
+   * Control the panels that are pushed to the input stream when an embeddable is
+   * removed. This can be used if removing one embeddable has knock-on effects, like
+   * re-ordering embeddables that come after it.
+   */
+  protected onRemoveEmbeddable(embeddableId: string): ContainerInput['panels'] {
     const panels = { ...this.input.panels };
     delete panels[embeddableId];
-    this.updateInput({ panels } as Partial<TContainerInput>);
+    return panels;
   }
 
   public getChildIds(): string[] {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Dashboard][Controls] Control Removal Fixes (#128699)](https://github.com/elastic/kibana/pull/128699)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)