### PR TITLE
[Security Solution] Fix empty User entry on All Users page

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/empty_value/__snapshots__/empty_value.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/common/components/empty_value/__snapshots__/empty_value.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`EmptyValue it renders against snapshot 1`] = `
 <p>
-  (Empty String)
+  (Empty string)
 </p>
 `;

--- a/x-pack/plugins/security_solution/public/common/components/empty_value/empty_value.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/empty_value/empty_value.test.tsx
@@ -39,7 +39,7 @@ describe('EmptyValue', () => {
           <p>{getEmptyString()}</p>
         </ThemeProvider>
       );
-      expect(wrapper.text()).toBe('(Empty String)');
+      expect(wrapper.text()).toBe('(Empty string)');
     });
   });
 

--- a/x-pack/plugins/security_solution/public/common/components/empty_value/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/empty_value/translations.ts
@@ -10,6 +10,6 @@ import { i18n } from '@kbn/i18n';
 export const EMPTY_STRING = i18n.translate(
   'xpack.securitySolution.emptyString.emptyStringDescription',
   {
-    defaultMessage: 'Empty String',
+    defaultMessage: 'Empty string',
   }
 );

--- a/x-pack/plugins/security_solution/public/common/components/tables/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/tables/helpers.test.tsx
@@ -58,7 +58,7 @@ describe('Table Helpers', () => {
       });
       const wrapper = mount(<TestProviders>{rowItem}</TestProviders>);
       expect(wrapper.find('[data-test-subj="render-content-attrName"]').first().text()).toBe(
-        '(Empty String)'
+        '(Empty string)'
       );
     });
 
@@ -119,7 +119,7 @@ describe('Table Helpers', () => {
       });
       const wrapper = mount(<TestProviders>{rowItems}</TestProviders>);
       expect(wrapper.find('[data-test-subj="render-content-attrName"]').first().text()).toBe(
-        '(Empty String)'
+        '(Empty string)'
       );
     });
 

--- a/x-pack/plugins/security_solution/public/users/components/all_users/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/all_users/index.test.tsx
@@ -48,5 +48,29 @@ describe('Users Table Component', () => {
       expect(getAllByRole('columnheader').length).toBe(3);
       expect(getByText(userName)).toBeInTheDocument();
     });
+
+    test('it renders empty string token when users name is empty', () => {
+      const { getByTestId } = render(
+        <TestProviders>
+          <UsersTable
+            users={[{ name: '', lastSeen: '2019-04-08T18:35:45.064Z', domain: 'test domain' }]}
+            fakeTotalCount={50}
+            id="users"
+            loading={false}
+            loadPage={loadPage}
+            showMorePagesIndicator={false}
+            totalCount={0}
+            type={usersModel.UsersType.page}
+            sort={{
+              field: UsersFields.name,
+              direction: Direction.asc,
+            }}
+            setQuerySkip={() => {}}
+          />
+        </TestProviders>
+      );
+
+      expect(getByTestId('table-allUsers-loading-false')).toHaveTextContent('(Empty string)');
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/users/components/all_users/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/all_users/index.tsx
@@ -10,6 +10,7 @@ import { useDispatch } from 'react-redux';
 
 import { FormattedRelativePreferenceDate } from '../../../common/components/formatted_date';
 import { UserDetailsLink } from '../../../common/components/links';
+import { getOrEmptyTagFromValue } from '../../../common/components/empty_value';
 
 import {
   Columns,
@@ -66,12 +67,14 @@ const getUsersColumns = (): UsersTableColumns => [
     sortable: true,
     mobileOptions: { show: true },
     render: (name) =>
-      getRowItemDraggables({
-        rowItems: [name],
-        attrName: 'user.name',
-        idPrefix: `users-table-${name}-name`,
-        render: (item) => <UserDetailsLink userName={item} />,
-      }),
+      name != null && name.length > 0
+        ? getRowItemDraggables({
+            rowItems: [name],
+            attrName: 'user.name',
+            idPrefix: `users-table-${name}-name`,
+            render: (item) => <UserDetailsLink userName={item} />,
+          })
+        : getOrEmptyTagFromValue(name),
   },
   {
     field: 'lastSeen',
@@ -88,11 +91,13 @@ const getUsersColumns = (): UsersTableColumns => [
     truncateText: false,
     mobileOptions: { show: true },
     render: (domain) =>
-      getRowItemDraggables({
-        rowItems: [domain],
-        attrName: 'user.domain',
-        idPrefix: `users-table-${domain}-domain`,
-      }),
+      domain != null && domain.length > 0
+        ? getRowItemDraggables({
+            rowItems: [domain],
+            attrName: 'user.domain',
+            idPrefix: `users-table-${domain}-domain`,
+          })
+        : getOrEmptyTagFromValue(domain),
   },
 ];
 


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/129723

## Summary

*  Display an empty string placeholder instead of an empty string
* The empty string field isn't interactive by design.
* Applies the same fix for the domain, in case it has an empty value.

After the change:
<img width="1511" alt="Screenshot 2022-04-12 at 12 51 51" src="https://user-images.githubusercontent.com/1490444/163133814-febab056-e78f-4dcc-bc74-f84c4fcf0617.png">

Before the change:
<img width="1520" alt="Screenshot 2022-04-13 at 10 27 14" src="https://user-images.githubusercontent.com/1490444/163133826-42c9cb82-422c-4e5b-989c-51a586a239c1.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
