### PR TITLE
[Visualize] Fixes the unclickable panel menu for all the pie charts

### DIFF
--- a/src/plugins/chart_expressions/expression_partition_vis/public/expression_renderers/partition_vis_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/expression_renderers/partition_vis_renderer.tsx
@@ -9,6 +9,7 @@
 import React, { lazy } from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { I18nProvider } from '@kbn/i18n-react';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { ExpressionRenderDefinition } from '../../../../expressions/public';
 import type { PersistedState } from '../../../../visualizations/public';
@@ -32,6 +33,12 @@ export const strings = {
 const LazyPartitionVisComponent = lazy(() => import('../components/partition_vis_component'));
 const PartitionVisComponent = withSuspense(LazyPartitionVisComponent);
 
+const partitionVisRenderer = css({
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+});
+
 export const getPartitionVisRenderer: (
   deps: VisTypePieDependencies
 ) => ExpressionRenderDefinition<RenderValue> = ({ theme, palettes, getStartDeps }) => ({
@@ -50,7 +57,7 @@ export const getPartitionVisRenderer: (
     render(
       <I18nProvider>
         <KibanaThemeProvider theme$={services.kibanaTheme.theme$}>
-          <div css={{ height: '100%' }}>
+          <div css={partitionVisRenderer}>
             <PartitionVisComponent
               chartsThemeService={theme}
               palettesRegistry={palettesRegistry}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/129256

The bug exists in 8.2+. If you embed a visualize pie on a dashboard, the menu (clicking the gear icon) is unreachable.
The problem is the css. Check the screenshot below:

<img width="638" alt="image (17)" src="https://user-images.githubusercontent.com/17003240/161502360-a27a3d87-0527-45fb-b36c-44b3e660823c.png">

As you can see the embeddable wrapper is above the menu icon and as a result  is not clickable. The problem is that we are creating an absolute positioned wrapper while the parent is not relative.

This PR is fixing the problem by adding the relative position to the parent wrapper.

<img width="648" alt="image (18)" src="https://user-images.githubusercontent.com/17003240/161502465-32142f5d-5ea3-4a3a-8f07-1d766e4fd46e.png">