### PR TITLE
Enhance Event Fields Browser performance

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_fields_browser.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_fields_browser.tsx
@@ -279,6 +279,7 @@ export const EventFieldsBrowser = React.memo<Props>(
         <StyledEuiInMemoryTable
           className={EVENT_FIELDS_TABLE_CLASS_NAME}
           items={items}
+          itemId={(item: TimelineEventsDetailsItem) => item.field}
           columns={columns}
           pagination={false}
           rowProps={onSetRowProps}

--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_fields_browser.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_fields_browser.tsx
@@ -279,7 +279,7 @@ export const EventFieldsBrowser = React.memo<Props>(
         <StyledEuiInMemoryTable
           className={EVENT_FIELDS_TABLE_CLASS_NAME}
           items={items}
-          itemId={(item: TimelineEventsDetailsItem) => item.field}
+          itemId="field"
           columns={columns}
           pagination={false}
           rowProps={onSetRowProps}

--- a/x-pack/plugins/timelines/public/plugin.ts
+++ b/x-pack/plugins/timelines/public/plugin.ts
@@ -28,12 +28,20 @@ export class TimelinesPlugin implements Plugin<void, TimelinesUIStart> {
   private _storage = new Storage(localStorage);
   private _storeUnsubscribe: Unsubscribe | undefined;
 
+  private _hoverActions: HoverActionsConfig | undefined;
+
   public setup(core: CoreSetup) {}
 
   public start(core: CoreStart, { data }: TimelinesStartPlugins): TimelinesUIStart {
     return {
+      /** `getHoverActions` returns a new reference to `getAddToTimelineButton` each time it is called, but that value is used in dependency arrays and so it should be as stable as possible. Therefore we lazily store the reference to it. Note: this reference is deleted when the store is changed. */
       getHoverActions: () => {
-        return getHoverActions(this._store);
+        if (this._hoverActions) {
+          return this._hoverActions;
+        } else {
+          this._hoverActions = getHoverActions(this._store);
+          return this._hoverActions;
+        }
       },
       getTGrid: (props: TGridProps) => {
         if (props.type === 'standalone' && this._store) {
@@ -89,6 +97,8 @@ export class TimelinesPlugin implements Plugin<void, TimelinesUIStart> {
 
   private setStore(store: Store) {
     this._store = store;
+    // this is lazily calculated and that is dependent on the store
+    delete this._hoverActions;
   }
 
   public stop() {

--- a/x-pack/plugins/timelines/public/plugin.ts
+++ b/x-pack/plugins/timelines/public/plugin.ts
@@ -21,7 +21,7 @@ import type { TimelinesUIStart, TGridProps, TimelinesStartPlugins } from './type
 import { tGridReducer } from './store/t_grid/reducer';
 import { useDraggableKeyboardWrapper } from './components/drag_and_drop/draggable_keyboard_wrapper_hook';
 import { useAddToTimeline, useAddToTimelineSensor } from './hooks/use_add_to_timeline';
-import { getHoverActions } from './components/hover_actions';
+import { getHoverActions, HoverActionsConfig } from './components/hover_actions';
 
 export class TimelinesPlugin implements Plugin<void, TimelinesUIStart> {
   private _store: Store | undefined;


### PR DESCRIPTION
## Summary

This PR enhances the performance of the Event Details 'Table' tab, especially the filtering interaction. This affects users with a Data View that has many fields. Note: the Security app creates a Data View that has one field for each mapping in a list of indices.

### Before

https://user-images.githubusercontent.com/35559/162643159-b30a530f-89af-4879-b72d-a82f0ef03c8c.mov

[Chrome dev tools performance profile from before the fix](https://gist.githubusercontent.com/oatkiller/981b502e34d8875f0d7cdf8426ed9b91/raw/d431d9a142c1827643f178dea8b9adff35094eed/before_event_fields_browser_enhancements.json)

### After


https://user-images.githubusercontent.com/35559/162643163-ca009fb9-5a8e-4434-b02c-ebb15362b9bb.mov

[Chrome dev tools performance profile from after the fix](https://gist.githubusercontent.com/oatkiller/981b502e34d8875f0d7cdf8426ed9b91/raw/d431d9a142c1827643f178dea8b9adff35094eed/after_event_fields_browser_enhancements.json)

## Reproducing the issue

1. Use the Elastic Security app to select a Data View that has many fields. If you don't have a Data View with many fields, reach out to me and I'll provide you with details on how to get one.
2. Have an alert. If you don't have one, try creating a simple rule that alerts on any event with `@timestamp` present in any form, then index a single document that has an `@timestamp` value.
3. View the details of the Alert
4. View the 'Table' tab. Notice that when clicking it, the app becomes unresponsive briefly.
5. Try filtering the list of fields. This process is slow. Especially if you type in a filter that limits the number of fields to a small number, and then erase that filter.

## Context: What is the code doing?

The `EventFieldsBrowser` component shows a row for each field. For each row, the component decides which actions a user can take. These actions are represented by small icons. For example, one action allows users to filter by the field with the given value. Another action lets users see the 'Top N' similar events. This action is only available on fields that are 'aggregatable'. Therefore, the component only shows this action for applicable fields.

## Areas to Enhance
In order to determine whether a given row should have the 'Top N' action, the component does a calculation for each row, up front. This algorithm has a runtime complexity of _`O(n*m)` where n is the number of fields in the data view and m is the number of rows/fields shown in the table._ This could be enhanced by doing the calculation lazily, only when the user accesses the overflow menu that shows the `Top N` action. However that fix will be non-trivial, so we'll postpone it for now.

The calculation to determine if each row is 'aggregatable' is also done on every render. This is because it is done using `useMemo`, but one value in the dependencies array changes on each render. This value is called `getAddToTimelineButton`. It is a function which is bound, via `.bind`, to the timeline store on each render. This results in a different function reference being passed to the dependencies array on each render, thereby forcing the calculation to happen on each render. This PR addresses the issue by lazily binding this function to the store, and then saving that reference. When the store is changed, the cached reference is removed. 

Once the first enhancement was made, a second issue was discovered. The table rows component instances were not being reconciled correctly by React. The `EuiInMemoryTableComponent` will set a React `key` property for rows, but only if the `itemId` property is passed. If this property is not passed to the table, then each row will use its positional index as a key. This will prevent React from correctly reconciling components. This means that a component may be re-rendered with props that previously belong to a sibling component. This can cause memos to be invalidated unnecessarily. This was corrected by passing the `itemId` property. We should consider requesting enhanced documentation about the importance of this property. Also, it may be useful to add a console warning when this property is missing (similar to how React shows a console warning when `key` properties are missing in certain situations.)

## What's left

The component should be enhanced so that the calculation to determine which fields can show the 'Top N' action is more efficient. The 'Top N' action is, in practice, only visible from an overflow menu. This means that the calculation could theoretically take place lazily, only when the user accesses the overflow menu. Instead, the component decides whether each field is 'aggregatable' before rendering. It could also be possible to improve the algorithm that determines which fields are aggregatable. Currently this is done by a simple search across all fields in the DataView.

Also, I would like to spend some time explaining the methods I used to find these issues.

### Checklist

- [x] Add more comments to the timelines plugin code explaining the need for the lazily calculated reference to the `getAddToTimelineButton` fn. This design is a stop gap fix.
- [x] Test this with a more realistic alert. The alert I suggest using is not representative of a realistic alert.
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| This does not fix all known performance issues that affect the Event Fields Browser | 100% | Low | This shouldn't have a negative impact on performance or behavior. Any improvement is good. These changes should go a long way for users with large data views. |

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
