### PR TITLE
[bazel/packages] find typescript projects in new bazel package dirs

### DIFF
--- a/src/dev/typescript/projects.ts
+++ b/src/dev/typescript/projects.ts
@@ -9,6 +9,7 @@
 import glob from 'glob';
 import Path from 'path';
 import { REPO_ROOT } from '@kbn/utils';
+import { BAZEL_PACKAGE_DIRS } from '@kbn/bazel-packages';
 import { Project, ProjectOptions } from './project';
 
 /**
@@ -72,7 +73,6 @@ export const PROJECTS = [
     disableTypeCheck: true,
   }),
 
-  ...findProjects('packages/*/tsconfig.json'),
   ...findProjects('src/plugins/*/tsconfig.json'),
   ...findProjects('src/plugins/chart_expressions/*/tsconfig.json'),
   ...findProjects('src/plugins/vis_types/*/tsconfig.json'),
@@ -83,4 +83,6 @@ export const PROJECTS = [
   ...findProjects('test/interpreter_functional/plugins/*/tsconfig.json'),
   ...findProjects('test/server_integration/__fixtures__/plugins/*/tsconfig.json'),
   ...findProjects('packages/kbn-type-summarizer/tests/tsconfig.json'),
+
+  ...BAZEL_PACKAGE_DIRS.flatMap((dir) => findProjects(`${dir}/*/tsconfig.json`)),
 ];


### PR DESCRIPTION
Updates the TypeScript project finder to look in the `BAZEL_PACKAGE_DIRS` rather than just `packages`.