### PR TITLE
[Osquery] Fix read + run permissions on new live query

### DIFF
--- a/x-pack/plugins/osquery/public/routes/live_queries/index.tsx
+++ b/x-pack/plugins/osquery/public/routes/live_queries/index.tsx
@@ -27,7 +27,8 @@ const LiveQueriesComponent = () => {
   return (
     <Switch>
       <Route path={`${match.url}/new`}>
-        {permissions.runSavedQueries || permissions.writeLiveQueries ? (
+        {(permissions.runSavedQueries && permissions.readSavedQueries) ||
+        permissions.writeLiveQueries ? (
           <NewLiveQueryPage />
         ) : (
           <MissingPrivileges />


### PR DESCRIPTION
## Summary

Now in order to have access to New Live query instead of only RUN saved queries, user has to have both RUN and Read saved queries. 

