### PR TITLE
Remove docs reference to ephemeral encryption key.

### DIFF
--- a/docs/user/security/secure-saved-objects.asciidoc
+++ b/docs/user/security/secure-saved-objects.asciidoc
@@ -16,7 +16,7 @@ xpack.encryptedSavedObjects:
 
 [IMPORTANT]
 ============================================================================
-If you don't specify an encryption key, {kib} might disable features that rely on the encrypted saved objects.
+If you don't specify an encryption key, {kib} might disable features that rely on encrypted saved objects.
 ============================================================================
 
 [[encryption-key-rotation]]

--- a/docs/user/security/secure-saved-objects.asciidoc
+++ b/docs/user/security/secure-saved-objects.asciidoc
@@ -16,7 +16,7 @@ xpack.encryptedSavedObjects:
 
 [IMPORTANT]
 ============================================================================
-If you don't specify an encryption key, {kib} automatically generates a random key at startup. Every time you restart {kib}, it uses a new ephemeral encryption key and is unable to decrypt saved objects encrypted with another key. To prevent data loss, {kib} might disable features that rely on this encryption until you explicitly set an encryption key.
+If you don't specify an encryption key, {kib} might disable features that rely on the encrypted saved objects.
 ============================================================================
 
 [[encryption-key-rotation]]


### PR DESCRIPTION
## Summary

[Since 7.12](https://github.com/elastic/kibana/pull/81511) we no longer generate an ephemeral saved objects encryption key, but we forgot to update the docs.

[Docs Preview](https://kibana_129331.docs-preview.app.elstc.co/guide/en/kibana/master/xpack-security-secure-saved-objects.html)

__Fixes: https://github.com/elastic/kibana/issues/129328__