### PR TITLE
[Controls] Undefine selected field when data view changes

### DIFF
--- a/src/plugins/controls/public/control_types/options_list/options_list_editor.tsx
+++ b/src/plugins/controls/public/control_types/options_list/options_list_editor.tsx
@@ -87,7 +87,7 @@ export const OptionsListEditor = ({
             setLastUsedDataViewId?.(dataViewId);
             onChange({ dataViewId });
             get(dataViewId).then((newDataView) =>
-              setState((s) => ({ ...s, dataView: newDataView }))
+              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }))
             );
           }}
           trigger={{

--- a/src/plugins/controls/public/control_types/options_list/options_list_editor.tsx
+++ b/src/plugins/controls/public/control_types/options_list/options_list_editor.tsx
@@ -85,10 +85,12 @@ export const OptionsListEditor = ({
           selectedDataViewId={dataView?.id}
           onChangeDataViewId={(dataViewId) => {
             setLastUsedDataViewId?.(dataViewId);
+            if (dataViewId === dataView?.id) return;
+
             onChange({ dataViewId });
+            setState((s) => ({ ...s, fieldName: undefined }));
             get(dataViewId).then((newDataView) => {
-              if (newDataView.id === dataView?.id) return;
-              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }));
+              setState((s) => ({ ...s, dataView: newDataView }));
             });
           }}
           trigger={{

--- a/src/plugins/controls/public/control_types/options_list/options_list_editor.tsx
+++ b/src/plugins/controls/public/control_types/options_list/options_list_editor.tsx
@@ -86,9 +86,10 @@ export const OptionsListEditor = ({
           onChangeDataViewId={(dataViewId) => {
             setLastUsedDataViewId?.(dataViewId);
             onChange({ dataViewId });
-            get(dataViewId).then((newDataView) =>
-              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }))
-            );
+            get(dataViewId).then((newDataView) => {
+              if (newDataView.id === dataView?.id) return;
+              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }));
+            });
           }}
           trigger={{
             label: state.dataView?.title ?? OptionsListStrings.editor.getNoDataViewTitle(),

--- a/src/plugins/controls/public/control_types/range_slider/range_slider_editor.tsx
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider_editor.tsx
@@ -82,9 +82,10 @@ export const RangeSliderEditor = ({
           onChangeDataViewId={(dataViewId) => {
             setLastUsedDataViewId?.(dataViewId);
             onChange({ dataViewId });
-            get(dataViewId).then((newDataView) =>
-              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }))
-            );
+            get(dataViewId).then((newDataView) => {
+              if (newDataView.id === dataView?.id) return;
+              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }));
+            });
           }}
           trigger={{
             label: state.dataView?.title ?? RangeSliderStrings.editor.getNoDataViewTitle(),

--- a/src/plugins/controls/public/control_types/range_slider/range_slider_editor.tsx
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider_editor.tsx
@@ -83,7 +83,7 @@ export const RangeSliderEditor = ({
             setLastUsedDataViewId?.(dataViewId);
             onChange({ dataViewId });
             get(dataViewId).then((newDataView) =>
-              setState((s) => ({ ...s, dataView: newDataView }))
+              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }))
             );
           }}
           trigger={{

--- a/src/plugins/controls/public/control_types/range_slider/range_slider_editor.tsx
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider_editor.tsx
@@ -81,10 +81,12 @@ export const RangeSliderEditor = ({
           selectedDataViewId={dataView?.id}
           onChangeDataViewId={(dataViewId) => {
             setLastUsedDataViewId?.(dataViewId);
+            if (dataViewId === dataView?.id) return;
+
             onChange({ dataViewId });
+            setState((s) => ({ ...s, fieldName: undefined }));
             get(dataViewId).then((newDataView) => {
-              if (newDataView.id === dataView?.id) return;
-              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }));
+              setState((s) => ({ ...s, dataView: newDataView }));
             });
           }}
           trigger={{

--- a/src/plugins/controls/public/control_types/time_slider/time_slider_editor.tsx
+++ b/src/plugins/controls/public/control_types/time_slider/time_slider_editor.tsx
@@ -82,7 +82,7 @@ export const TimeSliderEditor = ({
             setLastUsedDataViewId?.(dataViewId);
             onChange({ dataViewId });
             get(dataViewId).then((newDataView) =>
-              setState((s) => ({ ...s, dataView: newDataView }))
+              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }))
             );
           }}
           trigger={{

--- a/src/plugins/controls/public/control_types/time_slider/time_slider_editor.tsx
+++ b/src/plugins/controls/public/control_types/time_slider/time_slider_editor.tsx
@@ -81,9 +81,10 @@ export const TimeSliderEditor = ({
           onChangeDataViewId={(dataViewId) => {
             setLastUsedDataViewId?.(dataViewId);
             onChange({ dataViewId });
-            get(dataViewId).then((newDataView) =>
-              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }))
-            );
+            get(dataViewId).then((newDataView) => {
+              if (newDataView.id === dataView?.id) return;
+              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }));
+            });
           }}
           trigger={{
             label: state.dataView?.title ?? TimeSliderStrings.editor.getNoDataViewTitle(),

--- a/src/plugins/controls/public/control_types/time_slider/time_slider_editor.tsx
+++ b/src/plugins/controls/public/control_types/time_slider/time_slider_editor.tsx
@@ -80,10 +80,12 @@ export const TimeSliderEditor = ({
           selectedDataViewId={dataView?.id}
           onChangeDataViewId={(dataViewId) => {
             setLastUsedDataViewId?.(dataViewId);
+            if (dataViewId === dataView?.id) return;
+
             onChange({ dataViewId });
+            setState((s) => ({ ...s, fieldName: undefined }));
             get(dataViewId).then((newDataView) => {
-              if (newDataView.id === dataView?.id) return;
-              setState((s) => ({ ...s, dataView: newDataView, fieldName: undefined }));
+              setState((s) => ({ ...s, dataView: newDataView }));
             });
           }}
           trigger={{

--- a/test/functional/apps/dashboard_elements/controls/options_list.ts
+++ b/test/functional/apps/dashboard_elements/controls/options_list.ts
@@ -100,7 +100,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const firstId = (await dashboardControls.getAllControlIds())[0];
         await dashboardControls.editExistingControl(firstId);
 
+        const saveButton = await testSubjects.find('control-editor-save');
+        expect(await saveButton.isEnabled()).to.be(true);
         await dashboardControls.controlsEditorSetDataView('animals-*');
+        expect(await saveButton.isEnabled()).to.be(false);
         await dashboardControls.controlsEditorSetfield('animal.keyword');
         await dashboardControls.controlEditorSave();
 

--- a/test/functional/apps/dashboard_elements/controls/range_slider.ts
+++ b/test/functional/apps/dashboard_elements/controls/range_slider.ts
@@ -104,7 +104,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('can edit range slider control', async () => {
         const firstId = (await dashboardControls.getAllControlIds())[0];
         await dashboardControls.editExistingControl(firstId);
+
+        const saveButton = await testSubjects.find('control-editor-save');
+        expect(await saveButton.isEnabled()).to.be(true);
         await dashboardControls.controlsEditorSetDataView('kibana_sample_data_flights');
+        expect(await saveButton.isEnabled()).to.be(false);
         await dashboardControls.controlsEditorSetfield('dayOfWeek');
         await dashboardControls.controlEditorSave();
         await dashboardControls.rangeSliderWaitForLoading();


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/129403

## Summary

When either creating a new control or editing an existing control, users were able to create invalid controls via the following steps:
1. Select a data view and a relevant field
2. Change the data view
3. The field from the original data view would stay selected, which kept the editor in a valid state and allowed the user to save their new/edited control
4. The user has now created a control that references a field that does not exist in the selected data view

In order to avoid this, I made it so that, on a data view change, the field get sets to undefined for each control type.
Note that this will only happen if the user selects a **different** data view - if they simply re-select the same one, the field will remain selected.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
