### PR TITLE
[Console] Handle multiple request exceptions 

### DIFF
--- a/src/plugins/console/public/application/hooks/use_send_current_request/send_request.test.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request/send_request.test.ts
@@ -49,7 +49,7 @@ describe('sendRequest', () => {
     expect(mockedSendRequest).toHaveBeenCalledTimes(1);
   });
 
-  describe('with multiple requests', function () {
+  describe('with multiple requests', () => {
     it('should return results with exceptions', async () => {
       mockedSendRequest.mockResolvedValue([
         {

--- a/src/plugins/console/public/application/hooks/use_send_current_request/send_request.test.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request/send_request.test.ts
@@ -49,34 +49,43 @@ describe('sendRequest', () => {
     expect(mockedSendRequest).toHaveBeenCalledTimes(1);
   });
 
-  it('should send multiple requests', async () => {
-    mockedSendRequest.mockResolvedValue([
-      {
-        response: {
-          statusCode: 200,
+  describe('with multiple requests', function () {
+    it('should return results with exceptions', async () => {
+      mockedSendRequest.mockResolvedValue([
+        {
+          response: {
+            statusCode: 200,
+          },
         },
-      },
-      {
-        response: {
-          statusCode: 200,
+        {
+          response: {
+            statusCode: 200,
+          },
         },
-      },
-    ]);
+        {
+          response: {
+            statusCode: 400,
+          },
+        },
+      ]);
 
-    const args = {
-      http: mockContextValue.services.http,
-      requests: [
-        { method: 'GET', url: 'test-1', data: [] },
-        { method: 'GET', url: 'test-2', data: [] },
-      ],
-    };
-    const results = await sendRequest(args);
+      const args = {
+        http: mockContextValue.services.http,
+        requests: [
+          { method: 'GET', url: 'success', data: [] },
+          { method: 'GET', url: 'success', data: [] },
+          { method: 'GET', url: 'fail', data: [] },
+        ],
+      };
+      const results = await sendRequest(args);
 
-    const [firstRequest, secondRequest] = results;
-    expect(firstRequest.response.statusCode).toEqual(200);
-    expect(secondRequest.response.statusCode).toEqual(200);
-    expect(mockedSendRequest).toHaveBeenCalledWith(args);
-    expect(mockedSendRequest).toHaveBeenCalledTimes(1);
+      const [firstCall, secondCall, thirdCall] = results;
+      expect(firstCall.response.statusCode).toEqual(200);
+      expect(secondCall.response.statusCode).toEqual(200);
+      expect(thirdCall.response.statusCode).toEqual(400);
+      expect(mockedSendRequest).toHaveBeenCalledWith(args);
+      expect(mockedSendRequest).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should handle errors', async () => {

--- a/src/plugins/console/public/application/hooks/use_send_current_request/send_request.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request/send_request.ts
@@ -33,6 +33,9 @@ export interface RequestResult<V = unknown> {
   response: ResponseObject<V>;
 }
 
+const getContentType = (response: Response | undefined) =>
+  (response?.headers.get('Content-Type') as BaseResponseType) ?? '';
+
 let CURRENT_REQ_ID = 0;
 export function sendRequest(args: RequestArgs): Promise<RequestResult[]> {
   const requests = args.requests.slice();
@@ -111,7 +114,7 @@ export function sendRequest(args: RequestArgs): Promise<RequestResult[]> {
                 timeMs: Date.now() - startTime,
                 statusCode: response.status,
                 statusText: response.statusText,
-                contentType: response.headers.get('Content-Type') as BaseResponseType,
+                contentType: getContentType(response),
                 value,
               },
               request: {
@@ -128,7 +131,6 @@ export function sendRequest(args: RequestArgs): Promise<RequestResult[]> {
       } catch (error) {
         let value;
         const { response, body } = error as IHttpFetchError;
-        const contentType = (response?.headers.get('Content-Type') as BaseResponseType) ?? '';
         const statusCode = response?.status ?? 500;
         const statusText = response?.statusText ?? 'error';
 
@@ -145,7 +147,7 @@ export function sendRequest(args: RequestArgs): Promise<RequestResult[]> {
         const result = {
           response: {
             value,
-            contentType,
+            contentType: getContentType(response),
             timeMs: Date.now() - startTime,
             statusCode,
             statusText,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/78919

### Summary

Fixes outputting multiple request results with exceptions in editor output.

### Testing
To test this out, send the following requests at once
```
PUT test 
{
  "mappings": {
    "properties": {
      "trips" : {
        "type": "nested"
      }
    }
  }
}

POST test/_doc
{
  "value": "abc",
  "trips": [
    {
      "type": "home",
      "changes": 0
    },
    {
      "type": "home",
      "changes": 1
    }
  ]
}

POST test/_doc
{
  "value": "abc",
  "trips": [
    {
      "type": "home",
      "changes": 0
    },
    {
      "type": "home",
      "changes": 0
    }
  ]
}

POST test/_doc
{
  "trips" : 1
}

POST test/_refresh
```

## Release Note
Console now supports properly handling multiple requests. For es errors such as `400`, `405` exception results are displayed with successful request results in the order they called. For non-es errors such as `500`, it outputs only the first exception result.

<details>
<summary>
Screenshots
</summary>

![2022-04-14_13-39](https://user-images.githubusercontent.com/53621505/163350171-8d4326c2-abe2-41a2-8b7c-67108e336fc2.png)
![2022-04-14_13-43](https://user-images.githubusercontent.com/53621505/163349553-c0379204-a696-434f-86b7-d865f2019f86.png)

</details>
