### PR TITLE
[Uptime settings] Fix synthetics-* to include in the index pattern

### DIFF
--- a/x-pack/plugins/uptime/server/lib/saved_objects/uptime_settings.ts
+++ b/x-pack/plugins/uptime/server/lib/saved_objects/uptime_settings.ts
@@ -43,4 +43,20 @@ export const umDynamicSettings: SavedObjectsType = {
         defaultMessage: 'Uptime Settings - Index',
       }),
   },
+  migrations: {
+    // Takes a pre 8.2.0 doc, and converts it to 8.2.0
+    '8.2.0': (doc) => {
+      const { heartbeatIndices } = doc.attributes;
+
+      return {
+        ...doc,
+        attributes: {
+          ...doc.attributes,
+          heartbeatIndices: heartbeatIndices.includes('synthetics-*')
+            ? heartbeatIndices
+            : heartbeatIndices + ',synthetics-*',
+        },
+      };
+    },
+  },
 };


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/129297 

Include `synthetics-*` string in the existing saved objects. 