### PR TITLE
[7.17] es.createClient: improve config merging logic (#129587)

### DIFF
--- a/src/core/server/elasticsearch/client/client_config.test.ts
+++ b/src/core/server/elasticsearch/client/client_config.test.ts
@@ -243,9 +243,9 @@ describe('parseClientOptions', () => {
           )
         ).toEqual(
           expect.objectContaining({
-            headers: expect.objectContaining({
-              authorization: `Bearer ABC123`,
-            }),
+            auth: {
+              bearer: `ABC123`,
+            },
           })
         );
       });

--- a/src/core/server/elasticsearch/client/client_config.ts
+++ b/src/core/server/elasticsearch/client/client_config.ts
@@ -85,8 +85,9 @@ export function parseClientOptions(
         password: config.password,
       };
     } else if (config.serviceAccountToken) {
-      // TODO: change once ES client has native support for service account tokens: https://github.com/elastic/elasticsearch-js/issues/1477
-      clientOptions.headers!.authorization = `Bearer ${config.serviceAccountToken}`;
+      clientOptions.auth = {
+        bearer: config.serviceAccountToken,
+      };
     }
   }
 

--- a/src/core/server/elasticsearch/elasticsearch_service.ts
+++ b/src/core/server/elasticsearch/elasticsearch_service.ts
@@ -8,7 +8,6 @@
 
 import { Observable, Subject } from 'rxjs';
 import { first, map, shareReplay, takeUntil } from 'rxjs/operators';
-import { merge } from '@kbn/std';
 
 import { CoreService } from '../../types';
 import { CoreContext } from '../core_context';
@@ -29,6 +28,7 @@ import { pollEsNodesVersion } from './version_check/ensure_es_version';
 import { calculateStatus$ } from './status';
 import { isValidConnection } from './is_valid_connection';
 import { getElasticsearchDeprecationsProvider } from './deprecations';
