### PR TITLE
[8.2] [Session View] Fixed issue where details panel was showing wrong data for leader processes (#129816)

### DIFF
--- a/x-pack/plugins/session_view/common/mocks/constants/session_view_process.mock.ts
+++ b/x-pack/plugins/session_view/common/mocks/constants/session_view_process.mock.ts
@@ -1325,6 +1325,7 @@ export const childProcessMock: Process = {
     } as ProcessEvent),
   isUserEntered: () => false,
   getMaxAlertLevel: () => null,
+  getEndTime: () => '',
 };
 
 export const processMock: Process = {
@@ -1497,6 +1498,7 @@ export const processMock: Process = {
     } as ProcessEvent),
   isUserEntered: () => false,
   getMaxAlertLevel: () => null,
+  getEndTime: () => '',
 };
 
 export const sessionViewBasicProcessMock: Process = {
@@ -1504,6 +1506,7 @@ export const sessionViewBasicProcessMock: Process = {
   events: mockEvents,
   hasExec: () => true,
   isUserEntered: () => true,
+  getEndTime: () => '',
 };
 
 export const sessionViewAlertProcessMock: Process = {
@@ -1514,6 +1517,7 @@ export const sessionViewAlertProcessMock: Process = {
   getAlerts: () => mockAlerts,
   hasExec: () => true,
   isUserEntered: () => true,
+  getEndTime: () => '',
 };
 
 export const mockProcessMap = mockEvents.reduce(
@@ -1540,6 +1544,7 @@ export const mockProcessMap = mockEvents.reduce(
       getDetails: () => event,
       isUserEntered: () => false,
       getMaxAlertLevel: () => null,
+      getEndTime: () => '',
     };
     return processMap;
   },

--- a/x-pack/plugins/session_view/common/types/process_tree/index.ts
+++ b/x-pack/plugins/session_view/common/types/process_tree/index.ts
@@ -76,6 +76,11 @@ export interface ProcessFields {
   end?: string;
   user?: User;
   group?: Group;
+  real_user?: User;
+  real_group?: Group;
+  saved_user?: User;
+  saved_group?: Group;
+  supplemental_groups?: Group[];
   exit_code?: number;
   entry_meta?: EntryMeta;
   tty?: Teletype;
@@ -173,6 +178,7 @@ export interface Process {
   isUserEntered(): boolean;
   getMaxAlertLevel(): number | null;
   getChildren(verboseMode: boolean): Process[];
+  getEndTime(): string;
 }
 
 export type ProcessMap = {

--- a/x-pack/plugins/session_view/public/components/process_tree/hooks.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree/hooks.ts
@@ -148,11 +148,8 @@ export class ProcessImpl implements Process {
   }
 
   getEndTime() {
-    const endEvent = this.filterEventsByAction(this.events, EventAction.end);
-    if (endEvent.length === 0) {
-      return '';
-    }
-    return endEvent[endEvent.length - 1]['@timestamp'];
+    const endEvent = this.findEventByAction(this.events, EventAction.end);
+    return endEvent?.['@timestamp'] || '';
   }
 
   // isUserEntered is a best guess at which processes were initiated by a real person

--- a/x-pack/plugins/session_view/public/components/session_view_detail_panel/helpers.ts
+++ b/x-pack/plugins/session_view/public/components/session_view_detail_panel/helpers.ts
@@ -6,7 +6,6 @@
  */
 import { EventAction, Process, ProcessFields } from '../../../common/types/process_tree';
 import { DetailPanelProcess, EuiTabProps } from '../../types';
-import { ProcessImpl } from '../process_tree/hooks';
 
 const FILTER_FORKS_EXECS = [EventAction.fork, EventAction.exec];
 
@@ -57,33 +56,39 @@ export const getDetailPanelProcess = (process: Process | undefined) => {
     };
   }
 
-  const endProcesses = new ProcessImpl(process.id);
+  const details = process.getDetails();
 
   processData.id = process.id;
-  processData.start = process.events[0]?.['@timestamp'] ?? '';
+  processData.start = details.process?.start ?? '';
   processData.args = [];
   processData.executable = [];
 
-  process.events.forEach((event) => {
-    if (!processData.userName) {
-      processData.userName = event.user?.name ?? '';
-    }
-    if (!processData.groupName) {
-      processData.groupName = event.group?.name ?? '';
-    }
-    if (!processData.pid) {
-      processData.pid = event.process?.pid;
-    }
-    if (!processData.working_directory) {
-      processData.working_directory = event.process?.working_directory ?? '';
-    }
-    if (!processData.tty) {
-      processData.tty = event.process?.tty;
-    }
+  if (!processData.userName) {
+    processData.userName = details.process?.user?.name ?? '';
+  }
+  if (!processData.groupName) {
+    processData.groupName = details.process?.group?.name ?? '';
+  }
+  if (!processData.pid) {
+    processData.pid = details.process?.pid;
+  }
+  if (!processData.working_directory) {
+    processData.working_directory = details.process?.working_directory ?? '';
+  }
+  if (!processData.tty) {
+    processData.tty = details.process?.tty;
+  }
+  if (details.process?.args && details.process.args.length > 0) {
+    processData.args = details.process.args;
+  }
+  if (details.process?.exit_code !== undefined) {
+    processData.exit_code = details.process.exit_code;
+  }
 
-    if (event.process?.args && event.process.args.length > 0) {
-      processData.args = event.process.args;
-    }
+  // we grab the executable from each process lifecycle event to give an indication
+  // of the processes journey. Processes can sometimes exec multiple times, so it's good
+  // information to have.
+  process.events.forEach((event) => {
     if (
       event.process?.executable &&
       event.event?.action &&
@@ -91,19 +96,13 @@ export const getDetailPanelProcess = (process: Process | undefined) => {
     ) {
       processData.executable.push([event.process.executable, `(${event.event.action})`]);
     }
-    if (event.process?.exit_code !== undefined) {
-      processData.exit_code = event.process.exit_code;
-    }
-    endProcesses.addEvent(event);
   });
 
-  processData.end = endProcesses.getEndTime() as string;
-  processData.entryLeader = getDetailPanelProcessLeader(process.events[0]?.process?.entry_leader);
-  processData.sessionLeader = getDetailPanelProcessLeader(
-    process.events[0]?.process?.session_leader
-  );
-  processData.groupLeader = getDetailPanelProcessLeader(process.events[0]?.process?.group_leader);
-  processData.parent = getDetailPanelProcessLeader(process.events[0]?.process?.parent);
+  processData.end = process.getEndTime();
+  processData.entryLeader = getDetailPanelProcessLeader(details?.process?.entry_leader);
+  processData.sessionLeader = getDetailPanelProcessLeader(details?.process?.session_leader);
+  processData.groupLeader = getDetailPanelProcessLeader(details?.process?.group_leader);
+  processData.parent = getDetailPanelProcessLeader(details?.process?.parent);
 
   return processData;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Session View] Fixed issue where details panel was showing wrong data for leader processes (#129816)](https://github.com/elastic/kibana/pull/129816)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)