### PR TITLE
[DOCS] Add final case APIs

### DIFF
--- a/docs/api/cases.asciidoc
+++ b/docs/api/cases.asciidoc
@@ -8,20 +8,19 @@ these APIs:
 * <<cases-api-create>>
 * <<cases-api-delete-cases>>
 * <<cases-api-delete-comments>>
-* {security-guide}/cases-api-find-alert.html[Find all alerts attached to a case]
 * <<cases-api-find-cases>>
-* {security-guide}/cases-api-find-cases-by-alert.html[Find cases by alert]
 * <<cases-api-find-connectors>>
+* <<cases-api-get-alerts>>
 * <<cases-api-get-case-activity>>
 * <<cases-api-get-case>>
 * <<cases-api-get-status>>
+* <<cases-api-get-cases-by-alert>>
 * <<cases-api-get-comments>>
 * <<cases-get-configuration>>
 * <<cases-api-get-reporters>>
 * <<cases-api-get-tag>>
-* {security-guide}/cases-api-push.html[Push case]
+* <<cases-api-push>>
 * <<cases-api-set-configuration>>
-* {security-guide}/case-api-update-connector.html[Update case configurations]
 * <<cases-api-update>>
 * <<cases-api-update-comment>>
 * <<cases-api-update-configuration>>
@@ -37,13 +36,17 @@ include::cases/cases-api-delete-comments.asciidoc[leveloffset=+1]
 include::cases/cases-api-find-cases.asciidoc[leveloffset=+1]
 include::cases/cases-api-find-connectors.asciidoc[leveloffset=+1]
 //GET
+include::cases/cases-api-get-alerts.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-case-activity.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-case.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-status.asciidoc[leveloffset=+1]
+include::cases/cases-api-get-cases-by-alert.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-comments.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-configuration.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-reporters.asciidoc[leveloffset=+1]
 include::cases/cases-api-get-tags.asciidoc[leveloffset=+1]
+//PUSH
+include::cases/cases-api-push.asciidoc[leveloffset=+1]
 //SET
 include::cases/cases-api-set-configuration.asciidoc[leveloffset=+1]
 //UPDATE

--- a/docs/api/cases/cases-api-get-alerts.asciidoc
+++ b/docs/api/cases/cases-api-get-alerts.asciidoc
@@ -46,7 +46,7 @@ GET api/cases/293f1bc0-74f6-11ea-b83a-553aecdb28b6/alerts
 --------------------------------------------------
 // KIBANA
 
-The API returns a JSON array listing the alert comments. For example:
+The API returns a JSON array listing the alerts. For example:
 
 [source,json]
 --------------------------------------------------

--- a/docs/api/cases/cases-api-get-alerts.asciidoc
+++ b/docs/api/cases/cases-api-get-alerts.asciidoc
@@ -16,21 +16,20 @@ Gets all alerts attached to a case.
 
 === {api-prereq-title}
 
-////
-//TBD, for example
 You must have `read` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're seeking.
-////
 
 === {api-path-parms-title}
 
 `<case_id>`::
-(Required, string) The identifier for the case. To retrieve case IDs, use <<cases-api-find-cases>>.
+(Required, string) The identifier for the case. To retrieve case IDs, use
+<<cases-api-find-cases>>.
 
 `<space_id>`::
-(Optional, string) An identifier for the space. If it is not specified, the default space is used.
+(Optional, string) An identifier for the space. If it is not specified, the
+default space is used.
 
 === {api-response-codes-title}
 
@@ -47,15 +46,15 @@ GET api/cases/293f1bc0-74f6-11ea-b83a-553aecdb28b6/alerts
 --------------------------------------------------
 // KIBANA
 
