### PR TITLE
[Security Solution] [Session View] Set timeline session view flex item width to 100%

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/session_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/session_tab_content/index.tsx
@@ -12,6 +12,7 @@ import { TimelineId } from '../../../../../common/types/timeline';
 import { useSessionView } from './use_session_view';
 
 const FlexItemWithMargin = styled(EuiFlexItem)`
+  width: 100%;
   ${({ theme }) => `margin: 0 ${theme.eui.euiSizeM};`}
 `;
 


### PR DESCRIPTION
## Summary
Session view in timeline doesn't take the whole screen when details panel and alerts flyout are both closed
![image](https://user-images.githubusercontent.com/16872649/162318014-4a73131a-428b-4c0a-8ef6-c4d0353cdafb.png)

After the fix:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/16872649/162318791-c48bdeb7-1c06-4165-9700-fd4182e16b77.png">
