### PR TITLE
[Security Solution] [Session View] Update how the timeline flyout is hidden so that children are not rendered

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/pane/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/pane/__snapshots__/index.test.tsx.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Pane renders correctly against snapshot 1`] = `
-<Pane
-  timelineId="test"
-/>
-`;

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/pane/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/pane/index.test.tsx
@@ -5,20 +5,38 @@
  * 2.0.
  */
 
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import { TestProviders } from '../../../../common/mock';
 import { TimelineId } from '../../../../../common/types/timeline';
 import { Pane } from '.';
 
+jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../../common/components/url_state/normalize_time_range.ts');
+
+jest.mock('../../../../common/hooks/use_resolve_conflict', () => {
+  return {
+    useResolveConflict: jest.fn().mockImplementation(() => null),
+  };
+});
+
 describe('Pane', () => {
-  test('renders correctly against snapshot', () => {
-    const EmptyComponent = shallow(
+  test('renders with display block by default', () => {
+    const EmptyComponent = render(
       <TestProviders>
         <Pane timelineId={TimelineId.test} />
       </TestProviders>
     );
-    expect(EmptyComponent.find('Pane')).toMatchSnapshot();
+    expect(EmptyComponent.getByTestId('flyout-pane')).toHaveStyle('display: block');
+  });
+
+  test('renders with display none when visibility is set to false', () => {
+    const EmptyComponent = render(
+      <TestProviders>
+        <Pane timelineId={TimelineId.test} visible={false} />
+      </TestProviders>
+    );
+    expect(EmptyComponent.getByTestId('flyout-pane')).toHaveStyle('display: none');
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/pane/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/pane/index.tsx
@@ -51,7 +51,7 @@ const FlyoutPaneComponent: React.FC<FlyoutPaneComponentProps> = ({
   }, [dispatch, timelineId]);
 
   return (
-    <div data-test-subj="flyout-pane" style={{ visibility: visible ? 'visible' : 'hidden' }}>
+    <div data-test-subj="flyout-pane" style={{ display: visible ? 'block' : 'none' }}>
       <StyledEuiFlyout
         aria-label={i18n.TIMELINE_DESCRIPTION}
         className="timeline-flyout"
@@ -60,7 +60,7 @@ const FlyoutPaneComponent: React.FC<FlyoutPaneComponentProps> = ({
         onClose={handleClose}
         size="100%"
         ownFocus={false}
-        style={{ visibility: visible ? 'visible' : 'hidden' }}
+        style={{ display: visible ? 'block' : 'none' }}
       >
         <IndexPatternFieldEditorOverlayGlobalStyle />
         <StatefulTimeline


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/129539

EuiAccordion uses visibility: visible to render the content in the expanded portion of an accordion, and the timeline flyout also used visibility: visilble/hidden to show/hide the content within it, while maintaining all component state. This pr changes the styles on a wrapper div and the flyout itself to use display: none/block so that no children bleed through in the closed state, and component state is maintained when the flyout reopened.


https://user-images.githubusercontent.com/56408403/162065677-2bc71344-c38f-4288-a4d6-b8b38d1745c3.mov




### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