-The API returns a JSON array listing the retrieved alert comments. For example:
+The API returns a JSON array listing the alert comments. For example:
 
 [source,json]
 --------------------------------------------------
 [
    {
-      "id":"9241255e1e761ff068768671f6971bcbef869862b02188971036ed4ebba842f1",
-      "index":".siem-signals-siem-estc-dev-default-000028",
-      "attached_at": "2020-03-31T07:52:46.702Z",
+      "id": "09f0c261e39e36351d75995b78bb83673774d1bc2cca9df2d15f0e5c0a99a540",
+      "index": ".internal.alerts-security.alerts-default-000001",
+      "attached_at": "2022-04-13T21:35:24.602Z"
    }
 ]
 --------------------------------------------------

--- a/docs/api/cases/cases-api-get-alerts.asciidoc
+++ b/docs/api/cases/cases-api-get-alerts.asciidoc
@@ -1,0 +1,61 @@
+[[cases-api-get-alerts]]
+== Get alerts attached to case API
+++++
+<titleabbrev>Get alerts</titleabbrev>
+++++
+
+preview::[]
+
+Gets all alerts attached to a case.
+
+=== {api-request-title}
+
+`GET <kibana host>:<port>/api/cases/<case_id>/alerts`
+
+`GET <kibana host>:<port>/s/<space_id>/api/cases/<case_id>/alerts`
+
+=== {api-prereq-title}
+
+////
+//TBD, for example
+You must have `read` privileges for the *Cases* feature in the *Management*,
+*{observability}*, or *Security* section of the
+<<kibana-feature-privileges,{kib} feature privileges>>, depending on the
+`owner` of the cases you're seeking.
+////
+
+=== {api-path-parms-title}
+
+`<case_id>`::
+(Required, string) The identifier for the case. To retrieve case IDs, use <<cases-api-find-cases>>.
+
+`<space_id>`::
+(Optional, string) An identifier for the space. If it is not specified, the default space is used.
+
+=== {api-response-codes-title}
+
+`200`::
+   Indicates a successful call.
+
+=== {api-example-title}
+
+Return all alerts attached to case `293f1bc0-74f6-11ea-b83a-553aecdb28b6`:
+
+[source,sh]
+--------------------------------------------------
+GET api/cases/293f1bc0-74f6-11ea-b83a-553aecdb28b6/alerts
+--------------------------------------------------
+// KIBANA
+
+The API returns a JSON array listing the retrieved alert comments. For example:
+
+[source,json]
+--------------------------------------------------
+[
+   {
+      "id":"9241255e1e761ff068768671f6971bcbef869862b02188971036ed4ebba842f1",
+      "index":".siem-signals-siem-estc-dev-default-000028",
+      "attached_at": "2020-03-31T07:52:46.702Z",
+   }
+]
+--------------------------------------------------

--- a/docs/api/cases/cases-api-get-cases-by-alert.asciidoc
+++ b/docs/api/cases/cases-api-get-cases-by-alert.asciidoc
@@ -6,7 +6,7 @@
 
 preview::[]
 
-Uses an alert ID (`alert id`) to retrieve the case IDs of any cases the alert is attached to.
+Returns the cases associated with a specific alert.
 
 === {api-request-title}
 
@@ -16,13 +16,10 @@ Uses an alert ID (`alert id`) to retrieve the case IDs of any cases the alert is
 
 === {api-prereq-title}
 
-////
-//TBD, for example
 You must have `read` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're seeking.
-////
 
 === {api-path-parms-title}
 
@@ -30,7 +27,8 @@ You must have `read` privileges for the *Cases* feature in the *Management*,
 (Required, string) The alert identifier.
 
 `<space_id>`::
-(Optional, string) An identifier for the space. If it is not specified, the default space is used.
+(Optional, string) An identifier for the space. If it is not specified, the
+default space is used.
 
 === {api-query-parms-title}
 
@@ -47,28 +45,28 @@ cases that the user has access to read.
 
 === {api-example-title}
 
-Return cases with the alert ID `293f1bc0-74f6-11ea-b83a-553aecdb28b6` attached to them:
+Return cases associated with the alert ID
+`09f0c261e39e36351d75995b78bb83673774d1bc2cca9df2d15f0e5c0a99a540`:
 
 [source,sh]
 --------------------------------------------------
