### PR TITLE
[Cloud Posture] refactoring cspm plugin apis to internal

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -8,7 +8,8 @@
 export const STATS_ROUTE_PATH = '/internal/cloud_security_posture/stats';
 export const FINDINGS_ROUTE_PATH = '/internal/cloud_security_posture/findings';
 export const BENCHMARKS_ROUTE_PATH = '/internal/cloud_security_posture/benchmarks';
-export const UPDATE_RULES_CONFIG_ROUTE_PATH = '/internal/cloud_security_posture/update_rules_config';
+export const UPDATE_RULES_CONFIG_ROUTE_PATH =
+  '/internal/cloud_security_posture/update_rules_config';
 
 export const CSP_FINDINGS_INDEX_NAME = 'findings';
 export const CIS_KUBERNETES_PACKAGE_NAME = 'cis_kubernetes_benchmark';

--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-export const STATS_ROUTE_PATH = '/api/csp/stats';
-export const FINDINGS_ROUTE_PATH = '/api/csp/findings';
-export const BENCHMARKS_ROUTE_PATH = '/api/csp/benchmarks';
-export const UPDATE_RULES_CONFIG_ROUTE_PATH = '/api/csp/update_rules_config';
+export const STATS_ROUTE_PATH = '/internal/cloud_security_posture/stats';
+export const FINDINGS_ROUTE_PATH = '/internal/cloud_security_posture/findings';
+export const BENCHMARKS_ROUTE_PATH = '/internal/cloud_security_posture/benchmarks';
+export const UPDATE_RULES_CONFIG_ROUTE_PATH = '/internal/cloud_security_posture/update_rules_config';
 
 export const CSP_FINDINGS_INDEX_NAME = 'findings';
 export const CIS_KUBERNETES_PACKAGE_NAME = 'cis_kubernetes_benchmark';

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
@@ -88,7 +88,7 @@ describe('benchmarks API', () => {
 
     const [config] = router.get.mock.calls[0];
 
-    expect(config.path).toEqual('/api/csp/benchmarks');
+    expect(config.path).toEqual('/internal/cloud_security_posture/benchmarks');
   });
 
   it('should accept to a user with fleet.all privilege', async () => {

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
@@ -58,7 +58,7 @@ describe('Update rules configuration API', () => {
 
     const [config, _] = router.post.mock.calls[0];
 
-    expect(config.path).toEqual('/api/csp/update_rules_config');
+    expect(config.path).toEqual('/internal/cloud_security_posture/update_rules_config');
   });
 
   it('should accept to a user with fleet.all privilege', async () => {

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.test.ts
@@ -54,7 +54,7 @@ describe('findings API', () => {
 
     const [config, _] = router.get.mock.calls[0];
 
-    expect(config.path).toEqual('/api/csp/findings');
+    expect(config.path).toEqual('/internal/cloud_security_posture/findings');
   });
 
   it('should accept to a user with fleet.all privilege', async () => {


### PR DESCRIPTION
## Summary

Nothing much, moving cloud security posture apis to be internal as our plugin is currently in technical preview
for more information about internal convention [click here](https://docs.elastic.dev/kibana-dev-docs/standards)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
