### PR TITLE
[Security Solution] [Investigations] [Tech Debt] `StatefulBody`: remove `deepEqual` checks and replace `connect` + `mapStateToProps` with `useSelector`

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.test.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import { cloneDeep } from 'lodash/fp';
-import { set } from '@elastic/safer-lodash-set';
 import React from 'react';
 import { waitFor } from '@testing-library/react';
 
@@ -213,11 +211,23 @@ describe('Body', () => {
     test('it dispatches the `REMOVE_COLUMN` action when there is a field removed from the custom fields', async () => {
       const customFieldId = 'my.custom.runtimeField';
       const { storage } = createSecuritySolutionStorageMock();
-      const state = set<State>(cloneDeep(mockGlobalState), 'timeline.timelineById.timeline-test', {
-        ...mockGlobalState.timeline.timelineById.test,
-        id: 'timeline-test',
-        columns: [...defaultHeaders, { id: customFieldId, category: 'my' }],
-      });
+      const state: State = {
+        ...mockGlobalState,
+        timeline: {
+          ...mockGlobalState.timeline,
+          timelineById: {
+            ...mockGlobalState.timeline.timelineById,
+            'timeline-test': {
+              ...mockGlobalState.timeline.timelineById.test,
+              id: 'timeline-test',
+              columns: [
+                ...defaultHeaders,
+                { id: customFieldId, category: 'my', columnHeaderType: 'not-filtered' },
+              ],
+            },
+          },
+        },
+      };
       const store = createStore(state, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
 
       mount(
@@ -284,11 +294,21 @@ describe('Body', () => {
 
     test('Add two Note to an event', () => {
       const { storage } = createSecuritySolutionStorageMock();
-      const state = set<State>(cloneDeep(mockGlobalState), 'timeline.timelineById.timeline-test', {
-        ...mockGlobalState.timeline.timelineById.test,
-        id: 'timeline-test',
-        pinnedEventIds: { 1: true }, // we should NOT dispatch a pin event, because it's already pinned
-      });
+      const state: State = {
+        ...mockGlobalState,
+        timeline: {
+          ...mockGlobalState.timeline,
+          timelineById: {
+            ...mockGlobalState.timeline.timelineById,
+            'timeline-test': {
+              ...mockGlobalState.timeline.timelineById.test,
+              id: 'timeline-test',
+              pinnedEventIds: { 1: true }, // we should NOT dispatch a pin event, because it's already pinned
+            },
+          },
+        },
+      };
+
       const store = createStore(state, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
 
       const Proxy = (proxyProps: Props) => (

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.test.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { cloneDeep } from 'lodash/fp';
+import { set } from '@elastic/safer-lodash-set';
 import React from 'react';
 import { waitFor } from '@testing-library/react';
 
@@ -12,18 +14,27 @@ import { DefaultCellRenderer } from '../cell_rendering/default_cell_renderer';
 import '../../../../common/mock/match_media';
 import { mockBrowserFields } from '../../../../common/containers/source/mock';
 import { Direction } from '../../../../../common/search_strategy';
-import { defaultHeaders, mockTimelineData, mockTimelineModel } from '../../../../common/mock';
+import {
+  createSecuritySolutionStorageMock,
+  defaultHeaders,
+  kibanaObservable,
+  mockGlobalState,
+  mockTimelineData,
+  mockTimelineModel,
+  SUB_PLUGINS_REDUCER,
+} from '../../../../common/mock';
 import { TestProviders } from '../../../../common/mock/test_providers';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useAppToastsMock } from '../../../../common/hooks/use_app_toasts.mock';
 
-import { BodyComponent, StatefulBodyProps } from '.';
+import { StatefulBody, Props } from '.';
 import { Sort } from './sort';
 import { getDefaultControlColumn } from './control_columns';
 import { useMountAppended } from '../../../../common/utils/use_mount_appended';
 import { timelineActions } from '../../../store/timeline';
-import { ColumnHeaderOptions, TimelineTabs } from '../../../../../common/types/timeline';
+import { TimelineTabs } from '../../../../../common/types/timeline';
 import { defaultRowRenderers } from './renderers';
+import { createStore, State } from '../../../../common/store';
 
 jest.mock('../../../../common/lib/kibana/hooks');
 jest.mock('../../../../common/hooks/use_app_toasts');
@@ -126,26 +137,15 @@ describe('Body', () => {
 
   const ACTION_BUTTON_COUNT = 4;
 
-  const props: StatefulBodyProps = {
+  const props: Props = {
     activePage: 0,
     browserFields: mockBrowserFields,
-    clearSelected: jest.fn() as unknown as StatefulBodyProps['clearSelected'],
-    columnHeaders: defaultHeaders,
     data: mockTimelineData,
-    eventIdToNoteIds: {},
-    excludedRowRendererIds: [],
     id: 'timeline-test',
-    isSelectAllChecked: false,
-    loadingEventIds: [],
-    pinnedEventIds: {},
     refetch: mockRefetch,
     renderCellValue: DefaultCellRenderer,
     rowRenderers: defaultRowRenderers,
-    selectedEventIds: {},
-    setSelected: jest.fn() as unknown as StatefulBodyProps['setSelected'],
     sort: mockSort,
-    show: true,
-    showCheckboxes: false,
     tabType: TimelineTabs.query,
     totalPages: 1,
     leadingControlColumns: getDefaultControlColumn(ACTION_BUTTON_COUNT),
@@ -160,7 +160,7 @@ describe('Body', () => {
     test('it renders the column headers', () => {
       const wrapper = mount(
         <TestProviders>
-          <BodyComponent {...props} />
+          <StatefulBody {...props} />
         </TestProviders>
       );
 
@@ -170,7 +170,7 @@ describe('Body', () => {
     test('it renders the scroll container', () => {
       const wrapper = mount(
         <TestProviders>
-          <BodyComponent {...props} />
+          <StatefulBody {...props} />
         </TestProviders>
       );
 
@@ -180,7 +180,7 @@ describe('Body', () => {
     test('it renders events', () => {
       const wrapper = mount(
         <TestProviders>
-          <BodyComponent {...props} />
+          <StatefulBody {...props} />
         </TestProviders>
       );
 
@@ -192,7 +192,7 @@ describe('Body', () => {
       const testProps = { ...props, columnHeaders: headersJustTimestamp };
       const wrapper = mount(
         <TestProviders>
-          <BodyComponent {...testProps} />
+          <StatefulBody {...testProps} />
         </TestProviders>
       );
       wrapper.update();
@@ -212,16 +212,17 @@ describe('Body', () => {
 
     test('it dispatches the `REMOVE_COLUMN` action when there is a field removed from the custom fields', async () => {
       const customFieldId = 'my.custom.runtimeField';
-      const extraFieldProps = {
-        ...props,
-        columnHeaders: [
-          ...defaultHeaders,
-          { id: customFieldId, category: 'my' } as ColumnHeaderOptions,
-        ],
-      };
+      const { storage } = createSecuritySolutionStorageMock();
+      const state = set<State>(cloneDeep(mockGlobalState), 'timeline.timelineById.timeline-test', {
+        ...mockGlobalState.timeline.timelineById.test,
+        id: 'timeline-test',
+        columns: [...defaultHeaders, { id: customFieldId, category: 'my' }],
+      });
+      const store = createStore(state, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
+
       mount(
-        <TestProviders>
-          <BodyComponent {...extraFieldProps} />
+        <TestProviders store={store}>
+          <StatefulBody {...props} />
         </TestProviders>
       );
 
@@ -252,7 +253,7 @@ describe('Body', () => {
     test('Add a Note to an event', () => {
       const wrapper = mount(
         <TestProviders>
-          <BodyComponent {...props} />
+          <StatefulBody {...props} />
         </TestProviders>
       );
       addaNoteToEvent(wrapper, 'hello world');
@@ -282,17 +283,23 @@ describe('Body', () => {
     });
 
     test('Add two Note to an event', () => {
-      const Proxy = (proxyProps: StatefulBodyProps) => (
-        <TestProviders>
-          <BodyComponent {...proxyProps} />
+      const { storage } = createSecuritySolutionStorageMock();
+      const state = set<State>(cloneDeep(mockGlobalState), 'timeline.timelineById.timeline-test', {
+        ...mockGlobalState.timeline.timelineById.test,
+        id: 'timeline-test',
+        pinnedEventIds: { 1: true }, // we should NOT dispatch a pin event, because it's already pinned
+      });
+      const store = createStore(state, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
+
+      const Proxy = (proxyProps: Props) => (
+        <TestProviders store={store}>
+          <StatefulBody {...proxyProps} />
         </TestProviders>
       );
 
       const wrapper = mount(<Proxy {...props} />);
       addaNoteToEvent(wrapper, 'hello world');
       mockDispatch.mockClear();
-      wrapper.setProps({ pinnedEventIds: { 1: true } });
-      wrapper.update();
       addaNoteToEvent(wrapper, 'new hello world');
       expect(mockDispatch).toHaveBeenNthCalledWith(
         2,
@@ -309,6 +316,7 @@ describe('Body', () => {
           }).type,
         })
       );
+
       expect(mockDispatch).not.toHaveBeenCalledWith(
         timelineActions.pinEvent({
           eventId: '1',
@@ -325,7 +333,7 @@ describe('Body', () => {
     test('call the right reduce action to show event details for query tab', async () => {
       const wrapper = mount(
         <TestProviders>
-          <BodyComponent {...props} />
+          <StatefulBody {...props} />
         </TestProviders>
       );
 
@@ -350,7 +358,7 @@ describe('Body', () => {
     test('call the right reduce action to show event details for pinned tab', async () => {
       const wrapper = mount(
         <TestProviders>
-          <BodyComponent {...props} tabType={TimelineTabs.pinned} />
+          <StatefulBody {...props} tabType={TimelineTabs.pinned} />
         </TestProviders>
       );
 
@@ -375,7 +383,7 @@ describe('Body', () => {
     test('call the right reduce action to show event details for notes tab', async () => {
       const wrapper = mount(
         <TestProviders>
-          <BodyComponent {...props} tabType={TimelineTabs.notes} />
+          <StatefulBody {...props} tabType={TimelineTabs.notes} />
         </TestProviders>
       );
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.tsx
@@ -6,10 +6,8 @@
  */
 
 import { noop, isEmpty } from 'lodash/fp';
-import memoizeOne from 'memoize-one';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { connect, ConnectedProps, useDispatch } from 'react-redux';
-import deepEqual from 'fast-deep-equal';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { APP_ID } from '../../../../../common/constants';
 import { useGetUserCasesPermissions, useKibana } from '../../../../common/lib/kibana';
@@ -23,7 +21,6 @@ import {
 import { CellValueElementProps } from '../cell_rendering';
 import { DEFAULT_COLUMN_MIN_WIDTH } from './constants';
 import {
-  ColumnHeaderOptions,
   ControlColumnProps,
   RowRendererId,
   RowRenderer,
@@ -33,9 +30,8 @@ import {
 import { BrowserFields } from '../../../../common/containers/source';
 import { TimelineItem } from '../../../../../common/search_strategy/timeline';
 import { inputsModel, State } from '../../../../common/store';
-import { TimelineModel } from '../../../store/timeline/model';
 import { timelineDefaults } from '../../../store/timeline/defaults';
-import { timelineActions, timelineSelectors } from '../../../store/timeline';
+import { timelineActions } from '../../../store/timeline';
 import { OnRowSelected, OnSelectAll } from '../events';
 import { getColumnHeaders } from './column_headers/helpers';
 import { getEventIdToDataMapping } from './helpers';
@@ -44,9 +40,9 @@ import { plainRowRenderer } from './renderers/plain_row_renderer';
 import { EventsTable, TimelineBody, TimelineBodyGlobalStyle } from '../styles';
 import { ColumnHeaders } from './column_headers';
 import { Events } from './events';
-import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { timelineBodySelector } from './selectors';
 
-interface OwnProps {
+export interface Props {
   activePage: number;
   browserFields: BrowserFields;
   data: TimelineItem[];
@@ -68,31 +64,18 @@ export const hasAdditionalActions = (id: TimelineId): boolean =>
     id
   );
 
-export type StatefulBodyProps = OwnProps & PropsFromRedux;
-
 /**
  * The Body component is used everywhere timeline is used within the security application. It is the highest level component
  * that is shared across all implementations of the timeline.
  */
-export const BodyComponent = React.memo<StatefulBodyProps>(
+export const StatefulBody = React.memo<Props>(
   ({
     activePage,
     browserFields,
-    columnHeaders,
     data,
-    eventIdToNoteIds,
-    excludedRowRendererIds,
     id,
     isEventViewer = false,
-    isSelectAllChecked,
-    loadingEventIds,
-    pinnedEventIds,
-    selectedEventIds,
-    setSelected,
-    clearSelected,
     onRuleChange,
-    show,
-    showCheckboxes,
     refetch,
     renderCellValue,
     rowRenderers,
@@ -104,40 +87,59 @@ export const BodyComponent = React.memo<StatefulBodyProps>(
   }) => {
     const dispatch = useDispatch();
     const containerRef = useRef<HTMLDivElement | null>(null);
-    const getManageTimeline = useMemo(() => timelineSelectors.getManageTimelineById(), []);
-    const { queryFields, selectAll } = useDeepEqualSelector((state) =>
-      getManageTimeline(state, id)
+    const {
+      manageTimelineById: { queryFields, selectAll },
+      timeline: {
+        columns,
+        eventIdToNoteIds,
+        excludedRowRendererIds,
+        isSelectAllChecked,
+        loadingEventIds,
+        pinnedEventIds,
+        selectedEventIds,
+        showCheckboxes,
+        show,
+      } = timelineDefaults,
+    } = useSelector((state: State) => timelineBodySelector(state, id));
+
+    const columnHeaders = useMemo(
+      () => getColumnHeaders(columns, browserFields),
+      [browserFields, columns]
     );
     const ACTION_BUTTON_COUNT = 6;
 
     const onRowSelected: OnRowSelected = useCallback(
       ({ eventIds, isSelected }: { eventIds: string[]; isSelected: boolean }) => {
-        setSelected({
-          id,
-          eventIds: getEventIdToDataMapping(data, eventIds, queryFields),
-          isSelected,
-          isSelectAllChecked:
-            isSelected && Object.keys(selectedEventIds).length + 1 === data.length,
-        });
+        dispatch(
+          timelineActions.setSelected({
+            id,
+            eventIds: getEventIdToDataMapping(data, eventIds, queryFields),
+            isSelected,
+            isSelectAllChecked:
+              isSelected && Object.keys(selectedEventIds).length + 1 === data.length,
+          })
+        );
       },
-      [setSelected, id, data, selectedEventIds, queryFields]
+      [data, dispatch, id, queryFields, selectedEventIds]
     );
 
     const onSelectAll: OnSelectAll = useCallback(
       ({ isSelected }: { isSelected: boolean }) =>
         isSelected
-          ? setSelected({
-              id,
-              eventIds: getEventIdToDataMapping(
-                data,
-                data.map((event) => event._id),
-                queryFields
-              ),
-              isSelected,
-              isSelectAllChecked: isSelected,
-            })
-          : clearSelected({ id }),
-      [setSelected, clearSelected, id, data, queryFields]
+          ? dispatch(
+              timelineActions.setSelected({
+                id,
+                eventIds: getEventIdToDataMapping(
+                  data,
+                  data.map((event) => event._id),
+                  queryFields
+                ),
+                isSelected,
+                isSelectAllChecked: isSelected,
+              })
+            )
+          : dispatch(timelineActions.clearSelected({ id })),
+      [data, dispatch, id, queryFields]
     );
 
     // Sync to selectAll so parent components can select all events
@@ -290,73 +292,7 @@ export const BodyComponent = React.memo<StatefulBodyProps>(
         <TimelineBodyGlobalStyle />
       </>
     );
-  },
-  (prevProps, nextProps) =>
-    deepEqual(prevProps.browserFields, nextProps.browserFields) &&
-    deepEqual(prevProps.columnHeaders, nextProps.columnHeaders) &&
-    deepEqual(prevProps.data, nextProps.data) &&
-    deepEqual(prevProps.excludedRowRendererIds, nextProps.excludedRowRendererIds) &&
-    deepEqual(prevProps.sort, nextProps.sort) &&
-    deepEqual(prevProps.eventIdToNoteIds, nextProps.eventIdToNoteIds) &&
-    deepEqual(prevProps.pinnedEventIds, nextProps.pinnedEventIds) &&
-    deepEqual(prevProps.selectedEventIds, nextProps.selectedEventIds) &&
-    deepEqual(prevProps.loadingEventIds, nextProps.loadingEventIds) &&
-    prevProps.id === nextProps.id &&
-    prevProps.isEventViewer === nextProps.isEventViewer &&
-    prevProps.isSelectAllChecked === nextProps.isSelectAllChecked &&
-    prevProps.renderCellValue === nextProps.renderCellValue &&
-    prevProps.rowRenderers === nextProps.rowRenderers &&
-    prevProps.showCheckboxes === nextProps.showCheckboxes &&
-    prevProps.tabType === nextProps.tabType &&
-    prevProps.show === nextProps.show
+  }
 );
 
-BodyComponent.displayName = 'BodyComponent';
-
-const makeMapStateToProps = () => {
-  const memoizedColumnHeaders: (
-    headers: ColumnHeaderOptions[],
-    browserFields: BrowserFields
-  ) => ColumnHeaderOptions[] = memoizeOne(getColumnHeaders);
-
-  const getTimeline = timelineSelectors.getTimelineByIdSelector();
-  const mapStateToProps = (state: State, { browserFields, id }: OwnProps) => {
-    const timeline: TimelineModel = getTimeline(state, id) ?? timelineDefaults;
-    const {
-      columns,
-      eventIdToNoteIds,
-      excludedRowRendererIds,
-      isSelectAllChecked,
-      loadingEventIds,
-      pinnedEventIds,
-      selectedEventIds,
-      showCheckboxes,
-      show,
-    } = timeline;
-
-    return {
-      columnHeaders: memoizedColumnHeaders(columns, browserFields),
-      eventIdToNoteIds,
-      excludedRowRendererIds,
-      isSelectAllChecked,
-      loadingEventIds,
-      id,
-      pinnedEventIds,
-      selectedEventIds,
-      showCheckboxes,
-      show,
-    };
-  };
-  return mapStateToProps;
-};
-
-const mapDispatchToProps = {
-  clearSelected: timelineActions.clearSelected,
-  setSelected: timelineActions.setSelected,
-};
-
-const connector = connect(makeMapStateToProps, mapDispatchToProps);
-
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export const StatefulBody = connector(BodyComponent);
+StatefulBody.displayName = 'StatefulBody';

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/selectors/index.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/selectors/index.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockGlobalState } from '../../../../../common/mock/global_state';
+import { timelineBodySelector } from '.';
+
+describe('selectors', () => {
+  describe('timelineBodySelector', () => {
+    it('returns the expected results', () => {
+      const expected = mockGlobalState.timeline.timelineById.test;
+      const { dataViewId, documentType, defaultColumns, isLoading, queryFields, selectAll, title } =
+        expected;
+
+      const id = 'test';
+
+      expect(timelineBodySelector(mockGlobalState, id)).toEqual({
+        manageTimelineById: {
+          dataViewId,
+          documentType,
+          defaultColumns,
+          isLoading,
+          queryFields,
+          selectAll,
+          title,
+        },
+        timeline: expected,
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/selectors/index.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/selectors/index.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createSelector } from 'reselect';
+
+import {
+  getManageTimelineById,
+  getTimelineByIdSelector,
+} from '../../../../store/timeline/selectors';
+
+/**
+ * This selector combines all the selectors used by the Timeline `StatefulBody`,
+ * such that `StatefulBody` retrieves all it's Redux values via a singular
+ * usage of `useSelector`
+ *
+ * @param state - the state of the store as defined by `State` in common/store/types.ts
+ * @param id - a timeline id e.g. `timeline-1`
+ *
+ * Example:
+ *  `useSelector((state: State) => timelineBodySelector(state, id))`
+ */
+export const timelineBodySelector = createSelector(
+  getManageTimelineById(),
+  getTimelineByIdSelector(),
+  (manageTimelineById, timeline) => ({
+    manageTimelineById,
+    timeline,
+  })
+);


### PR DESCRIPTION
## [Security Solution] [Investigations] [Tech Debt] `StatefulBody`: remove `deepEqual` checks and replace `connect` + `mapStateToProps` with `useSelector`

This tech debt PR updates the Timeline `StatefulBody` component as part of a series of PRs to:

- Remove `deepEqual` checks, as detailed in <https://github.com/elastic/kibana/issues/124151>
- Replace the usage of legacy Redux APIs `connect` and `mapStateToProps` with `useSelector`, as detailed in <https://github.com/elastic/kibana/issues/124146>

There are no visual changes associated with this PR.
