### PR TITLE
[Enterprise Search] Pass custom headers from config to Enterprise Search backend

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -27,6 +27,7 @@ export const configSchema = schema.object({
       { defaultValue: 'full' }
     ),
   }),
+  customHeaders: schema.maybe(schema.object({}, { unknowns: 'allow' })),
 });
 
 export type ConfigType = TypeOf<typeof configSchema>;

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -59,10 +59,12 @@ export class EnterpriseSearchRequestHandler {
   private enterpriseSearchUrl: string;
   private log: Logger;
   private headers: Record<string, string> = {};
+  private customHeaders: Record<string, string> = {};
 
   constructor({ config, log }: ConstructorDependencies) {
     this.log = log;
     this.enterpriseSearchUrl = config.host as string;
+    this.customHeaders = config.customHeaders as Record<string, string>;
   }
 
   createRequest({
@@ -88,7 +90,11 @@ export class EnterpriseSearchRequestHandler {
         // Set up API options
         const options = {
           method: request.route.method as string,
-          headers: { Authorization: request.headers.authorization as string, ...JSON_HEADER },
+          headers: {
+            Authorization: request.headers.authorization as string,
+            ...JSON_HEADER,
+            ...this.customHeaders,
+          },
           body: this.getBodyAsString(request.body as object | Buffer),
           agent: entSearchHttpAgent.getHttpAgent(),
         };


### PR DESCRIPTION
closes https://github.com/elastic/enterprise-search-team/issues/1533

## Summary

Some users can't access Enterprise Search (App Search) UI from Kibana UI when the deployment has traffic filters set up (IP filters are enough to trigger this).

We need to ensure `enterpriseSearch.customHeaders` are sent in the requests from Kibana to Enterprise Search.