### PR TITLE
[Workplace Search] Private sources can now make an OAuth prepare call correctly

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -720,7 +720,7 @@ describe('AddSourceLogic', () => {
 
         expect(http.get).toHaveBeenCalledWith(
           '/internal/workplace_search/account/sources/github/prepare',
-          { query: { index_permissions: false } }
+          { query: {} }
         );
       });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -375,12 +375,17 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       const route = isOrganization
         ? `/internal/workplace_search/org/sources/${serviceType}/prepare`
         : `/internal/workplace_search/account/sources/${serviceType}/prepare`;
+
+      const indexPermissionsQuery = isOrganization
+        ? { index_permissions: indexPermissions }
+        : undefined;
+
       const query = subdomain
         ? {
-            index_permissions: indexPermissions,
+            ...indexPermissionsQuery,
             subdomain,
           }
-        : { index_permissions: indexPermissions };
+        : { ...indexPermissionsQuery };
 
       try {
         const response = await HttpLogic.values.http.get<SourceConnectData>(route, {


### PR DESCRIPTION
This fixes a bug where the Kibana server would reject a private sources prepare call because of an unnecessary query parameter.