### PR TITLE
[8.2][Session View][Security Solution] Fix partial QA-ed process tree styles

### DIFF
--- a/x-pack/plugins/session_view/public/components/process_tree_alerts/styles.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree_alerts/styles.ts
@@ -16,14 +16,13 @@ export const useStyles = () => {
     const { size, colors, border } = euiTheme;
 
     const container: CSSObject = {
-      margin: `${size.xs} ${size.s} 0 ${size.xs}`,
+      margin: `${size.xs} ${size.base} 0 ${size.xs}`,
       color: colors.text,
       padding: `${size.s} 0`,
       borderStyle: 'solid',
       borderColor: colors.lightShade,
       borderWidth: border.width.thin,
       borderRadius: border.radius.medium,
-      maxWidth: 800,
       maxHeight: 378,
       overflowY: 'auto',
       backgroundColor: colors.emptyShade,

--- a/x-pack/plugins/session_view/public/components/process_tree_node/styles.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/styles.ts
@@ -23,6 +23,7 @@ export const useStyles = ({ depth, hasAlerts, hasInvestigatedAlert, isSelected }
     const { colors, border, size, font } = euiTheme;
 
     const TREE_INDENT = `calc(${size.l} + ${size.xxs})`;
+    const PROCESS_TREE_LEFT_PADDING = size.s;
 
     const darkText: CSSObject = {
       color: colors.text,
@@ -79,10 +80,10 @@ export const useStyles = ({ depth, hasAlerts, hasInvestigatedAlert, isSelected }
         height: '100%',
         pointerEvents: 'none',
         content: `''`,
-        marginLeft: `calc(-${depth} * ${TREE_INDENT})`,
+        marginLeft: `calc(-${depth} * ${TREE_INDENT} - ${PROCESS_TREE_LEFT_PADDING})`,
         borderLeft: `${size.xs} solid ${borderColor}`,
         backgroundColor: bgColor,
-        width: `calc(100% + ${depth} * ${TREE_INDENT})`,
+        width: `calc(100% + ${depth} * ${TREE_INDENT} + ${PROCESS_TREE_LEFT_PADDING})`,
         transform: `translateY(-${size.xs})`,
       },
     };
@@ -99,8 +100,8 @@ export const useStyles = ({ depth, hasAlerts, hasInvestigatedAlert, isSelected }
       verticalAlign: 'middle',
       color: colors.mediumShade,
       wordBreak: 'break-all',
-      minHeight: size.l,
-      lineHeight: size.l,
+      minHeight: `calc(${size.l} - ${size.xxs})`,
+      lineHeight: `calc(${size.l} - ${size.xxs})`,
     };
 
     const workingDir: CSSObject = {


### PR DESCRIPTION
Issue: https://github.com/elastic/kibana/issues/128966

- Fix alerts expanded block should be full width
- Fix red left alert highlight border should be all the way left
- Fix command row hight
<img width="856" alt="image" src="https://user-images.githubusercontent.com/16872649/162839911-c1a12dfa-704b-4fce-85bb-a0de2e66c087.png">
