### PR TITLE
Add serialization/deserialization spans

### DIFF
--- a/src/core/server/elasticsearch/client/configure_client.ts
+++ b/src/core/server/elasticsearch/client/configure_client.ts
@@ -7,12 +7,8 @@
  */
 
 import { Client, HttpConnection } from '@elastic/elasticsearch';
-<<<<<<< HEAD
-=======
-import type { KibanaClient } from '@elastic/elasticsearch/lib/api/kibana';
 import agent, { Span } from 'elastic-apm-node';
 import LRUCache from 'lru-cache';
->>>>>>> 4c0efd95703 (Record request body for mget and add (de)serialization spans)
 import { Logger } from '../../logging';
 import { parseClientOptions, ElasticsearchClientConfig } from './client_config';
 import { instrumentEsQueryAndDeprecationLogger } from './log_query_and_deprecation';

--- a/src/core/server/elasticsearch/client/configure_client.ts
+++ b/src/core/server/elasticsearch/client/configure_client.ts
@@ -7,6 +7,12 @@
  */
 
 import { Client, HttpConnection } from '@elastic/elasticsearch';
+<<<<<<< HEAD
+=======
+import type { KibanaClient } from '@elastic/elasticsearch/lib/api/kibana';
+import agent, { Span } from 'elastic-apm-node';
+import LRUCache from 'lru-cache';
+>>>>>>> 4c0efd95703 (Record request body for mget and add (de)serialization spans)
 import { Logger } from '../../logging';
 import { parseClientOptions, ElasticsearchClientConfig } from './client_config';
 import { instrumentEsQueryAndDeprecationLogger } from './log_query_and_deprecation';
@@ -31,10 +37,43 @@ export const configureClient = (
   const clientOptions = parseClientOptions(config, scoped);
   const KibanaTransport = createTransport({ getExecutionContext });
 
+  const cache = new LRUCache<any, Span | undefined | null>({
+    max: 100,
+  });
+
   const client = new Client({
     ...clientOptions,
     Transport: KibanaTransport,
     Connection: HttpConnection,
+  });
+
+  function startSpan(name: string) {
+    const span = agent.startSpan(name, 'db', 'elasticsearch', { exitSpan: true });
+    return span;
+  }
+
+  client.diagnostic.on('serialization', (err, result) => {
+    if (!err) {
+      cache.set(result?.meta.request.id, startSpan('serialization'));
+    }
+  });
+
+  client.diagnostic.on('request', (err, result) => {
+    cache.get(result?.meta.request.id)?.end();
+    if (!err) {
+      cache.set(result?.meta.request.id, startSpan('request'));
+    }
+  });
+
+  client.diagnostic.on('deserialization', (err, result) => {
+    cache.get(result?.requestId)?.end();
+    if (!err) {
+      cache.set(result?.requestId, startSpan('deserialization'));
+    }
+  });
+
+  client.diagnostic.on('response', (err, result) => {
+    cache.get(result?.meta.request.id)?.end();
   });
 
   instrumentEsQueryAndDeprecationLogger({ logger, client, type });


### PR DESCRIPTION
Adds serialization, request and deserialization spans as child of Elasticsearch spans. 

Some things to be considered:

- is configure_client the right place to start listening to these events?
- how will this hurt performance? we are creating 3x more spans now. should we make it configurable, or drop spans that are very short?
- are spans the right approach? should they be custom marks on the span?

