### PR TITLE
Unskip session cleanup API integration tests.

### DIFF
--- a/x-pack/test/security_api_integration/session_idle.config.ts
+++ b/x-pack/test/security_api_integration/session_idle.config.ts
@@ -51,6 +51,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
             saml_disable: { order: 3, realm: 'saml1', session: { idleTimeout: 0 } },
           },
         })}`,
+        // Exclude Uptime tasks to not interfere (additional ES load) with the session cleanup task.
+        `--xpack.task_manager.unsafe.exclude_task_types=${JSON.stringify(['UPTIME:*'])}`,
       ],
     },
 

--- a/x-pack/test/security_api_integration/session_lifespan.config.ts
+++ b/x-pack/test/security_api_integration/session_lifespan.config.ts
@@ -51,6 +51,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
             saml_disable: { order: 3, realm: 'saml1', session: { lifespan: 0 } },
           },
         })}`,
+        // Exclude Uptime tasks to not interfere (additional ES load) with the session cleanup task.
+        `--xpack.task_manager.unsafe.exclude_task_types=${JSON.stringify(['UPTIME:*'])}`,
       ],
     },
 

--- a/x-pack/test/security_api_integration/tests/session_idle/cleanup.ts
+++ b/x-pack/test/security_api_integration/tests/session_idle/cleanup.ts
@@ -9,7 +9,7 @@ import { parse as parseCookie, Cookie } from 'tough-cookie';
 import { setTimeout as setTimeoutAsync } from 'timers/promises';
 import expect from '@kbn/expect';
 import { adminTestUser } from '@kbn/test';
-import type { AuthenticationProvider } from '../../../../plugins/security/common/model';
+import type { AuthenticationProvider } from '../../../../plugins/security/common';
 import { getSAMLRequestId, getSAMLResponse } from '../../fixtures/saml/saml_tools';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
@@ -76,8 +76,7 @@ export default function ({ getService }: FtrProviderContext) {
     return cookie;
   }
 
-  // FLAKY: https://github.com/elastic/kibana/issues/121482
-  describe.skip('Session Idle cleanup', () => {
+  describe('Session Idle cleanup', () => {
     beforeEach(async () => {
       await es.cluster.health({ index: '.kibana_security_session*', wait_for_status: 'green' });
       await esDeleteAllIndices('.kibana_security_session*');


### PR DESCRIPTION
## Summary

Unskip session cleanup API integration tests.

Flaky test runs:

* x100 (with `Uptime` task) :heavy_check_mark: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/443
* x50 (without `Uptime` task) :heavy_check_mark: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/444

__Fixes: https://github.com/elastic/kibana/issues/121482__