### PR TITLE
[8.2] [DOCS] Reorganizes Osquery docs (#128107)

### DIFF
--- a/docs/osquery/advanced-osquery.asciidoc
+++ b/docs/osquery/advanced-osquery.asciidoc
@@ -1,0 +1,103 @@
+[[advanced-osquery]]
+== Advanced Osquery
+
+[float]
+[[osquery-map-fields]]
+=== Map result fields to ECS
+
+When you save queries or add queries to a pack, you can optionally map Osquery results or static values to fields in
+the {ecs-ref}/ecs-reference.html[Elastic Common Schema] (ECS).
+This standardizes your Osquery data for use across detections, machine learning,
+and any other areas that rely on ECS-compliant data.
+When the query is run, the results include the original `osquery.<fields>`
+and the mapped ECS fields. For example, if you update a query to map `osquery.name` to `user.name`, the query results include both fields.
+
+. Edit saved queries or queries in a pack to map fields:
+
+* For *Saved queries*: Open the *Saved queries* tab, and then click the edit icon for the query that you want to map.
+
+* For *packs*: Open the *Packs* tab, edit a pack, and then click the edit icon for the query that you want to map.
+
+. In the **ECS mapping** section, select an **ECS field** to map.
+
+. In the **Value** column, use the dropdown on the left to choose what type of value to map to the ECS field:
+
+** **Osquery value**: Select an Osquery field. The fields available are based on the SQL query entered, and only include fields that the query returns. When the query runs, the ECS field is set dynamically to the value of the Osquery field selected.
+
+** **Static value**: Enter a static value. When the query runs, the ECS field is set to the value entered. For example, static fields can be used to apply `tags` or your preferred `event.category` to the query results.
+
+. Map more fields, as needed. To remove any mapped rows, click the delete icon.
+
+. Save your changes.
+
+[NOTE]
+=========================
+
+* Some ECS fields are restricted and cannot be mapped. These are not available in the ECS dropdown.
+
+* Some ECS fields are restricted to a set of allowed values, like {ecs-ref}/ecs-event.html#field-event-category[event.category]. Use the {ecs-ref}/ecs-field-reference.html[ECS Field Reference] for help when mapping fields.
+
+* Osquery date fields have a variety of data types (including integer, text, or bigint). When mapping an Osquery date field to an ECS date field, you might need to use SQL operators in the query to get an {es}-compatible
+{ref}/date.html[date] type.
+=========================
+
+
+[float]
+[[osquery-extended-tables]]
+=== Extended tables for Kubernetes queries
+In addition to the Osquery schema, the Elastic-provided version of Osquery also includes the following tables to support Kubernetes containers. These can be queried with live or scheduled queries.
+
+* `host_users`
+
+* `host_groups`
+
+* `host_processes`
+
+When querying these tables, the expectation is that the `/etc/passwd`, `/etc/group`, and `/proc` are available in the container under `/hostfs` as:
+`/hostfs/etc/passwd`, `/hostfs/etc/group`, and `/hostfs/proc`. For information about the fields available in these tables, see the
+https://docs.elastic.co/en/integrations/osquery_manager#exported-fields[exported fields] reference.
+
+[float]
+[[osquery-status]]
+=== Osquery status
+
+A query can have the following status:
+
+[cols="2*<"]
+|===
+| Successful | The query successfully completed.
+| Failed | The query encountered a problem, such as an issue with the query or the agent was disconnected, and might have failed.
+| Not yet responded | The query has not been sent to the agent.
+| Expired | The action request timed out. The agent may be offline.
+|===
+
+NOTE: If an agent is offline, the request status remains **pending** as {kib} retries the request.
+By default, a query request times out after five minutes. The time out applies to the time it takes
+to deliver the action request to an agent to run a query. If the action completes after the timeout period,
+the results are still returned.
+
+
+[float]
+[[osquery-results]]
+=== Osquery results
+When you run live or scheduled queries, the results are automatically
+stored in an {es} index, so that you can search, analyze, and visualize this data in {kib}.
+For a list of the Osquery fields that can be returned in query results,
+refer to https://docs.elastic.co/en/integrations/osquery_manager#exported-fields[exported fields].
+Query results can also include ECS fields, if the query has a defined ECS mapping.
+
+Osquery responses include the following information:
+
+* Everything prefaced with `osquery.` is part of the query response. These fields are not mapped to ECS by default.
+
+* Results include some ECS fields by default, such as `host.*` and `agent.*`, which provide information about the host that was queried.
+
+* For live queries, the `action_data.query` is the query that was sent.
+
+* For scheduled queries in a pack, the `action_id` has the format `pack_<pack-name>_<query-ID>`. You can use this information to look up the query that was run.
+
+* By default, all query results are https://osquery.readthedocs.io/en/stable/deployment/logging/#snapshot-logs[snapshot logs]
+that represent a point in time with a set of results, with no
+https://osquery.readthedocs.io/en/stable/deployment/logging/#differential-logs[differentials].
+
+* Osquery data is stored in the `logs-osquery_manager.result-<namespace>` datastream, and the result row data is under the `osquery` property in the document.

--- a/docs/osquery/exported-fields-reference.asciidoc
+++ b/docs/osquery/exported-fields-reference.asciidoc
@@ -1,0 +1,4 @@
+[[exported-fields-osquery]]
+== Exported fields reference
+
+_Content coming soon._

--- a/docs/osquery/manage-integration.asciidoc
+++ b/docs/osquery/manage-integration.asciidoc
@@ -1,0 +1,111 @@
+[[manage-osquery-integration]]
+== Manage the integration
+
+[float]
+=== System requirements
+
+* {fleet-guide}/fleet-overview.html[Fleet] is enabled on your cluster, and
+one or more {fleet-guide}/elastic-agent-installation.html[Elastic Agents] is enrolled.
+* The https://docs.elastic.co/en/integrations/osquery_manager[*Osquery Manager*] integration
+has been added and configured
+for an agent policy through Fleet.
+This integration supports x64 architecture on Windows, MacOS, and Linux platforms,
+and ARM64 architecture on Linux.
+
+[NOTE]
+=========================
+
+* The original {filebeat-ref}/filebeat-module-osquery.html[Filebeat Osquery module]
+and the https://docs.elastic.co/en/integrations/osquery[Osquery]
+integration collect logs from self-managed Osquery deployments.
+The *Osquery Manager* integration manages Osquery deployments
+and supports running and scheduling queries from {kib}.
+
+* *Osquery Manager* cannot be integrated with an Elastic Agent in standalone mode.
+=========================
+
+[float]
+=== Customize Osquery sub-feature privileges
+
+Depending on your https://www.elastic.co/subscriptions[subscription level],
+you can further customize the sub-feature privileges
+for *Osquery Manager*. These include options to grant specific access for running live queries,
+running saved queries, saving queries, and scheduling packs. For example,
+you can create roles for users who can only run live or saved queries, but who cannot save or schedule queries.
+This is useful for teams who need in-depth and detailed control.
+
+[float]
+=== Customize Osquery configuration
+experimental[] By default, all Osquery Manager integrations share the same osquery configuration. However, you can customize how Osquery is configured by editing the Osquery Manager integration for each agent policy
+you want to adjust. The custom configuration is then applied to all agents in the policy.
+This powerful feature allows you to configure
+https://osquery.readthedocs.io/en/stable/deployment/file-integrity-monitoring[File Integrity Monitoring], https://osquery.readthedocs.io/en/stable/deployment/process-auditing[Process auditing],
+and https://osquery.readthedocs.io/en/stable/deployment/configuration/#configuration-specification[others].
+
+[IMPORTANT]
+=========================
+
+* Take caution when editing this configuration. The changes you make are distributed to all agents in the policy.
+
+* Take caution when editing `packs` using the Advanced *Osquery config* field.
+Any changes you make to `packs` from this field are not reflected in the UI on the Osquery *Packs* page in {kib}, however, these changes are deployed to agents in the policy.
+While this allows you to use advanced Osquery functionality like pack discovery queries, you do lose the ability to manage packs defined this way from the Osquery *Packs* page.
+=========================
+
+. From the {kib} main menu, click *Fleet*, then the *Agent policies* tab.
+
+. Click the name of the agent policy where you want to adjust the Osquery configuration. The configuration changes you make only apply to the policy you select.
+
+. Click the name of the *Osquery Manager* integration, or add the integration first if the agent policy does not yet have it.
+
+. From the *Edit Osquery Manager integration* page, expand the *Advanced* section.
+
+. Edit the *Osquery config* JSON field to apply your preferred Osquery configuration. Note the following:
+
+* The field may already have content if you have scheduled packs for this agent policy. To keep these packs scheduled, do not remove the `packs` section.
+
+* Refer to the https://osquery.readthedocs.io/en/stable/[Osquery documentation] for configuration options.
+
+* Some fields are protected and cannot be set. A warning is displayed with details about which fields should be removed.
+
+* (Optional) To load a full configuration file, drag and drop an Osquery `.conf` file into the area at the bottom of the page.
+
+. Click *Save integration* to apply the custom configuration to all agents in the policy.
++
+As an example, the following configuration disables two tables.
++
+```ts
+{
+   "options":{
+      "disable_tables":"curl,process_envs"
+   }
+}
+```
+
+[float]
+=== Upgrade Osquery versions
+
+The https://github.com/osquery/osquery/releases[Osquery version] available on an Elastic Agent
+is associated to the version of Osquery Beat on the Agent.
+To get the latest version of Osquery Beat,
+https://www.elastic.co/guide/en/fleet/master/upgrade-elastic-agent.html[upgrade your Elastic Agent].
+
+[float]
+=== Debug issues
+If you encounter issues with *Osquery Manager*, find the relevant logs for {elastic-agent}
+and Osquerybeat in the agent directory. Refer to the {fleet-guide}/installation-layout.html[Fleet Installation layout] to find the log file location for your OS.
+
+```ts
+../data/elastic-agent-*/logs/elastic-agent-json.log-*
+../data/elastic-agent-*/logs/default/osquerybeat-json.log
+```
+
+To get more details in the logs, change the agent logging level to debug:
+
+. Open the main menu, and then select **Fleet**.
+
+. Select the agent that you want to debug.
+
+. On the **Logs** tab, change the **Agent logging level** to **debug**, and then click **Apply changes**.
++
+`agent.logging.level` is updated in `fleet.yml`, and the logging level is changed to `debug`.

--- a/docs/osquery/osquery.asciidoc
+++ b/docs/osquery/osquery.asciidoc
@@ -1,13 +1,13 @@
-[chapter]
-[role="xpack"]
 [[osquery]]
 = Osquery
 
+[partintro]
+--
 https://osquery.io[Osquery] is an open source tool that lets you query operating systems like a database, providing you with visibility into your infrastructure and operating systems.
-Using basic SQL commands, you can ask questions about devices, such as servers, 
+Using basic SQL commands, you can ask questions about devices, such as servers,
 Docker containers, and computers running Linux, macOS, or Windows.
 The https://osquery.io/schema[extensive schema] helps with a variety of use cases,
-including vulnerability detection, compliance monitoring, incident investigations, and more.  
+including vulnerability detection, compliance monitoring, incident investigations, and more.
 
 With Osquery in {kib}, you can:
 
@@ -56,11 +56,11 @@ image::images/enter-query.png[Select saved query dropdown name showing query nam
 or to the drag-and-drop *Lens* editor to create visualizations.
 . To view more information about the request, such as failures, open the *Status* tab.
 . To save the query for future use, click *Save for later* and define the ID,
-description, and other <<osquery-manage-query,details>>. 
+description, and other <<osquery-manage-query,details>>.
 
 [float]
 [[osquery-view-history]]
-===  View or rerun previous live queries
+== View or rerun previous live queries
 
 From the *Live queries history* section on the *Live queries* tab:
 
@@ -77,8 +77,8 @@ image::images/live-query-check-results.png[Results of OSquery]
 == Schedule queries with packs
 
 Create packs to organize sets of queries. For example, you might create one pack that checks
-for IT compliance-type issues, and another pack that monitors for evidence of malware. 
-You can schedule packs to run for one or more agent policies. When scheduled, queries in the pack are run at the set intervals for all agents in those policies. Scheduling packs is optional. 
+for IT compliance-type issues, and another pack that monitors for evidence of malware.
+You can schedule packs to run for one or more agent policies. When scheduled, queries in the pack are run at the set intervals for all agents in those policies. Scheduling packs is optional.
 
 . Open the **Packs** tab.
 
@@ -95,7 +95,7 @@ You can schedule packs to run for one or more agent policies. When scheduled, qu
 . Add queries to schedule:
 
 * To add a query to the pack, click *Add query*, and then either add a saved query or enter a new query.
-Each query must include a unique query ID and the interval at which it should run. 
+Each query must include a unique query ID and the interval at which it should run.
 Optionally, set the minimum Osquery version and platform,
 or <<osquery-map-fields,map ECS fields>>. When you add a saved query to a pack, this adds a copy of the query. A connection is not maintained between saved queries and packs.
 
@@ -105,7 +105,7 @@ or <<osquery-map-fields,map ECS fields>>. When you add a saved query to a pack, 
 
 [float]
 [[osquery-schedule-status]]
-=== View status of scheduled packs
+== View status of scheduled packs
 
 . Open the **Packs** tab.
 
@@ -151,222 +151,16 @@ To add or edit saved queries from the *Saved queries* tab:
 
 ** The operating system required to run the query. For information about supported platforms per table, refer to the https://osquery.io/schema[Osquery schema].
 
-. Click *Test configuration* to test the query and any mapped fields: 
+. Click *Test configuration* to test the query and any mapped fields:
 
 * From the *Test query* panel, select agents or groups to test the query, then click *Submit* to run a live query. Result columns with the image:images/mapped-icon.png[mapping] icon are mapped. Hover over the icon to see the mapped ECS field.
 
-. Click *Save* or *Update*. 
+. Click *Save* or *Update*.
 
-[float]
-[[osquery-map-fields]]
-== Map result fields to ECS
+--
 
-When you save queries or add queries to a pack, you can optionally map Osquery results or static values to fields in
-the {ecs-ref}/ecs-reference.html[Elastic Common Schema] (ECS).
-This standardizes your Osquery data for use across detections, machine learning,
-and any other areas that rely on ECS-compliant data.
-When the query is run, the results include the original `osquery.<fields>`
-and the mapped ECS fields. For example, if you update a query to map `osquery.name` to `user.name`, the query results include both fields. 
+include::advanced-osquery.asciidoc[]
 
-. Edit saved queries or queries in a pack to map fields:
+include::manage-integration.asciidoc[]
 
-* For *Saved queries*: Open the *Saved queries* tab, and then click the edit icon for the query that you want to map.
-
-* For *packs*: Open the *Packs* tab, edit a pack, and then click the edit icon for the query that you want to map.
-
-. In the **ECS mapping** section, select an **ECS field** to map. 
-
-. In the **Value** column, use the dropdown on the left to choose what type of value to map to the ECS field: 
-
-** **Osquery value**: Select an Osquery field. The fields available are based on the SQL query entered, and only include fields that the query returns. When the query runs, the ECS field is set dynamically to the value of the Osquery field selected.
-
-** **Static value**: Enter a static value. When the query runs, the ECS field is set to the value entered. For example, static fields can be used to apply `tags` or your preferred `event.category` to the query results. 
-
-. Map more fields, as needed. To remove any mapped rows, click the delete icon.
-
-. Save your changes.
-
-[NOTE]
-=========================
-
-* Some ECS fields are restricted and cannot be mapped. These are not available in the ECS dropdown.
-
-* Some ECS fields are restricted to a set of allowed values, like {ecs-ref}/ecs-event.html#field-event-category[event.category]. Use the {ecs-ref}/ecs-field-reference.html[ECS Field Reference] for help when mapping fields. 
-
-* Osquery date fields have a variety of data types (including integer, text, or bigint). When mapping an Osquery date field to an ECS date field, you might need to use SQL operators in the query to get an {es}-compatible 
-{ref}/date.html[date] type. 
-=========================
-
-
-[float]
-[[osquery-extended-tables]]
-== Extended tables for Kubernetes queries
-In addition to the Osquery schema, the Elastic-provided version of Osquery also includes the following tables to support Kubernetes containers. These can be queried with live or scheduled queries.
-
-* `host_users`
-
-* `host_groups`
-
-* `host_processes`
-
-When querying these tables, the expectation is that the `/etc/passwd`, `/etc/group`, and `/proc` are available in the container under `/hostfs` as:
-`/hostfs/etc/passwd`, `/hostfs/etc/group`, and `/hostfs/proc`. For information about the fields available in these tables, see the
-https://docs.elastic.co/en/integrations/osquery_manager#exported-fields[exported fields] reference. 
-
-[float]
-[[osquery-status]]
-== Osquery status
-
-A query can have the following status:
-
-[cols="2*<"]
-|===
-| Successful | The query successfully completed.
-| Failed | The query encountered a problem, such as an issue with the query or the agent was disconnected, and might have failed.
-| Not yet responded | The query has not been sent to the agent.
-| Expired | The action request timed out. The agent may be offline.
-|===
-
-NOTE: If an agent is offline, the request status remains **pending** as {kib} retries the request.
-By default, a query request times out after five minutes. The time out applies to the time it takes
-to deliver the action request to an agent to run a query. If the action completes after the timeout period,
-the results are still returned.
-
-
-[float]
-[[osquery-results]]
-== Osquery results
-When you run live or scheduled queries, the results are automatically 
-stored in an {es} index, so that you can search, analyze, and visualize this data in {kib}.
-For a list of the Osquery fields that can be returned in query results,
-refer to https://docs.elastic.co/en/integrations/osquery_manager#exported-fields[exported fields].
-Query results can also include ECS fields, if the query has a defined ECS mapping.
-
-Osquery responses include the following information:
-
-* Everything prefaced with `osquery.` is part of the query response. These fields are not mapped to ECS by default.
-
-* Results include some ECS fields by default, such as `host.*` and `agent.*`, which provide information about the host that was queried.
-
-* For live queries, the `action_data.query` is the query that was sent.
-
-* For scheduled queries in a pack, the `action_id` has the format `pack_<pack-name>_<query-ID>`. You can use this information to look up the query that was run.
-
-* By default, all query results are https://osquery.readthedocs.io/en/stable/deployment/logging/#snapshot-logs[snapshot logs]
-that represent a point in time with a set of results, with no 
-https://osquery.readthedocs.io/en/stable/deployment/logging/#differential-logs[differentials].
-
-* Osquery data is stored in the `logs-osquery_manager.result-<namespace>` datastream, and the result row data is under the `osquery` property in the document. 
-
-[float]
-[[manage-osquery-integration]]
-== Manage the integration
-
-[float]
-=== System requirements
-
-* {fleet-guide}/fleet-overview.html[Fleet] is enabled on your cluster, and
-one or more {fleet-guide}/elastic-agent-installation.html[Elastic Agents] is enrolled.
-* The https://docs.elastic.co/en/integrations/osquery_manager[*Osquery Manager*] integration
-has been added and configured
-for an agent policy through Fleet.
-This integration supports x64 architecture on Windows, MacOS, and Linux platforms, 
-and ARM64 architecture on Linux.
-
-[NOTE]
-=========================
-
-* The original {filebeat-ref}/filebeat-module-osquery.html[Filebeat Osquery module]
-and the https://docs.elastic.co/en/integrations/osquery[Osquery]
-integration collect logs from self-managed Osquery deployments.
-The *Osquery Manager* integration manages Osquery deployments
-and supports running and scheduling queries from {kib}.
-
-* *Osquery Manager* cannot be integrated with an Elastic Agent in standalone mode.
-=========================
-
-[float]
-=== Customize Osquery sub-feature privileges
-
-Depending on your https://www.elastic.co/subscriptions[subscription level],
-you can further customize the sub-feature privileges
-for *Osquery Manager*. These include options to grant specific access for running live queries,
-running saved queries, saving queries, and scheduling packs. For example,
-you can create roles for users who can only run live or saved queries, but who cannot save or schedule queries.
-This is useful for teams who need in-depth and detailed control.
-
-[float]
-=== Customize Osquery configuration
-experimental[] By default, all Osquery Manager integrations share the same osquery configuration. However, you can customize how Osquery is configured by editing the Osquery Manager integration for each agent policy
-you want to adjust. The custom configuration is then applied to all agents in the policy. 
-This powerful feature allows you to configure
-https://osquery.readthedocs.io/en/stable/deployment/file-integrity-monitoring[File Integrity Monitoring], https://osquery.readthedocs.io/en/stable/deployment/process-auditing[Process auditing], 
-and https://osquery.readthedocs.io/en/stable/deployment/configuration/#configuration-specification[others].
-
-[IMPORTANT]
-=========================
-
-* Take caution when editing this configuration. The changes you make are distributed to all agents in the policy.
-
-* Take caution when editing `packs` using the Advanced *Osquery config* field. 
-Any changes you make to `packs` from this field are not reflected in the UI on the Osquery *Packs* page in {kib}, however, these changes are deployed to agents in the policy. 
-While this allows you to use advanced Osquery functionality like pack discovery queries, you do lose the ability to manage packs defined this way from the Osquery *Packs* page.
-=========================
-
-. From the {kib} main menu, click *Fleet*, then the *Agent policies* tab.
-
-. Click the name of the agent policy where you want to adjust the Osquery configuration. The configuration changes you make only apply to the policy you select.
-
-. Click the name of the *Osquery Manager* integration, or add the integration first if the agent policy does not yet have it.
-
-. From the *Edit Osquery Manager integration* page, expand the *Advanced* section.
-
-. Edit the *Osquery config* JSON field to apply your preferred Osquery configuration. Note the following:
-
-* The field may already have content if you have scheduled packs for this agent policy. To keep these packs scheduled, do not remove the `packs` section.
-
-* Refer to the https://osquery.readthedocs.io/en/stable/[Osquery documentation] for configuration options. 
-
-* Some fields are protected and cannot be set. A warning is displayed with details about which fields should be removed.
-
-* (Optional) To load a full configuration file, drag and drop an Osquery `.conf` file into the area at the bottom of the page.
-
-. Click *Save integration* to apply the custom configuration to all agents in the policy.
-+
-As an example, the following configuration disables two tables.
-+
-```ts
-{
-   "options":{
-      "disable_tables":"curl,process_envs"
-   }
-}
-```
-
-[float]
-=== Upgrade Osquery versions
-
-The https://github.com/osquery/osquery/releases[Osquery version] available on an Elastic Agent
-is associated to the version of Osquery Beat on the Agent.
-To get the latest version of Osquery Beat,
-https://www.elastic.co/guide/en/fleet/master/upgrade-elastic-agent.html[upgrade your Elastic Agent].
-
-[float]
-=== Debug issues
-If you encounter issues with *Osquery Manager*, find the relevant logs for {elastic-agent}
-and Osquerybeat in the agent directory. Refer to the {fleet-guide}/installation-layout.html[Fleet Installation layout] to find the log file location for your OS.
-
-```ts
-../data/elastic-agent-*/logs/elastic-agent-json.log-*
-../data/elastic-agent-*/logs/default/osquerybeat-json.log
-```
-
-To get more details in the logs, change the agent logging level to debug:
-
-. Open the main menu, and then select **Fleet**.
-
-. Select the agent that you want to debug.
-
-. On the **Logs** tab, change the **Agent logging level** to **debug**, and then click **Apply changes**.
-+
-`agent.logging.level` is updated in `fleet.yml`, and the logging level is changed to `debug`.
+include::exported-fields-reference.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[DOCS] Reorganizes Osquery docs (#128107)](https://github.com/elastic/kibana/pull/128107)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)