### PR TITLE
[Workplace search] improve icon spacing on source table

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
@@ -112,7 +112,7 @@ export const SourceRow: React.FC<SourceRowProps> = ({
         <EuiFlexGroup
           justifyContent="flexStart"
           alignItems="center"
-          gutterSize="xs"
+          gutterSize="m"
           responsive={false}
         >
           <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

Improve icon spacing on source table
| Before | After |
|-|-|
| ![localhost_5601_app_enterprise_search_workplace_search_sources](https://user-images.githubusercontent.com/7115017/161757948-a3fb7c17-4f7d-465a-97d8-cb038dfd84e2.png) | ![localhost_5601_app_enterprise_search_workplace_search_sources (1)](https://user-images.githubusercontent.com/7115017/161757917-e8206a63-5dad-497d-9922-01e88f1ee887.png) | 

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

