### PR TITLE
[8.2] [Session View] Update/fix for process.end field on Details panel (#129417)

### DIFF
--- a/x-pack/plugins/session_view/public/components/process_tree/hooks.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree/hooks.ts
@@ -146,6 +146,14 @@ export class ProcessImpl implements Process {
     return '';
   }
 
+  getEndTime() {
+    const endEvent = this.filterEventsByAction(this.events, EventAction.end);
+    if (endEvent.length === 0) {
+      return '';
+    }
+    return endEvent[endEvent.length - 1]['@timestamp'];
+  }
+
   // isUserEntered is a best guess at which processes were initiated by a real person
   // In most situations a user entered command in a shell such as bash, will cause bash
   // to fork, create a new process group, and exec the command (e.g ls). If the session

--- a/x-pack/plugins/session_view/public/components/session_view_detail_panel/helpers.ts
+++ b/x-pack/plugins/session_view/public/components/session_view_detail_panel/helpers.ts
@@ -6,6 +6,7 @@
  */
 import { EventAction, Process, ProcessFields } from '../../../common/types/process_tree';
 import { DetailPanelProcess, EuiTabProps } from '../../types';
+import { ProcessImpl } from '../process_tree/hooks';
 
 const FILTER_FORKS_EXECS = [EventAction.fork, EventAction.exec];
 
@@ -56,9 +57,10 @@ export const getDetailPanelProcess = (process: Process | undefined) => {
     };
   }
 
+  const endProcesses = new ProcessImpl(process.id);
+
   processData.id = process.id;
   processData.start = process.events[0]?.['@timestamp'] ?? '';
-  processData.end = process.events[process.events.length - 1]?.['@timestamp'] ?? '';
   processData.args = [];
   processData.executable = [];
 
@@ -92,8 +94,10 @@ export const getDetailPanelProcess = (process: Process | undefined) => {
     if (event.process?.exit_code !== undefined) {
       processData.exit_code = event.process.exit_code;
     }
+    endProcesses.addEvent(event);
   });
 
+  processData.end = endProcesses.getEndTime() as string;
   processData.entryLeader = getDetailPanelProcessLeader(process.events[0]?.process?.entry_leader);
   processData.sessionLeader = getDetailPanelProcessLeader(
     process.events[0]?.process?.session_leader


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Session View] Update/fix for process.end field on Details panel (#129417)](https://github.com/elastic/kibana/pull/129417)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)