### PR TITLE
switched to use latest findings index

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.ts
@@ -5,16 +5,13 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient } from 'src/core/server';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import type {
-  AggregationsMultiBucketAggregateBase as Aggregation,
   AggregationsTopHitsAggregate,
   QueryDslQueryContainer,
-  SearchRequest,
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ComplianceDashboardData } from '../../../common/types';
-import { CSP_KUBEBEAT_INDEX_PATTERN, STATS_ROUTE_PATH } from '../../../common/constants';
+import { STATS_ROUTE_PATH } from '../../../common/constants';
 import { CspAppContext } from '../../plugin';
 import { getResourcesTypes } from './get_resources_types';
 import { ClusterWithoutTrend, getClusters } from './get_clusters';
@@ -26,54 +23,10 @@ export interface ClusterBucket {
   ordered_top_hits: AggregationsTopHitsAggregate;
 }
 
-interface ClustersQueryResult {
-  aggs_by_cluster_id: Aggregation<ClusterBucket>;
-}
-
 export interface KeyDocCount<TKey = string> {
   key: TKey;
   doc_count: number;
 }
-
-export const getLatestFindingQuery = (): SearchRequest => ({
-  index: CSP_KUBEBEAT_INDEX_PATTERN,
-  size: 0,
-  query: {
-    match_all: {},
-  },
-  aggs: {
-    aggs_by_cluster_id: {
-      terms: { field: 'cluster_id.keyword' },
-      aggs: {
-        ordered_top_hits: {
-          top_hits: {
-            size: 1,
-            sort: {
-              '@timestamp': {
-                order: 'desc',
-              },
-            },
-          },
-        },
-      },
-    },
-  },
-});
-
-const getLatestCyclesIds = async (esClient: ElasticsearchClient): Promise<string[]> => {
-  const queryResult = await esClient.search<unknown, ClustersQueryResult>(getLatestFindingQuery(), {
-    meta: true,
-  });
-
-  const clusters = queryResult.body.aggregations?.aggs_by_cluster_id.buckets;
-  if (!Array.isArray(clusters)) throw new Error('missing aggs by cluster id');
-
-  return clusters.map((c) => {
-    const topHit = c.ordered_top_hits.hits.hits[0];
-    if (!topHit) throw new Error('missing cluster latest hit');
-    return topHit._source.cycle_id;
-  });
-};
 
 const getClustersTrends = (clustersWithoutTrends: ClusterWithoutTrend[], trends: Trends) =>
   clustersWithoutTrends.map((cluster) => ({
@@ -100,13 +53,8 @@ export const defineGetComplianceDashboardRoute = (
     async (context, _, response) => {
       try {
         const esClient = context.core.elasticsearch.client.asCurrentUser;
-        const latestCyclesIds = await getLatestCyclesIds(esClient);
         const query: QueryDslQueryContainer = {
-          bool: {
-            should: latestCyclesIds.map((id) => ({
-              match: { 'cycle_id.keyword': { query: id } },
-            })),
-          },
+          match_all: {},
         };
 
         const [stats, resourcesTypes, clustersWithoutTrends, trends] = await Promise.all([

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
@@ -14,7 +14,7 @@ import type {
 import { Cluster } from '../../../common/types';
 import { getResourceTypeFromAggs, resourceTypeAggQuery } from './get_resources_types';
 import type { ResourceTypeQueryResult } from './get_resources_types';
-import { CSP_KUBEBEAT_INDEX_PATTERN } from '../../../common/constants';
+import { LATEST_FINDINGS_INDEX_PATTERN } from '../../../common/constants';
 import { findingsEvaluationAggsQuery, getStatsFromFindingsEvaluationsAggs } from './get_stats';
 import { KeyDocCount } from './compliance_dashboard';
 
@@ -38,7 +38,7 @@ interface ClustersQueryResult {
 export type ClusterWithoutTrend = Omit<Cluster, 'trend'>;
 
 export const getClustersQuery = (query: QueryDslQueryContainer): SearchRequest => ({
-  index: CSP_KUBEBEAT_INDEX_PATTERN,
+  index: LATEST_FINDINGS_INDEX_PATTERN,
   size: 0,
   query,
   aggs: {

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_resources_types.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_resources_types.ts
@@ -13,7 +13,7 @@ import type {
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ComplianceDashboardData } from '../../../common/types';
 import { KeyDocCount } from './compliance_dashboard';
-import { CSP_KUBEBEAT_INDEX_PATTERN } from '../../../common/constants';
+import { LATEST_FINDINGS_INDEX_PATTERN } from '../../../common/constants';
 
 export interface ResourceTypeQueryResult {
   aggs_by_resource_type: Aggregation<ResourceTypeBucket>;
@@ -45,7 +45,7 @@ export const resourceTypeAggQuery = {
 };
 
 export const getRisksEsQuery = (query: QueryDslQueryContainer): SearchRequest => ({
-  index: CSP_KUBEBEAT_INDEX_PATTERN,
+  index: LATEST_FINDINGS_INDEX_PATTERN,
   size: 0,
   query,
   aggs: resourceTypeAggQuery,

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_stats.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_stats.ts
@@ -7,7 +7,7 @@
 
 import { ElasticsearchClient } from 'kibana/server';
 import type { QueryDslQueryContainer, SearchRequest } from '@elastic/elasticsearch/lib/api/types';
-import { CSP_KUBEBEAT_INDEX_PATTERN } from '../../../common/constants';
+import { LATEST_FINDINGS_INDEX_PATTERN } from '../../../common/constants';
 import type { ComplianceDashboardData, Score } from '../../../common/types';
 
 /**
@@ -37,7 +37,7 @@ export const findingsEvaluationAggsQuery = {
 };
 
 export const getEvaluationsQuery = (query: QueryDslQueryContainer): SearchRequest => ({
-  index: CSP_KUBEBEAT_INDEX_PATTERN,
+  index: LATEST_FINDINGS_INDEX_PATTERN,
   query,
   aggs: findingsEvaluationAggsQuery,
 });


### PR DESCRIPTION
## Summary
Switched to use the `latest-findings` index which is being created by our transform.
Also fixes [this issue](https://github.com/elastic/security-team/issues/3628) which happened since we used 2 different sources of data. 

![image](https://user-images.githubusercontent.com/51442161/163359931-79631d5e-a299-4f0b-87bc-dbfe031d52d4.png)

## Related
Waiting for https://github.com/elastic/kibana/pull/129905 to be merged before this one can be merged