### PR TITLE
[Discover] Return keyboard focus to "Documents selected" button after closing the popover menu

### DIFF
--- a/src/plugins/discover/public/components/discover_grid/discover_grid_document_selection.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_document_selection.tsx
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { useCallback, useState, useContext, useMemo, useEffect } from 'react';
+import React, { useCallback, useState, useContext, useMemo, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import {
   EuiButtonEmpty,
@@ -80,6 +80,7 @@ export function DiscoverGridDocumentToolbarBtn({
   setSelectedDocs: (value: string[]) => void;
 }) {
   const [isSelectionPopoverOpen, setIsSelectionPopoverOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
 
   const getMenuItems = useCallback(() => {
     return [
@@ -154,13 +155,19 @@ export function DiscoverGridDocumentToolbarBtn({
     []
   );
 
+  const closePopover = useCallback(() => {
+    setIsSelectionPopoverOpen(false);
+    buttonRef.current?.focus();
+  }, [setIsSelectionPopoverOpen, buttonRef]);
+
   return (
     <EuiPopover
-      closePopover={() => setIsSelectionPopoverOpen(false)}
+      closePopover={closePopover}
       isOpen={isSelectionPopoverOpen}
       panelPaddingSize="none"
       button={
         <EuiButtonEmpty
+          buttonRef={buttonRef}
           size="xs"
           color="text"
           iconType="documents"


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/121347

## Summary

Navigating away from "N documents selected" popover with `ESC` key will now return focus back to the button.
![Apr-04-2022 11-42-54](https://user-images.githubusercontent.com/1415710/161520845-0e1c4df7-e2d5-4780-aefc-4991fb91a05e.gif)


### Checklist

- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
