### PR TITLE
Fix explore tables don't display data when a global filter is applied

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/search_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/search_bar/index.tsx
@@ -8,7 +8,7 @@
 import { set } from '@elastic/safer-lodash-set/fp';
 import { getOr } from 'lodash/fp';
 import React, { memo, useEffect, useCallback, useMemo } from 'react';
-import { connect, ConnectedProps } from 'react-redux';
+import { connect, ConnectedProps, useDispatch } from 'react-redux';
 import { Dispatch } from 'redux';
 import { Subscription } from 'rxjs';
 import styled from 'styled-components';
@@ -35,10 +35,11 @@ import {
   startSelector,
   toStrSelector,
 } from './selectors';
-import { hostsActions } from '../../../hosts/store';
-import { networkActions } from '../../../network/store';
 import { timelineActions } from '../../../timelines/store/timeline';
 import { useKibana } from '../../lib/kibana';
+import { usersActions } from '../../../users/store';
+import { hostsActions } from '../../../hosts/store';
+import { networkActions } from '../../../network/store';
 
 const APP_STATE_STORAGE_KEY = 'securitySolution.searchBar.appState';
 
@@ -91,16 +92,25 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
       },
     } = useKibana().services;
 
+    const dispatch = useDispatch();
+    const setTablesActivePageToZero = useCallback(() => {
+      dispatch(usersActions.setUsersTablesActivePageToZero());
+      dispatch(hostsActions.setHostTablesActivePageToZero());
+      dispatch(networkActions.setNetworkTablesActivePageToZero());
+    }, [dispatch]);
+
     useEffect(() => {
       if (fromStr != null && toStr != null) {
         timefilter.setTime({ from: fromStr, to: toStr });
       } else if (start != null && end != null) {
+        setTablesActivePageToZero();
+
         timefilter.setTime({
           from: new Date(start).toISOString(),
           to: new Date(end).toISOString(),
         });
       }
-    }, [end, fromStr, start, timefilter, toStr]);
+    }, [end, fromStr, start, timefilter, toStr, setTablesActivePageToZero]);
 
     const onQuerySubmit = useCallback(
       (payload: { dateRange: TimeRange; query?: Query }) => {
@@ -119,6 +129,7 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
           isQuickSelection,
           updateTime: false,
           filterManager,
+          setTablesActivePageToZero,
         };
         let isStateUpdated = false;
 
@@ -164,6 +175,7 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
         filterQuery,
         queries,
         updateSearch,
+        setTablesActivePageToZero,
       ]
     );
 
@@ -178,12 +190,13 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
             isQuickSelection: true,
             updateTime: true,
             filterManager,
+            setTablesActivePageToZero,
           });
         } else {
           queries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
         }
       },
-      [updateSearch, id, filterManager, queries]
+      [updateSearch, id, filterManager, queries, setTablesActivePageToZero]
     );
 
     const onSaved = useCallback(
@@ -209,6 +222,7 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
           isQuickSelection,
           updateTime: false,
           filterManager,
+          setTablesActivePageToZero,
         };
 
         if (savedQueryUpdated.attributes.timefilter) {
@@ -226,7 +240,7 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
 
         updateSearch(updateSearchBar);
       },
-      [id, toStr, end, fromStr, start, filterManager, updateSearch]
+      [id, toStr, end, fromStr, start, filterManager, updateSearch, setTablesActivePageToZero]
     );
 
     const onClearSavedQuery = useCallback(() => {
@@ -246,9 +260,20 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
           resetSavedQuery: true,
           savedQuery: undefined,
           filterManager,
+          setTablesActivePageToZero,
         });
       }
-    }, [savedQuery, updateSearch, id, toStr, end, fromStr, start, filterManager]);
+    }, [
+      savedQuery,
+      updateSearch,
+      id,
+      toStr,
+      end,
+      fromStr,
+      start,
+      filterManager,
+      setTablesActivePageToZero,
+    ]);
 
     const saveAppStateToStorage = useCallback(
       (filters: Filter[]) => storage.set(APP_STATE_STORAGE_KEY, filters),
@@ -273,6 +298,8 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
                 id,
                 filters: filterManager.getFilters(),
               });
+
+              setTablesActivePageToZero();
             }
           },
         })
@@ -369,6 +396,7 @@ interface UpdateReduxSearchBar extends OnTimeChangeProps {
   resetSavedQuery?: boolean;
   timelineId?: string;
   updateTime: boolean;
+  setTablesActivePageToZero: () => void;
 }
 
 export const dispatchUpdateSearch =
@@ -385,6 +413,7 @@ export const dispatchUpdateSearch =
     timelineId,
     filterManager,
     updateTime = false,
+    setTablesActivePageToZero,
   }: UpdateReduxSearchBar): void => {
     if (updateTime) {
       const fromDate = formatDate(start);
@@ -446,8 +475,7 @@ export const dispatchUpdateSearch =
       dispatch(inputsActions.setSavedQuery({ id, savedQuery }));
     }
 
-    dispatch(hostsActions.setHostTablesActivePageToZero());
-    dispatch(networkActions.setNetworkTablesActivePageToZero());
+    setTablesActivePageToZero();
   };
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/129986
## Summary
Tables inside security explore had the unexpected behaviour of persisting the selected page when the filter or time range changed. So when users changed the filter or time range and fewer items were returned, the table would still display the previously selected page even though that page had no data.

**Impact: Every table inside Security Solutions / Explore**

### How to reproduce it
* Open kibana security
* Open Host page
* Select the second page on all host's table 
* Hover a `host.name` on the table and click on  `filter in`

### Current behaviour
The table shows 0 items

### Expected behaviour
The table should reset the page selection when the query, filter, or time range changes.

### Before fix
![Apr-12-2022 11-03-20](https://user-images.githubusercontent.com/1490444/162923550-133465ef-7a51-42ba-b2cc-d0cec62af28a.gif)

### After fix
![Apr-12-2022 17-15-22](https://user-images.githubusercontent.com/1490444/162995636-f00e6f19-3c9b-4bd0-aee3-4d36e34f2154.gif)

