### PR TITLE
[Security Solution] Fix alerts and external alerts filters on Hots and Users pages

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../mock';
 import { getExternalAlertLensAttributes } from './lens_attributes/common/external_alert';
 import { useLensAttributes } from './use_lens_attributes';
-import { filterHostExternalAlertData, getHostDetailsPageFilter, getIndexFilters } from './utils';
+import { hostNameExistsFilter, getHostDetailsPageFilter, getIndexFilters } from './utils';
 import { createStore, State } from '../../store';
 
 jest.mock('../../containers/sourcerer', () => ({
@@ -80,7 +80,7 @@ describe('useLensAttributes', () => {
     store = createStore(myState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
   });
 
-  it('should should add query', () => {
+  it('should add query', () => {
     const wrapper = ({ children }: { children: React.ReactElement }) => (
       <TestProviders store={store}>{children}</TestProviders>
     );
@@ -96,7 +96,7 @@ describe('useLensAttributes', () => {
     expect(result?.current?.state.query).toEqual({ query: 'host.name: *', language: 'kql' });
   });
 
-  it('should should add filters', () => {
+  it('should add filters', () => {
     const wrapper = ({ children }: { children: React.ReactElement }) => (
       <TestProviders store={store}>{children}</TestProviders>
     );
@@ -113,12 +113,12 @@ describe('useLensAttributes', () => {
       ...getExternalAlertLensAttributes().state.filters,
       ...filterFromSearchBar,
       ...getHostDetailsPageFilter('mockHost'),
-      ...filterHostExternalAlertData,
+      ...hostNameExistsFilter,
       ...getIndexFilters(['auditbeat-*']),
     ]);
   });
 
-  it('should should add data view id to references', () => {
+  it('should add data view id to references', () => {
     const wrapper = ({ children }: { children: React.ReactElement }) => (
       <TestProviders store={store}>{children}</TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import { SecurityPageName } from '../../../../common/constants';
+import { HostsTableType } from '../../../hosts/store/model';
 import { NetworkRouteType } from '../../../network/pages/navigation/types';
 import { useSourcererDataView } from '../../containers/sourcerer';
 import { useDeepEqualSelector } from '../../hooks/use_selector';
@@ -16,7 +17,7 @@ import { LensAttributes, GetLensAttributes } from './types';
 import {
   getHostDetailsPageFilter,
   filterNetworkExternalAlertData,
-  filterHostExternalAlertData,
+  hostNameExistsFilter,
   getIndexFilters,
 } from './utils';
 
@@ -40,8 +41,11 @@ export const useLensAttributes = ({
   const [{ detailName, pageName, tabName }] = useRouteSpy();
 
   const tabsFilters = useMemo(() => {
-    if (pageName === SecurityPageName.hosts && tabName === 'externalAlerts') {
-      return filterHostExternalAlertData;
+    if (
+      pageName === SecurityPageName.hosts &&
+      (tabName === HostsTableType.alerts || tabName === HostsTableType.events)
+    ) {
+      return hostNameExistsFilter;
     }
 
     if (pageName === SecurityPageName.network && tabName === NetworkRouteType.alerts) {

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/utils.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/utils.ts
@@ -30,7 +30,7 @@ export const getHostDetailsPageFilter = (hostName?: string): Filter[] =>
       ]
     : [];
 
-export const filterHostExternalAlertData: Filter[] = [
+export const hostNameExistsFilter: Filter[] = [
   {
     query: {
       bool: {

--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
@@ -11,8 +11,8 @@ import { noop } from 'lodash/fp';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
+import { Filter } from '@kbn/es-query';
 import { isTab } from '../../../../timelines/public';
-
 import { SecurityPageName } from '../../app/types';
 import { UpdateDateRange } from '../../common/components/charts/common';
 import { FiltersGlobal } from '../../common/components/filters_global';
@@ -54,9 +54,10 @@ import { useDeepEqualSelector, useShallowEqualSelector } from '../../common/hook
 import { useInvalidFilterQuery } from '../../common/hooks/use_invalid_filter_query';
 import { ID } from '../containers/hosts';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
-import { filterHostExternalAlertData } from '../../common/components/visualization_actions/utils';
+
 import { LandingPageComponent } from '../../common/components/landing_page';
 import { Loader } from '../../common/components/loader';
+import { hostNameExistsFilter } from '../../common/components/visualization_actions/utils';
 
 /**
  * Need a 100% height here to account for the graph/analyze tool, which sets no explicit height parameters, but fills the available space.
@@ -99,17 +100,15 @@ const HostsComponent = () => {
   const capabilities = useMlCapabilities();
   const { uiSettings } = useKibana().services;
   const { tabName } = useParams<{ tabName: string }>();
-  const tabsFilters = React.useMemo(() => {
-    if (tabName === HostsTableType.alerts) {
-      return filters.length > 0
-        ? [...filters, ...filterHostExternalAlertData]
-        : filterHostExternalAlertData;
+  const tabsFilters: Filter[] = React.useMemo(() => {
+    if (tabName === HostsTableType.alerts || tabName === HostsTableType.events) {
+      return filters.length > 0 ? [...filters, ...hostNameExistsFilter] : hostNameExistsFilter;
     }
 
     if (tabName === HostsTableType.risk) {
       const severityFilter = generateSeverityFilter(severitySelection);
 
-      return [...severityFilter, ...filterHostExternalAlertData, ...filters];
+      return [...severityFilter, ...hostNameExistsFilter, ...filters];
     }
     return filters;
   }, [severitySelection, tabName, filters]);
@@ -242,6 +241,7 @@ const HostsComponent = () => {
               setQuery={setQuery}
               from={from}
               type={hostsModel.HostsType.page}
+              pageFilters={tabsFilters}
             />
           </SecuritySolutionPageWrapper>
         </StyledFullHeightContainer>

--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts_tabs.tsx
@@ -33,6 +33,7 @@ export const HostsTabs = memo<HostsTabsProps>(
     deleteQuery,
     docValueFields,
     filterQuery,
+    pageFilters,
     from,
     indexNames,
     isInitializing,
@@ -99,10 +100,14 @@ export const HostsTabs = memo<HostsTabsProps>(
           <AnomaliesQueryTabBody {...tabProps} AnomaliesTableComponent={AnomaliesHostTable} />
         </Route>
         <Route path={`${HOSTS_PATH}/:tabName(${HostsTableType.events})`}>
-          <EventsQueryTabBody {...tabProps} timelineId={TimelineId.hostsPageEvents} />
+          <EventsQueryTabBody
+            {...tabProps}
+            timelineId={TimelineId.hostsPageEvents}
+            pageFilters={pageFilters}
+          />
         </Route>
         <Route path={`${HOSTS_PATH}/:tabName(${HostsTableType.alerts})`}>
-          <HostAlertsQueryTabBody {...tabProps} />
+          <HostAlertsQueryTabBody {...tabProps} pageFilters={pageFilters} />
         </Route>
         <Route path={`${HOSTS_PATH}/:tabName(${HostsTableType.sessions})`}>
           <SessionsTabBody {...tabProps} />

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/alerts_query_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/alerts_query_tab_body.tsx
@@ -9,16 +9,13 @@ import React, { useMemo } from 'react';
 
 import { TimelineId } from '../../../../common/types/timeline';
 import { AlertsView } from '../../../common/components/alerts_viewer';
-import { filterHostExternalAlertData } from '../../../common/components/visualization_actions/utils';
+import { hostNameExistsFilter } from '../../../common/components/visualization_actions/utils';
 import { AlertsComponentQueryProps } from './types';
 
 export const HostAlertsQueryTabBody = React.memo((alertsProps: AlertsComponentQueryProps) => {
   const { pageFilters, ...rest } = alertsProps;
   const hostPageFilters = useMemo(
-    () =>
-      pageFilters != null
-        ? [...filterHostExternalAlertData, ...pageFilters]
-        : filterHostExternalAlertData,
+    () => (pageFilters != null ? [...hostNameExistsFilter, ...pageFilters] : hostNameExistsFilter),
     [pageFilters]
   );
 

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/sessions_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/sessions_tab_body.tsx
@@ -8,16 +8,13 @@
 import React, { useMemo } from 'react';
 import { TimelineId } from '../../../../common/types/timeline';
 import { SessionsView } from '../../../common/components/sessions_viewer';
-import { filterHostExternalAlertData } from '../../../common/components/visualization_actions/utils';
+import { hostNameExistsFilter } from '../../../common/components/visualization_actions/utils';
 import { AlertsComponentQueryProps } from './types';
 
 export const SessionsTabBody = React.memo((alertsProps: AlertsComponentQueryProps) => {
   const { pageFilters, filterQuery, ...rest } = alertsProps;
   const hostPageFilters = useMemo(
-    () =>
-      pageFilters != null
-        ? [...filterHostExternalAlertData, ...pageFilters]
-        : filterHostExternalAlertData,
+    () => (pageFilters != null ? [...hostNameExistsFilter, ...pageFilters] : hostNameExistsFilter),
     [pageFilters]
   );
 

--- a/x-pack/plugins/security_solution/public/hosts/pages/types.ts
+++ b/x-pack/plugins/security_solution/public/hosts/pages/types.ts
@@ -7,6 +7,7 @@
 
 import { ActionCreator } from 'typescript-fsa';
 
+import { Filter } from '@kbn/es-query';
 import { hostsModel } from '../store';
 import { GlobalTimeArgs } from '../../common/containers/use_global_time';
 import { InputsModelId } from '../../common/store/inputs/constants';
@@ -18,6 +19,7 @@ export const hostDetailsPagePath = `${HOSTS_PATH}/:detailName`;
 export type HostsTabsProps = GlobalTimeArgs & {
   docValueFields: DocValueFields[];
   filterQuery: string;
+  pageFilters?: Filter[];
   indexNames: string[];
   type: hostsModel.HostsType;
   setAbsoluteRangeDatePicker: ActionCreator<{

--- a/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
@@ -19,7 +19,7 @@ import { getEsQueryConfig } from '../../../../../../../src/plugins/data/common';
 import { GlobalTimeArgs } from '../../../common/containers/use_global_time';
 import { useInvalidFilterQuery } from '../../../common/hooks/use_invalid_filter_query';
 import {
-  filterHostExternalAlertData,
+  hostNameExistsFilter,
   filterNetworkExternalAlertData,
 } from '../../../common/components/visualization_actions/utils';
 
@@ -51,7 +51,7 @@ const EventCountsComponent: React.FC<Props> = ({
         config: getEsQueryConfig(uiSettings),
         indexPattern,
         queries: [query],
-        filters: [...filters, ...filterHostExternalAlertData],
+        filters: [...filters, ...hostNameExistsFilter],
       }),
     [filters, indexPattern, query, uiSettings]
   );

--- a/x-pack/plugins/security_solution/public/users/pages/details/details_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/details/details_tabs.tsx
@@ -19,7 +19,7 @@ import { usersDetailsPagePath } from '../constants';
 import { TimelineId } from '../../../../common/types';
 import { EventsQueryTabBody } from '../../../common/components/events_tab/events_query_tab_body';
 import { AlertsView } from '../../../common/components/alerts_viewer';
-import { filterUserExternalAlertData } from './helpers';
+import { userNameExistsFilter } from './helpers';
 
 export const UsersDetailsTabs = React.memo<UsersDetailsTabsProps>(
   ({
@@ -64,9 +64,7 @@ export const UsersDetailsTabs = React.memo<UsersDetailsTabsProps>(
 
     const alertsPageFilters = useMemo(
       () =>
-        pageFilters != null
-          ? [...filterUserExternalAlertData, ...pageFilters]
-          : filterUserExternalAlertData,
+        pageFilters != null ? [...userNameExistsFilter, ...pageFilters] : userNameExistsFilter,
       [pageFilters]
     );
 

--- a/x-pack/plugins/security_solution/public/users/pages/details/helpers.ts
+++ b/x-pack/plugins/security_solution/public/users/pages/details/helpers.ts
@@ -31,7 +31,7 @@ export const getUsersDetailsPageFilters = (userName: string): Filter[] => [
   },
 ];
 
-export const filterUserExternalAlertData: Filter[] = [
+export const userNameExistsFilter: Filter[] = [
   {
     query: {
       bool: {

--- a/x-pack/plugins/security_solution/public/users/pages/types.ts
+++ b/x-pack/plugins/security_solution/public/users/pages/types.ts
@@ -6,6 +6,7 @@
  */
 import { ActionCreator } from 'typescript-fsa';
 
+import { Filter } from '@kbn/es-query';
 import { GlobalTimeArgs } from '../../common/containers/use_global_time';
 
 import { usersModel } from '../../users/store';
@@ -15,6 +16,7 @@ import { InputsModelId } from '../../common/store/inputs/constants';
 export type UsersTabsProps = GlobalTimeArgs & {
   docValueFields: DocValueFields[];
   filterQuery: string;
+  pageFilters?: Filter[];
   indexNames: string[];
   type: usersModel.UsersType;
   setAbsoluteRangeDatePicker: ActionCreator<{

--- a/x-pack/plugins/security_solution/public/users/pages/users.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/users.tsx
@@ -11,6 +11,7 @@ import { noop } from 'lodash/fp';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
+import { Filter } from '@kbn/es-query';
 import { isTab } from '../../../../timelines/public';
 import { SecurityPageName } from '../../app/types';
 import { FiltersGlobal } from '../../common/components/filters_global';
@@ -49,6 +50,7 @@ import { hasMlUserPermissions } from '../../../common/machine_learning/has_ml_us
 import { useMlCapabilities } from '../../common/components/ml/hooks/use_ml_capabilities';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { LandingPageComponent } from '../../common/components/landing_page';
+import { userNameExistsFilter } from './details/helpers';
 
 const ID = 'UsersQueryId';
 
@@ -86,7 +88,11 @@ const UsersComponent = () => {
   const { uiSettings } = useKibana().services;
 
   const { tabName } = useParams<{ tabName: string }>();
-  const tabsFilters = React.useMemo(() => {
+  const tabsFilters: Filter[] = React.useMemo(() => {
+    if (tabName === UsersTableType.alerts || tabName === UsersTableType.events) {
+      return filters.length > 0 ? [...filters, ...userNameExistsFilter] : userNameExistsFilter;
+    }
+
     if (tabName === UsersTableType.risk) {
       const severityFilter = generateSeverityFilter(severitySelection);
 
@@ -216,6 +222,7 @@ const UsersComponent = () => {
               setQuery={setQuery}
               to={to}
               type={usersModel.UsersType.page}
+              pageFilters={tabsFilters}
             />
           </SecuritySolutionPageWrapper>
         </StyledFullHeightContainer>

--- a/x-pack/plugins/security_solution/public/users/pages/users_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/users_tabs.tsx
@@ -27,6 +27,7 @@ export const UsersTabs = memo<UsersTabsProps>(
   ({
     deleteQuery,
     filterQuery,
+    pageFilters,
     from,
     indexNames,
     isInitializing,
@@ -90,13 +91,17 @@ export const UsersTabs = memo<UsersTabsProps>(
           <UserRiskScoreQueryTabBody {...tabProps} />
         </Route>
         <Route path={`${USERS_PATH}/:tabName(${UsersTableType.events})`}>
-          <EventsQueryTabBody {...tabProps} timelineId={TimelineId.usersPageEvents} />
+          <EventsQueryTabBody
+            {...tabProps}
+            timelineId={TimelineId.usersPageEvents}
+            pageFilters={pageFilters}
+          />
         </Route>
         <Route path={`${USERS_PATH}/:tabName(${UsersTableType.alerts})`}>
           <AlertsView
             entityType="events"
             timelineId={TimelineId.usersPageExternalAlerts}
-            pageFilters={[]}
+            pageFilters={pageFilters ?? []}
             {...tabProps}
           />
         </Route>


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/129365

## Summary

The Alert table and external alert table should filter alerts by `host.name exists` or `user.name exists` on the Hosts and Users page.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

