### PR TITLE
[ML] Fix Single Metric Viewer chart failing to load if no points during calendar event

### DIFF
--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/_timeseriesexplorer.scss
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/_timeseriesexplorer.scss
@@ -131,7 +131,6 @@
       stroke-width: 1px;
       stroke: $euiColorDarkShade;
       fill: $euiColorLightShade;
-      pointer-events: none;
     }
 
     .forecast {

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer_utils/get_focus_data.ts
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer_utils/get_focus_data.ts
@@ -148,7 +148,11 @@ export function getFocusData(
         modelPlotEnabled,
         functionDescription
       );
-      focusChartData = processScheduledEventsForChart(focusChartData, scheduledEvents);
+      focusChartData = processScheduledEventsForChart(
+        focusChartData,
+        scheduledEvents,
+        focusAggregationInterval
+      );
 
       const refreshFocusData: FocusData = {
         scheduledEvents,

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer_utils/timeseriesexplorer_utils.d.ts
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer_utils/timeseriesexplorer_utils.d.ts
@@ -21,7 +21,11 @@ export function processDataForFocusAnomalies(
   functionDescription: any
 ): any;
 
-export function processScheduledEventsForChart(chartData: any, scheduledEvents: any): any;
+export function processScheduledEventsForChart(
+  chartData: any,
+  scheduledEvents: any,
+  aggregationInterval: any
+): any;
 
 export function findNearestChartPointToTime(chartData: any, time: any): any;
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/128462 where the main Single Metric Viewer chart would fail to load if there were no source data points during a calendar event.

Extra points are now manually added to the chart for scheduled events when there is absence of source metric data at the same time.

Before:
![image](https://user-images.githubusercontent.com/7405507/162950689-3c493395-d626-435e-855d-fc7c1753dc10.png)

After:
![image](https://user-images.githubusercontent.com/7405507/162950258-758307a0-c25f-481a-8b7b-4c211cc79574.png)

Note for reviewers - the `rare` and `high_non_zero_count` detectors as shown in https://github.com/elastic/kibana/issues/128462#issuecomment-1077486135 against the `filebeat-nginx-2019.02.05` index from the `filebeat_ecs` QA snapshot can be used to reproduce this issue.

Fixes https://github.com/elastic/kibana/issues/128462
