### PR TITLE
[7.17] Fix upgrade maps smoke tests (#128696)

### DIFF
--- a/x-pack/test/upgrade/apps/maps/maps_smoke_tests.ts
+++ b/x-pack/test/upgrade/apps/maps/maps_smoke_tests.ts
@@ -16,6 +16,7 @@ export default function ({
   updateBaselines,
 }: FtrProviderContext & { updateBaselines: boolean }) {
   const PageObjects = getPageObjects(['common', 'maps', 'header', 'home', 'timePicker']);
+  const mapsHelper = getService('mapsHelper');
   const screenshot = getService('screenshots');
   const testSubjects = getService('testSubjects');
   const kibanaServer = getService('kibanaServer');
@@ -111,7 +112,7 @@ export default function ({
           );
           await PageObjects.header.waitUntilLoadingHasFinished();
           await PageObjects.maps.waitForLayersToLoad();
-          await PageObjects.maps.toggleLayerVisibility('Road map');
+          await mapsHelper.toggleLayerVisibilityRoadMap();
           await PageObjects.maps.toggleLayerVisibility('United Kingdom');
           await PageObjects.maps.toggleLayerVisibility('France');
           await PageObjects.maps.toggleLayerVisibility('United States');
@@ -141,7 +142,7 @@ export default function ({
           );
           await PageObjects.header.waitUntilLoadingHasFinished();
           await PageObjects.maps.waitForLayersToLoad();
-          await PageObjects.maps.toggleLayerVisibility('Road map');
+          await mapsHelper.toggleLayerVisibilityRoadMap();
           await PageObjects.timePicker.setCommonlyUsedTime('sample_data range');
           await PageObjects.maps.enterFullScreen();
           await PageObjects.maps.closeLegend();
@@ -167,8 +168,8 @@ export default function ({
           );
           await PageObjects.header.waitUntilLoadingHasFinished();
           await PageObjects.maps.waitForLayersToLoad();
-          await PageObjects.maps.toggleLayerVisibility('Road map');
-          await PageObjects.maps.toggleLayerVisibility('Total Requests by Country');
+          await mapsHelper.toggleLayerVisibilityRoadMap();
+          await mapsHelper.toggleLayerVisibilityTotalRequests();
           await PageObjects.timePicker.setCommonlyUsedTime('sample_data range');
           await PageObjects.maps.enterFullScreen();
           await PageObjects.maps.closeLegend();

--- a/x-pack/test/upgrade/config.ts
+++ b/x-pack/test/upgrade/config.ts
@@ -8,6 +8,7 @@
 import { FtrConfigProviderContext } from '@kbn/test';
 import { pageObjects } from './page_objects';
 import { ReportingAPIProvider } from './reporting_services';
+import { MapsHelper } from './maps_upgrade_services';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const apiConfig = await readConfigFile(require.resolve('../api_integration/config'));
@@ -29,10 +30,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ...apiConfig.get('services'),
       ...functionalConfig.get('services'),
       reportingAPI: ReportingAPIProvider,
+      mapsHelper: MapsHelper,
     },
 
     junit: {
-      reportName: 'Upgrade Tests',
+      reportName: 'Kibana Core Tests',
     },
 
     timeouts: {

--- a/x-pack/test/upgrade/maps_upgrade_services.ts
+++ b/x-pack/test/upgrade/maps_upgrade_services.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from './ftr_provider_context';
+
+export function MapsHelper({ getPageObjects, getService }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['maps']);
+  const testSubjects = getService('testSubjects');
+
+  return {
+    // In v8.0, the default base map switched from bright to desaturated.
+    // https://github.com/elastic/kibana/pull/116179
+    // Maps created before this change will have a base map called "Road map"
+    // Maps created after this change will have a base map called "Road map - desaturated"
+    // toggleLayerVisibilityRoadMap will toggle layer visibility for either value
+    async toggleLayerVisibilityRoadMap() {
+      const isRoadMapDesaturated = await testSubjects.exists(
+        'layerTocActionsPanelToggleButtonRoad_map_-_desaturated'
+      );
+      const isRoadMap = await testSubjects.exists('layerTocActionsPanelToggleButtonRoad_map');
+      if (!isRoadMapDesaturated && !isRoadMap) {
+        throw new Error('Layer road map not found');
+      }
+      if (isRoadMapDesaturated) {
+        await PageObjects.maps.toggleLayerVisibility('Road map - desaturated');
+      }
+      if (isRoadMap) {
+        await PageObjects.maps.toggleLayerVisibility('Road map');
+      }
+    },
+
+    // In v7.16, e-commerce sample data was re-worked so that geo.src field to match country code of geo.coordinates
+    // https://github.com/elastic/kibana/pull/110885
+    // Maps created before this change will have a layer called "Total Requests by Country"
+    // Maps created after this change will have a layer called "Total Requests by Destination"
+    // toggleLayerVisibilityTotalRequests will toggle layer visibility for either value
+    async toggleLayerVisibilityTotalRequests() {
+      const isRequestByCountry = await testSubjects.exists(
+        'layerTocActionsPanelToggleButtonTotal_Requests_by_Country'
+      );
+      const isRequestByDestination = await testSubjects.exists(
+        'layerTocActionsPanelToggleButtonTotal_Requests_by_Destination'
+      );
+      if (!isRequestByCountry && !isRequestByDestination) {
+        throw new Error('Layer total requests not found');
+      }
+      if (isRequestByCountry) {
+        await PageObjects.maps.toggleLayerVisibility('Total Requests by Country');
+      }
+      if (isRequestByDestination) {
+        await PageObjects.maps.toggleLayerVisibility('Total Requests by Destination');
+      }
+    },
+  };
+}
+
+export const services = {
+  mapsHelper: MapsHelper,
+};

--- a/x-pack/test/upgrade/services.ts
+++ b/x-pack/test/upgrade/services.ts
@@ -7,8 +7,10 @@
 
 import { services as functionalServices } from '../functional/services';
 import { services as reportingServices } from './reporting_services';
+import { services as mapsUpgradeServices } from './maps_upgrade_services';
 
 export const services = {
   ...functionalServices,
   ...reportingServices,
+  ...mapsUpgradeServices,
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix upgrade maps smoke tests (#128696)](https://github.com/elastic/kibana/pull/128696)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)