### PR TITLE
[Cloud Posture] removed version check from integration installation hook

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/api/use_cis_kubernetes_integration.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/common/api/use_cis_kubernetes_integration.tsx
@@ -14,8 +14,6 @@ import {
 import { CIS_KUBERNETES_PACKAGE_NAME } from '../../../common/constants';
 import { useKibana } from '../hooks/use_kibana';
 
-export const CIS_KUBERNETES_INTEGRATION_VERSION = '0.0.1';
-
 /**
  * This hook will find our cis integration and return its PackageInfo
  * */
@@ -23,9 +21,8 @@ export const useCisKubernetesIntegration = () => {
   const { http } = useKibana().services;
 
   return useQuery<GetInfoResponse, DefaultPackagesInstallationError>(['integrations'], () =>
-    http.get<GetInfoResponse>(
-      epmRouteService.getInfoPath(CIS_KUBERNETES_PACKAGE_NAME, CIS_KUBERNETES_INTEGRATION_VERSION),
-      { query: { experimental: true } }
-    )
+    http.get<GetInfoResponse>(epmRouteService.getInfoPath(CIS_KUBERNETES_PACKAGE_NAME), {
+      query: { experimental: true },
+    })
   );
 };


### PR DESCRIPTION
version checking is optional, better off without it for now so we don't have to worry about it.
with it, failed check will cause a blank page since we assume our integration is not installed