### PR TITLE
[Security Solution] Fixes Getting Started layout on the users route

### DIFF
--- a/x-pack/plugins/security_solution/public/common/utils/empty_view/use_show_pages_with_empty_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/empty_view/use_show_pages_with_empty_view.tsx
@@ -17,6 +17,7 @@ const isPageNameWithEmptyView = (currentName: string) => {
     SecurityPageName.network,
     SecurityPageName.timelines,
     SecurityPageName.overview,
+    SecurityPageName.users,
   ];
   return pageNamesWithEmptyView.includes(currentName);
 };


### PR DESCRIPTION
## Summary

Users got left off from the empty page design.

Before:
<img width="1951" alt="users-1" src="https://user-images.githubusercontent.com/6935300/162073407-10d0ad93-e7e6-4965-9f13-b4d186f0c810.png">


After:
<img width="1951" alt="users-2" src="https://user-images.githubusercontent.com/6935300/162073391-b255f30e-484c-4798-8d44-2891be09b0ae.png">

