### PR TITLE
[Security Solution][Detections] Fixes utility bar text overflow issue on Rule Execution Log

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/execution_log_table/__snapshots__/execution_log_table.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/execution_log_table/__snapshots__/execution_log_table.test.tsx.snap
@@ -42,15 +42,17 @@ exports[`ExecutionLogTable snapshots renders correctly against snapshot 1`] = `
       </UtilityBarGroup>
     </UtilityBarSection>
     <UtilityBarSection>
-      <UtilityBarText
-        dataTestSubj="executionsShowing"
-      />
-      <Styled(EuiSwitch)
-        checked={false}
-        compressed={true}
-        label="Show metrics columns"
-        onChange={[Function]}
-      />
+      <UtilityBarGroup>
+        <UtilityBarText
+          dataTestSubj="executionsShowing"
+        />
+        <Styled(EuiSwitch)
+          checked={false}
+          compressed={true}
+          label="Show metrics columns"
+          onChange={[Function]}
+        />
+      </UtilityBarGroup>
     </UtilityBarSection>
   </UtilityBar>
   <EuiBasicTable

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/execution_log_table/execution_log_table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/execution_log_table/execution_log_table.tsx
@@ -314,18 +314,20 @@ const ExecutionLogTableComponent: React.FC<ExecutionLogTableProps> = ({
           )}
         </UtilityBarSection>
         <UtilityBarSection>
-          <UtilityBarText dataTestSubj="executionsShowing">
-            {timelines.getLastUpdated({
-              showUpdating: isLoading || isFetching,
-              updatedAt: dataUpdatedAt,
-            })}
-          </UtilityBarText>
-          <UtilitySwitch
-            label={i18n.RULE_EXECUTION_LOG_SHOW_METRIC_COLUMNS_SWITCH}
-            checked={showMetricColumns}
-            compressed={true}
-            onChange={(e) => onShowMetricColumnsCallback(e.target.checked)}
-          />
+          <UtilityBarGroup>
+            <UtilityBarText dataTestSubj="executionsShowing">
+              {timelines.getLastUpdated({
+                showUpdating: isLoading || isFetching,
+                updatedAt: dataUpdatedAt,
+              })}
+            </UtilityBarText>
+            <UtilitySwitch
+              label={i18n.RULE_EXECUTION_LOG_SHOW_METRIC_COLUMNS_SWITCH}
+              checked={showMetricColumns}
+              compressed={true}
+              onChange={(e) => onShowMetricColumnsCallback(e.target.checked)}
+            />
+          </UtilityBarGroup>
         </UtilityBarSection>
       </UtilityBar>
       <EuiBasicTable


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/129321#issuecomment-1091115109

#### Before:
<p align="center">
  <img width="700" src="https://user-images.githubusercontent.com/2946766/162233704-2d321bd0-bde8-4d3a-942a-9155138fffed.png" />
</p>


#### After:
<p align="center">
  <img width="700" src="https://user-images.githubusercontent.com/2946766/162219564-22fc4158-f2d8-4e5b-bf64-50dcc4034260.gif" />
</p>




### Checklist

Delete any items that are not applicable to this PR.

- [X] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
