### PR TITLE
[DOCS] Adds GET reporters to cases API docs

### DIFF
--- a/docs/api/cases.asciidoc
+++ b/docs/api/cases.asciidoc
@@ -17,7 +17,7 @@ these APIs:
 * <<cases-api-get-status>>
 * <<cases-api-get-comments>>
 * {security-guide}/cases-get-connector.html[Get current connector]
-* {security-guide}/cases-api-get-reporters.html[Get reporters]
+* <<cases-api-get-reporters>>
 * <<cases-api-get-tag>>
 * {security-guide}/cases-api-push.html[Push case]
 * {security-guide}/assign-connector.html[Set default Elastic Security UI connector]
@@ -40,6 +40,7 @@ include::cases/cases-api-get-case-activity.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-case.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-status.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-comments.asciidoc[leveloffset=+1]
+include::cases/cases-api-get-reporters.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-tags.asciidoc[leveloffset=+1]
 //UPDATE
 include::cases/cases-api-update.asciidoc[leveloffset=+1]

--- a/docs/api/cases/cases-api-get-reporters.asciidoc
+++ b/docs/api/cases/cases-api-get-reporters.asciidoc
@@ -1,0 +1,60 @@
+[[cases-api-get-reporters]]
+== Get reporters API
+++++
+<titleabbrev>Get reporters</titleabbrev>
+++++
+
+Returns all case reporters (users who opened cases).
+
+=== Request
+
+`GET <kibana host>:<port>/api/cases/reporters`
+
+`GET <kibana host>:<port>/s/api/cases/reporters`
+
+=== Prerequisite
+
+You must have `read` privileges for the *Cases* feature in the *Management*,
+*{observability}*, or *Security* section of the
+<<kibana-feature-privileges,{kib} feature privileges>>, depending on the
+`owner` of the cases you're seeking.
+
+=== Query parameters
+
+`owner`::
+(Optional, string) A filter to limit the retrieved reporters to a specific set 
+of applications. If this parameter is omitted, the response will contain all 
+reporters that the user has access to read.
+
+==== Response code
+
+`200`::
+   Indicates a successful call.
+
+==== Example
+
+Returns all case reporters:
+
+[source,sh]
+--------------------------------------------------
+GET api/cases/reporters
+--------------------------------------------------
+// KIBANA
+
+The API returns a JSON object with the retrieved reporters. For example:
+
+[source,json]
+--------------------------------------------------
+[
+  {
+    "full_name": "Alan Hunley",
+    "email": "ahunley@imf.usa.gov",
+    "username": "ahunley"
+  },
+  {
+    "full_name": "Rat Hustler",
+    "email": "jrhustler@aol.com",
+    "username": "rhustler"
+  }
+]
+--------------------------------------------------

--- a/docs/api/cases/cases-api-get-reporters.asciidoc
+++ b/docs/api/cases/cases-api-get-reporters.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get reporters</titleabbrev>
 ++++
 
-Returns all case reporters (users who opened cases).
+Returns information about the users who opened cases.
 
 === Request
 
@@ -22,9 +22,9 @@ You must have `read` privileges for the *Cases* feature in the *Management*,
 === Query parameters
 
 `owner`::
-(Optional, string) A filter to limit the retrieved reporters to a specific set 
-of applications. If this parameter is omitted, the response will contain all 
-reporters that the user has access to read.
+(Optional, string or array of strings) A filter to limit the retrieved reporters 
+to a specific set of applications. If this parameter is omitted, the response 
+will contain all reporters from cases that the user has access to read.
 
 ==== Response code
 

--- a/docs/api/cases/cases-api-get-tags.asciidoc
+++ b/docs/api/cases/cases-api-get-tags.asciidoc
@@ -32,9 +32,9 @@ default space is used.
 === Query parameters
 
 `owner`::
-(Optional, string) Specifies the set of applications to limit the retrieved 
-tags. If not specified, the response contains all tags that the user has access 
-to read.
+(Optional, string or array of strings) Specifies the set of applications to 
+limit the retrieved tags. If not specified, the response contains all tags from 
+cases that the user has access to read.
 
 ==== Response code
 
@@ -51,7 +51,8 @@ GET api/cases/tags
 --------------------------------------------------
 // KIBANA
 
-The API returns a JSON object with all tags for all cases. For example: 
+The API returns a JSON object with the names and email addresses of users who 
+opened cases. For example: 
 
 [source,json]
 --------------------------------------------------


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/126956

This PR copies the "get reporters" APIs from the [Security Guide](https://www.elastic.co/guide/en/security/master/cases-api-overview.html)  to the Kibana Guide. It also formats the content to align with existing Kibana APIs.

### Preview

* [GET reporters](https://kibana_129089.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-get-reporters.html)