### PR TITLE
[Security Solution][Admin][Policy Details] Policy details tabs maintains back button state

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/tabs/policy_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/tabs/policy_tabs.tsx
@@ -9,7 +9,7 @@ import { EuiSpacer, EuiTabbedContent, EuiTabbedContentTab } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
 import {
   getPolicyDetailPath,
@@ -50,6 +50,7 @@ import { SEARCHABLE_FIELDS as TRUSTED_APPS_SEARCHABLE_FIELDS } from '../../../tr
 import { SEARCHABLE_FIELDS as EVENT_FILTERS_SEARCHABLE_FIELDS } from '../../../event_filters/constants';
 import { SEARCHABLE_FIELDS as HOST_ISOLATION_EXCEPTIONS_SEARCHABLE_FIELDS } from '../../../host_isolation_exceptions/constants';
 import { SEARCHABLE_FIELDS as BLOCKLISTS_SEARCHABLE_FIELDS } from '../../../blocklist/constants';
+import { PolicyDetailsRouteState } from '../../../../../../common/endpoint/types';
 
 const enum PolicyTabKeys {
   SETTINGS = 'settings',
@@ -76,6 +77,7 @@ export const PolicyTabs = React.memo(() => {
   const policyId = usePolicyDetailsSelector(policyIdFromParams);
   const policyItem = usePolicyDetailsSelector(policyDetails);
   const privileges = useUserPrivileges().endpointPrivileges;
+  const { state: routeState = {} } = useLocation<PolicyDetailsRouteState>();
 
   const allPolicyHostIsolationExceptionsListRequest = useFetchHostIsolationExceptionsList({
     page: 1,
@@ -320,9 +322,9 @@ export const PolicyTabs = React.memo(() => {
           path = getPolicyBlocklistsPath(policyId);
           break;
       }
-      history.push(path);
+      history.push(path, routeState?.backLink ? { backLink: routeState.backLink } : null);
     },
-    [history, policyId]
+    [history, policyId, routeState]
   );
 
   // show loader for privileges validation


### PR DESCRIPTION
## Summary

- [x] Maintain route state between policy details tabs necessary for header back button
- [x] Fixes bug: https://github.com/elastic/kibana/issues/130241

# Screenshots
![policyTabs](https://user-images.githubusercontent.com/56409205/163484740-d7731b05-8abd-4d05-98ad-c0db7a2c5f17.gif)