### PR TITLE
[Workplace Search] Use baseServiceType for icon on source overview and source detail views

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
@@ -60,6 +60,7 @@ export const SourceRow: React.FC<SourceRowProps> = ({
   source: {
     id,
     serviceType,
+    baseServiceType,
     searchable,
     supportedByLicense,
     status,
@@ -117,7 +118,7 @@ export const SourceRow: React.FC<SourceRowProps> = ({
         >
           <EuiFlexItem grow={false}>
             <SourceIcon
-              serviceType={isIndexing ? 'loadingSmall' : serviceType}
+              serviceType={isIndexing ? 'loadingSmall' : baseServiceType || serviceType}
               name={name}
               iconAsBase64={mainIcon}
             />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_info_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_info_card.tsx
@@ -28,13 +28,18 @@ interface SourceInfoCardProps {
 }
 
 export const SourceInfoCard: React.FC<SourceInfoCardProps> = ({
-  contentSource: { createdAt, name, serviceType, isFederatedSource, mainIcon },
+  contentSource: { baseServiceType, createdAt, name, serviceType, isFederatedSource, mainIcon },
 }) => (
   <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween" alignItems="center">
     <EuiFlexItem>
       <EuiFlexGroup gutterSize="s" justifyContent="flexStart" alignItems="center">
         <EuiFlexItem grow={null}>
-          <SourceIcon serviceType={serviceType} name={name} iconAsBase64={mainIcon} size="l" />
+          <SourceIcon
+            serviceType={baseServiceType || serviceType}
+            name={name}
+            iconAsBase64={mainIcon}
+            size="l"
+          />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiTitle size="s">


### PR DESCRIPTION
## Summary

If a baseServiceType is provided for a content source, use that to determine a source's icon. 

Notably, this doesn't update the groups view, where we don't have access to a `baseServiceType` yet.  We'd need a back-end change to support that.  

https://user-images.githubusercontent.com/2479295/161852543-f1905e03-b837-4ee9-a449-07fcd469b556.mov


