### PR TITLE
[Cases] Multiple alerts user action on the UI

### DIFF
--- a/x-pack/plugins/cases/common/ui/types.ts
+++ b/x-pack/plugins/cases/common/ui/types.ts
@@ -17,6 +17,7 @@ import {
   CaseUserActionResponse,
   CaseMetricsResponse,
   CommentResponse,
+  CommentResponseAlertsType,
 } from '../api';
 import { SnakeToCamelCase } from '../types';
 
@@ -57,6 +58,7 @@ export type CaseViewRefreshPropInterface = null | {
 };
 
 export type Comment = SnakeToCamelCase<CommentResponse>;
+export type AlertComment = SnakeToCamelCase<CommentResponseAlertsType>;
 export type CaseUserActions = SnakeToCamelCase<CaseUserActionResponse>;
 export type CaseExternalService = SnakeToCamelCase<CaseExternalServiceBasic>;
 

--- a/x-pack/plugins/cases/public/components/user_actions/comment/alert.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/alert.tsx
@@ -61,6 +61,7 @@ const getSingleAlertUserAction = ({
       type: 'update',
       event: (
         <SingleAlertCommentEvent
+          actionId={userAction.actionId}
           getRuleDetailsHref={getRuleDetailsHref}
           loadingAlertData={loadingAlertData}
           onRuleDetailsClick={onRuleDetailsClick}
@@ -118,6 +119,7 @@ const getMultipleAlertsUserAction = ({
       type: 'update',
       event: (
         <MultipleAlertsCommentEvent
+          actionId={userAction.actionId}
           loadingAlertData={loadingAlertData}
           totalAlerts={totalAlerts}
           ruleId={ruleId}

--- a/x-pack/plugins/cases/public/components/user_actions/comment/alert.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/alert.tsx
@@ -7,15 +7,15 @@
 
 import React from 'react';
 import { get, isEmpty } from 'lodash';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiCommentProps, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils';
 
-import { CommentType, CommentResponseAlertsType } from '../../../../common/api';
+import { CommentResponseAlertsType } from '../../../../common/api';
 import { UserActionBuilder, UserActionBuilderArgs } from '../types';
 import { UserActionTimestamp } from '../timestamp';
 import { SnakeToCamelCase } from '../../../../common/types';
 import { UserActionUsernameWithAvatar } from '../avatar_username';
-import { AlertCommentEvent } from './alert_event';
+import { MultipleAlertsCommentEvent, SingleAlertCommentEvent } from './alert_event';
 import { UserActionCopyLink } from '../copy_link';
 import { UserActionShowAlert } from './show_alert';
 
@@ -29,7 +29,7 @@ type BuilderArgs = Pick<
   | 'onShowAlertDetails'
 > & { comment: SnakeToCamelCase<CommentResponseAlertsType> };
 
-export const createAlertAttachmentUserActionBuilder = ({
+const getSingleAlertUserAction = ({
   userAction,
   comment,
   alertData,
@@ -37,62 +37,121 @@ export const createAlertAttachmentUserActionBuilder = ({
   loadingAlertData,
   onRuleDetailsClick,
   onShowAlertDetails,
-}: BuilderArgs): ReturnType<UserActionBuilder> => ({
-  // TODO: Fix this manually. Issue #123375
-  // eslint-disable-next-line react/display-name
-  build: () => {
-    const alertId = getNonEmptyField(comment.alertId);
-    const alertIndex = getNonEmptyField(comment.index);
+}: BuilderArgs): EuiCommentProps[] => {
+  const alertId = getNonEmptyField(comment.alertId);
+  const alertIndex = getNonEmptyField(comment.index);
 
-    if (!alertId || !alertIndex) {
-      return [];
+  if (!alertId || !alertIndex) {
+    return [];
+  }
+
+  const alertField: unknown | undefined = alertData[alertId];
+  const ruleId = getRuleId(comment, alertField);
+  const ruleName = getRuleName(comment, alertField);
+
+  return [
+    {
+      username: (
+        <UserActionUsernameWithAvatar
+          username={userAction.createdBy.username}
+          fullName={userAction.createdBy.fullName}
+        />
+      ),
+      className: 'comment-alert',
+      type: 'update',
+      event: (
+        <SingleAlertCommentEvent
+          getRuleDetailsHref={getRuleDetailsHref}
+          loadingAlertData={loadingAlertData}
+          onRuleDetailsClick={onRuleDetailsClick}
+          ruleId={ruleId}
+          ruleName={ruleName}
+        />
+      ),
+      'data-test-subj': `user-action-alert-${userAction.type}-${userAction.action}-action-${userAction.actionId}`,
+      timestamp: <UserActionTimestamp createdAt={userAction.createdAt} />,
+      timelineIcon: 'bell',
+      actions: (
+        <EuiFlexGroup responsive={false}>
+          <EuiFlexItem grow={false}>
+            <UserActionCopyLink id={userAction.actionId} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <UserActionShowAlert
+              id={userAction.actionId}
+              alertId={alertId}
+              index={alertIndex}
+              onShowAlertDetails={onShowAlertDetails}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ),
+    },
+  ];
+};
+
+const getMultipleAlertsUserAction = ({
+  userAction,
+  comment,
+  alertData,
+  getRuleDetailsHref,
+  loadingAlertData,
+  onRuleDetailsClick,
+  onShowAlertDetails,
+}: BuilderArgs): EuiCommentProps[] => {
+  if (!Array.isArray(comment.alertId)) {
+    return [];
+  }
+
+  const totalAlerts = comment.alertId.length;
+  const { ruleId, ruleName } = getRuleInfo(comment, alertData);
+
+  return [
+    {
+      username: (
+        <UserActionUsernameWithAvatar
+          username={userAction.createdBy.username}
+          fullName={userAction.createdBy.fullName}
+        />
+      ),
+      className: 'comment-alert',
+      type: 'update',
+      event: (
+        <MultipleAlertsCommentEvent
+          loadingAlertData={loadingAlertData}
+          totalAlerts={totalAlerts}
+          ruleId={ruleId}
+          ruleName={ruleName}
+          getRuleDetailsHref={getRuleDetailsHref}
+          onRuleDetailsClick={onRuleDetailsClick}
+        />
+      ),
+      'data-test-subj': `user-action-alert-${userAction.type}-${userAction.action}-action-${userAction.actionId}`,
+      timestamp: <UserActionTimestamp createdAt={userAction.createdAt} />,
+      timelineIcon: 'bell',
+      actions: (
+        <EuiFlexGroup responsive={false}>
+          <EuiFlexItem grow={false}>
+            <UserActionCopyLink id={userAction.actionId} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ),
+    },
+  ];
+};
+
+export const createAlertAttachmentUserActionBuilder = (
+  params: BuilderArgs
+): ReturnType<UserActionBuilder> => ({
+  build: () => {
+    const { comment } = params;
+    const alertId = Array.isArray(comment.alertId) ? comment.alertId : [comment.alertId];
+
+    if (alertId.length === 1) {
+      return getSingleAlertUserAction(params);
     }
 
-    const alertField: unknown | undefined = alertData[alertId];
-    const ruleId = getRuleId(comment, alertField);
-    const ruleName = getRuleName(comment, alertField);
-
-    return [
-      {
-        username: (
-          <UserActionUsernameWithAvatar
-            username={userAction.createdBy.username}
-            fullName={userAction.createdBy.fullName}
-          />
-        ),
-        className: 'comment-alert',
-        type: 'update',
-        event: (
-          <AlertCommentEvent
-            alertId={alertId}
-            getRuleDetailsHref={getRuleDetailsHref}
-            loadingAlertData={loadingAlertData}
-            onRuleDetailsClick={onRuleDetailsClick}
-            ruleId={ruleId}
-            ruleName={ruleName}
-            commentType={CommentType.alert}
-          />
-        ),
-        'data-test-subj': `user-action-alert-${userAction.type}-${userAction.action}-action-${userAction.actionId}`,
-        timestamp: <UserActionTimestamp createdAt={userAction.createdAt} />,
-        timelineIcon: 'bell',
-        actions: (
-          <EuiFlexGroup responsive={false}>
-            <EuiFlexItem grow={false}>
-              <UserActionCopyLink id={userAction.actionId} />
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <UserActionShowAlert
-                id={userAction.actionId}
-                alertId={alertId}
-                index={alertIndex}
-                onShowAlertDetails={onShowAlertDetails}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        ),
-      },
-    ];
+    return getMultipleAlertsUserAction(params);
   },
 });
 
@@ -142,4 +201,18 @@ function getNonEmptyField(field: string | string[] | undefined | null): string |
   }
 
   return firstItem;
+}
+
+function getRuleInfo(comment: BuilderArgs['comment'], alertData: BuilderArgs['alertData']) {
+  const alertId = getNonEmptyField(comment.alertId);
+
+  if (!alertId) {
+    return { ruleId: null, ruleName: null };
+  }
+
+  const alertField: unknown | undefined = alertData[alertId];
+  const ruleId = getRuleId(comment, alertField);
+  const ruleName = getRuleName(comment, alertField);
+
+  return { ruleId, ruleName };
 }

--- a/x-pack/plugins/cases/public/components/user_actions/comment/alert.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/alert.tsx
@@ -98,7 +98,6 @@ const getMultipleAlertsUserAction = ({
   getRuleDetailsHref,
   loadingAlertData,
   onRuleDetailsClick,
-  onShowAlertDetails,
 }: BuilderArgs): EuiCommentProps[] => {
   if (!Array.isArray(comment.alertId)) {
     return [];
@@ -205,7 +204,7 @@ function getNonEmptyField(field: string | string[] | undefined | null): string |
   return firstItem;
 }
 
-function getRuleInfo(comment: BuilderArgs['comment'], alertData: BuilderArgs['alertData']) {
+export function getRuleInfo(comment: BuilderArgs['comment'], alertData: BuilderArgs['alertData']) {
   const alertId = getNonEmptyField(comment.alertId);
 
   if (!alertId) {

--- a/x-pack/plugins/cases/public/components/user_actions/comment/alert_event.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/alert_event.test.tsx
@@ -11,16 +11,13 @@ import { mount } from 'enzyme';
 import { TestProviders } from '../../../common/mock';
 import { useKibana } from '../../../common/lib/kibana';
 import { SingleAlertCommentEvent } from './alert_event';
-import { CommentType } from '../../../../common/api';
 
 const props = {
-  alertId: 'alert-id-1',
+  actionId: 'action-id-1',
   getRuleDetailsHref: jest.fn().mockReturnValue('https://example.com'),
   onRuleDetailsClick: jest.fn(),
   ruleId: 'rule-id-1',
   ruleName: 'Awesome rule',
-  alertsCount: 1,
-  commentType: CommentType.alert,
 };
 
 jest.mock('../../../common/lib/kibana');
@@ -43,7 +40,7 @@ describe('UserActionAvatar ', () => {
     );
 
     expect(
-      wrapper.find(`[data-test-subj="alert-rule-link-alert-id-1"]`).first().exists()
+      wrapper.find(`[data-test-subj="alert-rule-link-action-id-1"]`).first().exists()
     ).toBeTruthy();
     expect(wrapper.text()).toBe('added an alert from Awesome rule');
   });
@@ -56,7 +53,7 @@ describe('UserActionAvatar ', () => {
     );
 
     expect(
-      wrapper.find(`[data-test-subj="alert-rule-link-alert-id-1"]`).first().exists()
+      wrapper.find(`[data-test-subj="alert-rule-link-action-id-1"]`).first().exists()
     ).toBeFalsy();
 
     expect(wrapper.text()).toBe('added an alert from Awesome rule');
@@ -70,7 +67,7 @@ describe('UserActionAvatar ', () => {
     );
 
     expect(
-      wrapper.find(`[data-test-subj="alert-rule-link-alert-id-1"]`).first().exists()
+      wrapper.find(`[data-test-subj="alert-rule-link-action-id-1"]`).first().exists()
     ).toBeFalsy();
 
     expect(wrapper.text()).toBe('added an alert from Awesome rule');
@@ -84,7 +81,7 @@ describe('UserActionAvatar ', () => {
     );
 
     expect(
-      wrapper.find(`[data-test-subj="alert-rule-link-alert-id-1"]`).first().exists()
+      wrapper.find(`[data-test-subj="alert-rule-link-action-id-1"]`).first().exists()
     ).toBeTruthy();
     expect(wrapper.text()).toBe('added an alert from Unknown rule');
   });
@@ -98,7 +95,7 @@ describe('UserActionAvatar ', () => {
       </TestProviders>
     );
 
-    wrapper.find(`[data-test-subj="alert-rule-link-alert-id-1"]`).first().simulate('click');
+    wrapper.find(`[data-test-subj="alert-rule-link-action-id-1"]`).first().simulate('click');
     expect(onRuleDetailsClick).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/cases/public/components/user_actions/comment/alert_event.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/alert_event.test.tsx
@@ -10,7 +10,7 @@ import { mount } from 'enzyme';
 
 import { TestProviders } from '../../../common/mock';
 import { useKibana } from '../../../common/lib/kibana';
-import { AlertCommentEvent } from './alert_event';
+import { SingleAlertCommentEvent } from './alert_event';
 import { CommentType } from '../../../../common/api';
 
 const props = {
@@ -38,7 +38,7 @@ describe('UserActionAvatar ', () => {
   it('it renders', async () => {
     const wrapper = mount(
       <TestProviders>
-        <AlertCommentEvent {...props} />
+        <SingleAlertCommentEvent {...props} />
       </TestProviders>
     );
 
@@ -51,7 +51,7 @@ describe('UserActionAvatar ', () => {
   it('does NOT render the link when the rule is null', async () => {
     const wrapper = mount(
       <TestProviders>
-        <AlertCommentEvent {...props} ruleId={null} />
+        <SingleAlertCommentEvent {...props} ruleId={null} />
       </TestProviders>
     );
 
@@ -65,7 +65,7 @@ describe('UserActionAvatar ', () => {
   it('does NOT render the link when the href is invalid but it shows the rule name', async () => {
     const wrapper = mount(
       <TestProviders>
-        <AlertCommentEvent {...props} getRuleDetailsHref={undefined} />
+        <SingleAlertCommentEvent {...props} getRuleDetailsHref={undefined} />
       </TestProviders>
     );
 
@@ -79,7 +79,7 @@ describe('UserActionAvatar ', () => {
   it('show Unknown rule if the rule name is invalid', async () => {
     const wrapper = mount(
       <TestProviders>
-        <AlertCommentEvent {...props} ruleName={null} />
+        <SingleAlertCommentEvent {...props} ruleName={null} />
       </TestProviders>
     );
 
@@ -94,7 +94,7 @@ describe('UserActionAvatar ', () => {
 
     const wrapper = mount(
       <TestProviders>
-        <AlertCommentEvent {...props} onRuleDetailsClick={onRuleDetailsClick} />
+        <SingleAlertCommentEvent {...props} onRuleDetailsClick={onRuleDetailsClick} />
       </TestProviders>
     );
 

--- a/x-pack/plugins/cases/public/components/user_actions/comment/alert_event.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/alert_event.tsx
@@ -14,6 +14,7 @@ import { LinkAnchor } from '../../links';
 import { RuleDetailsNavigation } from '../types';
 
 interface SingleAlertProps {
+  actionId: string;
   ruleId?: string | null;
   ruleName?: string | null;
   getRuleDetailsHref?: RuleDetailsNavigation['href'];
@@ -26,7 +27,7 @@ interface MultipleAlertsProps extends SingleAlertProps {
 }
 
 const RuleLink: React.FC<SingleAlertProps> = memo(
-  ({ onRuleDetailsClick, getRuleDetailsHref, ruleId, ruleName, loadingAlertData }) => {
+  ({ onRuleDetailsClick, getRuleDetailsHref, ruleId, ruleName, loadingAlertData, actionId }) => {
     const onLinkClick = useCallback(
       (ev) => {
         ev.preventDefault();
@@ -43,7 +44,7 @@ const RuleLink: React.FC<SingleAlertProps> = memo(
         <LinkAnchor
           onClick={onLinkClick}
           href={ruleDetailsHref}
-          data-test-subj={`alert-rule-link-${ruleId ?? 'deleted'}`}
+          data-test-subj={`alert-rule-link-${actionId ?? 'deleted'}`}
         >
           {finalRuleName}
         </LinkAnchor>
@@ -57,6 +58,7 @@ const RuleLink: React.FC<SingleAlertProps> = memo(
 RuleLink.displayName = 'RuleLink';
 
 const SingleAlertCommentEventComponent: React.FC<SingleAlertProps> = ({
+  actionId,
   getRuleDetailsHref,
   loadingAlertData = false,
   onRuleDetailsClick,
@@ -68,6 +70,7 @@ const SingleAlertCommentEventComponent: React.FC<SingleAlertProps> = ({
       {`${i18n.ALERT_COMMENT_LABEL_TITLE} `}
       {loadingAlertData && <EuiLoadingSpinner size="m" />}
       <RuleLink
+        actionId={actionId}
         ruleId={ruleId}
         ruleName={ruleName}
         getRuleDetailsHref={getRuleDetailsHref}
@@ -83,6 +86,7 @@ SingleAlertCommentEventComponent.displayName = 'SingleAlertCommentEvent';
 export const SingleAlertCommentEvent = memo(SingleAlertCommentEventComponent);
 
 const MultipleAlertsCommentEventComponent: React.FC<MultipleAlertsProps> = ({
+  actionId,
   getRuleDetailsHref,
   loadingAlertData = false,
   onRuleDetailsClick,
@@ -94,6 +98,7 @@ const MultipleAlertsCommentEventComponent: React.FC<MultipleAlertsProps> = ({
     <>
       {`${i18n.MULTIPLE_ALERTS_COMMENT_LABEL_TITLE(totalAlerts)}`}{' '}
       <RuleLink
+        actionId={actionId}
         ruleId={ruleId}
         ruleName={ruleName}
         getRuleDetailsHref={getRuleDetailsHref}

--- a/x-pack/plugins/cases/public/components/user_actions/comment/alert_event.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/alert_event.tsx
@@ -39,12 +39,16 @@ const RuleLink: React.FC<SingleAlertProps> = memo(
     const ruleDetailsHref = getRuleDetailsHref?.(ruleId);
     const finalRuleName = ruleName ?? i18n.UNKNOWN_RULE;
 
-    if (!loadingAlertData && !isEmpty(ruleId) && ruleDetailsHref != null) {
+    if (loadingAlertData) {
+      return <EuiLoadingSpinner size="m" data-test-subj={`alert-loading-spinner-${actionId}`} />;
+    }
+
+    if (!isEmpty(ruleId) && ruleDetailsHref != null) {
       return (
         <LinkAnchor
           onClick={onLinkClick}
           href={ruleDetailsHref}
-          data-test-subj={`alert-rule-link-${actionId ?? 'deleted'}`}
+          data-test-subj={`alert-rule-link-${actionId}`}
         >
           {finalRuleName}
         </LinkAnchor>
@@ -66,9 +70,8 @@ const SingleAlertCommentEventComponent: React.FC<SingleAlertProps> = ({
   ruleName,
 }) => {
   return (
-    <>
+    <span data-test-subj={`single-alert-user-action-${actionId}`}>
       {`${i18n.ALERT_COMMENT_LABEL_TITLE} `}
-      {loadingAlertData && <EuiLoadingSpinner size="m" />}
       <RuleLink
         actionId={actionId}
         ruleId={ruleId}
@@ -77,7 +80,7 @@ const SingleAlertCommentEventComponent: React.FC<SingleAlertProps> = ({
         onRuleDetailsClick={onRuleDetailsClick}
         loadingAlertData={loadingAlertData}
       />
-    </>
+    </span>
   );
 };
 
@@ -95,7 +98,7 @@ const MultipleAlertsCommentEventComponent: React.FC<MultipleAlertsProps> = ({
   totalAlerts,
 }) => {
   return (
-    <>
+    <span data-test-subj={`multiple-alerts-user-action-${actionId}`}>
       {`${i18n.MULTIPLE_ALERTS_COMMENT_LABEL_TITLE(totalAlerts)}`}{' '}
       <RuleLink
         actionId={actionId}
@@ -105,7 +108,7 @@ const MultipleAlertsCommentEventComponent: React.FC<MultipleAlertsProps> = ({
         onRuleDetailsClick={onRuleDetailsClick}
         loadingAlertData={loadingAlertData}
       />
-    </>
+    </span>
   );
 };
 

--- a/x-pack/plugins/cases/public/components/user_actions/comment/comment.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/comment.test.tsx
@@ -86,27 +86,62 @@ describe('createCommentUserActionBuilder', () => {
     expect(screen.getByText('Solve this fast!')).toBeInTheDocument();
   });
 
-  it('renders correctly an alert', async () => {
-    const userAction = getAlertUserAction();
+  describe('Single alert', () => {
+    it('renders correctly a single alert', async () => {
+      const userAction = getAlertUserAction();
 
-    const builder = createCommentUserActionBuilder({
-      ...builderArgs,
-      caseData: {
-        ...builderArgs.caseData,
-        comments: [alertComment],
-      },
-      userAction,
+      const builder = createCommentUserActionBuilder({
+        ...builderArgs,
+        caseData: {
+          ...builderArgs.caseData,
+          comments: [alertComment],
+        },
+        userAction,
+      });
+
+      const createdUserAction = builder.build();
+      render(
+        <TestProviders>
+          <EuiCommentList comments={createdUserAction} />
+        </TestProviders>
+      );
+
+      expect(screen.getByTestId('single-alert-user-action-alert-action-id')).toHaveTextContent(
+        'added an alert from Awesome rule'
+      );
     });
+  });
 
-    const createdUserAction = builder.build();
-    render(
-      <TestProviders>
-        <EuiCommentList comments={createdUserAction} />
-      </TestProviders>
-    );
+  describe('Multiple alerts', () => {
+    it('renders correctly multiple alerts', async () => {
+      const userAction = getAlertUserAction();
 
-    expect(screen.getByText('added an alert from')).toBeInTheDocument();
-    expect(screen.getByText('Awesome rule')).toBeInTheDocument();
+      const builder = createCommentUserActionBuilder({
+        ...builderArgs,
+        caseData: {
+          ...builderArgs.caseData,
+          comments: [
+            {
+              ...alertComment,
+              alertId: ['alert-id-1', 'alert-id-2'],
+              index: ['alert-index-1', 'alert-index-2'],
+            },
+          ],
+        },
+        userAction,
+      });
+
+      const createdUserAction = builder.build();
+      render(
+        <TestProviders>
+          <EuiCommentList comments={createdUserAction} />
+        </TestProviders>
+      );
+
+      expect(screen.getByTestId('multiple-alerts-user-action-alert-action-id')).toHaveTextContent(
+        'added 2 alerts from Awesome rule'
+      );
+    });
   });
 
   it('renders correctly an action', async () => {

--- a/x-pack/plugins/cases/public/components/user_actions/translations.ts
+++ b/x-pack/plugins/cases/public/components/user_actions/translations.ts
@@ -39,7 +39,7 @@ export const ALERT_COMMENT_LABEL_TITLE = i18n.translate(
 export const MULTIPLE_ALERTS_COMMENT_LABEL_TITLE = (totalAlerts: number) =>
   i18n.translate('xpack.cases.caseView.generatedAlertCommentLabelTitle', {
     values: { totalAlerts },
-    defaultMessage: '{totalAlerts} alerts were added from',
+    defaultMessage: 'added {totalAlerts} alerts from',
   });
 
 export const SHOW_ALERT_TOOLTIP = i18n.translate('xpack.cases.caseView.showAlertTooltip', {

--- a/x-pack/plugins/cases/public/components/user_actions/translations.ts
+++ b/x-pack/plugins/cases/public/components/user_actions/translations.ts
@@ -36,17 +36,10 @@ export const ALERT_COMMENT_LABEL_TITLE = i18n.translate(
   }
 );
 
-export const GENERATED_ALERT_COMMENT_LABEL_TITLE = i18n.translate(
-  'xpack.cases.caseView.generatedAlertCommentLabelTitle',
-  {
-    defaultMessage: 'were added from',
-  }
-);
-
-export const GENERATED_ALERT_COUNT_COMMENT_LABEL_TITLE = (totalCount: number) =>
-  i18n.translate('xpack.cases.caseView.generatedAlertCountCommentLabelTitle', {
-    values: { totalCount },
-    defaultMessage: `{totalCount} {totalCount, plural, =1 {alert} other {alerts}}`,
+export const MULTIPLE_ALERTS_COMMENT_LABEL_TITLE = (totalAlerts: number) =>
+  i18n.translate('xpack.cases.caseView.generatedAlertCommentLabelTitle', {
+    values: { totalAlerts },
+    defaultMessage: '{totalAlerts} alerts were added from',
   });
 
 export const SHOW_ALERT_TOOLTIP = i18n.translate('xpack.cases.caseView.showAlertTooltip', {

--- a/x-pack/plugins/cases/public/containers/mock.ts
+++ b/x-pack/plugins/cases/public/containers/mock.ts
@@ -7,7 +7,12 @@
 
 import { ActionLicense, AllCases, Case, CasesStatus, CaseUserActions, Comment } from './types';
 
-import type { ResolvedCase, CaseMetrics, CaseMetricsFeature } from '../../common/ui/types';
+import type {
+  ResolvedCase,
+  CaseMetrics,
+  CaseMetricsFeature,
+  AlertComment,
+} from '../../common/ui/types';
 import {
   Actions,
   ActionTypes,
@@ -65,7 +70,7 @@ export const basicComment: Comment = {
   version: 'WzQ3LDFc',
 };
 
-export const alertComment: Comment = {
+export const alertComment: AlertComment = {
   alertId: 'alert-id-1',
   index: 'alert-index-1',
   type: CommentType.alert,

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -7661,8 +7661,6 @@
     "xpack.cases.caseView.errorsPushServiceCallOutTitle": "Sélectionner un connecteur externe",
     "xpack.cases.caseView.fieldChanged": "a modifié le champ du connecteur",
     "xpack.cases.caseView.fieldRequiredError": "Champ requis",
-    "xpack.cases.caseView.generatedAlertCommentLabelTitle": "ont été ajoutés à partir de",
-    "xpack.cases.caseView.generatedAlertCountCommentLabelTitle": "{totalCount} {totalCount, plural, =1 {alerte} other {alertes}}",
     "xpack.cases.caseView.isolatedHost": "a soumis une demande d'isolement sur l'hôte",
     "xpack.cases.caseView.lockedIncidentDesc": "Aucune mise à jour n'est requise",
     "xpack.cases.caseView.lockedIncidentTitle": "L'incident { thirdParty } est à jour",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -8929,8 +8929,6 @@
     "xpack.cases.caseView.errorsPushServiceCallOutTitle": "外部コネクターを選択",
     "xpack.cases.caseView.fieldChanged": "変更されたコネクターフィールド",
     "xpack.cases.caseView.fieldRequiredError": "必須フィールド",
-    "xpack.cases.caseView.generatedAlertCommentLabelTitle": "から追加されました",
-    "xpack.cases.caseView.generatedAlertCountCommentLabelTitle": "{totalCount} {totalCount, plural, other  {アラート}}",
     "xpack.cases.caseView.isolatedHost": "ホストで分離リクエストが送信されました",
     "xpack.cases.caseView.lockedIncidentDesc": "更新は必要ありません",
     "xpack.cases.caseView.lockedIncidentTitle": "{ thirdParty }インシデントは最新です",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -8946,8 +8946,6 @@
     "xpack.cases.caseView.errorsPushServiceCallOutTitle": "选择外部连接器",
     "xpack.cases.caseView.fieldChanged": "已更改连接器字段",
     "xpack.cases.caseView.fieldRequiredError": "必填字段",
-    "xpack.cases.caseView.generatedAlertCommentLabelTitle": "添加自",
-    "xpack.cases.caseView.generatedAlertCountCommentLabelTitle": "{totalCount} 个{totalCount, plural, other {告警}}",
     "xpack.cases.caseView.isolatedHost": "在主机上已提交隔离请求",
     "xpack.cases.caseView.lockedIncidentDesc": "不需要任何更新",
     "xpack.cases.caseView.lockedIncidentTitle": "{ thirdParty } 事件是最新的",


### PR DESCRIPTION
## Summary

This PR shows a user action on the single page of a case when bulk alerts are attached to a case. At the moment users are not able to bulk attach alerts to a case.

<img width="1697" alt="Screenshot 2022-04-15 at 11 45 15 AM" src="https://user-images.githubusercontent.com/7871006/163548606-cdd36da2-79e9-4caf-856b-83fd45d378cf.png">


## Testing

```
POST /api/cases/<case_id>/comments
{
    // You can add as many alert ids as you want.
    "alertId": [<alert_id>, <alert_id>],
    // Index should have the same length as the alertId array
    "index": [<index>, <index>],
    "rule": { "id": <rule_id>, "name": <rule_name> },
    "type": "alert",
    "owner": "securitySolution"
}
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
