### PR TITLE
[8.2] [Security Solution] Adds rule preview error message for users without appropriate `read` privilege (#129951)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.test.tsx
@@ -85,44 +85,44 @@ describe('PreviewQuery', () => {
     jest.clearAllMocks();
   });
 
-  test('it renders timeframe select and preview button on render', () => {
+  test('it renders timeframe select and preview button on render', async () => {
     const wrapper = render(
       <TestProviders>
         <RulePreview {...defaultProps} />
       </TestProviders>
     );
 
-    expect(wrapper.findByTestId('rule-preview')).toBeTruthy();
-    expect(wrapper.findByTestId('preview-time-frame')).toBeTruthy();
+    expect(await wrapper.findByTestId('rule-preview')).toBeTruthy();
+    expect(await wrapper.findByTestId('preview-time-frame')).toBeTruthy();
   });
 
-  test('it renders preview button disabled if "isDisabled" is true', () => {
+  test('it renders preview button disabled if "isDisabled" is true', async () => {
     const wrapper = render(
       <TestProviders>
         <RulePreview {...defaultProps} isDisabled={true} />
       </TestProviders>
     );
 
-    expect(wrapper.getByTestId('queryPreviewButton').closest('button')).toBeDisabled();
+    expect(await wrapper.getByTestId('queryPreviewButton').closest('button')).toBeDisabled();
   });
 
-  test('it renders preview button enabled if "isDisabled" is false', () => {
+  test('it renders preview button enabled if "isDisabled" is false', async () => {
     const wrapper = render(
       <TestProviders>
         <RulePreview {...defaultProps} />
       </TestProviders>
     );
 
-    expect(wrapper.getByTestId('queryPreviewButton').closest('button')).not.toBeDisabled();
+    expect(await wrapper.getByTestId('queryPreviewButton').closest('button')).not.toBeDisabled();
   });
 
-  test('does not render histogram when there is no previewId', () => {
+  test('does not render histogram when there is no previewId', async () => {
     const wrapper = render(
       <TestProviders>
         <RulePreview {...defaultProps} />
       </TestProviders>
     );
 
-    expect(wrapper.queryByTestId('[data-test-subj="preview-histogram-panel"]')).toBeNull();
+    expect(await wrapper.queryByTestId('[data-test-subj="preview-histogram-panel"]')).toBeNull();
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/detections_admin/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/detections_admin/detections_role.json
@@ -6,6 +6,8 @@
         "names": [
           ".siem-signals-*",
           ".alerts-security*",
+          ".preview.alerts-security*",
+          ".internal.preview.alerts-security*",
           ".lists*",
           ".items*",
           "apm-*-transaction*",
@@ -20,11 +22,7 @@
         "privileges": ["manage", "write", "read"]
       },
       {
-        "names": [
-          "metrics-endpoint.metadata_current_*",
-          ".fleet-agents*",
-          ".fleet-actions*"
-        ],
+        "names": ["metrics-endpoint.metadata_current_*", ".fleet-agents*", ".fleet-actions*"],
         "privileges": ["read"]
       }
     ]

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/platform_engineer/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/platform_engineer/detections_role.json
@@ -23,7 +23,12 @@
         "privileges": ["all"]
       },
       {
-        "names": [".alerts-security*", ".siem-signals-*"],
+        "names": [
+          ".alerts-security*",
+          ".preview.alerts-security*",
+          ".internal.preview.alerts-security*",
+          ".siem-signals-*"
+        ],
         "privileges": ["all"]
       }
     ]

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/rule_author/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/rule_author/detections_role.json
@@ -18,15 +18,16 @@
         "privileges": ["read", "write"]
       },
       {
-        "names": [".alerts-security*", ".siem-signals-*"],
+        "names": [
+          ".alerts-security*",
+          ".preview.alerts-security*",
+          ".internal.preview.alerts-security*",
+          ".siem-signals-*"
+        ],
         "privileges": ["read", "write", "maintenance", "view_index_metadata"]
       },
       {
-        "names": [
-          "metrics-endpoint.metadata_current_*",
-          ".fleet-agents*",
-          ".fleet-actions*"
-        ],
+        "names": ["metrics-endpoint.metadata_current_*", ".fleet-agents*", ".fleet-actions*"],
         "privileges": ["read"]
       }
     ]

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/soc_manager/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/soc_manager/detections_role.json
@@ -18,15 +18,16 @@
         "privileges": ["read", "write"]
       },
       {
-        "names": [".alerts-security*", ".siem-signals-*"],
+        "names": [
+          ".alerts-security*",
+          ".preview.alerts-security*",
+          ".internal.preview.alerts-security*",
+          ".siem-signals-*"
+        ],
         "privileges": ["read", "write", "manage"]
       },
       {
-        "names": [
-          "metrics-endpoint.metadata_current_*",
-          ".fleet-agents*",
-          ".fleet-actions*"
-        ],
+        "names": ["metrics-endpoint.metadata_current_*", ".fleet-agents*", ".fleet-actions*"],
         "privileges": ["read"]
       }
     ]

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t2_analyst/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t2_analyst/detections_role.json
@@ -2,7 +2,10 @@
   "elasticsearch": {
     "cluster": [],
     "indices": [
-      { "names": [".alerts-security*", ".siem-signals-*"], "privileges": ["read", "write", "maintenance"] },
+      {
+        "names": [".alerts-security*", ".siem-signals-*"],
+        "privileges": ["read", "write", "maintenance"]
+      },
       {
         "names": [
           ".lists*",

--- a/x-pack/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/plugins/security_solution/server/routes/index.ts
@@ -103,7 +103,8 @@ export const initRoutes = (
     security,
     ruleOptions,
     securityRuleTypeOptions,
-    previewRuleDataClient
+    previewRuleDataClient,
+    getStartServices
   );
 
   // Once we no longer have the legacy notifications system/"side car actions" this should be removed.

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/preview_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/preview_rules.ts
@@ -91,6 +91,38 @@ export default ({ getService }: FtrProviderContext) => {
             .expect(403);
         });
       });
+
+      describe('hunter', () => {
+        const role = ROLES.hunter;
+
+        beforeEach(async () => {
+          await createUserAndRole(getService, role);
+        });
+
+        afterEach(async () => {
+          await deleteUserAndRole(getService, role);
+        });
+
+        it('should return with an error about not having correct permissions', async () => {
+          const { body } = await supertestWithoutAuth
+            .post(DETECTION_ENGINE_RULES_PREVIEW)
+            .auth(role, 'changeme')
+            .set('kbn-xsrf', 'true')
+            .send(getSimplePreviewRule())
+            .expect(200);
+
+          const { logs } = getSimpleRulePreviewOutput(undefined, [
+            {
+              errors: [
+                'Missing "read" privileges for the ".preview.alerts-security.alerts" or ".internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
+              ],
+              warnings: [],
+              duration: 0,
+            },
+          ]);
+          expect(body).to.eql({ logs });
+        });
+      });
     });
   });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Security Solution] Adds rule preview error message for users without appropriate `read` privilege (#129951)](https://github.com/elastic/kibana/pull/129951)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)