### PR TITLE
[Cloud Posture] add findings group selector

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -29,4 +29,5 @@ export const INTERNAL_FEATURE_FLAGS = {
   showBenchmarks: false,
   showManageRulesMock: false,
   showRisksMock: false,
+  showFindingsGroupBy: false,
 } as const;

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_container.tsx
@@ -4,10 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import { EuiSpacer, EuiTitle, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { FindingsTable } from './findings_table';
 import { FindingsSearchBar } from './findings_search_bar';
 import * as TEST_SUBJECTS from './test_subjects';
@@ -15,20 +16,45 @@ import type { DataView } from '../../../../../../src/plugins/data/common';
 import { SortDirection } from '../../../../../../src/plugins/data/common';
 import { useUrlQuery } from '../../common/hooks/use_url_query';
 import { useFindings, type CspFindingsRequest } from './use_findings';
+import { FindingsGroupBySelector } from './findings_group_by_selector';
+
+export type GroupBy = 'none' | 'resourceType';
 
 // TODO: define this as a schema with default values
-const getDefaultQuery = (): CspFindingsRequest => ({
+const getDefaultQuery = (): CspFindingsRequest & { groupBy: GroupBy } => ({
   query: { language: 'kuery', query: '' },
   filters: [],
   sort: [{ ['@timestamp']: SortDirection.desc }],
   from: 0,
   size: 10,
+  groupBy: 'none',
 });
 
+const getGroupByOptions = () => [
+  {
+    value: 'none',
+    text: i18n.translate('xpack.csp.findings.groupBySelector.groupByNoneLabel', {
+      defaultMessage: 'None',
+    }),
+  },
+  {
+    value: 'resourceType',
+    text: i18n.translate('xpack.csp.findings.groupBySelector.groupByResourceTypeLabel', {
+      defaultMessage: 'Resource Type',
+    }),
+  },
+];
+
 export const FindingsContainer = ({ dataView }: { dataView: DataView }) => {
-  const { urlQuery: findingsQuery, setUrlQuery, key } = useUrlQuery(getDefaultQuery);
+  const {
+    urlQuery: { groupBy, ...findingsQuery },
+    setUrlQuery,
+    key,
+  } = useUrlQuery(getDefaultQuery);
   const findingsResult = useFindings(dataView, findingsQuery, key);
   const { euiTheme } = useEuiTheme();
+  const groupByOptions = useMemo(getGroupByOptions, []);
+
   return (
     <div data-test-subj={TEST_SUBJECTS.FINDINGS_CONTAINER}>
       <FindingsSearchBar
@@ -44,7 +70,16 @@ export const FindingsContainer = ({ dataView }: { dataView: DataView }) => {
       >
         <PageTitle />
         <EuiSpacer />
-        <FindingsTable setQuery={setUrlQuery} {...findingsQuery} {...findingsResult} />
+        <FindingsGroupBySelector
+          type={groupBy}
+          onChange={(type) => setUrlQuery({ groupBy: type })}
+          options={groupByOptions}
+        />
+        <EuiSpacer />
+        {groupBy === 'none' && (
+          <FindingsTable setQuery={setUrlQuery} {...findingsQuery} {...findingsResult} />
+        )}
+        {groupBy === 'resourceType' && <div />}
       </div>
     </div>
   );

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_container.tsx
@@ -17,6 +17,7 @@ import { SortDirection } from '../../../../../../src/plugins/data/common';
 import { useUrlQuery } from '../../common/hooks/use_url_query';
 import { useFindings, type CspFindingsRequest } from './use_findings';
 import { FindingsGroupBySelector } from './findings_group_by_selector';
+import { INTERNAL_FEATURE_FLAGS } from '../../../common/constants';
 
 export type GroupBy = 'none' | 'resourceType';
 
@@ -70,11 +71,13 @@ export const FindingsContainer = ({ dataView }: { dataView: DataView }) => {
       >
         <PageTitle />
         <EuiSpacer />
-        <FindingsGroupBySelector
-          type={groupBy}
-          onChange={(type) => setUrlQuery({ groupBy: type })}
-          options={groupByOptions}
-        />
+        {INTERNAL_FEATURE_FLAGS.showFindingsGroupBy && (
+          <FindingsGroupBySelector
+            type={groupBy}
+            onChange={(type) => setUrlQuery({ groupBy: type })}
+            options={groupByOptions}
+          />
+        )}
         <EuiSpacer />
         {groupBy === 'none' && (
           <FindingsTable setQuery={setUrlQuery} {...findingsQuery} {...findingsResult} />

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_container.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React, { useMemo } from 'react';
-import { EuiSpacer, EuiTitle, useEuiTheme } from '@elastic/eui';
+import { EuiComboBoxOptionOption, EuiSpacer, EuiTitle, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -31,16 +31,16 @@ const getDefaultQuery = (): CspFindingsRequest & { groupBy: GroupBy } => ({
   groupBy: 'none',
 });
 
-const getGroupByOptions = () => [
+const getGroupByOptions = (): Array<EuiComboBoxOptionOption<GroupBy>> => [
   {
     value: 'none',
-    text: i18n.translate('xpack.csp.findings.groupBySelector.groupByNoneLabel', {
+    label: i18n.translate('xpack.csp.findings.groupBySelector.groupByNoneLabel', {
       defaultMessage: 'None',
     }),
   },
   {
     value: 'resourceType',
-    text: i18n.translate('xpack.csp.findings.groupBySelector.groupByResourceTypeLabel', {
+    label: i18n.translate('xpack.csp.findings.groupBySelector.groupByResourceTypeLabel', {
       defaultMessage: 'Resource Type',
     }),
   },
@@ -74,7 +74,7 @@ export const FindingsContainer = ({ dataView }: { dataView: DataView }) => {
         {INTERNAL_FEATURE_FLAGS.showFindingsGroupBy && (
           <FindingsGroupBySelector
             type={groupBy}
-            onChange={(type) => setUrlQuery({ groupBy: type })}
+            onChange={(type) => setUrlQuery({ groupBy: type[0].value })}
             options={groupByOptions}
           />
         )}

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_container.tsx
@@ -74,7 +74,7 @@ export const FindingsContainer = ({ dataView }: { dataView: DataView }) => {
         {INTERNAL_FEATURE_FLAGS.showFindingsGroupBy && (
           <FindingsGroupBySelector
             type={groupBy}
-            onChange={(type) => setUrlQuery({ groupBy: type[0].value })}
+            onChange={(type) => setUrlQuery({ groupBy: type[0]?.value })}
             options={groupByOptions}
           />
         )}

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_group_by_selector.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_group_by_selector.tsx
@@ -5,24 +5,24 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiFormLabel, EuiSelect, EuiFormControlLayout, type EuiSelectOption } from '@elastic/eui';
+import { EuiComboBox, EuiFormLabel, type EuiComboBoxOptionOption } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { GroupBy } from './findings_container';
 
 interface Props {
   type: GroupBy;
-  options: EuiSelectOption[];
-  onChange(type: GroupBy): void;
+  options: Array<EuiComboBoxOptionOption<GroupBy>>;
+  onChange(selectedOptions: Array<EuiComboBoxOptionOption<GroupBy>>): void;
 }
 
 export const FindingsGroupBySelector = ({ type, options, onChange }: Props) => (
-  <EuiFormControlLayout prepend={<GroupByLabel />} style={{ maxWidth: 275 }}>
-    <EuiSelect
-      value={type}
-      options={options}
-      onChange={(event) => onChange(event.target.value as GroupBy)}
-    />
-  </EuiFormControlLayout>
+  <EuiComboBox
+    prepend={<GroupByLabel />}
+    singleSelection={{ asPlainText: true }}
+    options={options}
+    selectedOptions={options.filter((o) => o.value === type)}
+    onChange={onChange}
+  />
 );
 
 const GroupByLabel = () => (

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_group_by_selector.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_group_by_selector.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiFormLabel, EuiSelect, EuiFormControlLayout, type EuiSelectOption } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { GroupBy } from './findings_container';
+
+interface Props {
+  type: GroupBy;
+  options: EuiSelectOption[];
+  onChange(type: GroupBy): void;
+}
+
+export const FindingsGroupBySelector = ({ type, options, onChange }: Props) => (
+  <EuiFormControlLayout prepend={<GroupByLabel />} style={{ maxWidth: 275 }}>
+    <EuiSelect
+      value={type}
+      options={options}
+      onChange={(event) => onChange(event.target.value as GroupBy)}
+    />
+  </EuiFormControlLayout>
+);
+
+const GroupByLabel = () => (
+  <EuiFormLabel>
+    <FormattedMessage
+      id="xpack.csp.findings.groupBySelector.groupByLabel"
+      defaultMessage="Group by"
+    />
+  </EuiFormLabel>
+);


### PR DESCRIPTION
## Summary

- [x] adds a select box for group by options:
  - shows the regular table for `none` 
  - shows empty div for `resource type` (for now)

- [x]  currently hidden behind an internal feature flag

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


----

https://user-images.githubusercontent.com/20814186/163000057-9cdf5776-ff11-4e85-b8bd-a841b2ce5ca8.mov


