### PR TITLE
[SecuritySolution] Remove the cell hovers actions for agent status

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.test.tsx
@@ -14,6 +14,7 @@ import { TestProviders } from '../../../mock';
 import { EventFieldsData } from '../types';
 import { AlertSummaryRow } from '../helpers';
 import { TimelineId } from '../../../../../common/types';
+import { AGENT_STATUS_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
 
 jest.mock('../../../lib/kibana');
 
@@ -52,6 +53,27 @@ const enrichedHostIpData: AlertSummaryRow['description'] = {
   values: [...hostIpValues],
 };
 
+const enrichedAgentStatusData: AlertSummaryRow['description'] = {
+  data: {
+    field: AGENT_STATUS_FIELD_NAME,
+    format: '',
+    type: '',
+    aggregatable: false,
+    description: '',
+    example: '',
+    category: '',
+    fields: {},
+    indexes: [],
+    name: AGENT_STATUS_FIELD_NAME,
+    searchable: false,
+    readFromDocValues: false,
+    isObjectArray: false,
+  },
+  eventId,
+  values: [],
+  timelineId: TimelineId.test,
+};
+
 describe('SummaryValueCell', () => {
   test('it should render', async () => {
     render(
@@ -64,14 +86,26 @@ describe('SummaryValueCell', () => {
     expect(screen.getAllByTestId('test-filter-out')).toHaveLength(1);
   });
 
-  describe('When in the timeline flyout with timelineId active', () => {
-    test('it should not render the default hover actions', async () => {
+  describe('Without hover actions', () => {
+    test('When in the timeline flyout with timelineId active', async () => {
       render(
         <TestProviders>
           <SummaryValueCell {...enrichedHostIpData} timelineId={TimelineId.active} />
         </TestProviders>
       );
       hostIpValues.forEach((ipValue) => expect(screen.getByText(ipValue)).toBeInTheDocument());
+      expect(screen.queryByTestId('test-filter-for')).toBeNull();
+      expect(screen.queryByTestId('test-filter-out')).toBeNull();
+    });
+
+    test('When rendering the host status field', async () => {
+      render(
+        <TestProviders>
+          <SummaryValueCell {...enrichedAgentStatusData} />
+        </TestProviders>
+      );
+
+      expect(screen.getByTestId('event-field-agent.status')).toBeInTheDocument();
       expect(screen.queryByTestId('test-filter-for')).toBeNull();
       expect(screen.queryByTestId('test-filter-out')).toBeNull();
     });

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.tsx
@@ -12,6 +12,10 @@ import { FieldValueCell } from './field_value_cell';
 import { AlertSummaryRow } from '../helpers';
 import { TimelineId } from '../../../../../common/types';
 
+import { AGENT_STATUS_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
+
+const FIELDS_WITHOUT_ACTIONS = [AGENT_STATUS_FIELD_NAME];
+
 export const SummaryValueCell: React.FC<AlertSummaryRow['description']> = ({
   data,
   eventId,
@@ -33,19 +37,21 @@ export const SummaryValueCell: React.FC<AlertSummaryRow['description']> = ({
       style={{ flexGrow: 0 }}
       values={values}
     />
-    {timelineId !== TimelineId.active && !isReadOnly && (
-      <ActionCell
-        contextId={timelineId}
-        data={data}
-        eventId={eventId}
-        fieldFromBrowserField={fieldFromBrowserField}
-        linkValue={linkValue}
-        timelineId={timelineId}
-        values={values}
-        applyWidthAndPadding={false}
-        hideAddToTimeline={false}
-      />
-    )}
+    {timelineId !== TimelineId.active &&
+      !isReadOnly &&
+      !FIELDS_WITHOUT_ACTIONS.includes(data.field) && (
+        <ActionCell
+          contextId={timelineId}
+          data={data}
+          eventId={eventId}
+          fieldFromBrowserField={fieldFromBrowserField}
+          linkValue={linkValue}
+          timelineId={timelineId}
+          values={values}
+          applyWidthAndPadding={false}
+          hideAddToTimeline={false}
+        />
+      )}
   </>
 );
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.tsx
@@ -14,7 +14,7 @@ import { TimelineId } from '../../../../../common/types';
 
 import { AGENT_STATUS_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
 
-const FIELDS_WITHOUT_ACTIONS = [AGENT_STATUS_FIELD_NAME];
+const FIELDS_WITHOUT_ACTIONS: { [field: string]: boolean } = { [AGENT_STATUS_FIELD_NAME]: true };
 
 export const SummaryValueCell: React.FC<AlertSummaryRow['description']> = ({
   data,
@@ -37,21 +37,19 @@ export const SummaryValueCell: React.FC<AlertSummaryRow['description']> = ({
       style={{ flexGrow: 0 }}
       values={values}
     />
-    {timelineId !== TimelineId.active &&
-      !isReadOnly &&
-      !FIELDS_WITHOUT_ACTIONS.includes(data.field) && (
-        <ActionCell
-          contextId={timelineId}
-          data={data}
-          eventId={eventId}
-          fieldFromBrowserField={fieldFromBrowserField}
-          linkValue={linkValue}
-          timelineId={timelineId}
-          values={values}
-          applyWidthAndPadding={false}
-          hideAddToTimeline={false}
-        />
-      )}
+    {timelineId !== TimelineId.active && !isReadOnly && !FIELDS_WITHOUT_ACTIONS[data.field] && (
+      <ActionCell
+        contextId={timelineId}
+        data={data}
+        eventId={eventId}
+        fieldFromBrowserField={fieldFromBrowserField}
+        linkValue={linkValue}
+        timelineId={timelineId}
+        values={values}
+        applyWidthAndPadding={false}
+        hideAddToTimeline={false}
+      />
+    )}
   </>
 );
 


### PR DESCRIPTION

## Summary

As discussed in https://github.com/elastic/kibana/issues/127010, the `agent.status` cell should not have hover actions since the user cannot take actions on that field:


https://user-images.githubusercontent.com/68591/163014904-f1481cab-dd69-40b3-8965-1968bb10303e.mov




### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios