### PR TITLE
Codeowners observability change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,6 +102,7 @@
 /x-pack/plugins/observability/public/rules @elastic/actionable-observability
 /x-pack/plugins/observability/public/pages/alerts @elastic/actionable-observability
 /x-pack/plugins/observability/public/pages/cases  @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/rules  @elastic/actionable-observability
 
 # Infra Monitoring
 /x-pack/plugins/infra/ @elastic/infra-monitoring-ui

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,7 +88,6 @@
 ### Observability Plugins
 
 # Observability Shared
-/x-pack/plugins/observability/ @elastic/observability-ui
 /x-pack/plugins/observability/public/components/shared/date_picker/ @elastic/uptime
 
 # Unified Observability


### PR DESCRIPTION
This PR:
- Removes `observability-ui` from Observability Shared
- New o11y rules page is owned by `Actionable Observability`