### PR TITLE
[Fleet] Disable view agent dashboard for agent policy without monitoring

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_dashboard_link.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_dashboard_link.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 
 import { createFleetTestRendererMock } from '../../../../../../mock';
-import type { Agent } from '../../../../types';
+import type { Agent, AgentPolicy } from '../../../../types';
 import { useGetPackageInfoByKey } from '../../../../../../hooks/use_request/epm';
 
 import { AgentDashboardLink } from './agent_dashboard_link';
@@ -26,7 +26,7 @@ jest.mock('../../../../../../hooks/use_fleet_status', () => ({
 jest.mock('../../../../../../hooks/use_request/epm');
 
 describe('AgentDashboardLink', () => {
-  it('should enable the button if elastic_agent package is installed', async () => {
+  it('should enable the button if elastic_agent package is installed and policy has monitoring enabled', async () => {
     mockedUseGetPackageInfoByKey.mockReturnValue({
       isLoading: false,
       data: {
@@ -44,6 +44,11 @@ describe('AgentDashboardLink', () => {
             id: 'agent-id-123',
           } as unknown as Agent
         }
+        agentPolicy={
+          {
+            monitoring_enabled: ['logs', 'metrics'],
+          } as unknown as AgentPolicy
+        }
       />
     );
 
@@ -51,7 +56,7 @@ describe('AgentDashboardLink', () => {
     expect(result.getByRole('link').hasAttribute('href')).toBeTruthy();
   });
 
-  it('should not enable the button if elastic_agent package is installed', async () => {
+  it('should not enable the button if elastic_agent package is not installed and policy has monitoring enabled', async () => {
     mockedUseGetPackageInfoByKey.mockReturnValue({
       isLoading: false,
       data: {
@@ -68,6 +73,42 @@ describe('AgentDashboardLink', () => {
           {
             id: 'agent-id-123',
           } as unknown as Agent
+        }
+        agentPolicy={
+          {
+            monitoring_enabled: ['logs', 'metrics'],
+          } as unknown as AgentPolicy
+        }
+      />
+    );
+
+    expect(result.queryByRole('link')).toBeNull();
+    expect(result.queryByRole('button')).not.toBeNull();
+    expect(result.getByRole('button').hasAttribute('disabled')).toBeTruthy();
+  });
+
+  it('should not enable the button if elastic_agent package is installed and policy do not have monitoring enabled', async () => {
+    mockedUseGetPackageInfoByKey.mockReturnValue({
+      isLoading: false,
+      data: {
+        item: {
+          status: 'installed',
+        },
+      },
+    } as ReturnType<typeof useGetPackageInfoByKey>);
+    const testRenderer = createFleetTestRendererMock();
+
+    const result = testRenderer.render(
+      <AgentDashboardLink
+        agent={
+          {
+            id: 'agent-id-123',
+          } as unknown as Agent
+        }
+        agentPolicy={
+          {
+            monitoring_enabled: [],
+          } as unknown as AgentPolicy
         }
       />
     );

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_dashboard_link.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_dashboard_link.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiButton, EuiToolTip } from '@elastic/eui';
 
 import { useGetPackageInfoByKey, useKibanaLink } from '../../../../hooks';
-import type { Agent } from '../../../../types';
+import type { Agent, AgentPolicy } from '../../../../types';
 import {
   FLEET_ELASTIC_AGENT_PACKAGE,
   FLEET_ELASTIC_AGENT_DETAILS_DASHBOARD_ID,
@@ -34,10 +34,14 @@ function useAgentDashboardLink(agent: Agent) {
 
 export const AgentDashboardLink: React.FunctionComponent<{
   agent: Agent;
-}> = ({ agent }) => {
+  agentPolicy?: AgentPolicy;
+}> = ({ agent, agentPolicy }) => {
   const { isInstalled, link, isLoading } = useAgentDashboardLink(agent);
 
-  const buttonArgs = !isInstalled || isLoading ? { disabled: true } : { href: link };
+  const isLogAndMetricsEnabled = agentPolicy?.monitoring_enabled?.length ?? 0 > 0;
+
+  const buttonArgs =
+    !isInstalled || isLoading || !isLogAndMetricsEnabled ? { disabled: true } : { href: link };
 
   const button = (
     <EuiButton fill {...buttonArgs} isLoading={isLoading}>
@@ -48,12 +52,27 @@ export const AgentDashboardLink: React.FunctionComponent<{
     </EuiButton>
   );
 
+  if (!isLogAndMetricsEnabled) {
+    return (
+      <EuiToolTip
+        content={
+          <FormattedMessage
+            id="xpack.fleet.agentDetails.viewDashboardButton.disabledNoLogsAndMetricsTooltip"
+            defaultMessage="Logs and metrics for agent are not enabled in the agent policy."
+          />
+        }
+      >
+        {button}
+      </EuiToolTip>
+    );
+  }
+
   if (!isInstalled) {
     return (
       <EuiToolTip
         content={
           <FormattedMessage
-            id="xpack.fleet.agentDetails.viewDashboardButtonDisabledTooltip"
+            id="xpack.fleet.agentDetails.viewDashboardButton.disabledNoIntegrationTooltip"
             defaultMessage="Agent dashboard not found, you need to install the elastic_agent integration."
           />
         }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
@@ -124,7 +124,7 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
               </EuiFlexItem>
             )}
             <EuiFlexItem grow={false}>
-              <AgentDashboardLink agent={agentData?.item} />
+              <AgentDashboardLink agent={agentData?.item} agentPolicy={agentPolicyData?.item} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </>


### PR DESCRIPTION
Resolve #129335

Disable view agent dashboard button in the agent details page for agent with an agent policy without monitoring enabled.

## UI Changes

<img width="533" alt="Screen Shot 2022-04-05 at 1 03 41 PM" src="https://user-images.githubusercontent.com/1336873/161812790-2a322340-a475-41a9-bdbd-7882abd4162b.png">
