### PR TITLE
[8.2] [Dashboard][Controls] Select Appropriate data view for sliders (#128957)

### DIFF
--- a/src/plugins/controls/public/control_types/range_slider/range_slider_editor.tsx
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider_editor.tsx
@@ -35,6 +35,8 @@ export const RangeSliderEditor = ({
   initialInput,
   setValidState,
   setDefaultTitle,
+  getRelevantDataViewId,
+  setLastUsedDataViewId,
 }: ControlEditorProps<RangeSliderEmbeddableInput>) => {
   // Controls Services Context
   const { dataViews } = pluginServices.getHooks();
@@ -50,7 +52,8 @@ export const RangeSliderEditor = ({
     if (state.fieldName) setDefaultTitle(state.fieldName);
     (async () => {
       const dataViewListItems = await getIdsWithTitle();
-      const initialId = initialInput?.dataViewId ?? (await getDefaultId());
+      const initialId =
+        initialInput?.dataViewId ?? getRelevantDataViewId?.() ?? (await getDefaultId());
       let dataView: DataView | undefined;
       if (initialId) {
         onChange({ dataViewId: initialId });
@@ -77,6 +80,7 @@ export const RangeSliderEditor = ({
           dataViews={state.dataViewListItems}
           selectedDataViewId={dataView?.id}
           onChangeDataViewId={(dataViewId) => {
+            setLastUsedDataViewId?.(dataViewId);
             onChange({ dataViewId });
             get(dataViewId).then((newDataView) =>
               setState((s) => ({ ...s, dataView: newDataView }))

--- a/src/plugins/controls/public/control_types/time_slider/time_slider_editor.tsx
+++ b/src/plugins/controls/public/control_types/time_slider/time_slider_editor.tsx
@@ -34,6 +34,8 @@ export const TimeSliderEditor = ({
   initialInput,
   setValidState,
   setDefaultTitle,
+  getRelevantDataViewId,
+  setLastUsedDataViewId,
 }: ControlEditorProps<any>) => {
   // Controls Services Context
   const { dataViews } = pluginServices.getHooks();
@@ -49,7 +51,8 @@ export const TimeSliderEditor = ({
     if (state.fieldName) setDefaultTitle(state.fieldName);
     (async () => {
       const dataViewListItems = await getIdsWithTitle();
-      const initialId = initialInput?.dataViewId ?? (await getDefaultId());
+      const initialId =
+        initialInput?.dataViewId ?? getRelevantDataViewId?.() ?? (await getDefaultId());
       let dataView: DataView | undefined;
       if (initialId) {
         onChange({ dataViewId: initialId });
@@ -76,6 +79,7 @@ export const TimeSliderEditor = ({
           dataViews={state.dataViewListItems}
           selectedDataViewId={dataView?.id}
           onChangeDataViewId={(dataViewId) => {
+            setLastUsedDataViewId?.(dataViewId);
             onChange({ dataViewId });
             get(dataViewId).then((newDataView) =>
               setState((s) => ({ ...s, dataView: newDataView }))

--- a/test/functional/apps/dashboard_elements/controls/range_slider.ts
+++ b/test/functional/apps/dashboard_elements/controls/range_slider.ts
@@ -66,7 +66,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('create and edit', async () => {
       it('can create a new range slider control from a blank state', async () => {
-        await dashboardControls.createRangeSliderControl({ fieldName: 'bytes', width: 'small' });
+        await dashboardControls.createRangeSliderControl({
+          dataViewTitle: 'logstash-*',
+          fieldName: 'bytes',
+          width: 'small',
+        });
         expect(await dashboardControls.getControlsCount()).to.be(1);
       });
 
@@ -184,7 +188,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('disables inputs when no data available', async () => {
-        await dashboardControls.createRangeSliderControl({ fieldName: 'bytes', width: 'small' });
+        await dashboardControls.createRangeSliderControl({
+          dataViewTitle: 'logstash-*',
+          fieldName: 'bytes',
+          width: 'small',
+        });
         const secondId = (await dashboardControls.getAllControlIds())[1];
         expect(
           await dashboardControls.rangeSliderGetLowerBoundAttribute(secondId, 'disabled')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Dashboard][Controls] Select Appropriate data view for sliders (#128957)](https://github.com/elastic/kibana/pull/128957)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)