### PR TITLE
[kbn/telemetry-tools] use kibana resolver to handle module resolution

### DIFF
--- a/packages/kbn-telemetry-tools/BUILD.bazel
+++ b/packages/kbn-telemetry-tools/BUILD.bazel
@@ -31,7 +31,9 @@ NPM_MODULE_EXTRA_FILES = [
 
 RUNTIME_DEPS = [
   "//packages/kbn-dev-utils",
+  "//packages/kbn-eslint-plugin-imports",
   "//packages/kbn-utility-types",
+  "//packages/kbn-utils",
   "@npm//glob",
   "@npm//listr",
   "@npm//normalize-path",
@@ -39,7 +41,9 @@ RUNTIME_DEPS = [
 
 TYPES_DEPS = [
   "//packages/kbn-dev-utils:npm_module_types",
+  "//packages/kbn-eslint-plugin-imports:npm_module_types",
   "//packages/kbn-utility-types:npm_module_types",
+  "//packages/kbn-utils:npm_module_types",
   "@npm//tslib",
   "@npm//@types/glob",
   "@npm//@types/jest",

--- a/packages/kbn-telemetry-tools/src/tools/compiler_host.ts
+++ b/packages/kbn-telemetry-tools/src/tools/compiler_host.ts
@@ -28,6 +28,7 @@ function loadTsConfigFile(path: string) {
 
 const baseTsConfig = loadTsConfigFile(Path.resolve(REPO_ROOT, 'tsconfig.base.json'));
 
+// avoid passing .css/.html/.etc paths to TypeScript
 function isTsCompatible(path: string) {
   const extname = Path.extname(path);
   return extname === '.ts' || extname === '.tsx' || extname === '.js';

--- a/packages/kbn-telemetry-tools/src/tools/compiler_host.ts
+++ b/packages/kbn-telemetry-tools/src/tools/compiler_host.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import Path from 'path';
+
+import ts from 'typescript';
+import { REPO_ROOT } from '@kbn/utils';
+import { resolveKibanaImport } from '@kbn/eslint-plugin-imports';
+
+function readTsConfigFile(path: string) {
+  const json = ts.readConfigFile(path, ts.sys.readFile);
+
+  if (json.error) {
+    throw new Error(`Unable to load tsconfig file: ${json.error.messageText}`);
+  }
+
+  return json.config;
+}
+
+function loadTsConfigFile(path: string) {
+  return ts.parseJsonConfigFileContent(readTsConfigFile(path) ?? {}, ts.sys, Path.dirname(path));
+}
+
+const baseTsConfig = loadTsConfigFile(Path.resolve(REPO_ROOT, 'tsconfig.base.json'));
+
+function isTsCompatible(path: string) {
+  const extname = Path.extname(path);
+  return extname === '.ts' || extname === '.tsx' || extname === '.js';
+}
+
+export const compilerHost: ts.CompilerHost = {
+  ...ts.createCompilerHost(baseTsConfig.options),
+
+  resolveModuleNames(moduleNames, sourceFilePath) {
+    const dirname = Path.dirname(sourceFilePath);
+
+    const results: Array<ts.ResolvedModule | undefined> = [];
+
+    for (const req of moduleNames) {
+      const result = resolveKibanaImport(req, dirname);
+      if (result?.type !== 'file' || !isTsCompatible(result.absolute)) {
+        results.push(undefined);
+      } else {
+        results.push({
+          resolvedFileName: result.absolute,
+          isExternalLibraryImport: !!result.nodeModule,
+        });
+      }
+    }
+
+    return results;
+  },
+};

--- a/packages/kbn-telemetry-tools/src/tools/extract_collectors.ts
+++ b/packages/kbn-telemetry-tools/src/tools/extract_collectors.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { parseUsageCollection } from './ts_parser';
 import { globAsync } from './utils';
 import { TelemetryRC } from './config';
+import { compilerHost } from './compiler_host';
 
 export async function getProgramPaths({
   root,
@@ -48,7 +49,7 @@ export async function getProgramPaths({
 }
 
 export function* extractCollectors(fullPaths: string[], tsConfig: any) {
-  const program = ts.createProgram(fullPaths, tsConfig);
+  const program = ts.createProgram(fullPaths, tsConfig, compilerHost);
   program.getTypeChecker();
   const sourceFiles = fullPaths.map((fullPath) => {
     const sourceFile = program.getSourceFile(fullPath);

--- a/packages/kbn-telemetry-tools/src/tools/serializer.test.ts
+++ b/packages/kbn-telemetry-tools/src/tools/serializer.test.ts
@@ -10,6 +10,7 @@ import * as ts from 'typescript';
 import * as path from 'path';
 import { getDescriptor, TelemetryKinds } from './serializer';
 import { traverseNodes } from './ts_parser';
+import { compilerHost } from './compiler_host';
 
 export function loadFixtureProgram(fixtureName: string) {
   const fixturePath = path.resolve(
@@ -23,7 +24,7 @@ export function loadFixtureProgram(fixtureName: string) {
   if (!tsConfig) {
     throw new Error('Could not find a valid tsconfig.json.');
   }
-  const program = ts.createProgram([fixturePath], tsConfig as any);
+  const program = ts.createProgram([fixturePath], tsConfig as any, compilerHost);
   const checker = program.getTypeChecker();
   const sourceFile = program.getSourceFile(fixturePath);
   if (!sourceFile) {

--- a/packages/kbn-telemetry-tools/src/tools/ts_parser.test.ts
+++ b/packages/kbn-telemetry-tools/src/tools/ts_parser.test.ts
@@ -9,6 +9,7 @@
 import { parseUsageCollection } from './ts_parser';
 import * as ts from 'typescript';
 import * as path from 'path';
+import { compilerHost } from './compiler_host';
 import { parsedWorkingCollector } from './__fixture__/parsed_working_collector';
 import { parsedNestedCollector } from './__fixture__/parsed_nested_collector';
 import { parsedExternallyDefinedCollector } from './__fixture__/parsed_externally_defined_collector';
@@ -30,7 +31,7 @@ export function loadFixtureProgram(fixtureName: string) {
   if (!tsConfig) {
     throw new Error('Could not find a valid tsconfig.json.');
   }
-  const program = ts.createProgram([fixturePath], tsConfig as any);
+  const program = ts.createProgram([fixturePath], tsConfig as any, compilerHost);
   const checker = program.getTypeChecker();
   const sourceFile = program.getSourceFile(fixturePath);
   if (!sourceFile) {

--- a/packages/kbn-telemetry-tools/src/tools/ts_parser.ts
+++ b/packages/kbn-telemetry-tools/src/tools/ts_parser.ts
@@ -223,7 +223,7 @@ export function* parseUsageCollection(
           const collectorDetails = extractCollectorDetails(node, program, sourceFile);
           yield [relativePath, collectorDetails];
         } catch (err) {
-          throw createFailError(`Error extracting collector in ${relativePath}\n${err}`);
+          throw createFailError(`Error extracting collector in ${relativePath}\n${err.stack}`);
         }
       }
     }

--- a/packages/kbn-telemetry-tools/src/tools/utils.ts
+++ b/packages/kbn-telemetry-tools/src/tools/utils.ts
@@ -154,6 +154,12 @@ export function getResolvedModuleSourceFile(
   importedModuleName: string
 ) {
   const resolvedModule = (originalSource as any).resolvedModules.get(importedModuleName);
+  if (!resolvedModule) {
+    throw new Error(
+      `Import for [${importedModuleName}] in [${originalSource.fileName}] could not be resolved by TypeScript`
+    );
+  }
+
   const resolvedModuleSourceFile = program.getSourceFile(resolvedModule.resolvedFileName);
   if (!resolvedModuleSourceFile) {
     throw new Error(`Unable to find resolved module ${importedModuleName}`);


### PR DESCRIPTION
I ran into problems with `node scripts/telemetry_check` in https://github.com/elastic/kibana/pull/128700 so I took took a look at what might be happening and found that the telemetry check script doesn't seem to be using the actual `tsconfig.json` files to configure the typescript compiler. It seems to just be passing the string `'./tsconfig.json'` in place the parsed compiler options which I don't think work the way they are intended. Actually fixing the problem is complicated and they seem to function the way they are, but because they're not loading the updated `tsconfig.base.json` file in my PR the resolution rules are not loaded into the compiler. Thankfully, the compiler has a `resolveKibanaImport()` hook on the `CompilerHost` interface which we can use to shim the module resolution logic with our own from `@kbn/eslint-plugin-imports`. I think it would be ideal to fix the config loading mechanism in this script, but in the interest of time I propose we go this route instead. Thoughts?