### PR TITLE
[Fleet] Fix missing encryption key requirements make it optionnal

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3636,7 +3636,15 @@
                 "tls_required",
                 "api_keys",
                 "fleet_admin_user",
-                "fleet_server",
+                "fleet_server"
+              ]
+            }
+          },
+          "missing_optionnal_features": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
                 "encrypted_saved_object_encryption_key_required"
               ]
             }
@@ -3644,7 +3652,8 @@
         },
         "required": [
           "isReady",
-          "missing_requirements"
+          "missing_requirements",
+          "missing_optionnal_features"
         ]
       },
       "agent_type": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -115,10 +115,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "name",
-                          "version"
-                        ]
+                        "required": ["name", "version"]
                       }
                     }
                   }
@@ -340,21 +337,13 @@
                       "properties": {
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "installed",
-                            "installing",
-                            "install_failed",
-                            "not_installed"
-                          ]
+                          "enum": ["installed", "installing", "install_failed", "not_installed"]
                         },
                         "savedObject": {
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "status",
-                        "savedObject"
-                      ]
+                      "required": ["status", "savedObject"]
                     }
                   ]
                 }
@@ -410,16 +399,11 @@
                             ]
                           }
                         },
-                        "required": [
-                          "id",
-                          "type"
-                        ]
+                        "required": ["id", "type"]
                       }
                     }
                   },
-                  "required": [
-                    "response"
-                  ]
+                  "required": ["response"]
                 }
               }
             }
@@ -478,16 +462,11 @@
                             ]
                           }
                         },
-                        "required": [
-                          "id",
-                          "type"
-                        ]
+                        "required": ["id", "type"]
                       }
                     }
                   },
-                  "required": [
-                    "response"
-                  ]
+                  "required": ["response"]
                 }
               }
             }
@@ -539,21 +518,13 @@
                       "properties": {
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "installed",
-                            "installing",
-                            "install_failed",
-                            "not_installed"
-                          ]
+                          "enum": ["installed", "installing", "install_failed", "not_installed"]
                         },
                         "savedObject": {
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "status",
-                        "savedObject"
-                      ]
+                      "required": ["status", "savedObject"]
                     }
                   ]
                 }
@@ -616,10 +587,7 @@
                             ]
                           }
                         },
-                        "required": [
-                          "id",
-                          "type"
-                        ]
+                        "required": ["id", "type"]
                       }
                     },
                     "_meta": {
@@ -627,18 +595,12 @@
                       "properties": {
                         "install_source": {
                           "type": "string",
-                          "enum": [
-                            "registry",
-                            "upload",
-                            "bundled"
-                          ]
+                          "enum": ["registry", "upload", "bundled"]
                         }
                       }
                     }
                   },
-                  "required": [
-                    "items"
-                  ]
+                  "required": ["items"]
                 }
               }
             }
@@ -699,16 +661,11 @@
                             ]
                           }
                         },
-                        "required": [
-                          "id",
-                          "type"
-                        ]
+                        "required": ["id", "type"]
                       }
                     }
                   },
-                  "required": [
-                    "items"
-                  ]
+                  "required": ["items"]
                 }
               }
             }
@@ -779,16 +736,11 @@
                             ]
                           }
                         },
-                        "required": [
-                          "id",
-                          "type"
-                        ]
+                        "required": ["id", "type"]
                       }
                     }
                   },
-                  "required": [
-                    "items"
-                  ]
+                  "required": ["items"]
                 }
               }
             }
@@ -888,9 +840,7 @@
                       "$ref": "#/components/schemas/package_usage_stats"
                     }
                   },
-                  "required": [
-                    "response"
-                  ]
+                  "required": ["response"]
                 }
               }
             }
@@ -965,10 +915,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "admin_username",
-                  "admin_password"
-                ]
+                "required": ["admin_username", "admin_password"]
               }
             }
           }
@@ -1209,9 +1156,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "success"
-                    ]
+                    "required": ["success"]
                   }
                 }
               }
@@ -1272,9 +1217,7 @@
                       "$ref": "#/components/schemas/agent"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -1297,9 +1240,7 @@
                       "$ref": "#/components/schemas/agent"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -1325,14 +1266,10 @@
                   "properties": {
                     "action": {
                       "type": "string",
-                      "enum": [
-                        "deleted"
-                      ]
+                      "enum": ["deleted"]
                     }
                   },
-                  "required": [
-                    "action"
-                  ]
+                  "required": ["action"]
                 }
               }
             }
