### PR TITLE
[Cloud Posture] Package name refactored to `cloud_security_posture`

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -11,18 +11,16 @@ export const BENCHMARKS_ROUTE_PATH = '/internal/cloud_security_posture/benchmark
 export const UPDATE_RULES_CONFIG_ROUTE_PATH =
   '/internal/cloud_security_posture/update_rules_config';
 
-export const CSP_FINDINGS_INDEX_NAME = 'findings';
-export const CIS_KUBERNETES_PACKAGE_NAME = 'cis_kubernetes_benchmark';
-export const FINDINGS_DATA_STREAM_NAME =
-  // Currently 'cis_kubernetes_benchmark.findings', To be refactored to 'cloud_security_posture.findings'
-  CIS_KUBERNETES_PACKAGE_NAME + '.' + CSP_FINDINGS_INDEX_NAME;
-export const LATEST_FINDINGS_INDEX_NAME = 'cloud_security_posture.findings_latest';
-export const BENCHMARK_SCORE_INDEX_NAME = 'cloud_security_posture.scores';
+export const CLOUD_SECURITY_POSTURE_PACKAGE_NAME = 'cloud_security_posture';
 
-export const AGENT_LOGS_INDEX_PATTERN = '.logs-cis_kubernetes_benchmark.metadata*';
-export const CSP_KUBEBEAT_INDEX_PATTERN = 'logs-cis_kubernetes_benchmark.findings*';
-export const FINDINGS_INDEX_PATTERN = 'logs-' + FINDINGS_DATA_STREAM_NAME + '-default*';
+export const AGENT_LOGS_INDEX_PATTERN = '.logs-cloud_security_posture.metadata*';
+export const CSP_KUBEBEAT_INDEX_PATTERN = 'logs-cloud_security_posture.findings*';
+export const FINDINGS_INDEX_PATTERN = 'logs-cloud_security_posture.findings-default*';
+
+export const LATEST_FINDINGS_INDEX_NAME = 'cloud_security_posture.findings_latest';
 export const LATEST_FINDINGS_INDEX_DEFAULT_NS = 'logs-' + LATEST_FINDINGS_INDEX_NAME + '-default';
+
+export const BENCHMARK_SCORE_INDEX_NAME = 'cloud_security_posture.scores';
 export const BENCHMARK_SCORE_INDEX_DEFAULT_NS = 'logs-' + BENCHMARK_SCORE_INDEX_NAME + '-default';
 
 export const RULE_PASSED = `passed`;

--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -20,10 +20,10 @@ export const LATEST_FINDINGS_INDEX_NAME = 'cloud_security_posture.findings_lates
 export const BENCHMARK_SCORE_INDEX_NAME = 'cloud_security_posture.scores';
 
 export const AGENT_LOGS_INDEX_PATTERN = '.logs-cis_kubernetes_benchmark.metadata*';
-export const CSP_KUBEBEAT_INDEX_PATTERN = 'logs-cis_kubernetes_benchmark.findings-*';
+export const CSP_KUBEBEAT_INDEX_PATTERN = 'logs-cis_kubernetes_benchmark.findings*';
 export const FINDINGS_INDEX_PATTERN = 'logs-' + FINDINGS_DATA_STREAM_NAME + '-default*';
-export const LATEST_FINDINGS_INDEX_PATTERN = 'logs-' + LATEST_FINDINGS_INDEX_NAME + '-default';
-export const BENCHMARK_SCORE_INDEX_PATTERN = 'logs-' + BENCHMARK_SCORE_INDEX_NAME + '-default';
+export const LATEST_FINDINGS_INDEX_DEFAULT_NS = 'logs-' + LATEST_FINDINGS_INDEX_NAME + '-default';
+export const BENCHMARK_SCORE_INDEX_DEFAULT_NS = 'logs-' + BENCHMARK_SCORE_INDEX_NAME + '-default';
 
 export const RULE_PASSED = `passed`;
 export const RULE_FAILED = `failed`;

--- a/x-pack/plugins/cloud_security_posture/public/common/api/use_cis_kubernetes_integration.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/common/api/use_cis_kubernetes_integration.tsx
@@ -11,7 +11,7 @@ import {
   type GetInfoResponse,
   type DefaultPackagesInstallationError,
 } from '@kbn/fleet-plugin/common';
