### PR TITLE
[7.17] Removing axios from data_view_field_editor test  (#129116)

### DIFF
--- a/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor.test.tsx
+++ b/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor.test.tsx
@@ -21,7 +21,7 @@ import type { RuntimeFieldPainlessError } from '../../public/lib';
 import { setup, FieldEditorTestBed, defaultProps } from './field_editor.helpers';
 
 describe('<FieldEditor />', () => {
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpRequestsMockHelpers } = setupEnvironment();
 
   let testBed: FieldEditorTestBed;
   let onChange: jest.Mock<Props['onChange']> = jest.fn();
@@ -70,7 +70,6 @@ describe('<FieldEditor />', () => {
 
   afterAll(() => {
     jest.useRealTimers();
-    server.restore();
   });
 
   beforeEach(async () => {

--- a/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor_flyout_content.test.ts
+++ b/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor_flyout_content.test.ts
@@ -12,7 +12,7 @@ import { setupEnvironment } from './helpers';
 import { setup } from './field_editor_flyout_content.helpers';
 
 describe('<FieldEditorFlyoutContent />', () => {
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+  const { httpRequestsMockHelpers } = setupEnvironment();
 
   beforeAll(() => {
     httpRequestsMockHelpers.setFieldPreviewResponse({ values: ['foo'] });
@@ -21,7 +21,6 @@ describe('<FieldEditorFlyoutContent />', () => {
 
   afterAll(() => {
     jest.useRealTimers();
-    server.restore();
   });
 
   test('should have the correct title', async () => {

--- a/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor_flyout_preview.test.ts
+++ b/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor_flyout_preview.test.ts
@@ -342,13 +342,18 @@ describe('Field editor Preview panel', () => {
       httpRequestsMockHelpers.setFieldPreviewResponse({ values: [scriptEmitResponse] });
 
       const {
-        actions: { toggleFormRow, fields, waitForUpdates, getRenderedFieldsPreview },
+        actions: {
+          toggleFormRow,
+          fields,
+          getRenderedFieldsPreview,
+          waitForDocumentsAndPreviewUpdate,
+        },
       } = testBed;
 
       await toggleFormRow('value');
       await fields.updateName('myRuntimeField');
       await fields.updateScript('echo("hello")');
-      await waitForUpdates(); // Run validations
+      await waitForDocumentsAndPreviewUpdate();
 
       // Make sure the payload sent is correct
       const firstCall = server.post.mock.calls[0] as Array<{ body: any }>;

--- a/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor_flyout_preview.test.ts
+++ b/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor_flyout_preview.test.ts
@@ -339,7 +339,7 @@ describe('Field editor Preview panel', () => {
 
     test('should set the value returned by the painless _execute API', async () => {
       const scriptEmitResponse = 'Field emit() response';
-      httpRequestsMockHelpers.setFieldPreviewResponse({ values: ['ok'] });
+      httpRequestsMockHelpers.setFieldPreviewResponse({ values: [scriptEmitResponse] });
 
       const {
         actions: { toggleFormRow, fields, waitForUpdates, getRenderedFieldsPreview },
@@ -374,7 +374,7 @@ describe('Field editor Preview panel', () => {
     });
 
     test('should display an updating indicator while fetching the preview', async () => {
-      httpRequestsMockHelpers.setFieldPreviewResponse({ values: ['ok'] });
+      httpRequestsMockHelpers.setFieldPreviewResponse({ values: ['ok'] }, undefined, true);
 
       const {
         exists,
@@ -393,7 +393,7 @@ describe('Field editor Preview panel', () => {
     });
 
     test('should not display the updating indicator when neither the type nor the script has changed', async () => {
-      httpRequestsMockHelpers.setFieldPreviewResponse({ values: ['ok'] });
+      httpRequestsMockHelpers.setFieldPreviewResponse({ values: ['ok'] }, undefined, true);
 
       const {
         exists,

--- a/src/plugins/index_pattern_field_editor/__jest__/client_integration/helpers/http_requests.ts
+++ b/src/plugins/index_pattern_field_editor/__jest__/client_integration/helpers/http_requests.ts
@@ -6,42 +6,37 @@
  * Side Public License, v 1.
  */
 
-import sinon, { SinonFakeServer } from 'sinon';
-import { API_BASE_PATH } from '../../../common/constants';
+import { httpServiceMock } from '../../../../../../src/core/public/mocks';
 
 type HttpResponse = Record<string, any> | any[];
 
-// Register helpers to mock HTTP Requests
-const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
-  const setFieldPreviewResponse = (response?: HttpResponse, error?: any) => {
-    const status = error ? error.body.status || 400 : 200;
-    const body = error ? JSON.stringify(error.body) : JSON.stringify(response);
+const registerHttpRequestMockHelpers = (
+  httpSetup: ReturnType<typeof httpServiceMock.createStartContract>
+) => {
+  const setFieldPreviewResponse = (response?: HttpResponse, error?: any, delayResponse = false) => {
+    const body = error ? JSON.stringify(error.body) : response;
 
-    server.respondWith('POST', `${API_BASE_PATH}/field_preview`, [
-      status,
-      { 'Content-Type': 'application/json' },
-      body,
-    ]);
+    httpSetup.post.mockImplementation(() => {
+      if (delayResponse) {
+        return new Promise((resolve) => {
+          setTimeout(() => resolve({ data: body }), 1000);
+        });
+      } else {
+        return Promise.resolve({ data: body });
+      }
+    });
   };
-
   return {
     setFieldPreviewResponse,
   };
 };
 
 export const init = () => {
-  const server = sinon.fakeServer.create();
-  server.respondImmediately = true;
-
-  // Define default response for unhandled requests.
-  // We make requests to APIs which don't impact the component under test, e.g. UI metric telemetry,
-  // and we can mock them all with a 200 instead of mocking each one individually.
-  server.respondWith([200, {}, 'DefaultSinonMockServerResponse']);
-
-  const httpRequestsMockHelpers = registerHttpRequestMockHelpers(server);
+  const httpSetup = httpServiceMock.createSetupContract();
+  const httpRequestsMockHelpers = registerHttpRequestMockHelpers(httpSetup);
 
   return {
-    server,
+    httpSetup,
     httpRequestsMockHelpers,
   };
 };

--- a/src/plugins/index_pattern_field_editor/__jest__/client_integration/helpers/setup_environment.tsx
+++ b/src/plugins/index_pattern_field_editor/__jest__/client_integration/helpers/setup_environment.tsx
@@ -9,8 +9,6 @@
 import './jest.mocks';
 
 import React, { FunctionComponent } from 'react';
-import axios from 'axios';
-import axiosXhrAdapter from 'axios/lib/adapters/xhr';
 import { merge } from 'lodash';
 
 import { notificationServiceMock, uiSettingsServiceMock } from '../../../../../core/public/mocks';
@@ -20,7 +18,6 @@ import { FieldPreviewProvider } from '../../../public/components/preview';
 import { initApi, ApiService } from '../../../public/lib';
 import { init as initHttpRequests } from './http_requests';
 
-const mockHttpClient = axios.create({ adapter: axiosXhrAdapter });
 const dataStart = dataPluginMock.createStartContract();
 const { search, fieldFormats } = dataStart;
 
@@ -44,12 +41,11 @@ search.search = spySearchQuery;
 let apiService: ApiService;
 
 export const setupEnvironment = () => {
-  // @ts-expect-error Axios does not fullfill HttpSetupn from core but enough for our tests
-  apiService = initApi(mockHttpClient);
-  const { server, httpRequestsMockHelpers } = initHttpRequests();
+  const { httpSetup, httpRequestsMockHelpers } = initHttpRequests();
+  apiService = initApi(httpSetup);
 
   return {
-    server,
+    server: httpSetup,
     httpRequestsMockHelpers,
   };
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Removing axios from data_view_field_editor test  (#129116)](https://github.com/elastic/kibana/pull/129116)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)