### PR TITLE
[7.17] [Devtools] Compress mappings response size for autocomplete (#120456)

### DIFF
--- a/src/plugins/console/public/lib/mappings/mappings.js
+++ b/src/plugins/console/public/lib/mappings/mappings.js
@@ -250,8 +250,10 @@ function retrieveSettings(settingsKey, settingsToRetrieve) {
 
   // Fetch autocomplete info if setting is set to true, and if user has made changes.
   if (settingsToRetrieve[settingsKey] === true) {
-    const WITH_PRODUCT_ORIGIN = true;
-    return es.send('GET', settingKeyToPathMap[settingsKey], null, true, WITH_PRODUCT_ORIGIN);
+    // Use pretty=false in these request in order to compress the response by removing whitespace
+    const path = `${settingKeyToPathMap[settingsKey]}?pretty=false`;
+
+    return es.send('GET', path, null, true);
   } else {
     const settingsPromise = new $.Deferred();
     if (settingsToRetrieve[settingsKey] === false) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Devtools] Compress mappings response size for autocomplete (#120456)](https://github.com/elastic/kibana/pull/120456)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)