### PR TITLE
Removes references to kibana.yml settings from tooltip

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form.tsx
@@ -585,7 +585,7 @@ export const RuleForm = ({
         type="questionInCircle"
         content={i18n.translate('xpack.triggersActionsUI.sections.ruleForm.checkWithTooltip', {
           defaultMessage:
-            'Define how often to evaluate the condition. Checks are queued; they run as close to the defined value as capacity allows. The xpack.alerting.rules.minimumScheduleInterval.value setting defines the minimum value. The xpack.alerting.rules.minimumScheduleInterval.enforce setting defines whether this minimum is required or suggested.',
+            'Define how often to evaluate the condition. Checks are queued; they run as close to the defined value as capacity allows.',
         })}
       />
     </>


### PR DESCRIPTION
## Summary

This PR modifies a tooltip in `rule_form.tsx` which mentions two settings from `kibana.yml`. Tooltips rarely reference low-level technical info. It makes the tooltip long and harder to read.