### PR TITLE
[8.2] Fix User page tabs Events and External alerts should have the new visualisation action itens (#129721)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
@@ -181,8 +181,10 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
     useMatrixHistogramCombined(matrixHistogramRequest);
   const [{ pageName }] = useRouteSpy();
 
-  const onHostOrNetworkPage =
-    pageName === SecurityPageName.hosts || pageName === SecurityPageName.network;
+  const onHostOrNetworkOrUserPage =
+    pageName === SecurityPageName.hosts ||
+    pageName === SecurityPageName.network ||
+    pageName === SecurityPageName.users;
 
   const titleWithStackByField = useMemo(
     () => (title != null && typeof title === 'function' ? title(selectedStackByOption) : title),
@@ -259,11 +261,11 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
             toggleQuery={toggleQuery}
             subtitle={subtitleWithCounts}
             inspectMultiple
-            showInspectButton={showInspectButton || !onHostOrNetworkPage}
+            showInspectButton={showInspectButton || !onHostOrNetworkOrUserPage}
             isInspectDisabled={filterQuery === undefined}
           >
             <EuiFlexGroup alignItems="center" gutterSize="none">
-              {onHostOrNetworkPage && (getLensAttributes || lensAttributes) && timerange && (
+              {onHostOrNetworkOrUserPage && (getLensAttributes || lensAttributes) && timerange && (
                 <EuiFlexItem grow={false}>
                   <CasesContext owner={[APP_ID]} userCanCrud={userCanCrud ?? false}>
                     <VisualizationActions


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Fix User page tabs Events and External alerts should have the new visualisation action itens (#129721)](https://github.com/elastic/kibana/pull/129721)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)