### PR TITLE
[Lens] update defaults for metric vis

### DIFF
--- a/x-pack/plugins/lens/public/metric_visualization/metric_config_panel/align_options.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/metric_config_panel/align_options.tsx
@@ -15,6 +15,8 @@ export interface TitlePositionProps {
   setState: (newState: MetricState) => void;
 }
 
+export const DEFAULT_TEXT_ALIGNMENT = 'left';
+
 const alignButtonIcons = [
   {
     id: `left`,

--- a/x-pack/plugins/lens/public/metric_visualization/metric_config_panel/align_options.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/metric_config_panel/align_options.tsx
@@ -48,7 +48,7 @@ export const AlignOptions: React.FC<TitlePositionProps> = ({ state, setState }) 
         defaultMessage: 'Align',
       })}
       options={alignButtonIcons}
-      idSelected={state.textAlign ?? 'center'}
+      idSelected={state.textAlign ?? DEFAULT_TEXT_ALIGNMENT}
       onChange={(id) => {
         setState({ ...state, textAlign: id as MetricState['textAlign'] });
       }}

--- a/x-pack/plugins/lens/public/metric_visualization/metric_config_panel/size_options.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/metric_config_panel/size_options.tsx
@@ -15,6 +15,8 @@ export interface TitlePositionProps {
   setState: (newState: MetricState) => void;
 }
 
+export const DEFAULT_TITLE_SIZE = 'm';
+
 const titleSizes = [
   {
     id: 'xs',
@@ -55,7 +57,9 @@ const titleSizes = [
 ];
 
 export const SizeOptions: React.FC<TitlePositionProps> = ({ state, setState }) => {
-  const currSizeIndex = titleSizes.findIndex((size) => size.id === (state.size || 'xl'));
+  const currSizeIndex = titleSizes.findIndex(
+    (size) => size.id === (state.size || DEFAULT_TITLE_SIZE)
+  );
 
   const changeSize = (change: number) => {
     setState({ ...state, size: titleSizes[currSizeIndex + change].id });
@@ -86,7 +90,7 @@ export const SizeOptions: React.FC<TitlePositionProps> = ({ state, setState }) =
           inputDisplay: position.label,
         };
       })}
-      valueOfSelected={state.size ?? 'xl'}
+      valueOfSelected={state.size ?? DEFAULT_TITLE_SIZE}
       onChange={(value) => {
         setState({ ...state, size: value });
       }}

--- a/x-pack/plugins/lens/public/metric_visualization/metric_config_panel/title_position_option.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/metric_config_panel/title_position_option.tsx
@@ -15,9 +15,19 @@ export interface TitlePositionProps {
   setState: (newState: MetricState) => void;
 }
 
