### PR TITLE
[Stack Monitoring] support custom ccs remote prefixes

### DIFF
--- a/docs/settings/monitoring-settings.asciidoc
+++ b/docs/settings/monitoring-settings.asciidoc
@@ -40,6 +40,9 @@ When enabled, specifies the email address where you want to receive cluster aler
 `monitoring.ui.ccs.enabled`::
 Set to `true` (default) to enable {ref}/modules-cross-cluster-search.html[cross-cluster search] of your monitoring data. The {ref}/modules-remote-clusters.html#remote-cluster-settings[`remote_cluster_client`] role must exist on each node.
 
+`monitoring.ui.ccs.remotePatterns`::
+Set to `*` (default) to perform a {ref}/modules-cross-cluster-search.html[cross-cluster search] for all available clusters. Accepts a string or array of custom remote names to only search. The {ref}/modules-remote-clusters.html#remote-cluster-settings[`remote_cluster_client`] role must exist on each node. `monitoring.ui.ccs.enabled` must be enabled.
+
 `monitoring.ui.elasticsearch.hosts`::
 Specifies the location of the {es} cluster where your monitoring data is stored.
 +

--- a/x-pack/plugins/monitoring/common/ccs_utils.test.js
+++ b/x-pack/plugins/monitoring/common/ccs_utils.test.js
@@ -6,12 +6,12 @@
  */
 
 import expect from '@kbn/expect';
