### PR TITLE
[Discover] Fix inconsistent usage of arrow icons on Surrounding documents page

### DIFF
--- a/src/plugins/discover/public/application/context/components/action_bar/action_bar.tsx
+++ b/src/plugins/discover/public/application/context/components/action_bar/action_bar.tsx
@@ -92,7 +92,6 @@ export function ActionBar({
         <EuiFlexItem grow={false}>
           <EuiButtonEmpty
             data-test-subj={`${type}LoadMoreButton`}
-            iconType={isSuccessor ? 'arrowDown' : 'arrowUp'}
             isDisabled={isDisabled}
             isLoading={isLoading}
             onClick={() => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/122576

## Summary

The decision was to remove arrow icons (which were next to Load buttons) from Surrounding documents page to fix inconsistency in their usage across Discover pages.

<img width="356" alt="Screenshot 2022-04-04 at 10 11 12" src="https://user-images.githubusercontent.com/1415710/161503077-a0b42ff7-81b0-45c7-95b7-862c87296abe.png">
