### PR TITLE
[Session View] fixes alignment issue with timestamp when process is long and wraps

### DIFF
--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
@@ -249,6 +249,11 @@ export function ProcessTreeNode({
             </>
           ) : (
             <span>
+              {timeStampOn && (
+                <span data-test-subj="sessionView:processTreeNodeTimestamp" css={styles.timeStamp}>
+                  {timeStampsNormal}
+                </span>
+              )}
               <EuiToolTip position="top" content={iconTooltip}>
                 <EuiIcon data-test-subj={iconTestSubj} type={processIcon} />
               </EuiToolTip>{' '}
@@ -263,11 +268,6 @@ export function ProcessTreeNode({
                   </small>
                 )}
               </span>
-              {timeStampOn && (
-                <span data-test-subj="sessionView:processTreeNodeTimestamp" css={styles.timeStamp}>
-                  {timeStampsNormal}
-                </span>
-              )}
             </span>
           )}
 


### PR DESCRIPTION
## Summary

Fixes an alignment issue with floating the timestamp to the right of the process node. A simple fix, solved by moving the timestamp "span" to be before the content which wraps in the DOM, allowing it to not be shoved down when lines wrap.

![image](https://user-images.githubusercontent.com/16198204/162297337-b6f68d71-4b1d-4bb2-a9b5-f1c7cfab2e69.png)
