### PR TITLE
[Security Solution][Endpoint] Fix Host Isolation Exceptions summary card showing in Fleet with Basic license

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/user_privileges/endpoint/security_solution_start_dependencies.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/user_privileges/endpoint/security_solution_start_dependencies.tsx
@@ -13,7 +13,7 @@ import { StartPlugins } from '../../../../types';
  * provided to the Security Solution plugin.
  */
 export const SecuritySolutionStartDependenciesContext = React.createContext<
-  undefined | StartPlugins
+  undefined | Pick<StartPlugins, 'data' | 'fleet'>
 >(undefined);
 
 /**
@@ -21,6 +21,8 @@ export const SecuritySolutionStartDependenciesContext = React.createContext<
  * security solution, as is the case with UI extensions that are rendered within the Fleet
  * pages.
  */
-export const useSecuritySolutionStartDependencies = (): undefined | StartPlugins => {
+export const useSecuritySolutionStartDependencies = ():
+  | undefined
+  | Pick<StartPlugins, 'data' | 'fleet'> => {
   return useContext(SecuritySolutionStartDependenciesContext);
 };

--- a/x-pack/plugins/security_solution/public/common/components/user_privileges/endpoint/security_solution_start_dependencies.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/user_privileges/endpoint/security_solution_start_dependencies.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useContext } from 'react';
+import { StartPlugins } from '../../../../types';
+
+/**
+ * For use with the Fleet UI extensions, where `useKibana().services.**` does not return the services
+ * provided to the Security Solution plugin.
+ */
+export const SecuritySolutionStartDependenciesContext = React.createContext<
+  undefined | StartPlugins
+>(undefined);
+
+/**
+ * Hook used in `useEndpointPrivileges()` when that hook is being invoked from outside of
+ * security solution, as is the case with UI extensions that are rendered within the Fleet
+ * pages.
+ */
+export const useSecuritySolutionStartDependencies = (): undefined | StartPlugins => {
+  return useContext(SecuritySolutionStartDependenciesContext);
+};

--- a/x-pack/plugins/security_solution/public/common/components/user_privileges/endpoint/use_endpoint_privileges.ts
+++ b/x-pack/plugins/security_solution/public/common/components/user_privileges/endpoint/use_endpoint_privileges.ts
@@ -18,6 +18,7 @@ import {
   getEndpointAuthzInitialState,
 } from '../../../../../common/endpoint/service/authz';
 import { FleetAuthz } from '../../../../../../fleet/common';