+import { mergeConfig } from './merge_config';
 
 export interface SetupDeps {
   http: InternalHttpServiceSetup;
@@ -143,10 +143,10 @@ export class ElasticsearchService
 
   private createClusterClient(
     type: string,
-    baseConfig: ElasticsearchConfig,
-    clientConfig?: Partial<ElasticsearchClientConfig>
+    baseConfig: ElasticsearchClientConfig,
+    clientConfig: Partial<ElasticsearchClientConfig> = {}
   ) {
-    const config = clientConfig ? merge({}, baseConfig, clientConfig) : baseConfig;
+    const config = mergeConfig(baseConfig, clientConfig);
     return new ClusterClient(
       config,
       this.coreContext.logger.get('elasticsearch'),

--- a/src/core/server/elasticsearch/merge_config.test.ts
+++ b/src/core/server/elasticsearch/merge_config.test.ts
@@ -18,33 +18,33 @@ describe('mergeConfig', () => {
   it('merges the base config and the overrides', () => {
     const base = partialToConfig({
       hosts: ['localhost'],
-      compression: true,
+      sniffOnStart: true,
     });
     const overrides: Partial<ElasticsearchClientConfig> = {
-      maxSockets: 42,
+      requestTimeout: 42,
     };
 
     expect(mergeConfig(base, overrides)).toEqual({
       hosts: ['localhost'],
-      compression: true,
-      maxSockets: 42,
+      sniffOnStart: true,
+      requestTimeout: 42,
     });
   });
 
   it('properly override values that are present in both the base config and the overrides', () => {
     const base = partialToConfig({
       hosts: ['localhost'],
-      compression: true,
+      sniffOnStart: true,
     });
     const overrides: Partial<ElasticsearchClientConfig> = {
-      compression: false,
-      maxSockets: 42,
+      sniffOnStart: false,
+      requestTimeout: 42,
     };
 
     expect(mergeConfig(base, overrides)).toEqual({
       hosts: ['localhost'],
-      compression: false,
-      maxSockets: 42,
+      sniffOnStart: false,
+      requestTimeout: 42,
     });
   });
 
@@ -99,19 +99,19 @@ describe('mergeConfig', () => {
   it('does not mutate the base config', () => {
     const base = partialToConfig({
       hosts: ['localhost'],
-      maxSockets: 42,
+      requestTimeout: 42,
     });
     const overrides: Partial<ElasticsearchClientConfig> = {
       hosts: ['another-host'],
-      maxSockets: 9000,
-      compression: true,
+      requestTimeout: 9000,
+      sniffOnStart: true,
     };
 
     mergeConfig(base, overrides);
 
     expect(base).toEqual({
       hosts: ['localhost'],
-      maxSockets: 42,
+      requestTimeout: 42,
     });
   });
 

--- a/src/core/server/elasticsearch/merge_config.test.ts
+++ b/src/core/server/elasticsearch/merge_config.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { mergeConfig } from './merge_config';
+import type { ElasticsearchClientConfig } from './client';
+import { configSchema, ElasticsearchConfig } from './elasticsearch_config';
+
+const partialToConfig = (parts: Partial<ElasticsearchClientConfig>): ElasticsearchClientConfig => {
+  return parts as ElasticsearchClientConfig;
+};
+
+describe('mergeConfig', () => {
+  it('merges the base config and the overrides', () => {
+    const base = partialToConfig({
+      hosts: ['localhost'],
+      compression: true,
+    });
+    const overrides: Partial<ElasticsearchClientConfig> = {
+      maxSockets: 42,
+    };
+
+    expect(mergeConfig(base, overrides)).toEqual({
+      hosts: ['localhost'],
+      compression: true,
+      maxSockets: 42,
+    });
+  });
+
+  it('properly override values that are present in both the base config and the overrides', () => {
+    const base = partialToConfig({
+      hosts: ['localhost'],
+      compression: true,
+    });
+    const overrides: Partial<ElasticsearchClientConfig> = {
+      compression: false,
+      maxSockets: 42,
+    };
+
+    expect(mergeConfig(base, overrides)).toEqual({
+      hosts: ['localhost'],
+      compression: false,
+      maxSockets: 42,
+    });
+  });
+
+  it('fully override arrays instead of aggregating them', () => {
+    const base = partialToConfig({
+      hosts: ['localhost'],
+    });
+    const overrides: Partial<ElasticsearchClientConfig> = {
+      hosts: ['another-host'],
+    };
+
+    expect(mergeConfig(base, overrides)).toEqual({
+      hosts: ['another-host'],
+    });
+  });
+
+  it('ignores the `username` and `password` fields from the base config if overrides defines `serviceAccountToken`', () => {
+    const base = partialToConfig({
+      hosts: ['localhost'],
+      username: 'foo',
+      password: 'bar',
+    });
+    const overrides: Partial<ElasticsearchClientConfig> = {
+      hosts: ['another-host'],
+      serviceAccountToken: 'token',
+    };
+
+    expect(mergeConfig(base, overrides)).toEqual({
+      hosts: ['another-host'],
+      serviceAccountToken: 'token',
+    });
+  });
+
+  it('ignores the `serviceAccountToken` field from the base config if overrides defines `username` and `password`', () => {
+    const base = partialToConfig({
+      hosts: ['localhost'],
+      serviceAccountToken: 'token',
+    });
+    const overrides: Partial<ElasticsearchClientConfig> = {
+      hosts: ['another-host'],
+      username: 'foo',
+      password: 'bar',
+    };
+
+    expect(mergeConfig(base, overrides)).toEqual({
+      hosts: ['another-host'],
+      username: 'foo',
+      password: 'bar',
+    });
+  });
+
+  it('does not mutate the base config', () => {
+    const base = partialToConfig({
+      hosts: ['localhost'],
+      maxSockets: 42,
+    });
+    const overrides: Partial<ElasticsearchClientConfig> = {
+      hosts: ['another-host'],
+      maxSockets: 9000,
+      compression: true,
+    };
+
+    mergeConfig(base, overrides);
+
+    expect(base).toEqual({
+      hosts: ['localhost'],
+      maxSockets: 42,
+    });
+  });
+
+  it('works with a real instance of ElasticsearchConfig', () => {
+    const rawConfig = configSchema.validate({
+      username: 'foo',
+      password: 'bar',
+    });
+
+    const baseConfig = new ElasticsearchConfig(rawConfig);
+
+    const overrides: Partial<ElasticsearchClientConfig> = {
+      serviceAccountToken: 'token',
+    };
+
+    const output = mergeConfig(baseConfig, overrides);
+
+    expect(output.serviceAccountToken).toEqual('token');
+    expect(output.username).toBeUndefined();
+    expect(output.password).toBeUndefined();
+  });
+});

--- a/src/core/server/elasticsearch/merge_config.ts
+++ b/src/core/server/elasticsearch/merge_config.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { merge } from '@kbn/std';
+import { Writable } from '@kbn/utility-types';
+import type { ElasticsearchClientConfig } from './client';
+
+type WritableConfig = Writable<ElasticsearchClientConfig>;
+
+export const mergeConfig = (
+  baseConfig: ElasticsearchClientConfig,
+  configOverrides: Partial<ElasticsearchClientConfig>
+): ElasticsearchClientConfig => {
+  // note: spreading the source is sufficient because we're only removing keys
+  // if we were to perform more complex operations, a deep copy would be required here
+  const writableBaseConfig = { ...baseConfig } as WritableConfig;
+
+  if (configOverrides.serviceAccountToken) {
+    delete writableBaseConfig.username;
+    delete writableBaseConfig.password;
+  } else if (configOverrides.username && configOverrides.password) {
+    delete writableBaseConfig.serviceAccountToken;
+  }
+
+  return merge(writableBaseConfig, configOverrides);
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [es.createClient: improve config merging logic (#129587)](https://github.com/elastic/kibana/pull/129587)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)