### PR TITLE
[Reporting] Fix event.duration to use nanoseconds

### DIFF
--- a/x-pack/plugins/reporting/server/lib/event_logger/logger.test.ts
+++ b/x-pack/plugins/reporting/server/lib/event_logger/logger.test.ts
@@ -175,7 +175,7 @@ describe('Event Logger', () => {
     expect([result.event, result.kibana.reporting, result.message]).toMatchInlineSnapshot(`
       Array [
         Object {
-          "duration": 5500,
+          "duration": 5500000000,
           "timezone": "UTC",
         },
         Object {

--- a/x-pack/plugins/reporting/server/lib/event_logger/logger.ts
+++ b/x-pack/plugins/reporting/server/lib/event_logger/logger.ts
@@ -154,7 +154,7 @@ export function reportingEventLoggerFactory(logger: Logger) {
         {
           message,
           kibana: { reporting: { actionType: ActionType.CLAIM_TASK } },
-          event: { duration: queueDurationNs }, // this field is always assumed to be nanoseconds
+          event: { duration: queueDurationNs }, // this field is nanoseconds by ECS definition
         } as Partial<ClaimedTask>,
         this.eventObj
       );

--- a/x-pack/plugins/reporting/server/lib/event_logger/logger.ts
+++ b/x-pack/plugins/reporting/server/lib/event_logger/logger.ts
@@ -149,11 +149,12 @@ export function reportingEventLoggerFactory(logger: Logger) {
 
     logClaimTask({ queueDurationMs }: ExecutionClaimMetrics): ClaimedTask {
       const message = `claimed report ${this.report._id}`;
+      const queueDurationNs = queueDurationMs * 1000000;
       const event = deepMerge(
         {
           message,
           kibana: { reporting: { actionType: ActionType.CLAIM_TASK } },
-          event: { duration: queueDurationMs },
+          event: { duration: queueDurationNs }, // this field is always assumed to be nanoseconds
         } as Partial<ClaimedTask>,
         this.eventObj
       );


### PR DESCRIPTION
## Summary

By ECS definition, event.duration should be nanoseconds. 

Introduced in: #128325


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
