### PR TITLE
fix(NA): do not remote cache npm directories copies on rules_nodejs v5

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -10,8 +10,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch Node.js rules
 http_archive(
   name = "build_bazel_rules_nodejs",
-  urls = ["https://github.com/bazelbuild/rules_nodejs/archive/8a8b0779548a16c98c00ca141a856168a8484a87.zip"],
-  strip_prefix = "rules_nodejs-8a8b0779548a16c98c00ca141a856168a8484a87",
+  patch_args = ["-p1"],
+  patches = ["//:src/dev/bazel/rules_nodejs_patches/exclude_npm_directory_copies_from_remote_cache.patch"],
+  sha256 = "2b2004784358655f334925e7eadc7ba80f701144363df949b3293e1ae7a2fb7b",
+  urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.4.0/rules_nodejs-5.4.0.tar.gz"],
 )
 
 # Build Node.js rules dependencies

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -10,8 +10,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch Node.js rules
 http_archive(
   name = "build_bazel_rules_nodejs",
-  sha256 = "2b2004784358655f334925e7eadc7ba80f701144363df949b3293e1ae7a2fb7b",
-  urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.4.0/rules_nodejs-5.4.0.tar.gz"],
+  urls = ["https://github.com/bazelbuild/rules_nodejs/archive/8a8b0779548a16c98c00ca141a856168a8484a87.zip"],
+  strip_prefix = "rules_nodejs-8a8b0779548a16c98c00ca141a856168a8484a87",
 )
 
 # Build Node.js rules dependencies

--- a/src/dev/bazel/rules_nodejs_patches/exclude_npm_directory_copies_from_remote_cache.patch
+++ b/src/dev/bazel/rules_nodejs_patches/exclude_npm_directory_copies_from_remote_cache.patch
@@ -1,0 +1,15 @@
+diff --git a/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_file_private.bzl b/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_file_private.bzl
+index a719174c..273322d0 100644
+--- a/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_file_private.bzl
++++ b/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_file_private.bzl
+@@ -30,7 +30,9 @@ _execution_requirements = {
+     # Also, remote-execution does not allow source directory inputs, see
+     # https://github.com/bazelbuild/bazel/commit/c64421bc35214f0414e4f4226cc953e8c55fa0d2
+     # So we must not attempt to execute remotely in that case.
+-    "no-remote-exec": "1",
++    # no-remote | Prevents the action or test from being executed remotely or cached remotely.
++    #           | This is equivalent to using both `no-remote-cache` and `no-remote-exec`.
++    "no-remote": "1",
+ }
+ 
+ def _hash_file(file):


### PR DESCRIPTION
This PR introduces a patch to `rules_nodejs` v5.4.0 to fix a remote caching bug while the fix is not officially released. 

It avoids to remote cache assets under `copy_file` rules used to layout the node_modules on `rules_nodejs` since `v5.0.0` and that were being incorrectly cached on the remote server.