### PR TITLE
[@kbn/config-schema] properly identify our `string` schema to be of `string` type

### DIFF
--- a/packages/kbn-config-schema/src/types/string_type.ts
+++ b/packages/kbn-config-schema/src/types/string_type.ts
@@ -53,6 +53,7 @@ export class StringType extends Type<string> {
       );
     }
 
+    schema.type = 'string';
     super(schema, options);
   }
 


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/129438

Fix an issue causing `schema.string()` to be internally considered as an `any` type.

