### PR TITLE
[Security Solution] hide artifact cards if no endpoint authz

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/no_permissons/index.ts
+++ b/x-pack/plugins/security_solution/public/management/components/no_permissons/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { NoPermissions } from './no_permissions';

--- a/x-pack/plugins/security_solution/public/management/components/no_permissons/no_permissions.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/no_permissons/no_permissions.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { EuiEmptyPrompt, EuiText } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+export const NoPermissions = memo(() => {
+  return (
+    <>
+      <EuiEmptyPrompt
+        iconType="alert"
+        iconColor="danger"
+        titleSize="l"
+        data-test-subj="noIngestPermissions"
+        title={
+          <FormattedMessage
+            id="xpack.securitySolution.endpointManagemnet.noPermissionsText"
+            defaultMessage="You do not have the required Kibana permissions to use Elastic Security Administration"
+          />
+        }
+        body={
+          <EuiText color="subdued">
+            <FormattedMessage
+              id="xpack.securitySolution.endpointManagement.noPermissionsSubText"
+              defaultMessage="You must have the superuser role to use this feature. If you do not have the superuser role and do not have permissions to edit user roles, contact your Kibana administrator."
+            />
+          </EuiText>
+        }
+      />
+    </>
+  );
+});
+NoPermissions.displayName = 'NoPermissions';

--- a/x-pack/plugins/security_solution/public/management/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/index.tsx
@@ -7,8 +7,7 @@
 
 import React, { memo } from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
