### PR TITLE
[ML] Functional tests - stabilize and re-enable transform tests

### DIFF
--- a/x-pack/test/functional/apps/transform/cloning.ts
+++ b/x-pack/test/functional/apps/transform/cloning.ts
@@ -85,8 +85,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
-  // FAILING: https://github.com/elastic/kibana/issues/128967
-  describe.skip('cloning', function () {
+  describe('cloning', function () {
     const transformConfigWithPivot = getTransformConfig();
     const transformConfigWithRuntimeMapping = getTransformConfigWithRuntimeMappings();
     const transformConfigWithLatest = getLatestTransformConfig('cloning');

--- a/x-pack/test/functional/apps/transform/creation_index_pattern.ts
+++ b/x-pack/test/functional/apps/transform/creation_index_pattern.ts
@@ -21,8 +21,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
-  // Failing ES Promotion: https://github.com/elastic/kibana/issues/126812
-  describe.skip('creation_index_pattern', function () {
+  describe('creation_index_pattern', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
       await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
@@ -417,6 +416,7 @@ export default function ({ getService }: FtrProviderContext) {
         get destinationIndex(): string {
           return `user-${this.transformId}`;
         },
+        destinationDataViewTimeField: 'order_date',
         discoverAdjustSuperDatePicker: true,
         expected: {
           latestPreview: {
@@ -591,6 +591,12 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.testExecution.logTestStep('displays the create data view switch');
           await transform.wizard.assertCreateDataViewSwitchExists();
           await transform.wizard.assertCreateDataViewSwitchCheckState(true);
+
+          if (testData.destinationDataViewTimeField) {
+            await transform.testExecution.logTestStep('sets the data view time field');
+            await transform.wizard.assertDataViewTimeFieldInputExists();
+            await transform.wizard.setDataViewTimeField(testData.destinationDataViewTimeField);
+          }
 
           await transform.testExecution.logTestStep('displays the continuous mode switch');
           await transform.wizard.assertContinuousModeSwitchExists();

--- a/x-pack/test/functional/apps/transform/index.ts
+++ b/x-pack/test/functional/apps/transform/index.ts
@@ -66,6 +66,7 @@ export interface BaseTransformTestData {
   transformDescription: string;
   expected: any;
   destinationIndex: string;
+  destinationDataViewTimeField?: string;
   discoverAdjustSuperDatePicker: boolean;
 }
 

--- a/x-pack/test/functional/apps/transform/index.ts
+++ b/x-pack/test/functional/apps/transform/index.ts
@@ -15,8 +15,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
-  // FAILING TEST: https://github.com/elastic/kibana/issues/109687
-  describe.skip('transform', function () {
+  describe('transform', function () {
     this.tags(['ciGroup21', 'transform']);
 
     before(async () => {

--- a/x-pack/test/functional/services/transform/security_common.ts
+++ b/x-pack/test/functional/services/transform/security_common.ts
@@ -31,7 +31,7 @@ export function TransformSecurityCommonProvider({ getService }: FtrProviderConte
     {
       name: 'transform_dest',
       elasticsearch: {
-        indices: [{ names: ['user-*'], privileges: ['read', 'index', 'manage'] }],
+        indices: [{ names: ['user-*'], privileges: ['read', 'index', 'manage', 'delete'] }],
       },
       kibana: [],
     },

--- a/x-pack/test/functional/services/transform/wizard.ts
+++ b/x-pack/test/functional/services/transform/wizard.ts
@@ -684,6 +684,27 @@ export function TransformWizardProvider({ getService, getPageObjects }: FtrProvi
       );
     },
 
+    async assertDataViewTimeFieldInputExists() {
+      await testSubjects.existOrFail(`transformIndexPatternTimeFieldSelect`);
+    },
+
+    async assertDataViewTimeFieldValue(expectedValue: string) {
+      const actualValue = await testSubjects.getAttribute(
+        `transformIndexPatternTimeFieldSelect`,
+        'value'
+      );
+      expect(actualValue).to.eql(
+        expectedValue,
+        `Data view time field should be ${expectedValue}, got ${actualValue}`
+      );
+    },
+
+    async setDataViewTimeField(fieldName: string) {
+      const selectControl = await testSubjects.find('transformIndexPatternTimeFieldSelect');
+      await selectControl.type(fieldName);
+      await this.assertDataViewTimeFieldValue(fieldName);
+    },
+
     async assertContinuousModeSwitchExists() {
       await testSubjects.existOrFail(`transformContinuousModeSwitch`, { allowHidden: true });
     },

--- a/x-pack/test/functional/services/transform/wizard.ts
+++ b/x-pack/test/functional/services/transform/wizard.ts
@@ -685,12 +685,12 @@ export function TransformWizardProvider({ getService, getPageObjects }: FtrProvi
     },
 
     async assertDataViewTimeFieldInputExists() {
-      await testSubjects.existOrFail(`transformIndexPatternTimeFieldSelect`);
+      await testSubjects.existOrFail(`transformDataViewTimeFieldSelect`);
     },
 
     async assertDataViewTimeFieldValue(expectedValue: string) {
       const actualValue = await testSubjects.getAttribute(
-        `transformIndexPatternTimeFieldSelect`,
+        `transformDataViewTimeFieldSelect`,
         'value'
       );
       expect(actualValue).to.eql(
@@ -700,7 +700,7 @@ export function TransformWizardProvider({ getService, getPageObjects }: FtrProvi
     },
 
     async setDataViewTimeField(fieldName: string) {
-      const selectControl = await testSubjects.find('transformIndexPatternTimeFieldSelect');
+      const selectControl = await testSubjects.find('transformDataViewTimeFieldSelect');
       await selectControl.type(fieldName);
       await this.assertDataViewTimeFieldValue(fieldName);
     },


### PR DESCRIPTION
## Summary

This PR fixes and re-enables the transform functional tests.

### Details

Closes #126812
- We now make sure to explicitly set the destination index time field (by default, it stays with the alphabetically first one, which is not what we want here)

Closes #128967
Closes #109687
- We now give the `transform_poweruser` also `delete` privileges on destination indices, which are needed to apply the retention policy
- On the ES side, we're now failing early if this privilege is missing, that's why the tests started failing. The test run finishes before the retention policy is applied, that's why we didn't notice any issues with our setup before.
- For the ES changes see elastic/elasticsearch/pull/85413 