-import { parseCrossClusterPrefix, prefixIndexPattern } from './ccs_utils';
+import { parseCrossClusterPrefix, prefixIndexPatternWithCcs } from './ccs_utils';
 
 // TODO: tests were not running and are not updated.
 // They need to be changed to run.
 describe.skip('ccs_utils', () => {
-  describe('prefixIndexPattern', () => {
+  describe('prefixIndexPatternWithCcs', () => {
     const indexPattern = '.monitoring-xyz-1-*,.monitoring-xyz-2-*';
 
     it('returns the index pattern if ccs is not enabled', () => {
@@ -19,8 +19,8 @@ describe.skip('ccs_utils', () => {
       const config = { ui: { css: { enabled: false } } };
 
       // falsy string values should be ignored
-      const allPattern = prefixIndexPattern(config, indexPattern, '*');
-      const onePattern = prefixIndexPattern(config, indexPattern, 'do_not_use_me');
+      const allPattern = prefixIndexPatternWithCcs(config, indexPattern, '*');
+      const onePattern = prefixIndexPatternWithCcs(config, indexPattern, 'do_not_use_me');
 
       expect(allPattern).to.be(indexPattern);
       expect(onePattern).to.be(indexPattern);
@@ -31,9 +31,9 @@ describe.skip('ccs_utils', () => {
       const config = { ui: { css: { enabled: true } } };
 
       // falsy string values should be ignored
-      const undefinedPattern = prefixIndexPattern(config, indexPattern);
-      const nullPattern = prefixIndexPattern(config, indexPattern, null);
-      const blankPattern = prefixIndexPattern(config, indexPattern, '');
+      const undefinedPattern = prefixIndexPatternWithCcs(config, indexPattern);
+      const nullPattern = prefixIndexPatternWithCcs(config, indexPattern, null);
+      const blankPattern = prefixIndexPatternWithCcs(config, indexPattern, '');
 
       expect(undefinedPattern).to.be(indexPattern);
       expect(nullPattern).to.be(indexPattern);
@@ -44,8 +44,8 @@ describe.skip('ccs_utils', () => {
       // TODO apply as MonitoringConfig during typescript conversion
       const config = { ui: { css: { enabled: true } } };
 
-      const abcPattern = prefixIndexPattern(config, indexPattern, 'aBc');
-      const underscorePattern = prefixIndexPattern(config, indexPattern, 'cluster_one');
+      const abcPattern = prefixIndexPatternWithCcs(config, indexPattern, 'aBc');
+      const underscorePattern = prefixIndexPatternWithCcs(config, indexPattern, 'cluster_one');
 
       expect(abcPattern).to.eql(
         'aBc:.monitoring-xyz-1-*,aBc:.monitoring-xyz-2-*,aBc:monitoring-xyz-1-*,aBc:monitoring-xyz-2-*'
@@ -59,7 +59,7 @@ describe.skip('ccs_utils', () => {
       // TODO apply as MonitoringConfig during typescript conversion
       const config = { ui: { css: { enabled: true } } };
 
-      const pattern = prefixIndexPattern(config, indexPattern, '*');
+      const pattern = prefixIndexPatternWithCcs(config, indexPattern, '*');
 
       // it should have BOTH patterns so that it searches all CCS clusters and the local cluster
       expect(pattern).to.eql(

--- a/x-pack/plugins/monitoring/common/ccs_utils.ts
+++ b/x-pack/plugins/monitoring/common/ccs_utils.ts
@@ -16,10 +16,15 @@ import { MonitoringConfig } from '../server/config';
  *
  * @param  {Object} config The Kibana configuration object.
  * @param  {String} indexPattern The index pattern name
- * @param  {Array} ccs The optional cluster-prefixes to prepend.
+ * @param  {Array|String} ccs The optional cluster-prefixes to prepend. An array when passed from config
+ * and a string when passed from a request
  * @return {String} The index pattern with the {@code cluster} prefix appropriately prepended.
  */
-export function prefixIndexPattern(config: MonitoringConfig, indexPattern: string, ccs?: string[]) {
+export function prefixIndexPattern(
+  config: MonitoringConfig,
+  indexPattern: string,
+  ccs?: string[] | string
+) {
   const ccsEnabled = config.ui.ccs.enabled;
   if (!ccsEnabled || !ccs) {
     return indexPattern;
@@ -33,9 +38,10 @@ export function prefixIndexPattern(config: MonitoringConfig, indexPattern: strin
     )
     .join(',');
 
-  // if a wildcard is used, then we also want to search the local indices
-  // since we don't allow the user to an array with a *, this would only be the default value we set [*]
+  // if a wildcard is used, then we also want to search the local indices.
   if (ccs.includes('*')) {
+    // this case is met when user does not set monitoring.ui.ccs.remotePatterns and uses default ([*])
+    // or user explicitly sets monitoring.ui.ccs to '*'
     return `${prefixedPattern},${indexPattern}`;
   }
   return prefixedPattern;

--- a/x-pack/plugins/monitoring/common/ccs_utils.ts
+++ b/x-pack/plugins/monitoring/common/ccs_utils.ts
@@ -17,10 +17,10 @@ import { MonitoringConfig } from '../server/config';
  * @param  {Object} config The Kibana configuration object.
  * @param  {String} indexPattern The index pattern name
  * @param  {Array|String} ccs The optional cluster-prefixes to prepend. An array when passed from config
- * and a string when passed from a request
+ * and a string when passed from a request.  This is optional because the request could be empty if its not a remote cluster
  * @return {String} The index pattern with the {@code cluster} prefix appropriately prepended.
  */
-export function prefixIndexPattern(
+export function prefixIndexPatternWithCcs(
   config: MonitoringConfig,
   indexPattern: string,
   ccs?: string[] | string

--- a/x-pack/plugins/monitoring/public/alerts/components/param_details_form/use_derived_index_pattern.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/components/param_details_form/use_derived_index_pattern.tsx
@@ -22,7 +22,11 @@ export const useDerivedIndexPattern = (
   dataViews: DataViewsPublicPluginStart,
   config?: MonitoringConfig
 ): { loading: boolean; derivedIndexPattern?: DataView } => {
-  const indexPattern = prefixIndexPattern(config || ({} as MonitoringConfig), INDEX_PATTERNS, '*');
+  const indexPattern = prefixIndexPattern(
+    config || ({} as MonitoringConfig),
+    INDEX_PATTERNS,
+    config?.ui.ccs.remotePatterns
+  );
   const [loading, setLoading] = useState<boolean>(true);
   const [dataView, setDataView] = useState<DataView>();
   useEffect(() => {

--- a/x-pack/plugins/monitoring/public/alerts/components/param_details_form/use_derived_index_pattern.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/components/param_details_form/use_derived_index_pattern.tsx
@@ -7,7 +7,7 @@
 
 import { useEffect, useState } from 'react';
 import { DataViewsPublicPluginStart, DataView } from 'src/plugins/data_views/public';
-import { prefixIndexPattern } from '../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../common/ccs_utils';
 import {
   INDEX_PATTERN_BEATS,
   INDEX_PATTERN_ELASTICSEARCH,
@@ -22,7 +22,7 @@ export const useDerivedIndexPattern = (
   dataViews: DataViewsPublicPluginStart,
   config?: MonitoringConfig
 ): { loading: boolean; derivedIndexPattern?: DataView } => {
-  const indexPattern = prefixIndexPattern(
+  const indexPattern = prefixIndexPatternWithCcs(
     config || ({} as MonitoringConfig),
     INDEX_PATTERNS,
     config?.ui.ccs.remotePatterns

--- a/x-pack/plugins/monitoring/server/index.ts
+++ b/x-pack/plugins/monitoring/server/index.ts
@@ -27,6 +27,7 @@ export const config: PluginConfigDescriptor<TypeOf<typeof configSchema>> = {
       container: true,
       ccs: {
         enabled: true,
+        remotePatterns: true,
       },
     },
     kibana: true,

--- a/x-pack/plugins/monitoring/server/kibana_monitoring/collectors/lib/fetch_stack_product_usage.ts
+++ b/x-pack/plugins/monitoring/server/kibana_monitoring/collectors/lib/fetch_stack_product_usage.ts
@@ -10,7 +10,7 @@ import { ElasticsearchClient } from 'src/core/server';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { MonitoringConfig } from '../../../config';
 // @ts-ignore
-import { prefixIndexPattern } from '../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../common/ccs_utils';
 import { StackProductUsage } from '../types';
 
 interface ESResponse {

--- a/x-pack/plugins/monitoring/server/kibana_monitoring/collectors/lib/get_stack_products_usage.ts
+++ b/x-pack/plugins/monitoring/server/kibana_monitoring/collectors/lib/get_stack_products_usage.ts
@@ -12,7 +12,7 @@ import { MonitoringConfig } from '../../../config';
 // @ts-ignore
 import { getIndexPatterns } from '../../../lib/cluster/get_index_patterns';
 // @ts-ignore
-import { prefixIndexPattern } from '../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../common/ccs_utils';
 import {
   INDEX_PATTERN_ELASTICSEARCH,
   INDEX_PATTERN_KIBANA,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.test.ts
@@ -140,4 +140,21 @@ describe('fetchCCReadExceptions', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.ccr-*');
   });
+  it('should call ES with correct query when ccs enabled and monitoring.ui.ccs.remotePatterns has array value', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve(esRes as any);
+    });
+
+    await fetchCCRReadExceptions(esClient, 1643306331418, 1643309869056, 10000);
+
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-es-*,remote2:.monitoring-es-*,remote1:metrics-elasticsearch.ccr-*,remote2:metrics-elasticsearch.ccr-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.ts
@@ -11,7 +11,6 @@ import { CCRReadExceptionsStats } from '../../../common/types/alerts';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 
 export async function fetchCCRReadExceptions(
   esClient: ElasticsearchClient,
@@ -24,7 +23,7 @@ export async function fetchCCRReadExceptions(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'ccr',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_cluster_health.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_cluster_health.test.ts
@@ -15,7 +15,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_cluster_health.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_cluster_health.test.ts
@@ -111,4 +111,23 @@ describe('fetchClusterHealth', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.cluster_stats-*');
   });
+
+  it('should call ES with correct query when ccs enabled and monitoring.ui.ccs.remotePatterns has array value', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve({} as any);
+    });
+
+    await fetchClusterHealth(esClient, [{ clusterUuid: '1', clusterName: 'foo1' }]);
+
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-es-*,remote2:.monitoring-es-*,remote1:metrics-elasticsearch.cluster_stats-*,remote2:metrics-elasticsearch.cluster_stats-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_cluster_health.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_cluster_health.ts
@@ -9,7 +9,6 @@ import { AlertCluster, AlertClusterHealth } from '../../../common/types/alerts';
 import { ElasticsearchSource } from '../../../common/types/es';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 export async function fetchClusterHealth(
@@ -21,7 +20,7 @@ export async function fetchClusterHealth(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'cluster_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.test.ts
@@ -127,4 +127,20 @@ describe('fetchClusters', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.cluster_stats-*');
   });
+  it('should call ES with correct query when ccs enabled and monitoring.ui.ccs.remotePatterns has array value', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    const esClient = elasticsearchServiceMock.createScopedClusterClient().asCurrentUser;
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve({} as any);
+    });
+    await fetchClusters(esClient);
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-es-*,remote2:.monitoring-es-*,remote1:metrics-elasticsearch.cluster_stats-*,remote2:metrics-elasticsearch.cluster_stats-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.ts
@@ -11,7 +11,6 @@ import { AlertCluster } from '../../../common/types/alerts';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 
 interface RangeFilter {
   [field: string]: {
@@ -28,7 +27,7 @@ export async function fetchClusters(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'cluster_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_cpu_usage_node_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_cpu_usage_node_stats.test.ts
@@ -15,7 +15,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_cpu_usage_node_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_cpu_usage_node_stats.ts
@@ -13,7 +13,6 @@ import { AlertCluster, AlertCpuUsageNodeStats } from '../../../common/types/aler
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 
 interface NodeBucketESResponse {
   key: string;
@@ -43,7 +42,7 @@ export async function fetchCpuUsageNodeStats(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_disk_usage_node_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_disk_usage_node_stats.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_disk_usage_node_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_disk_usage_node_stats.test.ts
@@ -152,4 +152,19 @@ describe('fetchDiskUsageNodeStats', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.node_stats-*');
   });
+  it('should call ES with correct query when ccs enabled and monitoring.ui.ccs.remotePatterns has array value', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve(esRes as any);
+    });
+    await fetchDiskUsageNodeStats(esClient, clusters, duration, size);
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-es-*,remote2:.monitoring-es-*,remote1:metrics-elasticsearch.node_stats-*,remote2:metrics-elasticsearch.node_stats-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_disk_usage_node_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_disk_usage_node_stats.ts
@@ -10,7 +10,6 @@ import { get } from 'lodash';
 import { AlertCluster, AlertDiskUsageNodeStats } from '../../../common/types/alerts';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 export async function fetchDiskUsageNodeStats(
@@ -25,7 +24,7 @@ export async function fetchDiskUsageNodeStats(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_elasticsearch_versions.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_elasticsearch_versions.test.ts
@@ -112,4 +112,19 @@ describe('fetchElasticsearchVersions', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.cluster_stats-*');
   });
+  it('should call ES with correct query when ccs enabled and monitoring.ui.ccs.remotePatterns has array value', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve({} as estypes.SearchResponse);
+    });
+    await fetchElasticsearchVersions(esClient, clusters, size);
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-es-*,remote2:.monitoring-es-*,remote1:metrics-elasticsearch.cluster_stats-*,remote2:metrics-elasticsearch.cluster_stats-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_elasticsearch_versions.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_elasticsearch_versions.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_elasticsearch_versions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_elasticsearch_versions.ts
@@ -9,7 +9,6 @@ import { AlertCluster, AlertVersions } from '../../../common/types/alerts';
 import { ElasticsearchSource } from '../../../common/types/es';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 export async function fetchElasticsearchVersions(
@@ -22,7 +21,7 @@ export async function fetchElasticsearchVersions(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'cluster_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_index_shard_size.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_index_shard_size.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../static_globals', () => ({
       getKeyStoreValue: () => '*',
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_index_shard_size.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_index_shard_size.test.ts
@@ -213,4 +213,19 @@ describe('fetchIndexShardSize', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.index-*');
   });
+  it('should call ES with correct query when ccs enabled and monitoring.ui.ccs.remotePatterns has array value', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve(esRes as any);
+    });
+    await fetchIndexShardSize(esClient, clusters, threshold, shardIndexPatterns, size);
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-es-*,remote2:.monitoring-es-*,remote1:metrics-elasticsearch.index-*,remote2:metrics-elasticsearch.index-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_index_shard_size.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_index_shard_size.ts
@@ -11,7 +11,6 @@ import { ElasticsearchIndexStats, ElasticsearchResponseHit } from '../../../comm
 import { ESGlobPatterns, RegExPatterns } from '../../../common/es_glob_patterns';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 type TopHitType = ElasticsearchResponseHit & {
@@ -40,7 +39,7 @@ export async function fetchIndexShardSize(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'index',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_kibana_versions.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_kibana_versions.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_kibana_versions.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_kibana_versions.test.ts
@@ -148,4 +148,19 @@ describe('fetchKibanaVersions', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-kibana-*,metrics-kibana.stats-*');
   });
+  it('should call ES with correct query when ccs enabled and monitoring.ui.ccs.remotePatterns has array value', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve({} as any);
+    });
+    await fetchKibanaVersions(esClient, clusters, size);
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-kibana-*,remote2:.monitoring-kibana-*,remote1:metrics-kibana.stats-*,remote2:metrics-kibana.stats-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_kibana_versions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_kibana_versions.ts
@@ -9,7 +9,6 @@ import { get } from 'lodash';
 import { AlertCluster, AlertVersions } from '../../../common/types/alerts';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 interface ESAggResponse {
@@ -26,7 +25,7 @@ export async function fetchKibanaVersions(
     config: Globals.app.config,
     moduleType: 'kibana',
     dataset: 'stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_licenses.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_licenses.test.ts
@@ -128,4 +128,21 @@ describe('fetchLicenses', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.cluster_stats-*');
   });
+  it('should call ES with correct query when ccs enabled and monitoring.ui.ccs.remotePatterns has array value', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    const esClient = elasticsearchServiceMock.createScopedClusterClient().asCurrentUser;
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve({} as any);
+    });
+    const clusters = [{ clusterUuid, clusterName }];
+    await fetchLicenses(esClient, clusters);
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-es-*,remote2:.monitoring-es-*,remote1:metrics-elasticsearch.cluster_stats-*,remote2:metrics-elasticsearch.cluster_stats-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_licenses.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_licenses.test.ts
@@ -12,7 +12,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_licenses.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_licenses.ts
@@ -9,7 +9,6 @@ import { AlertLicense, AlertCluster } from '../../../common/types/alerts';
 import { ElasticsearchSource } from '../../../common/types/es';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 export async function fetchLicenses(
@@ -21,7 +20,7 @@ export async function fetchLicenses(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'cluster_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_logstash_versions.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_logstash_versions.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_logstash_versions.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_logstash_versions.test.ts
@@ -153,4 +153,19 @@ describe('fetchLogstashVersions', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-logstash-*,metrics-logstash.node_stats-*');
   });
+  it('should call ES with correct query when ccs enabled and monitoring.ui.ccs.remotePatterns has array value', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve({} as any);
+    });
+    await fetchLogstashVersions(esClient, clusters, size);
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-logstash-*,remote2:.monitoring-logstash-*,remote1:metrics-logstash.node_stats-*,remote2:metrics-logstash.node_stats-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_logstash_versions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_logstash_versions.ts
@@ -9,7 +9,6 @@ import { get } from 'lodash';
 import { AlertCluster, AlertVersions } from '../../../common/types/alerts';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 interface ESAggResponse {
@@ -26,7 +25,7 @@ export async function fetchLogstashVersions(
     config: Globals.app.config,
     moduleType: 'logstash',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.test.ts
@@ -171,4 +171,19 @@ describe('fetchMemoryUsageNodeStats', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.node_stats-*');
   });
+  it('should call ES with correct query  when monitoring.ui.ccs.remotePatterns has array of values', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve(esRes as any);
+    });
+    await fetchMemoryUsageNodeStats(esClient, clusters, startMs, endMs, size);
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-es-*,remote2:.monitoring-es-*,remote1:metrics-elasticsearch.node_stats-*,remote2:metrics-elasticsearch.node_stats-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.ts
@@ -10,7 +10,6 @@ import { get } from 'lodash';
 import { AlertCluster, AlertMemoryUsageNodeStats } from '../../../common/types/alerts';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 export async function fetchMemoryUsageNodeStats(
@@ -26,7 +25,7 @@ export async function fetchMemoryUsageNodeStats(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_missing_monitoring_data.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_missing_monitoring_data.test.ts
@@ -243,4 +243,26 @@ describe('fetchMissingMonitoringData', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.node_stats-*');
   });
+  it('should call ES with correct query  when monitoring.ui.ccs.remotePatterns has array of values', async () => {
+    const now = 10;
+    const clusters = [
+      {
+        clusterUuid: 'clusterUuid1',
+        clusterName: 'clusterName1',
+      },
+    ];
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve({} as any);
+    });
+    await fetchMissingMonitoringData(esClient, clusters, size, now, startMs);
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-es-*,remote2:.monitoring-es-*,remote1:metrics-elasticsearch.node_stats-*,remote2:metrics-elasticsearch.node_stats-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_missing_monitoring_data.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_missing_monitoring_data.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_missing_monitoring_data.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_missing_monitoring_data.ts
@@ -9,7 +9,6 @@ import { ElasticsearchClient } from 'kibana/server';
 import { get } from 'lodash';
 import { AlertCluster, AlertMissingData } from '../../../common/types/alerts';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 import { createDatasetFilter } from './create_dataset_query_filter';
 
@@ -59,7 +58,7 @@ export async function fetchMissingMonitoringData(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.test.ts
@@ -213,4 +213,19 @@ describe('fetchNodesFromClusterStats', () => {
     // @ts-ignore
     expect(params.index).toBe('.monitoring-es-*,metrics-elasticsearch.cluster_stats-*');
   });
+  it('should call ES with correct query when monitoring.ui.ccs.remotePatterns has array of values', async () => {
+    // @ts-ignore
+    Globals.app.config.ui.ccs.enabled = true;
+    Globals.app.config.ui.ccs.remotePatterns = ['remote1', 'remote2'];
+    let params = null;
+    esClient.search.mockImplementation((...args) => {
+      params = args[0];
+      return Promise.resolve(esRes as any);
+    });
+    await fetchNodesFromClusterStats(esClient, clusters);
+    // @ts-ignore
+    expect(params.index).toBe(
+      'remote1:.monitoring-es-*,remote2:.monitoring-es-*,remote1:metrics-elasticsearch.cluster_stats-*,remote2:metrics-elasticsearch.cluster_stats-*'
+    );
+  });
 });

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../static_globals', () => ({
     app: {
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
         },
       },
     },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.ts
@@ -9,7 +9,6 @@ import { AlertCluster, AlertClusterStatsNodes } from '../../../common/types/aler
 import { ElasticsearchSource } from '../../../common/types/es';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 function formatNode(
@@ -36,7 +35,7 @@ export async function fetchNodesFromClusterStats(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'cluster_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_status.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_status.test.ts
@@ -21,7 +21,7 @@ jest.mock('../../static_globals', () => ({
       getLogger: jest.fn(),
       config: {
         ui: {
-          ccs: { enabled: true },
+          ccs: { enabled: true, remotePatterns: '*' },
           metricbeat: { index: 'metricbeat-*' },
           container: { elasticsearch: { enabled: false } },
         },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_status.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_status.test.ts
@@ -22,7 +22,6 @@ jest.mock('../../static_globals', () => ({
       config: {
         ui: {
           ccs: { enabled: true, remotePatterns: '*' },
-          metricbeat: { index: 'metricbeat-*' },
           container: { elasticsearch: { enabled: false } },
         },
       },

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_thread_pool_rejections_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_thread_pool_rejections_stats.ts
@@ -10,7 +10,6 @@ import { get } from 'lodash';
 import { AlertCluster, AlertThreadPoolRejectionsStats } from '../../../common/types/alerts';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 const invalidNumberValue = (value: number) => {
@@ -52,7 +51,7 @@ export async function fetchThreadPoolRejectionStats(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: Globals.app.config.ui.ccs.remotePatterns,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/apm/get_apms_for_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/apm/get_apms_for_clusters.ts
@@ -33,7 +33,7 @@ export function handleResponse(clusterUuid: string, response: ElasticsearchRespo
   };
 }
 
-export function getApmsForClusters(req: LegacyRequest, clusters: Cluster[], ccs?: string) {
+export function getApmsForClusters(req: LegacyRequest, clusters: Cluster[], ccs?: string[]) {
   const start = req.payload.timeRange.min;
   const end = req.payload.timeRange.max;
   const config = req.server.config;

--- a/x-pack/plugins/monitoring/server/lib/beats/get_beats_for_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/beats/get_beats_for_clusters.ts
@@ -32,7 +32,7 @@ export function handleResponse(clusterUuid: string, response: ElasticsearchRespo
   };
 }
 
-export function getBeatsForClusters(req: LegacyRequest, clusters: Cluster[], ccs: string) {
+export function getBeatsForClusters(req: LegacyRequest, clusters: Cluster[], ccs: string[]) {
   const start = req.payload.timeRange.min;
   const end = req.payload.timeRange.max;
   const config = req.server.config;

--- a/x-pack/plugins/monitoring/server/lib/cluster/flag_supported_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/cluster/flag_supported_clusters.ts
@@ -16,7 +16,7 @@ import { Globals } from '../../static_globals';
 async function findSupportedBasicLicenseCluster(
   req: LegacyRequest,
   clusters: ElasticsearchModifiedSource[],
-  ccs: string,
+  ccs: string[],
   kibanaUuid: string,
   serverLog: (message: string) => void
 ) {
@@ -88,7 +88,7 @@ async function findSupportedBasicLicenseCluster(
  * Non-Basic license clusters and any cluster in a single-cluster environment
  * are also flagged as supported in this method.
  */
-export function flagSupportedClusters(req: LegacyRequest, ccs: string) {
+export function flagSupportedClusters(req: LegacyRequest, ccs: string[]) {
   const serverLog = (message: string) => req.getLogger('supported-clusters').debug(message);
   const flagAllSupported = (clusters: ElasticsearchModifiedSource[]) => {
     clusters.forEach((cluster) => {

--- a/x-pack/plugins/monitoring/server/lib/cluster/get_clusters_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_clusters_stats.ts
@@ -24,9 +24,11 @@ import { Globals } from '../../static_globals';
  *
  * @param  {Object} req The incoming user's request
  * @param  {String} clusterUuid (optional) If not undefined, getClusters will filter for a single cluster
+ * @param  {Array} ccs (optional) remote names to search for remote clusters, only called without ccs in getClusterStats
+ * when we're only searching for a particular cluster by clusterUuid from a view
  * @return {Promise} A promise containing an array of clusters.
  */
-export function getClustersStats(req: LegacyRequest, clusterUuid?: string, ccs?: string) {
+export function getClustersStats(req: LegacyRequest, clusterUuid?: string, ccs?: string[]) {
   return (
     fetchClusterStats(req, clusterUuid, ccs)
       .then((response) => handleClusterStats(response))
@@ -40,16 +42,17 @@ export function getClustersStats(req: LegacyRequest, clusterUuid?: string, ccs?:
  *
  * @param {Object} req (required) - server request
  * @param {String} clusterUuid (optional) - if not undefined, getClusters filters for a single clusterUuid
+ * @param  {Array} ccs (optional) remote names to search for remote clusters, only called without ccs in getClusterStats
+ * when we're only searching for a particular cluster by clusterUuid from a view
  * @return {Promise} Object representing each cluster.
  */
-function fetchClusterStats(req: LegacyRequest, clusterUuid?: string, ccs?: string) {
+function fetchClusterStats(req: LegacyRequest, clusterUuid?: string, ccs?: string[]) {
   const dataset = 'cluster_stats';
   const moduleType = 'elasticsearch';
   const indexPattern = getNewIndexPatterns({
     config: Globals.app.config,
     moduleType,
     dataset,
-    // this is will be either *, a request value, or null
     ccs: ccs || req.payload.ccs,
   });
 

--- a/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.test.ts
@@ -8,7 +8,7 @@
 import { MonitoringConfig } from '../..';
 import { getNewIndexPatterns } from './get_index_patterns';
 
-const getConfigWithCcs = (ccsEnabled: boolean) => {
+const getConfigWithCcs = (ccsEnabled: boolean, remotePatterns: string | string[] = ['*']) => {
   return {
     ui: {
       ccs: {
@@ -73,7 +73,7 @@ describe('getNewIndexPatterns', () => {
     });
     expect(indexPatterns).toBe('.monitoring-es-*,metrics-elasticsearch.*-*');
   });
-  it('returns elasticsearch index patterns without ccs prefixes when ccs is disabled but ccs request payload has a value', () => {
+  it('returns elasticsearch index patterns without ccs prefixes when ccs is disabled but ccs has a value', () => {
     const indexPatterns = getNewIndexPatterns({
       config: getConfigWithCcs(false),
       ccs: 'myccs',
@@ -81,7 +81,7 @@ describe('getNewIndexPatterns', () => {
     });
     expect(indexPatterns).toBe('.monitoring-es-*,metrics-elasticsearch.*-*');
   });
-  it('returns elasticsearch index patterns with custom ccs prefixes when ccs is enabled and ccs request payload has a value', () => {
+  it('returns elasticsearch index patterns with custom ccs prefixes when ccs is enabled and ccs has a value', () => {
     const indexPatterns = getNewIndexPatterns({
       config: getConfigWithCcs(true),
       ccs: 'myccs',
@@ -89,7 +89,7 @@ describe('getNewIndexPatterns', () => {
     });
     expect(indexPatterns).toBe('myccs:.monitoring-es-*,myccs:metrics-elasticsearch.*-*');
   });
-  it('returns elasticsearch index patterns with ccs prefixes and local index patterns when ccs is enabled and ccs request payload value is *', () => {
+  it('returns elasticsearch index patterns with ccs prefixes and local index patterns when ccs is enabled and ccs value is *', () => {
     const indexPatterns = getNewIndexPatterns({
       config: getConfigWithCcs(true),
       ccs: '*',
@@ -97,6 +97,26 @@ describe('getNewIndexPatterns', () => {
     });
     expect(indexPatterns).toBe(
       '*:.monitoring-es-*,.monitoring-es-*,*:metrics-elasticsearch.*-*,metrics-elasticsearch.*-*'
+    );
+  });
+  it('returns elasticsearch index patterns with ccs prefixes and local index patterns when monitoring.ui.ccs.enabled: true and ccs value is an array with default', () => {
+    const indexPatterns = getNewIndexPatterns({
+      config: getConfigWithCcs(true),
+      ccs: ['*'],
+      moduleType: 'elasticsearch',
+    });
+    expect(indexPatterns).toBe(
+      '*:.monitoring-es-*,.monitoring-es-*,*:metrics-elasticsearch.*-*,metrics-elasticsearch.*-*'
+    );
+  });
+  it('returns elasticsearch index patterns with ccs prefixes when monitoring.ui.ccs.enabled: true and ccs value is an array with multiple custom values', () => {
+    const indexPatterns = getNewIndexPatterns({
+      config: getConfigWithCcs(true),
+      ccs: ['myremote', 'myremote2'],
+      moduleType: 'elasticsearch',
+    });
+    expect(indexPatterns).toBe(
+      'myremote:.monitoring-es-*,myremote2:.monitoring-es-*,myremote:metrics-elasticsearch.*-*,myremote2:metrics-elasticsearch.*-*'
     );
   });
 });

--- a/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.ts
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.ts
@@ -65,7 +65,7 @@ export function getLegacyIndexPattern({
   moduleType: INDEX_PATTERN_TYPES;
   ecsLegacyOnly?: boolean;
   config: MonitoringConfig;
-  ccs?: string[];
+  ccs?: string[] | string;
 }) {
   let indexPattern = '';
   switch (moduleType) {
@@ -104,7 +104,7 @@ export function getDsIndexPattern({
   moduleType: INDEX_PATTERN_TYPES;
   namespace?: string;
   config: MonitoringConfig;
-  ccs?: string[];
+  ccs?: string[] | string;
 }): string {
   let datasetsPattern = '';
   if (dataset) {
@@ -129,7 +129,7 @@ export function getNewIndexPatterns({
   type?: DS_INDEX_PATTERN_TYPES;
   dataset?: string;
   namespace?: string;
-  ccs?: string[];
+  ccs?: string[] | string;
   ecsLegacyOnly?: boolean;
 }): string {
   const legacyIndexPattern = getLegacyIndexPattern({ moduleType, ecsLegacyOnly, config, ccs });

--- a/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.ts
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.ts
@@ -6,7 +6,7 @@
  */
 
 import { LegacyServer } from '../../types';
-import { prefixIndexPattern } from '../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../common/ccs_utils';
 import {
   INDEX_PATTERN_ELASTICSEARCH,
   INDEX_PATTERN_ELASTICSEARCH_ECS,
@@ -27,13 +27,13 @@ export function getIndexPatterns(
   ccs: string[] = server.config.ui.ccs.remotePatterns
 ) {
   const config = server.config;
-  const esIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
-  const kbnIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_KIBANA, ccs);
-  const lsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_LOGSTASH, ccs);
-  const beatsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
-  const apmIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
-  const alertsIndex = prefixIndexPattern(config, INDEX_ALERTS, ccs);
-  const enterpriseSearchIndexPattern = prefixIndexPattern(
+  const esIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
+  const kbnIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_KIBANA, ccs);
+  const lsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_LOGSTASH, ccs);
+  const beatsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
+  const apmIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
+  const alertsIndex = prefixIndexPatternWithCcs(config, INDEX_ALERTS, ccs);
+  const enterpriseSearchIndexPattern = prefixIndexPatternWithCcs(
     config,
     INDEX_PATTERN_ENTERPRISE_SEARCH,
     ccs
@@ -49,7 +49,7 @@ export function getIndexPatterns(
     ...Object.keys(additionalPatterns).reduce((accum, varName) => {
       return {
         ...accum,
-        [varName]: prefixIndexPattern(config, additionalPatterns[varName], ccs),
+        [varName]: prefixIndexPatternWithCcs(config, additionalPatterns[varName], ccs),
       };
     }, {}),
   };
@@ -88,7 +88,7 @@ export function getLegacyIndexPattern({
     default:
       throw new Error(`invalid module type to create index pattern: ${moduleType}`);
   }
-  return prefixIndexPattern(config, indexPattern, ccs);
+  return prefixIndexPatternWithCcs(config, indexPattern, ccs);
 }
 
 export function getDsIndexPattern({
@@ -112,7 +112,7 @@ export function getDsIndexPattern({
   } else {
     datasetsPattern = `${moduleType}.*`;
   }
-  return prefixIndexPattern(config, `${type}-${datasetsPattern}-${namespace}`, ccs);
+  return prefixIndexPatternWithCcs(config, `${type}-${datasetsPattern}-${namespace}`, ccs);
 }
 
 export function getNewIndexPatterns({

--- a/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.ts
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.ts
@@ -24,7 +24,7 @@ import { MonitoringConfig } from '../..';
 export function getIndexPatterns(
   server: LegacyServer,
   additionalPatterns: Record<string, string> = {},
-  ccs: string = '*'
+  ccs: string[] = server.config.ui.ccs.remotePatterns
 ) {
   const config = server.config;
   const esIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
@@ -65,7 +65,7 @@ export function getLegacyIndexPattern({
   moduleType: INDEX_PATTERN_TYPES;
   ecsLegacyOnly?: boolean;
   config: MonitoringConfig;
-  ccs?: string;
+  ccs?: string[];
 }) {
   let indexPattern = '';
   switch (moduleType) {
@@ -104,7 +104,7 @@ export function getDsIndexPattern({
   moduleType: INDEX_PATTERN_TYPES;
   namespace?: string;
   config: MonitoringConfig;
-  ccs?: string;
+  ccs?: string[];
 }): string {
   let datasetsPattern = '';
   if (dataset) {
@@ -129,7 +129,7 @@ export function getNewIndexPatterns({
   type?: DS_INDEX_PATTERN_TYPES;
   dataset?: string;
   namespace?: string;
-  ccs?: string;
+  ccs?: string[];
   ecsLegacyOnly?: boolean;
 }): string {
   const legacyIndexPattern = getLegacyIndexPattern({ moduleType, ecsLegacyOnly, config, ccs });

--- a/x-pack/plugins/monitoring/server/lib/elasticsearch/ccr.ts
+++ b/x-pack/plugins/monitoring/server/lib/elasticsearch/ccr.ts
@@ -17,7 +17,7 @@ import { LegacyRequest } from '../../types';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 import { Globals } from '../../static_globals';
 
-export async function checkCcrEnabled(req: LegacyRequest, ccs: string) {
+export async function checkCcrEnabled(req: LegacyRequest, ccs: string[]) {
   const dataset = 'cluster_stats';
   const moduleType = 'elasticsearch';
   const indexPatterns = getNewIndexPatterns({

--- a/x-pack/plugins/monitoring/server/lib/elasticsearch/get_ml_jobs.ts
+++ b/x-pack/plugins/monitoring/server/lib/elasticsearch/get_ml_jobs.ts
@@ -100,7 +100,11 @@ export function getMlJobs(req: LegacyRequest) {
  * cardinality isn't guaranteed to be accurate is the issue
  * but it will be as long as the precision threshold is >= the actual value
  */
-export function getMlJobsForCluster(req: LegacyRequest, cluster: ElasticsearchSource, ccs: string) {
+export function getMlJobsForCluster(
+  req: LegacyRequest,
+  cluster: ElasticsearchSource,
+  ccs: string[]
+) {
   const license = cluster.license ?? cluster.elasticsearch?.cluster?.stats?.license ?? {};
 
   if (license.status === 'active' && includes(ML_SUPPORTED_LICENSES, license.type)) {

--- a/x-pack/plugins/monitoring/server/lib/enterprise_search/get_enterprise_search_for_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/enterprise_search/get_enterprise_search_for_clusters.ts
@@ -29,7 +29,7 @@ function handleResponse(clusterUuid: string, response: ElasticsearchResponse) {
 export function getEnterpriseSearchForClusters(
   req: LegacyRequest,
   clusters: Cluster[],
-  ccs: string
+  ccs: string[]
 ) {
   const start = req.payload.timeRange.min;
   const end = req.payload.timeRange.max;

--- a/x-pack/plugins/monitoring/server/lib/kibana/get_kibanas_for_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/kibana/get_kibanas_for_clusters.ts
@@ -25,7 +25,7 @@ import { Globals } from '../../static_globals';
  *  - number of instances
  *  - combined health
  */
-export function getKibanasForClusters(req: LegacyRequest, clusters: Cluster[], ccs: string) {
+export function getKibanasForClusters(req: LegacyRequest, clusters: Cluster[], ccs: string[]) {
   const config = req.server.config;
   const start = req.payload.timeRange.min;
   const end = req.payload.timeRange.max;

--- a/x-pack/plugins/monitoring/server/lib/logs/init_infra_source.ts
+++ b/x-pack/plugins/monitoring/server/lib/logs/init_infra_source.ts
@@ -13,7 +13,11 @@ import { InfraPluginSetup } from '../../../../infra/server';
 
 export const initInfraSource = (config: MonitoringConfig, infraPlugin: InfraPluginSetup) => {
   if (infraPlugin) {
-    const filebeatIndexPattern = prefixIndexPattern(config, config.ui.logs.index, '*');
+    const filebeatIndexPattern = prefixIndexPattern(
+      config,
+      config.ui.logs.index,
+      config.ui.ccs.remotePatterns
+    );
     infraPlugin.defineInternalSourceConfiguration(INFRA_SOURCE_ID, {
       name: 'Elastic Stack Logs',
       logIndices: {

--- a/x-pack/plugins/monitoring/server/lib/logs/init_infra_source.ts
+++ b/x-pack/plugins/monitoring/server/lib/logs/init_infra_source.ts
@@ -6,14 +6,14 @@
  */
 
 // @ts-ignore
-import { prefixIndexPattern } from '../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../common/ccs_utils';
 import { INFRA_SOURCE_ID } from '../../../common/constants';
 import { MonitoringConfig } from '../../config';
 import { InfraPluginSetup } from '../../../../infra/server';
 
 export const initInfraSource = (config: MonitoringConfig, infraPlugin: InfraPluginSetup) => {
   if (infraPlugin) {
-    const filebeatIndexPattern = prefixIndexPattern(
+    const filebeatIndexPattern = prefixIndexPatternWithCcs(
       config,
       config.ui.logs.index,
       config.ui.ccs.remotePatterns

--- a/x-pack/plugins/monitoring/server/lib/logstash/get_logstash_for_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/logstash/get_logstash_for_clusters.ts
@@ -40,7 +40,7 @@ const getQueueTypes = (queueBuckets: Array<Bucket & { num_pipelines: { value: nu
 export function getLogstashForClusters(
   req: LegacyRequest,
   clusters: Array<{ cluster_uuid: string } | Cluster>,
-  ccs?: string
+  ccs?: string[]
 ) {
   const start = req.payload.timeRange.min;
   const end = req.payload.timeRange.max;

--- a/x-pack/plugins/monitoring/server/lib/logstash/get_pipeline_ids.ts
+++ b/x-pack/plugins/monitoring/server/lib/logstash/get_pipeline_ids.ts
@@ -18,7 +18,7 @@ interface GetLogstashPipelineIdsParams {
   clusterUuid?: string;
   size: number;
   logstashUuid?: string;
-  ccs?: string;
+  ccs?: string[];
 }
 export async function getLogstashPipelineIds({
   req,

--- a/x-pack/plugins/monitoring/server/lib/standalone_clusters/has_standalone_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/standalone_clusters/has_standalone_clusters.ts
@@ -12,7 +12,7 @@ import { standaloneClusterFilter } from './';
 import { Globals } from '../../static_globals';
 import { getLegacyIndexPattern, getNewIndexPatterns } from '../cluster/get_index_patterns';
 
-export async function hasStandaloneClusters(req: LegacyRequest, ccs: string) {
+export async function hasStandaloneClusters(req: LegacyRequest, ccs: string[]) {
   const lsIndexPatterns = getNewIndexPatterns({
     config: Globals.app.config,
     moduleType: 'logstash',

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/instance.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/instance.js
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { metricSet } from './metric_set_instance';
 import { handleError } from '../../../../lib/errors';
@@ -37,7 +37,7 @@ export function apmInstanceRoute(server) {
       const config = server.config;
       const clusterUuid = req.params.clusterUuid;
       const ccs = req.payload.ccs;
-      const apmIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
+      const apmIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
 
       const showCgroupMetrics = config.ui.container.apm.enabled;
       if (showCgroupMetrics) {

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/instances.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/instances.js
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { getStats, getApms } from '../../../../lib/apm';
 import { handleError } from '../../../../lib/errors';
 import { INDEX_PATTERN_BEATS } from '../../../../../common/constants';
@@ -33,7 +33,7 @@ export function apmInstancesRoute(server) {
       const config = server.config;
       const ccs = req.payload.ccs;
       const clusterUuid = req.params.clusterUuid;
-      const apmIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
+      const apmIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
 
       try {
         const [stats, apms] = await Promise.all([

--- a/x-pack/plugins/monitoring/server/routes/api/v1/beats/beat_detail.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/beats/beat_detail.js
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { getBeatSummary } from '../../../../lib/beats';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { handleError } from '../../../../lib/errors';
@@ -37,7 +37,7 @@ export function beatsDetailRoute(server) {
       const beatUuid = req.params.beatUuid;
       const config = server.config;
       const ccs = req.payload.ccs;
-      const beatsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
+      const beatsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
 
       const summaryOptions = {
         clusterUuid,

--- a/x-pack/plugins/monitoring/server/routes/api/v1/beats/beats.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/beats/beats.js
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { getStats, getBeats } from '../../../../lib/beats';
 import { handleError } from '../../../../lib/errors';
 import { INDEX_PATTERN_BEATS } from '../../../../../common/constants';
@@ -33,7 +33,7 @@ export function beatsListingRoute(server) {
       const config = server.config;
       const ccs = req.payload.ccs;
       const clusterUuid = req.params.clusterUuid;
-      const beatsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
+      const beatsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
 
       try {
         const [stats, listing] = await Promise.all([

--- a/x-pack/plugins/monitoring/server/routes/api/v1/beats/overview.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/beats/overview.js
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { getLatestStats, getStats } from '../../../../lib/beats';
 import { handleError } from '../../../../lib/errors';
@@ -35,7 +35,7 @@ export function beatsOverviewRoute(server) {
       const config = server.config;
       const ccs = req.payload.ccs;
       const clusterUuid = req.params.clusterUuid;
-      const beatsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
+      const beatsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
 
       try {
         const [latest, stats, metrics] = await Promise.all([

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/ccr.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/ccr.ts
@@ -11,7 +11,7 @@ import { get, groupBy } from 'lodash';
 // @ts-ignore
 import { handleError } from '../../../../lib/errors/handle_error';
 // @ts-ignore
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { INDEX_PATTERN_ELASTICSEARCH } from '../../../../../common/constants';
 import {
   ElasticsearchResponse,
@@ -216,7 +216,7 @@ export function ccrRoute(server: { route: (p: any) => void; config: MonitoringCo
     async handler(req: LegacyRequest) {
       const config = server.config;
       const ccs = req.payload.ccs;
-      const esIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
+      const esIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
 
       try {
         const { callWithRequest } = req.server.plugins.elasticsearch.getCluster('monitoring');

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/ccr_shard.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/ccr_shard.ts
@@ -10,7 +10,7 @@ import { schema } from '@kbn/config-schema';
 // @ts-ignore
 import { handleError } from '../../../../lib/errors/handle_error';
 // @ts-ignore
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 // @ts-ignore
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { ElasticsearchResponse } from '../../../../../common/types/es';

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/index_detail.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/index_detail.js
@@ -12,7 +12,7 @@ import { getIndexSummary } from '../../../../lib/elasticsearch/indices';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { getShardAllocation, getShardStats } from '../../../../lib/elasticsearch/shards';
 import { handleError } from '../../../../lib/errors/handle_error';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { metricSet } from './metric_set_index_detail';
 import { getLogs } from '../../../../lib/logs/get_logs';
 
@@ -45,7 +45,7 @@ export function esIndexRoute(server) {
         const indexUuid = req.params.id;
         const start = req.payload.timeRange.min;
         const end = req.payload.timeRange.max;
-        const filebeatIndexPattern = prefixIndexPattern(
+        const filebeatIndexPattern = prefixIndexPatternWithCcs(
           config,
           config.ui.logs.index,
           config.ui.ccs.remotePatterns

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/index_detail.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/index_detail.js
@@ -45,7 +45,11 @@ export function esIndexRoute(server) {
         const indexUuid = req.params.id;
         const start = req.payload.timeRange.min;
         const end = req.payload.timeRange.max;
-        const filebeatIndexPattern = prefixIndexPattern(config, config.ui.logs.index, '*');
+        const filebeatIndexPattern = prefixIndexPattern(
+          config,
+          config.ui.logs.index,
+          config.ui.ccs.remotePatterns
+        );
         const isAdvanced = req.payload.is_advanced;
         const metricSet = isAdvanced ? metricSetAdvanced : metricSetOverview;
 

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/node_detail.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/node_detail.js
@@ -47,7 +47,11 @@ export function esNodeRoute(server) {
       const nodeUuid = req.params.nodeUuid;
       const start = req.payload.timeRange.min;
       const end = req.payload.timeRange.max;
-      const filebeatIndexPattern = prefixIndexPattern(config, config.ui.logs.index, '*');
+      const filebeatIndexPattern = prefixIndexPattern(
+        config,
+        config.ui.logs.index,
+        config.ui.ccs.remotePatterns
+      );
       const isAdvanced = req.payload.is_advanced;
 
       let metricSet;

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/node_detail.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/node_detail.js
@@ -12,7 +12,7 @@ import { getNodeSummary } from '../../../../lib/elasticsearch/nodes';
 import { getShardStats, getShardAllocation } from '../../../../lib/elasticsearch/shards';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { handleError } from '../../../../lib/errors/handle_error';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { metricSets } from './metric_set_node_detail';
 import { getLogs } from '../../../../lib/logs/get_logs';
 
@@ -47,7 +47,7 @@ export function esNodeRoute(server) {
       const nodeUuid = req.params.nodeUuid;
       const start = req.payload.timeRange.min;
       const end = req.payload.timeRange.max;
-      const filebeatIndexPattern = prefixIndexPattern(
+      const filebeatIndexPattern = prefixIndexPatternWithCcs(
         config,
         config.ui.logs.index,
         config.ui.ccs.remotePatterns

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
@@ -37,7 +37,11 @@ export function esOverviewRoute(server) {
     async handler(req) {
       const config = server.config;
       const clusterUuid = req.params.clusterUuid;
-      const filebeatIndexPattern = prefixIndexPattern(config, config.ui.logs.index, '*');
+      const filebeatIndexPattern = prefixIndexPattern(
+        config,
+        config.ui.logs.index,
+        config.ui.ccs.remotePatterns
+      );
 
       const start = req.payload.timeRange.min;
       const end = req.payload.timeRange.max;

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
@@ -11,7 +11,7 @@ import { getClusterStatus } from '../../../../lib/cluster/get_cluster_status';
 import { getLastRecovery } from '../../../../lib/elasticsearch/get_last_recovery';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { handleError } from '../../../../lib/errors/handle_error';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { metricSet } from './metric_set_overview';
 import { getLogs } from '../../../../lib/logs';
 import { getIndicesUnassignedShardStats } from '../../../../lib/elasticsearch/shards/get_indices_unassigned_shard_stats';
@@ -37,7 +37,7 @@ export function esOverviewRoute(server) {
     async handler(req) {
       const config = server.config;
       const clusterUuid = req.params.clusterUuid;
-      const filebeatIndexPattern = prefixIndexPattern(
+      const filebeatIndexPattern = prefixIndexPatternWithCcs(
         config,
         config.ui.logs.index,
         config.ui.ccs.remotePatterns

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch_settings/check/internal_monitoring.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch_settings/check/internal_monitoring.ts
@@ -14,7 +14,7 @@ import {
   INDEX_PATTERN_LOGSTASH,
 } from '../../../../../../common/constants';
 // @ts-ignore
-import { prefixIndexPattern } from '../../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../../common/ccs_utils';
 // @ts-ignore
 import { handleError } from '../../../../../lib/errors';
 import { RouteDependencies, LegacyServer } from '../../../../../types';
@@ -89,9 +89,9 @@ export function internalMonitoringCheckRoute(server: LegacyServer, npRoute: Rout
 
         const config = server.config;
         const { ccs } = request.body;
-        const esIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
-        const kbnIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_KIBANA, ccs);
-        const lsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_LOGSTASH, ccs);
+        const esIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
+        const kbnIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_KIBANA, ccs);
+        const lsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_LOGSTASH, ccs);
         const indexCounts = await Promise.all([
           checkLatestMonitoringIsLegacy(context, esIndexPattern),
           checkLatestMonitoringIsLegacy(context, kbnIndexPattern),


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/120384
Adds the ability for the user to specify a remote prefix instead of searching cross cluster with the default "*" query which gets all available remotes.  

- add monitoring.ui.ccs.remotePatterns to kibana config
- rename function `prefixIndexPattern` to `prefixIndexPatternWithCcs`
- exposes to browser `monitoring.ui.ccs.remotePatterns` in order to use the KQL filter in the rules

Changes in behavior when using the monitoring.ui.ccs.remotePatterns and not using `*`
-  if `monitoring.ui.ccs.enabled` is `true` (default), a cross cluster search will only look for remotes in `monitoring.ui.ccs.remotePatterns` instead of all available. 
- If the user doesn't have access to some specified remote they will get this error when visiting Stack Monitoring and not be able to view any of their data.  This is also the case if the remote doesn't exist or doesn't exist anymore.
![Screen Shot 2022-04-13 at 10 11 29 AM](https://user-images.githubusercontent.com/1676003/163201810-d54d9060-0951-44a2-a98f-13606e3e735a.png)
 - If the user has rules and the remote pattern does not exist, all rule executions will fail for all clusters (` Error: security_exception: [no_such_remote_cluster_exception] Reason: no such remote cluster: [idontexist], caused by: "no such remote cluster: [idontexist]"`).  Previously we used `*` and before that [fetchAvailableCcs](https://github.com/elastic/kibana/blob/main/x-pack/plugins/monitoring/server/lib/alerts/fetch_available_ccs.ts#L10) when CCS was enabled so we did not have this issue, but that created a problem when there were too many remotes.   
![Screen Shot 2022-04-13 at 10 17 48 AM](https://user-images.githubusercontent.com/1676003/163201340-aab8f4a8-b2e6-41ed-8498-4f43550dfd89.png)

 ### Test
- I locally setup three ES clusters to test this and added 2 as remotes, `myremote` and `myremote2`.  Using `monitoring.ui.ccs.remotePatterns` I was able to "filter" out my remotes by adding `"myremote"` or `["myremote"]` and only that remote showed up in the cluster listing.  When i added the 2nd remote `["myremote", "myremote2"]`, both of them showed up in the cluster listing.  When I set `monitoring.ui.ccs.enabled: false`, neither showed up.
- new unit tests should pass