-import { CIS_KUBERNETES_PACKAGE_NAME } from '../../../common/constants';
+import { CLOUD_SECURITY_PACKAGE_NAME } from '../../../common/constants';
 import { useKibana } from '../hooks/use_kibana';
 
 /**
@@ -21,7 +21,7 @@ export const useCisKubernetesIntegration = () => {
   const { http } = useKibana().services;
 
   return useQuery<GetInfoResponse, DefaultPackagesInstallationError>(['integrations'], () =>
-    http.get<GetInfoResponse>(epmRouteService.getInfoPath(CIS_KUBERNETES_PACKAGE_NAME), {
+    http.get<GetInfoResponse>(epmRouteService.getInfoPath(CLOUD_SECURITY_PACKAGE_NAME), {
       query: { experimental: true },
     })
   );

--- a/x-pack/plugins/cloud_security_posture/server/create_indices/create_transforms_indices.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_indices/create_transforms_indices.ts
@@ -10,9 +10,9 @@ import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { benchmarkScoreMapping } from './benchmark_score_mapping';
 import { latestFindingsMapping } from './latest_findings_mapping';
 import {
-  LATEST_FINDINGS_INDEX_PATTERN,
+  LATEST_FINDINGS_INDEX_DEFAULT_NS,
   LATEST_FINDINGS_INDEX_NAME,
-  BENCHMARK_SCORE_INDEX_PATTERN,
+  BENCHMARK_SCORE_INDEX_DEFAULT_NS,
   BENCHMARK_SCORE_INDEX_NAME,
 } from '../../common/constants';
 
@@ -25,14 +25,14 @@ export const initializeCspTransformsIndices = async (
     createIndexIfNotExists(
       esClient,
       LATEST_FINDINGS_INDEX_NAME,
-      LATEST_FINDINGS_INDEX_PATTERN,
+      LATEST_FINDINGS_INDEX_DEFAULT_NS,
       latestFindingsMapping,
       logger
     ),
     createIndexIfNotExists(
       esClient,
       BENCHMARK_SCORE_INDEX_NAME,
-      BENCHMARK_SCORE_INDEX_PATTERN,
+      BENCHMARK_SCORE_INDEX_DEFAULT_NS,
       benchmarkScoreMapping,
       logger
     ),
@@ -65,7 +65,7 @@ export const createIndexIfNotExists = async (
     }
   } catch (err) {
     const error = transformError(err);
-    logger.error(`Failed to create ${LATEST_FINDINGS_INDEX_PATTERN}`);
+    logger.error(`Failed to create ${LATEST_FINDINGS_INDEX_DEFAULT_NS}`);
     logger.error(error.message);
   }
 };

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.test.ts
@@ -8,7 +8,7 @@
 import { loggingSystemMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { SavedObjectsClientContract, SavedObjectsFindResponse } from '@kbn/core/server';
 import { createPackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
-import { CIS_KUBERNETES_PACKAGE_NAME } from '../../common/constants';
+import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../../common/constants';
 import { onPackagePolicyPostCreateCallback } from './fleet_integration';
 
 describe('create CSP rules with post package create callback', () => {
@@ -40,7 +40,7 @@ describe('create CSP rules with post package create callback', () => {
   });
   it('should create stateful rules based on rule template', async () => {
     const mockPackagePolicy = createPackagePolicyMock();
-    mockPackagePolicy.package!.name = CIS_KUBERNETES_PACKAGE_NAME;
+    mockPackagePolicy.package!.name = CLOUD_SECURITY_POSTURE_PACKAGE_NAME;
     mockSoClient.find.mockResolvedValueOnce({
       saved_objects: [
         {

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
@@ -17,7 +17,7 @@ import {
   cloudSecurityPostureRuleTemplateSavedObjectType,
   CloudSecurityPostureRuleTemplateSchema,
 } from '../../common/schemas/csp_rule_template';
-import { CIS_KUBERNETES_PACKAGE_NAME } from '../../common/constants';
+import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../../common/constants';
 import { CspRuleSchema, cspRuleAssetSavedObjectType } from '../../common/schemas/csp_rule';
 
 type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends ReadonlyArray<
@@ -29,7 +29,7 @@ type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends Read
 const isCspPackagePolicy = <T extends { package?: { name: string } }>(
   packagePolicy: T
 ): boolean => {
-  return packagePolicy.package?.name === CIS_KUBERNETES_PACKAGE_NAME;
+  return packagePolicy.package?.name === CLOUD_SECURITY_POSTURE_PACKAGE_NAME;
 };
 
 /**

--- a/x-pack/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/server/plugin.ts
@@ -31,7 +31,7 @@ import {
   onPackagePolicyPostCreateCallback,
   onPackagePolicyDeleteCallback,
 } from './fleet_integration/fleet_integration';
-import { CIS_KUBERNETES_PACKAGE_NAME } from '../common/constants';
+import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../common/constants';
 
 export interface CspAppContext {
   logger: Logger;
@@ -87,7 +87,7 @@ export class CspPlugin
           context: RequestHandlerContext,
           request: KibanaRequest
         ): Promise<PackagePolicy> => {
-          if (packagePolicy.package?.name === CIS_KUBERNETES_PACKAGE_NAME) {
+          if (packagePolicy.package?.name === CLOUD_SECURITY_POSTURE_PACKAGE_NAME) {
             await onPackagePolicyPostCreateCallback(
               this.logger,
               packagePolicy,
@@ -103,7 +103,7 @@ export class CspPlugin
         'postPackagePolicyDelete',
         async (deletedPackagePolicies: DeepReadonly<DeletePackagePoliciesResponse>) => {
           for (const deletedPackagePolicy of deletedPackagePolicies) {
-            if (deletedPackagePolicy.package?.name === CIS_KUBERNETES_PACKAGE_NAME) {
+            if (deletedPackagePolicy.package?.name === CLOUD_SECURITY_POSTURE_PACKAGE_NAME) {
               await onPackagePolicyDeleteCallback(
                 this.logger,
                 deletedPackagePolicy,

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
@@ -19,7 +19,7 @@ import type {
   AgentPolicy,
   ListResult,
 } from '@kbn/fleet-plugin/common';
-import { BENCHMARKS_ROUTE_PATH, CIS_KUBERNETES_PACKAGE_NAME } from '../../../common/constants';
+import { BENCHMARKS_ROUTE_PATH, CLOUD_SECURITY_PACKAGE_NAME } from '../../../common/constants';
 import {
   BENCHMARK_PACKAGE_POLICY_PREFIX,
   benchmarksInputSchema,
@@ -165,7 +165,7 @@ export const defineGetBenchmarksRoute = (router: CspRouter, cspContext: CspAppCo
         const packagePolicies = await getPackagePolicies(
           soClient,
           packagePolicyService,
-          CIS_KUBERNETES_PACKAGE_NAME,
+          CLOUD_SECURITY_PACKAGE_NAME,
           query
         );
 

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_trends.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_trends.ts
@@ -6,7 +6,7 @@
  */
 
 import { ElasticsearchClient } from '@kbn/core/server';
