### PR TITLE
[ML] Fixes cell popover in data frame analytics results grid

### DIFF
--- a/x-pack/plugins/ml/public/application/components/data_grid/data_grid.tsx
+++ b/x-pack/plugins/ml/public/application/components/data_grid/data_grid.tsx
@@ -169,6 +169,8 @@ export const DataGrid: FC<Props> = memo(
             );
           } else if (schema === 'featureInfluence') {
             return <EuiCodeBlock isCopyable={true}>{cellContentsElement.textContent}</EuiCodeBlock>;
+          } else {
+            return <DefaultCellPopover {...popoverProps} />;
           }
         } else {
           return <DefaultCellPopover {...popoverProps} />;


### PR DESCRIPTION
## Summary

Fixes regression introduced by https://github.com/elastic/kibana/pull/126926, where the data frame analytics results page would fail to render if opening a popover on a cell (other than the feature importance or feature influence cells) in the results data grid.

Before: see example in #130277 

After fix:

![dfa_results_grid_popover](https://user-images.githubusercontent.com/7405507/163432885-ffa086f2-d73d-44bf-9928-d26ddca6448b.gif)

### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

Fixes #130277