@@ -1452,9 +1389,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "policy_id"
-                ]
+                "required": ["policy_id"]
               }
             }
           }
@@ -1501,9 +1436,7 @@
                     },
                     "statusCode": {
                       "type": "number",
-                      "enum": [
-                        400
-                      ]
+                      "enum": [400]
                     }
                   }
                 }
@@ -1611,9 +1544,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "success"
-                    ]
+                    "required": ["success"]
                   }
                 }
               }
@@ -1649,10 +1580,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "policy_id",
-                  "agents"
-                ]
+                "required": ["policy_id", "agents"]
               }
             }
           }
@@ -1680,9 +1608,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "success"
-                    ]
+                    "required": ["success"]
                   }
                 }
               }
@@ -1721,9 +1647,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "agents"
-                ]
+                "required": ["agents"]
               }
             }
           }
@@ -1758,12 +1682,7 @@
                       "type": "number"
                     }
                   },
-                  "required": [
-                    "items",
-                    "total",
-                    "page",
-                    "perPage"
-                  ]
+                  "required": ["items", "total", "page", "perPage"]
                 }
               }
             }
@@ -1847,9 +1766,7 @@
                       "$ref": "#/components/schemas/agent_policy"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -1874,9 +1791,7 @@
                       "$ref": "#/components/schemas/agent_policy"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -1930,9 +1845,7 @@
                       "$ref": "#/components/schemas/agent_policy"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -1951,9 +1864,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "name"
-                ]
+                "required": ["name"]
               }
             }
           },
@@ -1980,10 +1891,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "id",
-                    "success"
-                  ]
+                  "required": ["id", "success"]
                 }
               }
             }
@@ -1999,9 +1907,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "agentPolicyId"
-                ]
+                "required": ["agentPolicyId"]
               }
             }
           }
@@ -2077,12 +1983,7 @@
                       "type": "number"
                     }
                   },
-                  "required": [
-                    "items",
-                    "page",
-                    "perPage",
-                    "total"
-                  ]
+                  "required": ["items", "page", "perPage", "total"]
                 }
               }
             }
@@ -2108,9 +2009,7 @@
                     },
                     "action": {
                       "type": "string",
-                      "enum": [
-                        "created"
-                      ]
+                      "enum": ["created"]
                     }
                   }
                 }
@@ -2153,9 +2052,7 @@
                       "$ref": "#/components/schemas/enrollment_api_key"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -2177,14 +2074,10 @@
                   "properties": {
                     "action": {
                       "type": "string",
-                      "enum": [
-                        "deleted"
-                      ]
+                      "enum": ["deleted"]
                     }
                   },
-                  "required": [
-                    "action"
-                  ]
+                  "required": ["action"]
                 }
               }
             }
@@ -2234,12 +2127,7 @@
                       "type": "number"
                     }
                   },
-                  "required": [
-                    "items",
-                    "page",
-                    "perPage",
-                    "total"
-                  ]
+                  "required": ["items", "page", "perPage", "total"]
                 }
               }
             }
@@ -2264,9 +2152,7 @@
                     },
                     "action": {
                       "type": "string",
-                      "enum": [
-                        "created"
-                      ]
+                      "enum": ["created"]
                     }
                   }
                 }
@@ -2308,9 +2194,7 @@
                       "$ref": "#/components/schemas/enrollment_api_key"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -2331,14 +2215,10 @@
                   "properties": {
                     "action": {
                       "type": "string",
-                      "enum": [
-                        "deleted"
-                      ]
+                      "enum": ["deleted"]
                     }
                   },
-                  "required": [
-                    "action"
-                  ]
+                  "required": ["action"]
                 }
               }
             }
@@ -2380,9 +2260,7 @@
                       "type": "number"
                     }
                   },
-                  "required": [
-                    "items"
-                  ]
+                  "required": ["items"]
                 }
               }
             }
@@ -2408,9 +2286,7 @@
                       "$ref": "#/components/schemas/package_policy"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -2472,9 +2348,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "packagePolicyIds"
-                ]
+                "required": ["packagePolicyIds"]
               }
             }
           }
@@ -2499,10 +2373,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "id",
-                      "success"
-                    ]
+                    "required": ["id", "success"]
                   }
                 }
               }
@@ -2533,9 +2404,7 @@
                     }
                   }
                 },
-                "required": [
-                  "packagePolicyIds"
-                ]
+                "required": ["packagePolicyIds"]
               }
             }
           }
@@ -2560,10 +2429,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "id",
-                      "success"
-                    ]
+                    "required": ["id", "success"]
                   }
                 }
               }
