### PR TITLE
[Timelion] Turn graphite url options list into free form text

### DIFF
--- a/src/plugins/vis_types/timelion/server/plugin.ts
+++ b/src/plugins/vis_types/timelion/server/plugin.ts
@@ -7,7 +7,6 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { TypeOf } from '@kbn/config-schema';
 
 import type {
   PluginStart,
@@ -15,7 +14,6 @@ import type {
 } from '../../../../../src/plugins/data/server';
 import type { PluginStart as DataViewPluginStart } from '../../../../../src/plugins/data_views/server';
 import { CoreSetup, PluginInitializerContext, Plugin } from '../../../../../src/core/server';
-import { configSchema } from '../config';
 import loadFunctions from './lib/load_functions';
 import { functionsRoute } from './routes/functions';
 import { runRoute } from './routes/run';
@@ -34,8 +32,6 @@ export class TimelionPlugin implements Plugin<void, void, TimelionPluginStartDep
   constructor(private readonly initializerContext: PluginInitializerContext) {}
 
   public setup(core: CoreSetup<TimelionPluginStartDeps>): void {
-    const config = this.initializerContext.config.get<TypeOf<typeof configSchema>>();
-
     const configManager = new ConfigManager(this.initializerContext.config);
 
     const functions = loadFunctions('series_functions');
@@ -68,7 +64,7 @@ export class TimelionPlugin implements Plugin<void, void, TimelionPluginStartDep
     functionsRoute(router, deps);
     runRoute(router, deps);
 
-    core.uiSettings.register(getUiSettings(config));
+    core.uiSettings.register(getUiSettings());
   }
 
   public start() {

--- a/src/plugins/vis_types/timelion/server/series_functions/graphite.js
+++ b/src/plugins/vis_types/timelion/server/series_functions/graphite.js
@@ -36,7 +36,7 @@ export default new Datasource('graphite', {
       max: moment(tlConfig.time.to).format('HH:mm[_]YYYYMMDD'),
     };
     const allowedUrls = tlConfig.allowedGraphiteUrls;
-    const configuredUrl = tlConfig.settings['timelion:graphite.url'];
+    const configuredUrl = tlConfig.settings['timelion:graphite.url'] || allowedUrls[0];
     if (!allowedUrls.includes(configuredUrl)) {
       throw new Error(
         i18n.translate('timelion.help.functions.notAllowedGraphiteUrl', {
@@ -48,7 +48,7 @@ export default new Datasource('graphite', {
     }
 
     const URL =
-      tlConfig.settings['timelion:graphite.url'] +
+      configuredUrl +
       '/render/' +
       '?format=json' +
       '&from=' +

--- a/src/plugins/vis_types/timelion/server/ui_settings.ts
+++ b/src/plugins/vis_types/timelion/server/ui_settings.ts
@@ -7,19 +7,16 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { schema, TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
 import type { UiSettingsParams } from 'kibana/server';
 
 import { UI_SETTINGS } from '../common/constants';
-import { configSchema } from '../config';
 
 const experimentalLabel = i18n.translate('timelion.uiSettings.experimentalLabel', {
   defaultMessage: 'technical preview',
 });
 
-export function getUiSettings(
-  config: TypeOf<typeof configSchema>
-): Record<string, UiSettingsParams<unknown>> {
+export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
   return {
     [UI_SETTINGS.LEGACY_CHARTS_LIBRARY]: {
       name: i18n.translate('timelion.uiSettings.legacyChartsLibraryLabel', {
@@ -103,14 +100,12 @@ export function getUiSettings(
         description:
           'The URL should be in the form of https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite',
       }),
-      value: config.graphiteUrls && config.graphiteUrls.length ? config.graphiteUrls[0] : null,
+      value: '',
       description: i18n.translate('timelion.uiSettings.graphiteURLDescription', {
         defaultMessage:
-          '{experimentalLabel} The <a href="https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite" target="_blank" rel="noopener">URL</a> of your graphite host',
+          '{experimentalLabel} The <a href="https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite" target="_blank" rel="noopener">URL</a> of your graphite host.  If no URL is set, the first graphite URL configured in kibana.yml is used.',
         values: { experimentalLabel: `<em>[${experimentalLabel}]</em>` },
       }),
-      type: 'select',
-      options: config.graphiteUrls || [],
       category: ['timelion'],
       schema: schema.nullable(schema.string()),
     },


### PR DESCRIPTION
This PR turns the options list for the graphite url advanced setting into a free form text.

Before:
<img width="846" alt="Screenshot 2022-04-06 at 18 40 15" src="https://user-images.githubusercontent.com/1508364/162025117-18eebcba-6414-45b6-969f-ebd5c112dff0.png">
<img width="848" alt="Screenshot 2022-04-06 at 18 39 53" src="https://user-images.githubusercontent.com/1508364/162025131-c7cf27a9-857d-4292-8fed-0e608782031e.png">

After:
<img width="847" alt="Screenshot 2022-04-06 at 18 36 53" src="https://user-images.githubusercontent.com/1508364/162025173-2256b603-1dba-456f-998e-db1f415b4e3b.png">
<img width="839" alt="Screenshot 2022-04-06 at 18 39 13" src="https://user-images.githubusercontent.com/1508364/162025183-2983cd2b-acd9-4499-adb2-e64bd4d80775.png">


## How to test

### Scenario 1: A single graphite url setting via default

* Check out main, and set `vis_type_timelion.graphiteUrls` to a list of a single url
* Do **not** set the advanced setting
* Verify that for a timelion vis using graphite (e.g. `.graphite(metric="abc")`), the URL fetched here https://github.com/elastic/kibana/blob/2e61bc73207038e776bbb27f42b84b334689d8bf/src/plugins/vis_types/timelion/server/series_functions/graphite.js#L61 is using the configured setting
* Switch to this PR
* Verify that the timelion vis is still doing exactly the same request

### Scenario 2: Multiple graphite url settings via default

* Check out main, and set `vis_type_timelion.graphiteUrls` to a list of a multiple urls
* Do **not** set the advanced setting
* Verify that for a timelion vis using graphite (e.g. `.graphite(metric="abc")`), the URL fetched here https://github.com/elastic/kibana/blob/2e61bc73207038e776bbb27f42b84b334689d8bf/src/plugins/vis_types/timelion/server/series_functions/graphite.js#L61 is using the first url from the lsit
* Switch to this PR
* Verify that the timelion vis is still doing exactly the same request

### Scenario 3: Multiple graphite url settings non default

* Check out main, and set `vis_type_timelion.graphiteUrls` to a list of a multiple urls
* Set the advanced setting to something else than the first one
* Verify that for a timelion vis using graphite (e.g. `.graphite(metric="abc")`), the URL fetched here https://github.com/elastic/kibana/blob/2e61bc73207038e776bbb27f42b84b334689d8bf/src/plugins/vis_types/timelion/server/series_functions/graphite.js#L61 is using the configured one
* Switch to this PR
* Verify that the advanced setting retained its value
* Verify that the timelion vis is still doing exactly the same request
* Verify that manually entering another URL which is on the list works and the timelion vis is using it
* Verify that manually entering another URL which is **not** on the list causes an error like this one:
<img width="361" alt="Screenshot 2022-04-06 at 18 39 01" src="https://user-images.githubusercontent.com/1508364/162026115-9f24b761-8551-434b-a14a-230fcc055b33.png">
