### PR TITLE
[8.2] [Screenshotting] Ensure worker.js content contents are compiled in build (#129796)

### DIFF
--- a/x-pack/plugins/screenshotting/server/formats/pdf/index.ts
+++ b/x-pack/plugins/screenshotting/server/formats/pdf/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { groupBy } from 'lodash';
-import type { Logger } from 'src/core/server';
+import type { Logger, PackageInfo } from 'src/core/server';
 import { LayoutParams, LayoutTypes } from '../../../common';
 import { ScreenshotResult, ScreenshotOptions } from '../../screenshots';
 import { FormattedScreenshotResult } from '../types';
@@ -54,6 +54,7 @@ export interface PdfScreenshotResult extends Omit<FormattedScreenshotResult, 're
 
 interface ScreenshotsResultsToPdfArgs {
   logger: Logger;
+  packageInfo: PackageInfo;
   title?: string;
   logo?: string;
 }
@@ -68,13 +69,14 @@ const getTimeRange = (urlScreenshots: ScreenshotResult['results']) => {
   return null;
 };
 
-export function toPdf({ title, logo, logger }: ScreenshotsResultsToPdfArgs) {
+export function toPdf({ title, logo, logger, packageInfo }: ScreenshotsResultsToPdfArgs) {
   return async (screenshotResult: ScreenshotResult): Promise<PdfScreenshotResult> => {
     const timeRange = getTimeRange(screenshotResult.results);
     try {
       const { buffer, pageCount } = await pngsToPdf({
         results: screenshotResult.results,
         title: title ? title + (timeRange ? ` - ${timeRange}` : '') : undefined,
+        packageInfo,
         logo,
         layout: screenshotResult.layout,
         logger,

--- a/x-pack/plugins/screenshotting/server/formats/pdf/pdf_maker/index.ts
+++ b/x-pack/plugins/screenshotting/server/formats/pdf/pdf_maker/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Logger } from 'src/core/server';
+import type { Logger, PackageInfo } from 'src/core/server';
 import { PdfMaker } from './pdfmaker';
 import type { Layout } from '../../../layouts';
 import { getTracker } from './tracker';
@@ -17,6 +17,7 @@ interface PngsToPdfArgs {
   logger: Logger;
   logo?: string;
   title?: string;
+  packageInfo: PackageInfo;
 }
 
 export async function pngsToPdf({
@@ -24,9 +25,10 @@ export async function pngsToPdf({
   layout,
   logo,
   title,
+  packageInfo,
   logger,
 }: PngsToPdfArgs): Promise<{ buffer: Buffer; pageCount: number }> {
-  const pdfMaker = new PdfMaker(layout, logo, logger);
+  const pdfMaker = new PdfMaker(layout, logo, packageInfo, logger);
   const tracker = getTracker();
   if (title) {
     pdfMaker.setTitle(title);

--- a/x-pack/plugins/screenshotting/server/formats/pdf/pdf_maker/pdfmaker.ts
+++ b/x-pack/plugins/screenshotting/server/formats/pdf/pdf_maker/pdfmaker.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Logger } from 'src/core/server';
+import type { Logger, PackageInfo } from 'src/core/server';
 import { SerializableRecord } from '@kbn/utility-types';
 import path from 'path';
 import { Content, ContentImage, ContentText } from 'pdfmake/interfaces';
@@ -34,7 +34,7 @@ export class PdfMaker {
   private worker?: Worker;
   private pageCount: number = 0;
 
-  protected workerModulePath = path.resolve(__dirname, './worker.js');
+  protected workerModulePath: string;
 
   /**
    * The maximum heap size for old memory region of the worker thread.
@@ -65,10 +65,18 @@ export class PdfMaker {
   constructor(
     private readonly layout: Layout,
     private readonly logo: string | undefined,
+    { dist }: PackageInfo,
     private readonly logger: Logger
   ) {
     this.title = '';
     this.content = [];
+
+    // running in dist: `worker.ts` becomes `worker.js`
+    // running in source: `worker_src_harness.ts` needs to be wrapped in JS and have a ts-node environment initialized.
+    this.workerModulePath = path.resolve(
+      __dirname,
+      dist ? './worker.js' : './worker_src_harness.js'
+    );
   }
 
   _addContents(contents: Content[]) {

--- a/x-pack/plugins/screenshotting/server/formats/pdf/pdf_maker/worker_src_harness.js
+++ b/x-pack/plugins/screenshotting/server/formats/pdf/pdf_maker/worker_src_harness.js
@@ -5,5 +5,10 @@
  * 2.0.
  */
 
+/**
+ * This file is the harness for importing worker.ts with Kibana running in dev mode.
+ * The TS file needs to be compiled on the fly, unlike when Kibana is running as a dist.
+ */
+
 require('../../../../../../../src/setup_node_env');
 require('./worker.ts');

--- a/x-pack/plugins/screenshotting/server/mock.ts
+++ b/x-pack/plugins/screenshotting/server/mock.ts
@@ -17,6 +17,13 @@ export function createMockScreenshottingStart(): jest.Mocked<ScreenshottingStart
   const driver = createMockBrowserDriverFactory();
   const { getScreenshots } = createMockScreenshots();
   const { diagnose } = driver;
+  const packageInfo = {
+    branch: 'screenshot-test',
+    buildNum: 567891011,
+    buildSha: 'screenshot-dfdfed0a',
+    dist: false,
+    version: '5000.0.0',
+  };
 
   return {
     diagnose,
@@ -24,7 +31,9 @@ export function createMockScreenshottingStart(): jest.Mocked<ScreenshottingStart
       (options): ReturnType<ScreenshottingStart['getScreenshots']> =>
         getScreenshots(options).pipe(
           mergeMap<ScreenshotResult, Promise<PngScreenshotResult | PdfScreenshotResult>>(
-            options.format === 'pdf' ? toPdf({ logger: loggingSystemMock.createLogger() }) : toPng
+            options.format === 'pdf'
+              ? toPdf({ logger: loggingSystemMock.createLogger(), packageInfo })
+              : toPng
           )
         )
     ),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Screenshotting] Ensure worker.js content contents are compiled in build (#129796)](https://github.com/elastic/kibana/pull/129796)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)