@@ -2592,9 +2458,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "packagePolicyIds"
-                ]
+                "required": ["packagePolicyIds"]
               }
             }
           }
@@ -2619,9 +2483,7 @@
                         "$ref": "#/components/schemas/upgrade_agent_diff"
                       }
                     },
-                    "required": [
-                      "hasErrors"
-                    ]
+                    "required": ["hasErrors"]
                   }
                 }
               }
@@ -2646,9 +2508,7 @@
                       "$ref": "#/components/schemas/package_policy"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -2693,10 +2553,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "item",
-                    "sucess"
-                  ]
+                  "required": ["item", "sucess"]
                 }
               }
             }
@@ -2779,9 +2636,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "elasticsearch"
-                    ]
+                    "enum": ["elasticsearch"]
                   },
                   "is_default": {
                     "type": "boolean"
@@ -2802,10 +2657,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "name",
-                  "type"
-                ]
+                "required": ["name", "type"]
               }
             }
           }
@@ -2829,9 +2681,7 @@
                       "$ref": "#/components/schemas/output"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -2864,9 +2714,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "id"
-                  ]
+                  "required": ["id"]
                 }
               }
             }
@@ -2892,9 +2740,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "elasticsearch"
-                    ]
+                    "enum": ["elasticsearch"]
                   },
                   "is_default": {
                     "type": "boolean"
@@ -2918,10 +2764,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "name",
-                  "type"
-                ]
+                "required": ["name", "type"]
               }
             }
           }
@@ -2938,9 +2781,7 @@
                       "$ref": "#/components/schemas/output"
                     }
                   },
-                  "required": [
-                    "item"
-                  ]
+                  "required": ["item"]
                 }
               }
             }
@@ -3059,17 +2900,11 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "name",
-                "message"
-              ]
+              "required": ["name", "message"]
             }
           }
         },
-        "required": [
-          "isInitialized",
-          "nonFatalErrors"
-        ]
+        "required": ["isInitialized", "nonFatalErrors"]
       },
       "preconfigured_agent_policies": {
         "title": "Preconfigured agent policies",
@@ -3091,10 +2926,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "logs",
-                "metrics"
-              ]
+              "enum": ["logs", "metrics"]
             }
           },
           "namespace": {
@@ -3191,20 +3023,14 @@
                         }
                       }
                     },
-                    "required": [
-                      "type"
-                    ]
+                    "required": ["type"]
                   }
                 }
               }
             }
           }
         },
-        "required": [
-          "name",
-          "namespace",
-          "package_policies"
-        ]
+        "required": ["name", "namespace", "package_policies"]
       },
       "settings": {
         "title": "Settings",
@@ -3226,10 +3052,7 @@
             }
           }
         },
-        "required": [
-          "fleet_server_hosts",
-          "id"
-        ]
+        "required": ["fleet_server_hosts", "id"]
       },
       "fleet_settings_response": {
         "title": "Fleet settings response",
@@ -3239,9 +3062,7 @@
             "$ref": "#/components/schemas/settings"
           }
         },
-        "required": [
-          "item"
-        ]
+        "required": ["item"]
       },
       "get_categories_response": {
         "title": "Get categories response",
@@ -3263,11 +3084,7 @@
                   "type": "number"
                 }
               },
-              "required": [
-                "id",
-                "title",
-                "count"
-              ]
+              "required": ["id", "title", "count"]
             }
           },
           "items": {
@@ -3285,17 +3102,11 @@
                   "type": "number"
                 }
               },
-              "required": [
-                "id",
-                "title",
-                "count"
-              ]
+              "required": ["id", "title", "count"]
             }
           }
         },
-        "required": [
-          "items"
-        ]
+        "required": ["items"]
       },
       "search_result": {
         "title": "Search result",
@@ -3362,9 +3173,7 @@
             }
           }
         },
-        "required": [
-          "items"
-        ]
+        "required": ["items"]
       },
       "bulk_install_packages_response": {
         "title": "Bulk install packages response",
@@ -3400,9 +3209,7 @@
             }
           }
         },
