### PR TITLE
[7.17] [Snapshot & Restore] Remove `axios` dependency in tests (#128614)

### DIFF
--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/constant.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/constant.ts
@@ -13,4 +13,6 @@ export const REPOSITORY_EDIT = getRepository({ name: REPOSITORY_NAME });
 
 export const POLICY_NAME = 'my-test-policy';
 
+export const SNAPSHOT_NAME = 'my-test-snapshot';
+
 export const POLICY_EDIT = getPolicy({ name: POLICY_NAME, retention: { minCount: 1 } });

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/home.helpers.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/home.helpers.ts
@@ -14,6 +14,7 @@ import {
   AsyncTestBedConfig,
   delay,
 } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { SnapshotRestoreHome } from '../../../public/application/sections/home/home';
 import { BASE_PATH } from '../../../public/application/constants';
 import { WithAppDependencies } from './setup_environment';
@@ -25,8 +26,6 @@ const testBedConfig: AsyncTestBedConfig = {
   },
   doMountAsync: true,
 };
-
-const initTestBed = registerTestBed(WithAppDependencies(SnapshotRestoreHome), testBedConfig);
 
 export interface HomeTestBed extends TestBed {
   actions: {
@@ -40,7 +39,11 @@ export interface HomeTestBed extends TestBed {
   };
 }
 
-export const setup = async (): Promise<HomeTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<HomeTestBed> => {
+  const initTestBed = registerTestBed(
+    WithAppDependencies(SnapshotRestoreHome, httpSetup),
+    testBedConfig
+  );
   const testBed = await initTestBed();
   const REPOSITORY_TABLE = 'repositoryTable';
   const SNAPSHOT_TABLE = 'snapshotTable';

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/policy_add.helpers.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/policy_add.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, AsyncTestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { PolicyAdd } from '../../../public/application/sections/policy_add';
 import { formSetup, PolicyFormTestSubjects } from './policy_form.helpers';
 import { WithAppDependencies } from './setup_environment';
@@ -18,9 +19,11 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-const initTestBed = registerTestBed<PolicyFormTestSubjects>(
-  WithAppDependencies(PolicyAdd),
-  testBedConfig
-);
+export const setup = async (httpSetup: HttpSetup) => {
+  const initTestBed = registerTestBed<PolicyFormTestSubjects>(
+    WithAppDependencies(PolicyAdd, httpSetup),
+    testBedConfig
+  );
 
-export const setup = formSetup.bind(null, initTestBed);
+  return formSetup(initTestBed);
+};

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/policy_edit.helpers.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/policy_edit.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, AsyncTestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { PolicyEdit } from '../../../public/application/sections/policy_edit';
 import { WithAppDependencies } from './setup_environment';
 import { POLICY_NAME } from './constant';
@@ -19,9 +20,11 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-const initTestBed = registerTestBed<PolicyFormTestSubjects>(
-  WithAppDependencies(PolicyEdit),
-  testBedConfig
-);
+export const setup = async (httpSetup: HttpSetup) => {
+  const initTestBed = registerTestBed<PolicyFormTestSubjects>(
+    WithAppDependencies(PolicyEdit, httpSetup),
+    testBedConfig
+  );
 
-export const setup = formSetup.bind(null, initTestBed);
+  return formSetup(initTestBed);
+};

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/repository_add.helpers.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/repository_add.helpers.ts
@@ -6,13 +6,10 @@
  */
 
 import { registerTestBed, TestBed } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { RepositoryType } from '../../../common/types';
 import { RepositoryAdd } from '../../../public/application/sections/repository_add';
 import { WithAppDependencies } from './setup_environment';
-
-const initTestBed = registerTestBed<RepositoryAddTestSubjects>(WithAppDependencies(RepositoryAdd), {
-  doMountAsync: true,
-});
 
 export interface RepositoryAddTestBed extends TestBed<RepositoryAddTestSubjects> {
   actions: {
@@ -23,7 +20,13 @@ export interface RepositoryAddTestBed extends TestBed<RepositoryAddTestSubjects>
   };
 }
 
-export const setup = async (): Promise<RepositoryAddTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<RepositoryAddTestBed> => {
+  const initTestBed = registerTestBed<RepositoryAddTestSubjects>(
+    WithAppDependencies(RepositoryAdd, httpSetup),
+    {
+      doMountAsync: true,
+    }
+  );
   const testBed = await initTestBed();
 
   // User actions

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/repository_edit.helpers.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/repository_edit.helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { registerTestBed, AsyncTestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { RepositoryEdit } from '../../../public/application/sections/repository_edit';
 import { WithAppDependencies } from './setup_environment';
 import { REPOSITORY_NAME } from './constant';
@@ -18,10 +19,14 @@ const testBedConfig: AsyncTestBedConfig = {
   doMountAsync: true,
 };
 
-export const setup = registerTestBed<RepositoryEditTestSubjects>(
-  WithAppDependencies(RepositoryEdit),
-  testBedConfig
-);
+export const setup = async (httpSetup: HttpSetup) => {
+  const initTestBed = registerTestBed<RepositoryEditTestSubjects>(
+    WithAppDependencies(RepositoryEdit, httpSetup),
+    testBedConfig
+  );
+
+  return await initTestBed();
+};
 
 export type RepositoryEditTestSubjects = TestSubjects | ThreeLevelDepth | NonVisibleTestSubjects;
 

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/restore_snapshot.helpers.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/restore_snapshot.helpers.ts
@@ -7,21 +7,18 @@
 import { act } from 'react-dom/test-utils';
 
 import { registerTestBed, TestBed, AsyncTestBedConfig } from '@kbn/test/jest';
+import { HttpSetup } from 'src/core/public';
 import { RestoreSnapshot } from '../../../public/application/sections/restore_snapshot';
 import { WithAppDependencies } from './setup_environment';
+import { REPOSITORY_NAME, SNAPSHOT_NAME } from '../helpers/constant';
 
 const testBedConfig: AsyncTestBedConfig = {
   memoryRouter: {
-    initialEntries: ['/add_policy'],
-    componentRoutePath: '/add_policy',
+    initialEntries: [`/restore/${REPOSITORY_NAME}/${SNAPSHOT_NAME}`],
+    componentRoutePath: '/restore/:repositoryName?/:snapshotId*',
   },
   doMountAsync: true,
 };
-
-const initTestBed = registerTestBed<RestoreSnapshotFormTestSubject>(
-  WithAppDependencies(RestoreSnapshot),
-  testBedConfig
-);
 
 const setupActions = (testBed: TestBed<RestoreSnapshotFormTestSubject>) => {
   const { find, component, form, exists } = testBed;
@@ -84,7 +81,12 @@ export type RestoreSnapshotTestBed = TestBed<RestoreSnapshotFormTestSubject> & {
   actions: Actions;
 };
 
-export const setup = async (): Promise<RestoreSnapshotTestBed> => {
+export const setup = async (httpSetup: HttpSetup): Promise<RestoreSnapshotTestBed> => {
+  const initTestBed = registerTestBed<RestoreSnapshotFormTestSubject>(
+    WithAppDependencies(RestoreSnapshot, httpSetup),
+    testBedConfig
+  );
+
   const testBed = await initTestBed();
 
   return {

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/setup_environment.tsx
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/setup_environment.tsx
@@ -6,11 +6,10 @@
  */
 
 import React from 'react';
-import axios from 'axios';
-import axiosXhrAdapter from 'axios/lib/adapters/xhr';
 import { i18n } from '@kbn/i18n';
 import { LocationDescriptorObject } from 'history';
 
+import { HttpSetup } from 'src/core/public';
 import { coreMock, scopedHistoryMock } from 'src/core/public/mocks';
 import { setUiMetricService, httpService } from '../../../public/application/services/http';
 import {
@@ -21,8 +20,6 @@ import { AppContextProvider } from '../../../public/application/app_context';
 import { textService } from '../../../public/application/services/text';
 import { init as initHttpRequests } from './http_requests';
 import { UiMetricService } from '../../../public/application/services';
-
-const mockHttpClient = axios.create({ adapter: axiosXhrAdapter });
 
 const history = scopedHistoryMock.create();
 history.createHref.mockImplementation((location: LocationDescriptorObject) => {
@@ -48,18 +45,11 @@ const appDependencies = {
 };
 
 export const setupEnvironment = () => {
-  // @ts-ignore
-  httpService.setup(mockHttpClient);
   breadcrumbService.setup(() => undefined);
   textService.setup(i18n);
   docTitleService.setup(() => undefined);
 
-  const { server, httpRequestsMockHelpers } = initHttpRequests();
-
-  return {
-    server,
-    httpRequestsMockHelpers,
-  };
+  return initHttpRequests();
 };
 
 /**
@@ -70,9 +60,16 @@ export const setupEnvironment = () => {
   this.terminate = () => {};
 };
 
-export const WithAppDependencies = (Comp: any) => (props: any) =>
-  (
+export const WithAppDependencies = (Comp: any, httpSetup?: HttpSetup) => (props: any) => {
+  // We need to optionally setup the httpService since some cit helpers (such as snapshot_list.helpers)
+  // use jest mocks to stub the fetch hooks instead of mocking api responses.
+  if (httpSetup) {
+    httpService.setup(httpSetup);
+  }
+
+  return (
     <AppContextProvider value={appDependencies as any}>
       <Comp {...props} />
     </AppContextProvider>
   );
+};

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/snapshot_list.helpers.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/helpers/snapshot_list.helpers.ts
@@ -35,6 +35,7 @@ const searchErrorSelector = 'snapshotListSearchError';
 
 export const setup = async (query?: string): Promise<SnapshotListTestBed> => {
   const testBed = await initTestBed(query);
+
   const { form, component, find, exists } = testBed;
 
   const setSearchText = async (value: string, advanceTime = true) => {

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/home.test.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/home.test.ts
@@ -41,16 +41,12 @@ const removeWhiteSpaceOnArrayValues = (array: any[]) =>
   });
 
 describe('<SnapshotRestoreHome />', () => {
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
   let testBed: HomeTestBed;
-
-  afterAll(() => {
-    server.restore();
-  });
 
   describe('on component mount', () => {
     beforeEach(async () => {
-      testBed = await setup();
+      testBed = await setup(httpSetup);
     });
 
     test('should set the correct app title', () => {
@@ -79,7 +75,7 @@ describe('<SnapshotRestoreHome />', () => {
 
     describe('tabs', () => {
       beforeEach(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
 
         await act(async () => {
           await nextTick();
@@ -132,7 +128,7 @@ describe('<SnapshotRestoreHome />', () => {
       });
 
       test('should display an empty prompt', async () => {
-        const { component, exists } = await setup();
+        const { component, exists } = await setup(httpSetup);
 
         await act(async () => {
           await nextTick();
@@ -164,7 +160,7 @@ describe('<SnapshotRestoreHome />', () => {
       beforeEach(async () => {
         httpRequestsMockHelpers.setLoadRepositoriesResponse({ repositories });
 
-        testBed = await setup();
+        testBed = await setup(httpSetup);
 
         await act(async () => {
           await nextTick();
@@ -208,7 +204,6 @@ describe('<SnapshotRestoreHome />', () => {
 
       test('should have a button to reload the repositories', async () => {
         const { component, exists, actions } = testBed;
-        const totalRequests = server.requests.length;
         expect(exists('reloadButton')).toBe(true);
 
         await act(async () => {
@@ -217,9 +212,9 @@ describe('<SnapshotRestoreHome />', () => {
           component.update();
         });
 
-        expect(server.requests.length).toBe(totalRequests + 1);
-        expect(server.requests[server.requests.length - 1].url).toBe(
-          `${API_BASE_PATH}repositories`
+        expect(httpSetup.get).toHaveBeenLastCalledWith(
+          `${API_BASE_PATH}repositories`,
+          expect.anything()
         );
       });
 
@@ -273,10 +268,10 @@ describe('<SnapshotRestoreHome />', () => {
             component.update();
           });
 
-          const latestRequest = server.requests[server.requests.length - 1];
-
-          expect(latestRequest.method).toBe('DELETE');
-          expect(latestRequest.url).toBe(`${API_BASE_PATH}repositories/${repo1.name}`);
+          expect(httpSetup.delete).toHaveBeenLastCalledWith(
+            `${API_BASE_PATH}repositories/${repo1.name}`,
+            expect.anything()
+          );
         });
       });
 
@@ -304,23 +299,20 @@ describe('<SnapshotRestoreHome />', () => {
         });
 
         test('should show a loading state while fetching the repository', async () => {
-          server.respondImmediately = false;
           const { find, exists, actions } = testBed;
 
           // By providing undefined, the "loading section" will be displayed
-          httpRequestsMockHelpers.setGetRepositoryResponse(undefined);
+          httpRequestsMockHelpers.setGetRepositoryResponse(repo1.name, undefined);
 
           await actions.clickRepositoryAt(0);
 
           expect(exists('repositoryDetail.sectionLoading')).toBe(true);
           expect(find('repositoryDetail.sectionLoading').text()).toEqual('Loading repository…');
-
-          server.respondImmediately = true;
         });
 
         describe('when the repository has been fetched', () => {
           beforeEach(async () => {
-            httpRequestsMockHelpers.setGetRepositoryResponse({
+            httpRequestsMockHelpers.setGetRepositoryResponse(repo1.name, {
               repository: {
                 name: 'my-repo',
                 type: 'fs',
@@ -357,15 +349,15 @@ describe('<SnapshotRestoreHome />', () => {
               component.update();
             });
 
-            const latestRequest = server.requests[server.requests.length - 1];
-
-            expect(latestRequest.method).toBe('GET');
-            expect(latestRequest.url).toBe(`${API_BASE_PATH}repositories/${repo1.name}/verify`);
+            expect(httpSetup.get).toHaveBeenLastCalledWith(
+              `${API_BASE_PATH}repositories/${repo1.name}/verify`,
+              expect.anything()
+            );
           });
 
           describe('clean repository', () => {
             test('shows results when request succeeds', async () => {
-              httpRequestsMockHelpers.setCleanupRepositoryResponse({
+              httpRequestsMockHelpers.setCleanupRepositoryResponse(repo1.name, {
                 cleanup: {
                   cleaned: true,
                   response: {
@@ -383,16 +375,17 @@ describe('<SnapshotRestoreHome />', () => {
               });
               component.update();
 
-              const latestRequest = server.requests[server.requests.length - 1];
-              expect(latestRequest.method).toBe('POST');
-              expect(latestRequest.url).toBe(`${API_BASE_PATH}repositories/${repo1.name}/cleanup`);
+              expect(httpSetup.post).toHaveBeenLastCalledWith(
+                `${API_BASE_PATH}repositories/${repo1.name}/cleanup`,
+                expect.anything()
+              );
 
               expect(exists('repositoryDetail.cleanupCodeBlock')).toBe(true);
               expect(exists('repositoryDetail.cleanupError')).toBe(false);
             });
 
             test('shows error when success fails', async () => {
-              httpRequestsMockHelpers.setCleanupRepositoryResponse({
+              httpRequestsMockHelpers.setCleanupRepositoryResponse(repo1.name, {
                 cleanup: {
                   cleaned: false,
                   error: {
@@ -408,9 +401,10 @@ describe('<SnapshotRestoreHome />', () => {
               });
               component.update();
 
-              const latestRequest = server.requests[server.requests.length - 1];
-              expect(latestRequest.method).toBe('POST');
-              expect(latestRequest.url).toBe(`${API_BASE_PATH}repositories/${repo1.name}/cleanup`);
+              expect(httpSetup.post).toHaveBeenLastCalledWith(
+                `${API_BASE_PATH}repositories/${repo1.name}/cleanup`,
+                expect.anything()
+              );
 
               expect(exists('repositoryDetail.cleanupCodeBlock')).toBe(false);
               expect(exists('repositoryDetail.cleanupError')).toBe(true);
@@ -420,7 +414,7 @@ describe('<SnapshotRestoreHome />', () => {
 
         describe('when the repository has been fetched (and has snapshots)', () => {
           beforeEach(async () => {
-            httpRequestsMockHelpers.setGetRepositoryResponse({
+            httpRequestsMockHelpers.setGetRepositoryResponse(repo1.name, {
               repository: {
                 name: 'my-repo',
                 type: 'fs',
@@ -448,7 +442,7 @@ describe('<SnapshotRestoreHome />', () => {
       });
 
       beforeEach(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
 
         await act(async () => {
           testBed.actions.selectTab('snapshots');
@@ -478,7 +472,7 @@ describe('<SnapshotRestoreHome />', () => {
           total: 0,
         });
 
-        testBed = await setup();
+        testBed = await setup(httpSetup);
 
         await act(async () => {
           testBed.actions.selectTab('snapshots');
@@ -517,7 +511,7 @@ describe('<SnapshotRestoreHome />', () => {
           total: 2,
         });
 
-        testBed = await setup();
+        testBed = await setup(httpSetup);
 
         await act(async () => {
           testBed.actions.selectTab('snapshots');
@@ -561,7 +555,7 @@ describe('<SnapshotRestoreHome />', () => {
           },
         });
 
-        testBed = await setup();
+        testBed = await setup(httpSetup);
 
         await act(async () => {
           testBed.actions.selectTab('snapshots');
@@ -589,7 +583,7 @@ describe('<SnapshotRestoreHome />', () => {
           },
         });
 
-        testBed = await setup();
+        testBed = await setup(httpSetup);
 
         await act(async () => {
           testBed.actions.selectTab('snapshots');
@@ -625,7 +619,6 @@ describe('<SnapshotRestoreHome />', () => {
 
       test('should have a button to reload the snapshots', async () => {
         const { component, exists, actions } = testBed;
-        const totalRequests = server.requests.length;
         expect(exists('reloadButton')).toBe(true);
 
         await act(async () => {
@@ -634,13 +627,19 @@ describe('<SnapshotRestoreHome />', () => {
           component.update();
         });
 
-        expect(server.requests.length).toBe(totalRequests + 1);
-        expect(server.requests[server.requests.length - 1].url).toBe(`${API_BASE_PATH}snapshots`);
+        expect(httpSetup.get).toHaveBeenLastCalledWith(
+          `${API_BASE_PATH}snapshots`,
+          expect.anything()
+        );
       });
 
       describe('detail panel', () => {
         beforeEach(async () => {
-          httpRequestsMockHelpers.setGetSnapshotResponse(snapshot1);
+          httpRequestsMockHelpers.setGetSnapshotResponse(
+            snapshot1.repository,
+            snapshot1.snapshot,
+            snapshot1
+          );
         });
 
         test('should show the detail when clicking on a snapshot', async () => {
@@ -656,17 +655,18 @@ describe('<SnapshotRestoreHome />', () => {
         // that makes the component crash. I tried a few things with no luck so, as this
         // is a low impact test, I prefer to skip it and move on.
         test.skip('should show a loading while fetching the snapshot', async () => {
-          server.respondImmediately = false;
           const { find, exists, actions } = testBed;
           // By providing undefined, the "loading section" will be displayed
-          httpRequestsMockHelpers.setGetSnapshotResponse(undefined);
+          httpRequestsMockHelpers.setGetSnapshotResponse(
+            snapshot1.repository,
+            snapshot1.snapshot,
+            undefined
+          );
 
           await actions.clickSnapshotAt(0);
 
           expect(exists('snapshotDetail.sectionLoading')).toBe(true);
           expect(find('snapshotDetail.sectionLoading').text()).toEqual('Loading snapshot…');
-
-          server.respondImmediately = true;
         });
 
         describe('on mount', () => {
@@ -757,7 +757,11 @@ describe('<SnapshotRestoreHome />', () => {
 
                 const setSnapshotStateAndUpdateDetail = async (state: string) => {
                   const updatedSnapshot = { ...snapshot1, state };
-                  httpRequestsMockHelpers.setGetSnapshotResponse(updatedSnapshot);
+                  httpRequestsMockHelpers.setGetSnapshotResponse(
+                    itemIndexToClickOn === 0 ? snapshot1.repository : snapshot2.repository,
+                    itemIndexToClickOn === 0 ? snapshot1.snapshot : snapshot2.snapshot,
+                    updatedSnapshot
+                  );
                   await actions.clickSnapshotAt(itemIndexToClickOn); // click another snapshot to trigger the HTTP call
                 };
 
@@ -787,9 +791,12 @@ describe('<SnapshotRestoreHome />', () => {
                 };
 
                 // Call sequentially each state and verify that the message is ok
-                return Object.entries(mapStateToMessage).reduce((promise, [state, message]) => {
-                  return promise.then(async () => expectMessageForSnapshotState(state, message));
-                }, Promise.resolve());
+                return Object.entries(mapStateToMessage).reduce(
+                  async (promise, [state, message]) => {
+                    return promise.then(async () => expectMessageForSnapshotState(state, message));
+                  },
+                  Promise.resolve()
+                );
               });
             });
 
@@ -805,8 +812,12 @@ describe('<SnapshotRestoreHome />', () => {
 
               test('should display a message when snapshot in progress ', async () => {
                 const { find, actions } = testBed;
-                const updatedSnapshot = { ...snapshot1, state: 'IN_PROGRESS' };
-                httpRequestsMockHelpers.setGetSnapshotResponse(updatedSnapshot);
+                const updatedSnapshot = { ...snapshot2, state: 'IN_PROGRESS' };
+                httpRequestsMockHelpers.setGetSnapshotResponse(
+                  snapshot2.repository,
+                  snapshot2.snapshot,
+                  updatedSnapshot
+                );
 
                 await actions.clickSnapshotAt(1); // click another snapshot to trigger the HTTP call
                 actions.selectSnapshotDetailTab('failedIndices');
@@ -825,7 +836,11 @@ describe('<SnapshotRestoreHome />', () => {
 
         beforeEach(async () => {
           const updatedSnapshot = { ...snapshot1, indexFailures };
-          httpRequestsMockHelpers.setGetSnapshotResponse(updatedSnapshot);
+          httpRequestsMockHelpers.setGetSnapshotResponse(
+            updatedSnapshot.repository,
+            updatedSnapshot.snapshot,
+            updatedSnapshot
+          );
           await testBed.actions.clickSnapshotAt(0);
           testBed.actions.selectSnapshotDetailTab('failedIndices');
         });

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/repository_edit.test.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/repository_edit.test.ts
@@ -11,7 +11,7 @@ import { setupEnvironment, pageHelpers, nextTick, TestBed, getRandomString } fro
 import { RepositoryForm } from '../../public/application/components/repository_form';
 import { RepositoryEditTestSubjects } from './helpers/repository_edit.helpers';
 import { RepositoryAddTestSubjects } from './helpers/repository_add.helpers';
-import { REPOSITORY_EDIT } from './helpers/constant';
+import { REPOSITORY_EDIT, REPOSITORY_NAME } from './helpers/constant';
 
 const { setup } = pageHelpers.repositoryEdit;
 const { setup: setupRepositoryAdd } = pageHelpers.repositoryAdd;
@@ -19,19 +19,15 @@ const { setup: setupRepositoryAdd } = pageHelpers.repositoryAdd;
 describe('<RepositoryEdit />', () => {
   let testBed: TestBed<RepositoryEditTestSubjects>;
   let testBedRepositoryAdd: TestBed<RepositoryAddTestSubjects>;
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
-
-  afterAll(() => {
-    server.restore();
-  });
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
 
   describe('on component mount', () => {
     beforeEach(async () => {
-      httpRequestsMockHelpers.setGetRepositoryResponse({
+      httpRequestsMockHelpers.setGetRepositoryResponse(REPOSITORY_EDIT.name, {
         repository: REPOSITORY_EDIT,
         snapshots: { count: 0 },
       });
-      testBed = await setup();
+      testBed = await setup(httpSetup);
 
       await act(async () => {
         await nextTick();
@@ -54,7 +50,7 @@ describe('<RepositoryEdit />', () => {
     test('should use the same Form component as the "<RepositoryAdd />" section', async () => {
       httpRequestsMockHelpers.setLoadRepositoryTypesResponse(['fs', 'url']);
 
-      testBedRepositoryAdd = await setupRepositoryAdd();
+      testBedRepositoryAdd = await setupRepositoryAdd(httpSetup);
 
       const formEdit = testBed.component.find(RepositoryForm);
       const formAdd = testBedRepositoryAdd.component.find(RepositoryForm);
@@ -66,11 +62,11 @@ describe('<RepositoryEdit />', () => {
 
   describe('should populate the correct values', () => {
     const mountComponentWithMock = async (repository: any) => {
-      httpRequestsMockHelpers.setGetRepositoryResponse({
+      httpRequestsMockHelpers.setGetRepositoryResponse(REPOSITORY_NAME, {
         repository: { name: getRandomString(), ...repository },
         snapshots: { count: 0 },
       });
-      testBed = await setup();
+      testBed = await setup(httpSetup);
 
       await act(async () => {
         await nextTick();

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/restore_snapshot.test.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/restore_snapshot.test.ts
@@ -6,8 +6,10 @@
  */
 import { act } from 'react-dom/test-utils';
 
+import { API_BASE_PATH } from '../../common';
 import { pageHelpers, setupEnvironment } from './helpers';
 import { RestoreSnapshotTestBed } from './helpers/restore_snapshot.helpers';
+import { REPOSITORY_NAME, SNAPSHOT_NAME } from './helpers/constant';
 import * as fixtures from '../../test/fixtures';
 
 const {
@@ -15,19 +17,19 @@ const {
 } = pageHelpers;
 
 describe('<RestoreSnapshot />', () => {
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpSetup, httpRequestsMockHelpers } = setupEnvironment();
   let testBed: RestoreSnapshotTestBed;
-
-  afterAll(() => {
-    server.restore();
-  });
 
   describe('wizard navigation', () => {
     beforeEach(async () => {
-      httpRequestsMockHelpers.setGetSnapshotResponse(fixtures.getSnapshot());
+      httpRequestsMockHelpers.setGetSnapshotResponse(
+        REPOSITORY_NAME,
+        SNAPSHOT_NAME,
+        fixtures.getSnapshot()
+      );
 
       await act(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
       });
 
       testBed.component.update();
@@ -44,10 +46,14 @@ describe('<RestoreSnapshot />', () => {
 
   describe('with data streams', () => {
     beforeEach(async () => {
-      httpRequestsMockHelpers.setGetSnapshotResponse(fixtures.getSnapshot());
+      httpRequestsMockHelpers.setGetSnapshotResponse(
+        REPOSITORY_NAME,
+        SNAPSHOT_NAME,
+        fixtures.getSnapshot()
+      );
 
       await act(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
       });
 
       testBed.component.update();
@@ -61,9 +67,13 @@ describe('<RestoreSnapshot />', () => {
 
   describe('without data streams', () => {
     beforeEach(async () => {
-      httpRequestsMockHelpers.setGetSnapshotResponse(fixtures.getSnapshot({ totalDataStreams: 0 }));
+      httpRequestsMockHelpers.setGetSnapshotResponse(
+        REPOSITORY_NAME,
+        SNAPSHOT_NAME,
+        fixtures.getSnapshot({ totalDataStreams: 0 })
+      );
       await act(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
       });
 
       testBed.component.update();
@@ -77,9 +87,13 @@ describe('<RestoreSnapshot />', () => {
 
   describe('global state', () => {
     beforeEach(async () => {
-      httpRequestsMockHelpers.setGetSnapshotResponse(fixtures.getSnapshot());
+      httpRequestsMockHelpers.setGetSnapshotResponse(
+        REPOSITORY_NAME,
+        SNAPSHOT_NAME,
+        fixtures.getSnapshot()
+      );
       await act(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
       });
 
       testBed.component.update();
@@ -100,11 +114,14 @@ describe('<RestoreSnapshot />', () => {
   // the form controls and asserting that the correct payload is sent to the API.
   describe('include aliases', () => {
     beforeEach(async () => {
-      httpRequestsMockHelpers.setGetSnapshotResponse(fixtures.getSnapshot());
-      httpRequestsMockHelpers.setRestoreSnapshotResponse({});
+      httpRequestsMockHelpers.setGetSnapshotResponse(
+        REPOSITORY_NAME,
+        SNAPSHOT_NAME,
+        fixtures.getSnapshot()
+      );
 
       await act(async () => {
-        testBed = await setup();
+        testBed = await setup(httpSetup);
       });
 
       testBed.component.update();
@@ -116,9 +133,14 @@ describe('<RestoreSnapshot />', () => {
       actions.goToStep(3);
       await actions.clickRestore();
 
-      const expectedPayload = { includeAliases: false };
-      const latestRequest = server.requests[server.requests.length - 1];
-      expect(JSON.parse(JSON.parse(latestRequest.requestBody).body)).toEqual(expectedPayload);
+      expect(httpSetup.post).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}restore/${REPOSITORY_NAME}/${SNAPSHOT_NAME}`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            includeAliases: false,
+          }),
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Snapshot & Restore] Remove `axios` dependency in tests (#128614)](https://github.com/elastic/kibana/pull/128614)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)