### PR TITLE
[ML] Fixes alignment of Anomaly Explorer swim lane annotations label on Firefox

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/swimlane_annotation_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_annotation_container.tsx
@@ -68,7 +68,7 @@ export const SwimlaneAnnotationContainer: FC<SwimlaneAnnotationContainerProps> =
         )
         .attr('x', Y_AXIS_LABEL_WIDTH - Y_AXIS_LABEL_PADDING)
         .attr('y', ANNOTATION_CONTAINER_HEIGHT / 2)
-        .attr('alignment-baseline', 'middle')
+        .attr('dominant-baseline', 'middle')
         .style('fill', euiTheme.euiTextSubduedColor)
         .style('font-size', euiTheme.euiFontSizeXS);
 


### PR DESCRIPTION
## Summary

Fixes the alignment of the 'Annotations' label on the annotations swim lane in the Anomaly Explorer, so that it is fully visible on Firefox.

Before:

![image](https://user-images.githubusercontent.com/7405507/163416027-5bbc26ae-13a2-40a7-985c-1de2761690e5.png)

After:

![image](https://user-images.githubusercontent.com/7405507/163415903-6cfabf18-07f5-4cce-8acd-a16e6a05eb31.png)

Switches the use of the `alignment-baseline` attribute on the SVG `text` element to `dominant-baseline`

### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

Fixes #130114
