### PR TITLE
[Reporting/Docs] User guidance to enable reporting on Cloud (memory constraints)

### DIFF
--- a/docs/user/reporting/index.asciidoc
+++ b/docs/user/reporting/index.asciidoc
@@ -28,7 +28,7 @@ You access the options from the *Share* menu in the toolbar. The sharing options
 * *Embed code* &mdash; Embed a fully interactive dashboard or visualization as an iframe on a web page.
 
 [[reporting-on-cloud-resource-requirements]]
-NOTE: On Elastic Cloud *PDF* and *PNG* reports require minimum 2GB of memory. Visual reports
+NOTE: On Elastic Cloud *PDF* and *PNG* reports require a Kibana with minimum 2GB RAM. Visual reports
 will be more stable at higher memory capacities.
 
 [float]

--- a/docs/user/reporting/index.asciidoc
+++ b/docs/user/reporting/index.asciidoc
@@ -27,6 +27,10 @@ You access the options from the *Share* menu in the toolbar. The sharing options
 
 * *Embed code* &mdash; Embed a fully interactive dashboard or visualization as an iframe on a web page.
 
+[[reporting-on-cloud-resource-requirements]]
+NOTE: On Elastic Cloud *PDF* and *PNG* reports require minimum 2GB of memory. Visual reports
+will be more stable at higher memory capacities.
+
 [float]
 [[manually-generate-reports]]
 == Create reports

--- a/docs/user/reporting/index.asciidoc
+++ b/docs/user/reporting/index.asciidoc
@@ -28,8 +28,8 @@ You access the options from the *Share* menu in the toolbar. The sharing options
 * *Embed code* &mdash; Embed a fully interactive dashboard or visualization as an iframe on a web page.
 
 [[reporting-on-cloud-resource-requirements]]
-NOTE: On Elastic Cloud *PDF* and *PNG* reports require a Kibana with minimum 2GB RAM. Visual reports
-will be more stable at higher memory capacities.
+NOTE: On Elastic Cloud, Kibana requires a minimum of 2GB RAM to generate PDF or PNG reports. To edit Kibana deployments,
+use {ess-console}[Cloud Management].
 
 [float]
 [[manually-generate-reports]]


### PR DESCRIPTION
## Summary

Today, when a new Kibana is started and a user attempts to generate a PDF/PNG report it will fail due to CPU/memory constraints. This contribution adds guidance to our docs. In future work we will drive this UX from the Kibana UI to ensure that we don't fail in production (as we do today).

## Screenshots

<img width="895" alt="Screenshot 2022-04-14 at 11 23 42" src="https://user-images.githubusercontent.com/8155004/163355684-5584b73a-4743-49a1-a1f8-e5b93933e52e.png">

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
