### PR TITLE
[Cases] Limit the number of alerts that can be attached to a case

### DIFF
--- a/src/core/server/saved_objects/service/lib/aggregations/aggs_types/metrics_aggs.ts
+++ b/src/core/server/saved_objects/service/lib/aggregations/aggs_types/metrics_aggs.ts
@@ -19,6 +19,7 @@ import { sortSchema } from './common_schemas';
  * - max
  * - sum
  * - top_hits
+ * - value_count
  * - weighted_avg
  *
  * Not implemented:
@@ -75,6 +76,9 @@ export const metricsAggsSchemas: Record<string, ObjectType> = {
     track_scores: s.maybe(s.boolean()),
     highlight: s.maybe(s.any()),
     _source: s.maybe(s.oneOf([s.boolean(), s.string(), s.arrayOf(s.string())])),
+  }),
+  value_count: s.object({
+    field: s.maybe(s.string()),
   }),
   weighted_avg: s.object({
     format: s.maybe(s.string()),

--- a/x-pack/plugins/cases/common/constants.ts
+++ b/x-pack/plugins/cases/common/constants.ts
@@ -99,6 +99,9 @@ export const SUPPORTED_CONNECTORS = [
  */
 export const MAX_ALERTS_PER_CASE = 1000 as const;
 
+/**
+ * Owner
+ */
 export const SECURITY_SOLUTION_OWNER = 'securitySolution' as const;
 export const OBSERVABILITY_OWNER = 'observability' as const;
 
@@ -113,6 +116,9 @@ export const OWNER_INFO = {
   },
 } as const;
 
+/**
+ * Searching
+ */
 export const MAX_DOCS_PER_PAGE = 10000 as const;
 export const MAX_CONCURRENT_SEARCHES = 10 as const;
 

--- a/x-pack/plugins/cases/common/constants.ts
+++ b/x-pack/plugins/cases/common/constants.ts
@@ -97,7 +97,7 @@ export const SUPPORTED_CONNECTORS = [
 /**
  * Alerts
  */
-export const MAX_ALERTS_PER_CASE = 5000 as const;
+export const MAX_ALERTS_PER_CASE = 1000 as const;
 
 export const SECURITY_SOLUTION_OWNER = 'securitySolution' as const;
 export const OBSERVABILITY_OWNER = 'observability' as const;

--- a/x-pack/plugins/cases/server/services/attachments/index.ts
+++ b/x-pack/plugins/cases/server/services/attachments/index.ts
@@ -113,9 +113,7 @@ export class AttachmentService {
     };
   }
 
-  public async valueCountAlertsAttachedToCase(
-    params: AlertsAttachedToCaseArgs
-  ): Promise<number | undefined> {
+  public async valueCountAlertsAttachedToCase(params: AlertsAttachedToCaseArgs): Promise<number> {
     try {
       this.log.debug(`Attempting to value count alerts for case id ${params.caseId}`);
       const res = await this.executeCaseAggregations<{ alerts: { value: number } }>({
@@ -124,7 +122,7 @@ export class AttachmentService {
         aggregations: this.buildAlertsAggs('value_count'),
       });
 
-      return res?.alerts?.value;
+      return res?.alerts?.value ?? 0;
     } catch (error) {
       this.log.error(`Error while value counting alerts for case id ${params.caseId}: ${error}`);
       throw error;

--- a/x-pack/plugins/cases/server/services/attachments/index.ts
+++ b/x-pack/plugins/cases/server/services/attachments/index.ts
@@ -36,7 +36,13 @@ interface AttachedToCaseArgs extends ClientArgs {
 }
 
 type GetAllAlertsAttachToCaseArgs = AttachedToCaseArgs;
-type CountAlertsAttachedToCaseArgs = AttachedToCaseArgs;
+type AlertsAttachedToCaseArgs = AttachedToCaseArgs;
+
+interface AttachmentsAttachedToCaseArgs extends AttachedToCaseArgs {
+  attachmentType: CommentType;
+  aggregations: Record<string, estypes.AggregationsAggregationContainer>;
+}
+
 interface CountActionsAttachedToCaseArgs extends AttachedToCaseArgs {
   aggregations: Record<string, estypes.AggregationsAggregationContainer>;
 }
@@ -79,50 +85,50 @@ interface CommentStats {
 export class AttachmentService {
   constructor(private readonly log: Logger) {}
 
-  public async countAlertsAttachedToCase({
-    unsecuredSavedObjectsClient,
-    caseId,
-    filter,
-  }: CountAlertsAttachedToCaseArgs): Promise<number | undefined> {
+  public async countAlertsAttachedToCase(
+    params: AlertsAttachedToCaseArgs
+  ): Promise<number | undefined> {
     try {
-      this.log.debug(`Attempting to count alerts for case id ${caseId}`);
-      const alertsFilter = buildFilter({
-        filters: [CommentType.alert],
-        field: 'type',
-        operator: 'or',
-        type: CASE_COMMENT_SAVED_OBJECT,
+      this.log.debug(`Attempting to count alerts for case id ${params.caseId}`);
+      const res = await this.executeCaseAggregations<{ alerts: { value: number } }>({
+        ...params,
+        attachmentType: CommentType.alert,
+        aggregations: this.buildAlertsAggs('cardinality'),
       });
 
-      const combinedFilter = combineFilters([alertsFilter, filter]);
-
-      const response = await unsecuredSavedObjectsClient.find<
-        AttachmentAttributes,
-        { alerts: { value: number } }
-      >({
-        type: CASE_COMMENT_SAVED_OBJECT,
-        hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
-        page: 1,
-        perPage: 1,
-        sortField: defaultSortField,
-        aggs: this.buildCountAlertsAggs(),
-        filter: combinedFilter,
-      });
-
-      return response.aggregations?.alerts?.value;
+      return res?.alerts?.value;
     } catch (error) {
-      this.log.error(`Error while counting alerts for case id ${caseId}: ${error}`);
+      this.log.error(`Error while counting alerts for case id ${params.caseId}: ${error}`);
       throw error;
     }
   }
 
-  private buildCountAlertsAggs(): Record<string, estypes.AggregationsAggregationContainer> {
+  private buildAlertsAggs(agg: string): Record<string, estypes.AggregationsAggregationContainer> {
     return {
       alerts: {
-        cardinality: {
+        [agg]: {
           field: `${CASE_COMMENT_SAVED_OBJECT}.attributes.alertId`,
         },
       },
     };
+  }
+
+  public async valueCountAlertsAttachedToCase(
+    params: AlertsAttachedToCaseArgs
+  ): Promise<number | undefined> {
+    try {
+      this.log.debug(`Attempting to value count alerts for case id ${params.caseId}`);
+      const res = await this.executeCaseAggregations<{ alerts: { value: number } }>({
+        ...params,
+        attachmentType: CommentType.alert,
+        aggregations: this.buildAlertsAggs('value_count'),
+      });
+
+      return res?.alerts?.value;
+    } catch (error) {
+      this.log.error(`Error while value counting alerts for case id ${params.caseId}: ${error}`);
+      throw error;
+    }
   }
 
   /**
@@ -166,29 +172,27 @@ export class AttachmentService {
   }
 
   /**
-   * Executes the aggregations against the actions attached to a case.
+   * Executes the aggregations against a type of attachment attached to a case.
    */
-  public async executeCaseActionsAggregations({
+  public async executeCaseAggregations<Agg extends AggregationResponse = AggregationResponse>({
     unsecuredSavedObjectsClient,
     caseId,
     filter,
     aggregations,
-  }: CountActionsAttachedToCaseArgs): Promise<AggregationResponse | undefined> {
+    attachmentType,
+  }: AttachmentsAttachedToCaseArgs): Promise<Agg | undefined> {
     try {
-      this.log.debug(`Attempting to count actions for case id ${caseId}`);
-      const actionsFilter = buildFilter({
-        filters: [CommentType.actions],
+      this.log.debug(`Attempting to aggregate for case id ${caseId}`);
+      const attachmentFilter = buildFilter({
+        filters: attachmentType,
         field: 'type',
         operator: 'or',
         type: CASE_COMMENT_SAVED_OBJECT,
       });
 
-      const combinedFilter = combineFilters([actionsFilter, filter]);
+      const combinedFilter = combineFilters([attachmentFilter, filter]);
 
-      const response = await unsecuredSavedObjectsClient.find<
-        AttachmentAttributes,
-        AggregationResponse
-      >({
+      const response = await unsecuredSavedObjectsClient.find<AttachmentAttributes, Agg>({
         type: CASE_COMMENT_SAVED_OBJECT,
         hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
         page: 1,
@@ -200,7 +204,22 @@ export class AttachmentService {
 
       return response.aggregations;
     } catch (error) {
-      this.log.error(`Error while counting actions for case id ${caseId}: ${error}`);
+      this.log.error(`Error while executing aggregation for case id ${caseId}: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Executes the aggregations against the actions attached to a case.
+   */
+  public async executeCaseActionsAggregations(
+    params: CountActionsAttachedToCaseArgs
+  ): Promise<AggregationResponse | undefined> {
+    try {
+      this.log.debug(`Attempting to count actions for case id ${params.caseId}`);
+      return await this.executeCaseAggregations({ ...params, attachmentType: CommentType.actions });
+    } catch (error) {
+      this.log.error(`Error while counting actions for case id ${params.caseId}: ${error}`);
       throw error;
     }
   }

--- a/x-pack/plugins/cases/server/services/mocks.ts
+++ b/x-pack/plugins/cases/server/services/mocks.ts
@@ -110,6 +110,8 @@ export const createAttachmentServiceMock = (): AttachmentServiceMock => {
     countAlertsAttachedToCase: jest.fn(),
     executeCaseActionsAggregations: jest.fn(),
     getCaseCommentStats: jest.fn(),
+    valueCountAlertsAttachedToCase: jest.fn(),
+    executeCaseAggregations: jest.fn(),
   };
 
   // the cast here is required because jest.Mocked tries to include private members and would throw an error

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/post_comment.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/post_comment.ts
@@ -295,6 +295,48 @@ export default ({ getService }: FtrProviderContext): void => {
           expectedHttpCode: 400,
         });
       });
+
+      it('400s when attempting to add more than 1K alerts to a case', async () => {
+        const alerts = [...Array(1001).keys()].map((num) => `test-${num}`);
+        const postedCase = await createCase(supertest, postCaseReq);
+        await createComment({
+          supertest,
+          caseId: postedCase.id,
+          params: { ...postCommentAlertReq, alertId: alerts, index: alerts },
+          expectedHttpCode: 400,
+        });
+      });
+
+      it('400s when attempting to add more than 1K alerts to a case in multiple calls', async () => {
+        const alerts = [...Array(1000).keys()].map((num) => `test-${num}`);
+        const postedCase = await createCase(supertest, postCaseReq);
+        await createComment({
+          supertest,
+          caseId: postedCase.id,
+          params: {
+            ...postCommentAlertReq,
+            alertId: alerts.slice(0, 500),
+            index: alerts.slice(0, 500),
+          },
+        });
+
+        await createComment({
+          supertest,
+          caseId: postedCase.id,
+          params: {
+            ...postCommentAlertReq,
+            alertId: alerts.slice(500),
+            index: alerts.slice(500),
+          },
+        });
+
+        await createComment({
+          supertest,
+          caseId: postedCase.id,
+          params: postCommentAlertReq,
+          expectedHttpCode: 400,
+        });
+      });
     });
 
     describe('alerts', () => {


### PR DESCRIPTION
## Summary

This PR adds a limit to the maximum number of alerts that can be attached to a case. The limit is set to 1K and is applied to a) the total number of alerts attached to a case and b) the total number of alerts that can be saved in the doc of the `cases-comments` saved object.

Depends on https://github.com/elastic/kibana/pull/129092


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
