### PR TITLE
Remove Kibana tech lead group from requiring a review in a few places

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,11 +5,6 @@
 # The #CC# prefix delineates Code Coverage,
 # used for the 'team' designator within Kibana Stats
 
-# Tech leads
-/dev_docs @elastic/kibana-tech-leads
-/src/dev/license_checker/config.ts @elastic/kibana-tech-leads
-/packages/kbn-docs-utils/ @elastic/kibana-tech-leads @elastic/kibana-operations
-
 # Virtual teams
 /x-pack/plugins/rule_registry/ @elastic/rac @elastic/response-ops
 
@@ -216,6 +211,8 @@
 /packages/kbn-mapbox-gl @elastic/kibana-gis
 
 # Operations
+/src/dev/license_checker/config.ts @elastic/kibana-operations
+/packages/kbn-docs-utils/ @elastic/kibana-operations
 /src/dev/ @elastic/kibana-operations
 /src/setup_node_env/ @elastic/kibana-operations
 /packages/*eslint*/ @elastic/kibana-operations


### PR DESCRIPTION
I think I added this originally, but I've since changed my stance. People should be free to update dev_docs without being blocked on a tech lead. It creates needless overhead.  Also leaving api_docs to ops team.