### PR TITLE
[Lens] Fixes partition legend visibility

### DIFF
--- a/src/plugins/chart_expressions/expression_partition_vis/public/components/partition_vis_component.tsx
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/components/partition_vis_component.tsx
@@ -127,12 +127,8 @@ const PartitionVisComponent = (props: PartitionVisComponentProps) => {
 
   useEffect(() => {
     const legendShow = showLegendDefault();
-    const showLegendDef = shouldShowLegend(visType, visParams.legendDisplay, bucketColumns);
-    if (showLegendDef !== legendShow) {
-      setShowLegend(legendShow);
-      props.uiState?.set('vis.legendOpen', legendShow);
-    }
-  }, [showLegendDefault, props.uiState, visParams.legendDisplay, visType, bucketColumns]);
+    setShowLegend(legendShow);
+  }, [showLegendDefault]);
 
   const onRenderChange = useCallback<RenderChangeListener>(
     (isRendered) => {

--- a/src/plugins/vis_types/pie/public/editor/components/pie.tsx
+++ b/src/plugins/vis_types/pie/public/editor/components/pie.tsx
@@ -103,8 +103,8 @@ const PieOptions = (props: PieOptionsProps) => {
   );
 
   useEffect(() => {
-    setLegendVisibility(legendUiStateValue);
-  }, [legendUiStateValue]);
+    setLegendVisibility(legendUiStateValue ?? stateParams.legendDisplay === LegendDisplay.SHOW);
+  }, [legendUiStateValue, stateParams.legendDisplay]);
 
   useEffect(() => {
     const fetchPalettes = async () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/130096

By fixing this https://github.com/elastic/kibana/pull/129336 I created a bug in Lens partition pies. Specifically, the legend settings (show, hide) are not respected anymore.

This PR is fixing this. Things that need to be tested:

- I can create or edit a Lens partition chart and the legend visibility settings are working properly
- I can create edit a visualize pie chart and the legend visibility settings are working properly. Important note here: The legend visibility can change either from the options or from  the bottom left icon. Try them both!
- This bug https://github.com/elastic/kibana/pull/129336 is still fixed
![pie1](https://user-images.githubusercontent.com/17003240/163149204-f9efe7b2-c589-494e-be59-3cde3fb2f0e8.gif)
![pie2](https://user-images.githubusercontent.com/17003240/163149245-34f98021-f8a3-4b4d-86f2-eaa137433a9f.gif)

