### PR TITLE
[Fleet] Only expose minimum needed config to browser

### DIFF
--- a/x-pack/plugins/fleet/server/index.ts
+++ b/x-pack/plugins/fleet/server/index.ts
@@ -47,7 +47,9 @@ const DEFAULT_BUNDLED_PACKAGE_LOCATION = path.join(__dirname, '../target/bundled
 export const config: PluginConfigDescriptor = {
   exposeToBrowser: {
     epm: true,
-    agents: true,
+    agents: {
+      enabled: true,
+    },
   },
   deprecations: ({ renameFromRoot, unused, unusedFromRoot }) => [
     // Unused settings before Fleet server exists


### PR DESCRIPTION
## Summary

This changes Fleet's config to only expose the `xpack.fleet.agents.enabled` flag instead of the entire `xpack.fleet.agents.*` object to the browser. The other flags were unused.