-GET api/cases/alerts/293f1bc0-74f6-11ea-b83a-553aecdb28b6
+GET api/cases/alerts/09f0c261e39e36351d75995b78bb83673774d1bc2cca9df2d15f0e5c0a99a540
 --------------------------------------------------
 // KIBANA
 
-The API returns a JSON array containing any cases associated with the specified alert. For example:
+The API returns a JSON array containing the identifier and title of the cases.
+For example:
 
 [source,json]
 --------------------------------------------------
 [
     {
-        "id": "8af6ac20-74f6-11ea-b83a-553aecdb28b6", <1>
-        "title": "Test 1"
+        "id": "8af6ac20-74f6-11ea-b83a-553aecdb28b6",
+        "title": "Case 1"
     },
     {
         "id": "a18b38a0-71b0-11ea-a0b2-c51ea50a58e2",
-        "title": "Test 2"
+        "title": "Case 2"
     }
 ]
 --------------------------------------------------
-
-<1> The case identifier is identical to the saved object identifier for the case.

--- a/docs/api/cases/cases-api-get-cases-by-alert.asciidoc
+++ b/docs/api/cases/cases-api-get-cases-by-alert.asciidoc
@@ -1,0 +1,74 @@
+[[cases-api-get-cases-by-alert]]
+== Get cases by alert API
+++++
+<titleabbrev>Get cases by alert</titleabbrev>
+++++
+
+preview::[]
+
+Uses an alert ID (`alert id`) to retrieve the case IDs of any cases the alert is attached to.
+
+=== {api-request-title}
+
+`GET <kibana host>:<port>/api/cases/alerts/<alert_id>`
+
+`GET <kibana host>:<port>/s/<space_id>/api/cases/alerts/<alert_id>`
+
+=== {api-prereq-title}
+
+////
+//TBD, for example
+You must have `read` privileges for the *Cases* feature in the *Management*,
+*{observability}*, or *Security* section of the
+<<kibana-feature-privileges,{kib} feature privileges>>, depending on the
+`owner` of the cases you're seeking.
+////
+
+=== {api-path-parms-title}
+
+`<alert_id>`::
+(Required, string) The alert identifier.
+
+`<space_id>`::
+(Optional, string) An identifier for the space. If it is not specified, the default space is used.
+
+=== {api-query-parms-title}
+
+`owner`::
+(Optional, string or array of strings) A filter to limit the retrieved cases to
+a specific set of applications. Valid values are: `cases`, `observability`,
+and `securitySolution`. If this parameter is omitted, the response contains all
+cases that the user has access to read.
+
+=== {api-response-codes-title}
+
+`200`::
+   Indicates a successful call.
+
+=== {api-example-title}
+
+Return cases with the alert ID `293f1bc0-74f6-11ea-b83a-553aecdb28b6` attached to them:
+
+[source,sh]
+--------------------------------------------------
+GET api/cases/alerts/293f1bc0-74f6-11ea-b83a-553aecdb28b6
+--------------------------------------------------
+// KIBANA
+
+The API returns a JSON array containing any cases associated with the specified alert. For example:
+
+[source,json]
+--------------------------------------------------
+[
+    {
+        "id": "8af6ac20-74f6-11ea-b83a-553aecdb28b6", <1>
+        "title": "Test 1"
+    },
+    {
+        "id": "a18b38a0-71b0-11ea-a0b2-c51ea50a58e2",
+        "title": "Test 2"
+    }
+]
+--------------------------------------------------
+
+<1> The case identifier is identical to the saved object identifier for the case.