-        "required": [
-          "items"
-        ]
+        "required": ["items"]
       },
       "package_info": {
         "title": "Package information",
@@ -3482,10 +3289,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "src",
-                "path"
-              ]
+              "required": ["src", "path"]
             }
           },
           "icons": {
@@ -3535,10 +3339,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name",
-                      "default"
-                    ]
+                    "required": ["name", "default"]
                   }
                 },
                 "type": {
@@ -3548,14 +3349,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "title",
-                "name",
-                "release",
-                "ingeset_pipeline",
-                "type",
-                "package"
-              ]
+              "required": ["title", "name", "release", "ingeset_pipeline", "type", "package"]
             }
           },
           "download": {
@@ -3617,9 +3411,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "agent_policy_count"
-        ]
+        "required": ["agent_policy_count"]
       },
       "fleet_status_response": {
         "title": "Fleet status response",
@@ -3632,38 +3424,23 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "tls_required",
-                "api_keys",
-                "fleet_admin_user",
-                "fleet_server"
-              ]
+              "enum": ["tls_required", "api_keys", "fleet_admin_user", "fleet_server"]
             }
           },
-          "missing_optionnal_features": {
+          "missing_optional_features": {
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "encrypted_saved_object_encryption_key_required"
-              ]
+              "enum": ["encrypted_saved_object_encryption_key_required"]
             }
           }
         },
-        "required": [
-          "isReady",
-          "missing_requirements",
-          "missing_optionnal_features"
-        ]
+        "required": ["isReady", "missing_requirements", "missing_optional_features"]
       },
       "agent_type": {
         "type": "string",
         "title": "Agent type",
-        "enum": [
-          "PERMANENT",
-          "EPHEMERAL",
-          "TEMPORARY"
-        ]
+        "enum": ["PERMANENT", "EPHEMERAL", "TEMPORARY"]
       },
       "agent_metadata": {
         "title": "Agent metadata",
@@ -3672,13 +3449,7 @@
       "agent_status": {
         "type": "string",
         "title": "Agent status",
-        "enum": [
-          "offline",
-          "error",
-          "online",
-          "inactive",
-          "warning"
-        ]
+        "enum": ["offline", "error", "online", "inactive", "warning"]
       },
       "agent": {
         "title": "Agent",
@@ -3733,13 +3504,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "active",
-          "enrolled_at",
-          "id",
-          "status"
-        ]
+        "required": ["type", "active", "enrolled_at", "id", "status"]
       },
       "get_agents_response": {
         "title": "Get Agent response",
@@ -3768,12 +3533,7 @@
             "type": "number"
           }
         },
-        "required": [
-          "items",
-          "total",
-          "page",
-          "perPage"
-        ]
+        "required": ["items", "total", "page", "perPage"]
       },
       "bulk_upgrade_agents": {
         "title": "Bulk upgrade agents",
@@ -3799,10 +3559,7 @@
             ]
           }
         },
-        "required": [
-          "agents",
-          "version"
-        ]
+        "required": ["agents", "version"]
       },
       "upgrade_agent": {
         "title": "Upgrade agent",
@@ -3814,9 +3571,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "version"
-            ]
+            "required": ["version"]
           },
           {
             "type": "object",
@@ -3828,9 +3583,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "version"
-            ]
+            "required": ["version"]
           }
         ]
       },
@@ -3847,12 +3600,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "POLICY_CHANGE",
-                  "UNENROLL",
-                  "UPGRADE",
-                  "POLICY_REASSIGN"
-                ]
+                "enum": ["POLICY_CHANGE", "UNENROLL", "UPGRADE", "POLICY_REASSIGN"]
               }
             }
           },
@@ -3866,12 +3614,7 @@
                 "properties": {
                   "log_level": {
                     "type": "string",
-                    "enum": [
-                      "debug",
-                      "info",
-                      "warning",
-                      "error"
-                    ]
+                    "enum": ["debug", "info", "warning", "error"]
                   }
                 }
               }
@@ -3899,10 +3642,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "metrics",
-                "logs"
-              ]
+              "enum": ["metrics", "logs"]
             }
           },
           "data_output_id": {
@@ -3914,10 +3654,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "name",
-          "namespace"
-        ]
+        "required": ["name", "namespace"]
       },
       "new_package_policy": {
         "title": "New package policy",
@@ -3940,10 +3677,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "name",
-              "version"
-            ]
+            "required": ["name", "version"]
           },
           "namespace": {
             "type": "string"
@@ -3979,10 +3713,7 @@
                   "type": "object"
                 }
               },
-              "required": [
-                "type",
-                "enabled"
-              ]
+              "required": ["type", "enabled"]
             }
           },
           "policy_id": {
@@ -3995,10 +3726,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "inputs",
-          "name"
-        ]
+        "required": ["inputs", "name"]
       },
       "package_policy": {
         "title": "Package policy",
@@ -4017,10 +3745,7 @@
                 "items": {}
               }
             },
