### PR TITLE
Adds documentation for migrations failing on timeouts while waiting for index yellow status

### DIFF
--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -46,7 +46,12 @@ Take these extra steps to ensure you are ready for migration.
 
 [float]
 ==== Ensure your {es} cluster is healthy
-Problems with your {es} cluster can prevent {kib} upgrades from succeeding. Ensure that your cluster has:
+
+Problems with your {es} cluster can prevent {kib} upgrades from succeeding.
+
+During the upgrade process, {kib} creates new indices into which updated documents are written. If a cluster is approaching the low watermark, there's a high risk of {kib} not being able to create these. Reading, transforming and writing updated documents can be memory intensive, using more available heap than during routine operation. You need to make sure that there is anough heap available to prevent requests from timing out or throwing errors from circuit breaker exceptions. In addition, you should also ensure that all shards are replicated and assigned.
+
+A healthy cluster has:
 
  * Enough free disk space, at least twice the amount of storage taken up by the `.kibana` and `.kibana_task_manager` indices
  * Sufficient heap size

--- a/docs/setup/upgrade/resolving-migration-failures.asciidoc
+++ b/docs/setup/upgrade/resolving-migration-failures.asciidoc
@@ -99,7 +99,7 @@ object types will also log the following warning message:
 
 [source,sh]
 --------------------------------------------
-CHECK_UNKNOWN_DOCUMENTS Upgrades will fail for 8.0+ because documents were found for unknown saved object types. To ensure that upgrades will succeed in the future, either re-enable plugins or delete these documents from the ".kibana_7.17.0_001" index after the current upgrade completes.
+CHECK_UNKNOWN_DOCUMENTS Upgrades will fail for 8.0+ because documents were found for unknown saved object types. To ensure that future upgrades will succeed, either re-enable plugins or delete these documents from the ".kibana_7.17.0_001" index after the current upgrade completes.
 --------------------------------------------
 
 If you fail to remedy this, your upgrade to 8.0+ will fail with a message like:
@@ -123,3 +123,64 @@ In {kib} 7.5.0 and earlier, when the task manager index is set to `.tasks`
 with the configuration setting `xpack.tasks.index: ".tasks"`,
 upgrade migrations fail. In {kib} 7.5.1 and later, the incompatible configuration
 setting prevents upgrade migrations from starting.
+
+[float]
+==== Repeated time-out requests that eventually fail
+
+Migrations get stuck in a loop of retry attempts waiting for index yellow status that's never reached. If you see a log entry similar to `Action failed with "Request timed out". Retrying attempt 1 in 2 seconds.` in either the CLONE_TEMP_TO_TARGET or CREATE_REINDEX_TEMP steps, it's because the process is waiting for an index yellow status.
+
+There are two known potential causes:
+
+* cluster hits the low watermark for disk usage
+* cluster has <<routing-allocation-disabled,routing allocation disabled>>
+
+Before retrying the migration, inspect the output of the `_cluster/allocation/explain?index=${targetIndex}` API to identify what's preventing the index going yellow:
+
+[source,sh]
+--------------------------------------------
+GET _cluster/allocation/explain
+{
+  "index": ".kibana_8.1.0_001",
+  "shard": 0,
+  "primary": true,
+}
+--------------------------------------------
+
+If the cluster exceeded the low watermark for disc usage, the output should contain a message like 
+[source,sh]
+--------------------------------------------
+"the node is above the low watermark cluster setting [cluster.routing.allocation.disk.watermark.low=85%], using more disk space than the maximum allowed [85.0%], actual free: [11.692661332965082%]"
+--------------------------------------------
+
+Refer to the {es} guide on how to {ref}/fix-common-cluster-issues.html#_error_disk_usage_exceeded_flood_stage_watermark_index_has_read_only_allow_delete_block[fix common cluster issues].
+
+If routing allocation is the issue, you will should see an entry like
+[source,sh]
+--------------------------------------------
+"allocate_explanation" : "cannot allocate because allocation is not permitted to any of the nodes"
+--------------------------------------------
+
+[float]
+[[routing-allocation-disabled]]
+==== Routing allocation disabled or restricted
+Upgrade migrations fail because routing allocation is disabled or restricted (cluster.routing.allocation.enable: none/primaries/new_primaries), which causes {kib} to log errors such as:
+
+[source,sh]
+--------------------------------------------
+Unable to complete saved object migrations for the [.kibana] index: The elasticsearch cluster has cluster routing allocation incorrectly set for migrations to continue. To proceed, please remove the cluster routing allocation settings with PUT /_cluster/settings {"transient": {"cluster.routing.allocation.enable": null}, "persistent": {"cluster.routing.allocation.enable": null}}
+--------------------------------------------
+
+To get around the issue, remove the transient and persisted routing allocation settings:
+[source,sh]
+--------------------------------------------
+PUT /_cluster/settings
+{
+  "transient": {
+    "cluster.routing.allocation.enable": null
+  }, 
+  "persistent": {
+    "cluster.routing.allocation.enable": null
+  }
+}
+--------------------------------------------
+

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -639,5 +639,8 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
     legal: {
       privacyStatement: `${ELASTIC_WEBSITE_URL}legal/privacy-statement`,
     },
+    savedObjects: {
+      resolveMigrationFailures: `${KIBANA_DOCS}resolve-migrations-failures.html`,
+    },
   });
 };

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -639,7 +639,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
     legal: {
       privacyStatement: `${ELASTIC_WEBSITE_URL}legal/privacy-statement`,
     },
