### PR TITLE
[Fleet] fixed enrollment token modal for managed policy

### DIFF
--- a/x-pack/plugins/fleet/public/components/new_enrollment_key_modal.tsx
+++ b/x-pack/plugins/fleet/public/components/new_enrollment_key_modal.tsx
@@ -76,8 +76,18 @@ export const NewEnrollmentTokenModal: React.FunctionComponent<Props> = ({
   agentPolicies = [],
 }) => {
   const { notifications } = useStartServices();
+
+  const selectPolicyOptions = useMemo(() => {
+    return agentPolicies
+      .filter((agentPolicy) => !agentPolicy.is_managed)
+      .map((agentPolicy) => ({
+        value: agentPolicy.id,
+        text: agentPolicy.name,
+      }));
+  }, [agentPolicies]);
+
   const form = useCreateApiKeyForm(
-    agentPolicies.length > 0 ? agentPolicies[0].id : undefined,
+    selectPolicyOptions.length > 0 ? selectPolicyOptions[0].value : undefined,
     (key: EnrollmentAPIKey) => {
       onClose(key);
       notifications.toasts.addSuccess(
@@ -92,15 +102,6 @@ export const NewEnrollmentTokenModal: React.FunctionComponent<Props> = ({
       });
     }
   );
-
-  const selectPolicyOptions = useMemo(() => {
-    return agentPolicies
-      .filter((agentPolicy) => !agentPolicy.is_managed)
-      .map((agentPolicy) => ({
-        value: agentPolicy.id,
-        text: agentPolicy.name,
-      }));
-  }, [agentPolicies]);
 
   const body = (
     <EuiForm>


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/128599 for managed policies

To verify:

- create a managed policy in preconfig
- go to Enrollment tokens / Create enrollment token
- verify that Create button is disabled

<img width="1259" alt="image" src="https://user-images.githubusercontent.com/90178898/162691025-7eb6bac2-1054-42fb-beb9-4d4a27f9e23c.png">
<img width="438" alt="image" src="https://user-images.githubusercontent.com/90178898/162691082-399ca93f-b184-44b7-a96c-994464f28114.png">
