### PR TITLE
[CI] Don't generate an error comment when auto-committing changes

### DIFF
--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -47,6 +47,11 @@ check_for_changed_files() {
 
       git commit -m "$NEW_COMMIT_MESSAGE"
       git push
+
+      # After the git push, the new commit will trigger a new build within a few seconds and this build should get cancelled
+      # So, let's just sleep to give the build time to cancel itself without an error
+      # If it doesn't get cancelled for some reason, then exit with an error, because we don't want this build to be green (we just don't want it to generate an error either)
+      sleep 300
       exit 1
     else
       echo -e "\n${RED}ERROR: '$1' caused changes to the following files:${C_RESET}\n"


### PR DESCRIPTION
When auto-committing changes:

After the git push, the new commit will trigger a new build within a few seconds and this build should get cancelled. So, let's just sleep to give the build time to cancel itself without an error. If it doesn't get cancelled for some reason, then exit with an error, because we don't want this build to be green (we just don't want it to generate an error either).