### PR TITLE
chore(NA): upgrades rules_node_js to v5.4.0

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -10,8 +10,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch Node.js rules
 http_archive(
   name = "build_bazel_rules_nodejs",
-  sha256 = "523da2d6b50bc00eaf14b00ed28b1a366b3ab456e14131e9812558b26599125c",
-  urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.3.1/rules_nodejs-5.3.1.tar.gz"],
+  sha256 = "2b2004784358655f334925e7eadc7ba80f701144363df949b3293e1ae7a2fb7b",
+  urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.4.0/rules_nodejs-5.4.0.tar.gz"],
 )
 
 # Build Node.js rules dependencies

--- a/package.json
+++ b/package.json
@@ -456,7 +456,7 @@
     "@babel/traverse": "^7.17.3",
     "@babel/types": "^7.17.0",
     "@bazel/ibazel": "^0.16.2",
-    "@bazel/typescript": "5.3.1",
+    "@bazel/typescript": "5.4.0",
     "@cypress/code-coverage": "^3.9.12",
     "@cypress/snapshot": "^2.1.7",
     "@cypress/webpack-preprocessor": "^5.6.0",

--- a/src/dev/bazel/pkg_npm_types.bzl
+++ b/src/dev/bazel/pkg_npm_types.bzl
@@ -6,7 +6,7 @@
 # Side Public License, v 1.
 #
 
-load("@npm//@bazel/typescript/internal:ts_config.bzl", "TsConfigInfo")
+load("@rules_nodejs//nodejs/private:ts_config.bzl", "TsConfigInfo")
 load("@build_bazel_rules_nodejs//:providers.bzl", "run_node", "LinkablePackageInfo", "DeclarationInfo", "declaration_info")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "module_mappings_aspect")
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,21 +1228,21 @@
   resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.16.2.tgz#05dd7f06659759fda30f87b15534f1e42f1201bb"
   integrity sha512-KgqAWMH0emL6f3xH6nqyTryoBMqlJ627LBIe9PT1PRRQPz2FtHib3FIHJPukp1slzF3hJYZvdiVwgPnHbaSOOA==
 
-"@bazel/typescript@5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-5.3.1.tgz#f996abebfa57a29a170a83d0c84780286f06cb72"
-  integrity sha512-fP0fGzLbsOVdbAn6mlrX1LBAT0TJ+S0VVOap9SSSXCb2PknnKEHZupUww/raVSczy+cqcd/Vfpllzm/AcdOmyw==
+"@bazel/typescript@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-5.4.0.tgz#0a24e8d47152728f71b26b73adc3913645e5309e"
+  integrity sha512-AWmS9HcnjqGsPQv5lnqecA8xof+d4ChpbI/Z6aiSM0qOemc8e1WT9wb1VzM6g6hRfV5foWyIHt0VhTonTsPhYw==
   dependencies:
-    "@bazel/worker" "5.3.1"
+    "@bazel/worker" "5.4.0"
     protobufjs "6.8.8"
     semver "5.6.0"
     source-map-support "0.5.9"
     tsutils "3.21.0"
 
-"@bazel/worker@5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-5.3.1.tgz#87d850fdfc22cde24f380961f66daa5cbfd4acf7"
-  integrity sha512-KB+Xs198NLhN01zhlOPr/VEmz/tzwGq/pI1gdnCTLDMTCspV6LnJaIeGgicXuKrzz0V1LhvlvsI5lqJt9yuGYw==
+"@bazel/worker@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-5.4.0.tgz#ce50e34951ccf7233b651f0be665bbd43d7ed7f1"
+  integrity sha512-Rtkol9WoYs0NCZl1wt4Q8T7Rs0wbQjIvFiJzVeeoC/00TG0e/qi4mYE5iQwUJmO8st3N8VnaWz2N31UHc6yhRA==
   dependencies:
     google-protobuf "^3.6.1"
 


### PR DESCRIPTION
This PR upgrades the rules nodejs version we use into the latest one which brings fixes for rules that were acting differently across OS.