### PR TITLE
[Fleet] Improve Fleet preconfiguration tests

### DIFF
--- a/x-pack/plugins/fleet/server/integration_tests/__snapshots__/cloud_preconfiguration.test.ts.snap
+++ b/x-pack/plugins/fleet/server/integration_tests/__snapshots__/cloud_preconfiguration.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Fleet preconfiguration reset Preconfigred cloud policy Create correct .fleet-policies 1`] = `
+exports[`Fleet preconfiguration reset Preconfigured cloud policy With a full preconfigured cloud policy Create correct .fleet-policies 1`] = `
 Object {
   "agent": Object {
     "monitoring": Object {

--- a/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
@@ -281,7 +281,7 @@ describe('Fleet preconfiguration reset', () => {
           CLOUD_KIBANA_WITHOUT_PACKAGE_POLICY_ID_CONFIG
         );
 
-        // 2. Add APM to the preconfigured policy
+        // 2. Add pacakge policy ids to the preconfigured policy
         await startOrRestartKibana(CLOUD_KIBANA_CONFIG);
       });
 

--- a/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
@@ -14,7 +14,11 @@ import type { PackagePolicySOAttributes } from '../../common';
 import type { AgentPolicySOAttributes } from '../types';
 
 import { useDockerRegistry, waitForFleetSetup } from './helpers';
-import { CLOUD_KIBANA_CONFIG } from './fixtures/cloud_kibana_config';
+import {
+  CLOUD_KIBANA_CONFIG,
+  CLOUD_KIBANA_CONFIG_WITHOUT_APM,
+  CLOUD_KIBANA_WITHOUT_PACKAGE_POLICY_ID_CONFIG,
+} from './fixtures';
 
 const logFilePath = Path.join(__dirname, 'logs.log');
 
@@ -24,7 +28,7 @@ describe('Fleet preconfiguration reset', () => {
 
   const registryUrl = useDockerRegistry();
 
-  const startServers = async () => {
+  const startServers = async (defaultKbnConfig: any = CLOUD_KIBANA_CONFIG) => {
     const { startES } = kbnTestServer.createTestServers({
       adjustTimeout: (t) => jest.setTimeout(t),
       settings: {
@@ -36,13 +40,17 @@ describe('Fleet preconfiguration reset', () => {
     });
 
     esServer = await startES();
-    const startKibana = async () => {
+    const startOrRestartKibana = async (kbnConfig: any = defaultKbnConfig) => {
+      if (kbnServer) {
+        await kbnServer.stop();
+      }
+
       const root = kbnTestServer.createRootWithCorePlugins(
         {
           xpack: {
-            ...CLOUD_KIBANA_CONFIG.xpack,
+            ...kbnConfig.xpack,
             fleet: {
-              ...CLOUD_KIBANA_CONFIG.xpack.fleet,
+              ...kbnConfig.xpack.fleet,
               registryUrl,
             },
           },
@@ -75,15 +83,19 @@ describe('Fleet preconfiguration reset', () => {
       const coreSetup = await root.setup();
       const coreStart = await root.start();
 
-      return {
+      kbnServer = {
         root,
         coreSetup,
         coreStart,
         stop: async () => await root.shutdown(),
       };
+      await waitForFleetSetup(kbnServer.root);
     };
-    kbnServer = await startKibana();
-    await waitForFleetSetup(kbnServer.root);
+    await startOrRestartKibana();
+
+    return {
+      startOrRestartKibana,
+    };
   };
 
   const stopServers = async () => {
@@ -98,63 +110,65 @@ describe('Fleet preconfiguration reset', () => {
     await new Promise((res) => setTimeout(res, 10000));
   };
 
-  // Share the same servers for all the test to make test a lot faster (but test are not isolated anymore)
-  beforeAll(async () => {
-    await startServers();
-  });
-
-  afterAll(async () => {
-    await stopServers();
-  });
-
-  describe('Preconfigred cloud policy', () => {
-    it('Works and preconfigure correctly agent policies', async () => {
-      const agentPolicies = await kbnServer.coreStart.savedObjects
-        .createInternalRepository()
-        .find<AgentPolicySOAttributes>({
-          type: 'ingest-agent-policies',
-          perPage: 10000,
-        });
-
-      expect(agentPolicies.total).toBe(2);
-      expect(
-        agentPolicies.saved_objects.find((so) => so.id === 'policy-elastic-agent-on-cloud')
-      ).toBeDefined();
-      expect(agentPolicies.saved_objects.find((so) => so.id === 'default-policy')).toBeDefined();
-    });
-
-    it('Create correct .fleet-policies', async () => {
-      const res = await kbnServer.coreStart.elasticsearch.client.asInternalUser.search({
-        index: AGENT_POLICY_INDEX,
-        q: `policy_id:policy-elastic-agent-on-cloud`,
-        sort: 'revision_idx:desc',
+  describe('Preconfigured cloud policy', () => {
+    describe('With a full preconfigured cloud policy', () => {
+      beforeAll(async () => {
+        await startServers();
       });
 
-      expect((res.hits.hits[0]._source as any)!.data).toMatchSnapshot();
-    });
+      afterAll(async () => {
+        await stopServers();
+      });
 
-    it('Create correct package policies', async () => {
-      const packagePolicies = await kbnServer.coreStart.savedObjects
-        .createInternalRepository()
-        .find<PackagePolicySOAttributes>({
-          type: 'ingest-package-policies',
-          perPage: 10000,
+      it('Works and preconfigure correctly agent policies', async () => {
+        const agentPolicies = await kbnServer.coreStart.savedObjects
+          .createInternalRepository()
+          .find<AgentPolicySOAttributes>({
+            type: 'ingest-agent-policies',
+            perPage: 10000,
+          });
+
+        expect(agentPolicies.total).toBe(2);
+        expect(
+          agentPolicies.saved_objects.find((so) => so.id === 'policy-elastic-agent-on-cloud')
+        ).toBeDefined();
+        expect(agentPolicies.saved_objects.find((so) => so.id === 'default-policy')).toBeDefined();
+      });
+
+      it('Create correct .fleet-policies', async () => {
+        const res = await kbnServer.coreStart.elasticsearch.client.asInternalUser.search({
+          index: AGENT_POLICY_INDEX,
+          q: `policy_id:policy-elastic-agent-on-cloud`,
+          sort: 'revision_idx:desc',
         });
 
-      expect(packagePolicies.total).toBe(3);
-      expect(
-        packagePolicies.saved_objects.find((so) => so.id === 'elastic-cloud-fleet-server')
-      ).toBeDefined();
-      expect(
-        packagePolicies.saved_objects.find((so) => so.id === 'elastic-cloud-apm')
-      ).toBeDefined();
-      expect(packagePolicies.saved_objects.find((so) => so.id === 'default-system')).toBeDefined();
+        expect((res.hits.hits[0]._source as any)!.data).toMatchSnapshot();
+      });
 
-      const fleetServerPackagePolicy = packagePolicies.saved_objects.find(
-        (so) => so.id === 'elastic-cloud-fleet-server'
-      );
-      expect(fleetServerPackagePolicy?.attributes.vars).toMatchInlineSnapshot(`undefined`);
-      expect(fleetServerPackagePolicy?.attributes.inputs).toMatchInlineSnapshot(`
+      it('Create correct package policies', async () => {
+        const packagePolicies = await kbnServer.coreStart.savedObjects
+          .createInternalRepository()
+          .find<PackagePolicySOAttributes>({
+            type: 'ingest-package-policies',
+            perPage: 10000,
+          });
+
+        expect(packagePolicies.total).toBe(3);
+        expect(
+          packagePolicies.saved_objects.find((so) => so.id === 'elastic-cloud-fleet-server')
+        ).toBeDefined();
+        expect(
+          packagePolicies.saved_objects.find((so) => so.id === 'elastic-cloud-apm')
+        ).toBeDefined();
+        expect(
+          packagePolicies.saved_objects.find((so) => so.id === 'default-system')
+        ).toBeDefined();
+
+        const fleetServerPackagePolicy = packagePolicies.saved_objects.find(
+          (so) => so.id === 'elastic-cloud-fleet-server'
+        );
+        expect(fleetServerPackagePolicy?.attributes.vars).toMatchInlineSnapshot(`undefined`);
+        expect(fleetServerPackagePolicy?.attributes.inputs).toMatchInlineSnapshot(`
         Array [
           Object {
             "compiled_input": Object {
@@ -195,6 +209,117 @@ describe('Fleet preconfiguration reset', () => {
           },
         ]
       `);
+      });
+    });
+    describe('Adding APM to a preconfigured agent policy after first setup', () => {
+      beforeAll(async () => {
+        // 1. Start with a preconfigured policy withtout APM
+        const { startOrRestartKibana } = await startServers(CLOUD_KIBANA_CONFIG_WITHOUT_APM);
+
+        // 2. Add APM to the preconfigured policy
+        await startOrRestartKibana(CLOUD_KIBANA_CONFIG);
+      });
+
+      afterAll(async () => {
+        await stopServers();
+      });
+
+      it('Works and preconfigure correctly agent policies', async () => {
+        const agentPolicies = await kbnServer.coreStart.savedObjects
+          .createInternalRepository()
+          .find<AgentPolicySOAttributes>({
+            type: 'ingest-agent-policies',
+            perPage: 10000,
+          });
+
+        expect(agentPolicies.total).toBe(2);
+        expect(
+          agentPolicies.saved_objects.find((so) => so.id === 'policy-elastic-agent-on-cloud')
+        ).toBeDefined();
+        expect(agentPolicies.saved_objects.find((so) => so.id === 'default-policy')).toBeDefined();
+      });
+
+      it('Create a .fleet-policies document with the APM package policy', async () => {
+        const res = await kbnServer.coreStart.elasticsearch.client.asInternalUser.search({
+          index: AGENT_POLICY_INDEX,
+          q: `policy_id:policy-elastic-agent-on-cloud`,
+          sort: 'revision_idx:desc',
+        });
+
+        expect(
+          (res.hits.hits[0]._source as any)!.data.inputs.find(
+            (input: any) => input.meta.package.name === 'apm'
+          )
+        ).toBeDefined();
+      });
+
+      it('Create correct package policies', async () => {
+        const packagePolicies = await kbnServer.coreStart.savedObjects
+          .createInternalRepository()
+          .find<PackagePolicySOAttributes>({
+            type: 'ingest-package-policies',
+            perPage: 10000,
+          });
+
+        expect(packagePolicies.total).toBe(3);
+        expect(
+          packagePolicies.saved_objects.find((so) => so.id === 'elastic-cloud-fleet-server')
+        ).toBeDefined();
+        expect(
+          packagePolicies.saved_objects.find((so) => so.id === 'elastic-cloud-apm')
+        ).toBeDefined();
+        expect(
+          packagePolicies.saved_objects.find((so) => so.id === 'default-system')
+        ).toBeDefined();
+      });
+    });
+
+    describe('Adding package policy id to a preconfigured package policy after first setup', () => {
+      beforeAll(async () => {
+        // 1. Start with a preconfigured policy withtout APM
+        const { startOrRestartKibana } = await startServers(
+          CLOUD_KIBANA_WITHOUT_PACKAGE_POLICY_ID_CONFIG
+        );
+
+        // 2. Add APM to the preconfigured policy
+        await startOrRestartKibana(CLOUD_KIBANA_CONFIG);
+      });
+
+      afterAll(async () => {
+        await stopServers();
+      });
+
+      it('Works and preconfigure correctly agent policies', async () => {
+        const agentPolicies = await kbnServer.coreStart.savedObjects
+          .createInternalRepository()
+          .find<AgentPolicySOAttributes>({
+            type: 'ingest-agent-policies',
+            perPage: 10000,
+          });
+
+        expect(agentPolicies.total).toBe(2);
+        expect(
+          agentPolicies.saved_objects.find((so) => so.id === 'policy-elastic-agent-on-cloud')
+        ).toBeDefined();
+        expect(agentPolicies.saved_objects.find((so) => so.id === 'default-policy')).toBeDefined();
+      });
+
+      it('Create correct package policies and use the name of package policies instead of id', async () => {
+        const packagePolicies = await kbnServer.coreStart.savedObjects
+          .createInternalRepository()
+          .find<PackagePolicySOAttributes>({
+            type: 'ingest-package-policies',
+            perPage: 10000,
+          });
+
+        expect(packagePolicies.total).toBe(3);
+        expect(
+          packagePolicies.saved_objects.find((so) => so.attributes.name === 'Fleet Server')
+        ).toBeDefined();
+        expect(
+          packagePolicies.saved_objects.find((so) => so.attributes.name === 'Elastic APM')
+        ).toBeDefined();
+      });
     });
   });
 });

