### PR TITLE
[TSVB] Unskip test suite

### DIFF
--- a/test/functional/apps/visualize/_tsvb_time_series.ts
+++ b/test/functional/apps/visualize/_tsvb_time_series.ts
@@ -217,13 +217,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
             const el = await elasticChart.getCanvas();
             await el.scrollIntoViewIfNecessary();
-            await browser
-              .getActions()
-              .move({ x: 100, y: 65, origin: el._webElement })
-              .click()
-              .perform();
-
             await retry.try(async () => {
+              await browser
+                .getActions()
+                .move({ x: 100, y: 65, origin: el._webElement })
+                .click()
+                .perform();
+              await common.sleep(2000);
               await testSubjects.click('applyFiltersPopoverButton');
               await testSubjects.missingOrFail('applyFiltersPopoverButton');
             });

--- a/test/functional/apps/visualize/_tsvb_time_series.ts
+++ b/test/functional/apps/visualize/_tsvb_time_series.ts
@@ -27,8 +27,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const browser = getService('browser');
   const kibanaServer = getService('kibanaServer');
 
-  // Failing: See https://github.com/elastic/kibana/issues/129785
-  describe.skip('visual builder', function describeIndexTests() {
+  describe('visual builder', function describeIndexTests() {
     before(async () => {
       await security.testUser.setRoles([
         'kibana_admin',


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/129840

The fix for the flaky test went in, but in the meantime it got skipped - this is unskipping the suite, it should be more stable now.