### PR TITLE
[Security Solution] Adds rule preview error message for users without appropriate `read` privilege

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.test.tsx
@@ -85,44 +85,44 @@ describe('PreviewQuery', () => {
     jest.clearAllMocks();
   });
 
-  test('it renders timeframe select and preview button on render', () => {
+  test('it renders timeframe select and preview button on render', async () => {
     const wrapper = render(
       <TestProviders>
         <RulePreview {...defaultProps} />
       </TestProviders>
     );
 
-    expect(wrapper.findByTestId('rule-preview')).toBeTruthy();
-    expect(wrapper.findByTestId('preview-time-frame')).toBeTruthy();
+    expect(await wrapper.findByTestId('rule-preview')).toBeTruthy();
+    expect(await wrapper.findByTestId('preview-time-frame')).toBeTruthy();
   });
 
-  test('it renders preview button disabled if "isDisabled" is true', () => {
+  test('it renders preview button disabled if "isDisabled" is true', async () => {
     const wrapper = render(
       <TestProviders>
         <RulePreview {...defaultProps} isDisabled={true} />
       </TestProviders>
     );
 
-    expect(wrapper.getByTestId('queryPreviewButton').closest('button')).toBeDisabled();
+    expect(await wrapper.getByTestId('queryPreviewButton').closest('button')).toBeDisabled();
   });
 
-  test('it renders preview button enabled if "isDisabled" is false', () => {
+  test('it renders preview button enabled if "isDisabled" is false', async () => {
     const wrapper = render(
       <TestProviders>
         <RulePreview {...defaultProps} />
       </TestProviders>
     );
 
-    expect(wrapper.getByTestId('queryPreviewButton').closest('button')).not.toBeDisabled();
+    expect(await wrapper.getByTestId('queryPreviewButton').closest('button')).not.toBeDisabled();
   });
 
-  test('does not render histogram when there is no previewId', () => {
+  test('does not render histogram when there is no previewId', async () => {
     const wrapper = render(
       <TestProviders>
         <RulePreview {...defaultProps} />
       </TestProviders>
     );
 
-    expect(wrapper.queryByTestId('[data-test-subj="preview-histogram-panel"]')).toBeNull();
+    expect(await wrapper.queryByTestId('[data-test-subj="preview-histogram-panel"]')).toBeNull();
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.test.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-import * as i18n from '../rule_preview/translations';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { TestProviders } from '../../../../common/mock';
 import { usePreviewHistogram } from './use_preview_histogram';
@@ -49,7 +48,7 @@ describe('PreviewHistogram', () => {
       },
     ]);
 
-    test('it renders an empty histogram and table', () => {
+    test('it renders an empty histogram and table', async () => {
       const wrapper = render(
         <TestProviders>
           <PreviewHistogram
@@ -63,37 +62,38 @@ describe('PreviewHistogram', () => {
         </TestProviders>
       );
 
-      expect(wrapper.findByText('hello grid')).toBeTruthy();
-      expect(wrapper.findByText(ALL_VALUES_ZEROS_TITLE)).toBeTruthy();
+      expect(await wrapper.findByText('hello grid')).toBeTruthy();
+      expect(await wrapper.findByText(ALL_VALUES_ZEROS_TITLE)).toBeTruthy();
     });
   });
 
-  test('it renders loader when isLoading is true', () => {
-    (usePreviewHistogram as jest.Mock).mockReturnValue([
-      true,
-      {
-        inspect: { dsl: [], response: [] },
-        totalCount: 1,
-        refetch: jest.fn(),
-        data: [],
-        buckets: [],
-      },
-    ]);
+  describe('when there is data', () => {
+    test('it renders loader when isLoading is true', async () => {
+      (usePreviewHistogram as jest.Mock).mockReturnValue([
+        true,
+        {
+          inspect: { dsl: [], response: [] },
+          totalCount: 1,
+          refetch: jest.fn(),
+          data: [],
+          buckets: [],
+        },
+      ]);
 
-    const wrapper = render(
-      <TestProviders>
-        <PreviewHistogram
-          addNoiseWarning={jest.fn()}
-          timeFrame="M"
-          previewId={'test-preview-id'}
-          spaceId={'default'}
-          ruleType={'query'}
-          index={['']}
-        />
-      </TestProviders>
-    );
+      const wrapper = render(
+        <TestProviders>
+          <PreviewHistogram
+            addNoiseWarning={jest.fn()}
+            timeFrame="M"
+            previewId={'test-preview-id'}
+            spaceId={'default'}
+            ruleType={'query'}
+            index={['']}
+          />
+        </TestProviders>
+      );
 
-    expect(wrapper.findByTestId('preview-histogram-loading')).toBeTruthy();
-    expect(wrapper.findByText(i18n.QUERY_PREVIEW_SUBTITLE_LOADING)).toBeTruthy();
+      expect(await wrapper.findByTestId('preview-histogram-loading')).toBeTruthy();
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/translations.ts
@@ -146,13 +146,6 @@ export const ML_PREVIEW_HISTOGRAM_DISCLAIMER = i18n.translate(
   }
 );
 
-export const QUERY_PREVIEW_SUBTITLE_LOADING = i18n.translate(
-  'xpack.securitySolution.detectionEngine.queryPreview.queryPreviewSubtitleLoading',
-  {
-    defaultMessage: '...loading',
-  }
-);
-
 export const QUERY_PREVIEW_EQL_SEQUENCE_TITLE = i18n.translate(
   'xpack.securitySolution.detectionEngine.queryPreview.queryPreviewEqlSequenceTitle',
   {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
@@ -142,7 +142,7 @@ export const previewRulesRoute = async (
               logs: [
                 {
                   errors: [
-                    'Missing "read" privileges for the ".preview.alerts-security.alerts" or "internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
+                    'Missing "read" privileges for the ".preview.alerts-security.alerts" or ".internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
                   ],
                   warnings: [],
                   duration: 0,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
@@ -124,19 +124,25 @@ export const previewRulesRoute = async (
         const logs: RulePreviewLogs[] = [];
         let isAborted = false;
 
-        const { privileges } = await securityService.authz
+        const { hasAllRequested } = await securityService.authz
           .checkPrivilegesWithRequest(request)
           .atSpace(spaceId, {
-            elasticsearch: { index: { [DEFAULT_PREVIEW_INDEX]: ['read'] }, cluster: [] },
+            elasticsearch: {
+              index: {
+                [DEFAULT_PREVIEW_INDEX]: ['read'],
+                [`internal.${DEFAULT_PREVIEW_INDEX}`]: ['read'],
+              },
+              cluster: [],
+            },
           });
 
-        if (!privileges.elasticsearch.index[DEFAULT_PREVIEW_INDEX][0].authorized) {
+        if (!hasAllRequested) {
           return response.ok({
             body: {
               logs: [
                 {
                   errors: [
-                    'Missing "read" privileges for the ".preview.alerts-security.alerts" index. Without that privilege you cannot use the Rule Preview feature.',
+                    'Missing "read" privileges for the ".preview.alerts-security.alerts" and "internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
                   ],
                   warnings: [],
                   duration: 0,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
@@ -130,7 +130,7 @@ export const previewRulesRoute = async (
             elasticsearch: {
               index: {
                 [`${DEFAULT_PREVIEW_INDEX}`]: ['read'],
-                [`internal.${DEFAULT_PREVIEW_INDEX}`]: ['read'],
+                [`.internal${DEFAULT_PREVIEW_INDEX}-`]: ['read'],
               },
               cluster: [],
             },

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
@@ -129,7 +129,7 @@ export const previewRulesRoute = async (
           .atSpace(spaceId, {
             elasticsearch: {
               index: {
-                [DEFAULT_PREVIEW_INDEX]: ['read'],
+                [`${DEFAULT_PREVIEW_INDEX}`]: ['read'],
                 [`internal.${DEFAULT_PREVIEW_INDEX}`]: ['read'],
               },
               cluster: [],
@@ -142,7 +142,7 @@ export const previewRulesRoute = async (
               logs: [
                 {
                   errors: [
-                    'Missing "read" privileges for the ".preview.alerts-security.alerts" and "internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
+                    'Missing "read" privileges for the ".preview.alerts-security.alerts" or "internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
                   ],
                   warnings: [],
                   duration: 0,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/detections_admin/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/detections_admin/detections_role.json
@@ -7,6 +7,7 @@
           ".siem-signals-*",
           ".alerts-security*",
           ".preview.alerts-security*",
+          ".internal.preview.alerts-security*",
           ".lists*",
           ".items*",
           "apm-*-transaction*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/detections_admin/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/detections_admin/detections_role.json
@@ -6,6 +6,7 @@
         "names": [
           ".siem-signals-*",
           ".alerts-security*",
+          ".preview.alerts-security*",
           ".lists*",
           ".items*",
           "apm-*-transaction*",
@@ -20,11 +21,7 @@
         "privileges": ["manage", "write", "read"]
       },
       {
-        "names": [
-          "metrics-endpoint.metadata_current_*",
-          ".fleet-agents*",
-          ".fleet-actions*"
-        ],
+        "names": ["metrics-endpoint.metadata_current_*", ".fleet-agents*", ".fleet-actions*"],
         "privileges": ["read"]
       }
     ]

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/hunter/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/hunter/detections_role.json
@@ -16,7 +16,7 @@
         "privileges": ["read", "write"]
       },
       {
-        "names": [".alerts-security*", ".siem-signals-*"],
+        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
         "privileges": ["read", "write"]
       },
       {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/hunter/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/hunter/detections_role.json
@@ -16,7 +16,7 @@
         "privileges": ["read", "write"]
       },
       {
-        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
+        "names": [".alerts-security*", ".siem-signals-*"],
         "privileges": ["read", "write"]
       },
       {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/hunter_no_actions/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/hunter_no_actions/detections_role.json
@@ -16,7 +16,7 @@
         "privileges": ["read", "write"]
       },
       {
-        "names": [".alerts-security*", ".siem-signals-*"],
+        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
         "privileges": ["read", "write"]
       },
       {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/hunter_no_actions/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/hunter_no_actions/detections_role.json
@@ -16,7 +16,7 @@
         "privileges": ["read", "write"]
       },
       {
-        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
+        "names": [".alerts-security*", ".siem-signals-*"],
         "privileges": ["read", "write"]
       },
       {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/platform_engineer/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/platform_engineer/detections_role.json
@@ -23,7 +23,7 @@
         "privileges": ["all"]
       },
       {
-        "names": [".alerts-security*", ".siem-signals-*"],
+        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
         "privileges": ["all"]
       }
     ]

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/platform_engineer/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/platform_engineer/detections_role.json
@@ -23,7 +23,12 @@
         "privileges": ["all"]
       },
       {
-        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
+        "names": [
+          ".alerts-security*",
+          ".preview.alerts-security*",
+          ".internal.preview.alerts-security*",
+          ".siem-signals-*"
+        ],
         "privileges": ["all"]
       }
     ]

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/rule_author/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/rule_author/detections_role.json
@@ -18,15 +18,11 @@
         "privileges": ["read", "write"]
       },
       {
-        "names": [".alerts-security*", ".siem-signals-*"],
+        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
         "privileges": ["read", "write", "maintenance", "view_index_metadata"]
       },
       {
-        "names": [
-          "metrics-endpoint.metadata_current_*",
-          ".fleet-agents*",
-          ".fleet-actions*"
-        ],
+        "names": ["metrics-endpoint.metadata_current_*", ".fleet-agents*", ".fleet-actions*"],
         "privileges": ["read"]
       }
     ]

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/rule_author/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/rule_author/detections_role.json
@@ -18,7 +18,12 @@
         "privileges": ["read", "write"]
       },
       {
-        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
+        "names": [
+          ".alerts-security*",
+          ".preview.alerts-security*",
+          ".internal.preview.alerts-security*",
+          ".siem-signals-*"
+        ],
         "privileges": ["read", "write", "maintenance", "view_index_metadata"]
       },
       {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/soc_manager/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/soc_manager/detections_role.json
@@ -18,7 +18,12 @@
         "privileges": ["read", "write"]
       },
       {
-        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
+        "names": [
+          ".alerts-security*",
+          ".preview.alerts-security*",
+          ".internal.preview.alerts-security*",
+          ".siem-signals-*"
+        ],
         "privileges": ["read", "write", "manage"]
       },
       {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/soc_manager/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/soc_manager/detections_role.json
@@ -18,15 +18,11 @@
         "privileges": ["read", "write"]
       },
       {
-        "names": [".alerts-security*", ".siem-signals-*"],
+        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
         "privileges": ["read", "write", "manage"]
       },
       {
-        "names": [
-          "metrics-endpoint.metadata_current_*",
-          ".fleet-agents*",
-          ".fleet-actions*"
-        ],
+        "names": ["metrics-endpoint.metadata_current_*", ".fleet-agents*", ".fleet-actions*"],
         "privileges": ["read"]
       }
     ]

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t2_analyst/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t2_analyst/detections_role.json
@@ -2,7 +2,10 @@
   "elasticsearch": {
     "cluster": [],
     "indices": [
-      { "names": [".alerts-security*", ".siem-signals-*"], "privileges": ["read", "write", "maintenance"] },
+      {
+        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
+        "privileges": ["read", "write", "maintenance"]
+      },
       {
         "names": [
           ".lists*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t2_analyst/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t2_analyst/detections_role.json
@@ -3,7 +3,7 @@
     "cluster": [],
     "indices": [
       {
-        "names": [".alerts-security*", ".preview.alerts-security*", ".siem-signals-*"],
+        "names": [".alerts-security*", ".siem-signals-*"],
         "privileges": ["read", "write", "maintenance"]
       },
       {

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -20732,7 +20732,6 @@
     "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewGraphTitle": "{hits} {hits, plural, =1 {résultat} other {résultats}}",
     "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewHelpText": "Sélectionner une période de temps pour les données afin d'afficher l'aperçu des résultats de requête",
     "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewLabel": "Aperçu de la recherche rapide",
-    "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewSubtitleLoading": "... en cours de chargement",
     "xpack.securitySolution.detectionEngine.queryPreview.queryThresholdGraphCountLabel": "Compte de seuil cumulé",
     "xpack.securitySolution.detectionEngine.rule.editRule.errorMsgDescription": "Une entrée est incorrecte dans {countError, plural, one {cet onglet} other {ces onglets}} : {tabHasError}",
     "xpack.securitySolution.detectionEngine.ruleDescription.mlJobStartedDescription": "Démarré",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -23592,7 +23592,6 @@
     "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewLabel": "クイッククエリプレビュー",
     "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewSeeAllErrors": "すべてのエラーを表示",
     "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewSeeAllWarnings": "すべての警告を表示",
-    "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewSubtitleLoading": "...loading",
     "xpack.securitySolution.detectionEngine.queryPreview.queryThresholdGraphCountLabel": "累積しきい値数",
     "xpack.securitySolution.detectionEngine.rule.editRule.errorMsgDescription": "{countError, plural, one {このタブ} other {これらのタブ}}に無効な入力があります：{tabHasError}",
     "xpack.securitySolution.detectionEngine.ruleDescription.mlJobStartedDescription": "開始",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -23619,7 +23619,6 @@
     "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewLabel": "快速查询预览",
     "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewSeeAllErrors": "查看所有错误",
     "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewSeeAllWarnings": "查看所有警告",
-    "xpack.securitySolution.detectionEngine.queryPreview.queryPreviewSubtitleLoading": "...正在加载",
     "xpack.securitySolution.detectionEngine.queryPreview.queryThresholdGraphCountLabel": "累计阈值计数",
     "xpack.securitySolution.detectionEngine.rule.editRule.errorMsgDescription": "您在{countError, plural, other {以下选项卡}}中的输入无效：{tabHasError}",
     "xpack.securitySolution.detectionEngine.ruleDescription.mlJobStartedDescription": "已启动",

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/preview_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/preview_rules.ts
@@ -92,8 +92,8 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      describe('rule_author', () => {
-        const role = ROLES.rule_author;
+      describe('hunter', () => {
+        const role = ROLES.hunter;
 
         beforeEach(async () => {
           await createUserAndRole(getService, role);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/preview_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/preview_rules.ts
@@ -114,7 +114,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { logs } = getSimpleRulePreviewOutput(undefined, [
             {
               errors: [
-                'Missing "read" privileges for the ".preview.alerts-security.alerts" or "internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
+                'Missing "read" privileges for the ".preview.alerts-security.alerts" or ".internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
               ],
               warnings: [],
               duration: 0,

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/preview_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/preview_rules.ts
@@ -91,6 +91,38 @@ export default ({ getService }: FtrProviderContext) => {
             .expect(403);
         });
       });
+
+      describe('rule_author', () => {
+        const role = ROLES.rule_author;
+
+        beforeEach(async () => {
+          await createUserAndRole(getService, role);
+        });
+
+        afterEach(async () => {
+          await deleteUserAndRole(getService, role);
+        });
+
+        it('should return with an error about not having correct permissions', async () => {
+          const { body } = await supertestWithoutAuth
+            .post(DETECTION_ENGINE_RULES_PREVIEW)
+            .auth(role, 'changeme')
+            .set('kbn-xsrf', 'true')
+            .send(getSimplePreviewRule())
+            .expect(200);
+
+          const { logs } = getSimpleRulePreviewOutput(undefined, [
+            {
+              errors: [
+                'Missing "read" privileges for the ".preview.alerts-security.alerts" or "internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
+              ],
+              warnings: [],
+              duration: 0,
+            },
+          ]);
+          expect(body).to.eql({ logs });
+        });
+      });
     });
   });
 };


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/128284

Adds an error message for when a user attempts to use the rule preview feature without the necessary `read` privilege for the `.preview.alerts-security.alerts` index.

To test:

- Create a role with the usual detection alerts index permissions, but _without_ `.preview.alerts-security.alerts` and/or `.internal.preview.alerts-security.alerts`
- Attempt to use the rule preview feature within rule creation
- See that no histogram shows up

#### Screenshots
![Screen Shot 2022-04-11 at 5 34 19 PM](https://user-images.githubusercontent.com/56367316/162837224-19ebbf25-ce35-4a62-b2c6-a69d41eef447.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
