### PR TITLE
[Lens] Range event annotations

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/common/expression_functions/annotation_layer_config.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/expression_functions/annotation_layer_config.ts
@@ -33,7 +33,7 @@ export function annotationLayerConfigFunction(): ExpressionFunctionDefinition<
         help: 'Show details',
       },
       annotations: {
-        types: ['manual_event_annotation'],
+        types: ['manual_point_event_annotation', 'manual_range_event_annotation'],
         help: '',
         multi: true,
       },

--- a/src/plugins/chart_expressions/expression_xy/public/components/__snapshots__/xy_chart.test.tsx.snap
+++ b/src/plugins/chart_expressions/expression_xy/public/components/__snapshots__/xy_chart.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`XYChart component annotations should render basic annotation 1`] = `
           "label": "Annotation",
           "roundedTimestamp": 1647591917100,
           "time": "2022-03-18T08:25:17.140Z",
-          "type": "manual_event_annotation",
+          "type": "manual_point_event_annotation",
         }
       }
       hasReducedPadding={false}
@@ -78,7 +78,7 @@ exports[`XYChart component annotations should render grouped annotations preserv
           "roundedTimestamp": 1647591900000,
           "textVisibility": undefined,
           "time": "2022-03-18T08:25:00.000Z",
-          "type": "manual_event_annotation",
+          "type": "manual_point_event_annotation",
         }
       }
       hasReducedPadding={true}
@@ -137,7 +137,7 @@ exports[`XYChart component annotations should render grouped annotations with de
           "roundedTimestamp": 1647591900000,
           "textVisibility": undefined,
           "time": "2022-03-18T08:25:00.000Z",
-          "type": "manual_event_annotation",
+          "type": "manual_point_event_annotation",
         }
       }
       hasReducedPadding={true}
@@ -186,7 +186,7 @@ exports[`XYChart component annotations should render simplified annotation when 
           "label": "Annotation",
           "roundedTimestamp": 1647591917100,
           "time": "2022-03-18T08:25:17.140Z",
-          "type": "manual_event_annotation",
+          "type": "manual_point_event_annotation",
         }
       }
       hasReducedPadding={false}

