### PR TITLE
Fix nav-kibana-dev.docnav.json

### DIFF
--- a/nav-kibana-dev.docnav.json
+++ b/nav-kibana-dev.docnav.json
@@ -62,7 +62,7 @@
         { "id": "kibDevTutorialCI" },
         { "id": "kibDevTutorialServerEndpoint" },
         { "id": "kibDevTutorialAdvancedSettings" },
-        { "id": "kibDevSharePluginReadme" }
+        { "id": "kibDevSharePluginReadme" },
         { "id": "kibDevTutorialScreenshotting" }
       ]
     },


### PR DESCRIPTION
## Summary

There was a missing comma in #129794 causing the docs build to fail.

### Checklist

Delete any items that are not applicable to this PR.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
