### PR TITLE
Upgrade EUI to v53.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.2.0-canary.2",
     "@elastic/ems-client": "8.2.0",
-    "@elastic/eui": "53.0.1",
+    "@elastic/eui": "53.0.2",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "1.2.1",
     "@elastic/numeral": "^2.5.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -77,6 +77,6 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.2.0': ['Elastic License 2.0'],
-  '@elastic/eui@53.0.1': ['SSPL-1.0 OR Elastic License 2.0'],
+  '@elastic/eui@53.0.2': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,10 +1527,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@53.0.1":
-  version "53.0.1"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-53.0.1.tgz#82359460ae4edab3a538846b6915518cb1214848"
-  integrity sha512-fPOuDyc7adjHBp+UHOtIJTHdZVKi8MGzyuYxTRN8ZYLHbzcNTaCsogdk+0eb6u4ISRqhk3tudG8Q0znksVHt1w==
+"@elastic/eui@53.0.2":
+  version "53.0.2"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-53.0.2.tgz#6cca9ebc0f324961e936b8134e3fd814ef45811d"
+  integrity sha512-+eH2kn91KIYUF4RdEzGm7eDuJSVUM70pKcWibsBrBNvcbvHdZW+vdczLfNe5AZQIgOg2zgAj+jMkKbfAoIWHCw==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
## Summary

`eui@53.0.1` ⏩ `eui@53.0.2`

## [`53.0.2`](https://github.com/elastic/eui/tree/v53.0.2)

**Bug fixes**

- Fixed an `EuiDataGrid` bug occurring when closing cell popovers on clicking the originating cell. The original fix was unintentionally affecting cell popovers with nested modals, popovers, etc. ([#5797](https://github.com/elastic/eui/pull/5797))