### PR TITLE
[8.2] [Reporting] Reinstate ability to return partial CSVs (#128732)

### DIFF
--- a/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.test.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.test.ts
@@ -28,7 +28,6 @@ import {
   UI_SETTINGS_CSV_SEPARATOR,
   UI_SETTINGS_DATEFORMAT_TZ,
 } from '../../../../common/constants';
-import { UnknownError } from '../../../../common/errors';
 import { createMockConfig, createMockConfigSchema } from '../../../test_helpers';
 import { JobParamsCSV } from '../types';
 import { CsvGenerator } from './generate_csv';
@@ -805,6 +804,87 @@ it('can override ignoring frozen indices', async () => {
   );
 });
 
+it('will return partial data if the scroll or search fails', async () => {
+  mockDataClient.search = jest.fn().mockImplementation(() => {
+    throw new esErrors.ResponseError({
+      statusCode: 500,
+      meta: {} as any,
+      body: 'my error',
+      warnings: [],
+    });
+  });
+  const generateCsv = new CsvGenerator(
+    createMockJob({ columns: ['date', 'ip', 'message'] }),
+    mockConfig,
+    {
+      es: mockEsClient,
+      data: mockDataClient,
+      uiSettings: uiSettingsClient,
+    },
+    {
+      searchSourceStart: mockSearchSourceService,
+      fieldFormatsRegistry: mockFieldFormatsRegistry,
+    },
+    new CancellationToken(),
+    logger,
+    stream
+  );
+  await expect(generateCsv.generateData()).resolves.toMatchInlineSnapshot(`
+          Object {
+            "content_type": "text/csv",
+            "csv_contains_formulas": false,
+            "error_code": undefined,
+            "max_size_reached": false,
+            "metrics": Object {
+              "csv": Object {
+                "rows": 0,
+              },
+            },
+            "warnings": Array [
+              "Received a 500 response from Elasticsearch: my error",
+            ],
+          }
+        `);
+});
+
+it('handles unknown errors', async () => {
+  mockDataClient.search = jest.fn().mockImplementation(() => {
+    throw new Error('An unknown error');
+  });
+  const generateCsv = new CsvGenerator(
+    createMockJob({ columns: ['date', 'ip', 'message'] }),
+    mockConfig,
+    {
+      es: mockEsClient,
+      data: mockDataClient,
+      uiSettings: uiSettingsClient,
+    },
+    {
+      searchSourceStart: mockSearchSourceService,
+      fieldFormatsRegistry: mockFieldFormatsRegistry,
+    },
+    new CancellationToken(),
+    logger,
+    stream
+  );
+  await expect(generateCsv.generateData()).resolves.toMatchInlineSnapshot(`
+          Object {
+            "content_type": "text/csv",
+            "csv_contains_formulas": false,
+            "error_code": undefined,
+            "max_size_reached": false,
+            "metrics": Object {
+              "csv": Object {
+                "rows": 0,
+              },
+            },
+            "warnings": Array [
+              "Encountered an unknown error: An unknown error",
+            ],
+          }
+        `);
+});
+
 describe('error codes', () => {
   it('returns the expected error code when authentication expires', async () => {
     mockDataClient.search = jest.fn().mockImplementation(() =>
@@ -853,28 +933,5 @@ describe('error codes', () => {
         "This report contains partial CSV results because the authentication token expired. Export a smaller amount of data or increase the timeout of the authentication token.",
       ]
     `);
-  });
-
-  it('throws for unknown errors', async () => {
-    mockDataClient.search = jest.fn().mockImplementation(() => {
-      throw new esErrors.ResponseError({ statusCode: 500, meta: {} as any, warnings: [] });
-    });
-    const generateCsv = new CsvGenerator(
-      createMockJob({ columns: ['date', 'ip', 'message'] }),
-      mockConfig,
-      {
-        es: mockEsClient,
-        data: mockDataClient,
-        uiSettings: uiSettingsClient,
-      },
-      {
-        searchSourceStart: mockSearchSourceService,
-        fieldFormatsRegistry: mockFieldFormatsRegistry,
-      },
-      new CancellationToken(),
-      logger,
-      stream
-    );
-    await expect(generateCsv.generateData()).rejects.toBeInstanceOf(UnknownError);
   });
 });

--- a/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
@@ -27,14 +27,9 @@ import type {
   FieldFormatConfig,
   IFieldFormatsRegistry,
 } from '../../../../../../../src/plugins/field_formats/common';
-import { KbnServerError } from '../../../../../../../src/plugins/kibana_utils/server';
 import type { CancellationToken } from '../../../../common/cancellation_token';
 import { CONTENT_TYPE_CSV } from '../../../../common/constants';
-import {
-  AuthenticationExpiredError,
-  ReportingError,
-  UnknownError,
-} from '../../../../common/errors';
+import { AuthenticationExpiredError, ReportingError } from '../../../../common/errors';
 import { byteSizeValueToNumber } from '../../../../common/schema_utils';
 import type { TaskRunResult } from '../../../lib/tasks';
 import type { JobParamsCSV } from '../types';
@@ -368,15 +363,15 @@ export class CsvGenerator {
       }
     } catch (err) {
       this.logger.error(err);
-      if (err instanceof KbnServerError && err.errBody) {
-        throw JSON.stringify(err.errBody.error);
-      }
-
-      if (err instanceof esErrors.ResponseError && [401, 403].includes(err.statusCode ?? 0)) {
-        reportingError = new AuthenticationExpiredError();
-        warnings.push(i18nTexts.authenticationError.partialResultsMessage);
+      if (err instanceof esErrors.ResponseError) {
+        if ([401, 403].includes(err.statusCode ?? 0)) {
+          reportingError = new AuthenticationExpiredError();
+          warnings.push(i18nTexts.authenticationError.partialResultsMessage);
+        } else {
+          warnings.push(i18nTexts.esErrorMessage(err.statusCode ?? 0, String(err.body)));
+        }
       } else {
-        throw new UnknownError(err.message);
+        warnings.push(i18nTexts.unknownError(err?.message));
       }
     } finally {
       // clear scrollID

--- a/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/i18n_texts.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/i18n_texts.ts
@@ -23,4 +23,14 @@ export const i18nTexts = {
       }
     ),
   },
+  esErrorMessage: (statusCode: number, message: string) =>
+    i18n.translate('xpack.reporting.exportTypes.csv.generateCsv.esErrorMessage', {
+      defaultMessage: 'Received a {statusCode} response from Elasticsearch: {message}',
+      values: { statusCode, message },
+    }),
+  unknownError: (message: string = 'unknown') =>
+    i18n.translate('xpack.reporting.exportTypes.csv.generateCsv.unknownErrorMessage', {
+      defaultMessage: 'Encountered an unknown error: {message}',
+      values: { message },
+    }),
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Reporting] Reinstate ability to return partial CSVs (#128732)](https://github.com/elastic/kibana/pull/128732)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)