### PR TITLE
[Security Solution] Update event rendered view action column width to account for session view

### DIFF
--- a/x-pack/plugins/timelines/public/components/t_grid/event_rendered_view/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/event_rendered_view/index.tsx
@@ -140,7 +140,8 @@ const EventRenderedViewComponent = ({
             </ActionsContainer>
           );
         },
-        width: '152px',
+        // TODO: derive this from ACTION_BUTTON_COUNT as other columns are done
+        width: '184px',
       },
       {
         field: 'ecs.timestamp',


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/130367

Updates an evil magic number to create room for the session view button. This should be derived from the ACTION_BUTTON_COUNT const, but since this is an embarrassing oversight in 8.2, just update in place for now.

![image](https://user-images.githubusercontent.com/56408403/163604997-b384f020-2a6d-4feb-b179-2ea55092cd7e.png)