--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
@@ -2568,7 +2568,7 @@ describe('XYChart component', () => {
       time: '2022-03-18T08:25:00.000Z',
       label: 'Event 1',
       icon: 'triangle',
-      type: 'manual_event_annotation',
+      type: 'manual_point_event_annotation',
       color: 'red',
       lineStyle: 'dashed',
       lineWidth: 3,
@@ -2582,7 +2582,7 @@ describe('XYChart component', () => {
           {
             time: '2022-03-18T08:25:17.140Z',
             label: 'Annotation',
-            type: 'manual_event_annotation',
+            type: 'manual_point_event_annotation',
           },
         ],
       },

--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -71,7 +71,7 @@ import { getLegendAction } from './legend_action';
 import { ReferenceLineAnnotations, computeChartMargins } from './reference_lines';
 import { visualizationDefinitions } from '../definitions';
 import { XYLayerConfigResult } from '../../common/types';
-import { Annotations, getAnnotationsGroupedByInterval } from './annotations';
+import { Annotations, getAnnotationsGroupedByInterval, getRangeAnnotations } from './annotations';
 
 import './xy_chart.scss';
 
@@ -271,18 +271,21 @@ export function XYChart({
 
   const xColumnId = firstTable.columns.find((col) => col.id === filteredLayers[0].xAccessor)?.id;
 
-  const groupedAnnotations = getAnnotationsGroupedByInterval(
+  const groupedLineAnnotations = getAnnotationsGroupedByInterval(
     annotationsLayers,
     minInterval,
     xColumnId ? firstTable.rows[0]?.[xColumnId] : undefined,
     xAxisFormatter
   );
+  const rangeAnnotations = getRangeAnnotations(annotationsLayers);
+
   const visualConfigs = [
     ...referenceLineLayers.flatMap(({ yConfig }) => yConfig),
-    ...groupedAnnotations,
+    ...groupedLineAnnotations,
   ].filter(Boolean);
 
-  const linesPaddings = getLinesCausedPaddings(visualConfigs, yAxesMap);
+  const shouldHideDetails = annotationsLayers.length > 0 ? annotationsLayers[0].hide : false;
+  const linesPaddings = !shouldHideDetails ? getLinesCausedPaddings(visualConfigs, yAxesMap) : {};
 
   const getYAxesStyle = (groupId: 'left' | 'right') => {
     const tickVisible =
@@ -936,15 +939,16 @@ export function XYChart({
           paddingMap={linesPaddings}
         />
       ) : null}
-      {groupedAnnotations.length ? (
+      {rangeAnnotations.length || groupedLineAnnotations.length ? (
         <Annotations
-          hide={annotationsLayers?.[0].hide}
-          groupedAnnotations={groupedAnnotations}
+          rangeAnnotations={rangeAnnotations}
+          groupedLineAnnotations={groupedLineAnnotations}
           formatter={xAxisFormatter}
           isHorizontal={shouldRotate}
           paddingMap={linesPaddings}
           isBarChart={filteredBarLayers.length > 0}
           minInterval={minInterval}
+          hide={annotationsLayers?.[0].hide}
         />
       ) : null}
     </Chart>

--- a/src/plugins/event_annotation/common/event_annotation_group/index.ts
+++ b/src/plugins/event_annotation/common/event_annotation_group/index.ts
@@ -35,7 +35,7 @@ export function eventAnnotationGroup(): ExpressionFunctionDefinition<
     }),
     args: {
       annotations: {
-        types: ['manual_event_annotation'],
+        types: ['manual_point_event_annotation', 'manual_range_event_annotation'],
         help: i18n.translate('eventAnnotation.group.args.annotationConfigs', {
           defaultMessage: 'Annotation configs',
         }),

--- a/src/plugins/event_annotation/common/index.ts
+++ b/src/plugins/event_annotation/common/index.ts
@@ -7,7 +7,7 @@
  */
 
 export type { EventAnnotationArgs, EventAnnotationOutput } from './manual_event_annotation/types';
-export { manualEventAnnotation } from './manual_event_annotation';
+export { manualPointEventAnnotation, manualRangeEventAnnotation } from './manual_event_annotation';
 export { eventAnnotationGroup } from './event_annotation_group';
 export type { EventAnnotationGroupArgs } from './event_annotation_group';
 export type { EventAnnotationConfig } from './types';

--- a/src/plugins/event_annotation/common/manual_event_annotation/index.ts
+++ b/src/plugins/event_annotation/common/manual_event_annotation/index.ts
@@ -8,16 +8,22 @@
 
 import type { ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
 import { i18n } from '@kbn/i18n';
-import type { EventAnnotationArgs, EventAnnotationOutput } from './types';
-export const manualEventAnnotation: ExpressionFunctionDefinition<
-  'manual_event_annotation',
+import type {
+  ManualRangeEventAnnotationArgs,
+  ManualRangeEventAnnotationOutput,
+  ManualPointEventAnnotationArgs,
+  ManualPointEventAnnotationOutput,
+} from './types';
+
+export const manualPointEventAnnotation: ExpressionFunctionDefinition<
+  'manual_point_event_annotation',
   null,
-  EventAnnotationArgs,
-  EventAnnotationOutput
+  ManualPointEventAnnotationArgs,
+  ManualPointEventAnnotationOutput
 > = {
-  name: 'manual_event_annotation',
+  name: 'manual_point_event_annotation',
   aliases: [],
-  type: 'manual_event_annotation',
+  type: 'manual_point_event_annotation',
   help: i18n.translate('eventAnnotation.manualAnnotation.description', {
     defaultMessage: `Configure manual annotation`,
   }),
@@ -73,9 +79,68 @@ export const manualEventAnnotation: ExpressionFunctionDefinition<
       }),
     },
   },
-  fn: function fn(input: unknown, args: EventAnnotationArgs) {
+  fn: function fn(input: unknown, args: ManualPointEventAnnotationArgs) {
     return {
-      type: 'manual_event_annotation',
+      type: 'manual_point_event_annotation',
+      ...args,
+    };
+  },
+};
+
+export const manualRangeEventAnnotation: ExpressionFunctionDefinition<
+  'manual_range_event_annotation',
+  null,
+  ManualRangeEventAnnotationArgs,
+  ManualRangeEventAnnotationOutput
+> = {
+  name: 'manual_range_event_annotation',
+  aliases: [],
+  type: 'manual_range_event_annotation',
+  help: i18n.translate('eventAnnotation.manualAnnotation.description', {
+    defaultMessage: `Configure manual annotation`,
+  }),
+  inputTypes: ['null'],
+  args: {
+    time: {
+      types: ['string'],
+      help: i18n.translate('eventAnnotation.manualAnnotation.args.time', {
+        defaultMessage: `Timestamp for annotation`,
+      }),
+    },
+    endTime: {
+      types: ['string'],
+      help: i18n.translate('eventAnnotation.manualAnnotation.args.endTime', {
+        defaultMessage: `Timestamp for range annotation`,
+      }),
+      required: false,
+    },
+    outside: {
+      types: ['boolean'],
+      help: '',
+      required: false,
+    },
+    label: {
+      types: ['string'],
+      help: i18n.translate('eventAnnotation.manualAnnotation.args.label', {
+        defaultMessage: `The name of the annotation`,
+      }),
+    },
+    color: {
+      types: ['string'],
+      help: i18n.translate('eventAnnotation.manualAnnotation.args.color', {
+        defaultMessage: 'The color of the line',
+      }),
+    },
+    isHidden: {
+      types: ['boolean'],
+      help: i18n.translate('eventAnnotation.manualAnnotation.args.isHidden', {
+        defaultMessage: `Switch to hide annotation`,
+      }),
+    },
+  },
+  fn: function fn(input: unknown, args: ManualRangeEventAnnotationArgs) {
+    return {
+      type: 'manual_range_event_annotation',
       ...args,
     };
   },

--- a/src/plugins/event_annotation/common/manual_event_annotation/types.ts
+++ b/src/plugins/event_annotation/common/manual_event_annotation/types.ts
@@ -6,10 +6,26 @@
  * Side Public License, v 1.
  */
 
-import { StyleProps } from '../types';
+import { PointStyleProps, RangeStyleProps } from '../types';
 
-export type EventAnnotationArgs = {
+export type ManualPointEventAnnotationArgs = {
   time: string;
-} & StyleProps;
+} & PointStyleProps;
 
-export type EventAnnotationOutput = EventAnnotationArgs & { type: 'manual_event_annotation' };
+export type ManualPointEventAnnotationOutput = ManualPointEventAnnotationArgs & {
+  type: 'manual_point_event_annotation';
+};
+
+export type ManualRangeEventAnnotationArgs = {
+  time: string;
+  endTime: string;
+} & RangeStyleProps;
+
+export type ManualRangeEventAnnotationOutput = ManualRangeEventAnnotationArgs & {
+  type: 'manual_range_event_annotation';
+};
+
+export type EventAnnotationArgs = ManualPointEventAnnotationArgs | ManualRangeEventAnnotationArgs;
+export type EventAnnotationOutput =
+  | ManualPointEventAnnotationOutput
+  | ManualRangeEventAnnotationOutput;

--- a/src/plugins/event_annotation/common/types.ts
+++ b/src/plugins/event_annotation/common/types.ts
@@ -7,10 +7,11 @@
  */
 
 export type LineStyle = 'solid' | 'dashed' | 'dotted';
+export type Fill = 'inside' | 'outside' | 'none';
 export type AnnotationType = 'manual';
-export type KeyType = 'point_in_time';
+export type KeyType = 'point_in_time' | 'range';
 
-export interface StyleProps {
+export interface PointStyleProps {
   label: string;
   color?: string;
   icon?: string;
@@ -20,10 +21,31 @@ export interface StyleProps {
   isHidden?: boolean;
 }
 
-export type EventAnnotationConfig = {
+export type PointInTimeEventAnnotationConfig = {
   id: string;
   key: {
-    type: KeyType;
+    type: 'point_in_time';
     timestamp: string;
   };
-} & StyleProps;
+} & PointStyleProps;
+
+export interface RangeStyleProps {
+  label: string;
+  color?: string;
+  outside?: boolean;
+  textVisibility?: boolean;
+  isHidden?: boolean;
+}
+
+export type RangeEventAnnotationConfig = {
+  id: string;
+  key: {
+    type: 'range';
+    timestamp: string;
+    endTimestamp: string;
+  };
+} & RangeStyleProps;
+
+export type StyleProps = PointStyleProps & RangeStyleProps;
+
+export type EventAnnotationConfig = PointInTimeEventAnnotationConfig | RangeEventAnnotationConfig;

--- a/src/plugins/event_annotation/public/event_annotation_service/helpers.ts
+++ b/src/plugins/event_annotation/public/event_annotation_service/helpers.ts
@@ -5,5 +5,13 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+import { i18n } from '@kbn/i18n';
 import { euiLightVars } from '@kbn/ui-theme';
 export const defaultAnnotationColor = euiLightVars.euiColorAccent;
+
+export const defaultAnnotationLabel = i18n.translate(
+  'eventAnnotation.manualAnnotation.defaultAnnotationLabel',
+  {
+    defaultMessage: 'Event',
+  }
+);

--- a/src/plugins/event_annotation/public/event_annotation_service/service.tsx
+++ b/src/plugins/event_annotation/public/event_annotation_service/service.tsx
@@ -7,43 +7,66 @@
  */
 
 import { EventAnnotationServiceType } from './types';
-import { defaultAnnotationColor } from './helpers';
+import { defaultAnnotationColor, defaultAnnotationLabel } from './helpers';
+import { EventAnnotationConfig } from '../../common';
+import { RangeEventAnnotationConfig } from '../../common/types';
 
 export function hasIcon(icon: string | undefined): icon is string {
   return icon != null && icon !== 'empty';
 }
 
+const isRangeAnnotation = (
+  annotation?: EventAnnotationConfig
+): annotation is RangeEventAnnotationConfig => {
+  return Boolean(annotation && annotation?.key.type === 'range');
+};
+
 export function getEventAnnotationService(): EventAnnotationServiceType {
   return {
-    toExpression: ({
-      label,
-      isHidden,
-      color,
-      lineStyle,
-      lineWidth,
-      icon,
-      textVisibility,
-      time,
-    }) => {
-      return {
-        type: 'expression',
-        chain: [
-          {
-            type: 'function',
-            function: 'manual_event_annotation',
-            arguments: {
-              time: [time],
-              label: [label],
-              color: [color || defaultAnnotationColor],
-              lineWidth: [lineWidth || 1],
-              lineStyle: [lineStyle || 'solid'],
-              icon: hasIcon(icon) ? [icon] : ['triangle'],
-              textVisibility: [textVisibility || false],
-              isHidden: [Boolean(isHidden)],
+    toExpression: (annotation) => {
+      if (isRangeAnnotation(annotation)) {
+        const { label, isHidden, color, key, outside } = annotation;
+        const { timestamp: time, endTimestamp: endTime } = key;
+        return {
+          type: 'expression',
+          chain: [
+            {
+              type: 'function',
+              function: 'manual_range_event_annotation',
+              arguments: {
+                time: [time],
+                endTime: [endTime],
+                label: [label || defaultAnnotationLabel],
+                color: [color || defaultAnnotationColor],
+                outside: [Boolean(outside)],
+                isHidden: [Boolean(isHidden)],
+              },
             },
-          },
-        ],
-      };
+          ],
+        };
+      } else {
+        const { label, isHidden, color, lineStyle, lineWidth, icon, key, textVisibility } =
+          annotation;
+        return {
+          type: 'expression',
+          chain: [
+            {
+              type: 'function',
+              function: 'manual_point_event_annotation',
+              arguments: {
+                time: [key.timestamp],
+                label: [label || defaultAnnotationLabel],
+                color: [color || defaultAnnotationColor],
+                lineWidth: [lineWidth || 1],
+                lineStyle: [lineStyle || 'solid'],
+                icon: hasIcon(icon) ? [icon] : ['triangle'],
+                textVisibility: [textVisibility || false],
+                isHidden: [Boolean(isHidden)],
+              },
+            },
+          ],
+        };
+      }
     },
   };
 }

--- a/src/plugins/event_annotation/public/event_annotation_service/types.ts
+++ b/src/plugins/event_annotation/public/event_annotation_service/types.ts
@@ -7,8 +7,8 @@
  */
 
 import { ExpressionAstExpression } from '../../../expressions/common/ast';
-import { EventAnnotationArgs } from '../../common';
+import { EventAnnotationConfig } from '../../common';
 
 export interface EventAnnotationServiceType {
-  toExpression: (props: EventAnnotationArgs) => ExpressionAstExpression;
+  toExpression: (props: EventAnnotationConfig) => ExpressionAstExpression;
 }

--- a/src/plugins/event_annotation/public/plugin.ts
+++ b/src/plugins/event_annotation/public/plugin.ts
@@ -8,7 +8,11 @@
 
 import { Plugin, CoreSetup } from 'kibana/public';
 import { ExpressionsSetup } from '../../expressions/public';
-import { manualEventAnnotation, eventAnnotationGroup } from '../common';
+import {
+  manualPointEventAnnotation,
+  manualRangeEventAnnotation,
+  eventAnnotationGroup,
+} from '../common';
 import { EventAnnotationService } from './event_annotation_service';
 
 interface SetupDependencies {
@@ -28,7 +32,8 @@ export class EventAnnotationPlugin
   private readonly eventAnnotationService = new EventAnnotationService();
 
   public setup(core: CoreSetup, dependencies: SetupDependencies): EventAnnotationPluginSetup {
-    dependencies.expressions.registerFunction(manualEventAnnotation);
+    dependencies.expressions.registerFunction(manualPointEventAnnotation);
+    dependencies.expressions.registerFunction(manualRangeEventAnnotation);
     dependencies.expressions.registerFunction(eventAnnotationGroup);
     return this.eventAnnotationService;
   }

--- a/src/plugins/event_annotation/server/plugin.ts
+++ b/src/plugins/event_annotation/server/plugin.ts
@@ -7,7 +7,11 @@
  */
 
 import { CoreSetup, Plugin } from 'kibana/server';
-import { manualEventAnnotation, eventAnnotationGroup } from '../common';
+import {
+  manualPointEventAnnotation,
+  eventAnnotationGroup,
+  manualRangeEventAnnotation,
+} from '../common';
 import { ExpressionsServerSetup } from '../../expressions/server';
 
 interface SetupDependencies {
@@ -16,7 +20,8 @@ interface SetupDependencies {
 
 export class EventAnnotationServerPlugin implements Plugin<object, object> {
   public setup(core: CoreSetup, dependencies: SetupDependencies) {
-    dependencies.expressions.registerFunction(manualEventAnnotation);
+    dependencies.expressions.registerFunction(manualPointEventAnnotation);
+    dependencies.expressions.registerFunction(manualRangeEventAnnotation);
     dependencies.expressions.registerFunction(eventAnnotationGroup);
 
     return {};

--- a/x-pack/plugins/lens/public/xy_visualization/annotations/helpers.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/annotations/helpers.tsx
@@ -29,6 +29,13 @@ export const defaultAnnotationLabel = i18n.translate('xpack.lens.xyChart.default
   defaultMessage: 'Event',
 });
 
+export const defaultRangeAnnotationLabel = i18n.translate(
+  'xpack.lens.xyChart.defaultRangeAnnotationLabel',
+  {
+    defaultMessage: 'Event range',
+  }
+);
+
 export function getStaticDate(
   dataLayers: XYDataLayerConfig[],
   activeData: FramePublicAPI['activeData']

--- a/x-pack/plugins/lens/public/xy_visualization/to_expression.ts
+++ b/x-pack/plugins/lens/public/xy_visualization/to_expression.ts
@@ -31,7 +31,7 @@ import {
   getReferenceLayers,
   getAnnotationsLayers,
 } from './visualization_helpers';
-import { getUniqueLabels, defaultAnnotationLabel } from './annotations/helpers';
+import { getUniqueLabels } from './annotations/helpers';
 import { layerTypes } from '../../common';
 
 export const getSortedAccessors = (
@@ -86,7 +86,7 @@ const simplifiedLayerExpression = {
   [layerTypes.REFERENCELINE]: (layer: XYReferenceLineLayerConfig) => ({
     ...layer,
     hide: true,
-    yConfig: layer.yConfig?.map(({ lineWidth, ...rest }) => ({
+    yConfig: layer.yConfig?.map(({ ...rest }) => ({
       ...rest,
       lineWidth: 1,
       icon: undefined,
@@ -96,12 +96,6 @@ const simplifiedLayerExpression = {
   [layerTypes.ANNOTATIONS]: (layer: XYAnnotationLayerConfig) => ({
     ...layer,
     hide: true,
-    annotations: layer.annotations?.map(({ lineWidth, ...rest }) => ({
-      ...rest,
-      lineWidth: 1,
-      icon: undefined,
-      textVisibility: false,
-    })),
   }),
 };
 
@@ -420,19 +414,7 @@ const annotationLayerToExpression = (
           hide: [Boolean(layer.hide)],
           layerId: [layer.layerId],
           annotations: layer.annotations
-            ? layer.annotations.map(
-                (ann): Ast =>
-                  eventAnnotationService.toExpression({
-                    time: ann.key.timestamp,
-                    label: ann.label || defaultAnnotationLabel,
-                    textVisibility: ann.textVisibility,
-                    icon: ann.icon,
-                    lineStyle: ann.lineStyle,
-                    lineWidth: ann.lineWidth,
-                    color: ann.color,
-                    isHidden: Boolean(ann.isHidden),
-                  })
-              )
+            ? layer.annotations.map((ann): Ast => eventAnnotationService.toExpression(ann))
             : [],
         },
       },

--- a/x-pack/plugins/lens/public/xy_visualization/xy_config_panel/annotations_config_panel/index.scss
+++ b/x-pack/plugins/lens/public/xy_visualization/xy_config_panel/annotations_config_panel/index.scss
@@ -1,0 +1,8 @@
+
+.lnsRowCompressedMargin + .lnsRowCompressedMargin {
+  margin-top: $euiSizeS;
+}
+
+.lnsConfigPanelNoPadding {
+  padding: 0;
+}

--- a/x-pack/plugins/lens/public/xy_visualization/xy_config_panel/annotations_config_panel/index.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/xy_config_panel/annotations_config_panel/index.tsx
@@ -5,23 +5,70 @@
  * 2.0.
  */
 
+import './index.scss';
 import React, { useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiDatePicker, EuiFormRow, EuiSwitch, EuiSwitchEvent } from '@elastic/eui';
 import type { PaletteRegistry } from '@kbn/coloring';
+import {
+  EuiDatePicker,
+  EuiFormRow,
+  EuiSwitch,
+  EuiSwitchEvent,
+  EuiButtonGroup,
+  EuiFormLabel,
+  EuiFormControlLayout,
+} from '@elastic/eui';
 import moment from 'moment';
-import { EventAnnotationConfig } from 'src/plugins/event_annotation/common/types';
-import type { VisualizationDimensionEditorProps } from '../../../types';
-import { State, XYState, XYAnnotationLayerConfig } from '../../types';
+import {
+  EventAnnotationConfig,
+  PointInTimeEventAnnotationConfig,
+  RangeEventAnnotationConfig,
+} from 'src/plugins/event_annotation/common/types';
+import { search } from '../../../../../../../src/plugins/data/public';
+import type { FramePublicAPI, VisualizationDimensionEditorProps } from '../../../types';
+import { State, XYState, XYAnnotationLayerConfig, XYDataLayerConfig } from '../../types';
 import { FormatFactory } from '../../../../common';
 import { DimensionEditorSection, NameInput, useDebouncedValue } from '../../../shared_components';
 import { isHorizontalChart } from '../../state_helpers';
-import { defaultAnnotationLabel } from '../../annotations/helpers';
+import { defaultAnnotationLabel, defaultRangeAnnotationLabel } from '../../annotations/helpers';
 import { ColorPicker } from '../color_picker';
 import { IconSelectSetting, TextDecorationSetting } from '../shared/marker_decoration_settings';
 import { LineStyleSettings } from '../shared/line_style_settings';
 import { updateLayer } from '..';
 import { annotationsIconSet } from './icon_set';
+import { getDataLayers } from '../../visualization_helpers';
+
+export const getEndTimestamp = (
+  startTime: string,
+  activeData: FramePublicAPI['activeData'],
+  dataLayers: XYDataLayerConfig[]
+) => {
+  const startTimeNumber = moment(startTime).valueOf();
+  const fallbackValue = moment(startTimeNumber + 8.64e7).toISOString();
+
+  const dataLayersId = dataLayers.map(({ layerId }) => layerId);
+  if (
+    !dataLayersId.length ||
+    !activeData ||
+    Object.entries(activeData)
+      .filter(([key]) => dataLayersId.includes(key))
+      .every(([, { rows }]) => !rows || !rows.length)
+  ) {
+    return fallbackValue;
+  }
+  const xColumn = activeData?.[dataLayersId[0]].columns.find(
+    (column) => column.id === dataLayers[0].xAccessor
+  );
+  if (!xColumn) {
+    return fallbackValue;
+  }
+
+  const dateInterval = search.aggs.getDateHistogramMetaDataByDatatableColumn(xColumn)?.interval;
+  if (!dateInterval) return fallbackValue;
+  const intervalDuration = search.aggs.parseInterval(dateInterval);
+  if (!intervalDuration) return fallbackValue;
+  return moment(startTimeNumber + 3 * intervalDuration.as('milliseconds')).toISOString();
+};
 
 export const AnnotationsPanel = (
   props: VisualizationDimensionEditorProps<State> & {
@@ -29,7 +76,7 @@ export const AnnotationsPanel = (
     paletteService: PaletteRegistry;
   }
 ) => {
-  const { state, setState, layerId, accessor } = props;
+  const { state, setState, layerId, accessor, frame } = props;
   const isHorizontal = isHorizontalChart(state.layers);
 
   const { inputValue: localState, handleInputChange: setLocalState } = useDebouncedValue<XYState>({
@@ -42,10 +89,12 @@ export const AnnotationsPanel = (
     (l) => l.layerId === layerId
   ) as XYAnnotationLayerConfig;
 
-  const currentAnnotations = localLayer.annotations?.find((c) => c.id === accessor);
+  const currentAnnotation = localLayer.annotations?.find((c) => c.id === accessor);
+
+  const isRange = isRangeAnnotation(currentAnnotation);
 
   const setAnnotations = useCallback(
-    (annotations: Partial<EventAnnotationConfig> | undefined) => {
+    (annotations) => {
       if (annotations == null) {
         return;
       }
@@ -68,21 +117,94 @@ export const AnnotationsPanel = (
           defaultMessage: 'Placement',
         })}
       >
-        <ConfigPanelDatePicker
-          value={moment(currentAnnotations?.key.timestamp)}
-          onChange={(date) => {
-            if (date) {
-              setAnnotations({
-                key: {
-                  ...(currentAnnotations?.key || { type: 'point_in_time' }),
-                  timestamp: date.toISOString(),
-                },
-              });
-            }
-          }}
-          label={i18n.translate('xpack.lens.xyChart.annotationDate', {
-            defaultMessage: 'Annotation date',
-          })}
+        {isRange ? (
+          <>
+            <ConfigPanelRangeDatePicker
+              prependLabel={i18n.translate('xpack.lens.xyChart.annotationDate.from', {
+                defaultMessage: 'From',
+              })}
+              value={moment(currentAnnotation?.key.timestamp)}
+              onChange={(date) => {
+                if (date) {
+                  const currentEndTime = moment(currentAnnotation?.key.endTimestamp).valueOf();
+                  if (currentEndTime < date.valueOf()) {
+                    const currentStartTime = moment(currentAnnotation?.key.timestamp).valueOf();
+                    const dif = currentEndTime - currentStartTime;
+                    setAnnotations({
+                      key: {
+                        ...(currentAnnotation?.key || { type: 'range' }),
+                        timestamp: date.toISOString(),
+                        endTimestamp: moment(date.valueOf() + dif).toISOString(),
+                      },
+                    });
+                  } else {
+                    setAnnotations({
+                      key: {
+                        ...(currentAnnotation?.key || { type: 'range' }),
+                        timestamp: date.toISOString(),
+                      },
+                    });
+                  }
+                }
+              }}
+              label={i18n.translate('xpack.lens.xyChart.annotationDate', {
+                defaultMessage: 'Annotation date',
+              })}
+            />
+            <ConfigPanelRangeDatePicker
+              prependLabel={i18n.translate('xpack.lens.xyChart.annotationDate.to', {
+                defaultMessage: 'To',
+              })}
+              value={moment(currentAnnotation?.key.endTimestamp)}
+              onChange={(date) => {
+                if (date) {
+                  const currentStartTime = moment(currentAnnotation?.key.timestamp).valueOf();
+                  if (currentStartTime > date.valueOf()) {
+                    const currentEndTime = moment(currentAnnotation?.key.endTimestamp).valueOf();
+                    const dif = currentEndTime - currentStartTime;
+                    setAnnotations({
+                      key: {
+                        ...(currentAnnotation?.key || { type: 'range' }),
+                        endTimestamp: date.toISOString(),
+                        timestamp: moment(date.valueOf() - dif).toISOString(),
+                      },
+                    });
+                  } else {
+                    setAnnotations({
+                      key: {
+                        ...(currentAnnotation?.key || { type: 'range' }),
+                        endTimestamp: date.toISOString(),
+                      },
+                    });
+                  }
+                }
+              }}
+            />
+          </>
+        ) : (
+          <ConfigPanelRangeDatePicker
+            label={i18n.translate('xpack.lens.xyChart.annotationDate', {
+              defaultMessage: 'Annotation date',
+            })}
+            value={moment(currentAnnotation?.key.timestamp)}
+            onChange={(date) => {
+              if (date) {
+                setAnnotations({
+                  key: {
+                    ...(currentAnnotation?.key || { type: 'point_in_time' }),
+                    timestamp: date.toISOString(),
+                  },
+                });
+              }
+            }}
+          />
+        )}
+
+        <ConfigPanelApplyAsRangeSwitch
+          annotation={currentAnnotation}
+          onChange={setAnnotations}
+          activeData={frame.activeData}
+          state={state}
         />
       </DimensionEditorSection>
       <DimensionEditorSection
@@ -91,32 +213,83 @@ export const AnnotationsPanel = (
         })}
       >
         <NameInput
-          value={currentAnnotations?.label || defaultAnnotationLabel}
+          value={currentAnnotation?.label || defaultAnnotationLabel}
           defaultValue={defaultAnnotationLabel}
           onChange={(value) => {
             setAnnotations({ label: value });
           }}
         />
-        <IconSelectSetting
-          setConfig={setAnnotations}
-          currentConfig={{
-            axisMode: 'bottom',
-            ...currentAnnotations,
-          }}
-          customIconSet={annotationsIconSet}
-        />
-        <TextDecorationSetting
-          setConfig={setAnnotations}
-          currentConfig={{
-            axisMode: 'bottom',
-            ...currentAnnotations,
-          }}
-        />
-        <LineStyleSettings
-          isHorizontal={isHorizontal}
-          setConfig={setAnnotations}
-          currentConfig={currentAnnotations}
-        />
+        {!isRange && (
+          <IconSelectSetting
+            setConfig={setAnnotations}
+            currentConfig={{
+              axisMode: 'bottom',
+              ...currentAnnotation,
+            }}
+            customIconSet={annotationsIconSet}
+          />
+        )}
+        {!isRange && (
+          <TextDecorationSetting
+            setConfig={setAnnotations}
+            currentConfig={{
+              axisMode: 'bottom',
+              ...currentAnnotation,
+            }}
+          />
+        )}
+        {!isRange && (
+          <LineStyleSettings
+            isHorizontal={isHorizontal}
+            setConfig={setAnnotations}
+            currentConfig={currentAnnotation}
+          />
+        )}
+
+        {isRange && (
+          <EuiFormRow
+            label={i18n.translate('xpack.lens.xyChart.fillStyle', {
+              defaultMessage: 'Fill',
+            })}
+            display="columnCompressed"
+            fullWidth
+          >
+            <EuiButtonGroup
+              legend={i18n.translate('xpack.lens.xyChart.fillStyle', {
+                defaultMessage: 'Fill',
+              })}
+              data-test-subj="lns-xyChart-fillStyle"
+              name="fillStyle"
+              buttonSize="compressed"
+              options={[
+                {
+                  id: `lens_xyChart_fillStyle_inside`,
+                  label: i18n.translate('xpack.lens.xyChart.fillStyle.inside', {
+                    defaultMessage: 'Inside',
+                  }),
+                  'data-test-subj': 'lnsXY_fillStyle_inside',
+                },
+                {
+                  id: `lens_xyChart_fillStyle_outside`,
+                  label: i18n.translate('xpack.lens.xyChart.fillStyle.outside', {
+                    defaultMessage: 'Outside',
+                  }),
+                  'data-test-subj': 'lnsXY_fillStyle_inside',
+                },
+              ]}
+              idSelected={`lens_xyChart_fillStyle_${
+                Boolean(currentAnnotation?.outside) ? 'outside' : 'inside'
+              }`}
+              onChange={(id) => {
+                setAnnotations({
+                  outside: id === `lens_xyChart_fillStyle_outside`,
+                });
+              }}
+              isFullWidth
+            />
+          </EuiFormRow>
+        )}
+
         <ColorPicker
           {...props}
           setConfig={setAnnotations}
@@ -126,7 +299,7 @@ export const AnnotationsPanel = (
           })}
         />
         <ConfigPanelHideSwitch
-          value={Boolean(currentAnnotations?.isHidden)}
+          value={Boolean(currentAnnotation?.isHidden)}
           onChange={(ev) => setAnnotations({ isHidden: ev.target.checked })}
         />
       </DimensionEditorSection>
@@ -134,25 +307,110 @@ export const AnnotationsPanel = (
   );
 };
 
-const ConfigPanelDatePicker = ({
+const isRangeAnnotation = (
+  annotation?: EventAnnotationConfig
+): annotation is RangeEventAnnotationConfig => {
+  return Boolean(annotation && annotation?.key.type === 'range');
+};
+
+const ConfigPanelApplyAsRangeSwitch = ({
+  annotation,
+  onChange,
+  activeData,
+  state,
+}: {
+  annotation?: EventAnnotationConfig;
+  onChange: (annotations: Partial<EventAnnotationConfig> | undefined) => void;
+  activeData: FramePublicAPI['activeData'];
+  state: XYState;
+}) => {
+  const isRange = isRangeAnnotation(annotation);
+  return (
+    <EuiFormRow display="columnCompressed" className="lnsRowCompressedMargin">
+      <EuiSwitch
+        label={i18n.translate('xpack.lens.xyChart.applyAsRange', {
+          defaultMessage: 'Apply as range',
+        })}
+        checked={isRange}
+        onChange={() => {
+          if (isRange) {
+            const newPointAnnotation: PointInTimeEventAnnotationConfig = {
+              key: {
+                type: 'point_in_time',
+                timestamp: annotation.key.timestamp,
+              },
+              id: annotation.id,
+              label:
+                annotation.label === defaultRangeAnnotationLabel
+                  ? defaultAnnotationLabel
+                  : annotation.label,
+              color: annotation.color,
+              isHidden: annotation.isHidden,
+            };
+            onChange(newPointAnnotation);
+          } else if (annotation) {
+            const fromTimestamp = moment(annotation?.key.timestamp);
+            const dataLayers = getDataLayers(state.layers);
+            const newRangeAnnotation: RangeEventAnnotationConfig = {
+              key: {
+                type: 'range',
+                timestamp: annotation.key.timestamp,
+                endTimestamp: getEndTimestamp(fromTimestamp.toISOString(), activeData, dataLayers),
+              },
+              id: annotation.id,
+              label:
+                annotation.label === defaultAnnotationLabel
+                  ? defaultRangeAnnotationLabel
+                  : annotation.label,
+              color: annotation.color,
+              isHidden: annotation.isHidden,
+            };
+            onChange(newRangeAnnotation);
+          }
+        }}
+        compressed
+      />
+    </EuiFormRow>
+  );
+};
+
+const ConfigPanelRangeDatePicker = ({
   value,
   label,
+  prependLabel,
   onChange,
 }: {
   value: moment.Moment;
-  label: string;
+  prependLabel?: string;
+  label?: string;
   onChange: (val: moment.Moment | null) => void;
 }) => {
   return (
-    <EuiFormRow display="rowCompressed" fullWidth label={label}>
-      <EuiDatePicker
-        fullWidth
-        showTimeSelect
-        selected={value}
-        onChange={onChange}
-        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-        data-test-subj="lnsXY_annotation_date_picker"
-      />
+    <EuiFormRow display="rowCompressed" fullWidth label={label} className="lnsRowCompressedMargin">
+      {prependLabel ? (
+        <EuiFormControlLayout
+          className="lnsConfigPanelNoPadding"
+          prepend={<EuiFormLabel>{prependLabel}</EuiFormLabel>}
+        >
+          <EuiDatePicker
+            fullWidth
+            showTimeSelect
+            selected={value}
+            onChange={onChange}
+            dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+            data-test-subj="lnsXY_annotation_date_picker"
+          />
+        </EuiFormControlLayout>
+      ) : (
+        <EuiDatePicker
+          fullWidth
+          showTimeSelect
+          selected={value}
+          onChange={onChange}
+          dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+          data-test-subj="lnsXY_annotation_date_picker"
+        />
+      )}
     </EuiFormRow>
   );
 };


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/128507

<img width="888" alt="Screenshot 2022-04-01 at 11 07 00" src="https://user-images.githubusercontent.com/4283304/161232511-0d41faf3-74a3-4b99-adbe-dbfe98cacd1f.png">

<img width="306" alt="Screenshot 2022-04-01 at 11 07 40" src="https://user-images.githubusercontent.com/4283304/161232598-fe3dc0c6-afd9-4eb2-8e45-25ba7efef78a.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