-import { EuiEmptyPrompt, EuiLoadingSpinner, EuiText } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiLoadingSpinner } from '@elastic/eui';
 import {
   MANAGEMENT_ROUTING_ENDPOINTS_PATH,
   MANAGEMENT_ROUTING_EVENT_FILTERS_PATH,
@@ -29,35 +28,7 @@ import { getEndpointListPath } from '../common/routing';
 import { useUserPrivileges } from '../../common/components/user_privileges';
 import { HostIsolationExceptionsContainer } from './host_isolation_exceptions';
 import { BlocklistContainer } from './blocklist';
-
-const NoPermissions = memo(() => {
-  return (
-    <>
-      <EuiEmptyPrompt
-        iconType="alert"
-        iconColor="danger"
-        titleSize="l"
-        data-test-subj="noIngestPermissions"
-        title={
-          <FormattedMessage
-            id="xpack.securitySolution.endpointManagemnet.noPermissionsText"
-            defaultMessage="You do not have the required Kibana permissions to use Elastic Security Administration"
-          />
-        }
-        body={
-          <EuiText color="subdued">
-            <FormattedMessage
-              id="xpack.securitySolution.endpointManagement.noPermissionsSubText"
-              defaultMessage="You must have the superuser role to use this feature. If you do not have the superuser role and do not have permissions to edit user roles, contact your Kibana administrator."
-            />
-          </EuiText>
-        }
-      />
-      <SpyRoute pageName={SecurityPageName.administration} />
-    </>
-  );
-});
-NoPermissions.displayName = 'NoPermissions';
+import { NoPermissions } from '../components/no_permissons';
 
 const EndpointTelemetry = () => (
   <TrackApplicationView viewId={SecurityPageName.endpoints}>
@@ -99,7 +70,12 @@ export const ManagementContainer = memo(() => {
   }
 
   if (!canAccessEndpointManagement) {
-    return <Route path="*" component={NoPermissions} />;
+    return (
+      <>
+        <Route path="*" component={NoPermissions} />
+        <SpyRoute pageName={SecurityPageName.administration} />
+      </>
+    );
   }
 
   return (

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/index.tsx
@@ -23,6 +23,8 @@ import { EventFiltersApiClient } from '../../../../event_filters/service/event_f
 import { HostIsolationExceptionsApiClient } from '../../../../host_isolation_exceptions/host_isolation_exceptions_api_client';
 import { BlocklistsApiClient } from '../../../../blocklist/services';
 import { useCanSeeHostIsolationExceptionsMenu } from '../../../../host_isolation_exceptions/view/hooks';
+import { useEndpointPrivileges } from '../../../../../../common/components/user_privileges/endpoint';
+import { NoPermissions } from '../../../../../components/no_permissons';
 
 export const TRUSTED_APPS_LABELS = {
   artifactsSummaryApiError: (error: string) =>
@@ -97,6 +99,7 @@ export const EndpointPackageCustomExtension = memo<PackageCustomExtensionCompone
   (props) => {
     const http = useHttp();
     const canSeeHostIsolationExceptions = useCanSeeHostIsolationExceptionsMenu();
+    const { canAccessEndpointManagement } = useEndpointPrivileges();
 
     const trustedAppsApiClientInstance = useMemo(
       () => TrustedAppsApiClient.getInstance(http),
@@ -113,47 +116,62 @@ export const EndpointPackageCustomExtension = memo<PackageCustomExtensionCompone
       [http]
     );
 
-    const bloklistsApiClientInstance = useMemo(() => BlocklistsApiClient.getInstance(http), [http]);
-
-    return (
-      <div data-test-subj="fleetEndpointPackageCustomContent">
-        <FleetArtifactsCard
-          {...props}
-          artifactApiClientInstance={trustedAppsApiClientInstance}
-          getArtifactsPath={getTrustedAppsListPath}
-          labels={TRUSTED_APPS_LABELS}
-          data-test-subj="trustedApps"
-        />
-        <EuiSpacer />
-        <FleetArtifactsCard
-          {...props}
-          artifactApiClientInstance={eventFiltersApiClientInstance}
-          getArtifactsPath={getEventFiltersListPath}
-          labels={EVENT_FILTERS_LABELS}
-          data-test-subj="eventFilters"
-        />
-        {canSeeHostIsolationExceptions && (
-          <>
-            <EuiSpacer />
-            <FleetArtifactsCard
-              {...props}
-              artifactApiClientInstance={hostIsolationExceptionsApiClientInstance}
-              getArtifactsPath={getHostIsolationExceptionsListPath}
-              labels={HOST_ISOLATION_EXCEPTIONS_LABELS}
-              data-test-subj="hostIsolationExceptions"
-            />
-          </>
-        )}
-        <EuiSpacer />
-        <FleetArtifactsCard
-          {...props}
-          artifactApiClientInstance={bloklistsApiClientInstance}
-          getArtifactsPath={getBlocklistsListPath}
-          labels={BLOCKLISTS_LABELS}
-          data-test-subj="blocklists"
-        />
-      </div>
+    const blocklistsApiClientInstance = useMemo(
+      () => BlocklistsApiClient.getInstance(http),
+      [http]
     );
+
+    const artifactCards = useMemo(
+      () => (
+        <div data-test-subj="fleetEndpointPackageCustomContent">
+          <FleetArtifactsCard
+            {...props}
+            artifactApiClientInstance={trustedAppsApiClientInstance}
+            getArtifactsPath={getTrustedAppsListPath}
+            labels={TRUSTED_APPS_LABELS}
+            data-test-subj="trustedApps"
+          />
+          <EuiSpacer />
+          <FleetArtifactsCard
+            {...props}
+            artifactApiClientInstance={eventFiltersApiClientInstance}
+            getArtifactsPath={getEventFiltersListPath}
+            labels={EVENT_FILTERS_LABELS}
+            data-test-subj="eventFilters"
+          />
+          {canSeeHostIsolationExceptions && (
+            <>
+              <EuiSpacer />
+              <FleetArtifactsCard
+                {...props}
+                artifactApiClientInstance={hostIsolationExceptionsApiClientInstance}
+                getArtifactsPath={getHostIsolationExceptionsListPath}
+                labels={HOST_ISOLATION_EXCEPTIONS_LABELS}
+                data-test-subj="hostIsolationExceptions"
+              />
+            </>
+          )}
+          <EuiSpacer />
+          <FleetArtifactsCard
+            {...props}
+            artifactApiClientInstance={blocklistsApiClientInstance}
+            getArtifactsPath={getBlocklistsListPath}
+            labels={BLOCKLISTS_LABELS}
+            data-test-subj="blocklists"
+          />
+        </div>
+      ),
+      [
+        blocklistsApiClientInstance,
+        canSeeHostIsolationExceptions,
+        eventFiltersApiClientInstance,
+        hostIsolationExceptionsApiClientInstance,
+        trustedAppsApiClientInstance,
+        props,
+      ]
+    );
+
+    return canAccessEndpointManagement ? artifactCards : <NoPermissions />;
   }
 );
 

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_policy_edit_extension.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_policy_edit_extension.tsx
@@ -41,6 +41,7 @@ import { SEARCHABLE_FIELDS as BLOCKLIST_SEARCHABLE_FIELDS } from '../../../block
 import { SEARCHABLE_FIELDS as HOST_ISOLATION_EXCEPTIONS_SEARCHABLE_FIELDS } from '../../../host_isolation_exceptions/constants';
 import { SEARCHABLE_FIELDS as EVENT_FILTERS_SEARCHABLE_FIELDS } from '../../../event_filters/constants';
 import { SEARCHABLE_FIELDS as TRUSTED_APPS_SEARCHABLE_FIELDS } from '../../../trusted_apps/constants';
+import { useEndpointPrivileges } from '../../../../../common/components/user_privileges/endpoint';
 
 export const BLOCKLISTS_LABELS = {
   artifactsSummaryApiError: (error: string) =>
@@ -158,6 +159,7 @@ const WrappedPolicyDetailsForm = memo<{
 
   const http = useHttp();
   const blocklistsApiClientInstance = useMemo(() => BlocklistsApiClient.getInstance(http), [http]);
+  const { canAccessEndpointManagement } = useEndpointPrivileges();
 
   const hostIsolationExceptionsApiClientInstance = useMemo(
     () => HostIsolationExceptionsApiClient.getInstance(http),
@@ -225,8 +227,8 @@ const WrappedPolicyDetailsForm = memo<{
     });
   }, [onChange, updatedPolicy]);
 
-  return (
-    <div data-test-subj="endpointIntegrationPolicyForm">
+  const artifactCards = useMemo(
+    () => (
       <>
         <div>
           <EuiText>
@@ -276,6 +278,22 @@ const WrappedPolicyDetailsForm = memo<{
           />
         </div>
         <EuiSpacer size="l" />
+      </>
+    ),
+    [
+      blocklistsApiClientInstance,
+      eventFiltersApiClientInstance,
+      hostIsolationExceptionsApiClientInstance,
+      policyId,
+      privileges.canIsolateHost,
+      trustedAppsApiClientInstance,
+    ]
+  );
+
+  return (
+    <div data-test-subj="endpointIntegrationPolicyForm">
+      <>
+        {canAccessEndpointManagement && artifactCards}
         <div>
           <EuiText>
             <h5>


### PR DESCRIPTION
## Summary

Hide artifact cards in Endpoint integration advanced tab (with message) and fleet policy details.

Endpoint integration advanced tab:
![Screen Shot 2022-04-07 at 5 51 21 PM](https://user-images.githubusercontent.com/11009772/162332783-32222930-44f5-47de-9351-91fee5aeca1b.png)

Fleet policy details:
![Screen Shot 2022-04-07 at 5 51 39 PM](https://user-images.githubusercontent.com/11009772/162332788-5e9e8872-d7c7-4913-858b-ca474cc9c6ad.png)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