+import { useSecuritySolutionStartDependencies } from './security_solution_start_dependencies';
 
 /**
  * Retrieve the endpoint privileges for the current user.
@@ -27,13 +28,19 @@ import { FleetAuthz } from '../../../../../../fleet/common';
  */
 export const useEndpointPrivileges = (): Immutable<EndpointPrivileges> => {
   const user = useCurrentUser();
-  const fleetServices = useKibana().services.fleet;
+  const fleetServicesFromUseKibana = useKibana().services.fleet;
+  // The `fleetServicesFromPluginStart` will be defined when this hooks called from a component
+  // that is being rendered under the Fleet context (UI extensions). The `fleetServicesFromUseKibana`
+  // above will be `undefined` in this case.
+  const fleetServicesFromPluginStart = useSecuritySolutionStartDependencies()?.fleet;
   const isMounted = useRef<boolean>(true);
   const licenseService = useLicense();
   const [fleetCheckDone, setFleetCheckDone] = useState<boolean>(false);
   const [fleetAuthz, setFleetAuthz] = useState<FleetAuthz | null>(null);
   const [userRolesCheckDone, setUserRolesCheckDone] = useState<boolean>(false);
   const [userRoles, setUserRoles] = useState<MaybeImmutable<string[]>>([]);
+
+  const fleetServices = fleetServicesFromUseKibana ?? fleetServicesFromPluginStart;
 
   const privileges = useMemo(() => {
     const privilegeList: EndpointPrivileges = Object.freeze({

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/index.tsx
@@ -11,7 +11,6 @@ import { EuiSpacer } from '@elastic/eui';
 import React, { memo, useMemo } from 'react';
 import { useHttp } from '../../../../../../common/lib/kibana/hooks';
 import { PackageCustomExtensionComponentProps } from '../../../../../../../../fleet/public';
-import { ReactQueryClientProvider } from '../../../../../../common/containers/query_client/query_client_provider';
 import { FleetArtifactsCard } from './components/fleet_artifacts_card';
 import {
   getBlocklistsListPath,
@@ -23,6 +22,7 @@ import { TrustedAppsApiClient } from '../../../../trusted_apps/service/trusted_a
 import { EventFiltersApiClient } from '../../../../event_filters/service/event_filters_api_client';
 import { HostIsolationExceptionsApiClient } from '../../../../host_isolation_exceptions/host_isolation_exceptions_api_client';
 import { BlocklistsApiClient } from '../../../../blocklist/services';
+import { useCanSeeHostIsolationExceptionsMenu } from '../../../../host_isolation_exceptions/view/hooks';
 
 export const TRUSTED_APPS_LABELS = {
   artifactsSummaryApiError: (error: string) =>
@@ -96,6 +96,8 @@ export const BLOCKLISTS_LABELS = {
 export const EndpointPackageCustomExtension = memo<PackageCustomExtensionComponentProps>(
   (props) => {
     const http = useHttp();
+    const canSeeHostIsolationExceptions = useCanSeeHostIsolationExceptionsMenu();
+
     const trustedAppsApiClientInstance = useMemo(
       () => TrustedAppsApiClient.getInstance(http),
       [http]
@@ -115,39 +117,41 @@ export const EndpointPackageCustomExtension = memo<PackageCustomExtensionCompone
 
     return (
       <div data-test-subj="fleetEndpointPackageCustomContent">
-        <ReactQueryClientProvider>
-          <FleetArtifactsCard
-            {...props}
-            artifactApiClientInstance={trustedAppsApiClientInstance}
-            getArtifactsPath={getTrustedAppsListPath}
-            labels={TRUSTED_APPS_LABELS}
-            data-test-subj="trustedApps"
-          />
-          <EuiSpacer />
-          <FleetArtifactsCard
-            {...props}
-            artifactApiClientInstance={eventFiltersApiClientInstance}
-            getArtifactsPath={getEventFiltersListPath}
-            labels={EVENT_FILTERS_LABELS}
-            data-test-subj="eventFilters"
-          />
-          <EuiSpacer />
-          <FleetArtifactsCard
-            {...props}
-            artifactApiClientInstance={hostIsolationExceptionsApiClientInstance}
-            getArtifactsPath={getHostIsolationExceptionsListPath}
-            labels={HOST_ISOLATION_EXCEPTIONS_LABELS}
-            data-test-subj="hostIsolationExceptions"
-          />
-          <EuiSpacer />
-          <FleetArtifactsCard
-            {...props}
-            artifactApiClientInstance={bloklistsApiClientInstance}
-            getArtifactsPath={getBlocklistsListPath}
-            labels={BLOCKLISTS_LABELS}
-            data-test-subj="blocklists"
-          />
-        </ReactQueryClientProvider>
+        <FleetArtifactsCard
+          {...props}
+          artifactApiClientInstance={trustedAppsApiClientInstance}
+          getArtifactsPath={getTrustedAppsListPath}
+          labels={TRUSTED_APPS_LABELS}
+          data-test-subj="trustedApps"
+        />
+        <EuiSpacer />
+        <FleetArtifactsCard
+          {...props}
+          artifactApiClientInstance={eventFiltersApiClientInstance}
+          getArtifactsPath={getEventFiltersListPath}
+          labels={EVENT_FILTERS_LABELS}
+          data-test-subj="eventFilters"
+        />
+        {canSeeHostIsolationExceptions && (
+          <>
+            <EuiSpacer />
+            <FleetArtifactsCard
+              {...props}
+              artifactApiClientInstance={hostIsolationExceptionsApiClientInstance}
+              getArtifactsPath={getHostIsolationExceptionsListPath}
+              labels={HOST_ISOLATION_EXCEPTIONS_LABELS}
+              data-test-subj="hostIsolationExceptions"
+            />
+          </>
+        )}
+        <EuiSpacer />
+        <FleetArtifactsCard
+          {...props}
+          artifactApiClientInstance={bloklistsApiClientInstance}
+          getArtifactsPath={getBlocklistsListPath}
+          labels={BLOCKLISTS_LABELS}
+          data-test-subj="blocklists"
+        />
       </div>
     );
   }

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_policy_edit_extension.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_policy_edit_extension.tsx
@@ -31,7 +31,6 @@ import {
   policyDetailsForUpdate,
 } from '../../store/policy_details/selectors';
 
-import { ReactQueryClientProvider } from '../../../../../common/containers/query_client/query_client_provider';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
 import { FleetIntegrationArtifactsCard } from './endpoint_package_custom_extension/components/fleet_integration_artifacts_card';
 import { BlocklistsApiClient } from '../../../blocklist/services';
@@ -137,10 +136,10 @@ export const TRUSTED_APPS_LABELS = {
 export const EndpointPolicyEditExtension = memo<PackagePolicyEditExtensionComponentProps>(
   ({ policy, onChange }) => {
     return (
-      <ReactQueryClientProvider>
+      <>
         <EuiSpacer size="m" />
         <WrappedPolicyDetailsForm policyId={policy.id} onChange={onChange} />
-      </ReactQueryClientProvider>
+      </>
     );
   }
 );

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/with_security_context.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/with_security_context.tsx
@@ -28,7 +28,7 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 interface WithSecurityContextProps<P extends {}> {
   coreStart: CoreStart;
-  depsStart: StartPlugins;
+  depsStart: Pick<StartPlugins, 'data' | 'fleet'>;
   WrappedComponent: ComponentType<P>;
 }
 

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/with_security_context.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/with_security_context.tsx
@@ -15,6 +15,8 @@ import { managementReducer } from '../../../../store/reducer';
 import { managementMiddlewareFactory } from '../../../../store/middleware';
 import { appReducer } from '../../../../../common/store/app';
 import { ExperimentalFeaturesService } from '../../../../../common/experimental_features_service';
+import { SecuritySolutionStartDependenciesContext } from '../../../../../common/components/user_privileges/endpoint/security_solution_start_dependencies';
+import { ReactQueryClientProvider } from '../../../../../common/containers/query_client/query_client_provider';
 
 type ComposeType = typeof compose;
 declare global {
@@ -26,7 +28,7 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 interface WithSecurityContextProps<P extends {}> {
   coreStart: CoreStart;
-  depsStart: Pick<StartPlugins, 'data' | 'fleet'>;
+  depsStart: StartPlugins;
   WrappedComponent: ComponentType<P>;
 }
 
@@ -69,9 +71,13 @@ export const withSecurityContext = <P extends {}>({
 
     return (
       <ReduxStoreProvider store={store}>
-        <CurrentLicense>
-          <WrappedComponent {...props} />
-        </CurrentLicense>
+        <ReactQueryClientProvider>
+          <SecuritySolutionStartDependenciesContext.Provider value={depsStart}>
+            <CurrentLicense>
+              <WrappedComponent {...props} />
+            </CurrentLicense>
+          </SecuritySolutionStartDependenciesContext.Provider>
+        </ReactQueryClientProvider>
       </ReduxStoreProvider>
     );
   });


### PR DESCRIPTION
## Summary

See #129325 for full details

- Changes `useEndpointPrivileges()` to enable it to work when rendered under the fleet context. (for endpoint's UI extensions)
- Add check to the Host Isolation Exceptions card to ensure card can/should be shown


![olm-129325-card-hidden-in-basic](https://user-images.githubusercontent.com/56442535/161627347-0583a399-3033-4a97-b7e4-bdc5021af9a3.gif)

