### PR TITLE
[Lens] Fixes flakiness on switchToVisualization search input

### DIFF
--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -720,6 +720,8 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
      */
     async switchToVisualization(subVisualizationId: string, searchTerm?: string) {
       await this.openChartSwitchPopover();
+      const searchInput = await testSubjects.find('lnsChartSwitchSearch');
+      await searchInput.focus();
       await this.searchOnChartSwitch(subVisualizationId, searchTerm);
       await testSubjects.click(`lnsChartSwitchPopover_${subVisualizationId}`);
       await PageObjects.header.waitUntilLoadingHasFinished();


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/129407

Makes sure that the input text on the switch chart popover is focused before start typing. 

We had a cloud failure, it seems that the test is start writing but without the input being focused.

![image](https://user-images.githubusercontent.com/17003240/161740466-9fd35c2c-74ac-4a2b-a27a-c27d77394b2f.png)

I run it 100 times on the normal flaky test runner.
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/375
https://internal-ci.elastic.co/view/Stack%20Tests/job/elastic+estf-cloud-kibana-flaky-test-runner/360/ (cloud flaky runner)
### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios