### PR TITLE
[CI] Balance/split CI groups and remove docker-specific group

### DIFF
--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -29,24 +29,12 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/xpack_cigroup.sh
     label: 'Default CI Group'
-    parallelism: 27
+    parallelism: 29
     agents:
       queue: n2-4
     depends_on: build
     timeout_in_minutes: 150
     key: default-cigroup
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
-  - command: CI_GROUP=Docker .buildkite/scripts/steps/functional/xpack_cigroup.sh
-    label: 'Docker CI Group'
-    agents:
-      queue: n2-4
-    depends_on: build
-    timeout_in_minutes: 120
-    key: default-cigroup-docker
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/flaky_tests/groups.json
+++ b/.buildkite/pipelines/flaky_tests/groups.json
@@ -32,11 +32,7 @@
     {
       "key": "xpack/cigroup",
       "name": "Default CI Group",
-      "ciGroups": 27
-    },
-    {
-      "key": "xpack/cigroup/Docker",
-      "name": "Default CI Group Docker"
+      "ciGroups": 29
     },
     {
       "key": "xpack/firefox",

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -51,26 +51,12 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/xpack_cigroup.sh
     label: 'Default CI Group'
-    parallelism: 27
+    parallelism: 29
     agents:
       queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 250
     key: default-cigroup
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-        - exit_status: '*'
-          limit: 1
-
-  - command: CI_GROUP=Docker .buildkite/scripts/steps/functional/xpack_cigroup.sh
-    label: 'Docker CI Group'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 120
-    key: default-cigroup-docker
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -17,24 +17,12 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/xpack_cigroup.sh
     label: 'Default CI Group'
-    parallelism: 27
+    parallelism: 29
     agents:
       queue: n2-4
     depends_on: build
     timeout_in_minutes: 150
     key: default-cigroup
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
-  - command: CI_GROUP=Docker .buildkite/scripts/steps/functional/xpack_cigroup.sh
-    label: 'Docker CI Group'
-    agents:
-      queue: n2-4
-    depends_on: build
-    timeout_in_minutes: 120
-    key: default-cigroup-docker
     retry:
       automatic:
         - exit_status: '*'

--- a/.ci/ci_groups.yml
+++ b/.ci/ci_groups.yml
@@ -39,4 +39,5 @@ xpack:
   - ciGroup25
   - ciGroup26
   - ciGroup27
-  - ciGroupDocker
+  - ciGroup28
+  - ciGroup29

--- a/packages/kbn-test/src/functional_test_runner/lib/mocha/decorate_mocha_ui.js
+++ b/packages/kbn-test/src/functional_test_runner/lib/mocha/decorate_mocha_ui.js
@@ -12,16 +12,7 @@ import { createAssignmentProxy } from './assignment_proxy';
 import { wrapFunction } from './wrap_function';
 import { wrapRunnableArgs } from './wrap_runnable_args';
 
-function split(arr, fn) {
-  const a = [];
-  const b = [];
-  for (const i of arr) {
-    (fn(i) ? a : b).push(i);
-  }
-  return [a, b];
-}
-
-export function decorateMochaUi(log, lifecycle, context, { isDockerGroup, rootTags }) {
+export function decorateMochaUi(log, lifecycle, context, { rootTags }) {
   // incremented at the start of each suite, decremented after
   // so that in each non-suite call we can know if we are within
   // a suite, or that when a suite is defined it is within a suite
@@ -63,7 +54,7 @@ export function decorateMochaUi(log, lifecycle, context, { isDockerGroup, rootTa
 
           const relativeFilePath = relative(REPO_ROOT, this.file);
           this._tags = [
-            ...(isDockerGroup ? ['ciGroupDocker', relativeFilePath] : [relativeFilePath]),
+            relativeFilePath,
             // we attach the "root tags" to all the child suites of the root suite, so that if they
             // need to be excluded they can be removed from the root suite without removing the entire
             // root suite
@@ -71,17 +62,7 @@ export function decorateMochaUi(log, lifecycle, context, { isDockerGroup, rootTa
           ];
           this.suiteTag = relativeFilePath; // The tag that uniquely targets this suite/file
           this.tags = (tags) => {
-            const newTags = Array.isArray(tags) ? tags : [tags];
-            const [tagsToAdd, tagsToIgnore] = split(newTags, (t) =>
-              !isDockerGroup ? true : !t.startsWith('ciGroup')
-            );
-
-            if (tagsToIgnore.length) {
-              log.warning(
-                `ignoring ciGroup tags because test is being run by a config using 'dockerServers', tags: ${tagsToIgnore}`
-              );
-            }
-
+            const tagsToAdd = Array.isArray(tags) ? tags : [tags];
             this._tags = [...this._tags, ...tagsToAdd];
           };
           this.onlyEsVersion = (semver) => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/telemetry/index.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/telemetry/index.ts
@@ -11,7 +11,7 @@ import { FtrProviderContext } from '../../../common/ftr_provider_context';
 export default ({ loadTestFile }: FtrProviderContext): void => {
   describe('Detection rule type telemetry', function () {
     describe('', function () {
-      this.tags('ciGroup11');
+      this.tags('ciGroup28');
       loadTestFile(require.resolve('./usage_collector/all_types'));
       loadTestFile(require.resolve('./usage_collector/detection_rules'));
       loadTestFile(require.resolve('./usage_collector/detection_rule_status'));

--- a/x-pack/test/fleet_api_integration/apis/index.js
+++ b/x-pack/test/fleet_api_integration/apis/index.js
@@ -9,6 +9,8 @@ import { setupTestUsers } from './test_users';
 
 export default function ({ loadTestFile, getService }) {
   describe('Fleet Endpoints', function () {
+    this.tags('ciGroup29');
+
     before(async () => {
       await setupTestUsers(getService('security'));
     });

--- a/x-pack/test/functional_synthetics/apps/uptime/index.ts
+++ b/x-pack/test/functional_synthetics/apps/uptime/index.ts
@@ -9,6 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default ({ loadTestFile, getService }: FtrProviderContext) => {
   describe('Uptime app', function () {
+    this.tags('ciGroup8');
     describe('with generated data', () => {
       loadTestFile(require.resolve('./synthetics_integration'));
     });

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/index.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/index.ts
@@ -14,7 +14,7 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
   const searchSessions = getService('searchSessions');
 
   describe('Dashboard', function () {
-    this.tags('ciGroup3');
+    this.tags('ciGroup5');
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/session_sharing/index.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/session_sharing/index.ts
@@ -13,7 +13,7 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
   const PageObjects = getPageObjects(['common']);
 
   describe('Search session sharing', function () {
-    this.tags('ciGroup3');
+    this.tags('ciGroup5');
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');

--- a/x-pack/test/search_sessions_integration/tests/apps/discover/index.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/discover/index.ts
@@ -14,7 +14,7 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
   const searchSessions = getService('searchSessions');
 
   describe('Discover', function () {
-    this.tags('ciGroup3');
+    this.tags('ciGroup5');
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');

--- a/x-pack/test/search_sessions_integration/tests/apps/lens/index.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/lens/index.ts
@@ -12,7 +12,7 @@ export default function ({ loadTestFile, getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
 
   describe('lens search sessions', function () {
-    this.tags('ciGroup3');
+    this.tags('ciGroup5');
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');

--- a/x-pack/test/search_sessions_integration/tests/apps/management/search_sessions/index.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/management/search_sessions/index.ts
@@ -12,7 +12,7 @@ export default function ({ loadTestFile, getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
 
   describe('search sessions management', function () {
-    this.tags('ciGroup3');
+    this.tags('ciGroup5');
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
@@ -16,6 +16,7 @@ export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService } = providerContext;
 
   describe('endpoint', function () {
+    this.tags('ciGroup7');
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');

--- a/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
@@ -13,6 +13,8 @@ export default function endpointAPIIntegrationTests(providerContext: FtrProvider
   const { loadTestFile, getService } = providerContext;
 
   describe('Endpoint plugin', function () {
+    this.tags('ciGroup9');
+
     const ingestManager = getService('ingestManager');
 
     const log = getService('log');


### PR DESCRIPTION
Brings CI time back down to 1h20m. Working on further improvements separately.

- Removes ciGroupDocker as it's no longer needed and makes it difficult to balance the ciGroups
- Split the tests in ciGroupDocker into two different ciGroups, since they were getting pretty long
- Balance a few other ciGroups