### PR TITLE
[RAM] Rename "trigger actions" to "state" in rule list/summary

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.tsx
@@ -271,8 +271,8 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
                   <EuiText size="s">
                     <p>
                       <FormattedMessage
-                        id="xpack.triggersActionsUI.sections.ruleDetails.triggerActionsTitle"
-                        defaultMessage="Trigger actions"
+                        id="xpack.triggersActionsUI.sections.ruleDetails.stateTitle"
+                        defaultMessage="State"
                       />
                     </p>
                   </EuiText>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
@@ -832,8 +832,8 @@ export const RulesList: React.FunctionComponent = () => {
       {
         field: 'enabled',
         name: i18n.translate(
-          'xpack.triggersActionsUI.sections.rulesList.rulesListTable.columns.triggerActionsTitle',
-          { defaultMessage: 'Trigger actions' }
+          'xpack.triggersActionsUI.sections.rulesList.rulesListTable.columns.stateTitle',
+          { defaultMessage: 'State' }
         ),
         sortable: true,
         truncateText: false,


### PR DESCRIPTION
## Summary

Resolves: https://github.com/elastic/kibana/issues/129815

Renames "trigger actions" to "state" in the rule list and rule summary components in `triggers_actions_ui`