### PR TITLE
[ML] Fix the `nodes_overview` endpoint 

### DIFF
--- a/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.test.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.test.ts
@@ -24,12 +24,36 @@ describe('Model service', () => {
     getMemoryStats: jest.fn(() => {
       return Promise.resolve({
         _nodes: {
-          total: 3,
-          successful: 3,
+          total: 4,
+          successful: 4,
           failed: 0,
         },
         cluster_name: 'test_cluster',
         nodes: {
+          '3qIoLFnbSi-DwVr2333UCdw': {
+            name: 'node3',
+            transport_address: '10.10.10.2:9353',
+            // missing the ml role
+            roles: ['data', 'ingest', 'master', 'transform'],
+            attributes: {},
+            jvm: {
+              heap_max_in_bytes: 1073741824,
+              java_inference_in_bytes: 0,
+              java_inference_max_in_bytes: 0,
+            },
+            mem: {
+              adjusted_total_in_bytes: 15599742976,
+              total_in_bytes: 15599742976,
+              ml: {
+                data_frame_analytics_in_bytes: 0,
+                native_code_overhead_in_bytes: 0,
+                max_in_bytes: 1073741824,
+                anomaly_detectors_in_bytes: 0,
+                native_inference_in_bytes: 1555161790,
+              },
+            },
+            ephemeral_id: '3qIoLFnbSi-DwVrYioUCdw',
+          },
           '3qIoLFnbSi-DwVrYioUCdw': {
             name: 'node3',
             transport_address: '10.10.10.2:9353',

--- a/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
@@ -111,13 +111,16 @@ export function modelsProvider(client: IScopedClusterClient, mlClient: MlClient)
      * Provides the ML nodes overview with allocated models.
      */
     async getNodesOverview(): Promise<NodesOverviewResponse> {
+      // TODO set node_id to ml:true when elasticsearch client is updated.
       const response = (await mlClient.getMemoryStats()) as MemoryStatsResponse;
 
       const { trained_model_stats: trainedModelStats } = await mlClient.getTrainedModelsStats({
         size: 10000,
       });
 
-      const mlNodes = Object.entries(response.nodes);
+      const mlNodes = Object.entries(response.nodes).filter(([, node]) =>
+        node.roles.includes('ml')
+      );
 
       const nodeDeploymentStatsResponses: NodeDeploymentStatsResponse[] = mlNodes.map(
         ([nodeId, node]) => {
@@ -204,7 +207,12 @@ export function modelsProvider(client: IScopedClusterClient, mlClient: MlClient)
       );
 
       return {
-        _nodes: response._nodes,
+        // TODO preserve _nodes from the response when getMemoryStats method is updated to support ml:true filter
+        _nodes: {
+          ...response._nodes,
+          total: mlNodes.length,
+          successful: mlNodes.length,
+        },
         nodes: nodeDeploymentStatsResponses,
       };
     },


### PR DESCRIPTION
## Summary

Filters out the `_ml/memory/_stats` response for nodes with `ml` role. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




