### PR TITLE
[Fleet] fixed windows command line separator

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
@@ -235,7 +235,6 @@ export const useFleetServerInstructions = (policyId?: string) => {
     }
 
     return getInstallCommandForPlatform(
-      platform,
       esHost,
       serviceToken,
       policyId,
@@ -243,15 +242,7 @@ export const useFleetServerInstructions = (policyId?: string) => {
       deploymentMode === 'production',
       sslCATrustedFingerprint
     );
-  }, [
-    serviceToken,
-    esHost,
-    platform,
-    policyId,
-    fleetServerHost,
-    deploymentMode,
-    sslCATrustedFingerprint,
-  ]);
+  }, [serviceToken, esHost, policyId, fleetServerHost, deploymentMode, sslCATrustedFingerprint]);
 
   const getServiceToken = useCallback(async () => {
     setIsLoadingServiceToken(true);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/install_command_utils.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/install_command_utils.test.ts
@@ -10,11 +10,7 @@ import { getInstallCommandForPlatform } from './install_command_utils';
 describe('getInstallCommandForPlatform', () => {
   describe('without policy id', () => {
     it('should return the correct command if the the policyId is not set for linux', () => {
-      const res = getInstallCommandForPlatform(
-        'linux',
-        'http://elasticsearch:9200',
-        'service-token-1'
-      );
+      const res = getInstallCommandForPlatform('http://elasticsearch:9200', 'service-token-1');
 
       expect(res.linux).toMatchInlineSnapshot(`
         "sudo ./elastic-agent install  \\\\
@@ -25,11 +21,7 @@ describe('getInstallCommandForPlatform', () => {
     });
 
     it('should return the correct command if the the policyId is not set for mac', () => {
-      const res = getInstallCommandForPlatform(
-        'mac',
-        'http://elasticsearch:9200',
-        'service-token-1'
-      );
+      const res = getInstallCommandForPlatform('http://elasticsearch:9200', 'service-token-1');
 
       expect(res.mac).toMatchInlineSnapshot(`
         "sudo ./elastic-agent install  \\\\
@@ -40,11 +32,7 @@ describe('getInstallCommandForPlatform', () => {
     });
 
     it('should return the correct command if the the policyId is not set for windows', () => {
-      const res = getInstallCommandForPlatform(
-        'windows',
-        'http://elasticsearch:9200',
-        'service-token-1'
-      );
+      const res = getInstallCommandForPlatform('http://elasticsearch:9200', 'service-token-1');
 
       expect(res.windows).toMatchInlineSnapshot(`
         ".\\\\elastic-agent.exe install  \`
@@ -55,11 +43,7 @@ describe('getInstallCommandForPlatform', () => {
     });
 
     it('should return the correct command if the the policyId is not set for rpm', () => {
-      const res = getInstallCommandForPlatform(
-        'rpm',
-        'http://elasticsearch:9200',
-        'service-token-1'
-      );
+      const res = getInstallCommandForPlatform('http://elasticsearch:9200', 'service-token-1');
 
       expect(res.rpm).toMatchInlineSnapshot(`
         "sudo elastic-agent enroll  \\\\
@@ -70,11 +54,7 @@ describe('getInstallCommandForPlatform', () => {
     });
 
     it('should return the correct command if the the policyId is not set for deb', () => {
-      const res = getInstallCommandForPlatform(
-        'deb',
-        'http://elasticsearch:9200',
-        'service-token-1'
-      );
+      const res = getInstallCommandForPlatform('http://elasticsearch:9200', 'service-token-1');
 
       expect(res.deb).toMatchInlineSnapshot(`
         "sudo elastic-agent enroll  \\\\
@@ -86,7 +66,6 @@ describe('getInstallCommandForPlatform', () => {
 
     it('should return the correct command sslCATrustedFingerprint option is passed', () => {
       const res = getInstallCommandForPlatform(
-        'linux',
         'http://elasticsearch:9200',
         'service-token-1',
         undefined,
@@ -108,7 +87,6 @@ describe('getInstallCommandForPlatform', () => {
   describe('with policy id', () => {
     it('should return the correct command if the the policyId is set for linux', () => {
       const res = getInstallCommandForPlatform(
-        'linux',
         'http://elasticsearch:9200',
         'service-token-1',
         'policy-1'
@@ -125,7 +103,6 @@ describe('getInstallCommandForPlatform', () => {
 
     it('should return the correct command if the the policyId is set for mac', () => {
       const res = getInstallCommandForPlatform(
-        'mac',
         'http://elasticsearch:9200',
         'service-token-1',
         'policy-1'
@@ -142,7 +119,6 @@ describe('getInstallCommandForPlatform', () => {
 
     it('should return the correct command if the the policyId is set for windows', () => {
       const res = getInstallCommandForPlatform(
-        'windows',
         'http://elasticsearch:9200',
         'service-token-1',
         'policy-1'
@@ -159,7 +135,6 @@ describe('getInstallCommandForPlatform', () => {
 
     it('should return the correct command if the the policyId is set for rpm', () => {
       const res = getInstallCommandForPlatform(
-        'rpm',
         'http://elasticsearch:9200',
         'service-token-1',
         'policy-1'
@@ -176,7 +151,6 @@ describe('getInstallCommandForPlatform', () => {
 
     it('should return the correct command if the the policyId is set for deb', () => {
       const res = getInstallCommandForPlatform(
-        'deb',
         'http://elasticsearch:9200',
         'service-token-1',
         'policy-1'
@@ -195,7 +169,6 @@ describe('getInstallCommandForPlatform', () => {
   describe('with policy id and fleet server host and production deployment', () => {
     it('should return the correct command if the the policyId is set for linux', () => {
       const res = getInstallCommandForPlatform(
-        'linux',
         'http://elasticsearch:9200',
         'service-token-1',
         'policy-1',
@@ -217,7 +190,6 @@ describe('getInstallCommandForPlatform', () => {
 
     it('should return the correct command if the the policyId is set for mac', () => {
       const res = getInstallCommandForPlatform(
-        'mac',
         'http://elasticsearch:9200',
         'service-token-1',
         'policy-1',
@@ -239,7 +211,6 @@ describe('getInstallCommandForPlatform', () => {
 
     it('should return the correct command if the the policyId is set for windows', () => {
       const res = getInstallCommandForPlatform(
-        'windows',
         'http://elasticsearch:9200',
         'service-token-1',
         'policy-1',
@@ -261,7 +232,6 @@ describe('getInstallCommandForPlatform', () => {
 
     it('should return the correct command if the the policyId is set for rpm', () => {
       const res = getInstallCommandForPlatform(
-        'rpm',
         'http://elasticsearch:9200',
         'service-token-1',
         'policy-1',
@@ -283,7 +253,6 @@ describe('getInstallCommandForPlatform', () => {
 
     it('should return the correct command if the the policyId is set for deb', () => {
       const res = getInstallCommandForPlatform(
-        'deb',
         'http://elasticsearch:9200',
         'service-token-1',
         'policy-1',

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/install_command_utils.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/install_command_utils.ts
@@ -12,7 +12,6 @@ export type CommandsByPlatform = {
 };
 
 export function getInstallCommandForPlatform(
-  platform: PLATFORM_TYPE,
   esHost: string,
   serviceToken: string,
   policyId?: string,
@@ -20,8 +19,7 @@ export function getInstallCommandForPlatform(
   isProductionDeployment?: boolean,
   sslCATrustedFingerprint?: string
 ): CommandsByPlatform {
-  const commandArguments = [];
-  const newLineSeparator = platform === 'windows' ? '`\n' : '\\\n';
+  const commandArguments: Array<[string, string] | [string]> = [];
 
   if (isProductionDeployment && fleetServerHost) {
     commandArguments.push(['url', fleetServerHost]);
@@ -48,19 +46,22 @@ export function getInstallCommandForPlatform(
     commandArguments.push(['fleet-server-insecure-http']);
   }
 
-  const commandArgumentsStr = commandArguments.reduce((acc, [key, val]) => {
-    if (acc === '' && key === 'url') {
-      return `--${key}=${val}`;
-    }
-    const valOrEmpty = val ? `=${val}` : '';
-    return (acc += ` ${newLineSeparator}  --${key}${valOrEmpty}`);
-  }, '');
+  const commandArgumentsStr = (platform?: string) => {
+    const newLineSeparator = platform === 'windows' ? '`\n' : '\\\n';
+    return commandArguments.reduce((acc, [key, val]) => {
+      if (acc === '' && key === 'url') {
+        return `--${key}=${val}`;
+      }
+      const valOrEmpty = val ? `=${val}` : '';
+      return (acc += ` ${newLineSeparator}  --${key}${valOrEmpty}`);
+    }, '');
+  };
 
   return {
-    linux: `sudo ./elastic-agent install ${commandArgumentsStr}`,
-    mac: `sudo ./elastic-agent install ${commandArgumentsStr}`,
-    windows: `.\\elastic-agent.exe install ${commandArgumentsStr}`,
-    deb: `sudo elastic-agent enroll ${commandArgumentsStr}`,
-    rpm: `sudo elastic-agent enroll ${commandArgumentsStr}`,
+    linux: `sudo ./elastic-agent install ${commandArgumentsStr()}`,
+    mac: `sudo ./elastic-agent install ${commandArgumentsStr()}`,
+    windows: `.\\elastic-agent.exe install ${commandArgumentsStr('windows')}`,
+    deb: `sudo elastic-agent enroll ${commandArgumentsStr()}`,
+    rpm: `sudo elastic-agent enroll ${commandArgumentsStr()}`,
   };
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/128867

Fixed windows install command line separator in Fleet Server instructions.
It was broken in https://github.com/elastic/kibana/pull/127900 when `getInstallCommandForPlatform` changed, and all platform commands were calculated at once on the first call with `linux` platform.

<img width="1250" alt="image" src="https://user-images.githubusercontent.com/90178898/161254700-7c76c4e7-63cc-4c41-900a-16a6fbb0aa69.png">
