### PR TITLE
[package testing] Stabilize status api test

### DIFF
--- a/test/package/roles/assert_kibana_available/tasks/main.yml
+++ b/test/package/roles/assert_kibana_available/tasks/main.yml
@@ -4,6 +4,6 @@
     status_code: [200, 401]
     timeout: 120
   register: result
-  until: result.status != 503
+  until: result.status not in [503, -1]
   retries: 3
   delay: 30


### PR DESCRIPTION
There appears to be a brief moment after kibana starts where we are
listening for http connections but immediately closing requests to the
status API.  The return code by ansible here is -1, so this adds that as
a valid response to retry.

@elastic/kibana-core FYI.  https://buildkite.com/elastic/kibana-package-testing/builds?branch=main - starting failing on March 26th.