### PR TITLE
Fix roles for discover ccs test

### DIFF
--- a/test/functional/apps/discover/_data_view_editor.ts
+++ b/test/functional/apps/discover/_data_view_editor.ts
@@ -43,7 +43,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('discover integration with data view editor', function describeIndexTests() {
     before(async function () {
-      await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
+      await security.testUser.setRoles([
+        'kibana_admin',
+        'test_logstash_reader',
+        'ccs_remote_search',
+      ]);
       await esNode.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.savedObjects.clean({ types: ['saved-search', 'index-pattern'] });
       await kibanaServer.importExport.load(kbnDirectory);

--- a/test/functional/apps/discover/_data_view_editor.ts
+++ b/test/functional/apps/discover/_data_view_editor.ts
@@ -43,11 +43,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('discover integration with data view editor', function describeIndexTests() {
     before(async function () {
-      await security.testUser.setRoles([
-        'kibana_admin',
-        'test_logstash_reader',
-        'ccs_remote_search',
-      ]);
+      const roles = config.get('esTestCluster.ccs')
+        ? ['kibana_admin', 'test_logstash_reader', 'ccs_remote_search']
+        : ['kibana_admin', 'test_logstash_reader'];
+      await security.testUser.setRoles(roles);
       await esNode.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.savedObjects.clean({ types: ['saved-search', 'index-pattern'] });
       await kibanaServer.importExport.load(kbnDirectory);


### PR DESCRIPTION
Add role ```ccs_remote_search``` role to discover test. This is needed to be run against cloud, otherwise the test fails.    Part of https://github.com/elastic/elastic-stack-testing/issues/1221
