### PR TITLE
[7.17] [Uptime] Add summary exists filter in monitor list (#128640)

### DIFF
--- a/x-pack/plugins/uptime/server/lib/requests/search/find_potential_matches.ts
+++ b/x-pack/plugins/uptime/server/lib/requests/search/find_potential_matches.ts
@@ -51,6 +51,8 @@ const queryBody = async (queryContext: QueryContext, searchAfter: any, size: num
     filters.push({ match: { 'monitor.status': queryContext.statusFilter } });
   }
 
+  filters.push({ exists: { field: 'summary' } });
+
   const body = {
     size: 0,
     query: {

--- a/x-pack/test/api_integration/apis/uptime/rest/monitor_states_generated.ts
+++ b/x-pack/test/api_integration/apis/uptime/rest/monitor_states_generated.ts
@@ -84,15 +84,6 @@ export default function ({ getService }: FtrProviderContext) {
         nonSummaryIp = checks[0][0].monitor.ip;
       });
 
-      it('should match non summary documents without a status filter', async () => {
-        const filters = makeApiParams(testMonitorId, [{ match: { 'monitor.ip': nonSummaryIp } }]);
-
-        const url = getBaseUrl(dateRangeStart, dateRangeEnd) + `&filters=${filters}`;
-        const apiResponse = await supertest.get(url);
-        const nonSummaryRes = apiResponse.body;
-        expect(nonSummaryRes.summaries.length).to.eql(1);
-      });
-
       it('should not match non summary documents if the check status does not match the document status', async () => {
         const filters = makeApiParams(testMonitorId, [{ match: { 'monitor.ip': nonSummaryIp } }]);
         const url =


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Uptime] Add summary exists filter in monitor list (#128640)](https://github.com/elastic/kibana/pull/128640)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)