### PR TITLE
[data view mgmt] reset selection after deleting data view from list

### DIFF
--- a/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -94,7 +94,10 @@ export const IndexPatternTable = ({
       dataViews,
       overlays,
       uiSettings,
-      onDelete: () => loadDataViews(),
+      onDelete: () => {
+        setSelectedItems([]);
+        loadDataViews();
+      },
     });
     if (selectedItems.length === 0) {
       return;


### PR DESCRIPTION
## Summary

Reset selection after deleting data view from list via selection and delete button (not individual data view delete buttons)

Closes https://github.com/elastic/kibana/issues/129049