### PR TITLE
[CI] Add SSH info to agent debug logs

### DIFF
--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+echo '--- Agent Debug Info'
 node .buildkite/scripts/lifecycle/print_agent_links.js || true
 
 IS_TEST_EXECUTION_STEP="$(buildkite-agent meta-data get "${BUILDKITE_JOB_ID}_is_test_execution_step" --default '')"

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -30,8 +30,10 @@ echo '--- Agent Debug/SSH Info'
 node .buildkite/scripts/lifecycle/print_agent_links.js || true
 
 if [[ "$(curl -is metadata.google.internal || true)" ]]; then
+  echo ""
   echo 'To SSH into this agent, run:'
   echo "gcloud compute ssh --tunnel-through-iap --project elastic-kibana-ci --zone \"$(curl -sH Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/zone)\" \"$(curl -sH Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/name)\""
+  echo ""
 fi
 
 

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -31,7 +31,7 @@ node .buildkite/scripts/lifecycle/print_agent_links.js || true
 
 if [[ "$(curl -is metadata.google.internal || true)" ]]; then
   echo ""
-  echo 'To SSH into this agent, run:'
+  echo "To SSH into this agent, run:"
   echo "gcloud compute ssh --tunnel-through-iap --project elastic-kibana-ci --zone \"$(curl -sH Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/zone)\" \"$(curl -sH Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/name)\""
   echo ""
 fi

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -26,7 +26,14 @@ retry 5 15 install_deps
 
 cd ..
 
+echo '--- Agent Debug/SSH Info'
 node .buildkite/scripts/lifecycle/print_agent_links.js || true
+
+if [[ "$(curl -is metadata.google.internal || true)" ]]; then
+  echo 'To SSH into this agent, run:'
+  echo "gcloud compute ssh --tunnel-through-iap --project elastic-kibana-ci --zone \"$(curl -sH Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/zone)\" \"$(curl -sH Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/name)\""
+fi
+
 
 echo '--- Job Environment Setup'
 

--- a/.buildkite/scripts/lifecycle/print_agent_links.js
+++ b/.buildkite/scripts/lifecycle/print_agent_links.js
@@ -30,7 +30,6 @@ const { BuildkiteClient } = require('kibana-buildkite-library');
       `?time=${startTime.getTime()}`,
     ].join('');
 
-    console.log('--- Agent Debug Links');
     console.log('Agent Metrics:');
     console.log('\u001b]1339;' + `url='${METRICS_URL}'\u0007`);
     console.log('Agent Logs:');


### PR DESCRIPTION
Elastic employees should now be able to SSH into agent instances, so let's detect that the instance is running on GCP, and then output the info to do so.