### PR TITLE
[build] Update artifact checksums to sha512, properly format file

### DIFF
--- a/src/dev/build/tasks/write_sha_sums_task.ts
+++ b/src/dev/build/tasks/write_sha_sums_task.ts
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
+import path from 'path';
 import globby from 'globby';
 
-import path from 'path';
 import { getFileHash, write, GlobalTask } from '../lib';
 
 export const WriteShaSums: GlobalTask = {

--- a/src/dev/build/tasks/write_sha_sums_task.ts
+++ b/src/dev/build/tasks/write_sha_sums_task.ts
@@ -8,6 +8,7 @@
 
 import globby from 'globby';
 
+import path from 'path';
 import { getFileHash, write, GlobalTask } from '../lib';
 
 export const WriteShaSums: GlobalTask = {
@@ -21,7 +22,10 @@ export const WriteShaSums: GlobalTask = {
     });
 
     for (const artifact of artifacts) {
-      await write(`${artifact}.sha512.txt`, `${await getFileHash(artifact, 'sha512')} ${artifact}`);
+      await write(
+        `${artifact}.sha512.txt`,
+        `${await getFileHash(artifact, 'sha512')} ${path.basename(artifact)}`
+      );
     }
   },
 };

--- a/src/dev/build/tasks/write_sha_sums_task.ts
+++ b/src/dev/build/tasks/write_sha_sums_task.ts
@@ -21,7 +21,7 @@ export const WriteShaSums: GlobalTask = {
     });
 
     for (const artifact of artifacts) {
-      await write(`${artifact}.sha1.txt`, await getFileHash(artifact, 'sha1'));
+      await write(`${artifact}.sha512.txt`, `${await getFileHash(artifact, 'sha512')} ${artifact}`);
     }
   },
 };


### PR DESCRIPTION
This updates the checksum algorithm from sha1 to sha512 to be consistent
with the checksums shared on our downloads page.  It also formats the
file to include the file name after the checksum so we can perform
validation via the `shasum` cli.

This will be used by the artifacts pipeline before publishing.  These artifacts are passed around to different machines for testing, and the final step before uploading will be to verify the artifact downloaded is the same artifact that was tested.