--- a/docs/api/cases/cases-api-push.asciidoc
+++ b/docs/api/cases/cases-api-push.asciidoc
@@ -1,0 +1,111 @@
+[[cases-api-push]]
+== Push case API
+++++
+<titleabbrev>Push case</titleabbrev>
+++++
+
+Push case to an external service.
+
+=== {api-request-title}
+
+`POST <kibana host>:<port>/api/cases/<case_id>/connector/<connector_id>/_push`
+
+`POST <kibana host>:<port>/s/<space_id>/api/cases/<case_id>/connector/<connector_id>/_push`
+
+=== {api-prereq-title}
+
+////
+//TBD, for example
+You must have `all` privileges for the *Actions and Connectors* feature in the
+*Management* section of the
+<<kibana-feature-privileges,{kib} feature privileges>>.
+////
+
+=== {api-path-parms-title}
+
+`<case_id>`::
+(Required, string) The identifier for the case. To retrieve case IDs, use
+<<cases-api-find-cases>>.
+
+`<connector_id>`::
+(Required, string) The identifier for the connector. To retrieve connector IDs,
+use <<cases-api-find-connectors>>.
+
+<space_id>::
+(Optional, string) An identifier for the space. If it is not specified, the default space is used.
+
+=== {api-response-codes-title}
+
+`200`::
+   Indicates a successful call.
+
+=== {api-example-title}
+
+Push the case to an external service:
+
+[source,sh]
+--------------------------------------------------
+POST api/cases/7349772f-421a-4de3-b8bb-2d9b22ccee30/connector/abed3a70-71bd-11ea-a0b2-c51ea50a58e2/_push
+{}
+--------------------------------------------------
+// KIBANA
+
+The API returns a JSON object representing the pushed case. For example:
+
+[source,json]
+--------------------------------------------------
+{
+  "id": "a18b38a0-71b0-11ea-a0b2-c51ea50a58e2",
+  "version": "Wzk4LDFd",
+  "comments": [],
+  "totalComment": 0,
+  "closed_at": null,
+  "closed_by": null,
+  "created_at": "2020-03-29T11:30:02.658Z",
+  "created_by": {
+    "email": "ahunley@imf.usa.gov",
+    "full_name": "Alan Hunley",
+    "username": "ahunley"
+  },
+  "external_service": {
+    "pushed_at":"2021-07-26T18:19:43.688Z",
+    "pushed_by":{
+        "username":"classified@hms.oo.gov.uk",
+        "full_name":null,
+        "email":null
+    },
+    "connector_id":"3d6c7b20-e5ab-11eb-98bb-85a0e2a49315",
+    "connector_name":"Test",
+    "external_id":"10110",
+    "external_title":"TPN-103",
+    "external_url":"https://cases.jira.com"
+  },
+  "updated_at": "2020-03-29T12:01:50.244Z",
+  "updated_by": {
+    "full_name": "Classified",
+    "email": "classified@hms.oo.gov.uk",
+    "username": "M"
+  },
+  "description": "James Bond clicked on a highly suspicious email banner advertising cheap holidays for underpaid civil servants. Operation bubblegum is active. Repeat - operation bubblegum is now active!",
+  "title": "This case will self-destruct in 5 seconds",
+  "status": "open",
+  "connector": {
+    "id": "131d4448-abe0-4789-939d-8ef60680b498",
+    "name": "My connector",
+    "type": ".jira",
+    "fields": {
+      "issueType": "10006",
+      "priority": "High",
+    }
+  },
+  "settings": {
+    "syncAlerts": true
+  },
+  "owner": "securitySolution",
+  "tags": [
+    "phishing",
+    "social engineering",
+    "bubblegum"
+  ]
+}
+--------------------------------------------------

--- a/docs/api/cases/cases-api-push.asciidoc
+++ b/docs/api/cases/cases-api-push.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Push case</titleabbrev>
 ++++
 
-Push case to an external service.
+Pushes a case to an external service.
 
 === {api-request-title}
 
@@ -14,12 +14,12 @@ Push case to an external service.
 
 === {api-prereq-title}
 
-////
-//TBD, for example
 You must have `all` privileges for the *Actions and Connectors* feature in the
 *Management* section of the
-<<kibana-feature-privileges,{kib} feature privileges>>.
-////
+<<kibana-feature-privileges,{kib} feature privileges>>. You must also have `all`
+privileges for the *Cases* feature in the *Management*, *{observability}*, or
+*Security* section of the {kib} feature privileges, depending on the
+`owner` of the case you're pushing.
 
 === {api-path-parms-title}
 