+export const DEFAULT_TITLE_POSITION = 'top';
+
 const titlePositions = [
-  { id: 'top', label: 'Top' },
-  { id: 'bottom', label: 'Bottom' },
+  {
+    id: 'top',
+    label: i18n.translate('xpack.lens.metricChart.titlePositions.top', { defaultMessage: 'Top' }),
+  },
+  {
+    id: 'bottom',
+    label: i18n.translate('xpack.lens.metricChart.titlePositions.bottom', {
+      defaultMessage: 'Bottom',
+    }),
+  },
 ];
 
 export const TitlePositionOptions: React.FC<TitlePositionProps> = ({ state, setState }) => {
@@ -38,7 +48,7 @@ export const TitlePositionOptions: React.FC<TitlePositionProps> = ({ state, setS
         data-test-subj="lnsMissingValuesSelect"
         legend="This is a basic group"
         options={titlePositions}
-        idSelected={state.titlePosition ?? 'bottom'}
+        idSelected={state.titlePosition ?? DEFAULT_TITLE_POSITION}
         onChange={(value) => {
           setState({ ...state, titlePosition: value as MetricState['titlePosition'] });
         }}

--- a/x-pack/plugins/lens/public/metric_visualization/visualization.test.ts
+++ b/x-pack/plugins/lens/public/metric_visualization/visualization.test.ts
@@ -301,7 +301,7 @@ describe('metric_visualization', () => {
                       Object {
                         "arguments": Object {
                           "align": Array [
-                            "center",
+                            "left",
                           ],
                           "lHeight": Array [
                             82.5,
@@ -329,7 +329,7 @@ describe('metric_visualization', () => {
                       Object {
                         "arguments": Object {
                           "align": Array [
-                            "center",
+                            "left",
                           ],
                           "lHeight": Array [
                             24,

--- a/x-pack/plugins/lens/public/metric_visualization/visualization.test.ts
+++ b/x-pack/plugins/lens/public/metric_visualization/visualization.test.ts
@@ -304,10 +304,10 @@ describe('metric_visualization', () => {
                             "center",
                           ],
                           "lHeight": Array [
-                            127.5,
+                            82.5,
                           ],
                           "size": Array [
-                            85,
+                            55,
                           ],
                           "sizeUnit": Array [
                             "px",
@@ -332,10 +332,10 @@ describe('metric_visualization', () => {
                             "center",
                           ],
                           "lHeight": Array [
-                            40.5,
+                            24,
                           ],
                           "size": Array [
-                            27,
+                            16,
                           ],
                           "sizeUnit": Array [
                             "px",
@@ -349,7 +349,7 @@ describe('metric_visualization', () => {
                   },
                 ],
                 "labelPosition": Array [
-                  "bottom",
+                  "top",
                 ],
                 "metric": Array [
                   Object {

--- a/x-pack/plugins/lens/public/metric_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/visualization.tsx
@@ -24,6 +24,7 @@ import { MetricDimensionEditor } from './dimension_editor';
 import { MetricToolbar } from './metric_config_panel';
 import { DEFAULT_TITLE_POSITION } from './metric_config_panel/title_position_option';
 import { DEFAULT_TITLE_SIZE } from './metric_config_panel/size_options';
+import { DEFAULT_TEXT_ALIGNMENT } from './metric_config_panel/align_options';
 
 interface MetricConfig extends Omit<MetricState, 'palette' | 'colorMode'> {
   title: string;
@@ -111,7 +112,7 @@ const toExpression = (
                   type: 'function',
                   function: 'font',
                   arguments: {
-                    align: [state?.textAlign || 'center'],
+                    align: [state?.textAlign || DEFAULT_TEXT_ALIGNMENT],
                     size: [metricFontSize],
                     weight: ['600'],
                     lHeight: [metricFontSize * 1.5],
@@ -129,7 +130,7 @@ const toExpression = (
                   type: 'function',
                   function: 'font',
                   arguments: {
-                    align: [state?.textAlign || 'center'],
+                    align: [state?.textAlign || DEFAULT_TEXT_ALIGNMENT],
                     size: [labelFont.size],
                     lHeight: [labelFont.size * 1.5],
                     sizeUnit: [labelFont.sizeUnit],

--- a/x-pack/plugins/lens/public/metric_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/visualization.tsx
@@ -22,6 +22,8 @@ import type { MetricState } from '../../common/types';
 import { layerTypes } from '../../common';
 import { MetricDimensionEditor } from './dimension_editor';
 import { MetricToolbar } from './metric_config_panel';
+import { DEFAULT_TITLE_POSITION } from './metric_config_panel/title_position_option';
+import { DEFAULT_TITLE_SIZE } from './metric_config_panel/size_options';
 
 interface MetricConfig extends Omit<MetricState, 'palette' | 'colorMode'> {
   title: string;
@@ -82,7 +84,7 @@ const toExpression = (
     xxl: getFontSizeAndUnit(euiThemeVars.euiFontSizeXXL),
   };
 
-  const labelFont = fontSizes[state?.size || 'xl'];
+  const labelFont = fontSizes[state?.size || DEFAULT_TITLE_SIZE];
   const labelToMetricFontSizeMap: Record<string, number> = {
     xs: fontSizes.xs.size * 2,
     s: fontSizes.m.size * 2.5,
@@ -91,7 +93,7 @@ const toExpression = (
     xl: fontSizes.xxl.size * 2.5,
     xxl: fontSizes.xxl.size * 3,
   };
-  const metricFontSize = labelToMetricFontSizeMap[state?.size || 'xl'];
+  const metricFontSize = labelToMetricFontSizeMap[state?.size || DEFAULT_TITLE_SIZE];
 
   return {
     type: 'expression',
@@ -100,7 +102,7 @@ const toExpression = (
         type: 'function',
         function: 'metricVis',
         arguments: {
-          labelPosition: [state?.titlePosition || 'bottom'],
+          labelPosition: [state?.titlePosition || DEFAULT_TITLE_POSITION],
           font: [
             {
               type: 'expression',

--- a/x-pack/plugins/lens/server/embeddable/make_lens_embeddable_factory.ts
+++ b/x-pack/plugins/lens/server/embeddable/make_lens_embeddable_factory.ts
@@ -14,6 +14,7 @@ import {
 import { DOC_TYPE } from '../../common';
 import {
   commonEnhanceTableRowHeight,
+  commonLockOldMetricVisSettings,
   commonMakeReversePaletteAsCustom,
   commonRemoveTimezoneDateHistogramParam,
   commonRenameFilterReferences,
@@ -98,6 +99,14 @@ export const makeLensEmbeddableFactory =
               let migratedLensState = commonSetLastValueShowArrayValues(lensState.attributes);
               migratedLensState = commonEnhanceTableRowHeight(migratedLensState);
               migratedLensState = commonSetIncludeEmptyRowsDateHistogram(migratedLensState);
+              return {
+                ...lensState,
+                attributes: migratedLensState,
+              } as unknown as SerializableRecord;
+            },
+            '8.3.0': (state) => {
+              const lensState = state as unknown as { attributes: LensDocShape810<VisState810> };
+              const migratedLensState = commonLockOldMetricVisSettings(lensState.attributes);
               return {
                 ...lensState,
                 attributes: migratedLensState,

--- a/x-pack/plugins/lens/server/migrations/common_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/common_migrations.ts
@@ -248,6 +248,7 @@ export const commonLockOldMetricVisSettings = (
   }
 
   const visState = newAttributes.state.visualization as MetricState;
+  visState.textAlign = visState.textAlign ?? 'center';
   visState.titlePosition = visState.titlePosition ?? 'bottom';
   visState.size = visState.size ?? 'xl';
   return newAttributes;

--- a/x-pack/plugins/lens/server/migrations/common_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/common_migrations.ts
@@ -28,7 +28,7 @@ import {
   CustomVisualizationMigrations,
   LensDocShape810,
 } from './types';
-import { DOCUMENT_FIELD_NAME, layerTypes } from '../../common';
+import { DOCUMENT_FIELD_NAME, layerTypes, MetricState } from '../../common';
 import { LensDocShape } from './saved_object_migrations';
 
 export const commonRenameOperationsForFormula = (
@@ -236,6 +236,20 @@ export const commonSetIncludeEmptyRowsDateHistogram = (
       }
     }
   }
+  return newAttributes;
+};
+
+export const commonLockOldMetricVisSettings = (
+  attributes: LensDocShape810
+): LensDocShape810<VisState820> => {
+  const newAttributes = cloneDeep(attributes);
+  if (newAttributes.visualizationType !== 'lnsMetric') {
+    return newAttributes;
+  }
+
+  const visState = newAttributes.state.visualization as MetricState;
+  visState.titlePosition = visState.titlePosition ?? 'bottom';
+  visState.size = visState.size ?? 'xl';
   return newAttributes;
 };
 

--- a/x-pack/plugins/lens/server/migrations/saved_object_migrations.test.ts
+++ b/x-pack/plugins/lens/server/migrations/saved_object_migrations.test.ts
@@ -22,7 +22,7 @@ import {
   VisState810,
   VisState820,
 } from './types';
-import { layerTypes } from '../../common';
+import { layerTypes, MetricState } from '../../common';
 import { Filter } from '@kbn/es-query';
 
 describe('Lens migrations', () => {
@@ -2062,6 +2062,52 @@ describe('Lens migrations', () => {
         result.attributes.state.datasourceStates.indexpattern.layers['2'].columns;
       expect(layer2Columns['3'].params).toHaveProperty('includeEmptyRows', true);
       expect(layer2Columns['4'].params).toHaveProperty('includeEmptyRows', true);
+    });
+  });
+  describe('8.3.0 old metric visualization defaults', () => {
+    const context = { log: { warning: () => {} } } as unknown as SavedObjectMigrationContext;
+    const example = {
+      type: 'lens',
+      id: 'mocked-saved-object-id',
+      attributes: {
+        savedObjectId: '1',
+        title: 'MyRenamedOps',
+        description: '',
+        visualizationType: 'lnsMetric',
+        state: {
+          visualization: {},
+        },
+      },
+    } as unknown as SavedObjectUnsanitizedDoc<LensDocShape810>;
+
+    it('preserves current config for existing visualizations that are using the DEFAULTS', () => {
+      const result = migrations['8.3.0'](example, context) as ReturnType<
+        SavedObjectMigrationFn<LensDocShape, LensDocShape>
+      >;
+      const visState = result.attributes.state.visualization as MetricState;
+      expect(visState.titlePosition).toBe('bottom');
+      expect(visState.size).toBe('xl');
+    });
+
+    it('preserves current config for existing visualizations that are using CUSTOM settings', () => {
+      const result = migrations['8.3.0'](
+        {
+          ...example,
+          attributes: {
+            ...example.attributes,
+            state: {
+              visualization: {
+                titlePosition: 'top',
+                size: 's',
+              },
+            },
+          },
+        },
+        context
+      ) as ReturnType<SavedObjectMigrationFn<LensDocShape, LensDocShape>>;
+      const visState = result.attributes.state.visualization as MetricState;
+      expect(visState.titlePosition).toBe('top');
+      expect(visState.size).toBe('s');
     });
   });
 });

--- a/x-pack/plugins/lens/server/migrations/saved_object_migrations.test.ts
+++ b/x-pack/plugins/lens/server/migrations/saved_object_migrations.test.ts
@@ -2085,6 +2085,7 @@ describe('Lens migrations', () => {
         SavedObjectMigrationFn<LensDocShape, LensDocShape>
       >;
       const visState = result.attributes.state.visualization as MetricState;
+      expect(visState.textAlign).toBe('center');
       expect(visState.titlePosition).toBe('bottom');
       expect(visState.size).toBe('xl');
     });
@@ -2097,6 +2098,7 @@ describe('Lens migrations', () => {
             ...example.attributes,
             state: {
               visualization: {
+                textAlign: 'right',
                 titlePosition: 'top',
                 size: 's',
               },
@@ -2106,6 +2108,7 @@ describe('Lens migrations', () => {
         context
       ) as ReturnType<SavedObjectMigrationFn<LensDocShape, LensDocShape>>;
       const visState = result.attributes.state.visualization as MetricState;
+      expect(visState.textAlign).toBe('right');
       expect(visState.titlePosition).toBe('top');
       expect(visState.size).toBe('s');
     });

--- a/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts
@@ -44,6 +44,7 @@ import {
   commonSetLastValueShowArrayValues,
   commonEnhanceTableRowHeight,
   commonSetIncludeEmptyRowsDateHistogram,
+  commonLockOldMetricVisSettings,
 } from './common_migrations';
 
 interface LensDocShapePre710<VisualizationState = unknown> {
@@ -485,6 +486,10 @@ const setIncludeEmptyRowsDateHistogram: SavedObjectMigrationFn<LensDocShape810, 
   return { ...doc, attributes: commonSetIncludeEmptyRowsDateHistogram(doc.attributes) };
 };
 
+const lockOldMetricVisSettings: SavedObjectMigrationFn<LensDocShape810, LensDocShape810> = (
+  doc
+) => ({ ...doc, attributes: commonLockOldMetricVisSettings(doc.attributes) });
+
 const lensMigrations: SavedObjectMigrationMap = {
   '7.7.0': removeInvalidAccessors,
   // The order of these migrations matter, since the timefield migration relies on the aggConfigs
@@ -504,6 +509,7 @@ const lensMigrations: SavedObjectMigrationMap = {
     setIncludeEmptyRowsDateHistogram,
     enhanceTableRowHeight
   ),
+  '8.3.0': lockOldMetricVisSettings,
 };
 
 export const getAllMigrations = (


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/129301

<img width="742" alt="Screen Shot 2022-04-12 at 1 20 41 PM" src="https://user-images.githubusercontent.com/315764/163028236-d0a0d552-dcfc-4850-a36f-c3c085d58134.png">



### Testing migrations
Can use [this exported 8.1 dashboard](https://drive.google.com/file/d/1MP2Y72zXbVOH99_gShavJYtH0VAXODFT/view?usp=sharing) to test by-value and by-reference metric visualizations. Just add the server logs sample data.

Should look like:
<img width="1426" alt="Screen Shot 2022-04-12 at 1 25 34 PM" src="https://user-images.githubusercontent.com/315764/163028851-47c74dcd-655a-49ad-8551-01c17edb1cd9.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios