### PR TITLE
[Monitor Management] Fix "Discard" action button link in Monitor Management Add/Edit page.

### DIFF
--- a/x-pack/plugins/uptime/public/components/monitor_management/action_bar/action_bar.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/action_bar/action_bar.tsx
@@ -121,7 +121,7 @@ export const ActionBar = ({
             <EuiButtonEmpty
               color="ghost"
               size="s"
-              href={`${basePath}/app/uptime/${MONITOR_MANAGEMENT_ROUTE}`}
+              href={`${basePath}/app/uptime/${MONITOR_MANAGEMENT_ROUTE}/all`}
             >
               {DISCARD_LABEL}
             </EuiButtonEmpty>


### PR DESCRIPTION
## Summary

Discard button on Monitor Management Add Edit page leads to Not Found. This PRs corrects the link.
