### PR TITLE
[8.2] jump to nested entity_id fixed. verbose mode now defaults to OFF (#129783)

### DIFF
--- a/x-pack/plugins/session_view/public/components/process_tree/helpers.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree/helpers.ts
@@ -170,11 +170,11 @@ export const searchProcessTree = (processMap: ProcessMap, searchQuery: string | 
 // b) matches the plain text search above
 // Returns the processMap with it's processes autoExpand bool set to true or false
 // process.autoExpand is read by process_tree_node to determine whether to auto expand it's child processes.
-export const autoExpandProcessTree = (processMap: ProcessMap) => {
+export const autoExpandProcessTree = (processMap: ProcessMap, jumpToEntityId?: string) => {
   for (const processId of Object.keys(processMap)) {
     const process = processMap[processId];
 
-    if (process.searchMatched || process.isUserEntered()) {
+    if (process.searchMatched || process.isUserEntered() || jumpToEntityId === process.id) {
       let { parent } = process;
       const parentIdSet = new Set<string>();
 

--- a/x-pack/plugins/session_view/public/components/process_tree/hooks.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree/hooks.ts
@@ -31,6 +31,7 @@ interface UseProcessTreeDeps {
   alerts: ProcessEvent[];
   searchQuery?: string;
   updatedAlertsStatus: AlertStatusEventEntityIdMap;
+  jumpToEntityId?: string;
 }
 
 export class ProcessImpl implements Process {
@@ -223,6 +224,7 @@ export const useProcessTree = ({
   alerts,
   searchQuery,
   updatedAlertsStatus,
+  jumpToEntityId,
 }: UseProcessTreeDeps) => {
   // initialize map, as well as a placeholder for session leader process
   // we add a fake session leader event, sourced from wide event data.
@@ -297,8 +299,8 @@ export const useProcessTree = ({
 
   useEffect(() => {
     setSearchResults(searchProcessTree(processMap, searchQuery));
-    autoExpandProcessTree(processMap);
-  }, [searchQuery, processMap]);
+    autoExpandProcessTree(processMap, jumpToEntityId);
+  }, [searchQuery, processMap, jumpToEntityId]);
 
   // set new orphans array on the session leader
   const sessionLeader = processMap[sessionEntityId];

--- a/x-pack/plugins/session_view/public/components/process_tree/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree/index.tsx
@@ -96,6 +96,7 @@ export const ProcessTree = ({
     alerts,
     searchQuery,
     updatedAlertsStatus,
+    jumpToEntityId,
   });
 
   const eventsRemaining = useMemo(() => {

--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.test.tsx
@@ -64,7 +64,7 @@ describe('ProcessTreeNode component', () => {
     //   expect(renderResult.queryByText(/orphaned/i)).toBeTruthy();
     // });
 
-    it('renders Exec icon and exit code for executed process', async () => {
+    it('renders Exec icon', async () => {
       const executedProcessMock: typeof processMock = {
         ...processMock,
         hasExec: () => true,
@@ -75,26 +75,6 @@ describe('ProcessTreeNode component', () => {
       );
 
       expect(renderResult.queryByTestId('sessionView:processTreeNodeExecIcon')).toBeTruthy();
-      expect(renderResult.queryByTestId('sessionView:processTreeNodeExitCode')).toBeTruthy();
-    });
-
-    it('does not render exit code if it does not exist', async () => {
-      const processWithoutExitCode: typeof processMock = {
-        ...processMock,
-        hasExec: () => true,
-        getDetails: () => ({
-          ...processMock.getDetails(),
-          process: {
-            ...processMock.getDetails().process,
-            exit_code: undefined,
-          },
-        }),
-      };
-
-      renderResult = mockedContext.render(
-        <ProcessTreeNode {...props} process={processWithoutExitCode} />
-      );
-      expect(renderResult.queryByTestId('sessionView:processTreeNodeExitCode')).toBeFalsy();
     });
 
     it('calls onChangeJumpToEventVisibility with isVisible false if jumpToEvent is not visible', async () => {

--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
@@ -209,7 +209,6 @@ export function ProcessTreeNode({
     tty,
     parent,
     working_directory: workingDirectory,
-    exit_code: exitCode,
     start,
   } = processDetails.process;
 
@@ -261,12 +260,6 @@ export function ProcessTreeNode({
                 <span css={styles.workingDir}>{dataOrDash(workingDirectory)}</span>&nbsp;
                 <span css={styles.darkText}>{dataOrDash(args?.[0])}</span>{' '}
                 {args?.slice(1).join(' ')}
-                {exitCode !== undefined && (
-                  <small data-test-subj="sessionView:processTreeNodeExitCode">
-                    {' '}
-                    [exit_code: {exitCode}]
-                  </small>
-                )}
               </span>
             </span>
           )}

--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -62,7 +62,7 @@ export const SessionView = ({
     LOCAL_STORAGE_DISPLAY_OPTIONS_KEY,
     {
       timestamp: true,
-      verboseMode: true,
+      verboseMode: false,
     }
   );
   const [fetchAlertStatus, setFetchAlertStatus] = useState<string[]>([]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [jump to nested entity_id fixed. verbose mode now defaults to OFF (#129783)](https://github.com/elastic/kibana/pull/129783)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)