### PR TITLE
[8.2] [Session view] Only return default value when process is undefined

### DIFF
--- a/x-pack/plugins/session_view/public/components/detail_panel_process_tab/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_process_tab/index.test.tsx
@@ -76,14 +76,14 @@ describe('DetailPanelProcessTab component', () => {
       expect(renderResult.queryByText(TEST_PROCESS_DETAIL.id)).toBeVisible();
       expect(renderResult.queryByText(TEST_PROCESS_DETAIL.start)).toBeVisible();
       expect(renderResult.queryByText(TEST_PROCESS_DETAIL.end)).toBeVisible();
-      expect(renderResult.queryByText(TEST_PROCESS_DETAIL.exit_code)).toBeVisible();
+      expect(renderResult.queryByText(TEST_PROCESS_DETAIL.exit_code!)).toBeVisible();
       expect(renderResult.queryByText(TEST_PROCESS_DETAIL.userName)).toBeVisible();
       expect(renderResult.queryByText(`['vi', 'test.txt']`)).toBeVisible();
       expect(renderResult.queryAllByText('test-executable-cmd')).toHaveLength(3);
       expect(renderResult.queryByText('(fork)')).toBeVisible();
       expect(renderResult.queryByText('(exec)')).toBeVisible();
       expect(renderResult.queryByText('(end)')).toBeVisible();
-      expect(renderResult.queryByText(TEST_PROCESS_DETAIL.pid)).toBeVisible();
+      expect(renderResult.queryByText(TEST_PROCESS_DETAIL.pid!)).toBeVisible();
 
       // Process tab accordions rendered correctly
       // TODO: revert back when we have jump to leaders button working

--- a/x-pack/plugins/session_view/public/components/session_view_detail_panel/helpers.ts
+++ b/x-pack/plugins/session_view/public/components/session_view_detail_panel/helpers.ts
@@ -14,12 +14,10 @@ const DEFAULT_PROCESS_DATA = {
   name: '',
   start: '',
   end: '',
-  exit_code: -1,
   userName: '',
   groupName: '',
   working_directory: '',
   args: [],
-  pid: -1,
   entryMetaType: '',
   entryMetaSourceIp: '',
   executable: '',
@@ -31,7 +29,6 @@ const getDetailPanelProcessLeader = (leader: ProcessFields | undefined) => ({
   start: leader?.start ?? DEFAULT_PROCESS_DATA.start,
   working_directory: leader?.working_directory ?? DEFAULT_PROCESS_DATA.working_directory,
   args: leader?.args ?? DEFAULT_PROCESS_DATA.args,
-  pid: leader?.pid ?? DEFAULT_PROCESS_DATA.pid,
   executable: leader?.executable ?? DEFAULT_PROCESS_DATA.executable,
   id: leader?.entity_id ?? DEFAULT_PROCESS_DATA.id,
   entryMetaType: leader?.entry_meta?.type ?? DEFAULT_PROCESS_DATA.entryMetaType,
@@ -41,24 +38,22 @@ const getDetailPanelProcessLeader = (leader: ProcessFields | undefined) => ({
 });
 
 export const getDetailPanelProcess = (process: Process | undefined) => {
-  const processData = {
-    id: DEFAULT_PROCESS_DATA.id,
-    start: DEFAULT_PROCESS_DATA.start,
-    end: DEFAULT_PROCESS_DATA.end,
-    exit_code: DEFAULT_PROCESS_DATA.exit_code,
-    userName: DEFAULT_PROCESS_DATA.userName,
-    groupName: DEFAULT_PROCESS_DATA.groupName,
-    args: DEFAULT_PROCESS_DATA.args,
-    executable: [],
-    working_directory: DEFAULT_PROCESS_DATA.working_directory,
-    pid: DEFAULT_PROCESS_DATA.pid,
-    entryLeader: DEFAULT_PROCESS_DATA,
-    sessionLeader: DEFAULT_PROCESS_DATA,
-    groupLeader: DEFAULT_PROCESS_DATA,
-    parent: DEFAULT_PROCESS_DATA,
-  } as DetailPanelProcess;
+  const processData = {} as DetailPanelProcess;
   if (!process) {
-    return processData;
+    return {
+      id: DEFAULT_PROCESS_DATA.id,
+      start: DEFAULT_PROCESS_DATA.start,
+      end: DEFAULT_PROCESS_DATA.end,
+      userName: DEFAULT_PROCESS_DATA.userName,
+      groupName: DEFAULT_PROCESS_DATA.groupName,
+      args: DEFAULT_PROCESS_DATA.args,
+      executable: [],
+      working_directory: DEFAULT_PROCESS_DATA.working_directory,
+      entryLeader: DEFAULT_PROCESS_DATA,
+      sessionLeader: DEFAULT_PROCESS_DATA,
+      groupLeader: DEFAULT_PROCESS_DATA,
+      parent: DEFAULT_PROCESS_DATA,
+    };
   }
 
   processData.id = process.id;
@@ -75,7 +70,7 @@ export const getDetailPanelProcess = (process: Process | undefined) => {
       processData.groupName = event.group?.name ?? '';
     }
     if (!processData.pid) {
-      processData.pid = event.process?.pid ?? -1;
+      processData.pid = event.process?.pid;
     }
     if (!processData.working_directory) {
       processData.working_directory = event.process?.working_directory ?? '';

--- a/x-pack/plugins/session_view/public/types.ts
+++ b/x-pack/plugins/session_view/public/types.ts
@@ -38,14 +38,14 @@ export interface DetailPanelProcess {
   id: string;
   start: string;
   end: string;
-  exit_code: number;
+  exit_code?: number;
   userName: string;
   groupName: string;
   args: string[];
   executable: string[][];
   working_directory: string;
   tty?: Teletype;
-  pid: number;
+  pid?: number;
   entryLeader: DetailPanelProcessLeader;
   sessionLeader: DetailPanelProcessLeader;
   groupLeader: DetailPanelProcessLeader;
@@ -63,7 +63,7 @@ export interface DetailPanelProcessLeader {
   working_directory: string;
   tty?: Teletype;
   args: string[];
-  pid: number;
+  pid?: number;
   entryMetaType: string;
   entryMetaSourceIp: string;
   executable: string;


### PR DESCRIPTION
Default values were used later on in `getDetailPanelProcess` without overwriting