### PR TITLE
[8.2] presave transform function no longer compares no changes to the fieldName and dataViewId (#128990)

### DIFF
--- a/src/plugins/controls/public/control_types/options_list/options_list_embeddable_factory.tsx
+++ b/src/plugins/controls/public/control_types/options_list/options_list_embeddable_factory.tsx
@@ -37,8 +37,8 @@ export class OptionsListEmbeddableFactory
   ) => {
     if (
       embeddable &&
-      (!deepEqual(newInput.fieldName, embeddable.getInput().fieldName) ||
-        !deepEqual(newInput.dataViewId, embeddable.getInput().dataViewId))
+      ((newInput.fieldName && !deepEqual(newInput.fieldName, embeddable.getInput().fieldName)) ||
+        (newInput.dataViewId && !deepEqual(newInput.dataViewId, embeddable.getInput().dataViewId)))
     ) {
       // if the field name or data view id has changed in this editing session, selected options are invalid, so reset them.
       newInput.selectedOptions = [];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [presave transform function no longer compares no changes to the fieldName and dataViewId (#128990)](https://github.com/elastic/kibana/pull/128990)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)