### PR TITLE
Fix typo in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -482,6 +482,6 @@ x-pack/plugins/session_view @elastic/awp-platform
 
 ## Shared UX
 /src/plugins/shared_ux/ @elastic/shared-ux
-/pacakges/shared-ux-*/ @elastic/shared-ux
+/packages/shared-ux-*/ @elastic/shared-ux
 /src/plugins/kibana_react/ @elastic/shared-ux
 /src/plugins/kibana_react/public/code_editor @elastic/shared-ux @elastic/kibana-presentation


### PR DESCRIPTION
> Blames to #129109

Looks like we both missed it, @brianseeders 😄 🤖 