-            "required": [
-              "id",
-              "revision"
-            ]
+            "required": ["id", "revision"]
           },
           {
             "$ref": "#/components/schemas/new_package_policy"
@@ -4040,10 +3765,7 @@
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "active",
-                  "inactive"
-                ]
+                "enum": ["active", "inactive"]
               },
               "packagePolicies": {
                 "oneOf": [
@@ -4081,10 +3803,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "id",
-              "status"
-            ]
+            "required": ["id", "status"]
           }
         ]
       },
@@ -4161,13 +3880,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "api_key_id",
-          "api_key",
-          "active",
-          "created_at"
-        ]
+        "required": ["id", "api_key_id", "api_key", "active", "created_at"]
       },
       "upgrade_diff": {
         "title": "Package policy Upgrade dryrun",
@@ -4233,16 +3946,10 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "dataset",
-                  "type"
-                ]
+                "required": ["dataset", "type"]
               }
             },
-            "required": [
-              "id",
-              "data_stream"
-            ]
+            "required": ["id", "data_stream"]
           }
         ]
       },
@@ -4272,9 +3979,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "namespace"
-                ]
+                "required": ["namespace"]
               },
               "use_output": {
                 "type": "string"
@@ -4293,10 +3998,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name",
-                      "version"
-                    ]
+                    "required": ["name", "version"]
                   }
                 }
               },
@@ -4304,14 +4006,7 @@
                 "$ref": "#/components/schemas/full_agent_policy_input_stream"
               }
             },
-            "required": [
-              "id",
-              "name",
-              "revision",
-              "type",
-              "data_stream",
-              "use_output"
-            ]
+            "required": ["id", "name", "revision", "type", "data_stream", "use_output"]
           }
         ]
       },
@@ -4349,11 +4044,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "name",
-              "title",
-              "version"
-            ]
+            "required": ["name", "title", "version"]
           },
           "namespace": {
             "type": "string"
@@ -4389,11 +4080,7 @@
                   "type": "object"
                 }
               },
-              "required": [
-                "type",
-                "enabled",
-                "streams"
-              ]
+              "required": ["type", "enabled", "streams"]
             }
           },
           "policy_id": {
@@ -4409,12 +4096,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "name",
-          "namespace",
-          "policy_id",
-          "enabled"
-        ]
+        "required": ["name", "namespace", "policy_id", "enabled"]
       },
       "output": {
         "title": "Output",
@@ -4434,9 +4116,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "elasticsearch"
-            ]
+            "enum": ["elasticsearch"]
           },
           "hosts": {
             "type": "array",
@@ -4474,12 +4154,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "is_default",
-          "name",
-          "type"
-        ]
+        "required": ["id", "is_default", "name", "type"]
       }
     }
   },

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2277,7 +2277,7 @@ components:
               - api_keys
               - fleet_admin_user
               - fleet_server
-        missing_optionnal_features:
+        missing_optional_features:
           type: array
           items:
             type: string
@@ -2286,7 +2286,7 @@ components:
       required:
         - isReady
         - missing_requirements
-        - missing_optionnal_features
+        - missing_optional_features
     agent_type:
       type: string
       title: Agent type

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2277,10 +2277,16 @@ components:
               - api_keys
               - fleet_admin_user
               - fleet_server
+        missing_optionnal_features:
+          type: array
+          items:
+            type: string
+            enum:
               - encrypted_saved_object_encryption_key_required
       required:
         - isReady
         - missing_requirements
+        - missing_optionnal_features
     agent_type:
       type: string
       title: Agent type

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/fleet_status_response.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/fleet_status_response.yaml
@@ -12,7 +12,7 @@ properties:
         - 'api_keys'
         - 'fleet_admin_user'
         - 'fleet_server'
-  missing_optionnal_features: 
+  missing_optional_features: 
     type: array
     items:
       type: string
@@ -21,4 +21,4 @@ properties:
 required:
   - isReady
   - missing_requirements
-  - missing_optionnal_features
+  - missing_optional_features

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/fleet_status_response.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/fleet_status_response.yaml
@@ -12,7 +12,13 @@ properties:
         - 'api_keys'
         - 'fleet_admin_user'
         - 'fleet_server'
+  missing_optionnal_features: 
+    type: array
+    items:
+      type: string
+      enum:
         - 'encrypted_saved_object_encryption_key_required'
 required:
   - isReady
   - missing_requirements
+  - missing_optionnal_features

