### PR TITLE
[Security Solution] Update advanced Policy check for capture_mode

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -880,7 +880,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.kernel.capture_mode',
       {
         defaultMessage:
-          'Allows users to control whether kprobes or ebpf are used to gather data. Possible options are kprobes, ebpf, or auto. Default: auto',
+          'Allows users to control whether kprobes or ebpf are used to gather data. Possible options are kprobes, ebpf, or auto. Default: kprobes',
       }
     ),
   },


### PR DESCRIPTION
## Summary

Ticket: https://github.com/elastic/kibana/issues/129692

Update the Advanced policy text to have the correct default value for `capture_mode`

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/56395104/162800238-0ec9beb3-5de4-416c-b927-41792f016bb3.png">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md))
