### PR TITLE
[8.1] [Stack Monitoring] Rename "APM & Fleet Server" to "Integrations Server" (#128574)

### DIFF
--- a/x-pack/plugins/monitoring/public/components/apm/apm_metrics.tsx
+++ b/x-pack/plugins/monitoring/public/components/apm/apm_metrics.tsx
@@ -22,8 +22,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 
 // @ts-ignore could not find declaration file
 import { MonitoringTimeseriesContainer } from '../chart';
-// @ts-ignore could not find declaration file
-import { Status } from './instance/status';
 import { checkAgentTypeMetric } from '../../lib/apm_agent';
 
 interface TitleType {
@@ -63,12 +61,12 @@ const getHeading = (isFleetTypeMetric: boolean) => {
   const titles: TitleType = {};
   if (isFleetTypeMetric) {
     titles.title = i18n.translate('xpack.monitoring.apm.metrics.topCharts.agentTitle', {
-      defaultMessage: 'APM & Fleet Server - Resource Usage',
+      defaultMessage: 'Integrations Server - Resource Usage',
     });
     titles.heading = (
       <FormattedMessage
         id="xpack.monitoring.apm.metrics.agentHeading"
-        defaultMessage="APM & Fleet Server"
+        defaultMessage="Integrations Server"
       />
     );
     return titles;

--- a/x-pack/plugins/monitoring/public/components/cluster/overview/apm_panel.js
+++ b/x-pack/plugins/monitoring/public/components/cluster/overview/apm_panel.js
@@ -39,14 +39,14 @@ const getServerTitle = (isFleetTypeMetric, total) => {
     linkLabel.link = (
       <FormattedMessage
         id="xpack.monitoring.cluster.overview.apmPanel.agentServersTotalLinkLabel"
-        defaultMessage="APM & Fleet Servers: {apmsTotal}"
+        defaultMessage="Integrations Servers: {apmsTotal}"
         values={{ apmsTotal }}
       />
     );
     linkLabel.aria = i18n.translate(
       'xpack.monitoring.cluster.overview.apmPanel.instancesAndFleetsTotalLinkAriaLabel',
       {
-        defaultMessage: 'APM and Fleet server instances: {apmsTotal}',
+        defaultMessage: 'Integrations server instances: {apmsTotal}',
         values: { apmsTotal },
       }
     );
@@ -73,7 +73,7 @@ const getServerTitle = (isFleetTypeMetric, total) => {
 const getOverviewTitle = (isFleetTypeMetric) => {
   if (isFleetTypeMetric) {
     return i18n.translate('xpack.monitoring.cluster.overview.apmPanel.overviewFleetLinkLabel', {
-      defaultMessage: 'APM & Fleet server overview',
+      defaultMessage: 'Integrations server overview',
     });
   }
   return i18n.translate('xpack.monitoring.cluster.overview.apmPanel.overviewLinkLabel', {
@@ -84,7 +84,7 @@ const getOverviewTitle = (isFleetTypeMetric) => {
 const getHeadingTitle = (isFleetTypeMetric) => {
   if (isFleetTypeMetric) {
     return i18n.translate('xpack.monitoring.cluster.overview.apmPanel.apmFleetTitle', {
-      defaultMessage: 'APM & Fleet server',
+      defaultMessage: 'Integrations server',
     });
   }
   return i18n.translate('xpack.monitoring.cluster.overview.apmPanel.apmTitle', {

--- a/x-pack/plugins/monitoring/public/lib/apm_agent.ts
+++ b/x-pack/plugins/monitoring/public/lib/apm_agent.ts
@@ -8,8 +8,9 @@
 import { Legacy } from '../legacy_shims';
 
 /**
- * Possible temporary work arround to establish if APM might also be monitoring fleet:
- * https://github.com/elastic/kibana/pull/95129/files#r604815886
+ * Checks if on cloud and >= 7.13
+ * In this configuration APM server should be running within elastic agent.
+ * See https://github.com/elastic/kibana/issues/97879 for details.
  */
 export const checkAgentTypeMetric = (versions?: string[]) => {
   if (!Legacy.shims.isCloud || !versions) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Stack Monitoring] Rename "APM & Fleet Server" to "Integrations Server" (#128574)](https://github.com/elastic/kibana/pull/128574)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)