### PR TITLE
[Maps] fix lens region map visualization throws a silent error

### DIFF
--- a/x-pack/plugins/maps/public/connected_components/mb_map/draw_control/draw_control.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/draw_control/draw_control.tsx
@@ -36,6 +36,7 @@ export interface Props {
 
 export class DrawControl extends Component<Props> {
   private _isMounted = false;
+  private _isMapRemoved = false;
   private _mbDrawControlAdded = false;
   private _mbDrawControl = new MapboxDraw({
     displayControlsDefault: false,
@@ -49,13 +50,19 @@ export class DrawControl extends Component<Props> {
 
   componentDidMount() {
     this._isMounted = true;
+    this.props.mbMap.on('remove', this._setIsMapRemoved);
     this._syncDrawControl();
   }
 
   componentWillUnmount() {
     this._isMounted = false;
+    this.props.mbMap.off('remove', this._setIsMapRemoved);
     this._removeDrawControl();
   }
+
+  _setIsMapRemoved = () => {
+    this._isMapRemoved = true;
+  };
 
   _onDraw = (event: { features: Feature[] }) => {
     this.props.onDraw(event, this._mbDrawControl);
@@ -83,8 +90,7 @@ export class DrawControl extends Component<Props> {
 
   _removeDrawControl() {
     // Do not remove draw control after mbMap.remove is called, causes execeptions and mbMap.remove cleans up all map resources.
-    const isMapRemoved = !this.props.mbMap.loaded();
-    if (!this._mbDrawControlAdded || isMapRemoved) {
+    if (!this._mbDrawControlAdded || this._isMapRemoved) {
       return;
     }
 

--- a/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
@@ -263,7 +263,9 @@ export class MbMap extends Component<Props, State> {
     mbMap.on(
       'moveend',
       _.debounce(() => {
-        this.props.extentChanged(this._getMapExtentState());
+        if (this._isMounted) {
+          this.props.extentChanged(this._getMapExtentState());
+        }
       }, 100)
     );
 
@@ -434,7 +436,9 @@ export class MbMap extends Component<Props, State> {
     // hack to update extent after zoom update finishes moving map.
     if (zoomRangeChanged) {
       setTimeout(() => {
-        this.props.extentChanged(this._getMapExtentState());
+        if (this._isMounted) {
+          this.props.extentChanged(this._getMapExtentState());
+        }
       }, 300);
     }
   }

--- a/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/tooltip_control.test.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/tooltip_control.test.tsx
@@ -154,7 +154,7 @@ describe('TooltipControl', () => {
     test('should un-register all map callbacks on unmount', () => {
       const component = mount(<TooltipControl {...defaultProps} />);
 
-      expect(Object.keys(mockMbMapHandlers).length).toBe(3);
+      expect(Object.keys(mockMbMapHandlers).length).toBe(4);
 
       component.unmount();
       expect(Object.keys(mockMbMapHandlers).length).toBe(0);

--- a/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/tooltip_control.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/tooltip_control.tsx
@@ -72,17 +72,25 @@ export interface Props {
 }
 
 export class TooltipControl extends Component<Props, {}> {
+  private _isMapRemoved = false;
+
   componentDidMount() {
     this.props.mbMap.on('mouseout', this._onMouseout);
     this.props.mbMap.on('mousemove', this._updateHoverTooltipState);
     this.props.mbMap.on('click', this._lockTooltip);
+    this.props.mbMap.on('remove', this._setIsMapRemoved);
   }
 
   componentWillUnmount() {
     this.props.mbMap.off('mouseout', this._onMouseout);
     this.props.mbMap.off('mousemove', this._updateHoverTooltipState);
     this.props.mbMap.off('click', this._lockTooltip);
+    this.props.mbMap.off('remove', this._setIsMapRemoved);
   }
+
+  _setIsMapRemoved = () => {
+    this._isMapRemoved = true;
+  };
 
   _onMouseout = () => {
     this._updateHoverTooltipState.cancel();
@@ -273,6 +281,11 @@ export class TooltipControl extends Component<Props, {}> {
   };
 
   _updateHoverTooltipState = _.debounce((e: MapMouseEvent) => {
+    if (this._isMapRemoved) {
+      // ignore debounced events after mbMap.remove is called.
+      return;
+    }
+
     if (this.props.filterModeActive || this.props.hasLockedTooltips || this.props.drawModeActive) {
       // ignore hover events when in draw mode or when there are locked tooltips
       return;


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/129576

tooltip_control.tsx uses debounce for `mousemove` event. https://github.com/elastic/kibana/issues/129576 highlights a timing error where mbMap.remove has been called in mb_map.tsx before debounce handler in tooltip_control is fired.

This PR fixes the timing issue by tracking `remove` event state in tooltip_control. Debounced `mousemove` event handler returns immediately if `remove` event has been fired.

https://github.com/elastic/kibana/pull/122353 fixed a similar problem in the draw_control.tsx. However that fix used `mbMap.loaded` method to check for `remove` state. Upon further reading of `loaded` docs, it was determined that `loaded` is not the correct state to check. This PR also updates the remove state check for draw_control.tsx

<img width="600" alt="Screen Shot 2022-04-06 at 9 12 31 AM" src="https://user-images.githubusercontent.com/373691/162007838-ec6489c3-47f7-43e7-90c6-afa6c4357af3.png">

<img width="600" alt="Screen Shot 2022-04-06 at 9 12 58 AM" src="https://user-images.githubusercontent.com/373691/162007962-8433e4a3-4f64-4a58-803a-f41bdf58795b.png">
