### PR TITLE
[Cases] Use the bulk create attachment endpoint on the UI

### DIFF
--- a/x-pack/plugins/cases/public/components/add_comment/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/index.test.tsx
@@ -14,17 +14,17 @@ import { TestProviders } from '../../common/mock';
 
 import { CommentRequest, CommentType } from '../../../common/api';
 import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
-import { usePostComment } from '../../containers/use_post_comment';
+import { useBulkCreateAttachments } from '../../containers/use_bulk_create_attachments';
 import { AddComment, AddCommentProps, AddCommentRefObject } from '.';
 import { CasesTimelineIntegrationProvider } from '../timeline_context';
 import { timelineIntegrationMock } from '../__mock__/timeline';
 
-jest.mock('../../containers/use_post_comment');
+jest.mock('../../containers/use_bulk_create_attachments');
 
-const usePostCommentMock = usePostComment as jest.Mock;
+const useBulkCreateAttachmentsMock = useBulkCreateAttachments as jest.Mock;
 const onCommentSaving = jest.fn();
 const onCommentPosted = jest.fn();
-const postComment = jest.fn();
+const bulkCreateAttachments = jest.fn();
 
 const addCommentProps: AddCommentProps = {
   id: 'newComment',
@@ -36,10 +36,10 @@ const addCommentProps: AddCommentProps = {
   statusActionButton: null,
 };
 
-const defaultPostComment = {
+const defaultResponse = {
   isLoading: false,
   isError: false,
-  postComment,
+  bulkCreateAttachments,
 };
 
 const sampleData: CommentRequest = {
@@ -51,7 +51,7 @@ const sampleData: CommentRequest = {
 describe('AddComment ', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    usePostCommentMock.mockImplementation(() => defaultPostComment);
+    useBulkCreateAttachmentsMock.mockImplementation(() => defaultResponse);
   });
 
   it('should post comment on submit click', async () => {
@@ -72,7 +72,7 @@ describe('AddComment ', () => {
     wrapper.find(`[data-test-subj="submit-comment"]`).first().simulate('click');
     await waitFor(() => {
       expect(onCommentSaving).toBeCalled();
-      expect(postComment).toBeCalledWith({
+      expect(bulkCreateAttachments).toBeCalledWith({
         caseId: addCommentProps.caseId,
         data: sampleData,
         updateCase: onCommentPosted,
@@ -82,7 +82,10 @@ describe('AddComment ', () => {
   });
 
   it('should render spinner and disable submit when loading', () => {
-    usePostCommentMock.mockImplementation(() => ({ ...defaultPostComment, isLoading: true }));
+    useBulkCreateAttachmentsMock.mockImplementation(() => ({
+      ...defaultResponse,
+      isLoading: true,
+    }));
     const wrapper = mount(
       <TestProviders>
         <AddComment {...{ ...addCommentProps, showLoading: true }} />
@@ -96,7 +99,10 @@ describe('AddComment ', () => {
   });
 
   it('should disable submit button when isLoading is true', () => {
-    usePostCommentMock.mockImplementation(() => ({ ...defaultPostComment, isLoading: true }));
+    useBulkCreateAttachmentsMock.mockImplementation(() => ({
+      ...defaultResponse,
+      isLoading: true,
+    }));
     const wrapper = mount(
       <TestProviders>
         <AddComment {...addCommentProps} />
@@ -109,7 +115,10 @@ describe('AddComment ', () => {
   });
 
   it('should hide the component when the user does not have crud permissions', () => {
-    usePostCommentMock.mockImplementation(() => ({ ...defaultPostComment, isLoading: true }));
+    useBulkCreateAttachmentsMock.mockImplementation(() => ({
+      ...defaultResponse,
+      isLoading: true,
+    }));
     const wrapper = mount(
       <TestProviders>
         <AddComment {...{ ...addCommentProps, userCanCrud: false }} />

--- a/x-pack/plugins/cases/public/components/add_comment/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/index.test.tsx
@@ -14,17 +14,17 @@ import { TestProviders } from '../../common/mock';
 
 import { CommentRequest, CommentType } from '../../../common/api';
 import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
-import { useBulkCreateAttachments } from '../../containers/use_bulk_create_attachments';
+import { useCreateAttachments } from '../../containers/use_create_attachments';
 import { AddComment, AddCommentProps, AddCommentRefObject } from '.';
 import { CasesTimelineIntegrationProvider } from '../timeline_context';
 import { timelineIntegrationMock } from '../__mock__/timeline';
 
-jest.mock('../../containers/use_bulk_create_attachments');
+jest.mock('../../containers/use_create_attachments');
 
-const useBulkCreateAttachmentsMock = useBulkCreateAttachments as jest.Mock;
+const useCreateAttachmentsMock = useCreateAttachments as jest.Mock;
 const onCommentSaving = jest.fn();
 const onCommentPosted = jest.fn();
-const bulkCreateAttachments = jest.fn();
+const createAttachments = jest.fn();
 
 const addCommentProps: AddCommentProps = {
   id: 'newComment',
@@ -39,7 +39,7 @@ const addCommentProps: AddCommentProps = {
 const defaultResponse = {
   isLoading: false,
   isError: false,
-  bulkCreateAttachments,
+  createAttachments,
 };
 
 const sampleData: CommentRequest = {
@@ -51,7 +51,7 @@ const sampleData: CommentRequest = {
 describe('AddComment ', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useBulkCreateAttachmentsMock.mockImplementation(() => defaultResponse);
+    useCreateAttachmentsMock.mockImplementation(() => defaultResponse);
   });
 
   it('should post comment on submit click', async () => {
@@ -72,7 +72,7 @@ describe('AddComment ', () => {
     wrapper.find(`[data-test-subj="submit-comment"]`).first().simulate('click');
     await waitFor(() => {
       expect(onCommentSaving).toBeCalled();
-      expect(bulkCreateAttachments).toBeCalledWith({
+      expect(createAttachments).toBeCalledWith({
         caseId: addCommentProps.caseId,
         data: sampleData,
         updateCase: onCommentPosted,
@@ -82,7 +82,7 @@ describe('AddComment ', () => {
   });
 
   it('should render spinner and disable submit when loading', () => {
-    useBulkCreateAttachmentsMock.mockImplementation(() => ({
+    useCreateAttachmentsMock.mockImplementation(() => ({
       ...defaultResponse,
       isLoading: true,
     }));
@@ -99,7 +99,7 @@ describe('AddComment ', () => {
   });
 
   it('should disable submit button when isLoading is true', () => {
-    useBulkCreateAttachmentsMock.mockImplementation(() => ({
+    useCreateAttachmentsMock.mockImplementation(() => ({
       ...defaultResponse,
       isLoading: true,
     }));
@@ -115,7 +115,7 @@ describe('AddComment ', () => {
   });
 
   it('should hide the component when the user does not have crud permissions', () => {
-    useBulkCreateAttachmentsMock.mockImplementation(() => ({
+    useCreateAttachmentsMock.mockImplementation(() => ({
       ...defaultResponse,
       isLoading: true,
     }));

--- a/x-pack/plugins/cases/public/components/add_comment/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/index.test.tsx
@@ -74,7 +74,7 @@ describe('AddComment ', () => {
       expect(onCommentSaving).toBeCalled();
       expect(createAttachments).toBeCalledWith({
         caseId: addCommentProps.caseId,
-        data: sampleData,
+        data: [sampleData],
         updateCase: onCommentPosted,
       });
       expect(wrapper.find(`[data-test-subj="add-comment"] textarea`).text()).toBe('');

--- a/x-pack/plugins/cases/public/components/add_comment/index.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/index.tsx
@@ -114,7 +114,7 @@ export const AddComment = React.memo(
           }
           createAttachments({
             caseId,
-            data: { ...data, type: CommentType.user, owner: owner[0] },
+            data: [{ ...data, type: CommentType.user, owner: owner[0] }],
             updateCase: onCommentPosted,
           });
           reset();

--- a/x-pack/plugins/cases/public/components/add_comment/index.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/index.tsx
@@ -18,7 +18,7 @@ import styled from 'styled-components';
 import { isEmpty } from 'lodash';
 
 import { CommentType } from '../../../common/api';
-import { usePostComment } from '../../containers/use_post_comment';
+import { useBulkCreateAttachments } from '../../containers/use_bulk_create_attachments';
 import { Case } from '../../containers/types';
 import { EuiMarkdownEditorRef, MarkdownEditorForm } from '../markdown_editor';
 import { Form, useForm, UseField, useFormData } from '../../common/shared_imports';
@@ -71,7 +71,7 @@ export const AddComment = React.memo(
       const editorRef = useRef<EuiMarkdownEditorRef>(null);
       const [focusOnContext, setFocusOnContext] = useState(false);
       const { owner } = useCasesContext();
-      const { isLoading, postComment } = usePostComment();
+      const { isLoading, bulkCreateAttachments } = useBulkCreateAttachments();
 
       const { form } = useForm<AddCommentFormSchema>({
         defaultValue: initialCommentValue,
@@ -112,14 +112,14 @@ export const AddComment = React.memo(
           if (onCommentSaving != null) {
             onCommentSaving();
           }
-          postComment({
+          bulkCreateAttachments({
             caseId,
             data: { ...data, type: CommentType.user, owner: owner[0] },
             updateCase: onCommentPosted,
           });
           reset();
         }
-      }, [submit, onCommentSaving, postComment, caseId, owner, onCommentPosted, reset]);
+      }, [submit, onCommentSaving, bulkCreateAttachments, caseId, owner, onCommentPosted, reset]);
 
       /**
        * Focus on the text area when a quote has been added.

--- a/x-pack/plugins/cases/public/components/add_comment/index.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/index.tsx
@@ -18,7 +18,7 @@ import styled from 'styled-components';
 import { isEmpty } from 'lodash';
 
 import { CommentType } from '../../../common/api';
-import { useBulkCreateAttachments } from '../../containers/use_bulk_create_attachments';
+import { useCreateAttachments } from '../../containers/use_create_attachments';
 import { Case } from '../../containers/types';
 import { EuiMarkdownEditorRef, MarkdownEditorForm } from '../markdown_editor';
 import { Form, useForm, UseField, useFormData } from '../../common/shared_imports';
@@ -71,7 +71,7 @@ export const AddComment = React.memo(
       const editorRef = useRef<EuiMarkdownEditorRef>(null);
       const [focusOnContext, setFocusOnContext] = useState(false);
       const { owner } = useCasesContext();
-      const { isLoading, bulkCreateAttachments } = useBulkCreateAttachments();
+      const { isLoading, createAttachments } = useCreateAttachments();
 
       const { form } = useForm<AddCommentFormSchema>({
         defaultValue: initialCommentValue,
@@ -112,14 +112,14 @@ export const AddComment = React.memo(
           if (onCommentSaving != null) {
             onCommentSaving();
           }
-          bulkCreateAttachments({
+          createAttachments({
             caseId,
             data: { ...data, type: CommentType.user, owner: owner[0] },
             updateCase: onCommentPosted,
           });
           reset();
         }
-      }, [submit, onCommentSaving, bulkCreateAttachments, caseId, owner, onCommentPosted, reset]);
+      }, [submit, onCommentSaving, createAttachments, caseId, owner, onCommentPosted, reset]);
 
       /**
        * Focus on the text area when a quote has been added.

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -33,11 +33,11 @@ import { triggersActionsUiMock } from '../../../../triggers_actions_ui/public/mo
 import { registerConnectorsToMockActionRegistry } from '../../common/mock/register_connectors';
 import { createStartServicesMock } from '../../common/lib/kibana/kibana_react.mock';
 import { waitForComponentToUpdate } from '../../common/test_utils';
-import { usePostComment } from '../../containers/use_post_comment';
+import { useBulkCreateAttachments } from '../../containers/use_bulk_create_attachments';
 import { useGetTags } from '../../containers/use_get_tags';
 import { useGetReporters } from '../../containers/use_get_reporters';
 
-jest.mock('../../containers/use_post_comment');
+jest.mock('../../containers/use_bulk_create_attachments');
 jest.mock('../../containers/use_bulk_update_case');
 jest.mock('../../containers/use_delete_cases');
 jest.mock('../../containers/use_get_cases');
@@ -61,7 +61,7 @@ const useGetTagsMock = useGetTags as jest.Mock;
 const useGetReportersMock = useGetReporters as jest.Mock;
 const useKibanaMock = useKibana as jest.MockedFunction<typeof useKibana>;
 const useConnectorsMock = useConnectors as jest.Mock;
-const usePostCommentMock = usePostComment as jest.Mock;
+const useBulkCreateAttachmentsMock = useBulkCreateAttachments as jest.Mock;
 
 const mockTriggersActionsUiService = triggersActionsUiMock.createStart();
 
@@ -88,7 +88,10 @@ describe('AllCasesListGeneric', () => {
   const fetchCasesStatus = jest.fn();
   const onRowClick = jest.fn();
   const emptyTag = getEmptyTagValue().props.children;
-  usePostCommentMock.mockReturnValue({ status: { isLoading: false }, postComment: jest.fn() });
+  useBulkCreateAttachmentsMock.mockReturnValue({
+    status: { isLoading: false },
+    bulkCreateAttachments: jest.fn(),
+  });
 
   const defaultGetCases = {
     ...useGetCasesMockState,

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -33,11 +33,11 @@ import { triggersActionsUiMock } from '../../../../triggers_actions_ui/public/mo
 import { registerConnectorsToMockActionRegistry } from '../../common/mock/register_connectors';
 import { createStartServicesMock } from '../../common/lib/kibana/kibana_react.mock';
 import { waitForComponentToUpdate } from '../../common/test_utils';
-import { useBulkCreateAttachments } from '../../containers/use_bulk_create_attachments';
+import { useCreateAttachments } from '../../containers/use_create_attachments';
 import { useGetTags } from '../../containers/use_get_tags';
 import { useGetReporters } from '../../containers/use_get_reporters';
 
-jest.mock('../../containers/use_bulk_create_attachments');
+jest.mock('../../containers/use_create_attachments');
 jest.mock('../../containers/use_bulk_update_case');
 jest.mock('../../containers/use_delete_cases');
 jest.mock('../../containers/use_get_cases');
@@ -61,7 +61,7 @@ const useGetTagsMock = useGetTags as jest.Mock;
 const useGetReportersMock = useGetReporters as jest.Mock;
 const useKibanaMock = useKibana as jest.MockedFunction<typeof useKibana>;
 const useConnectorsMock = useConnectors as jest.Mock;
-const useBulkCreateAttachmentsMock = useBulkCreateAttachments as jest.Mock;
+const useCreateAttachmentsMock = useCreateAttachments as jest.Mock;
 
 const mockTriggersActionsUiService = triggersActionsUiMock.createStart();
 
@@ -88,9 +88,9 @@ describe('AllCasesListGeneric', () => {
   const fetchCasesStatus = jest.fn();
   const onRowClick = jest.fn();
   const emptyTag = getEmptyTagValue().props.children;
-  useBulkCreateAttachmentsMock.mockReturnValue({
+  useCreateAttachmentsMock.mockReturnValue({
     status: { isLoading: false },
-    bulkCreateAttachments: jest.fn(),
+    createAttachments: jest.fn(),
   });
 
   const defaultGetCases = {

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
@@ -14,14 +14,14 @@ import { Case, CaseStatuses, StatusAll } from '../../../../common';
 import { AppMockRenderer, createAppMockRenderer } from '../../../common/mock';
 import { useCasesToast } from '../../../common/use_cases_toast';
 import { alertComment } from '../../../containers/mock';
-import { usePostComment } from '../../../containers/use_post_comment';
+import { useBulkCreateAttachments } from '../../../containers/use_bulk_create_attachments';
 import { SupportedCaseAttachment } from '../../../types';
 import { CasesContext } from '../../cases_context';
 import { CasesContextStoreActionsList } from '../../cases_context/cases_context_reducer';
 import { useCasesAddToExistingCaseModal } from './use_cases_add_to_existing_case_modal';
 
 jest.mock('../../../common/use_cases_toast');
-jest.mock('../../../containers/use_post_comment');
+jest.mock('../../../containers/use_bulk_create_attachments');
 // dummy mock, will call onRowclick when rendering
 jest.mock('./all_cases_selector_modal', () => {
   return {
@@ -46,11 +46,11 @@ const TestComponent: React.FC = () => {
   return <button type="button" data-test-subj="open-modal" onClick={onClick} />;
 };
 
-const usePostCommentMock = usePostComment as jest.Mock;
+const useBulkCreateAttachmentsMock = useBulkCreateAttachments as jest.Mock;
 
 describe('use cases add to existing case modal hook', () => {
-  usePostCommentMock.mockReturnValue({
-    postComment: jest.fn(),
+  useBulkCreateAttachmentsMock.mockReturnValue({
+    bulkCreateAttachments: jest.fn(),
   });
 
   const dispatch = jest.fn();
@@ -130,10 +130,10 @@ describe('use cases add to existing case modal hook', () => {
     );
   });
 
-  it('should call postComment when a case is selected and show a toast message', async () => {
+  it('should call bulkCreateAttachments when a case is selected and show a toast message', async () => {
     const mockedPostMessage = jest.fn();
-    usePostCommentMock.mockReturnValueOnce({
-      postComment: mockedPostMessage,
+    useBulkCreateAttachmentsMock.mockReturnValueOnce({
+      bulkCreateAttachments: mockedPostMessage,
     });
 
     const mockedToastSuccess = jest.fn();
@@ -159,10 +159,10 @@ describe('use cases add to existing case modal hook', () => {
     expect(mockedToastSuccess).toHaveBeenCalled();
   });
 
-  it('should not call postComment nor show toast success when  a case is not selected', async () => {
+  it('should not call bulkCreateAttachments nor show toast success when  a case is not selected', async () => {
     const mockedPostMessage = jest.fn();
-    usePostCommentMock.mockReturnValueOnce({
-      postComment: mockedPostMessage,
+    useBulkCreateAttachmentsMock.mockReturnValueOnce({
+      bulkCreateAttachments: mockedPostMessage,
     });
 
     const mockedToastSuccess = jest.fn();
@@ -187,8 +187,8 @@ describe('use cases add to existing case modal hook', () => {
 
   it('should not show toast success when a case is selected with attachments and fails to update attachments', async () => {
     const mockedPostMessage = jest.fn().mockRejectedValue(new Error('Impossible'));
-    usePostCommentMock.mockReturnValueOnce({
-      postComment: mockedPostMessage,
+    useBulkCreateAttachmentsMock.mockReturnValueOnce({
+      bulkCreateAttachments: mockedPostMessage,
     });
 
     const mockedToast = jest.fn();

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
@@ -131,9 +131,9 @@ describe('use cases add to existing case modal hook', () => {
   });
 
   it('should call bulkCreateAttachments when a case is selected and show a toast message', async () => {
-    const mockedPostMessage = jest.fn();
+    const mockBulkCreateAttachments = jest.fn();
     useBulkCreateAttachmentsMock.mockReturnValueOnce({
-      bulkCreateAttachments: mockedPostMessage,
+      bulkCreateAttachments: mockBulkCreateAttachments,
     });
 
     const mockedToastSuccess = jest.fn();
@@ -150,7 +150,8 @@ describe('use cases add to existing case modal hook', () => {
     userEvent.click(result.getByTestId('open-modal'));
 
     await waitFor(() => {
-      expect(mockedPostMessage).toHaveBeenCalledWith({
+      expect(mockBulkCreateAttachments).toHaveBeenCalledTimes(1);
+      expect(mockBulkCreateAttachments).toHaveBeenCalledWith({
         caseId: 'test',
         data: [alertComment],
         throwOnError: true,
@@ -160,9 +161,9 @@ describe('use cases add to existing case modal hook', () => {
   });
 
   it('should not call bulkCreateAttachments nor show toast success when  a case is not selected', async () => {
-    const mockedPostMessage = jest.fn();
+    const mockBulkCreateAttachments = jest.fn();
     useBulkCreateAttachmentsMock.mockReturnValueOnce({
-      bulkCreateAttachments: mockedPostMessage,
+      bulkCreateAttachments: mockBulkCreateAttachments,
     });
 
     const mockedToastSuccess = jest.fn();
@@ -180,15 +181,15 @@ describe('use cases add to existing case modal hook', () => {
     // give a small delay for the reducer to run
 
     act(() => {
-      expect(mockedPostMessage).not.toHaveBeenCalled();
+      expect(mockBulkCreateAttachments).not.toHaveBeenCalled();
       expect(mockedToastSuccess).not.toHaveBeenCalled();
     });
   });
 
   it('should not show toast success when a case is selected with attachments and fails to update attachments', async () => {
-    const mockedPostMessage = jest.fn().mockRejectedValue(new Error('Impossible'));
+    const mockBulkCreateAttachments = jest.fn().mockRejectedValue(new Error('Impossible'));
     useBulkCreateAttachmentsMock.mockReturnValueOnce({
-      bulkCreateAttachments: mockedPostMessage,
+      bulkCreateAttachments: mockBulkCreateAttachments,
     });
 
     const mockedToast = jest.fn();
@@ -206,7 +207,7 @@ describe('use cases add to existing case modal hook', () => {
     userEvent.click(result.getByTestId('open-modal'));
 
     await waitFor(() => {
-      expect(mockedPostMessage).toHaveBeenCalledWith({
+      expect(mockBulkCreateAttachments).toHaveBeenCalledWith({
         caseId: 'test',
         data: [alertComment],
         throwOnError: true,
@@ -214,7 +215,7 @@ describe('use cases add to existing case modal hook', () => {
     });
 
     act(() => {
-      expect(mockedPostMessage).toHaveBeenCalled();
+      expect(mockBulkCreateAttachments).toHaveBeenCalled();
       expect(mockedToast).not.toHaveBeenCalled();
     });
   });

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
@@ -14,14 +14,14 @@ import { Case, CaseStatuses, StatusAll } from '../../../../common';
 import { AppMockRenderer, createAppMockRenderer } from '../../../common/mock';
 import { useCasesToast } from '../../../common/use_cases_toast';
 import { alertComment } from '../../../containers/mock';
-import { useBulkCreateAttachments } from '../../../containers/use_bulk_create_attachments';
+import { useCreateAttachments } from '../../../containers/use_create_attachments';
 import { SupportedCaseAttachment } from '../../../types';
 import { CasesContext } from '../../cases_context';
 import { CasesContextStoreActionsList } from '../../cases_context/cases_context_reducer';
 import { useCasesAddToExistingCaseModal } from './use_cases_add_to_existing_case_modal';
 
 jest.mock('../../../common/use_cases_toast');
-jest.mock('../../../containers/use_bulk_create_attachments');
+jest.mock('../../../containers/use_create_attachments');
 // dummy mock, will call onRowclick when rendering
 jest.mock('./all_cases_selector_modal', () => {
   return {
@@ -46,11 +46,11 @@ const TestComponent: React.FC = () => {
   return <button type="button" data-test-subj="open-modal" onClick={onClick} />;
 };
 
-const useBulkCreateAttachmentsMock = useBulkCreateAttachments as jest.Mock;
+const useCreateAttachmentsMock = useCreateAttachments as jest.Mock;
 
 describe('use cases add to existing case modal hook', () => {
-  useBulkCreateAttachmentsMock.mockReturnValue({
-    bulkCreateAttachments: jest.fn(),
+  useCreateAttachmentsMock.mockReturnValue({
+    createAttachments: jest.fn(),
   });
 
   const dispatch = jest.fn();
@@ -130,10 +130,10 @@ describe('use cases add to existing case modal hook', () => {
     );
   });
 
-  it('should call bulkCreateAttachments when a case is selected and show a toast message', async () => {
+  it('should call createAttachments when a case is selected and show a toast message', async () => {
     const mockBulkCreateAttachments = jest.fn();
-    useBulkCreateAttachmentsMock.mockReturnValueOnce({
-      bulkCreateAttachments: mockBulkCreateAttachments,
+    useCreateAttachmentsMock.mockReturnValueOnce({
+      createAttachments: mockBulkCreateAttachments,
     });
 
     const mockedToastSuccess = jest.fn();
@@ -160,10 +160,10 @@ describe('use cases add to existing case modal hook', () => {
     expect(mockedToastSuccess).toHaveBeenCalled();
   });
 
-  it('should not call bulkCreateAttachments nor show toast success when  a case is not selected', async () => {
+  it('should not call createAttachments nor show toast success when  a case is not selected', async () => {
     const mockBulkCreateAttachments = jest.fn();
-    useBulkCreateAttachmentsMock.mockReturnValueOnce({
-      bulkCreateAttachments: mockBulkCreateAttachments,
+    useCreateAttachmentsMock.mockReturnValueOnce({
+      createAttachments: mockBulkCreateAttachments,
     });
 
     const mockedToastSuccess = jest.fn();
@@ -188,8 +188,8 @@ describe('use cases add to existing case modal hook', () => {
 
   it('should not show toast success when a case is selected with attachments and fails to update attachments', async () => {
     const mockBulkCreateAttachments = jest.fn().mockRejectedValue(new Error('Impossible'));
-    useBulkCreateAttachmentsMock.mockReturnValueOnce({
-      bulkCreateAttachments: mockBulkCreateAttachments,
+    useCreateAttachmentsMock.mockReturnValueOnce({
+      createAttachments: mockBulkCreateAttachments,
     });
 
     const mockedToast = jest.fn();

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
@@ -152,7 +152,7 @@ describe('use cases add to existing case modal hook', () => {
     await waitFor(() => {
       expect(mockedPostMessage).toHaveBeenCalledWith({
         caseId: 'test',
-        data: alertComment,
+        data: [alertComment],
         throwOnError: true,
       });
     });
@@ -208,7 +208,7 @@ describe('use cases add to existing case modal hook', () => {
     await waitFor(() => {
       expect(mockedPostMessage).toHaveBeenCalledWith({
         caseId: 'test',
-        data: alertComment,
+        data: [alertComment],
         throwOnError: true,
       });
     });

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.tsx
@@ -14,7 +14,7 @@ import { CasesContextStoreActionsList } from '../../cases_context/cases_context_
 import { useCasesContext } from '../../cases_context/use_cases_context';
 import { useCasesAddToNewCaseFlyout } from '../../create/flyout/use_cases_add_to_new_case_flyout';
 import { CaseAttachments } from '../../../types';
-import { usePostComment } from '../../../containers/use_post_comment';
+import { useBulkCreateAttachments } from '../../../containers/use_bulk_create_attachments';
 
 type AddToExistingFlyoutProps = AllCasesSelectorModalProps & {
   toastTitle?: string;
@@ -39,7 +39,7 @@ export const useCasesAddToExistingCaseModal = (props: AddToExistingFlyoutProps) 
 
   const { dispatch } = useCasesContext();
   const casesToasts = useCasesToast();
-  const { postComment } = usePostComment();
+  const { bulkCreateAttachments } = useBulkCreateAttachments();
 
   const closeModal = useCallback(() => {
     dispatch({
@@ -67,7 +67,7 @@ export const useCasesAddToExistingCaseModal = (props: AddToExistingFlyoutProps) 
         const attachments = props.attachments;
         if (attachments !== undefined && attachments.length > 0) {
           for (const attachment of attachments) {
-            await postComment({
+            await bulkCreateAttachments({
               caseId: theCase.id,
               data: attachment,
               throwOnError: true,
@@ -82,14 +82,14 @@ export const useCasesAddToExistingCaseModal = (props: AddToExistingFlyoutProps) 
         }
       } catch (error) {
         // error toast is handled
-        // inside the postComment method
+        // inside the bulkCreateAttachments method
       }
 
       if (props.onRowClick) {
         props.onRowClick(theCase);
       }
     },
-    [casesToasts, closeModal, createNewCaseFlyout, postComment, props]
+    [casesToasts, closeModal, createNewCaseFlyout, bulkCreateAttachments, props]
   );
 
   const openModal = useCallback(() => {

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.tsx
@@ -14,7 +14,7 @@ import { CasesContextStoreActionsList } from '../../cases_context/cases_context_
 import { useCasesContext } from '../../cases_context/use_cases_context';
 import { useCasesAddToNewCaseFlyout } from '../../create/flyout/use_cases_add_to_new_case_flyout';
 import { CaseAttachments } from '../../../types';
-import { useBulkCreateAttachments } from '../../../containers/use_bulk_create_attachments';
+import { useCreateAttachments } from '../../../containers/use_create_attachments';
 
 type AddToExistingFlyoutProps = AllCasesSelectorModalProps & {
   toastTitle?: string;
@@ -39,7 +39,7 @@ export const useCasesAddToExistingCaseModal = (props: AddToExistingFlyoutProps) 
 
   const { dispatch } = useCasesContext();
   const casesToasts = useCasesToast();
-  const { bulkCreateAttachments } = useBulkCreateAttachments();
+  const { createAttachments } = useCreateAttachments();
 
   const closeModal = useCallback(() => {
     dispatch({
@@ -66,7 +66,7 @@ export const useCasesAddToExistingCaseModal = (props: AddToExistingFlyoutProps) 
         // add attachments to the case
         const attachments = props.attachments;
         if (attachments !== undefined && attachments.length > 0) {
-          await bulkCreateAttachments({
+          await createAttachments({
             caseId: theCase.id,
             data: attachments,
             throwOnError: true,
@@ -81,14 +81,14 @@ export const useCasesAddToExistingCaseModal = (props: AddToExistingFlyoutProps) 
         }
       } catch (error) {
         // error toast is handled
-        // inside the bulkCreateAttachments method
+        // inside the createAttachments method
       }
 
       if (props.onRowClick) {
         props.onRowClick(theCase);
       }
     },
-    [casesToasts, closeModal, createNewCaseFlyout, bulkCreateAttachments, props]
+    [casesToasts, closeModal, createNewCaseFlyout, createAttachments, props]
   );
 
   const openModal = useCallback(() => {

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.tsx
@@ -66,13 +66,12 @@ export const useCasesAddToExistingCaseModal = (props: AddToExistingFlyoutProps) 
         // add attachments to the case
         const attachments = props.attachments;
         if (attachments !== undefined && attachments.length > 0) {
-          for (const attachment of attachments) {
-            await bulkCreateAttachments({
-              caseId: theCase.id,
-              data: attachment,
-              throwOnError: true,
-            });
-          }
+          await bulkCreateAttachments({
+            caseId: theCase.id,
+            data: attachments,
+            throwOnError: true,
+          });
+
           casesToasts.showSuccessAttach({
             theCase,
             attachments: props.attachments,

--- a/x-pack/plugins/cases/public/components/create/flyout/create_case_flyout.tsx
+++ b/x-pack/plugins/cases/public/components/create/flyout/create_case_flyout.tsx
@@ -12,13 +12,13 @@ import { EuiFlyout, EuiFlyoutHeader, EuiTitle, EuiFlyoutBody } from '@elastic/eu
 import * as i18n from '../translations';
 import { Case } from '../../../../common/ui/types';
 import { CreateCaseForm } from '../form';
-import { UseBulkCreateAttachments } from '../../../containers/use_bulk_create_attachments';
+import { UseCreateAttachments } from '../../../containers/use_create_attachments';
 import { CaseAttachments } from '../../../types';
 
 export interface CreateCaseFlyoutProps {
   afterCaseCreated?: (
     theCase: Case,
-    bulkCreateAttachments: UseBulkCreateAttachments['bulkCreateAttachments']
+    createAttachments: UseCreateAttachments['createAttachments']
   ) => Promise<void>;
   onClose?: () => void;
   onSuccess?: (theCase: Case) => Promise<void>;

--- a/x-pack/plugins/cases/public/components/create/flyout/create_case_flyout.tsx
+++ b/x-pack/plugins/cases/public/components/create/flyout/create_case_flyout.tsx
@@ -12,11 +12,14 @@ import { EuiFlyout, EuiFlyoutHeader, EuiTitle, EuiFlyoutBody } from '@elastic/eu
 import * as i18n from '../translations';
 import { Case } from '../../../../common/ui/types';
 import { CreateCaseForm } from '../form';
-import { UsePostComment } from '../../../containers/use_post_comment';
+import { UseBulkCreateAttachments } from '../../../containers/use_bulk_create_attachments';
 import { CaseAttachments } from '../../../types';
 
 export interface CreateCaseFlyoutProps {
-  afterCaseCreated?: (theCase: Case, postComment: UsePostComment['postComment']) => Promise<void>;
+  afterCaseCreated?: (
+    theCase: Case,
+    bulkCreateAttachments: UseBulkCreateAttachments['bulkCreateAttachments']
+  ) => Promise<void>;
   onClose?: () => void;
   onSuccess?: (theCase: Case) => Promise<void>;
   attachments?: CaseAttachments;

--- a/x-pack/plugins/cases/public/components/create/form.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.tsx
@@ -27,7 +27,7 @@ import { ActionConnector } from '../../../common/api';
 import { Case } from '../../containers/types';
 import { CasesTimelineIntegration, CasesTimelineIntegrationProvider } from '../timeline_context';
 import { InsertTimeline } from '../insert_timeline';
-import { UsePostComment } from '../../containers/use_post_comment';
+import { UseBulkCreateAttachments } from '../../containers/use_bulk_create_attachments';
 import { SubmitCaseButton } from './submit_button';
 import { FormContext } from './form_context';
 import { useCasesFeatures } from '../cases_context/use_cases_features';
@@ -61,7 +61,10 @@ export interface CreateCaseFormFieldsProps {
 export interface CreateCaseFormProps extends Pick<Partial<CreateCaseFormFieldsProps>, 'withSteps'> {
   onCancel: () => void;
   onSuccess: (theCase: Case) => Promise<void>;
-  afterCaseCreated?: (theCase: Case, postComment: UsePostComment['postComment']) => Promise<void>;
+  afterCaseCreated?: (
+    theCase: Case,
+    bulkCreateAttachments: UseBulkCreateAttachments['bulkCreateAttachments']
+  ) => Promise<void>;
   timelineIntegration?: CasesTimelineIntegration;
   attachments?: CaseAttachments;
 }

--- a/x-pack/plugins/cases/public/components/create/form.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.tsx
@@ -27,7 +27,7 @@ import { ActionConnector } from '../../../common/api';
 import { Case } from '../../containers/types';
 import { CasesTimelineIntegration, CasesTimelineIntegrationProvider } from '../timeline_context';
 import { InsertTimeline } from '../insert_timeline';
-import { UseBulkCreateAttachments } from '../../containers/use_bulk_create_attachments';
+import { UseCreateAttachments } from '../../containers/use_create_attachments';
 import { SubmitCaseButton } from './submit_button';
 import { FormContext } from './form_context';
 import { useCasesFeatures } from '../cases_context/use_cases_features';
@@ -63,7 +63,7 @@ export interface CreateCaseFormProps extends Pick<Partial<CreateCaseFormFieldsPr
   onSuccess: (theCase: Case) => Promise<void>;
   afterCaseCreated?: (
     theCase: Case,
-    bulkCreateAttachments: UseBulkCreateAttachments['bulkCreateAttachments']
+    createAttachments: UseCreateAttachments['createAttachments']
   ) => Promise<void>;
   timelineIntegration?: CasesTimelineIntegration;
   attachments?: CaseAttachments;

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -41,6 +41,7 @@ import { usePostPushToService } from '../../containers/use_post_push_to_service'
 import { Choice } from '../connectors/servicenow/types';
 import userEvent from '@testing-library/user-event';
 import { connectorsMock } from '../../common/mock/connectors';
+import { CaseAttachments } from '../../types';
 
 const sampleId = 'case-id';
 
@@ -781,6 +782,29 @@ describe('Create case', () => {
 
     expect(createAttachments).toHaveBeenCalledTimes(1);
     expect(createAttachments).toHaveBeenCalledWith({ caseId: 'case-id', data: attachments });
+  });
+
+  it('should NOT call createAttachments if the attachments are an empty array', async () => {
+    useConnectorsMock.mockReturnValue({
+      ...sampleConnectorData,
+      connectors: connectorsMock,
+    });
+    const attachments: CaseAttachments = [];
+
+    const wrapper = mockedContext.render(
+      <FormContext onSuccess={onFormSubmitSuccess} attachments={attachments}>
+        <CreateCaseFormFields {...defaultCreateCaseForm} />
+        <SubmitCaseButton />
+      </FormContext>
+    );
+
+    await fillFormReactTestingLib(wrapper);
+
+    await act(async () => {
+      userEvent.click(wrapper.getByTestId('create-case-submit'));
+    });
+
+    expect(createAttachments).not.toHaveBeenCalled();
   });
 
   it(`should call callbacks in correct order`, async () => {

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -14,7 +14,7 @@ import { CommentType, ConnectorTypes } from '../../../common/api';
 import { useKibana } from '../../common/lib/kibana';
 import { AppMockRenderer, createAppMockRenderer, TestProviders } from '../../common/mock';
 import { usePostCase } from '../../containers/use_post_case';
-import { usePostComment } from '../../containers/use_post_comment';
+import { useBulkCreateAttachments } from '../../containers/use_bulk_create_attachments';
 import { useGetTags } from '../../containers/use_get_tags';
 import { useConnectors } from '../../containers/configure/use_connectors';
 import { useCaseConfigure } from '../../containers/configure/use_configure';
@@ -45,7 +45,7 @@ import { connectorsMock } from '../../common/mock/connectors';
 const sampleId = 'case-id';
 
 jest.mock('../../containers/use_post_case');
-jest.mock('../../containers/use_post_comment');
+jest.mock('../../containers/use_bulk_create_attachments');
 jest.mock('../../containers/use_post_push_to_service');
 jest.mock('../../containers/use_get_tags');
 jest.mock('../../containers/configure/use_connectors');
@@ -62,7 +62,7 @@ jest.mock('../../common/lib/kibana');
 const useConnectorsMock = useConnectors as jest.Mock;
 const useCaseConfigureMock = useCaseConfigure as jest.Mock;
 const usePostCaseMock = usePostCase as jest.Mock;
-const usePostCommentMock = usePostComment as jest.Mock;
+const useBulkCreateAttachmentsMock = useBulkCreateAttachments as jest.Mock;
 const usePostPushToServiceMock = usePostPushToService as jest.Mock;
 const useGetIncidentTypesMock = useGetIncidentTypes as jest.Mock;
 const useGetSeverityMock = useGetSeverity as jest.Mock;
@@ -132,7 +132,7 @@ describe('Create case', () => {
   const fetchTags = jest.fn();
   const onFormSubmitSuccess = jest.fn();
   const afterCaseCreated = jest.fn();
-  const postComment = jest.fn();
+  const bulkCreateAttachments = jest.fn();
   let onChoicesSuccess: (values: Choice[]) => void;
   let mockedContext: AppMockRenderer;
 
@@ -142,7 +142,7 @@ describe('Create case', () => {
       ...sampleData,
     });
     usePostCaseMock.mockImplementation(() => defaultPostCase);
-    usePostCommentMock.mockImplementation(() => ({ postComment }));
+    useBulkCreateAttachmentsMock.mockImplementation(() => ({ bulkCreateAttachments }));
     usePostPushToServiceMock.mockImplementation(() => defaultPostPushToService);
     useConnectorsMock.mockReturnValue(sampleConnectorData);
     useCaseConfigureMock.mockImplementation(() => useCaseConfigureResponse);
@@ -733,12 +733,12 @@ describe('Create case', () => {
           id: sampleId,
           ...sampleData,
         },
-        postComment
+        bulkCreateAttachments
       );
     });
   });
 
-  it('should call `postComment` with the attachments after the case is created', async () => {
+  it('should call `bulkCreateAttachments` with the attachments after the case is created', async () => {
     useConnectorsMock.mockReturnValue({
       ...sampleConnectorData,
       connectors: connectorsMock,
@@ -778,8 +778,8 @@ describe('Create case', () => {
     await act(async () => {
       userEvent.click(wrapper.getByTestId('create-case-submit'));
     });
-    expect(postComment).toHaveBeenCalledWith({ caseId: 'case-id', data: attachments[0] });
-    expect(postComment).toHaveBeenCalledWith({ caseId: 'case-id', data: attachments[1] });
+    expect(bulkCreateAttachments).toHaveBeenCalledWith({ caseId: 'case-id', data: attachments[0] });
+    expect(bulkCreateAttachments).toHaveBeenCalledWith({ caseId: 'case-id', data: attachments[1] });
   });
 
   it(`should call callbacks in correct order`, async () => {
@@ -826,14 +826,14 @@ describe('Create case', () => {
     wrapper.find(`[data-test-subj="create-case-submit"]`).first().simulate('click');
     await waitFor(() => {
       expect(postCase).toHaveBeenCalled();
-      expect(postComment).toHaveBeenCalled();
+      expect(bulkCreateAttachments).toHaveBeenCalled();
       expect(afterCaseCreated).toHaveBeenCalled();
       expect(pushCaseToExternalService).toHaveBeenCalled();
       expect(onFormSubmitSuccess).toHaveBeenCalled();
     });
 
     const postCaseOrder = postCase.mock.invocationCallOrder[0];
-    const postCommentOrder = postComment.mock.invocationCallOrder[0];
+    const postCommentOrder = bulkCreateAttachments.mock.invocationCallOrder[0];
     const afterCaseOrder = afterCaseCreated.mock.invocationCallOrder[0];
     const pushCaseToExternalServiceOrder = pushCaseToExternalService.mock.invocationCallOrder[0];
     const onFormSubmitSuccessOrder = onFormSubmitSuccess.mock.invocationCallOrder[0];

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -738,7 +738,7 @@ describe('Create case', () => {
     });
   });
 
-  it('should call `bulkCreateAttachments` with the attachments after the case is created', async () => {
+  it('should call bulkCreateAttachments with the attachments after the case is created', async () => {
     useConnectorsMock.mockReturnValue({
       ...sampleConnectorData,
       connectors: connectorsMock,
@@ -778,8 +778,9 @@ describe('Create case', () => {
     await act(async () => {
       userEvent.click(wrapper.getByTestId('create-case-submit'));
     });
-    expect(bulkCreateAttachments).toHaveBeenCalledWith({ caseId: 'case-id', data: attachments[0] });
-    expect(bulkCreateAttachments).toHaveBeenCalledWith({ caseId: 'case-id', data: attachments[1] });
+
+    expect(bulkCreateAttachments).toHaveBeenCalledTimes(1);
+    expect(bulkCreateAttachments).toHaveBeenCalledWith({ caseId: 'case-id', data: attachments });
   });
 
   it(`should call callbacks in correct order`, async () => {

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -14,7 +14,7 @@ import { CommentType, ConnectorTypes } from '../../../common/api';
 import { useKibana } from '../../common/lib/kibana';
 import { AppMockRenderer, createAppMockRenderer, TestProviders } from '../../common/mock';
 import { usePostCase } from '../../containers/use_post_case';
-import { useBulkCreateAttachments } from '../../containers/use_bulk_create_attachments';
+import { useCreateAttachments } from '../../containers/use_create_attachments';
 import { useGetTags } from '../../containers/use_get_tags';
 import { useConnectors } from '../../containers/configure/use_connectors';
 import { useCaseConfigure } from '../../containers/configure/use_configure';
@@ -45,7 +45,7 @@ import { connectorsMock } from '../../common/mock/connectors';
 const sampleId = 'case-id';
 
 jest.mock('../../containers/use_post_case');
-jest.mock('../../containers/use_bulk_create_attachments');
+jest.mock('../../containers/use_create_attachments');
 jest.mock('../../containers/use_post_push_to_service');
 jest.mock('../../containers/use_get_tags');
 jest.mock('../../containers/configure/use_connectors');
@@ -62,7 +62,7 @@ jest.mock('../../common/lib/kibana');
 const useConnectorsMock = useConnectors as jest.Mock;
 const useCaseConfigureMock = useCaseConfigure as jest.Mock;
 const usePostCaseMock = usePostCase as jest.Mock;
-const useBulkCreateAttachmentsMock = useBulkCreateAttachments as jest.Mock;
+const useCreateAttachmentsMock = useCreateAttachments as jest.Mock;
 const usePostPushToServiceMock = usePostPushToService as jest.Mock;
 const useGetIncidentTypesMock = useGetIncidentTypes as jest.Mock;
 const useGetSeverityMock = useGetSeverity as jest.Mock;
@@ -132,7 +132,7 @@ describe('Create case', () => {
   const fetchTags = jest.fn();
   const onFormSubmitSuccess = jest.fn();
   const afterCaseCreated = jest.fn();
-  const bulkCreateAttachments = jest.fn();
+  const createAttachments = jest.fn();
   let onChoicesSuccess: (values: Choice[]) => void;
   let mockedContext: AppMockRenderer;
 
@@ -142,7 +142,7 @@ describe('Create case', () => {
       ...sampleData,
     });
     usePostCaseMock.mockImplementation(() => defaultPostCase);
-    useBulkCreateAttachmentsMock.mockImplementation(() => ({ bulkCreateAttachments }));
+    useCreateAttachmentsMock.mockImplementation(() => ({ createAttachments }));
     usePostPushToServiceMock.mockImplementation(() => defaultPostPushToService);
     useConnectorsMock.mockReturnValue(sampleConnectorData);
     useCaseConfigureMock.mockImplementation(() => useCaseConfigureResponse);
@@ -733,12 +733,12 @@ describe('Create case', () => {
           id: sampleId,
           ...sampleData,
         },
-        bulkCreateAttachments
+        createAttachments
       );
     });
   });
 
-  it('should call bulkCreateAttachments with the attachments after the case is created', async () => {
+  it('should call createAttachments with the attachments after the case is created', async () => {
     useConnectorsMock.mockReturnValue({
       ...sampleConnectorData,
       connectors: connectorsMock,
@@ -779,8 +779,8 @@ describe('Create case', () => {
       userEvent.click(wrapper.getByTestId('create-case-submit'));
     });
 
-    expect(bulkCreateAttachments).toHaveBeenCalledTimes(1);
-    expect(bulkCreateAttachments).toHaveBeenCalledWith({ caseId: 'case-id', data: attachments });
+    expect(createAttachments).toHaveBeenCalledTimes(1);
+    expect(createAttachments).toHaveBeenCalledWith({ caseId: 'case-id', data: attachments });
   });
 
   it(`should call callbacks in correct order`, async () => {
@@ -827,21 +827,21 @@ describe('Create case', () => {
     wrapper.find(`[data-test-subj="create-case-submit"]`).first().simulate('click');
     await waitFor(() => {
       expect(postCase).toHaveBeenCalled();
-      expect(bulkCreateAttachments).toHaveBeenCalled();
+      expect(createAttachments).toHaveBeenCalled();
       expect(afterCaseCreated).toHaveBeenCalled();
       expect(pushCaseToExternalService).toHaveBeenCalled();
       expect(onFormSubmitSuccess).toHaveBeenCalled();
     });
 
     const postCaseOrder = postCase.mock.invocationCallOrder[0];
-    const postCommentOrder = bulkCreateAttachments.mock.invocationCallOrder[0];
+    const createAttachmentsOrder = createAttachments.mock.invocationCallOrder[0];
     const afterCaseOrder = afterCaseCreated.mock.invocationCallOrder[0];
     const pushCaseToExternalServiceOrder = pushCaseToExternalService.mock.invocationCallOrder[0];
     const onFormSubmitSuccessOrder = onFormSubmitSuccess.mock.invocationCallOrder[0];
 
     expect(
-      postCaseOrder < postCommentOrder &&
-        postCommentOrder < afterCaseOrder &&
+      postCaseOrder < createAttachmentsOrder &&
+        createAttachmentsOrder < afterCaseOrder &&
         afterCaseOrder < pushCaseToExternalServiceOrder &&
         pushCaseToExternalServiceOrder < onFormSubmitSuccessOrder
     ).toBe(true);

--- a/x-pack/plugins/cases/public/components/create/form_context.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.tsx
@@ -15,7 +15,10 @@ import { usePostPushToService } from '../../containers/use_post_push_to_service'
 import { useConnectors } from '../../containers/configure/use_connectors';
 import { Case } from '../../containers/types';
 import { NONE_CONNECTOR_ID } from '../../../common/api';
-import { UsePostComment, usePostComment } from '../../containers/use_post_comment';
+import {
+  UseBulkCreateAttachments,
+  useBulkCreateAttachments,
+} from '../../containers/use_bulk_create_attachments';
 import { useCasesContext } from '../cases_context/use_cases_context';
 import { useCasesFeatures } from '../cases_context/use_cases_features';
 import { getConnectorById } from '../utils';
@@ -32,7 +35,10 @@ const initialCaseValue: FormProps = {
 };
 
 interface Props {
-  afterCaseCreated?: (theCase: Case, postComment: UsePostComment['postComment']) => Promise<void>;
+  afterCaseCreated?: (
+    theCase: Case,
+    bulkCreateAttachments: UseBulkCreateAttachments['bulkCreateAttachments']
+  ) => Promise<void>;
   children?: JSX.Element | JSX.Element[];
   onSuccess?: (theCase: Case) => Promise<void>;
   attachments?: CaseAttachments;
@@ -48,7 +54,7 @@ export const FormContext: React.FC<Props> = ({
   const { owner } = useCasesContext();
   const { isSyncAlertsEnabled } = useCasesFeatures();
   const { postCase } = usePostCase();
-  const { postComment } = usePostComment();
+  const { bulkCreateAttachments } = useBulkCreateAttachments();
   const { pushCaseToExternalService } = usePostPushToService();
 
   const submitCase = useCallback(
@@ -82,7 +88,7 @@ export const FormContext: React.FC<Props> = ({
           // once the API is updated we should use bulk post comment #124814
           // this operation is intentionally made in sequence
           for (const attachment of attachments) {
-            await postComment({
+            await bulkCreateAttachments({
               caseId: updatedCase.id,
               data: attachment,
             });
@@ -90,7 +96,7 @@ export const FormContext: React.FC<Props> = ({
         }
 
         if (afterCaseCreated && updatedCase) {
-          await afterCaseCreated(updatedCase, postComment);
+          await afterCaseCreated(updatedCase, bulkCreateAttachments);
         }
 
         if (updatedCase?.id && connectorToUpdate.id !== 'none') {
@@ -113,7 +119,7 @@ export const FormContext: React.FC<Props> = ({
       afterCaseCreated,
       onSuccess,
       attachments,
-      postComment,
+      bulkCreateAttachments,
       pushCaseToExternalService,
     ]
   );

--- a/x-pack/plugins/cases/public/components/create/form_context.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.tsx
@@ -83,7 +83,7 @@ export const FormContext: React.FC<Props> = ({
         });
 
         // add attachments to the case
-        if (updatedCase && Array.isArray(attachments)) {
+        if (updatedCase && Array.isArray(attachments) && attachments.length > 0) {
           await createAttachments({
             caseId: updatedCase.id,
             data: attachments,

--- a/x-pack/plugins/cases/public/components/create/form_context.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.tsx
@@ -16,9 +16,9 @@ import { useConnectors } from '../../containers/configure/use_connectors';
 import { Case } from '../../containers/types';
 import { NONE_CONNECTOR_ID } from '../../../common/api';
 import {
-  UseBulkCreateAttachments,
-  useBulkCreateAttachments,
-} from '../../containers/use_bulk_create_attachments';
+  UseCreateAttachments,
+  useCreateAttachments,
+} from '../../containers/use_create_attachments';
 import { useCasesContext } from '../cases_context/use_cases_context';
 import { useCasesFeatures } from '../cases_context/use_cases_features';
 import { getConnectorById } from '../utils';
@@ -37,7 +37,7 @@ const initialCaseValue: FormProps = {
 interface Props {
   afterCaseCreated?: (
     theCase: Case,
-    bulkCreateAttachments: UseBulkCreateAttachments['bulkCreateAttachments']
+    createAttachments: UseCreateAttachments['createAttachments']
   ) => Promise<void>;
   children?: JSX.Element | JSX.Element[];
   onSuccess?: (theCase: Case) => Promise<void>;
@@ -54,7 +54,7 @@ export const FormContext: React.FC<Props> = ({
   const { owner } = useCasesContext();
   const { isSyncAlertsEnabled } = useCasesFeatures();
   const { postCase } = usePostCase();
-  const { bulkCreateAttachments } = useBulkCreateAttachments();
+  const { createAttachments } = useCreateAttachments();
   const { pushCaseToExternalService } = usePostPushToService();
 
   const submitCase = useCallback(
@@ -84,14 +84,14 @@ export const FormContext: React.FC<Props> = ({
 
         // add attachments to the case
         if (updatedCase && Array.isArray(attachments)) {
-          await bulkCreateAttachments({
+          await createAttachments({
             caseId: updatedCase.id,
             data: attachments,
           });
         }
 
         if (afterCaseCreated && updatedCase) {
-          await afterCaseCreated(updatedCase, bulkCreateAttachments);
+          await afterCaseCreated(updatedCase, createAttachments);
         }
 
         if (updatedCase?.id && connectorToUpdate.id !== 'none') {
@@ -114,7 +114,7 @@ export const FormContext: React.FC<Props> = ({
       afterCaseCreated,
       onSuccess,
       attachments,
-      bulkCreateAttachments,
+      createAttachments,
       pushCaseToExternalService,
     ]
   );

--- a/x-pack/plugins/cases/public/components/create/form_context.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.tsx
@@ -84,15 +84,10 @@ export const FormContext: React.FC<Props> = ({
 
         // add attachments to the case
         if (updatedCase && Array.isArray(attachments)) {
-          // TODO currently the API only supports to add a comment at the time
-          // once the API is updated we should use bulk post comment #124814
-          // this operation is intentionally made in sequence
-          for (const attachment of attachments) {
-            await bulkCreateAttachments({
-              caseId: updatedCase.id,
-              data: attachment,
-            });
-          }
+          await bulkCreateAttachments({
+            caseId: updatedCase.id,
+            data: attachments,
+          });
         }
 
         if (afterCaseCreated && updatedCase) {

--- a/x-pack/plugins/cases/public/containers/__mocks__/api.ts
+++ b/x-pack/plugins/cases/public/containers/__mocks__/api.ts
@@ -101,7 +101,7 @@ export const patchCasesStatus = async (
   signal: AbortSignal
 ): Promise<Case[]> => Promise.resolve(allCases.cases);
 
-export const postComment = async (
+export const bulkCreateAttachments = async (
   newComment: CommentRequest,
   caseId: string,
   signal: AbortSignal

--- a/x-pack/plugins/cases/public/containers/__mocks__/api.ts
+++ b/x-pack/plugins/cases/public/containers/__mocks__/api.ts
@@ -101,7 +101,7 @@ export const patchCasesStatus = async (
   signal: AbortSignal
 ): Promise<Case[]> => Promise.resolve(allCases.cases);
 
-export const bulkCreateAttachments = async (
+export const createAttachments = async (
   newComment: CommentRequest,
   caseId: string,
   signal: AbortSignal

--- a/x-pack/plugins/cases/public/containers/api.test.tsx
+++ b/x-pack/plugins/cases/public/containers/api.test.tsx
@@ -23,7 +23,7 @@ import {
   patchCasesStatus,
   patchComment,
   postCase,
-  postComment,
+  bulkCreateAttachments,
   pushCase,
   resolveCase,
 } from './api';
@@ -458,7 +458,7 @@ describe('Case Configuration API', () => {
     });
   });
 
-  describe('postComment', () => {
+  describe('bulkCreateAttachments', () => {
     beforeEach(() => {
       fetchMock.mockClear();
       fetchMock.mockResolvedValue(basicCaseSnake);
@@ -470,7 +470,7 @@ describe('Case Configuration API', () => {
     };
 
     test('should be called with correct check url, method, signal', async () => {
-      await postComment(data, basicCase.id, abortCtrl.signal);
+      await bulkCreateAttachments([data], basicCase.id, abortCtrl.signal);
       expect(fetchMock).toHaveBeenCalledWith(`${CASES_URL}/${basicCase.id}/comments`, {
         method: 'POST',
         body: JSON.stringify(data),
@@ -479,7 +479,7 @@ describe('Case Configuration API', () => {
     });
 
     test('should return correct response', async () => {
-      const resp = await postComment(data, basicCase.id, abortCtrl.signal);
+      const resp = await bulkCreateAttachments([data], basicCase.id, abortCtrl.signal);
       expect(resp).toEqual(basicCase);
     });
   });

--- a/x-pack/plugins/cases/public/containers/api.test.tsx
+++ b/x-pack/plugins/cases/public/containers/api.test.tsx
@@ -8,7 +8,11 @@
 import { KibanaServices } from '../common/lib/kibana';
 
 import { ConnectorTypes, CommentType, CaseStatuses } from '../../common/api';
-import { CASES_URL, SECURITY_SOLUTION_OWNER } from '../../common/constants';
+import {
+  CASES_URL,
+  INTERNAL_BULK_CREATE_ATTACHMENTS_URL,
+  SECURITY_SOLUTION_OWNER,
+} from '../../common/constants';
 
 import {
   deleteCases,
@@ -471,11 +475,14 @@ describe('Case Configuration API', () => {
 
     test('should be called with correct check url, method, signal', async () => {
       await bulkCreateAttachments([data], basicCase.id, abortCtrl.signal);
-      expect(fetchMock).toHaveBeenCalledWith(`${CASES_URL}/${basicCase.id}/comments`, {
-        method: 'POST',
-        body: JSON.stringify(data),
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        INTERNAL_BULK_CREATE_ATTACHMENTS_URL.replace('{case_id}', basicCase.id),
+        {
+          method: 'POST',
+          body: JSON.stringify([data]),
+          signal: abortCtrl.signal,
+        }
+      );
     });
 
     test('should return correct response', async () => {

--- a/x-pack/plugins/cases/public/containers/api.test.tsx
+++ b/x-pack/plugins/cases/public/containers/api.test.tsx
@@ -27,7 +27,7 @@ import {
   patchCasesStatus,
   patchComment,
   postCase,
-  bulkCreateAttachments,
+  createAttachments,
   pushCase,
   resolveCase,
 } from './api';
@@ -462,7 +462,7 @@ describe('Case Configuration API', () => {
     });
   });
 
-  describe('bulkCreateAttachments', () => {
+  describe('createAttachments', () => {
     beforeEach(() => {
       fetchMock.mockClear();
       fetchMock.mockResolvedValue(basicCaseSnake);
@@ -486,7 +486,7 @@ describe('Case Configuration API', () => {
     ];
 
     test('should be called with correct check url, method, signal', async () => {
-      await bulkCreateAttachments(data, basicCase.id, abortCtrl.signal);
+      await createAttachments(data, basicCase.id, abortCtrl.signal);
       expect(fetchMock).toHaveBeenCalledWith(
         INTERNAL_BULK_CREATE_ATTACHMENTS_URL.replace('{case_id}', basicCase.id),
         {
@@ -498,7 +498,7 @@ describe('Case Configuration API', () => {
     });
 
     test('should return correct response', async () => {
-      const resp = await bulkCreateAttachments(data, basicCase.id, abortCtrl.signal);
+      const resp = await createAttachments(data, basicCase.id, abortCtrl.signal);
       expect(resp).toEqual(basicCase);
     });
   });

--- a/x-pack/plugins/cases/public/containers/api.test.tsx
+++ b/x-pack/plugins/cases/public/containers/api.test.tsx
@@ -467,26 +467,38 @@ describe('Case Configuration API', () => {
       fetchMock.mockClear();
       fetchMock.mockResolvedValue(basicCaseSnake);
     });
-    const data = {
-      comment: 'comment',
-      owner: SECURITY_SOLUTION_OWNER,
-      type: CommentType.user as const,
-    };
+    const data = [
+      {
+        comment: 'comment',
+        owner: SECURITY_SOLUTION_OWNER,
+        type: CommentType.user as const,
+      },
+      {
+        alertId: 'test-id',
+        index: 'test-index',
+        rule: {
+          id: 'test-rule',
+          name: 'Test',
+        },
+        owner: SECURITY_SOLUTION_OWNER,
+        type: CommentType.alert as const,
+      },
+    ];
 
     test('should be called with correct check url, method, signal', async () => {
-      await bulkCreateAttachments([data], basicCase.id, abortCtrl.signal);
+      await bulkCreateAttachments(data, basicCase.id, abortCtrl.signal);
       expect(fetchMock).toHaveBeenCalledWith(
         INTERNAL_BULK_CREATE_ATTACHMENTS_URL.replace('{case_id}', basicCase.id),
         {
           method: 'POST',
-          body: JSON.stringify([data]),
+          body: JSON.stringify(data),
           signal: abortCtrl.signal,
         }
       );
     });
 
     test('should return correct response', async () => {
-      const resp = await bulkCreateAttachments([data], basicCase.id, abortCtrl.signal);
+      const resp = await bulkCreateAttachments(data, basicCase.id, abortCtrl.signal);
       expect(resp).toEqual(basicCase);
     });
   });

--- a/x-pack/plugins/cases/public/containers/api.ts
+++ b/x-pack/plugins/cases/public/containers/api.ts
@@ -33,7 +33,6 @@ import {
   CASE_STATUS_URL,
   CASE_TAGS_URL,
   CASES_URL,
-  CASES_INTERNAL_URL,
   INTERNAL_BULK_CREATE_ATTACHMENTS_URL,
 } from '../../common/constants';
 import { getAllConnectorTypesUrl } from '../../common/utils/connectors_api';

--- a/x-pack/plugins/cases/public/containers/api.ts
+++ b/x-pack/plugins/cases/public/containers/api.ts
@@ -9,6 +9,7 @@ import { omit } from 'lodash';
 
 import { StatusAll, ResolvedCase } from '../../common/ui/types';
 import {
+  BulkCreateCommentRequest,
   CasePatchRequest,
   CasePostRequest,
   CaseResponse,
@@ -32,6 +33,8 @@ import {
   CASE_STATUS_URL,
   CASE_TAGS_URL,
   CASES_URL,
+  CASES_INTERNAL_URL,
+  INTERNAL_BULK_CREATE_ATTACHMENTS_URL,
 } from '../../common/constants';
 import { getAllConnectorTypesUrl } from '../../common/utils/connectors_api';
 
@@ -307,4 +310,20 @@ export const getActionLicense = async (signal: AbortSignal): Promise<ActionLicen
   );
 
   return convertArrayToCamelCase(response) as ActionLicense[];
+};
+
+export const bulkCreateAttachments = async (
+  attachments: BulkCreateCommentRequest,
+  caseId: string,
+  signal: AbortSignal
+): Promise<Case> => {
+  const response = await KibanaServices.get().http.fetch<CaseResponse>(
+    INTERNAL_BULK_CREATE_ATTACHMENTS_URL.replace('{case_id}', caseId),
+    {
+      method: 'POST',
+      body: JSON.stringify(attachments),
+      signal,
+    }
+  );
+  return convertToCamelCase<CaseResponse, Case>(decodeCaseResponse(response));
 };

--- a/x-pack/plugins/cases/public/containers/api.ts
+++ b/x-pack/plugins/cases/public/containers/api.ts
@@ -311,7 +311,7 @@ export const getActionLicense = async (signal: AbortSignal): Promise<ActionLicen
   return convertArrayToCamelCase(response) as ActionLicense[];
 };
 
-export const bulkCreateAttachments = async (
+export const createAttachments = async (
   attachments: BulkCreateCommentRequest,
   caseId: string,
   signal: AbortSignal

--- a/x-pack/plugins/cases/public/containers/use_bulk_create_attachments.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_bulk_create_attachments.test.tsx
@@ -51,7 +51,7 @@ describe('useBulkCreateAttachments', () => {
     });
   });
 
-  it('calls bulkCreateAttachments with correct arguments - case', async () => {
+  it('calls bulkCreateAttachments with data not as an array', async () => {
     const spyOnBulkCreateAttachments = jest.spyOn(api, 'bulkCreateAttachments');
 
     await act(async () => {
@@ -63,6 +63,30 @@ describe('useBulkCreateAttachments', () => {
       result.current.bulkCreateAttachments({
         caseId: basicCaseId,
         data: samplePost,
+        updateCase: updateCaseCallback,
+      });
+      await waitForNextUpdate();
+      expect(spyOnBulkCreateAttachments).toBeCalledWith(
+        [samplePost],
+        basicCaseId,
+        abortCtrl.signal
+      );
+      expect(toastErrorMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('calls bulkCreateAttachments with data as an array', async () => {
+    const spyOnBulkCreateAttachments = jest.spyOn(api, 'bulkCreateAttachments');
+
+    await act(async () => {
+      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
+        useBulkCreateAttachments()
+      );
+      await waitForNextUpdate();
+
+      result.current.bulkCreateAttachments({
+        caseId: basicCaseId,
+        data: [samplePost],
         updateCase: updateCaseCallback,
       });
       await waitForNextUpdate();

--- a/x-pack/plugins/cases/public/containers/use_bulk_create_attachments.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_bulk_create_attachments.test.tsx
@@ -9,7 +9,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 
 import { CommentType } from '../../common/api';
 import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
-import { usePostComment, UsePostComment } from './use_post_comment';
+import { useBulkCreateAttachments, UseBulkCreateAttachments } from './use_bulk_create_attachments';
 import { basicCaseId } from './mock';
 import * as api from './api';
 import { useToasts } from '../common/lib/kibana';
@@ -19,7 +19,7 @@ jest.mock('../common/lib/kibana');
 
 const useToastMock = useToasts as jest.Mock;
 
-describe('usePostComment', () => {
+describe('useBulkCreateAttachments', () => {
   const toastErrorMock = jest.fn();
   useToastMock.mockReturnValue({
     addError: toastErrorMock,
@@ -39,28 +39,28 @@ describe('usePostComment', () => {
 
   it('init', async () => {
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UsePostComment>(() =>
-        usePostComment()
+      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
+        useBulkCreateAttachments()
       );
       await waitForNextUpdate();
       expect(result.current).toEqual({
         isLoading: false,
         isError: false,
-        postComment: result.current.postComment,
+        bulkCreateAttachments: result.current.bulkCreateAttachments,
       });
     });
   });
 
-  it('calls postComment with correct arguments - case', async () => {
-    const spyOnPostCase = jest.spyOn(api, 'postComment');
+  it('calls bulkCreateAttachments with correct arguments - case', async () => {
+    const spyOnPostCase = jest.spyOn(api, 'bulkCreateAttachments');
 
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UsePostComment>(() =>
-        usePostComment()
+      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
+        useBulkCreateAttachments()
       );
       await waitForNextUpdate();
 
-      result.current.postComment({
+      result.current.bulkCreateAttachments({
         caseId: basicCaseId,
         data: samplePost,
         updateCase: updateCaseCallback,
@@ -73,11 +73,11 @@ describe('usePostComment', () => {
 
   it('post case', async () => {
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UsePostComment>(() =>
-        usePostComment()
+      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
+        useBulkCreateAttachments()
       );
       await waitForNextUpdate();
-      result.current.postComment({
+      result.current.bulkCreateAttachments({
         caseId: basicCaseId,
         data: samplePost,
         updateCase: updateCaseCallback,
@@ -86,18 +86,18 @@ describe('usePostComment', () => {
       expect(result.current).toEqual({
         isLoading: false,
         isError: false,
-        postComment: result.current.postComment,
+        bulkCreateAttachments: result.current.bulkCreateAttachments,
       });
     });
   });
 
   it('set isLoading to true when posting case', async () => {
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UsePostComment>(() =>
-        usePostComment()
+      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
+        useBulkCreateAttachments()
       );
       await waitForNextUpdate();
-      result.current.postComment({
+      result.current.bulkCreateAttachments({
         caseId: basicCaseId,
         data: samplePost,
         updateCase: updateCaseCallback,
@@ -108,17 +108,17 @@ describe('usePostComment', () => {
   });
 
   it('set isError true and shows a toast error when an error occurs', async () => {
-    const spyOnPostCase = jest.spyOn(api, 'postComment');
+    const spyOnPostCase = jest.spyOn(api, 'bulkCreateAttachments');
     spyOnPostCase.mockImplementation(() => {
       throw new Error('Something went wrong');
     });
 
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UsePostComment>(() =>
-        usePostComment()
+      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
+        useBulkCreateAttachments()
       );
       await waitForNextUpdate();
-      result.current.postComment({
+      result.current.bulkCreateAttachments({
         caseId: basicCaseId,
         data: samplePost,
         updateCase: updateCaseCallback,
@@ -127,7 +127,7 @@ describe('usePostComment', () => {
       expect(result.current).toEqual({
         isLoading: false,
         isError: true,
-        postComment: result.current.postComment,
+        bulkCreateAttachments: result.current.bulkCreateAttachments,
       });
 
       expect(toastErrorMock).toHaveBeenCalledWith(expect.any(Error), {
@@ -137,18 +137,18 @@ describe('usePostComment', () => {
   });
 
   it('throws an error when invoked with throwOnError true', async () => {
-    const spyOnPostCase = jest.spyOn(api, 'postComment');
+    const spyOnPostCase = jest.spyOn(api, 'bulkCreateAttachments');
     spyOnPostCase.mockImplementation(() => {
       throw new Error('This is not possible');
     });
 
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UsePostComment>(() =>
-        usePostComment()
+      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
+        useBulkCreateAttachments()
       );
       await waitForNextUpdate();
       async function test() {
-        await result.current.postComment({
+        await result.current.bulkCreateAttachments({
           caseId: basicCaseId,
           data: samplePost,
           updateCase: updateCaseCallback,

--- a/x-pack/plugins/cases/public/containers/use_bulk_create_attachments.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_bulk_create_attachments.test.tsx
@@ -52,7 +52,7 @@ describe('useBulkCreateAttachments', () => {
   });
 
   it('calls bulkCreateAttachments with correct arguments - case', async () => {
-    const spyOnPostCase = jest.spyOn(api, 'bulkCreateAttachments');
+    const spyOnBulkCreateAttachments = jest.spyOn(api, 'bulkCreateAttachments');
 
     await act(async () => {
       const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
@@ -66,7 +66,11 @@ describe('useBulkCreateAttachments', () => {
         updateCase: updateCaseCallback,
       });
       await waitForNextUpdate();
-      expect(spyOnPostCase).toBeCalledWith(samplePost, basicCaseId, abortCtrl.signal);
+      expect(spyOnBulkCreateAttachments).toBeCalledWith(
+        [samplePost],
+        basicCaseId,
+        abortCtrl.signal
+      );
       expect(toastErrorMock).not.toHaveBeenCalled();
     });
   });
@@ -108,8 +112,8 @@ describe('useBulkCreateAttachments', () => {
   });
 
   it('set isError true and shows a toast error when an error occurs', async () => {
-    const spyOnPostCase = jest.spyOn(api, 'bulkCreateAttachments');
-    spyOnPostCase.mockImplementation(() => {
+    const spyOnBulkCreateAttachments = jest.spyOn(api, 'bulkCreateAttachments');
+    spyOnBulkCreateAttachments.mockImplementation(() => {
       throw new Error('Something went wrong');
     });
 
@@ -137,8 +141,8 @@ describe('useBulkCreateAttachments', () => {
   });
 
   it('throws an error when invoked with throwOnError true', async () => {
-    const spyOnPostCase = jest.spyOn(api, 'bulkCreateAttachments');
-    spyOnPostCase.mockImplementation(() => {
+    const spyOnBulkCreateAttachments = jest.spyOn(api, 'bulkCreateAttachments');
+    spyOnBulkCreateAttachments.mockImplementation(() => {
       throw new Error('This is not possible');
     });
 

--- a/x-pack/plugins/cases/public/containers/use_bulk_create_attachments.tsx
+++ b/x-pack/plugins/cases/public/containers/use_bulk_create_attachments.tsx
@@ -47,11 +47,11 @@ export interface PostComment {
   updateCase?: (newCase: Case) => void;
   throwOnError?: boolean;
 }
-export interface UsePostComment extends NewCommentState {
-  postComment: (args: PostComment) => Promise<void>;
+export interface UseBulkCreateAttachments extends NewCommentState {
+  bulkCreateAttachments: (args: PostComment) => Promise<void>;
 }
 
-export const usePostComment = (): UsePostComment => {
+export const useBulkCreateAttachments = (): UseBulkCreateAttachments => {
   const [state, dispatch] = useReducer(dataFetchReducer, {
     isLoading: false,
     isError: false,
@@ -60,7 +60,7 @@ export const usePostComment = (): UsePostComment => {
   const isCancelledRef = useRef(false);
   const abortCtrlRef = useRef(new AbortController());
 
-  const postMyComment = useCallback(
+  const fetch = useCallback(
     async ({ caseId, data, updateCase, throwOnError }: PostComment) => {
       const attachments = Array.isArray(data) ? data : [data];
       try {
@@ -107,5 +107,5 @@ export const usePostComment = (): UsePostComment => {
     []
   );
 
-  return { ...state, postComment: postMyComment };
+  return { ...state, bulkCreateAttachments: fetch };
 };

--- a/x-pack/plugins/cases/public/containers/use_create_attachments.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_create_attachments.test.tsx
@@ -9,7 +9,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 
 import { CommentType } from '../../common/api';
 import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
-import { useBulkCreateAttachments, UseBulkCreateAttachments } from './use_bulk_create_attachments';
+import { useCreateAttachments, UseCreateAttachments } from './use_create_attachments';
 import { basicCaseId } from './mock';
 import * as api from './api';
 import { useToasts } from '../common/lib/kibana';
@@ -19,7 +19,7 @@ jest.mock('../common/lib/kibana');
 
 const useToastMock = useToasts as jest.Mock;
 
-describe('useBulkCreateAttachments', () => {
+describe('useCreateAttachments', () => {
   const toastErrorMock = jest.fn();
   useToastMock.mockReturnValue({
     addError: toastErrorMock,
@@ -39,28 +39,28 @@ describe('useBulkCreateAttachments', () => {
 
   it('init', async () => {
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
-        useBulkCreateAttachments()
+      const { result, waitForNextUpdate } = renderHook<string, UseCreateAttachments>(() =>
+        useCreateAttachments()
       );
       await waitForNextUpdate();
       expect(result.current).toEqual({
         isLoading: false,
         isError: false,
-        bulkCreateAttachments: result.current.bulkCreateAttachments,
+        createAttachments: result.current.createAttachments,
       });
     });
   });
 
-  it('calls bulkCreateAttachments with data not as an array', async () => {
-    const spyOnBulkCreateAttachments = jest.spyOn(api, 'bulkCreateAttachments');
+  it('calls createAttachments with data not as an array', async () => {
+    const spyOnBulkCreateAttachments = jest.spyOn(api, 'createAttachments');
 
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
-        useBulkCreateAttachments()
+      const { result, waitForNextUpdate } = renderHook<string, UseCreateAttachments>(() =>
+        useCreateAttachments()
       );
       await waitForNextUpdate();
 
-      result.current.bulkCreateAttachments({
+      result.current.createAttachments({
         caseId: basicCaseId,
         data: samplePost,
         updateCase: updateCaseCallback,
@@ -75,16 +75,16 @@ describe('useBulkCreateAttachments', () => {
     });
   });
 
-  it('calls bulkCreateAttachments with data as an array', async () => {
-    const spyOnBulkCreateAttachments = jest.spyOn(api, 'bulkCreateAttachments');
+  it('calls createAttachments with data as an array', async () => {
+    const spyOnBulkCreateAttachments = jest.spyOn(api, 'createAttachments');
 
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
-        useBulkCreateAttachments()
+      const { result, waitForNextUpdate } = renderHook<string, UseCreateAttachments>(() =>
+        useCreateAttachments()
       );
       await waitForNextUpdate();
 
-      result.current.bulkCreateAttachments({
+      result.current.createAttachments({
         caseId: basicCaseId,
         data: [samplePost],
         updateCase: updateCaseCallback,
@@ -101,11 +101,11 @@ describe('useBulkCreateAttachments', () => {
 
   it('post case', async () => {
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
-        useBulkCreateAttachments()
+      const { result, waitForNextUpdate } = renderHook<string, UseCreateAttachments>(() =>
+        useCreateAttachments()
       );
       await waitForNextUpdate();
-      result.current.bulkCreateAttachments({
+      result.current.createAttachments({
         caseId: basicCaseId,
         data: samplePost,
         updateCase: updateCaseCallback,
@@ -114,18 +114,18 @@ describe('useBulkCreateAttachments', () => {
       expect(result.current).toEqual({
         isLoading: false,
         isError: false,
-        bulkCreateAttachments: result.current.bulkCreateAttachments,
+        createAttachments: result.current.createAttachments,
       });
     });
   });
 
   it('set isLoading to true when posting case', async () => {
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
-        useBulkCreateAttachments()
+      const { result, waitForNextUpdate } = renderHook<string, UseCreateAttachments>(() =>
+        useCreateAttachments()
       );
       await waitForNextUpdate();
-      result.current.bulkCreateAttachments({
+      result.current.createAttachments({
         caseId: basicCaseId,
         data: samplePost,
         updateCase: updateCaseCallback,
@@ -136,17 +136,17 @@ describe('useBulkCreateAttachments', () => {
   });
 
   it('set isError true and shows a toast error when an error occurs', async () => {
-    const spyOnBulkCreateAttachments = jest.spyOn(api, 'bulkCreateAttachments');
+    const spyOnBulkCreateAttachments = jest.spyOn(api, 'createAttachments');
     spyOnBulkCreateAttachments.mockImplementation(() => {
       throw new Error('Something went wrong');
     });
 
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
-        useBulkCreateAttachments()
+      const { result, waitForNextUpdate } = renderHook<string, UseCreateAttachments>(() =>
+        useCreateAttachments()
       );
       await waitForNextUpdate();
-      result.current.bulkCreateAttachments({
+      result.current.createAttachments({
         caseId: basicCaseId,
         data: samplePost,
         updateCase: updateCaseCallback,
@@ -155,7 +155,7 @@ describe('useBulkCreateAttachments', () => {
       expect(result.current).toEqual({
         isLoading: false,
         isError: true,
-        bulkCreateAttachments: result.current.bulkCreateAttachments,
+        createAttachments: result.current.createAttachments,
       });
 
       expect(toastErrorMock).toHaveBeenCalledWith(expect.any(Error), {
@@ -165,18 +165,18 @@ describe('useBulkCreateAttachments', () => {
   });
 
   it('throws an error when invoked with throwOnError true', async () => {
-    const spyOnBulkCreateAttachments = jest.spyOn(api, 'bulkCreateAttachments');
+    const spyOnBulkCreateAttachments = jest.spyOn(api, 'createAttachments');
     spyOnBulkCreateAttachments.mockImplementation(() => {
       throw new Error('This is not possible');
     });
 
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseBulkCreateAttachments>(() =>
-        useBulkCreateAttachments()
+      const { result, waitForNextUpdate } = renderHook<string, UseCreateAttachments>(() =>
+        useCreateAttachments()
       );
       await waitForNextUpdate();
       async function test() {
-        await result.current.bulkCreateAttachments({
+        await result.current.createAttachments({
           caseId: basicCaseId,
           data: samplePost,
           updateCase: updateCaseCallback,

--- a/x-pack/plugins/cases/public/containers/use_create_attachments.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_create_attachments.test.tsx
@@ -26,11 +26,13 @@ describe('useCreateAttachments', () => {
   });
 
   const abortCtrl = new AbortController();
-  const samplePost = {
-    comment: 'a comment',
-    type: CommentType.user as const,
-    owner: SECURITY_SOLUTION_OWNER,
-  };
+  const samplePost = [
+    {
+      comment: 'a comment',
+      type: CommentType.user as const,
+      owner: SECURITY_SOLUTION_OWNER,
+    },
+  ];
   const updateCaseCallback = jest.fn();
   beforeEach(() => {
     jest.clearAllMocks();
@@ -66,11 +68,7 @@ describe('useCreateAttachments', () => {
         updateCase: updateCaseCallback,
       });
       await waitForNextUpdate();
-      expect(spyOnBulkCreateAttachments).toBeCalledWith(
-        [samplePost],
-        basicCaseId,
-        abortCtrl.signal
-      );
+      expect(spyOnBulkCreateAttachments).toBeCalledWith(samplePost, basicCaseId, abortCtrl.signal);
       expect(toastErrorMock).not.toHaveBeenCalled();
     });
   });
@@ -86,15 +84,11 @@ describe('useCreateAttachments', () => {
 
       result.current.createAttachments({
         caseId: basicCaseId,
-        data: [samplePost],
+        data: samplePost,
         updateCase: updateCaseCallback,
       });
       await waitForNextUpdate();
-      expect(spyOnBulkCreateAttachments).toBeCalledWith(
-        [samplePost],
-        basicCaseId,
-        abortCtrl.signal
-      );
+      expect(spyOnBulkCreateAttachments).toBeCalledWith(samplePost, basicCaseId, abortCtrl.signal);
       expect(toastErrorMock).not.toHaveBeenCalled();
     });
   });

--- a/x-pack/plugins/cases/public/containers/use_create_attachments.tsx
+++ b/x-pack/plugins/cases/public/containers/use_create_attachments.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useReducer, useCallback, useRef, useEffect } from 'react';
-import { BulkCreateCommentRequest, CommentRequest } from '../../common/api';
+import { BulkCreateCommentRequest } from '../../common/api';
 
 import { createAttachments } from './api';
 import * as i18n from './translations';
@@ -43,7 +43,7 @@ const dataFetchReducer = (state: NewCommentState, action: Action): NewCommentSta
 
 export interface PostComment {
   caseId: string;
-  data: CommentRequest | BulkCreateCommentRequest;
+  data: BulkCreateCommentRequest;
   updateCase?: (newCase: Case) => void;
   throwOnError?: boolean;
 }
@@ -62,14 +62,13 @@ export const useCreateAttachments = (): UseCreateAttachments => {
 
   const fetch = useCallback(
     async ({ caseId, data, updateCase, throwOnError }: PostComment) => {
-      const attachments = Array.isArray(data) ? data : [data];
       try {
         isCancelledRef.current = false;
         abortCtrlRef.current.abort();
         abortCtrlRef.current = new AbortController();
         dispatch({ type: 'FETCH_INIT' });
 
-        const response = await createAttachments(attachments, caseId, abortCtrlRef.current.signal);
+        const response = await createAttachments(data, caseId, abortCtrlRef.current.signal);
 
         if (!isCancelledRef.current) {
           dispatch({ type: 'FETCH_SUCCESS' });

--- a/x-pack/plugins/cases/public/containers/use_create_attachments.tsx
+++ b/x-pack/plugins/cases/public/containers/use_create_attachments.tsx
@@ -8,7 +8,7 @@
 import { useReducer, useCallback, useRef, useEffect } from 'react';
 import { BulkCreateCommentRequest, CommentRequest } from '../../common/api';
 
-import { bulkCreateAttachments } from './api';
+import { createAttachments } from './api';
 import * as i18n from './translations';
 import { Case } from './types';
 import { useToasts } from '../common/lib/kibana';
@@ -47,11 +47,11 @@ export interface PostComment {
   updateCase?: (newCase: Case) => void;
   throwOnError?: boolean;
 }
-export interface UseBulkCreateAttachments extends NewCommentState {
-  bulkCreateAttachments: (args: PostComment) => Promise<void>;
+export interface UseCreateAttachments extends NewCommentState {
+  createAttachments: (args: PostComment) => Promise<void>;
 }
 
-export const useBulkCreateAttachments = (): UseBulkCreateAttachments => {
+export const useCreateAttachments = (): UseCreateAttachments => {
   const [state, dispatch] = useReducer(dataFetchReducer, {
     isLoading: false,
     isError: false,
@@ -69,11 +69,7 @@ export const useBulkCreateAttachments = (): UseBulkCreateAttachments => {
         abortCtrlRef.current = new AbortController();
         dispatch({ type: 'FETCH_INIT' });
 
-        const response = await bulkCreateAttachments(
-          attachments,
-          caseId,
-          abortCtrlRef.current.signal
-        );
+        const response = await createAttachments(attachments, caseId, abortCtrlRef.current.signal);
 
         if (!isCancelledRef.current) {
           dispatch({ type: 'FETCH_SUCCESS' });
@@ -107,5 +103,5 @@ export const useBulkCreateAttachments = (): UseBulkCreateAttachments => {
     []
   );
 
-  return { ...state, bulkCreateAttachments: fetch };
+  return { ...state, createAttachments: fetch };
 };


### PR DESCRIPTION
Fix mapping## Summary

This PR changes the UI to use the new [bulk create attachment](https://github.com/elastic/kibana/pull/129092) internal API.

Depends on: https://github.com/elastic/kibana/pull/129092

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
