### PR TITLE
[Enterprise Search] Change logic to fetch role mappings data after enabling RBAC

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
@@ -113,13 +113,6 @@ describe('RoleMappingsLogic', () => {
       });
     });
 
-    it('setRoleMappings', () => {
-      RoleMappingsLogic.actions.setRoleMappings({ roleMappings: [asRoleMapping] });
-
-      expect(RoleMappingsLogic.values.roleMappings).toEqual([asRoleMapping]);
-      expect(RoleMappingsLogic.values.dataLoading).toEqual(false);
-    });
-
     describe('setElasticsearchUser', () => {
       it('sets user', () => {
         RoleMappingsLogic.actions.setElasticsearchUser(elasticsearchUsers[0]);
@@ -323,7 +316,10 @@ describe('RoleMappingsLogic', () => {
   describe('listeners', () => {
     describe('enableRoleBasedAccess', () => {
       it('calls API and sets values', async () => {
-        const setRoleMappingsSpy = jest.spyOn(RoleMappingsLogic.actions, 'setRoleMappings');
+        const initializeRoleMappingsSpy = jest.spyOn(
+          RoleMappingsLogic.actions,
+          'initializeRoleMappings'
+        );
         http.post.mockReturnValue(Promise.resolve(mappingsServerProps));
         RoleMappingsLogic.actions.enableRoleBasedAccess();
 
@@ -333,7 +329,7 @@ describe('RoleMappingsLogic', () => {
           '/internal/app_search/role_mappings/enable_role_based_access'
         );
         await nextTick();
-        expect(setRoleMappingsSpy).toHaveBeenCalledWith(mappingsServerProps);
+        expect(initializeRoleMappingsSpy).toHaveBeenCalled();
       });
 
       itShowsServerErrorAsFlashMessage(http.post, () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
@@ -47,9 +47,6 @@ const emptyUser = { username: '', email: '' } as ElasticsearchUser;
 interface RoleMappingsActions extends RoleMappingsBaseActions {
   setRoleMapping(roleMapping: ASRoleMapping): { roleMapping: ASRoleMapping };
   setSingleUserRoleMapping(data?: UserMapping): { singleUserRoleMapping: UserMapping };
-  setRoleMappings({ roleMappings }: { roleMappings: ASRoleMapping[] }): {
-    roleMappings: ASRoleMapping[];
-  };
   setRoleMappingsData(data: RoleMappingsServerDetails): RoleMappingsServerDetails;
   handleAccessAllEnginesChange(selected: boolean): { selected: boolean };
   handleEngineSelectionChange(engineNames: string[]): { engineNames: string[] };
@@ -322,8 +319,8 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
       const route = '/internal/app_search/role_mappings/enable_role_based_access';
 
       try {
-        const response = await http.post<{ roleMappings: ASRoleMapping[] }>(route);
-        actions.setRoleMappings(response);
+        await http.post<{ roleMappings: ASRoleMapping[] }>(route);
+        actions.initializeRoleMappings();
       } catch (e) {
         flashAPIErrors(e);
       }

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
@@ -118,13 +118,6 @@ describe('RoleMappingsLogic', () => {
       });
     });
 
-    it('setRoleMappings', () => {
-      RoleMappingsLogic.actions.setRoleMappings({ roleMappings: [wsRoleMapping] });
-
-      expect(RoleMappingsLogic.values.roleMappings).toEqual([wsRoleMapping]);
-      expect(RoleMappingsLogic.values.dataLoading).toEqual(false);
-    });
-
     describe('setElasticsearchUser', () => {
       it('sets user', () => {
         RoleMappingsLogic.actions.setElasticsearchUser(elasticsearchUsers[0]);
@@ -283,7 +276,10 @@ describe('RoleMappingsLogic', () => {
   describe('listeners', () => {
     describe('enableRoleBasedAccess', () => {
       it('calls API and sets values', async () => {
-        const setRoleMappingsSpy = jest.spyOn(RoleMappingsLogic.actions, 'setRoleMappings');
+        const initializeRoleMappingsSpy = jest.spyOn(
+          RoleMappingsLogic.actions,
+          'initializeRoleMappings'
+        );
         http.post.mockReturnValue(Promise.resolve(mappingsServerProps));
         RoleMappingsLogic.actions.enableRoleBasedAccess();
 
@@ -293,7 +289,7 @@ describe('RoleMappingsLogic', () => {
           '/internal/workplace_search/org/role_mappings/enable_role_based_access'
         );
         await nextTick();
-        expect(setRoleMappingsSpy).toHaveBeenCalledWith(mappingsServerProps);
+        expect(initializeRoleMappingsSpy).toHaveBeenCalled();
       });
 
       itShowsServerErrorAsFlashMessage(http.post, () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
@@ -46,9 +46,6 @@ interface RoleMappingsActions extends RoleMappingsBaseActions {
   setDefaultGroup(availableGroups: RoleGroup[]): { availableGroups: RoleGroup[] };
   setRoleMapping(roleMapping: WSRoleMapping): { roleMapping: WSRoleMapping };
   setSingleUserRoleMapping(data?: UserMapping): { singleUserRoleMapping: UserMapping };
-  setRoleMappings({ roleMappings }: { roleMappings: WSRoleMapping[] }): {
-    roleMappings: WSRoleMapping[];
-  };
   setRoleMappingsData(data: RoleMappingsServerDetails): RoleMappingsServerDetails;
   handleAllGroupsSelectionChange(selected: boolean): { selected: boolean };
   handleGroupSelectionChange(groupIds: string[]): { groupIds: string[] };
@@ -322,10 +319,8 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
       const route = '/internal/workplace_search/org/role_mappings/enable_role_based_access';
 
       try {
-        const response = await http.post<{
-          roleMappings: WSRoleMapping[];
-        }>(route);
-        actions.setRoleMappings(response);
+        await http.post<{ roleMappings: WSRoleMapping[] }>(route);
+        actions.initializeRoleMappings();
       } catch (e) {
         flashAPIErrors(e);
       }


### PR DESCRIPTION
## Summary

The Enterprise Search API is being changed to return an empty array unless RBAC has been enabled and the user has access. As a result of the change, the user list will be empty in the UI after a user enables RBAC, unless the page is refreshed. This PR re-fetches the role mappings data after a successful enabling of RBAC so that the UI has the user list it needs.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