--- a/x-pack/plugins/fleet/common/types/rest_spec/fleet_setup.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/fleet_setup.ts
@@ -15,5 +15,5 @@ export interface GetFleetStatusResponse {
   missing_requirements: Array<
     'security_required' | 'tls_required' | 'api_keys' | 'fleet_admin_user' | 'fleet_server'
   >;
-  missing_optionnal_features: Array<'encrypted_saved_object_encryption_key_required'>;
+  missing_optional_features: Array<'encrypted_saved_object_encryption_key_required'>;
 }

--- a/x-pack/plugins/fleet/common/types/rest_spec/fleet_setup.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/fleet_setup.ts
@@ -13,11 +13,7 @@ export interface PostFleetSetupResponse {
 export interface GetFleetStatusResponse {
   isReady: boolean;
   missing_requirements: Array<
-    | 'security_required'
-    | 'tls_required'
-    | 'api_keys'
-    | 'fleet_admin_user'
-    | 'fleet_server'
-    | 'encrypted_saved_object_encryption_key_required'
+    'security_required' | 'tls_required' | 'api_keys' | 'fleet_admin_user' | 'fleet_server'
   >;
+  missing_optionnal_features: Array<'encrypted_saved_object_encryption_key_required'>;
 }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/index.test.tsx
@@ -7,15 +7,12 @@
 
 import React from 'react';
 
-// import type { Output } from '../../../../types';
 import { createFleetTestRendererMock } from '../../../../mock';
 import { useFleetStatus } from '../../../../hooks/use_fleet_status';
 import { useGetSettings } from '../../../../hooks/use_request/settings';
 import { useAuthz } from '../../../../hooks/use_authz';
 
 import { AgentsApp } from '.';
-
-// jest.mock('');
 
 jest.mock('../../../../hooks/use_fleet_status', () => ({
   FleetStatusProvider: (props: any) => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/index.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+// import type { Output } from '../../../../types';
+import { createFleetTestRendererMock } from '../../../../mock';
+import { useFleetStatus } from '../../../../hooks/use_fleet_status';
+import { useGetSettings } from '../../../../hooks/use_request/settings';
+import { useAuthz } from '../../../../hooks/use_authz';
+
+import { AgentsApp } from '.';
+
+// jest.mock('');
+
+jest.mock('../../../../hooks/use_fleet_status', () => ({
+  FleetStatusProvider: (props: any) => {
+    return props.children;
+  },
+  useFleetStatus: jest.fn().mockReturnValue({}),
+}));
+jest.mock('../../../../hooks/use_request/settings');
+jest.mock('../../../../hooks/use_authz');
+jest.mock('./agent_requirements_page', () => {
+  return {
+    FleetServerRequirementPage: () => <>FleetServerRequirementPage</>,
+    MissingESRequirementsPage: () => <>MissingESRequirementsPage</>,
+  };
+});
+jest.mock('./agent_list_page', () => {
+  return {
+    AgentListPage: () => <>AgentListPage</>,
+  };
+});
+
+const mockedUsedFleetStatus = useFleetStatus as jest.MockedFunction<typeof useFleetStatus>;
+const mockedUseGetSettings = useGetSettings as jest.MockedFunction<typeof useGetSettings>;
+const mockedUseAuthz = useAuthz as jest.MockedFunction<typeof useAuthz>;
+
+function renderAgentsApp() {
+  const renderer = createFleetTestRendererMock();
+  renderer.mountHistory.push('/agents');
+
+  const utils = renderer.render(<AgentsApp />);
+
+  return { utils };
+}
+describe('AgentApp', () => {
+  beforeEach(() => {
+    mockedUseGetSettings.mockReturnValue({
+      isLoading: false,
+      data: {
+        item: {
+          has_seen_fleet_migration_notice: true,
+        },
+      },
+    } as any);
+    mockedUseAuthz.mockReturnValue({
+      fleet: {
+        all: true,
+      },
+    } as any);
+  });
+
+  it('should render the loading component if the status is loading', async () => {
+    mockedUsedFleetStatus.mockReturnValue({
+      isLoading: true,
+      enabled: true,
+      isReady: false,
+      refresh: async () => {},
+    });
+    const { utils } = renderAgentsApp();
+
+    expect(utils.container.querySelector('[data-test-subj=loadingSpinner]')).not.toBeNull();
+  });
+
+  it('should render the missing requirement component if the status contains missing requirement', async () => {
+    mockedUsedFleetStatus.mockReturnValue({
+      isLoading: false,
+      enabled: true,
+      isReady: false,
+      missingRequirements: ['api_keys'],
+      refresh: async () => {},
+    });
+    const { utils } = renderAgentsApp();
+    expect(utils.queryByText('MissingESRequirementsPage')).not.toBeNull();
+    expect(utils.queryByText('AgentListPage')).toBeNull();
+  });
+
+  it('should render the FleetServerRequirementPage if the status contains only fleet server missing requirement', async () => {
+    mockedUsedFleetStatus.mockReturnValue({
+      isLoading: false,
+      enabled: true,
+      isReady: false,
+      missingRequirements: ['fleet_server'],
+      refresh: async () => {},
+    });
+    const { utils } = renderAgentsApp();
+    expect(utils.queryByText('FleetServerRequirementPage')).not.toBeNull();
+    expect(utils.queryByText('AgentListPage')).toBeNull();
+  });
+
+  it('should render the App if there is no missing requirements and optionnal requirements', async () => {
+    mockedUsedFleetStatus.mockReturnValue({
+      isLoading: false,
+      enabled: true,
+      isReady: false,
+      missingRequirements: [],
+      missingOptionalFeatures: ['encrypted_saved_object_encryption_key_required'],
+      refresh: async () => {},
+    });
+    const { utils } = renderAgentsApp();
+
+    expect(utils.queryByText('AgentListPage')).not.toBeNull();
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.test.tsx
@@ -73,7 +73,7 @@ describe('EditOutputFlyout', () => {
 
   it('should show a callout in the flyout if the selected output is logstash and no encrypted key is set', async () => {
     mockedUsedFleetStatus.mockReturnValue({
-      missingOptionnalFeatures: ['encrypted_saved_object_encryption_key_required'],
+      missingOptionalFeatures: ['encrypted_saved_object_encryption_key_required'],
     } as any);
     const { utils } = renderFlyout({
       type: 'logstash',

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.test.tsx
@@ -73,7 +73,7 @@ describe('EditOutputFlyout', () => {
 
   it('should show a callout in the flyout if the selected output is logstash and no encrypted key is set', async () => {
     mockedUsedFleetStatus.mockReturnValue({
-      missingRequirements: ['encrypted_saved_object_encryption_key_required'],
+      missingOptionnalFeatures: ['encrypted_saved_object_encryption_key_required'],
     } as any);
     const { utils } = renderFlyout({
       type: 'logstash',

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -35,7 +35,7 @@ import { confirmUpdate } from './confirm_update';
 export function useOutputForm(onSucess: () => void, output?: Output) {
   const fleetStatus = useFleetStatus();
 
-  const hasEncryptedSavedObjectConfigured = !fleetStatus.missingOptionnalFeatures?.includes(
+  const hasEncryptedSavedObjectConfigured = !fleetStatus.missingOptionalFeatures?.includes(
     'encrypted_saved_object_encryption_key_required'
   );
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -35,7 +35,7 @@ import { confirmUpdate } from './confirm_update';
 export function useOutputForm(onSucess: () => void, output?: Output) {
   const fleetStatus = useFleetStatus();
 
-  const hasEncryptedSavedObjectConfigured = !fleetStatus.missingRequirements?.includes(
+  const hasEncryptedSavedObjectConfigured = !fleetStatus.missingOptionnalFeatures?.includes(
     'encrypted_saved_object_encryption_key_required'
   );
 

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -530,7 +530,7 @@ On Windows, the module was tested with Nginx installed from the Chocolatey repos
   const agentsSetupResponse: GetFleetStatusResponse = {
     isReady: true,
     missing_requirements: [],
-    missing_optionnal_features: [],
+    missing_optional_features: [],
   };
 
   const packagePoliciesResponse: GetPackagePoliciesResponse = {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -527,7 +527,11 @@ The logs were tested with version 1.10.
 On Windows, the module was tested with Nginx installed from the Chocolatey repository.
 `;
 
-  const agentsSetupResponse: GetFleetStatusResponse = { isReady: true, missing_requirements: [] };
+  const agentsSetupResponse: GetFleetStatusResponse = {
+    isReady: true,
+    missing_requirements: [],
+    missing_optionnal_features: [],
+  };
 
   const packagePoliciesResponse: GetPackagePoliciesResponse = {
     items: [

--- a/x-pack/plugins/fleet/public/hooks/use_fleet_status.tsx
+++ b/x-pack/plugins/fleet/public/hooks/use_fleet_status.tsx
@@ -18,6 +18,7 @@ interface FleetStatusState {
   isReady: boolean;
   error?: Error;
   missingRequirements?: GetFleetStatusResponse['missing_requirements'];
+  missingOptionnalFeatures?: GetFleetStatusResponse['missing_optionnal_features'];
 }
 
 interface FleetStatus extends FleetStatusState {
@@ -47,6 +48,7 @@ export const FleetStatusProvider: React.FC = ({ children }) => {
           isLoading: false,
           isReady: res.data?.isReady ?? false,
           missingRequirements: res.data?.missing_requirements,
+          missingOptionnalFeatures: res.data?.missing_optionnal_features,
         }));
       } catch (error) {
         setState((s) => ({ ...s, isLoading: false, error }));

--- a/x-pack/plugins/fleet/public/hooks/use_fleet_status.tsx
+++ b/x-pack/plugins/fleet/public/hooks/use_fleet_status.tsx
@@ -18,7 +18,7 @@ interface FleetStatusState {
   isReady: boolean;
   error?: Error;
   missingRequirements?: GetFleetStatusResponse['missing_requirements'];
-  missingOptionnalFeatures?: GetFleetStatusResponse['missing_optionnal_features'];
+  missingOptionalFeatures?: GetFleetStatusResponse['missing_optional_features'];
 }
 
 interface FleetStatus extends FleetStatusState {
@@ -48,7 +48,7 @@ export const FleetStatusProvider: React.FC = ({ children }) => {
           isLoading: false,
           isReady: res.data?.isReady ?? false,
           missingRequirements: res.data?.missing_requirements,
-          missingOptionnalFeatures: res.data?.missing_optionnal_features,
+          missingOptionalFeatures: res.data?.missing_optional_features,
         }));
       } catch (error) {
         setState((s) => ({ ...s, isLoading: false, error }));

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.ts
@@ -21,26 +21,25 @@ export const getFleetStatusHandler: FleetRequestHandler = async (context, reques
       context.core.elasticsearch.client.asInternalUser
     );
 
-    let isReady = true;
     const missingRequirements: GetFleetStatusResponse['missing_requirements'] = [];
+    const missingOptionnalFeatures: GetFleetStatusResponse['missing_optionnal_features'] = [];
 
     if (!isApiKeysEnabled) {
-      isReady = false;
       missingRequirements.push('api_keys');
     }
 
     if (!isFleetServerSetup) {
-      isReady = false;
       missingRequirements.push('fleet_server');
     }
 
     if (!appContextService.getEncryptedSavedObjectsSetup()?.canEncrypt) {
-      missingRequirements.push('encrypted_saved_object_encryption_key_required');
+      missingOptionnalFeatures.push('encrypted_saved_object_encryption_key_required');
     }
 
     const body: GetFleetStatusResponse = {
-      isReady,
+      isReady: missingRequirements.length > 0,
       missing_requirements: missingRequirements,
+      missing_optionnal_features: missingOptionnalFeatures,
     };
 
     return response.ok({

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.ts
@@ -37,7 +37,7 @@ export const getFleetStatusHandler: FleetRequestHandler = async (context, reques
     }
 
     const body: GetFleetStatusResponse = {
-      isReady: missingRequirements.length > 0,
+      isReady: missingRequirements.length === 0,
       missing_requirements: missingRequirements,
       missing_optionnal_features: missingOptionnalFeatures,
     };

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.ts
@@ -22,7 +22,7 @@ export const getFleetStatusHandler: FleetRequestHandler = async (context, reques
     );
 
     const missingRequirements: GetFleetStatusResponse['missing_requirements'] = [];
-    const missingOptionnalFeatures: GetFleetStatusResponse['missing_optionnal_features'] = [];
+    const missingOptionalFeatures: GetFleetStatusResponse['missing_optional_features'] = [];
 
     if (!isApiKeysEnabled) {
       missingRequirements.push('api_keys');
@@ -33,13 +33,13 @@ export const getFleetStatusHandler: FleetRequestHandler = async (context, reques
     }
 
     if (!appContextService.getEncryptedSavedObjectsSetup()?.canEncrypt) {
-      missingOptionnalFeatures.push('encrypted_saved_object_encryption_key_required');
+      missingOptionalFeatures.push('encrypted_saved_object_encryption_key_required');
     }
 
     const body: GetFleetStatusResponse = {
       isReady: missingRequirements.length === 0,
       missing_requirements: missingRequirements,
-      missing_optionnal_features: missingOptionnalFeatures,
+      missing_optional_features: missingOptionalFeatures,
     };
 
     return response.ok({


### PR DESCRIPTION
## Summary

Resolve #129568 

When encryption key is not set we show the missing requirement page in Fleet we should not, that PR fix that by introducing a new `optionnal_missing_features` (any idea on better naming?) to the status response.



