### PR TITLE
[ci] add check to make sure CODEOWNERS isn't backported

### DIFF
--- a/.buildkite/scripts/steps/checks.sh
+++ b/.buildkite/scripts/steps/checks.sh
@@ -6,6 +6,7 @@ export DISABLE_BOOTSTRAP_VALIDATION=false
 .buildkite/scripts/bootstrap.sh
 
 .buildkite/scripts/steps/checks/commit/commit.sh
+.buildkite/scripts/steps/checks/no_codeowners.sh
 .buildkite/scripts/steps/checks/bazel_packages.sh
 .buildkite/scripts/steps/checks/telemetry.sh
 .buildkite/scripts/steps/checks/ts_projects.sh

--- a/.buildkite/scripts/steps/checks/no_codeowners.sh
+++ b/.buildkite/scripts/steps/checks/no_codeowners.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+
+if [[ "${GITHUB_PR_LABELS:-}" == *"backport"* ]]; then
+  echo "--- removing codeowners file"
+  rm .github/CODEOWNERS || true
+  check_for_changed_files 'rm .github/CODEOWNERS' true
+fi

--- a/.buildkite/scripts/steps/checks/no_codeowners.sh
+++ b/.buildkite/scripts/steps/checks/no_codeowners.sh
@@ -4,8 +4,27 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
-if [[ "${GITHUB_PR_LABELS:-}" == *"backport"* ]]; then
-  echo "--- removing codeowners file"
-  rm .github/CODEOWNERS || true
-  check_for_changed_files 'rm .github/CODEOWNERS' true
+# logic is different for PRs
+if [ "$GITHUB_PR_TARGET_BRANCH" != "" ]; then
+  # ignore prs targetting main
+  if [ "$GITHUB_PR_TARGET_BRANCH" != "main" ]; then
+    # try to find a version matching the target branch
+    version=$(jq '.versions[] | select(.branch == env.GITHUB_PR_TARGET_BRANCH) | .version' versions.json)
+    # if the target branch represents a tracked version then run the check
+    if [ "$version" != "" ]; then
+      echo "--- removing codeowners file"
+      rm .github/CODEOWNERS || true
+      check_for_changed_files 'rm .github/CODEOWNERS' true
+    fi
+  fi
+# when we're running on-merge or something on a non-pr
+elif [ "$BUILDKITE_BRANCH" != "main" ]; then
+  # try to find a version matching the branch being built
+  version=$(jq '.versions[] | select(.branch == env.BUILDKITE_BRANCH) | .version' versions.json)
+  # if the branch being built represents a tracked version then run the check
+  if [ "$version" != "" ]; then
+    echo "--- removing codeowners file"
+    rm .github/CODEOWNERS || true
+    check_for_changed_files 'rm .github/CODEOWNERS' true
+  fi
 fi

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,27 @@
+{
+  "notice": "This file is not maintained outside of the main branch and should only be used for tooling.",
+  "versions": [
+    {
+      "version": "8.3.0",
+      "branch": "main",
+      "currentMajor": true,
+      "currentMinor": true
+    },
+    {
+      "version": "8.2.0",
+      "branch": "8.2",
+      "currentMajor": true,
+      "previousMinor": true
+    },
+    {
+      "version": "8.1.3",
+      "branch": "8.1",
+      "currentMajor": true
+    },
+    {
+      "version": "7.17.3",
+      "branch": "7.17",
+      "previousMajor": true
+    }
+  ]
+}


### PR DESCRIPTION
We regularly accidentally backport the CODEOWNERS file, this check just removes the file and commits the changes back to the PR when a PR is labeled with `backport`.