-import { BENCHMARK_SCORE_INDEX_PATTERN } from '../../../common/constants';
+import { BENCHMARK_SCORE_INDEX_DEFAULT_NS } from '../../../common/constants';
 import { Stats } from '../../../common/types';
 import { calculatePostureScore } from './get_stats';
 
@@ -26,7 +26,7 @@ export interface ScoreTrendDoc {
 }
 
 export const getTrendsQuery = () => ({
-  index: BENCHMARK_SCORE_INDEX_PATTERN,
+  index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
   size: 5,
   sort: '@timestamp:desc',
 });

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -22,7 +22,7 @@ import { CspAppContext } from '../../plugin';
 import { CspRulesConfigSchema } from '../../../common/schemas/csp_configuration';
 import { CspRuleSchema, cspRuleAssetSavedObjectType } from '../../../common/schemas/csp_rule';
 import { UPDATE_RULES_CONFIG_ROUTE_PATH } from '../../../common/constants';
-import { CIS_KUBERNETES_PACKAGE_NAME } from '../../../common/constants';
+import { CLOUD_SECURITY_PACKAGE_NAME } from '../../../common/constants';
 import { CspRouter } from '../../types';
 
 export const getPackagePolicy = async (
@@ -36,9 +36,8 @@ export const getPackagePolicy = async (
   if (!packagePolicies || !packagePolicies[0].version) {
     throw new Error(`package policy Id '${packagePolicyId}' is not exist`);
   }
-  if (packagePolicies[0].package?.name !== CIS_KUBERNETES_PACKAGE_NAME) {
-    // TODO: improve this validator to support any future CSP package
-    throw new Error(`Package Policy Id '${packagePolicyId}' is not CSP package`);
+  if (packagePolicies[0].package?.name !== CLOUD_SECURITY_PACKAGE_NAME) {
+    throw new Error(`Package Policy Id '${packagePolicyId}' is not of type cloud security posture package`);
   }
 
   return packagePolicies![0];

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -37,7 +37,9 @@ export const getPackagePolicy = async (
     throw new Error(`package policy Id '${packagePolicyId}' is not exist`);
   }
   if (packagePolicies[0].package?.name !== CLOUD_SECURITY_PACKAGE_NAME) {
-    throw new Error(`Package Policy Id '${packagePolicyId}' is not of type cloud security posture package`);
+    throw new Error(
+      `Package Policy Id '${packagePolicyId}' is not of type cloud security posture package`
+    );
   }
 
   return packagePolicies![0];


### PR DESCRIPTION
## Summary

This pr is part of a larger change to rename the current integration/ package name of `cis_kubernetes_benchmark` to `cloud_security_posture`, as it will contain more benchmarks in the future and should have a proper naming.

Checkout also https://github.com/elastic/integrations/pull/3113

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
