### PR TITLE
[8.2] [RAM] Disable rule status dropdown on readonly user (#128971)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_dropdown.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_dropdown.test.tsx
@@ -22,6 +22,8 @@ describe('RuleStatusDropdown', () => {
     enableRule,
     snoozeRule,
     unsnoozeRule,
+    isEditable: true,
+    previousSnoozeInterval: null,
     item: {
       id: '1',
       name: 'test rule',
@@ -112,6 +114,21 @@ describe('RuleStatusDropdown', () => {
     );
     expect(wrapper.find('[data-test-subj="statusDropdown"]').first().props().title).toBe(
       'Disabled'
+    );
+  });
+
+  test('renders read-only status control when isEditable is false', () => {
+    const wrapper = mountWithIntl(
+      <RuleStatusDropdown
+        {...{
+          ...props,
+          item: { ...props.item, snoozeEndTime: SNOOZE_END_TIME },
+        }}
+        isEditable={false}
+      />
+    );
+    expect(wrapper.find('[data-test-subj="statusDropdownReadonly"]').first().props().children).toBe(
+      'Enabled'
     );
   });
 });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_dropdown.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_dropdown.test.tsx
@@ -23,7 +23,6 @@ describe('RuleStatusDropdown', () => {
     snoozeRule,
     unsnoozeRule,
     isEditable: true,
-    previousSnoozeInterval: null,
     item: {
       id: '1',
       name: 'test rule',

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_dropdown.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_dropdown.tsx
@@ -42,6 +42,8 @@ export interface ComponentOpts {
   disableRule: () => Promise<void>;
   snoozeRule: (snoozeEndTime: string | -1) => Promise<void>;
   unsnoozeRule: () => Promise<void>;
+  isEditable: boolean;
+  previousSnoozeInterval: string | null;
 }
 
 export const RuleStatusDropdown: React.FunctionComponent<ComponentOpts> = ({
@@ -51,6 +53,8 @@ export const RuleStatusDropdown: React.FunctionComponent<ComponentOpts> = ({
   enableRule,
   snoozeRule,
   unsnoozeRule,
+  isEditable,
+  previousSnoozeInterval,
 }: ComponentOpts) => {
   const [isEnabled, setIsEnabled] = useState<boolean>(item.enabled);
   const [isSnoozed, setIsSnoozed] = useState<boolean>(isItemSnoozed(item));
@@ -108,11 +112,17 @@ export const RuleStatusDropdown: React.FunctionComponent<ComponentOpts> = ({
       </EuiToolTip>
     ) : null;
 
-  const badge = (
+  const nonEditableBadge = (
+    <EuiBadge color={badgeColor} data-test-subj="statusDropdownReadonly">
+      {badgeMessage}
+    </EuiBadge>
+  );
+
+  const editableBadge = (
     <EuiBadge
       color={badgeColor}
       iconSide="right"
-      iconType={!isUpdating ? 'arrowDown' : undefined}
+      iconType={!isUpdating && isEditable ? 'arrowDown' : undefined}
       onClick={onClickBadge}
       iconOnClick={onClickBadge}
       onClickAriaLabel={OPEN_MENU_ARIA_LABEL}
@@ -134,23 +144,28 @@ export const RuleStatusDropdown: React.FunctionComponent<ComponentOpts> = ({
       gutterSize="s"
     >
       <EuiFlexItem grow={false}>
-        <EuiPopover
-          button={badge}
-          isOpen={isPopoverOpen}
-          closePopover={onClosePopover}
-          panelPaddingSize="s"
-          data-test-subj="statusDropdown"
-          title={badgeMessage}
-        >
-          <RuleStatusMenu
-            onClosePopover={onClosePopover}
-            onChangeEnabledStatus={onChangeEnabledStatus}
-            onChangeSnooze={onChangeSnooze}
-            isEnabled={isEnabled}
-            isSnoozed={isSnoozed}
-            snoozeEndTime={item.snoozeEndTime}
-          />
-        </EuiPopover>
+        {isEditable ? (
+          <EuiPopover
+            button={editableBadge}
+            isOpen={isPopoverOpen && isEditable}
+            closePopover={onClosePopover}
+            panelPaddingSize="s"
+            data-test-subj="statusDropdown"
+            title={badgeMessage}
+          >
+            <RuleStatusMenu
+              onClosePopover={onClosePopover}
+              onChangeEnabledStatus={onChangeEnabledStatus}
+              onChangeSnooze={onChangeSnooze}
+              isEnabled={isEnabled}
+              isSnoozed={isSnoozed}
+              snoozeEndTime={item.snoozeEndTime}
+              previousSnoozeInterval={previousSnoozeInterval}
+            />
+          </EuiPopover>
+        ) : (
+          nonEditableBadge
+        )}
       </EuiFlexItem>
       <EuiFlexItem data-test-subj="remainingSnoozeTime" grow={false}>
         {remainingSnoozeTime}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_dropdown.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_dropdown.tsx
@@ -54,7 +54,6 @@ export const RuleStatusDropdown: React.FunctionComponent<ComponentOpts> = ({
   snoozeRule,
   unsnoozeRule,
   isEditable,
-  previousSnoozeInterval,
 }: ComponentOpts) => {
   const [isEnabled, setIsEnabled] = useState<boolean>(item.enabled);
   const [isSnoozed, setIsSnoozed] = useState<boolean>(isItemSnoozed(item));
@@ -160,7 +159,6 @@ export const RuleStatusDropdown: React.FunctionComponent<ComponentOpts> = ({
               isEnabled={isEnabled}
               isSnoozed={isSnoozed}
               snoozeEndTime={item.snoozeEndTime}
-              previousSnoozeInterval={previousSnoozeInterval}
             />
           </EuiPopover>
         ) : (

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_dropdown.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_dropdown.tsx
@@ -43,7 +43,6 @@ export interface ComponentOpts {
   snoozeRule: (snoozeEndTime: string | -1) => Promise<void>;
   unsnoozeRule: () => Promise<void>;
   isEditable: boolean;
-  previousSnoozeInterval: string | null;
 }
 
 export const RuleStatusDropdown: React.FunctionComponent<ComponentOpts> = ({

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
@@ -358,6 +358,8 @@ export const RulesList: React.FunctionComponent = () => {
         unsnoozeRule={async () => await unsnoozeRule({ http, id: item.id })}
         item={item}
         onRuleChanged={() => loadRulesData()}
+        isEditable={item.isEditable && isRuleTypeEditableInContext(item.ruleTypeId)}
+        previousSnoozeInterval={previousSnoozeInterval}
       />
     );
   };

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
@@ -359,7 +359,6 @@ export const RulesList: React.FunctionComponent = () => {
         item={item}
         onRuleChanged={() => loadRulesData()}
         isEditable={item.isEditable && isRuleTypeEditableInContext(item.ruleTypeId)}
-        previousSnoozeInterval={previousSnoozeInterval}
       />
     );
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[RAM] Disable rule status dropdown on readonly user (#128971)](https://github.com/elastic/kibana/pull/128971)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)