### PR TITLE
[Discover] account for hidden time column in default sort

### DIFF
--- a/src/plugins/discover/public/application/main/utils/get_state_defaults.ts
+++ b/src/plugins/discover/public/application/main/utils/get_state_defaults.ts
@@ -10,6 +10,7 @@ import { cloneDeep, isEqual } from 'lodash';
 import { IUiSettingsClient } from 'kibana/public';
 import {
   DEFAULT_COLUMNS_SETTING,
+  DOC_HIDE_TIME_COLUMN_SETTING,
   SEARCH_FIELDS_FROM_SOURCE,
   SORT_DEFAULT_ORDER_SETTING,
 } from '../../../../common';
@@ -53,7 +54,11 @@ export function getStateDefaults({
   const defaultState = {
     query,
     sort: !sort.length
-      ? getDefaultSort(indexPattern, config.get(SORT_DEFAULT_ORDER_SETTING, 'desc'))
+      ? getDefaultSort(
+          indexPattern,
+          config.get(SORT_DEFAULT_ORDER_SETTING, 'desc'),
+          config.get(DOC_HIDE_TIME_COLUMN_SETTING, false)
+        )
       : sort,
     columns,
     index: indexPattern?.id,

--- a/src/plugins/discover/public/components/doc_table/components/table_header/table_header.tsx
+++ b/src/plugins/discover/public/components/doc_table/components/table_header/table_header.tsx
@@ -54,7 +54,9 @@ export function TableHeader({
             customLabel={indexPattern.getFieldByName(col.name)?.customLabel}
             isTimeColumn={indexPattern.timeFieldName === col.name}
             sortOrder={
-              sortOrder.length ? sortOrder : getDefaultSort(indexPattern, defaultSortOrder)
+              sortOrder.length
+                ? sortOrder
+                : getDefaultSort(indexPattern, defaultSortOrder, hideTimeColumn)
             }
             onMoveColumn={onMoveColumn}
             onRemoveColumn={onRemoveColumn}

--- a/src/plugins/discover/public/components/doc_table/lib/get_default_sort.test.ts
+++ b/src/plugins/discover/public/components/doc_table/lib/get_default_sort.test.ts
@@ -27,7 +27,7 @@ describe('getDefaultSort function', function () {
     expect(getDefaultSort(stubDataViewWithoutTimeField, 'asc', false)).toEqual([]);
   });
 
-  test('should return empty sourt for data view when time column is hidden', function () {
+  test('should return empty sort for data view when time column is hidden', function () {
     expect(getDefaultSort(stubDataView, 'desc', true)).toEqual([]);
     expect(getDefaultSort(stubDataView, 'asc', true)).toEqual([]);
   });

--- a/src/plugins/discover/public/components/doc_table/lib/get_default_sort.test.ts
+++ b/src/plugins/discover/public/components/doc_table/lib/get_default_sort.test.ts
@@ -18,12 +18,17 @@ describe('getDefaultSort function', function () {
   });
 
   test('should return default sort for an index pattern with timeFieldName', function () {
-    expect(getDefaultSort(stubDataView, 'desc')).toEqual([['@timestamp', 'desc']]);
-    expect(getDefaultSort(stubDataView, 'asc')).toEqual([['@timestamp', 'asc']]);
+    expect(getDefaultSort(stubDataView, 'desc', false)).toEqual([['@timestamp', 'desc']]);
+    expect(getDefaultSort(stubDataView, 'asc', false)).toEqual([['@timestamp', 'asc']]);
   });
 
   test('should return default sort for an index pattern without timeFieldName', function () {
-    expect(getDefaultSort(stubDataViewWithoutTimeField, 'desc')).toEqual([]);
-    expect(getDefaultSort(stubDataViewWithoutTimeField, 'asc')).toEqual([]);
+    expect(getDefaultSort(stubDataViewWithoutTimeField, 'desc', false)).toEqual([]);
+    expect(getDefaultSort(stubDataViewWithoutTimeField, 'asc', false)).toEqual([]);
+  });
+
+  test('should return empty sourt for data view when time column is hidden', function () {
+    expect(getDefaultSort(stubDataView, 'desc', true)).toEqual([]);
+    expect(getDefaultSort(stubDataView, 'asc', true)).toEqual([]);
   });
 });

--- a/src/plugins/discover/public/components/doc_table/lib/get_default_sort.ts
+++ b/src/plugins/discover/public/components/doc_table/lib/get_default_sort.ts
@@ -17,7 +17,7 @@ import { SortOrder } from '../components/table_header/helpers';
 export function getDefaultSort(
   indexPattern: DataView | undefined,
   defaultSortOrder: string = 'desc',
-  hidingTimeColumn: boolean
+  hidingTimeColumn: boolean = false
 ): SortOrder[] {
   if (
     indexPattern?.timeFieldName &&

--- a/src/plugins/discover/public/components/doc_table/lib/get_default_sort.ts
+++ b/src/plugins/discover/public/components/doc_table/lib/get_default_sort.ts
@@ -16,9 +16,14 @@ import { SortOrder } from '../components/table_header/helpers';
  */
 export function getDefaultSort(
   indexPattern: DataView | undefined,
-  defaultSortOrder: string = 'desc'
+  defaultSortOrder: string = 'desc',
+  hidingTimeColumn: boolean
 ): SortOrder[] {
-  if (indexPattern?.timeFieldName && isSortable(indexPattern.timeFieldName, indexPattern)) {
+  if (
+    indexPattern?.timeFieldName &&
+    isSortable(indexPattern.timeFieldName, indexPattern) &&
+    !hidingTimeColumn
+  ) {
     return [[indexPattern.timeFieldName, defaultSortOrder]];
   } else {
     return [];

--- a/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx
+++ b/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx
@@ -213,6 +213,12 @@ export class SavedSearchEmbeddable
     }
   };
 
+  private getDefaultSort(dataView?: DataView) {
+    const defaultSortOrder = this.services.uiSettings.get(SORT_DEFAULT_ORDER_SETTING, 'desc');
+    const hidingTimeColumn = this.services.uiSettings.get(DOC_HIDE_TIME_COLUMN_SETTING, false);
+    return getDefaultSort(dataView, defaultSortOrder, hidingTimeColumn);
+  }
+
   private initializeSearchEmbeddableProps() {
     const { searchSource } = this.savedSearch;
 
@@ -223,20 +229,14 @@ export class SavedSearchEmbeddable
     }
 
     if (!this.savedSearch.sort || !this.savedSearch.sort.length) {
-      this.savedSearch.sort = getDefaultSort(
-        indexPattern,
-        this.services.uiSettings.get(SORT_DEFAULT_ORDER_SETTING, 'desc')
-      );
+      this.savedSearch.sort = this.getDefaultSort(indexPattern);
     }
 
     const props: SearchProps = {
       columns: this.savedSearch.columns,
       indexPattern,
       isLoading: false,
-      sort: getDefaultSort(
-        indexPattern,
-        this.services.uiSettings.get(SORT_DEFAULT_ORDER_SETTING, 'desc')
-      ),
+      sort: this.getDefaultSort(indexPattern),
       rows: [],
       searchDescription: this.savedSearch.description,
       description: this.savedSearch.description,
@@ -344,10 +344,7 @@ export class SavedSearchEmbeddable
     const savedSearchSort =
       this.savedSearch.sort && this.savedSearch.sort.length
         ? this.savedSearch.sort
-        : getDefaultSort(
-            this.searchProps?.indexPattern,
-            this.services.uiSettings.get(SORT_DEFAULT_ORDER_SETTING, 'desc')
-          );
+        : this.getDefaultSort(this.searchProps?.indexPattern);
     searchProps.sort = this.input.sort || savedSearchSort;
     searchProps.sharedItemTitle = this.panelTitle;
     searchProps.rowHeightState = this.input.rowHeight || this.savedSearch.rowHeight;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/121263

The time column is no longer assigned as the default sort when it is hidden via advanced settings.

<img width="952" alt="Screen Shot 2022-04-06 at 3 28 07 PM" src="https://user-images.githubusercontent.com/315764/162065221-d10dc977-18b5-42a8-91b0-626376b85b0a.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios