### PR TITLE
[SecuritySolution] Remove additional Visualization labels

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_user_authentication_metric_failure.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_user_authentication_metric_failure.ts
@@ -8,7 +8,7 @@
 import { LensAttributes } from '../../types';
 
 export const kpiUserAuthenticationsMetricFailureLensAttributes: LensAttributes = {
-  title: '[Host] User authentications - metric failure ',
+  title: '[Host] User authentications - metric failure',
   description: '',
   visualizationType: 'lnsMetric',
   state: {
@@ -61,7 +61,7 @@ export const kpiUserAuthenticationsMetricFailureLensAttributes: LensAttributes =
                   query: 'event.outcome : "failure" ',
                 },
                 isBucketed: false,
-                label: '',
+                label: ' ',
                 operationType: 'count',
                 scale: 'ratio',
                 sourceField: '___records___',

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_user_authentication_metric_failure.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_user_authentication_metric_failure.ts
@@ -8,7 +8,7 @@
 import { LensAttributes } from '../../types';
 
 export const kpiUserAuthenticationsMetricFailureLensAttributes: LensAttributes = {
-  title: '[Host] User authentications - metric failure',
+  title: '[Host] User authentications - metric failure ',
   description: '',
   visualizationType: 'lnsMetric',
   state: {
@@ -61,7 +61,7 @@ export const kpiUserAuthenticationsMetricFailureLensAttributes: LensAttributes =
                   query: 'event.outcome : "failure" ',
                 },
                 isBucketed: false,
-                label: ' ',
+                label: '',
                 operationType: 'count',
                 scale: 'ratio',
                 sourceField: '___records___',

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_user_authentications_metric_success.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_user_authentications_metric_success.ts
@@ -8,7 +8,7 @@
 import { LensAttributes } from '../../types';
 
 export const kpiUserAuthenticationsMetricSuccessLensAttributes: LensAttributes = {
-  title: '[Host] User authentications - metric success',
+  title: '[Host] User authentications - metric success ',
   description: '',
   visualizationType: 'lnsMetric',
   state: {

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_user_authentications_metric_success.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_user_authentications_metric_success.ts
@@ -8,7 +8,7 @@
 import { LensAttributes } from '../../types';
 
 export const kpiUserAuthenticationsMetricSuccessLensAttributes: LensAttributes = {
-  title: '[Host] User authentications - metric success ',
+  title: '[Host] User authentications - metric success',
   description: '',
   visualizationType: 'lnsMetric',
   state: {

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_dns_queries.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_dns_queries.ts
@@ -69,7 +69,7 @@ export const kpiDnsQueriesLensAttributes: LensAttributes = {
           'cea37c70-8f91-43bf-b9fe-72d8c049f6a3': {
             columns: {
               '0374e520-eae0-4ac1-bcfe-37565e7fc9e3': {
-                label: ' ',
+                label: '',
                 dataType: 'number',
                 operationType: 'count',
                 isBucketed: false,

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_dns_queries.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_dns_queries.ts
@@ -69,7 +69,7 @@ export const kpiDnsQueriesLensAttributes: LensAttributes = {
           'cea37c70-8f91-43bf-b9fe-72d8c049f6a3': {
             columns: {
               '0374e520-eae0-4ac1-bcfe-37565e7fc9e3': {
-                label: 'DNS',
+                label: ' ',
                 dataType: 'number',
                 operationType: 'count',
                 isBucketed: false,

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_destination_metric.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_destination_metric.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { DESTINATION_CHART_LABEL } from '../../translations';
 import { LensAttributes } from '../../types';
 
 export const kpiUniquePrivateIpsDestinationMetricLensAttributes: LensAttributes = {
@@ -21,7 +20,7 @@ export const kpiUniquePrivateIpsDestinationMetricLensAttributes: LensAttributes 
                 customLabel: true,
                 dataType: 'number',
                 isBucketed: false,
-                label: ' ',
+                label: '',
                 operationType: 'unique_count',
                 scale: 'ratio',
                 sourceField: 'destination.ip',

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_destination_metric.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_destination_metric.ts
@@ -21,7 +21,7 @@ export const kpiUniquePrivateIpsDestinationMetricLensAttributes: LensAttributes 
                 customLabel: true,
                 dataType: 'number',
                 isBucketed: false,
-                label: DESTINATION_CHART_LABEL,
+                label: ' ',
                 operationType: 'unique_count',
                 scale: 'ratio',
                 sourceField: 'destination.ip',

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_source_metric.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_source_metric.ts
@@ -20,7 +20,7 @@ export const kpiUniquePrivateIpsSourceMetricLensAttributes: LensAttributes = {
                 customLabel: true,
                 dataType: 'number',
                 isBucketed: false,
-                label: SOURCE_CHART_LABEL,
+                label: ' ',
                 operationType: 'unique_count',
                 scale: 'ratio',
                 sourceField: 'source.ip',

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_source_metric.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_source_metric.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { SOURCE_CHART_LABEL } from '../../translations';
 import { LensAttributes } from '../../types';
 
 export const kpiUniquePrivateIpsSourceMetricLensAttributes: LensAttributes = {
@@ -20,7 +19,7 @@ export const kpiUniquePrivateIpsSourceMetricLensAttributes: LensAttributes = {
                 customLabel: true,
                 dataType: 'number',
                 isBucketed: false,
-                label: ' ',
+                label: '',
                 operationType: 'unique_count',
                 scale: 'ratio',
                 sourceField: 'source.ip',


### PR DESCRIPTION
## Summary

Some KPIs have additional label when opened in Lens, removing them to make them consistence.
Fixes: https://github.com/elastic/kibana/issues/128597

Steps to Reproduce:

1. Navigate to Network page
2. Open DNS KPI, Unique private IPs - source, and Unique private IPs - destination (Not bar charts or area charts) in Lens
3. It should have **no** label under the number

**Example**
Before:
<img width="1675" alt="Screenshot 2022-04-12 at 00 53 27" src="https://user-images.githubusercontent.com/6295984/162791193-bc012af4-0634-41d8-8f4a-86412324a06e.png">
After:
<img width="1674" alt="Screenshot 2022-04-12 at 00 53 52" src="https://user-images.githubusercontent.com/6295984/162791235-9c4c4af2-48ae-4cb4-a8b0-b7838ca92d92.png">
