### PR TITLE
[Fleet] added missing change to show Monitor logs/metrics as Enabled/Disabled

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -146,12 +146,12 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
               agentPolicy?.monitoring_enabled?.includes('logs') ? (
                 <FormattedMessage
                   id="xpack.fleet.agentList.monitorLogsEnabledText"
-                  defaultMessage="True"
+                  defaultMessage="Enabled"
                 />
               ) : (
                 <FormattedMessage
                   id="xpack.fleet.agentList.monitorLogsDisabledText"
-                  defaultMessage="False"
+                  defaultMessage="Disabled"
                 />
               )
             ) : null,
@@ -164,12 +164,12 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
               agentPolicy?.monitoring_enabled?.includes('metrics') ? (
                 <FormattedMessage
                   id="xpack.fleet.agentList.monitorMetricsEnabledText"
-                  defaultMessage="True"
+                  defaultMessage="Enabled"
                 />
               ) : (
                 <FormattedMessage
                   id="xpack.fleet.agentList.monitorMetricsDisabledText"
-                  defaultMessage="False"
+                  defaultMessage="Disabled"
                 />
               )
             ) : null,


### PR DESCRIPTION
## Summary

Fixes missed change in https://github.com/elastic/kibana/issues/102954

- Change monitor logs / metrics to read "Enabled" / "Disabled" rather than True/False.

<img width="983" alt="image" src="https://user-images.githubusercontent.com/90178898/161228192-f706e113-7f05-4aa8-a57e-e6517614f7e1.png">

<img width="498" alt="image" src="https://user-images.githubusercontent.com/90178898/161228331-92a42229-fca1-475d-b3ed-a393c192fb3a.png">



