### PR TITLE
[Fleet] Small clean up on add agent instructions

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_selection.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_selection.tsx
@@ -119,6 +119,7 @@ export const AgentPolicySelection: React.FC<Props> = (props) => {
           />
         )}
       </EuiText>
+      <EuiSpacer size="m" />
       <AgentPolicyFormRow
         fullWidth={true}
         label={
@@ -165,14 +166,14 @@ export const AgentPolicySelection: React.FC<Props> = (props) => {
           />
         </>
       )}
-      {props.withKeySelection && props.onKeyChange && (
+      {props.withKeySelection && props.onKeyChange && selectedPolicy?.id && (
         <>
-          <EuiSpacer />
+          <EuiSpacer size="m" />
           <AdvancedAgentAuthenticationSettings
             selectedApiKeyId={props.selectedApiKeyId}
             onKeyChange={props.onKeyChange}
             initialAuthenticationSettingsOpen={!props.selectedApiKeyId}
-            agentPolicyId={selectedPolicy?.id}
+            agentPolicyId={selectedPolicy.id}
           />
         </>
       )}

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/index.tsx
@@ -59,7 +59,7 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<FlyOutProps> = ({
   const [isFleetServerPolicySelected, setIsFleetServerPolicySelected] = useState<boolean>(false);
   const [selectedApiKeyId, setSelectedAPIKeyId] = useState<string | undefined>();
   const [mode, setMode] = useState<FlyoutMode>(defaultMode);
-  const [selectionType, setSelectionType] = useState<SelectionType>('tabs');
+  const [selectionType, setSelectionType] = useState<SelectionType>();
 
   const {
     agentPolicies,

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
@@ -32,6 +32,7 @@ export const Instructions = (props: InstructionProps) => {
     isFleetServerPolicySelected,
     settings,
     isLoadingAgentPolicies,
+    selectionType,
     setSelectionType,
     mode,
     isIntegrationFlow,
@@ -89,13 +90,17 @@ export const Instructions = (props: InstructionProps) => {
     } else if (showAgentEnrollment) {
       return (
         <>
-          <EuiText>
-            <FormattedMessage
-              id="xpack.fleet.agentEnrollment.managedDescription"
-              defaultMessage="Enroll an Elastic Agent in Fleet to automatically deploy updates and centrally manage the agent."
-            />
-          </EuiText>
-          <EuiSpacer size="l" />
+          {selectionType === 'tabs' && (
+            <>
+              <EuiText>
+                <FormattedMessage
+                  id="xpack.fleet.agentEnrollment.managedDescription"
+                  defaultMessage="Enroll an Elastic Agent in Fleet to automatically deploy updates and centrally manage the agent."
+                />
+              </EuiText>
+              <EuiSpacer size="l" />
+            </>
+          )}
           {isFleetServerPolicySelected ? (
             <FleetServerSteps {...props} />
           ) : (

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/types.ts
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/types.ts
@@ -11,7 +11,7 @@ import type { InstalledIntegrationPolicy } from './use_get_agent_incoming_data';
 
 export type K8sMode = 'IS_LOADING' | 'IS_KUBERNETES' | 'IS_NOT_KUBERNETES';
 export type FlyoutMode = 'managed' | 'standalone';
-export type SelectionType = 'tabs' | 'radio';
+export type SelectionType = 'tabs' | 'radio' | undefined;
 
 export interface BaseProps {
   /**


### PR DESCRIPTION
## Summary

I noticed a few small UI issues when I was testing the redesigned agent instructions:

- Fixes #130080: set selection type to `undefined` in the beginning so that managed/standalone tabs don't appear and disappear
- Hide copy about enrolling in Fleet when doing selection via radio since the same copy is already in the radio copy
- Add more spacing around policy selection dropdown, after the copy above it
- Hide authentication settings when policy has been chosen yet, since it will just expand and toggle empty content