### PR TITLE
Fix inspect button on User page tabs Events and External alerts

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
@@ -181,8 +181,10 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
     useMatrixHistogramCombined(matrixHistogramRequest);
   const [{ pageName }] = useRouteSpy();
 
-  const onHostOrNetworkPage =
-    pageName === SecurityPageName.hosts || pageName === SecurityPageName.network;
+  const onHostOrNetworkOrUserPage =
+    pageName === SecurityPageName.hosts ||
+    pageName === SecurityPageName.network ||
+    pageName === SecurityPageName.users;
 
   const titleWithStackByField = useMemo(
     () => (title != null && typeof title === 'function' ? title(selectedStackByOption) : title),
@@ -259,11 +261,11 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
             toggleQuery={toggleQuery}
             subtitle={subtitleWithCounts}
             inspectMultiple
-            showInspectButton={showInspectButton || !onHostOrNetworkPage}
+            showInspectButton={showInspectButton || !onHostOrNetworkOrUserPage}
             isInspectDisabled={filterQuery === undefined}
           >
             <EuiFlexGroup alignItems="center" gutterSize="none">
-              {onHostOrNetworkPage && (getLensAttributes || lensAttributes) && timerange && (
+              {onHostOrNetworkOrUserPage && (getLensAttributes || lensAttributes) && timerange && (
                 <EuiFlexItem grow={false}>
                   <CasesContext owner={[APP_ID]} userCanCrud={userCanCrud ?? false}>
                     <VisualizationActions


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/129708

## Summary
Add new inspect actions to user page events and external alerts.

**Before:**
<img width="1507" alt="162156655-276835e5-a5f4-4ede-a2d3-c57881fecea8" src="https://user-images.githubusercontent.com/1490444/162180622-4a2076e4-2747-425f-bcdb-f4d0629b29ab.png">
**After:**
<img width="1493" alt="162157275-09f9f8a3-e259-43a2-85d5-dd60e2317576" src="https://user-images.githubusercontent.com/1490444/162180628-4233d81f-8693-47ee-ba83-61ab4f4b0312.png">




