### PR TITLE
[ML] Resizable/Collapsible Top Influencers section 

### DIFF
--- a/x-pack/plugins/ml/common/types/storage.ts
+++ b/x-pack/plugins/ml/common/types/storage.ts
@@ -15,6 +15,8 @@ export const ML_GETTING_STARTED_CALLOUT_DISMISSED = 'ml.gettingStarted.isDismiss
 
 export const ML_FROZEN_TIER_PREFERENCE = 'ml.frozenDataTierPreference';
 
+export const ML_ANOMALY_EXPLORER_PANELS = 'ml.anomalyExplorerPanels';
+
 export type PartitionFieldConfig =
   | {
       /**
@@ -42,11 +44,22 @@ export type PartitionFieldsConfig =
 
 export type ApplyTimeRangeConfig = boolean | undefined;
 
+export interface PanelState {
+  size: number;
+  isCollapsed: boolean;
+}
+
+export interface AnomalyExplorerPanelsState {
+  topInfluencers: PanelState;
+  mainPage: PanelState;
+}
+
 export type MlStorage = Partial<{
   [ML_ENTITY_FIELDS_CONFIG]: PartitionFieldsConfig;
   [ML_APPLY_TIME_RANGE_CONFIG]: ApplyTimeRangeConfig;
   [ML_GETTING_STARTED_CALLOUT_DISMISSED]: boolean | undefined;
   [ML_FROZEN_TIER_PREFERENCE]: 'exclude_frozen' | 'include_frozen';
+  [ML_ANOMALY_EXPLORER_PANELS]: AnomalyExplorerPanelsState | undefined;
 }> | null;
 
 export type MlStorageKey = keyof Exclude<MlStorage, null>;

--- a/x-pack/plugins/ml/common/types/storage.ts
+++ b/x-pack/plugins/ml/common/types/storage.ts
@@ -51,7 +51,7 @@ export interface PanelState {
 
 export interface AnomalyExplorerPanelsState {
   topInfluencers: PanelState;
-  mainPage: PanelState;
+  mainPage: { size: number };
 }
 
 export type MlStorage = Partial<{

--- a/x-pack/plugins/ml/public/application/explorer/_explorer.scss
+++ b/x-pack/plugins/ml/public/application/explorer/_explorer.scss
@@ -1,12 +1,7 @@
 $borderRadius: $euiBorderRadius / 2;
 
 .ml-explorer {
-  width: 100%;
-  display: inline-block;
-  color: $euiColorDarkShade;
-
   .results-container {
-    padding: 0 0 $euiSize 0;
 
     .no-influencers-warning {
       float: left;

--- a/x-pack/plugins/ml/public/application/explorer/_explorer.scss
+++ b/x-pack/plugins/ml/public/application/explorer/_explorer.scss
@@ -8,12 +8,6 @@ $borderRadius: $euiBorderRadius / 2;
   .results-container {
     padding: 0 0 $euiSize 0;
 
-    // SASSTODO: Overwrite of bootstrap
-    .col-xs-12 {
-      width: calc(100% - #{$euiSizeXL});
-      padding-left: $euiSize;
-    }
-
     .no-influencers-warning {
       float: left;
       padding-top: $euiSizeXS;

--- a/x-pack/plugins/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.tsx
@@ -184,19 +184,19 @@ export const Explorer: FC<ExplorerUIProps> = ({
   const topInfluencersPanelRef = useRef<HTMLDivElement | null>(null);
 
   const collapseFn = useRef<() => void | undefined>();
-  const [panelsInitialized, setPanelsInitialized] = useState(false);
+  const panelsInitialized = useRef<boolean>(false);
 
   useEffect(
     function initTopInfluencersPanelCollapse() {
       if (
-        panelsInitialized ||
+        panelsInitialized.current ||
         !collapseFn.current ||
         !topInfluencersPanelRef.current ||
         !anomalyExplorerPanelState.topInfluencers.isCollapsed
       )
         return;
 
-      setPanelsInitialized(true);
+      panelsInitialized.current = true;
 
       setTimeout(() => {
         if (collapseFn.current) {
@@ -228,6 +228,8 @@ export const Explorer: FC<ExplorerUIProps> = ({
   );
 
   const onToggleCollapsed = useCallback(() => {
+    panelsInitialized.current = true;
+
     const isCurrentlyCollapsed = anomalyExplorerPanelState.topInfluencers.isCollapsed;
 
     if (isCurrentlyCollapsed) {

--- a/x-pack/plugins/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.tsx
@@ -177,7 +177,6 @@ export const Explorer: FC<ExplorerUIProps> = ({
         size: 20,
       },
       mainPage: {
-        isCollapsed: false,
         size: 80,
       },
     });
@@ -187,32 +186,36 @@ export const Explorer: FC<ExplorerUIProps> = ({
   const collapseFn = useRef<() => void | undefined>();
   const [panelsInitialized, setPanelsInitialized] = useState(false);
 
-  // useEffect(
-  //   function initTopInfluencersPanelCollapse() {
-  //     if (
-  //       panelsInitialized ||
-  //       !collapseFn.current ||
-  //       !topInfluencersPanelRef.current ||
-  //       anomalyExplorerPanelState.topInfluencers.isCollapsed === false
-  //     )
-  //       return;
-  //
-  //     collapseFn.current();
-  //     setPanelsInitialized(true);
-  //   },
-  //   [
-  //     collapseFn.current,
-  //     panelsInitialized,
-  //     topInfluencersPanelRef.current,
-  //     anomalyExplorerPanelState,
-  //   ]
-  // );
+  useEffect(
+    function initTopInfluencersPanelCollapse() {
+      if (
+        panelsInitialized ||
+        !collapseFn.current ||
+        !topInfluencersPanelRef.current ||
+        !anomalyExplorerPanelState.topInfluencers.isCollapsed
+      )
+        return;
+
+      setPanelsInitialized(true);
+
+      setTimeout(() => {
+        if (collapseFn.current) {
+          collapseFn.current();
+        }
+      }, 0);
+    },
+    [
+      collapseFn.current,
+      panelsInitialized,
+      topInfluencersPanelRef.current,
+      anomalyExplorerPanelState,
+    ]
+  );
 
   const onPanelWidthChange = useCallback(
     (newSizes) => {
       setAnomalyExplorerPanelState({
         mainPage: {
-          ...anomalyExplorerPanelState.mainPage,
           size: newSizes.mainPage,
         },
         topInfluencers: {
@@ -225,11 +228,26 @@ export const Explorer: FC<ExplorerUIProps> = ({
   );
 
   const onToggleCollapsed = useCallback(() => {
+    const isCurrentlyCollapsed = anomalyExplorerPanelState.topInfluencers.isCollapsed;
+
+    if (isCurrentlyCollapsed) {
+      setAnomalyExplorerPanelState({
+        mainPage: {
+          size: 80,
+        },
+        topInfluencers: {
+          size: 20,
+          isCollapsed: !isCurrentlyCollapsed,
+        },
+      });
+      return;
+    }
+
     setAnomalyExplorerPanelState({
       mainPage: anomalyExplorerPanelState.mainPage,
       topInfluencers: {
         ...anomalyExplorerPanelState.topInfluencers,
-        isCollapsed: true,
+        isCollapsed: !isCurrentlyCollapsed,
       },
     });
   }, [anomalyExplorerPanelState]);
@@ -448,7 +466,8 @@ export const Explorer: FC<ExplorerUIProps> = ({
                     position: 'top',
                   },
                 ]}
-                size={anomalyExplorerPanelState.topInfluencers.size}
+                minSize={'200px'}
+                initialSize={20}
                 paddingSize={'s'}
               >
                 {noInfluencersConfigured ? (
@@ -496,7 +515,8 @@ export const Explorer: FC<ExplorerUIProps> = ({
               <EuiResizablePanel
                 id="mainPage"
                 mode="main"
-                size={anomalyExplorerPanelState.mainPage.size}
+                minSize={'70%'}
+                initialSize={80}
                 paddingSize={'s'}
               >
                 <div>

--- a/x-pack/plugins/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.tsx
@@ -621,73 +621,76 @@ export const Explorer: FC<ExplorerUIProps> = ({
           <EuiFlexItem>{mainPanelContent}</EuiFlexItem>
         </EuiFlexGroup>
       ) : (
-        <EuiResizableContainer
-          direction={isMobile ? 'vertical' : 'horizontal'}
-          onPanelWidthChange={onPanelWidthChange}
-        >
-          {(EuiResizablePanel, EuiResizableButton, actions) => {
-            collapseFn.current = () =>
-              actions.togglePanel!('topInfluencers', { direction: 'left' });
+        <div>
+          <EuiSpacer size={'s'} />
+          <EuiResizableContainer
+            direction={isMobile ? 'vertical' : 'horizontal'}
+            onPanelWidthChange={onPanelWidthChange}
+          >
+            {(EuiResizablePanel, EuiResizableButton, actions) => {
+              collapseFn.current = () =>
+                actions.togglePanel!('topInfluencers', { direction: 'left' });
 
-            return (
-              <>
-                <EuiResizablePanel
-                  panelRef={topInfluencersPanelRef}
-                  id={'topInfluencers'}
-                  mode={[
-                    'collapsible',
-                    {
-                      'data-test-subj': 'mlTopInfluencersToggle',
-                      position: 'top',
-                    },
-                  ]}
-                  minSize={'200px'}
-                  initialSize={20}
-                  paddingSize={'s'}
-                  onToggleCollapsed={onToggleCollapsed}
-                >
-                  <div data-test-subj="mlAnomalyExplorerInfluencerList">
-                    <EuiSpacer size={'s'} />
-                    <EuiTitle className="panel-title">
-                      <h2>
-                        <FormattedMessage
-                          id="xpack.ml.explorer.topInfuencersTitle"
-                          defaultMessage="Top influencers"
-                        />
-                        <EuiIconTip
-                          content={
-                            <FormattedMessage
-                              id="xpack.ml.explorer.topInfluencersTooltip"
-                              defaultMessage="View the relative impact of the top influencers in the selected time period and add them as filters on the results. Each influencer has a maximum anomaly score between 0-100 and a total anomaly score for that period."
-                            />
-                          }
-                          position="right"
-                        />
-                      </h2>
-                    </EuiTitle>
-                    {loading ? (
-                      <EuiLoadingContent lines={10} />
-                    ) : (
-                      <InfluencersList influencers={influencers} influencerFilter={applyFilter} />
-                    )}
-                  </div>
-                </EuiResizablePanel>
+              return (
+                <>
+                  <EuiResizablePanel
+                    panelRef={topInfluencersPanelRef}
+                    id={'topInfluencers'}
+                    mode={[
+                      'collapsible',
+                      {
+                        'data-test-subj': 'mlTopInfluencersToggle',
+                        position: 'top',
+                      },
+                    ]}
+                    minSize={'200px'}
+                    initialSize={20}
+                    paddingSize={'s'}
+                    onToggleCollapsed={onToggleCollapsed}
+                  >
+                    <div data-test-subj="mlAnomalyExplorerInfluencerList">
+                      <EuiSpacer size={'s'} />
+                      <EuiTitle className="panel-title">
+                        <h2>
+                          <FormattedMessage
+                            id="xpack.ml.explorer.topInfuencersTitle"
+                            defaultMessage="Top influencers"
+                          />
+                          <EuiIconTip
+                            content={
+                              <FormattedMessage
+                                id="xpack.ml.explorer.topInfluencersTooltip"
+                                defaultMessage="View the relative impact of the top influencers in the selected time period and add them as filters on the results. Each influencer has a maximum anomaly score between 0-100 and a total anomaly score for that period."
+                              />
+                            }
+                            position="right"
+                          />
+                        </h2>
+                      </EuiTitle>
+                      {loading ? (
+                        <EuiLoadingContent lines={10} />
+                      ) : (
+                        <InfluencersList influencers={influencers} influencerFilter={applyFilter} />
+                      )}
+                    </div>
+                  </EuiResizablePanel>
 
-                <EuiResizableButton />
+                  <EuiResizableButton />
 
-                <EuiResizablePanel
-                  id="mainPage"
-                  mode="main"
-                  minSize={'70%'}
-                  initialSize={80}
-                  paddingSize={'s'}
-                >
-                  {mainPanelContent}
-                </EuiResizablePanel>
-              </>
-            );
-          }}
-        </EuiResizableContainer>
+                  <EuiResizablePanel
+                    id="mainPage"
+                    mode="main"
+                    minSize={'70%'}
+                    initialSize={80}
+                    paddingSize={'s'}
+                  >
+                    {mainPanelContent}
+                  </EuiResizablePanel>
+                </>
+              );
+            }}
+          </EuiResizableContainer>
+        </div>
       )}
     </ExplorerPage>
   );

--- a/x-pack/plugins/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.tsx
@@ -187,22 +187,23 @@ export const Explorer: FC<ExplorerUIProps> = ({
   const panelsInitialized = useRef<boolean>(false);
 
   useEffect(
+    /**
+     * Preserve collapsible panel state on page load.
+     * TODO Remove when https://github.com/elastic/eui/issues/4736 is resolved.
+     */
     function initTopInfluencersPanelCollapse() {
-      if (
-        panelsInitialized.current ||
-        !collapseFn.current ||
-        !topInfluencersPanelRef.current ||
-        !anomalyExplorerPanelState.topInfluencers.isCollapsed
-      )
+      if (panelsInitialized.current || !collapseFn.current || !topInfluencersPanelRef.current)
         return;
 
       panelsInitialized.current = true;
 
-      setTimeout(() => {
-        if (collapseFn.current) {
-          collapseFn.current();
-        }
-      }, 0);
+      if (anomalyExplorerPanelState.topInfluencers.isCollapsed) {
+        setTimeout(() => {
+          if (collapseFn.current) {
+            collapseFn.current();
+          }
+        }, 0);
+      }
     },
     [
       collapseFn.current,
@@ -451,7 +452,6 @@ export const Explorer: FC<ExplorerUIProps> = ({
       <EuiResizableContainer
         direction={isMobile ? 'vertical' : 'horizontal'}
         onPanelWidthChange={onPanelWidthChange}
-        onToggleCollapsed={onToggleCollapsed}
       >
         {(EuiResizablePanel, EuiResizableButton, actions) => {
           collapseFn.current = () => actions.togglePanel!('topInfluencers', { direction: 'left' });
@@ -471,6 +471,7 @@ export const Explorer: FC<ExplorerUIProps> = ({
                 minSize={'200px'}
                 initialSize={20}
                 paddingSize={'s'}
+                onToggleCollapsed={onToggleCollapsed}
               >
                 {noInfluencersConfigured ? (
                   <div className="no-influencers-warning">

--- a/x-pack/plugins/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.tsx
@@ -624,7 +624,6 @@ export const Explorer: FC<ExplorerUIProps> = ({
         <EuiResizableContainer
           direction={isMobile ? 'vertical' : 'horizontal'}
           onPanelWidthChange={onPanelWidthChange}
-          style={{ margin: '0 -8px' }}
         >
           {(EuiResizablePanel, EuiResizableButton, actions) => {
             collapseFn.current = () =>

--- a/x-pack/plugins/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.tsx
@@ -24,6 +24,7 @@ import {
   EuiAccordion,
   EuiBadge,
   EuiResizableContainer,
+  useIsWithinBreakpoints,
 } from '@elastic/eui';
 import useObservable from 'react-use/lib/useObservable';
 import { AnnotationFlyout } from '../components/annotations/annotation_flyout';
@@ -149,6 +150,8 @@ export const Explorer: FC<ExplorerUIProps> = ({
   explorerState,
   overallSwimlaneData,
 }) => {
+  const isMobile = useIsWithinBreakpoints(['xs', 's']);
+
   const { displayWarningToast, displayDangerToast } = useToastNotificationService();
   const { anomalyTimelineStateService, anomalyExplorerCommonStateService, chartsStateService } =
     useAnomalyExplorerContext();
@@ -343,7 +346,7 @@ export const Explorer: FC<ExplorerUIProps> = ({
       queryString={queryString}
       updateLanguage={updateLanguage}
     >
-      <EuiResizableContainer>
+      <EuiResizableContainer direction={isMobile ? 'vertical' : 'horizontal'}>
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
             <EuiResizablePanel
@@ -357,7 +360,7 @@ export const Explorer: FC<ExplorerUIProps> = ({
               ]}
               initialSize={20}
               minSize="10%"
-              paddingSize={'s'}
+              paddingSize={'none'}
             >
               {noInfluencersConfigured ? (
                 <div className="no-influencers-warning">
@@ -399,9 +402,9 @@ export const Explorer: FC<ExplorerUIProps> = ({
               )}
             </EuiResizablePanel>
 
-            <EuiResizableButton />
+            <EuiResizableButton style={{ margin: '0 8px' }} />
 
-            <EuiResizablePanel mode="main" initialSize={80} minSize="50px" paddingSize={'s'}>
+            <EuiResizablePanel mode="main" initialSize={80} minSize="50px" paddingSize={'none'}>
               <div>
                 <EuiSpacer size="m" />
                 {stoppedPartitions && (


### PR DESCRIPTION
## Summary

- Makes the Top influencers panel resizable and collapsible 
- Stored the collapsed state in the localStorage 

![Apr-13-2022 16-25-52](https://user-images.githubusercontent.com/5236598/163202810-5e3f5bf4-7ff6-4fa8-93d8-02358c38c0a6.gif)

I also wanted to store the size of the panels but it's not possible at the moment (https://github.com/elastic/eui/issues/5789)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)