### PR TITLE
[Workplace Search] Private sources with multiple options now route correctly

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
@@ -87,6 +87,19 @@ describe('AddSourceList', () => {
     );
   });
 
+  it('renders default state correctly when there are not multiple connector options, and the connector has been configured', () => {
+    const sourceData = {
+      ...staticSourceData[0],
+      externalConnectorAvailable: false,
+      configured: true,
+    };
+    shallow(<AddSource sourceData={sourceData} />);
+    expect(initializeAddSource).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ connect: true })
+    );
+  });
+
   it('renders default state correctly when there are multiple connector options', () => {
     const wrapper = shallow(
       <AddSource

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -58,7 +58,8 @@ export const AddSource: React.FC<AddSourceProps> = (props) => {
   useEffect(() => {
     // We can land on this page from a choice page for multiple types of connectors
     // If that's the case we want to skip the intro and configuration, if the external & internal connector have already been configured
-    const goToConnect = externalConnectorAvailable && externalConfigured && configured;
+    // Otherwise, we skip to connect if the source is already configured
+    const goToConnect = externalConnectorAvailable ? externalConfigured && configured : configured;
     initializeAddSource(goToConnect ? { ...props, connect: true } : props);
     return resetSourceState;
   }, [configured]);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -232,6 +232,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         setSourceConfigData: () => false,
         resetSourceState: () => false,
         setPreContentSourceConfigData: () => false,
+        getSourceConfigData: () => true,
       },
     ],
     buttonLoading: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configured_sources_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configured_sources_list.test.tsx
@@ -50,7 +50,51 @@ describe('ConfiguredSourcesList', () => {
         }}
       />
     );
-    expect(wrapper.find(EuiButtonEmptyTo)).toHaveLength(1);
+    const button = wrapper.find(EuiButtonEmptyTo);
+    expect(button).toHaveLength(1);
+    expect(button.prop('to')).toEqual('/sources/add/external/connect');
+  });
+
+  it('connect button for an unconnected source with multiple connector options routes to choice page', () => {
+    const wrapper = shallow(
+      <ConfiguredSourcesList
+        {...{
+          sources: [
+            {
+              ...mergedConfiguredSources[0],
+              connected: false,
+              serviceType: 'share_point',
+              externalConnectorAvailable: true,
+            },
+          ],
+          isOrganization: true,
+        }}
+      />
+    );
+    const button = wrapper.find(EuiButtonEmptyTo);
+    expect(button).toHaveLength(1);
+    expect(button.prop('to')).toEqual('/sources/add/share_point/');
+  });
+
+  it('connect button for a source with multiple connector options routes to connect page for private sources', () => {
+    const wrapper = shallow(
+      <ConfiguredSourcesList
+        {...{
+          sources: [
+            {
+              ...mergedConfiguredSources[0],
+              connected: false,
+              serviceType: 'share_point',
+              externalConnectorAvailable: true,
+            },
+          ],
+          isOrganization: false,
+        }}
+      />
+    );
+    const button = wrapper.find(EuiButtonEmptyTo);
+    expect(button).toHaveLength(1);
+    expect(button.prop('to')).toEqual('/p/sources/add/share_point/connect');
   });
 
   it('handles empty state', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configured_sources_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configured_sources_list.tsx
@@ -132,7 +132,9 @@ export const ConfiguredSourcesList: React.FC<ConfiguredSourcesProps> = ({
                           <EuiButtonEmptyTo
                             className="eui-fullWidth"
                             to={`${getSourcesPath(getAddPath(serviceType), isOrganization)}/${
-                              hasMultipleConnectorOptions(sourceData) ? '' : 'connect'
+                              hasMultipleConnectorOptions(sourceData) && isOrganization
+                                ? ''
+                                : 'connect'
                             }`}
                           >
                             {!connected


### PR DESCRIPTION
This fixes a bug where private sources would route to the config page instead of the connect page if there were multiple connector options.