### PR TITLE
[Fleet] Make add agent step styling more consistent

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/agent_enrollment_confirmation_step.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/agent_enrollment_confirmation_step.tsx
@@ -26,7 +26,7 @@ export const AgentEnrollmentConfirmationStep = ({
 }): EuiContainedStepProps => {
   return {
     title: i18n.translate('xpack.fleet.agentEnrollment.stepAgentEnrollmentConfirmation', {
-      defaultMessage: 'Confirm agent Enrollment',
+      defaultMessage: 'Confirm agent enrollment',
     }),
     children: (
       <ConfirmAgentEnrollment
@@ -36,6 +36,6 @@ export const AgentEnrollmentConfirmationStep = ({
         agentCount={agentCount}
       />
     ),
-    status: !agentCount ? 'incomplete' : 'complete',
+    status: !agentCount ? undefined : 'complete',
   };
 };

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/compute_steps.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/compute_steps.tsx
@@ -145,7 +145,9 @@ export const StandaloneSteps: React.FunctionComponent<InstructionProps> = ({
       : [];
 
     if (selectionType === 'radio') {
-      steps.push(InstallationModeSelectionStep({ mode, setMode }));
+      steps.push(
+        InstallationModeSelectionStep({ selectedPolicyId: selectedPolicy?.id, mode, setMode })
+      );
     }
 
     steps.push(
@@ -236,7 +238,9 @@ export const ManagedSteps: React.FunctionComponent<InstructionProps> = ({
         ];
 
     if (selectionType === 'radio') {
-      steps.push(InstallationModeSelectionStep({ mode, setMode }));
+      steps.push(
+        InstallationModeSelectionStep({ selectedPolicyId: selectedPolicy?.id, mode, setMode })
+      );
     }
 
     steps.push(
@@ -257,7 +261,7 @@ export const ManagedSteps: React.FunctionComponent<InstructionProps> = ({
         })
       );
     }
-    if (selectedPolicy && enrolledAgentIds.length) {
+    if (selectedPolicy) {
       steps.push(
         IncomingDataConfirmationStep({
           agentIds: enrolledAgentIds,

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/configure_standalone_agent_step.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/configure_standalone_agent_step.tsx
@@ -111,6 +111,6 @@ export const ConfigureStandaloneAgentStep = ({
         )}
       </>
     ),
-    status: !yaml ? 'loading' : 'incomplete',
+    status: !yaml ? 'loading' : undefined,
   };
 };

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/incoming_data_confirmation_step.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/incoming_data_confirmation_step.tsx
@@ -34,14 +34,15 @@ export const IncomingDataConfirmationStep = ({
       : i18n.translate('xpack.fleet.agentEnrollment.stepConfirmIncomingData.completed', {
           defaultMessage: 'Incoming data confirmed',
         }),
-    children: (
-      <ConfirmIncomingData
-        agentIds={agentIds}
-        installedPolicy={installedPolicy}
-        agentDataConfirmed={agentDataConfirmed}
-        setAgentDataConfirmed={setAgentDataConfirmed}
-      />
-    ),
-    status: !agentDataConfirmed ? 'loading' : 'complete',
+    children:
+      agentIds.length > 0 ? (
+        <ConfirmIncomingData
+          agentIds={agentIds}
+          installedPolicy={installedPolicy}
+          agentDataConfirmed={agentDataConfirmed}
+          setAgentDataConfirmed={setAgentDataConfirmed}
+        />
+      ) : null,
+    status: agentIds.length > 0 ? (!agentDataConfirmed ? 'loading' : 'complete') : 'disabled',
   };
 };

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/install_managed_agent_step.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/install_managed_agent_step.tsx
@@ -27,6 +27,7 @@ export const InstallManagedAgentStep = ({
   isK8s?: string;
 }): EuiContainedStepProps => {
   return {
+    status: selectedApiKeyId ? undefined : 'disabled',
     title: i18n.translate('xpack.fleet.agentEnrollment.stepEnrollAndRunAgentTitle', {
       defaultMessage: 'Install Elastic Agent on your host',
     }),

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/installation_mode_selection_step.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/installation_mode_selection_step.tsx
@@ -15,9 +15,11 @@ import type { EuiContainedStepProps } from '@elastic/eui/src/components/steps/st
 import type { FlyoutMode } from '../types';
 
 export const InstallationModeSelectionStep = ({
+  selectedPolicyId,
   mode,
   setMode,
 }: {
+  selectedPolicyId: string | undefined;
   mode: FlyoutMode;
   setMode: (v: FlyoutMode) => void;
 }): EuiContainedStepProps => {
@@ -32,10 +34,11 @@ export const InstallationModeSelectionStep = ({
   };
 
   return {
+    status: selectedPolicyId ? undefined : 'disabled',
     title: i18n.translate('xpack.fleet.agentEnrollment.stepInstallType', {
       defaultMessage: 'Enroll in Fleet?',
     }),
-    children: (
+    children: selectedPolicyId ? (
       <EuiRadioGroup
         options={[
           {
@@ -83,6 +86,6 @@ export const InstallationModeSelectionStep = ({
         onChange={onChangeCallback}
         name={`radio group ${radioSuffix}`}
       />
-    ),
+    ) : null,
   };
 };


### PR DESCRIPTION
## Summary

While testing the add agent instructions redesign I noticed that the look of the steps is a little bit inconsistent, sometimes they are colored in (`undefined`/default look) and sometimes they are not (`incomplete` status). Per designs, I replaced instances of `incomplete` with either the default or `disabled` styling.

Example of disabled steps when no policy has been chosen yet:
![image](https://user-images.githubusercontent.com/1965714/163272073-14b6e600-d47f-4f44-94c3-2cf288b23d47.png)

Example of disabled confirm data step:
![image](https://user-images.githubusercontent.com/1965714/163272203-76525023-344d-4193-99f0-c51cc5b44a13.png)
