### PR TITLE
[SecuritySolution] Remove `empty row`

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/investigation_guide_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/investigation_guide_view.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiSpacer, EuiHorizontalRule, EuiTitle, EuiText } from '@elastic/eui';
+import { EuiSpacer, EuiTitle, EuiText } from '@elastic/eui';
 import { ALERT_RULE_UUID } from '@kbn/rule-data-utils';
 
 import React, { useMemo } from 'react';

--- a/x-pack/plugins/security_solution/public/common/components/event_details/investigation_guide_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/investigation_guide_view.tsx
@@ -39,7 +39,7 @@ const InvestigationGuideViewComponent: React.FC<{
 
   return (
     <>
-      <EuiHorizontalRule />
+      <EuiSpacer size="l" />
       <EuiTitle size="xxxs" data-test-subj="summary-view-guide">
         <h5>{i18n.INVESTIGATION_GUIDE}</h5>
       </EuiTitle>


### PR DESCRIPTION
## Summary

The horizontal rule in the `Investigation guide` component in combination with the bottom border of the `Highlighted fields` table made it look like there is an empty row in the table. The divider is now replaced by a spacer to visually separate the `Investigation guide` and the `Highlighted fields`.

| Before | After |
|---|---|
| <img width="748" alt="Screenshot 2022-04-11 at 17 41 54" src="https://user-images.githubusercontent.com/68591/162778732-7050aa38-e6db-4c0f-83f9-c1a4179bd2ea.png"> | <img width="750" alt="Screenshot 2022-04-11 at 17 41 27" src="https://user-images.githubusercontent.com/68591/162778719-48a563ab-35d2-4122-b026-4c207ae495c6.png"> |

Related issue: https://github.com/elastic/kibana/issues/129296
