### PR TITLE
[8.2] bump endpoint bundled ver to release (#129449)

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -23,7 +23,7 @@
   },
   {
     "name": "endpoint",
-    "version": "1.5.0"
+    "version": "8.2.0"
   },
   {
     "name": "fleet_server",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [bump endpoint bundled ver to release (#129449)](https://github.com/elastic/kibana/pull/129449)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)