### PR TITLE
[8.2] define configuration to expose to the browser (#128938)

### DIFF
--- a/x-pack/plugins/monitoring/server/index.ts
+++ b/x-pack/plugins/monitoring/server/index.ts
@@ -20,7 +20,15 @@ export const config: PluginConfigDescriptor<TypeOf<typeof configSchema>> = {
   schema: configSchema,
   deprecations,
   exposeToBrowser: {
-    ui: true,
+    ui: {
+      enabled: true,
+      min_interval_seconds: true,
+      show_license_expiration: true,
+      container: true,
+      ccs: {
+        enabled: true,
+      },
+    },
     kibana: true,
   },
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [define configuration to expose to the browser (#128938)](https://github.com/elastic/kibana/pull/128938)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)