--- a/x-pack/plugins/fleet/server/integration_tests/fixtures/cloud_kibana_config_without_apm.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fixtures/cloud_kibana_config_without_apm.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const CLOUD_KIBANA_CONFIG_WITHOUT_APM = {
+  xpack: {
+    fleet: {
+      packages: [
+        {
+          name: 'fleet_server',
+          version: 'latest',
+        },
+        {
+          name: 'system',
+          version: 'latest',
+        },
+      ],
+      outputs: [
+        {
+          name: 'Elastic Cloud internal output',
+          type: 'elasticsearch',
+          id: 'es-containerhost',
+          hosts: ['https://cloudinternales:9200'],
+        },
+      ],
+      agentPolicies: [
+        {
+          name: 'Elastic Cloud agent policy',
+          description: 'Default agent policy for agents hosted on Elastic Cloud',
+          id: 'policy-elastic-agent-on-cloud',
+          data_output_id: 'es-containerhost',
+          monitoring_output_id: 'es-containerhost',
+          is_default: false,
+          is_managed: true,
+          is_default_fleet_server: false,
+          namespace: 'default',
+          monitoring_enabled: [],
+          unenroll_timeout: 86400,
+          package_policies: [
+            {
+              name: 'Fleet Server',
+              id: 'elastic-cloud-fleet-server',
+              package: {
+                name: 'fleet_server',
+              },
+              inputs: [
+                {
+                  type: 'fleet-server',
+                  keep_enabled: true,
+                  vars: [
+                    {
+                      name: 'host',
+                      value: '0.0.0.0',
+                      frozen: true,
+                    },
+                    {
+                      name: 'port',
+                      value: 8220,
+                      frozen: true,
+                    },
+                    {
+                      name: 'custom',
+                      value:
+                        'server.runtime:\n  gc_percent: 20          # Force the GC to execute more frequently: see https://golang.org/pkg/runtime/debug/#SetGCPercent\n',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'Default policy',
+          id: 'default-policy',
+          description: 'Default agent policy created by Kibana',
+          is_default: true,
+          is_managed: false,
+          namespace: 'default',
+          monitoring_enabled: ['logs', 'metrics'],
+          package_policies: [
+            {
+              name: 'system-1',
+              id: 'default-system',
+              package: {
+                name: 'system',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/x-pack/plugins/fleet/server/integration_tests/fixtures/cloud_kibana_config_without_policy_id.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fixtures/cloud_kibana_config_without_policy_id.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const CLOUD_KIBANA_WITHOUT_PACKAGE_POLICY_ID_CONFIG = {
+  xpack: {
+    fleet: {
+      packages: [
+        {
+          name: 'apm',
+          version: 'latest',
+        },
+        {
+          name: 'fleet_server',
+          version: 'latest',
+        },
+        {
+          name: 'system',
+          version: 'latest',
+        },
+      ],
+      outputs: [
+        {
+          name: 'Elastic Cloud internal output',
+          type: 'elasticsearch',
+          id: 'es-containerhost',
+          hosts: ['https://cloudinternales:9200'],
+        },
+      ],
+      agentPolicies: [
+        {
+          name: 'Elastic Cloud agent policy',
+          description: 'Default agent policy for agents hosted on Elastic Cloud',
+          id: 'policy-elastic-agent-on-cloud',
+          data_output_id: 'es-containerhost',
+          monitoring_output_id: 'es-containerhost',
+          is_default: false,
+          is_managed: true,
+          is_default_fleet_server: false,
+          namespace: 'default',
+          monitoring_enabled: [],
+          unenroll_timeout: 86400,
+          package_policies: [
+            {
+              name: 'Fleet Server',
+              package: {
+                name: 'fleet_server',
+              },
+              inputs: [
+                {
+                  type: 'fleet-server',
+                  keep_enabled: true,
+                  vars: [
+                    {
+                      name: 'host',
+                      value: '0.0.0.0',
+                      frozen: true,
+                    },
+                    {
+                      name: 'port',
+                      value: 8220,
+                      frozen: true,
+                    },
+                    {
+                      name: 'custom',
+                      value:
+                        'server.runtime:\n  gc_percent: 20          # Force the GC to execute more frequently: see https://golang.org/pkg/runtime/debug/#SetGCPercent\n',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'Elastic APM',
+              package: {
+                name: 'apm',
+              },
+              inputs: [
+                {
+                  type: 'apm',
+                  keep_enabled: true,
+                  vars: [
+                    {
+                      name: 'api_key_enabled',
+                      value: true,
+                    },
+                    {
+                      name: 'host',
+                      value: '0.0.0.0:8200',
+                      frozen: true,
+                    },
+                    {
+                      name: 'secret_token',
+                      value: 'CLOUD_SECRET_TOKEN',
+                    },
+                    {
+                      name: 'tls_enabled',
+                      value: true,
+                      frozen: true,
+                    },
+                    {
+                      name: 'tls_certificate',
+                      value: '/app/config/certs/node.crt',
+                      frozen: true,
+                    },
+                    {
+                      name: 'tls_key',
+                      value: '/app/config/certs/node.key',
+                      frozen: true,
+                    },
+                    {
+                      name: 'url',
+                      value: 'CLOUD_APM_URL',
+                      frozen: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'Default policy',
+          id: 'default-policy',
+          description: 'Default agent policy created by Kibana',
+          is_default: true,
+          is_managed: false,
+          namespace: 'default',
+          monitoring_enabled: ['logs', 'metrics'],
+          package_policies: [
+            {
+              name: 'system-1',
+              id: 'default-system',
+              package: {
+                name: 'system',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/x-pack/plugins/fleet/server/integration_tests/fixtures/index.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fixtures/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { CLOUD_KIBANA_CONFIG_WITHOUT_APM } from './cloud_kibana_config_without_apm';
+export { CLOUD_KIBANA_CONFIG } from './cloud_kibana_config';
+export { CLOUD_KIBANA_WITHOUT_PACKAGE_POLICY_ID_CONFIG } from './cloud_kibana_config_without_policy_id';


### PR DESCRIPTION
## Summary

Resolve #115044

Add more scenarios to the functionnal test we have for preconfiguration:
* Add a package policy after the first setup (APM)
* Add package policy id after the first setup 