@@ -32,7 +32,8 @@ You must have `all` privileges for the *Actions and Connectors* feature in the
 use <<cases-api-find-connectors>>.
 
 <space_id>::
-(Optional, string) An identifier for the space. If it is not specified, the default space is used.
+(Optional, string) An identifier for the space. If it is not specified, the
+default space is used.
 
 === {api-response-codes-title}
 
@@ -59,53 +60,51 @@ The API returns a JSON object representing the pushed case. For example:
   "version": "Wzk4LDFd",
   "comments": [],
   "totalComment": 0,
+  "totalAlerts": 0,
+  "title": "This case will self-destruct in 5 seconds",
+  "tags": [ "phishing", "social engineering", "bubblegum" ],
+  "description": "James Bond clicked on a highly suspicious email banner advertising cheap holidays for underpaid civil servants. Operation bubblegum is active. Repeat - operation bubblegum is now active!",
+  "settings": {
+    "syncAlerts": true
+  },
+  "owner": "securitySolution",
   "closed_at": null,
   "closed_by": null,
-  "created_at": "2020-03-29T11:30:02.658Z",
+  "created_at": "2022-03-29T11:30:02.658Z",
   "created_by": {
     "email": "ahunley@imf.usa.gov",
     "full_name": "Alan Hunley",
     "username": "ahunley"
   },
-  "external_service": {
-    "pushed_at":"2021-07-26T18:19:43.688Z",
-    "pushed_by":{
-        "username":"classified@hms.oo.gov.uk",
-        "full_name":null,
-        "email":null
-    },
-    "connector_id":"3d6c7b20-e5ab-11eb-98bb-85a0e2a49315",
-    "connector_name":"Test",
-    "external_id":"10110",
-    "external_title":"TPN-103",
-    "external_url":"https://cases.jira.com"
-  },
-  "updated_at": "2020-03-29T12:01:50.244Z",
+  "status": "open",
+  "updated_at": "2022-03-29T12:01:50.244Z",
   "updated_by": {
     "full_name": "Classified",
     "email": "classified@hms.oo.gov.uk",
     "username": "M"
   },
-  "description": "James Bond clicked on a highly suspicious email banner advertising cheap holidays for underpaid civil servants. Operation bubblegum is active. Repeat - operation bubblegum is now active!",
-  "title": "This case will self-destruct in 5 seconds",
-  "status": "open",
   "connector": {
-    "id": "131d4448-abe0-4789-939d-8ef60680b498",
+    "id": "08046500-bb7b-11ec-89c3-ef74ed34b2e9",
     "name": "My connector",
     "type": ".jira",
     "fields": {
       "issueType": "10006",
       "priority": "High",
+      "parent": null
     }
   },
-  "settings": {
-    "syncAlerts": true
-  },
-  "owner": "securitySolution",
-  "tags": [
-    "phishing",
-    "social engineering",
-    "bubblegum"
-  ]
+  "external_service": {
+    "pushed_at":"2022-07-26T18:19:43.688Z",
+    "pushed_by":{
+        "username":"classified@hms.oo.gov.uk",
+        "full_name":null,
+        "email":null
+    },
+    "connector_name":"My connector",
+    "external_id":"10110",
+    "external_title":"TPN-103",
+    "external_url":"https://cases.jira.com",
+    "connector_id":"08046500-bb7b-11ec-89c3-ef74ed34b2e9",
+  }
 }
 --------------------------------------------------


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/126956

This PR copies following case APIs from the Security Guide to the Kibana Guide. It also formats the content to align with existing Kibana APIs:

- https://www.elastic.co/guide/en/security/master/cases-api-find-alert.html
- https://www.elastic.co/guide/en/security/master/cases-api-find-cases-by-alert.html
- https://www.elastic.co/guide/en/security/master/cases-api-push.html

### Preview

- https://kibana_130161.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-get-alerts.html
- https://kibana_130161.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-get-cases-by-alert.html
- https://kibana_130161.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-push.html