### PR TITLE
[Uptime] Remove latency warnings on monitor management UI

### DIFF
--- a/x-pack/plugins/uptime/common/runtime_types/monitor_management/locations.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/monitor_management/locations.ts
@@ -12,19 +12,16 @@ import { tEnum } from '../../utils/t_enum';
 export enum BandwidthLimitKey {
   DOWNLOAD = 'download',
   UPLOAD = 'upload',
-  LATENCY = 'latency',
 }
 
 export const DEFAULT_BANDWIDTH_LIMIT = {
   [BandwidthLimitKey.DOWNLOAD]: 100,
   [BandwidthLimitKey.UPLOAD]: 30,
-  [BandwidthLimitKey.LATENCY]: 1000,
 };
 
 export const DEFAULT_THROTTLING = {
   [BandwidthLimitKey.DOWNLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.DOWNLOAD],
   [BandwidthLimitKey.UPLOAD]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.UPLOAD],
-  [BandwidthLimitKey.LATENCY]: DEFAULT_BANDWIDTH_LIMIT[BandwidthLimitKey.LATENCY],
 };
 
 export const BandwidthLimitKeyCodec = tEnum<BandwidthLimitKey>(
@@ -107,7 +104,6 @@ export const isServiceLocationInvalid = (location: MonitorServiceLocation) =>
 export const ThrottlingOptionsCodec = t.interface({
   [BandwidthLimitKey.DOWNLOAD]: t.number,
   [BandwidthLimitKey.UPLOAD]: t.number,
-  [BandwidthLimitKey.LATENCY]: t.number,
 });
 
 export const ServiceLocationsApiResponseCodec = t.interface({

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.test.tsx
@@ -214,7 +214,6 @@ describe('<ThrottlingFields />', () => {
     const throttling = {
       [BandwidthLimitKey.DOWNLOAD]: 100,
       [BandwidthLimitKey.UPLOAD]: 50,
-      [BandwidthLimitKey.LATENCY]: 25,
     };
 
     const defaultLocations = [defaultLocation];
@@ -326,54 +325,6 @@ describe('<ThrottlingFields />', () => {
       expect(
         queryByText(
           `You have exceeded the upload limit for Synthetic Nodes. The upload value can't be larger than ${uploadLimit}Mbps.`
-        )
-      ).not.toBeInTheDocument();
-
-      expect(
-        queryByText("You've exceeded the Synthetics Node bandwidth limits")
-      ).not.toBeInTheDocument();
-
-      expect(
-        queryByText(
-          'When using throttling values larger than a Synthetics Node bandwidth limit, your monitor will still have its bandwidth capped.'
-        )
-      ).not.toBeInTheDocument();
-    });
-
-    it("shows latency warnings when exceeding the node's latency limits", () => {
-      const { getByLabelText, queryByText } = render(
-        <WrappedComponent
-          policyConfigOverrides={{ throttling, defaultLocations, runsOnService: true }}
-        />
-      );
-
-      const latencyLimit = throttling[BandwidthLimitKey.LATENCY];
-
-      const latency = getByLabelText('Latency') as HTMLInputElement;
-      userEvent.clear(latency);
-      userEvent.type(latency, String(latencyLimit + 1));
-
-      expect(
-        queryByText(
-          `You have exceeded the latency limit for Synthetic Nodes. The latency value can't be larger than ${latencyLimit}ms.`
-        )
-      ).toBeInTheDocument();
-
-      expect(
-        queryByText("You've exceeded the Synthetics Node bandwidth limits")
-      ).toBeInTheDocument();
-
-      expect(
-        queryByText(
-          'When using throttling values larger than a Synthetics Node bandwidth limit, your monitor will still have its bandwidth capped.'
-        )
-      ).toBeInTheDocument();
-
-      userEvent.clear(latency);
-      userEvent.type(latency, String(latencyLimit - 1));
-      expect(
-        queryByText(
-          `You have exceeded the latency limit for Synthetic Nodes. The latency value can't be larger than ${latencyLimit}ms.`
         )
       ).not.toBeInTheDocument();
 

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.tsx
@@ -76,17 +76,15 @@ export const ThrottlingExceededCallout = () => {
 export const ThrottlingExceededMessage = ({
   throttlingField,
   limit,
-  unit,
 }: {
   throttlingField: string;
   limit: number;
-  unit: string;
 }) => {
   return (
     <FormattedMessage
       id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.throttling_exceeded.message"
-      defaultMessage="You have exceeded the { throttlingField } limit for Synthetic Nodes. The { throttlingField } value can't be larger than { limit }{unit}."
-      values={{ throttlingField, limit, unit }}
+      defaultMessage="You have exceeded the { throttlingField } limit for Synthetic Nodes. The { throttlingField } value can't be larger than { limit }Mbps."
+      values={{ throttlingField, limit }}
     />
   );
 };
@@ -97,7 +95,6 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
 
   const maxDownload = throttling[BandwidthLimitKey.DOWNLOAD];
   const maxUpload = throttling[BandwidthLimitKey.UPLOAD];
-  const maxLatency = throttling[BandwidthLimitKey.LATENCY];
 
   const handleInputChange = useCallback(
     ({ value, configKey }: { value: unknown; configKey: ThrottlingConfigs }) => {
@@ -110,7 +107,6 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
     runsOnService && parseFloat(fields[ConfigKey.DOWNLOAD_SPEED]) > maxDownload;
   const exceedsUploadLimits =
     runsOnService && parseFloat(fields[ConfigKey.UPLOAD_SPEED]) > maxUpload;
-  const exceedsLatencyLimits = runsOnService && parseFloat(fields[ConfigKey.LATENCY]) > maxLatency;
   const isThrottlingEnabled = fields[ConfigKey.IS_THROTTLING_ENABLED];
 
   const throttlingInputs = isThrottlingEnabled ? (
@@ -127,7 +123,7 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
         isInvalid={!!validate[ConfigKey.DOWNLOAD_SPEED]?.(fields) || exceedsDownloadLimits}
         error={
           exceedsDownloadLimits ? (
-            <ThrottlingExceededMessage throttlingField="download" limit={maxDownload} unit="Mbps" />
+            <ThrottlingExceededMessage throttlingField="download" limit={maxDownload} />
           ) : (
             <FormattedMessage
               id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.error"
@@ -166,7 +162,7 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
         isInvalid={!!validate[ConfigKey.UPLOAD_SPEED]?.(fields) || exceedsUploadLimits}
         error={
           exceedsUploadLimits ? (
-            <ThrottlingExceededMessage throttlingField="upload" limit={maxUpload} unit="Mbps" />
+            <ThrottlingExceededMessage throttlingField="upload" limit={maxUpload} />
           ) : (
             <FormattedMessage
               id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.error"
@@ -202,16 +198,12 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
           />
         }
         labelAppend={<OptionalLabel />}
-        isInvalid={!!validate[ConfigKey.LATENCY]?.(fields) || exceedsLatencyLimits}
+        isInvalid={!!validate[ConfigKey.LATENCY]?.(fields)}
         error={
-          exceedsLatencyLimits ? (
-            <ThrottlingExceededMessage throttlingField="latency" limit={maxLatency} unit="ms" />
-          ) : (
-            <FormattedMessage
-              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.error"
-              defaultMessage="Latency must not be negative."
-            />
-          )
+          <FormattedMessage
+            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.error"
+            defaultMessage="Latency must not be negative."
+          />
         }
       >
         <EuiFieldNumber
@@ -277,8 +269,7 @@ export const ThrottlingFields = memo<Props>(({ validate, minColumnWidth, onField
         }
         onBlur={() => onFieldBlur?.(ConfigKey.IS_THROTTLING_ENABLED)}
       />
-      {isThrottlingEnabled &&
-      (exceedsDownloadLimits || exceedsUploadLimits || exceedsLatencyLimits) ? (
+      {isThrottlingEnabled && (exceedsDownloadLimits || exceedsUploadLimits) ? (
         <>
           <EuiSpacer />
           <ThrottlingExceededCallout />

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.test.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.test.ts
@@ -18,7 +18,6 @@ describe('getServiceLocations', function () {
       throttling: {
         [BandwidthLimitKey.DOWNLOAD]: 100,
         [BandwidthLimitKey.UPLOAD]: 50,
-        [BandwidthLimitKey.LATENCY]: 20,
       },
       locations: {
         us_central: {
@@ -50,7 +49,6 @@ describe('getServiceLocations', function () {
       throttling: {
         [BandwidthLimitKey.DOWNLOAD]: 100,
         [BandwidthLimitKey.UPLOAD]: 50,
-        [BandwidthLimitKey.LATENCY]: 20,
       },
       locations: [
         {

--- a/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.ts
+++ b/x-pack/plugins/uptime/server/lib/synthetics_service/get_service_locations.ts
@@ -54,8 +54,7 @@ export async function getServiceLocations(server: UptimeServerSetup) {
     const throttling = pick(
       data.throttling,
       BandwidthLimitKey.DOWNLOAD,
-      BandwidthLimitKey.UPLOAD,
-      BandwidthLimitKey.LATENCY
+      BandwidthLimitKey.UPLOAD
     ) as ThrottlingOptions;
 
     return { throttling, locations };


### PR DESCRIPTION
## Summary

**This PR removes the latency warnings one would get when exceeding the minimum latency in the monitor management UI**.

It complements the work we had previously done for https://github.com/elastic/synthetics-service/issues/324. It also adds work on top of https://github.com/elastic/kibana/pull/127961.

In the previous cloud/synthetics meeting we have decided we would scrape these warnings because latency doesn't actually impact the platform's usage so we don't need to apply a minimum.

**PS: I've added this PR to the board so that we can be sure we have done Post-FF testing on it, not only on the first one. I've also updated the previous PR with a link to this one to be sure people will be testing the right thing.**

Given we're removing functionality that shouldn't be there, I've also added the `bug` label to this.

## How to test this PR Locally

1. Create a new `manifest.json` with the following content and place it under a folder named, for example, `manifest_folder`.
    ⚠️ Notice there's no latency limits here.
    ```json
    {
      "throttling": {
        "downloadBandwidthLimit": 20,
        "uploadBandwidthLimit": 10
      },
      "locations": {
        "Local Synth Node [MANIFEST]": {
          "url": "https://localhost:10001",
          "geo": {
            "name": "Example - Local",
            "location": {"lat": 41.25, "lon": -95.86}
          },
          "status": "beta"
        }
      }
    }
    ```
2. Run an HTTP server to serve the contents of the `manifest_folder`
    ```
    $ npx http-server manifest_folder --port 8082
    ```
3. In Kibana's config, fill the following options:
    ```yaml
    # Make sure your pods will be able to send data to ES which should be bound to your host's 9200 port
    xpack.uptime.service.hosts: [http://host.docker.internal:9200]
    
    # Add the URL for the manifest with the `throttling` configs you're serving
    xpack.uptime.service.manifestUrl: http://localhost:8082/manifest.json

    # Make sure to disable the devUrl so you're only fetching locations from the `manifest` as we'll do in production
    # xpack.uptime.service.devUrl: https://localhost:10001

    # Enable the Monitor Management UI
    xpack.uptime.ui.monitorManagement.enabled: true
    ```
4. Run the service locally
    ```
    $ DEV=true LOGLEVEL=trace CACERTFILE=./k8s/cert-test/build/bundle.pem SERVERCERT=./k8s/cert-test/build/local-server.pem SERVERKEYFILE=./k8s/cert-test/build/local-server.key PORT=10001 ./synthetics-service
    ```
5. Run Kibana and try to add a monitor. You should see the warnings above when exceeding the limits defined in your `manifest.json` file.
    **You should be able to set latency values to _any_ value and shouldn't see a warning**.
6. Disable throttling and you should see a warning about the automatic caps.
7. Create a monitor with a particular throttling value set and save it. Use the following code for that monitor:
    ```js
    step("load homepage", async () => {
        await page.goto('https://www.fast.com');
    });
    
    step("wait for test", async () => {
      await page.waitForSelector('#show-more-details-link');
      await page.waitForTimeout(10000);
      await page.click("#show-more-details-link");
    });
    
    step("wait for up/lat", async () => {
      await page.waitForSelector(".extra-measurement-value-container.succeeded");
      await page.waitForTimeout(10000);
    });
    ```
8. Wait for that monitor to run and ensure your throttling values have been applied.
9. Create a monitor with throttling disabled using the same script as above and confirm that your script has not been throtted.
    ⚠️ It will be throttled on the service because of platform limits.
10. Create a monitor with throttling values which exceed the limits for the node. You should still be able to save such monitors.

⚠️ You should _not_ be able to see these warnings in the Fleet UI.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios (actually I removed some that were unnecessary)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
