### PR TITLE
[docs] Adds paragraphs on inter-app navigation with application service

### DIFF
--- a/dev_docs/key_concepts/navigation.mdx
+++ b/dev_docs/key_concepts/navigation.mdx
@@ -124,6 +124,22 @@ const MyApp = () =>
 </RedirectAppLinks>
 ```
 
+NOTE: There may be cases where you need a full page reload. While rare and should be avoided, rather than implement your own navigation, 
+you can use the `navigateToUrl` `forceRedirect` option.
+
+```tsx
+const MyForcedPageReloadLink = () => 
+  <a 
+    href={urlToSomeSpecialApp} 
+    onClick={(e) => {
+      e.preventDefault();
+      core.application.navigateToUrl('someSpecialApp', { forceRedirect: true }); 
+    }}
+  > 
+    Go to Some Special App 
+  </a>;
+```
+
 ## Setting up internal app routing
 
 It is very common for Kibana apps to use React and React Router.

--- a/dev_docs/key_concepts/navigation.mdx
+++ b/dev_docs/key_concepts/navigation.mdx
@@ -89,6 +89,10 @@ To navigate between different Kibana apps without a page reload there are APIs i
 * [core.application.navigateToApp](https://github.com/elastic/kibana/blob/main/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetoapp.md)
 * [core.application.navigateToUrl](https://github.com/elastic/kibana/blob/main/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetourl.md)
 
+Both methods offer customization such as opening the target in a new page, with an `options` parameter. All the options are optional be default.
+* [core.application.navigateToApp options](https://github.com/elastic/kibana/blob/main/docs/development/core/public/kibana-plugin-core-public.navigatetoappoptions.md)
+* [core.application.navigateToUrl options](https://github.com/elastic/kibana/blob/main/docs/development/core/public/kibana-plugin-core-public.navigatetourloptions.md)
+
 *Rendering a link to a different app on its own would also cause a full page reload:*
 
 ```jsx

--- a/dev_docs/key_concepts/navigation.mdx
+++ b/dev_docs/key_concepts/navigation.mdx
@@ -140,6 +140,8 @@ const MyForcedPageReloadLink = () =>
   </a>;
 ```
 
+If you also need to bypass the default onAppLeave behavior, you can set the `skipUnload` option to `true`.
+
 ## Setting up internal app routing
 
 It is very common for Kibana apps to use React and React Router.

--- a/dev_docs/key_concepts/navigation.mdx
+++ b/dev_docs/key_concepts/navigation.mdx
@@ -140,7 +140,7 @@ const MyForcedPageReloadLink = () =>
   </a>;
 ```
 
-If you also need to bypass the default onAppLeave behavior, you can set the `skipUnload` option to `true`.
+If you also need to bypass the default onAppLeave behavior, you can set the `skipUnload` option to `true`. This option is also available in `navigateToApp`.
 
 ## Setting up internal app routing
 

