### PR TITLE
Add missing link that is used in elasticsearch guide

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -242,6 +242,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       asyncSearch: `${ELASTICSEARCH_DOCS}async-search-intro.html`,
       dataStreams: `${ELASTICSEARCH_DOCS}data-streams.html`,
       deprecationLogging: `${ELASTICSEARCH_DOCS}logging.html#deprecation-logging`,
+      createIndex: `${ELASTICSEARCH_DOCS}indices-create-index.html`,
       frozenIndices: `${ELASTICSEARCH_DOCS}frozen-indices.html`,
       gettingStarted: `${ELASTICSEARCH_DOCS}getting-started.html`,
       hiddenIndices: `${ELASTICSEARCH_DOCS}multi-index.html#hidden`,


### PR DESCRIPTION
## Summary
This PR adds a link that was previously missed in the original PR: https://github.com/elastic/kibana/pull/128190

Before:

![Screen Cast 2022-04-01 at 2 46 01 PM](https://user-images.githubusercontent.com/11838280/161345509-90e5f829-45ac-4ee1-8009-b65209b1e39d.gif)

After:

![Screen Cast 2022-04-01 at 2 46 40 PM](https://user-images.githubusercontent.com/11838280/161345559-6d17bce7-ac72-485b-a9e6-02a9641cc09f.gif)

### Checklist

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
