### PR TITLE
[8.0] fix paths in sample code in docs (#130278)

### DIFF
--- a/docs/api/data-views/update-fields.asciidoc
+++ b/docs/api/data-views/update-fields.asciidoc
@@ -44,7 +44,7 @@ Set popularity `count` for field `foo`:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/saved_objects/index-pattern/my-pattern/fields
+$ curl -X POST api/index-patterns/index-pattern/my-pattern/fields
 {
     "fields": {
         "foo": {
@@ -59,7 +59,8 @@ Update multiple metadata fields in one request:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/saved_objects/index-pattern/my-pattern/fields
+
+$ curl -X POST api/index-patterns/index-pattern/my-pattern/fields
 {
     "fields": {
         "foo": {
@@ -77,7 +78,7 @@ $ curl -X POST api/saved_objects/index-pattern/my-pattern/fields
 Use `null` value to delete metadata:
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/saved_objects/index-pattern/my-pattern/fields
+$ curl -X POST api/index-patterns/index-pattern/my-pattern/fields
 {
     "fields": {
         "foo": {

--- a/docs/api/data-views/update.asciidoc
+++ b/docs/api/data-views/update.asciidoc
@@ -56,7 +56,7 @@ Update a title of the `<my-pattern>` data view:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/saved_objects/index-pattern/my-pattern
+$ curl -X POST api/index-patterns/index-pattern/my-pattern
 {
   "index_pattern": {
     "title": "some-other-pattern-*"
@@ -69,7 +69,7 @@ Customize the update behavior:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/saved_objects/index-pattern/my-pattern
+$ curl -X POST api/index-patterns/index-pattern/my-pattern
 {
   "refresh_fields": true,
   "index_pattern": {
@@ -84,7 +84,7 @@ All update fields are optional, but you can specify the following fields:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/saved_objects/index-pattern/my-pattern
+$ curl -X POST api/index-patterns/index-pattern/my-pattern
 {
   "index_pattern": {
     "title": "...",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [fix paths in sample code in docs (#130278)](https://github.com/elastic/kibana/pull/130278)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)