--- a/docs/developer/architecture/core/application_service.asciidoc
+++ b/docs/developer/architecture/core/application_service.asciidoc
@@ -38,8 +38,3 @@ export class MyPlugin implements Plugin {
 NOTE: you are free to use any UI library to render a plugin application in DOM.
 However, we recommend using React and https://elastic.github.io/eui[EUI] for all your basic UI
 components to create a consistent UI experience.
-
-[[application-service-interapp-routing]]
-=== Routing between applications
-There are two api's exposed from the `applicationStart` contract use can use to route bewteen apps in {kib}: 
-{kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetoapp.md[`navigateToApp`] and {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetourl.md[`navigateToUrl`]. Both methods will handle SPA navigation. You can fine tune the behavior with the options they expose. Refer to the APIs for more information.

--- a/docs/developer/architecture/core/application_service.asciidoc
+++ b/docs/developer/architecture/core/application_service.asciidoc
@@ -38,3 +38,8 @@ export class MyPlugin implements Plugin {
 NOTE: you are free to use any UI library to render a plugin application in DOM.
 However, we recommend using React and https://elastic.github.io/eui[EUI] for all your basic UI
 components to create a consistent UI experience.
+
+[[application-service-interapp-routing]]
+=== Routing between applications
+There are two api's exposed from the `applicationStart` contract use can use to route bewteen apps in {kib}: 
+{kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetoapp.md[`navigateToApp`] and {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetourl.md[`navigateToUrl`]. Both methods will handle SPA navigation. You can fine tune the behavior with the options they expose. Refer to the APIs for more information.

--- a/docs/developer/best-practices/navigation.asciidoc
+++ b/docs/developer/best-practices/navigation.asciidoc
@@ -147,7 +147,7 @@ const MyForcedPageReloadLink = () =>
   </a>;
 ----
 
-If you also need to bypass the default onAppLeave behavior, you can set the `skipUnload` option to `true`.
+If you also need to bypass the default onAppLeave behavior, you can set the `skipUnload` option to `true`. This option is also available in `navigateToApp`.
 
 [[routing]]
 === Setting up internal app routing

--- a/docs/developer/best-practices/navigation.asciidoc
+++ b/docs/developer/best-practices/navigation.asciidoc
@@ -85,10 +85,12 @@ const urlToADashboard = core.http.basePath.prepend(`/dashboard/my-dashboard`);
 window.location.href = urlToADashboard; 
 ----
 
-To navigate between different {kib} apps without a page reload there are APIs in `core`:
+To navigate between different {kib} apps without a page reload (by default) there are APIs in `core`:
 
 * {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetoapp.md[core.application.navigateToApp]
 * {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetourl.md[core.application.navigateToUrl]
+
+Both methods offer customization such as opening the target in a new page, with an `options` parameter. All the options are optional be default.
 
 *Rendering a link to a different {kib} app on its own would also cause a full page reload:*
 
@@ -126,6 +128,23 @@ const MyApp = () =>
       <a href={urlToADashboard}>Go to Dashboard</a>
     {/*...*/}
   </RedirectAppLinks>
+----
+
+NOTE: There may be cases where you need a full page reload. While rare and should be avoided, rather than implement your own navigation, 
+you can use the `navigateToUrl` `forceRedirect` option.
+
+[source,typescript jsx]
+----
+const MyForcedPageReloadLink = () => 
+  <a 
+    href={urlToSomeSpecialApp} 
+    onClick={(e) => {
+      e.preventDefault();
+      core.application.navigateToUrl('someSpecialApp', { forceRedirect: true }); 
+    }}
+  > 
+    Go to Some Special App 
+  </a>;
 ----
 
 [[routing]]

--- a/docs/developer/best-practices/navigation.asciidoc
+++ b/docs/developer/best-practices/navigation.asciidoc
@@ -91,6 +91,8 @@ To navigate between different {kib} apps without a page reload (by default) ther
 * {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetourl.md[core.application.navigateToUrl]
 
 Both methods offer customization such as opening the target in a new page, with an `options` parameter. All the options are optional be default.
+* {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.navigatetoappoptions.md[core.application.navigateToApp options]
+* {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.navigatetourloptions.md[core.application.navigateToUrl options]
 
 *Rendering a link to a different {kib} app on its own would also cause a full page reload:*
 

--- a/docs/developer/best-practices/navigation.asciidoc
+++ b/docs/developer/best-practices/navigation.asciidoc
@@ -147,6 +147,8 @@ const MyForcedPageReloadLink = () =>
   </a>;
 ----
 
+If you also need to bypass the default onAppLeave behavior, you can set the `skipUnload` option to `true`.
+
 [[routing]]
 === Setting up internal app routing
 

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -821,6 +821,7 @@ export interface ApplicationStart {
    * ```
    *
    * @param url - an absolute URL, an absolute path or a relative path, to navigate to.
+   * @param options - navigation options
    */
   navigateToUrl(url: string, options?: NavigateToUrlOptions): Promise<void>;
   /**


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/114225.

Adds documentation on using the `skipUnload` and `forceRedirect` navigation options.

### Docs preview (`.asciidoc`)
![Screen Shot 2022-04-04 at 2 39 54 PM](https://user-images.githubusercontent.com/11909450/161637331-94f84638-9c58-488e-ba97-9f8e0181a1d4.png)

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials