### PR TITLE
[7.17] [DOCS][8.0] Fixes formatting in setting docs (#129930)

### DIFF
--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -788,7 +788,7 @@ out through *Advanced Settings*. *Default: `true`*
 sources and images. When false, Vega can only get data from {es}. *Default: `false`*
 
 | `xpack.ccr.ui.enabled`
-Set this value to false to disable the Cross-Cluster Replication UI.
+ | Set this value to false to disable the Cross-Cluster Replication UI.
 *Default: `true`*
 
 |[[settings-explore-data-in-context]] `xpack.discoverEnhanced.actions.`
@@ -801,11 +801,11 @@ Set this value to false to disable the Cross-Cluster Replication UI.
 
 
 | `xpack.ilm.ui.enabled`
-Set this value to false to disable the Index Lifecycle Policies UI.
+ | Set this value to false to disable the Index Lifecycle Policies UI.
 *Default: `true`*
 
 | `xpack.index_management.ui.enabled`
-Set this value to false to disable the Index Management UI.
+ | Set this value to false to disable the Index Management UI.
 *Default: `true`*
 
 | `xpack.license_management.enabled`
@@ -814,11 +814,11 @@ Set this value to false to disable the License Management UI.
 *Default: `true`*
 
 | `xpack.license_management.ui.enabled`
-Set this value to false to disable the License Management UI.
+ | Set this value to false to disable the License Management UI.
 *Default: `true`*
 
 | `xpack.remote_clusters.ui.enabled`
-Set this value to false to disable the Remote Clusters UI.
+ | Set this value to false to disable the Remote Clusters UI.
 *Default: `true`*
 
 | `xpack.rollup.enabled:`
@@ -826,13 +826,13 @@ Set this value to false to disable the Remote Clusters UI.
 Set this value to false to disable the Rollup UI. *Default: true*
 
 | `xpack.rollup.ui.enabled:`
-Set this value to false to disable the Rollup Jobs UI. *Default: true*
+ | Set this value to false to disable the Rollup Jobs UI. *Default: true*
 
 | `xpack.snapshot_restore.ui.enabled:`
-Set this value to false to disable the Snapshot and Restore UI. *Default: true*
+ | Set this value to false to disable the Snapshot and Restore UI. *Default: true*
 
 | `xpack.upgrade_assistant.ui.enabled:`
-Set this value to false to disable the Upgrade Assistant UI. *Default: true*
+ | Set this value to false to disable the Upgrade Assistant UI. *Default: true*
 
 | `i18n.locale` {ess-icon}
  | Set this value to change the {kib} interface language.


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.0` to `7.17`:
 - [[DOCS][8.0] Fixes formatting in setting docs (#129930)](https://github.com/elastic/kibana/pull/129930)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)