-    savedObjects: {
+    kibanaUpgradeSavedObjects: {
       resolveMigrationFailures: `${KIBANA_DOCS}resolve-migrations-failures.html`,
     },
   });

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -395,4 +395,7 @@ export interface DocLinks {
   readonly legal: {
     readonly privacyStatement: string;
   };
+  readonly savedObjects: {
+    readonly resolveMigrationFailures: string;
+  };
 }

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -395,7 +395,7 @@ export interface DocLinks {
   readonly legal: {
     readonly privacyStatement: string;
   };
-  readonly savedObjects: {
+  readonly kibanaUpgradeSavedObjects: {
     readonly resolveMigrationFailures: string;
   };
 }

--- a/src/core/server/saved_objects/migrations/__snapshots__/migrations_state_action_machine.test.ts.snap
+++ b/src/core/server/saved_objects/migrations/__snapshots__/migrations_state_action_machine.test.ts.snap
@@ -32,6 +32,9 @@ Object {
                 },
               ],
               "maxBatchSizeBytes": 100000000,
+              "migrationDocLinks": Object {
+                "resolveMigrationFailures": "https://www.elastic.co/guide/en/kibana/test-branch/resolve-migrations-failures.html",
+              },
               "outdatedDocuments": Array [],
               "outdatedDocumentsQuery": Object {
                 "bool": Object {
@@ -193,6 +196,9 @@ Object {
                 },
               ],
               "maxBatchSizeBytes": 100000000,
+              "migrationDocLinks": Object {
+                "resolveMigrationFailures": "https://www.elastic.co/guide/en/kibana/test-branch/resolve-migrations-failures.html",
+              },
               "outdatedDocuments": Array [],
               "outdatedDocumentsQuery": Object {
                 "bool": Object {
@@ -358,6 +364,9 @@ Object {
                 },
               ],
               "maxBatchSizeBytes": 100000000,
+              "migrationDocLinks": Object {
+                "resolveMigrationFailures": "https://www.elastic.co/guide/en/kibana/test-branch/resolve-migrations-failures.html",
+              },
               "outdatedDocuments": Array [],
               "outdatedDocumentsQuery": Object {
                 "bool": Object {
@@ -527,6 +536,9 @@ Object {
                 },
               ],
               "maxBatchSizeBytes": 100000000,
+              "migrationDocLinks": Object {
+                "resolveMigrationFailures": "https://www.elastic.co/guide/en/kibana/test-branch/resolve-migrations-failures.html",
+              },
               "outdatedDocuments": Array [],
               "outdatedDocumentsQuery": Object {
                 "bool": Object {
@@ -722,6 +734,9 @@ Object {
                 },
               ],
               "maxBatchSizeBytes": 100000000,
+              "migrationDocLinks": Object {
+                "resolveMigrationFailures": "https://www.elastic.co/guide/en/kibana/test-branch/resolve-migrations-failures.html",
+              },
               "outdatedDocuments": Array [
                 Object {
                   "_id": "1234",
@@ -894,6 +909,9 @@ Object {
                 },
               ],
               "maxBatchSizeBytes": 100000000,
+              "migrationDocLinks": Object {
+                "resolveMigrationFailures": "https://www.elastic.co/guide/en/kibana/test-branch/resolve-migrations-failures.html",
+              },
               "outdatedDocuments": Array [
                 Object {
                   "_id": "1234",

--- a/src/core/server/saved_objects/migrations/actions/clone_index.test.ts
+++ b/src/core/server/saved_objects/migrations/actions/clone_index.test.ts
@@ -40,6 +40,7 @@ describe('cloneIndex', () => {
       client,
       source: 'my_source_index',
       target: 'my_target_index',
+      migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
     });
     try {
       await task();

--- a/src/core/server/saved_objects/migrations/actions/clone_index.ts
+++ b/src/core/server/saved_objects/migrations/actions/clone_index.ts
@@ -32,6 +32,7 @@ export interface CloneIndexParams {
   target: string;
   /** only used for testing */
   timeout?: string;
+  migrationDocLinks: Record<string, string>;
 }
 /**
  * Makes a clone of the source index into the target.
@@ -48,6 +49,7 @@ export const cloneIndex = ({
   source,
   target,
   timeout = DEFAULT_TIMEOUT,
+  migrationDocLinks,
 }: CloneIndexParams): TaskEither.TaskEither<
   RetryableEsClientError | IndexNotFound,
   CloneIndexResponse
@@ -129,7 +131,7 @@ export const cloneIndex = ({
       } else {
         // Otherwise, wait until the target index has a 'yellow' status.
         return pipe(
-          waitForIndexStatusYellow({ client, index: target, timeout }),
+          waitForIndexStatusYellow({ client, index: target, timeout, migrationDocLinks }),
           TaskEither.map((value) => {
             /** When the index status is 'yellow' we know that all shards were started */
             return { acknowledged: true, shardsAcknowledged: true };

--- a/src/core/server/saved_objects/migrations/actions/create_index.test.ts
+++ b/src/core/server/saved_objects/migrations/actions/create_index.test.ts
@@ -39,6 +39,7 @@ describe('createIndex', () => {
       client,
       indexName: 'new_index',
       mappings: { properties: {} },
+      migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
     });
     try {
       await task();

--- a/src/core/server/saved_objects/migrations/actions/create_index.ts
+++ b/src/core/server/saved_objects/migrations/actions/create_index.ts
@@ -38,6 +38,7 @@ export interface CreateIndexParams {
   indexName: string;
   mappings: IndexMapping;
   aliases?: string[];
+  migrationDocLinks: Record<string, string>;
 }
 /**
  * Creates an index with the given mappings
@@ -54,6 +55,7 @@ export const createIndex = ({
   indexName,
   mappings,
   aliases = [],
+  migrationDocLinks,
 }: CreateIndexParams): TaskEither.TaskEither<RetryableEsClientError, 'create_index_succeeded'> => {
   const createIndexTask: TaskEither.TaskEither<
     RetryableEsClientError,
@@ -133,7 +135,12 @@ export const createIndex = ({
       } else {
         // Otherwise, wait until the target index has a 'yellow' status.
         return pipe(
-          waitForIndexStatusYellow({ client, index: indexName, timeout: DEFAULT_TIMEOUT }),
+          waitForIndexStatusYellow({
+            client,
+            index: indexName,
+            timeout: DEFAULT_TIMEOUT,
+            migrationDocLinks,
+          }),
           TaskEither.map(() => {
             /** When the index status is 'yellow' we know that all shards were started */
             return 'create_index_succeeded';

--- a/src/core/server/saved_objects/migrations/actions/integration_tests/actions.test.ts
+++ b/src/core/server/saved_objects/migrations/actions/integration_tests/actions.test.ts
@@ -508,7 +508,7 @@ describe('migration actions', () => {
         Object {
           "_tag": "Left",
           "left": Object {
-            "message": "Timeout waiting for the status of the [clone_red_index] index to become 'yellow'",
+            "message": "Timeout waiting for the status of the [clone_red_index] index to become 'yellow'. Refer to resolveMigrationFailures for more information.",
             "type": "retryable_es_client_error",
           },
         }

--- a/src/core/server/saved_objects/migrations/actions/integration_tests/actions.test.ts
+++ b/src/core/server/saved_objects/migrations/actions/integration_tests/actions.test.ts
@@ -73,6 +73,7 @@ describe('migration actions', () => {
         dynamic: true,
         properties: {},
       },
+      migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
     })();
     const sourceDocs = [
       { _source: { title: 'doc 1' } },
@@ -88,11 +89,17 @@ describe('migration actions', () => {
       refresh: 'wait_for',
     })();
 
-    await createIndex({ client, indexName: 'existing_index_2', mappings: { properties: {} } })();
+    await createIndex({
+      client,
+      indexName: 'existing_index_2',
+      mappings: { properties: {} },
+      migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
+    })();
     await createIndex({
       client,
       indexName: 'existing_index_with_write_block',
       mappings: { properties: {} },
+      migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
     })();
     await bulkOverwriteTransformedDocuments({
       client,
@@ -220,6 +227,7 @@ describe('migration actions', () => {
         client,
         indexName: 'new_index_without_write_block',
         mappings: { properties: {} },
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
     });
     it('resolves right when setting the write block succeeds', async () => {
@@ -285,11 +293,13 @@ describe('migration actions', () => {
         client,
         indexName: 'existing_index_without_write_block_2',
         mappings: { properties: {} },
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
       await createIndex({
         client,
         indexName: 'existing_index_with_write_block_2',
         mappings: { properties: {} },
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
       await setWriteBlock({ client, index: 'existing_index_with_write_block_2' })();
     });
@@ -347,6 +357,7 @@ describe('migration actions', () => {
       const indexStatusPromise = waitForIndexStatusYellow({
         client,
         index: 'red_then_yellow_index',
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
 
       const redStatusResponse = await client.cluster.health({ index: 'red_then_yellow_index' });
@@ -381,6 +392,7 @@ describe('migration actions', () => {
         client,
         source: 'existing_index_with_write_block',
         target: 'clone_target_1',
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       });
       expect.assertions(1);
       await expect(task()).resolves.toMatchInlineSnapshot(`
@@ -418,6 +430,7 @@ describe('migration actions', () => {
         client,
         source: 'existing_index_with_write_block',
         target: 'clone_red_then_yellow_index',
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
 
       let indexYellow = false;
@@ -448,7 +461,12 @@ describe('migration actions', () => {
     });
     it('resolves left index_not_found_exception if the source index does not exist', async () => {
       expect.assertions(1);
-      const task = cloneIndex({ client, source: 'no_such_index', target: 'clone_target_3' });
+      const task = cloneIndex({
+        client,
+        source: 'no_such_index',
+        target: 'clone_target_3',
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
+      });
       await expect(task()).resolves.toMatchInlineSnapshot(`
           Object {
             "_tag": "Left",
@@ -483,6 +501,7 @@ describe('migration actions', () => {
         source: 'existing_index_with_write_block',
         target: 'clone_red_index',
         timeout: '1s',
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
 
       await expect(cloneIndexPromise).resolves.toMatchInlineSnapshot(`
@@ -511,6 +530,7 @@ describe('migration actions', () => {
         source: 'existing_index_with_write_block',
         target: 'clone_red_index',
         timeout: '30s',
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
 
       await expect(cloneIndexPromise2).resolves.toMatchInlineSnapshot(`
@@ -692,7 +712,12 @@ describe('migration actions', () => {
       expect.assertions(2);
       // Simulate a reindex that only adds some of the documents from the
       // source index into the target index
-      await createIndex({ client, indexName: 'reindex_target_4', mappings: { properties: {} } })();
+      await createIndex({
+        client,
+        indexName: 'reindex_target_4',
+        mappings: { properties: {} },
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
+      })();
       const sourceDocs = (
         (await searchForOutdatedDocuments(client, {
           batchSize: 1000,
@@ -765,6 +790,7 @@ describe('migration actions', () => {
             /** no title field */
           },
         },
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
 
       const {
@@ -804,6 +830,7 @@ describe('migration actions', () => {
           dynamic: false,
           properties: { title: { type: 'integer' } }, // integer is incompatible with string title
         },
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
 
       const {
@@ -900,6 +927,7 @@ describe('migration actions', () => {
       await waitForIndexStatusYellow({
         client,
         index: '.kibana_1',
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
 
       const res = (await reindex({
@@ -1315,6 +1343,7 @@ describe('migration actions', () => {
           dynamic: false,
           properties: {},
         },
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
       const sourceDocs = [
         { _source: { title: 'doc 1' } },
@@ -1543,6 +1572,7 @@ describe('migration actions', () => {
         client,
         indexName: 'red_then_yellow_index',
         mappings: undefined as any,
+        migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
       })();
       let indexYellow = false;
 
@@ -1572,7 +1602,12 @@ describe('migration actions', () => {
       // Creating an index with the same name as an existing alias to induce
       // failure
       await expect(
-        createIndex({ client, indexName: 'existing_index_2_alias', mappings: undefined as any })()
+        createIndex({
+          client,
+          indexName: 'existing_index_2_alias',
+          mappings: undefined as any,
+          migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
+        })()
       ).rejects.toThrow('invalid_index_name_exception');
     });
   });

--- a/src/core/server/saved_objects/migrations/actions/integration_tests/es_errors.test.ts
+++ b/src/core/server/saved_objects/migrations/actions/integration_tests/es_errors.test.ts
@@ -41,6 +41,7 @@ describe('Elasticsearch Errors', () => {
       client,
       indexName: 'existing_index_with_write_block',
       mappings: { properties: {} },
+      migrationDocLinks: { resolveMigrationFailures: 'resolveMigrationFailures' },
     })();
     await setWriteBlock({ client, index: 'existing_index_with_write_block' })();
   });

--- a/src/core/server/saved_objects/migrations/actions/wait_for_index_status_yellow.test.ts
+++ b/src/core/server/saved_objects/migrations/actions/wait_for_index_status_yellow.test.ts
@@ -10,6 +10,7 @@ import { errors as EsErrors } from '@elastic/elasticsearch';
 import { waitForIndexStatusYellow } from './wait_for_index_status_yellow';
 import { elasticsearchClientMock } from '../../../elasticsearch/client/mocks';
 import { catchRetryableEsClientErrors } from './catch_retryable_es_client_errors';
+import { docLinksServiceMock } from 'src/core/public/mocks';
 jest.mock('./catch_retryable_es_client_errors');
 
 describe('waitForIndexStatusYellow', () => {
@@ -28,11 +29,12 @@ describe('waitForIndexStatusYellow', () => {
   const client = elasticsearchClientMock.createInternalClient(
     elasticsearchClientMock.createErrorTransportRequestPromise(retryableError)
   );
-
+  const docLinks = docLinksServiceMock.createStartContract().links;
   it('calls catchRetryableEsClientErrors when the promise rejects', async () => {
     const task = waitForIndexStatusYellow({
       client,
       index: 'my_index',
+      migrationDocLinks: docLinks.kibanaUpgradeSavedObjects,
     });
     try {
       await task();

--- a/src/core/server/saved_objects/migrations/actions/wait_for_index_status_yellow.ts
+++ b/src/core/server/saved_objects/migrations/actions/wait_for_index_status_yellow.ts
@@ -20,6 +20,7 @@ export interface WaitForIndexStatusYellowParams {
   client: ElasticsearchClient;
   index: string;
   timeout?: string;
+  migrationDocLinks: Record<string, string>;
 }
 /**
  * A yellow index status means the index's primary shard is allocated and the
@@ -37,6 +38,7 @@ export const waitForIndexStatusYellow =
     client,
     index,
     timeout = DEFAULT_TIMEOUT,
+    migrationDocLinks,
   }: WaitForIndexStatusYellowParams): TaskEither.TaskEither<RetryableEsClientError, {}> =>
   () => {
     return client.cluster
@@ -54,7 +56,7 @@ export const waitForIndexStatusYellow =
         if (res.timed_out === true) {
           return Either.left({
             type: 'retryable_es_client_error' as const,
-            message: `Timeout waiting for the status of the [${index}] index to become 'yellow'`,
+            message: `Timeout waiting for the status of the [${index}] index to become 'yellow'. Refer to ${migrationDocLinks.resolveMigrationFailures} for more information.`,
           });
         }
         return Either.right({});

--- a/src/core/server/saved_objects/migrations/initial_state.test.ts
+++ b/src/core/server/saved_objects/migrations/initial_state.test.ts
@@ -8,15 +8,19 @@
 
 import { ByteSizeValue } from '@kbn/config-schema';
 import * as Option from 'fp-ts/Option';
+import { DocLinksServiceSetup } from '../../doc_links';
+import { docLinksServiceMock } from '../../mocks';
 import { SavedObjectsMigrationConfigType } from '../saved_objects_config';
 import { SavedObjectTypeRegistry } from '../saved_objects_type_registry';
 import { createInitialState } from './initial_state';
 
 describe('createInitialState', () => {
   let typeRegistry: SavedObjectTypeRegistry;
+  let docLinks: DocLinksServiceSetup;
 
   beforeEach(() => {
     typeRegistry = new SavedObjectTypeRegistry();
+    docLinks = docLinksServiceMock.createSetupContract();
   });
 
   const migrationsConfig = {
@@ -36,6 +40,7 @@ describe('createInitialState', () => {
         indexPrefix: '.kibana_task_manager',
         migrationsConfig,
         typeRegistry,
+        docLinks,
       })
     ).toEqual({
       batchSize: 1000,
@@ -108,6 +113,10 @@ describe('createInitialState', () => {
       },
       versionAlias: '.kibana_task_manager_8.1.0',
       versionIndex: '.kibana_task_manager_8.1.0_001',
+      migrationDocLinks: {
+        resolveMigrationFailures:
+          'https://www.elastic.co/guide/en/kibana/test-branch/resolve-migrations-failures.html',
+      },
     });
   });
 
@@ -135,6 +144,7 @@ describe('createInitialState', () => {
       indexPrefix: '.kibana_task_manager',
       migrationsConfig,
       typeRegistry,
+      docLinks,
     });
 
     expect(initialState.knownTypes).toEqual(['foo', 'bar']);
@@ -160,6 +170,7 @@ describe('createInitialState', () => {
       indexPrefix: '.kibana_task_manager',
       migrationsConfig,
       typeRegistry,
+      docLinks,
     });
 
     expect(initialState.excludeFromUpgradeFilterHooks).toEqual({ foo: fooExcludeOnUpgradeHook });
@@ -178,6 +189,7 @@ describe('createInitialState', () => {
       indexPrefix: '.kibana_task_manager',
       migrationsConfig,
       typeRegistry,
+      docLinks,
     });
 
     expect(Option.isSome(initialState.preMigrationScript)).toEqual(true);
@@ -199,6 +211,7 @@ describe('createInitialState', () => {
           indexPrefix: '.kibana_task_manager',
           migrationsConfig,
           typeRegistry,
+          docLinks,
         }).preMigrationScript
       )
     ).toEqual(true);
@@ -216,6 +229,7 @@ describe('createInitialState', () => {
         indexPrefix: '.kibana_task_manager',
         migrationsConfig,
         typeRegistry,
+        docLinks,
       }).outdatedDocumentsQuery
     ).toMatchInlineSnapshot(`
         Object {

--- a/src/core/server/saved_objects/migrations/initial_state.ts
+++ b/src/core/server/saved_objects/migrations/initial_state.ts
@@ -68,7 +68,7 @@ export const createInitialState = ({
       .map((type) => [type.name, type.excludeOnUpgrade!])
   );
   // short key to access savedObjects entries directly from docLinks
-  const migrationDocLinks = docLinks.links.savedObjects;
+  const migrationDocLinks = docLinks.links.kibanaUpgradeSavedObjects;
 
   return {
     controlState: 'INIT',

--- a/src/core/server/saved_objects/migrations/initial_state.ts
+++ b/src/core/server/saved_objects/migrations/initial_state.ts
@@ -13,6 +13,7 @@ import { SavedObjectsMigrationConfigType } from '../saved_objects_config';
 import type { ISavedObjectTypeRegistry } from '../saved_objects_type_registry';
 import { InitState } from './state';
 import { excludeUnusedTypesQuery } from '../migrations/core';
+import { DocLinksServiceStart } from '../../doc_links';
 
 /**
  * Construct the initial state for the model
@@ -25,6 +26,7 @@ export const createInitialState = ({
   indexPrefix,
   migrationsConfig,
   typeRegistry,
+  docLinks,
 }: {
   kibanaVersion: string;
   targetMappings: IndexMapping;
@@ -33,6 +35,7 @@ export const createInitialState = ({
   indexPrefix: string;
   migrationsConfig: SavedObjectsMigrationConfigType;
   typeRegistry: ISavedObjectTypeRegistry;
+  docLinks: DocLinksServiceStart;
 }): InitState => {
   const outdatedDocumentsQuery = {
     bool: {
@@ -64,6 +67,8 @@ export const createInitialState = ({
       .filter((type) => !!type.excludeOnUpgrade)
       .map((type) => [type.name, type.excludeOnUpgrade!])
   );
+  // short key to access savedObjects entries directly from docLinks
+  const migrationDocLinks = docLinks.links.savedObjects;
 
   return {
     controlState: 'INIT',
@@ -87,5 +92,6 @@ export const createInitialState = ({
     unusedTypesQuery: excludeUnusedTypesQuery,
     knownTypes,
     excludeFromUpgradeFilterHooks: excludeFilterHooks,
+    migrationDocLinks,
   };
 };

--- a/src/core/server/saved_objects/migrations/kibana_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/kibana_migrator.test.ts
@@ -16,6 +16,7 @@ import { SavedObjectTypeRegistry } from '../saved_objects_type_registry';
 import { SavedObjectsType } from '../types';
 import { DocumentMigrator } from './core/document_migrator';
 import { ByteSizeValue } from '@kbn/config-schema';
+import { docLinksServiceMock } from '../../mocks';
 
 jest.mock('./core/document_migrator', () => {
   return {
@@ -286,6 +287,7 @@ const mockOptions = () => {
       retryAttempts: 20,
     },
     client: elasticsearchClientMock.createElasticsearchClient(),
+    docLinks: docLinksServiceMock.createSetupContract(),
   };
   return options;
 };

--- a/src/core/server/saved_objects/migrations/kibana_migrator.ts
+++ b/src/core/server/saved_objects/migrations/kibana_migrator.ts
@@ -29,6 +29,7 @@ import { ISavedObjectTypeRegistry } from '../saved_objects_type_registry';
 import { SavedObjectsType } from '../types';
 import { runResilientMigrator } from './run_resilient_migrator';
 import { migrateRawDocsSafely } from './core/migrate_raw_docs';
+import { DocLinksServiceStart } from '../../doc_links';
 
 export interface KibanaMigratorOptions {
   client: ElasticsearchClient;
@@ -37,6 +38,7 @@ export interface KibanaMigratorOptions {
   kibanaIndex: string;
   kibanaVersion: string;
   logger: Logger;
+  docLinks: DocLinksServiceStart;
 }
 
 export type IKibanaMigrator = Pick<KibanaMigrator, keyof KibanaMigrator>;
@@ -65,6 +67,7 @@ export class KibanaMigrator {
   private readonly activeMappings: IndexMapping;
   private readonly soMigrationsConfig: SavedObjectsMigrationConfigType;
   public readonly kibanaVersion: string;
+  private readonly docLinks: DocLinksServiceStart;
 
   /**
    * Creates an instance of KibanaMigrator.
@@ -76,6 +79,7 @@ export class KibanaMigrator {
     soMigrationsConfig,
     kibanaVersion,
     logger,
+    docLinks,
   }: KibanaMigratorOptions) {
     this.client = client;
     this.kibanaIndex = kibanaIndex;
@@ -93,6 +97,7 @@ export class KibanaMigrator {
     // Building the active mappings (and associated md5sums) is an expensive
     // operation so we cache the result
     this.activeMappings = buildActiveMappings(this.mappingProperties);
+    this.docLinks = docLinks;
   }
 
   /**
@@ -177,6 +182,7 @@ export class KibanaMigrator {
             indexPrefix: index,
             migrationsConfig: this.soMigrationsConfig,
             typeRegistry: this.typeRegistry,
+            docLinks: this.docLinks,
           });
         },
       };

--- a/src/core/server/saved_objects/migrations/migrations_state_action_machine.test.ts
+++ b/src/core/server/saved_objects/migrations/migrations_state_action_machine.test.ts
@@ -8,7 +8,7 @@
 
 import { cleanupMock } from './migrations_state_machine_cleanup.mocks';
 import { migrationStateActionMachine } from './migrations_state_action_machine';
-import { loggingSystemMock, elasticsearchServiceMock } from '../../mocks';
+import { loggingSystemMock, elasticsearchServiceMock, docLinksServiceMock } from '../../mocks';
 import { typeRegistryMock } from '../saved_objects_type_registry.mock';
 import * as Either from 'fp-ts/lib/Either';
 import * as Option from 'fp-ts/lib/Option';
@@ -20,7 +20,6 @@ import { createInitialState } from './initial_state';
 import { ByteSizeValue } from '@kbn/config-schema';
 
 const esClient = elasticsearchServiceMock.createElasticsearchClient();
-
 describe('migrationsStateActionMachine', () => {
   beforeAll(() => {
     jest
@@ -33,7 +32,7 @@ describe('migrationsStateActionMachine', () => {
 
   const mockLogger = loggingSystemMock.create();
   const typeRegistry = typeRegistryMock.create();
-
+  const docLinks = docLinksServiceMock.createSetupContract();
   const initialState = createInitialState({
     kibanaVersion: '7.11.0',
     targetMappings: { properties: {} },
@@ -48,6 +47,7 @@ describe('migrationsStateActionMachine', () => {
       retryAttempts: 5,
     },
     typeRegistry,
+    docLinks,
   });
 
   const next = jest.fn((s: State) => {

--- a/src/core/server/saved_objects/migrations/migrations_state_action_machine.ts
+++ b/src/core/server/saved_objects/migrations/migrations_state_action_machine.ts
@@ -15,7 +15,6 @@ import { Model, Next, stateActionMachine } from './state_action_machine';
 import { cleanup } from './migrations_state_machine_cleanup';
 import { ReindexSourceToTempTransform, ReindexSourceToTempIndexBulk, State } from './state';
 import { SavedObjectsRawDoc } from '../serialization';
-import { DocLinksServiceStart } from '../../doc_links';
 
 interface StateTransitionLogMeta extends LogMeta {
   kibana: {

--- a/src/core/server/saved_objects/migrations/migrations_state_action_machine.ts
+++ b/src/core/server/saved_objects/migrations/migrations_state_action_machine.ts
@@ -15,6 +15,7 @@ import { Model, Next, stateActionMachine } from './state_action_machine';
 import { cleanup } from './migrations_state_machine_cleanup';
 import { ReindexSourceToTempTransform, ReindexSourceToTempIndexBulk, State } from './state';
 import { SavedObjectsRawDoc } from '../serialization';
+import { DocLinksServiceStart } from '../../doc_links';
 
 interface StateTransitionLogMeta extends LogMeta {
   kibana: {

--- a/src/core/server/saved_objects/migrations/model/model.test.ts
+++ b/src/core/server/saved_objects/migrations/model/model.test.ts
@@ -94,6 +94,10 @@ describe('migrations v2 model', () => {
     },
     knownTypes: ['dashboard', 'config'],
     excludeFromUpgradeFilterHooks: {},
+    migrationDocLinks: {
+      resolveMigrationFailures:
+        'https://www.elastic.co/guide/en/kibana/test-branch/resolve-migrations-failures.html',
+    },
   };
 
   describe('exponential retry delays for retryable_es_client_error', () => {
@@ -299,7 +303,7 @@ describe('migrations v2 model', () => {
 
         expect(newState.controlState).toEqual('FATAL');
         expect(newState.reason).toMatchInlineSnapshot(
-          `"The elasticsearch cluster has cluster routing allocation incorrectly set for migrations to continue. To proceed, please remove the cluster routing allocation settings with PUT /_cluster/settings {\\"transient\\": {\\"cluster.routing.allocation.enable\\": null}, \\"persistent\\": {\\"cluster.routing.allocation.enable\\": null}}"`
+          `"The elasticsearch cluster has cluster routing allocation incorrectly set for migrations to continue. To proceed, please remove the cluster routing allocation settings with PUT /_cluster/settings {\\"transient\\": {\\"cluster.routing.allocation.enable\\": null}, \\"persistent\\": {\\"cluster.routing.allocation.enable\\": null}}. Refer to https://www.elastic.co/guide/en/kibana/test-branch/resolve-migrations-failures.html for more information"`
         );
       });
       test("INIT -> FATAL when .kibana points to newer version's index", () => {

--- a/src/core/server/saved_objects/migrations/model/model.ts
+++ b/src/core/server/saved_objects/migrations/model/model.ts
@@ -44,7 +44,6 @@ const fatalReasonDocumentExceedsMaxBatchSizeBytes = ({
   maxBatchSizeBytes: number;
 }) =>
   `The document with _id "${_id}" is ${docSizeBytes} bytes which exceeds the configured maximum batch size of ${maxBatchSizeBytes} bytes. To proceed, please increase the 'migrations.maxBatchSizeBytes' Kibana configuration option and ensure that the Elasticsearch 'http.max_content_length' configuration option is set to an equal or larger value.`;
-
 export const model = (currentState: State, resW: ResponseType<AllActionStates>): State => {
   // The action response `resW` is weakly typed, the type includes all action
   // responses. Each control state only triggers one action so each control
@@ -78,12 +77,12 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
         return {
           ...stateP,
           controlState: 'FATAL',
-          reason: `The elasticsearch cluster has cluster routing allocation incorrectly set for migrations to continue. To proceed, please remove the cluster routing allocation settings with PUT /_cluster/settings {"transient": {"cluster.routing.allocation.enable": null}, "persistent": {"cluster.routing.allocation.enable": null}}`,
+          reason: `The elasticsearch cluster has cluster routing allocation incorrectly set for migrations to continue. To proceed, please remove the cluster routing allocation settings with PUT /_cluster/settings {"transient": {"cluster.routing.allocation.enable": null}, "persistent": {"cluster.routing.allocation.enable": null}}. Refer to ${stateP.migrationDocLinks.resolveMigrationFailures} for more information`,
           logs: [
             ...stateP.logs,
             {
               level: 'error',
-              message: `The elasticsearch cluster has cluster routing allocation incorrectly set for migrations to continue. Ensure that the persistent and transient Elasticsearch configuration option 'cluster.routing.allocation.enable' is not set or set it to a value of 'all'.`,
+              message: `The elasticsearch cluster has cluster routing allocation incorrectly set for migrations to continue. Ensure that the persistent and transient Elasticsearch configuration option 'cluster.routing.allocation.enable' is not set or set it to a value of 'all'. Refer to ${stateP.migrationDocLinks.resolveMigrationFailures} for more information.`,
             },
           ],
         };

--- a/src/core/server/saved_objects/migrations/next.ts
+++ b/src/core/server/saved_objects/migrations/next.ts
@@ -61,7 +61,11 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
     INIT: (state: InitState) =>
       Actions.initAction({ client, indices: [state.currentAlias, state.versionAlias] }),
     WAIT_FOR_YELLOW_SOURCE: (state: WaitForYellowSourceState) =>
-      Actions.waitForIndexStatusYellow({ client, index: state.sourceIndex.value }),
+      Actions.waitForIndexStatusYellow({
+        client,
+        index: state.sourceIndex.value,
+        migrationDocLinks: state.migrationDocLinks,
+      }),
     CHECK_UNKNOWN_DOCUMENTS: (state: CheckUnknownDocumentsState) =>
       Actions.checkForUnknownDocs({
         client,
@@ -81,12 +85,14 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
         client,
         indexName: state.targetIndex,
         mappings: state.targetIndexMappings,
+        migrationDocLinks: state.migrationDocLinks,
       }),
     CREATE_REINDEX_TEMP: (state: CreateReindexTempState) =>
       Actions.createIndex({
         client,
         indexName: state.tempIndex,
         mappings: state.tempIndexMappings,
+        migrationDocLinks: state.migrationDocLinks,
       }),
     REINDEX_SOURCE_TO_TEMP_OPEN_PIT: (state: ReindexSourceToTempOpenPit) =>
       Actions.openPit({ client, index: state.sourceIndex.value }),
@@ -123,7 +129,12 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
     SET_TEMP_WRITE_BLOCK: (state: SetTempWriteBlock) =>
       Actions.setWriteBlock({ client, index: state.tempIndex }),
     CLONE_TEMP_TO_TARGET: (state: CloneTempToSource) =>
-      Actions.cloneIndex({ client, source: state.tempIndex, target: state.targetIndex }),
+      Actions.cloneIndex({
+        client,
+        source: state.tempIndex,
+        target: state.targetIndex,
+        migrationDocLinks: state.migrationDocLinks,
+      }),
     REFRESH_TARGET: (state: RefreshTarget) =>
       Actions.refreshIndex({ client, targetIndex: state.targetIndex }),
     UPDATE_TARGET_MAPPINGS: (state: UpdateTargetMappingsState) =>
@@ -179,6 +190,7 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
         client,
         indexName: state.sourceIndex.value,
         mappings: state.legacyReindexTargetMappings,
+        migrationDocLinks: state.migrationDocLinks,
       }),
     LEGACY_REINDEX: (state: LegacyReindexState) =>
       Actions.reindex({

--- a/src/core/server/saved_objects/migrations/run_resilient_migrator.ts
+++ b/src/core/server/saved_objects/migrations/run_resilient_migrator.ts
@@ -18,6 +18,7 @@ import { createInitialState } from './initial_state';
 import { migrationStateActionMachine } from './migrations_state_action_machine';
 import { SavedObjectsMigrationConfigType } from '../saved_objects_config';
 import type { ISavedObjectTypeRegistry } from '../saved_objects_type_registry';
+import { DocLinksServiceStart } from '../../doc_links';
 
 /**
  * Migrates the provided indexPrefix index using a resilient algorithm that is
@@ -35,6 +36,7 @@ export async function runResilientMigrator({
   indexPrefix,
   migrationsConfig,
   typeRegistry,
+  docLinks,
 }: {
   client: ElasticsearchClient;
   kibanaVersion: string;
@@ -46,6 +48,7 @@ export async function runResilientMigrator({
   indexPrefix: string;
   migrationsConfig: SavedObjectsMigrationConfigType;
   typeRegistry: ISavedObjectTypeRegistry;
+  docLinks: DocLinksServiceStart;
 }): Promise<MigrationResult> {
   const initialState = createInitialState({
     kibanaVersion,
@@ -55,6 +58,7 @@ export async function runResilientMigrator({
     indexPrefix,
     migrationsConfig,
     typeRegistry,
+    docLinks,
   });
   return migrationStateActionMachine({
     initialState,

--- a/src/core/server/saved_objects/migrations/state.ts
+++ b/src/core/server/saved_objects/migrations/state.ts
@@ -122,6 +122,10 @@ export interface BaseState extends ControlState {
     string,
     SavedObjectTypeExcludeFromUpgradeFilterHook
   >;
+  /**
+   * DocLinks for savedObjects. to reference online documentation
+   */
+  readonly migrationDocLinks: Record<string, string>;
 }
 
 export interface InitState extends BaseState {

--- a/src/core/server/saved_objects/saved_objects_service.test.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.ts
@@ -36,7 +36,7 @@ import { NodesVersionCompatibility } from '../elasticsearch/version_check/ensure
 import { SavedObjectsRepository } from './service/lib/repository';
 import { registerCoreObjectTypes } from './object_types';
 import { getSavedObjectsDeprecationsProvider } from './deprecations';
-import { docLinksServiceMock } from 'src/core/public/mocks';
+import { docLinksServiceMock } from '../doc_links/doc_links_service.mock';
 
 jest.mock('./service/lib/repository');
 jest.mock('./object_types');

--- a/src/core/server/saved_objects/saved_objects_service.test.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.ts
@@ -36,6 +36,7 @@ import { NodesVersionCompatibility } from '../elasticsearch/version_check/ensure
 import { SavedObjectsRepository } from './service/lib/repository';
 import { registerCoreObjectTypes } from './object_types';
 import { getSavedObjectsDeprecationsProvider } from './deprecations';
+import { docLinksServiceMock } from 'src/core/public/mocks';
 
 jest.mock('./service/lib/repository');
 jest.mock('./object_types');
@@ -79,6 +80,7 @@ describe('SavedObjectsService', () => {
     return {
       pluginsInitialized,
       elasticsearch: elasticsearchServiceMock.createInternalStart(),
+      docLinks: docLinksServiceMock.createStartContract(),
     };
   };
 

--- a/src/core/server/saved_objects/saved_objects_service.ts
+++ b/src/core/server/saved_objects/saved_objects_service.ts
@@ -50,7 +50,7 @@ import { ServiceStatus } from '../status';
 import { calculateStatus$ } from './status';
 import { registerCoreObjectTypes } from './object_types';
 import { getSavedObjectsDeprecationsProvider } from './deprecations';
-import { DocLinksServiceSetup, DocLinksServiceStart } from '../doc_links';
+import { DocLinksServiceStart } from '../doc_links';
 
 const kibanaIndex = '.kibana';
 
@@ -273,7 +273,6 @@ export interface SavedObjectsSetupDeps {
   elasticsearch: InternalElasticsearchServiceSetup;
   coreUsageData: InternalCoreUsageDataSetup;
   deprecations: InternalDeprecationsServiceSetup;
-  docLinks: DocLinksServiceSetup;
 }
 
 interface WrappedClientFactoryWrapper {
@@ -315,7 +314,7 @@ export class SavedObjectsService
     this.logger.debug('Setting up SavedObjects service');
 
     this.setupDeps = setupDeps;
-    const { http, elasticsearch, coreUsageData, deprecations, docLinks } = setupDeps;
+    const { http, elasticsearch, coreUsageData, deprecations } = setupDeps;
 
     const savedObjectsConfig = await this.coreContext.configService
       .atPath<SavedObjectsConfigType>('savedObjects')

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -242,7 +242,6 @@ export class Server {
       elasticsearch: elasticsearchServiceSetup,
       deprecations: deprecationsSetup,
       coreUsageData: coreUsageDataSetup,
-      docLinks: docLinksSetup,
     });
 
     const uiSettingsSetup = await this.uiSettings.setup({

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -242,6 +242,7 @@ export class Server {
       elasticsearch: elasticsearchServiceSetup,
       deprecations: deprecationsSetup,
       coreUsageData: coreUsageDataSetup,
+      docLinks: docLinksSetup,
     });
 
     const uiSettingsSetup = await this.uiSettings.setup({
@@ -316,6 +317,7 @@ export class Server {
     const savedObjectsStart = await this.savedObjects.start({
       elasticsearch: elasticsearchStart,
       pluginsInitialized: this.#pluginsInitialized,
+      docLinks: docLinkStart,
     });
     await this.resolveSavedObjectsStartPromise!(savedObjectsStart);
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/126864
Resolves https://github.com/elastic/kibana/issues/128585

This PR adds documentation on how to get more information when migrations fail because of a timeout while waiting for the `.kibana` or `.kibana_task_manager` index yellow status or if the cluster routing allocation is not set to `all`.

This PR also adds the `docLinks` service to saved objects for referencing in log messages. In this PR, we reference the entire page on how to resolve migration failures because that page is already publically available.

There will be a follow-up PR to change the link to the specific section that is included in this PR.

## What is not covered:
- adding error labels
- further discussions around surfacing the error in the migration assistant

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| References to the online documentation in migrations logs become outdated | medium | High | Developers need to ensure that any changes to log messages from within saved objects migrations stay updated |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
