### PR TITLE
[Discover] Disable Load surrounding documents button if "Context step size" is 0

### DIFF
--- a/src/plugins/discover/public/application/context/components/action_bar/action_bar.test.tsx
+++ b/src/plugins/discover/public/application/context/components/action_bar/action_bar.test.tsx
@@ -79,5 +79,17 @@ describe('Test Discover Context ActionBar for successor | predecessor records', 
         );
       }
     });
+
+    test(`${type}: Load button disabled when defaultStepSize is 0`, () => {
+      const wrapperWhenZeroStep = mountWithIntl(<ActionBar {...props} defaultStepSize={0} />);
+      const inputWhenZeroStep = findTestSubject(wrapperWhenZeroStep, `${type}CountPicker`);
+      const btnWhenZeroStep = findTestSubject(wrapperWhenZeroStep, `${type}LoadMoreButton`);
+      expect(btnWhenZeroStep.props().disabled).toBe(true);
+      btnWhenZeroStep.simulate('click');
+      expect(onChangeCount).toHaveBeenCalledTimes(0);
+      inputWhenZeroStep.simulate('change', { target: { valueAsNumber: 3 } });
+      btnWhenZeroStep.simulate('click');
+      expect(onChangeCount).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/plugins/discover/public/application/context/components/action_bar/action_bar.tsx
+++ b/src/plugins/discover/public/application/context/components/action_bar/action_bar.tsx
@@ -71,6 +71,7 @@ export function ActionBar({
   const showWarning = !isDisabled && !isLoading && docCountAvailable < docCount;
   const isSuccessor = type === SurrDocType.SUCCESSORS;
   const [newDocCount, setNewDocCount] = useState(docCount);
+  const canLoadMore = defaultStepSize > 0 || newDocCount !== docCount;
   const isValid = (value: number) => value >= MIN_CONTEXT_SIZE && value <= MAX_CONTEXT_SIZE;
   const onSubmit = (ev: React.FormEvent<HTMLFormElement>) => {
     ev.preventDefault();
@@ -92,7 +93,7 @@ export function ActionBar({
         <EuiFlexItem grow={false}>
           <EuiButtonEmpty
             data-test-subj={`${type}LoadMoreButton`}
-            isDisabled={isDisabled}
+            isDisabled={isDisabled || !canLoadMore}
             isLoading={isLoading}
             onClick={() => {
               const value = newDocCount + defaultStepSize;


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/94898

## Summary

This PR disables "Load" buttons on Surrounding documents page if "Context step size" is set to 0 as a new fetching would not increase the size. And we enable this button again when user changes input value manually.

Steps:
- Go to Discover settings page and set "Context step size" to 0
- Return back to Discover, expand a row and navigate to Surrounding documents page
- Observe that "Load" button is disabled and loading is still possible for manually entered values (or by pressing up/down on keyboard)

![Apr-06-2022 13-49-13](https://user-images.githubusercontent.com/1415710/161969675-084f062d-893a-4067-84d5-2f60f001c496.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
