### PR TITLE
[SharedUX] Fix warning in solution_nav test

### DIFF
--- a/packages/kbn-shared-ux-components/src/page_template/solution_nav/solution_nav.test.tsx
+++ b/packages/kbn-shared-ux-components/src/page_template/solution_nav/solution_nav.test.tsx
@@ -14,6 +14,9 @@ jest.mock('@elastic/eui', () => ({
   useIsWithinBreakpoints: (args: string[]) => {
     return args[0] === 'xs';
   },
+  EuiSideNav: function Component() {
+    // no-op
+  },
 }));
 
 const items: KibanaPageTemplateSolutionNavProps['items'] = [


### PR DESCRIPTION
## Summary

This PR fixes the following warning in the `solution_nav` test.
```
    Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined
```

The problem was that `@elastic/eui` library is mocked, but only one method was actually implemented. The PR adds a mock implementation of `EuiSideNav` as well.

### Checklist

Delete any items that are not applicable to this PR.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
~- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
~- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
~- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
