### PR TITLE
[Security Solution] fix endpoint list paging reset

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/search_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/search_bar.test.tsx
@@ -99,10 +99,18 @@ describe('when rendering the endpoint list `AdminSearchBar`', () => {
     }
   );
 
-  it('should reset the `page_index` to zero', async () => {
+  it('should reset the `page_index` to zero if query changes', async () => {
     await render({ page_index: '10' });
     await submitQuery('foo');
 
     expect(getQueryParamsFromStore().page_index).toBe('0');
+  });
+
+  it('should not reset the `page_index` if query unchanged', async () => {
+    const pageIndex = '10';
+    await render({ admin_query: "(language:kuery,query:'foo')", page_index: pageIndex });
+    await submitQuery('foo');
+
+    expect(getQueryParamsFromStore().page_index).toBe(pageIndex);
   });
 });

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/search_bar.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/search_bar.tsx
@@ -39,15 +39,16 @@ export const AdminSearchBar = memo(() => {
       history.push(
         urlFromQueryParams({
           ...queryParams,
-          // ensure we reset the page back to the first one, so that user id not (possibly) being left on an invalid page
-          page_index: '0',
+          // if query is changed, reset back to first page
+          // so that user is not (possibly) being left on an invalid page
+          page_index: params.query?.query === searchBarQuery.query ? queryParams.page_index : '0',
           ...(params.query?.query.trim()
             ? { admin_query: encode(params.query as unknown as RisonValue) }
             : {}),
         })
       );
     },
-    [history, queryParams]
+    [history, queryParams, searchBarQuery.query]
   );
 
   const timeHistory = useMemo(() => new TimeHistory(new Storage(localStorage)), []);


### PR DESCRIPTION
## Summary

only reset endpoint list page back to 1 if query changes


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
