### PR TITLE
[Cloud Posture] add findings group by resource table

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
@@ -9,9 +9,9 @@ import { useHistory } from 'react-router-dom';
 import { Query } from '@kbn/es-query';
 import { allNavigationItems } from '../navigation/constants';
 import { encodeQuery } from '../navigation/query_utils';
-import { CspFindingsRequest } from '../../pages/findings/use_findings';
+import { FindingsBaseURLQuery } from '../../pages/findings/types';
 
-const getFindingsQuery = (queryValue: Query['query']): Pick<CspFindingsRequest, 'query'> => {
+const getFindingsQuery = (queryValue: Query['query']): Pick<FindingsBaseURLQuery, 'query'> => {
   const query =
     typeof queryValue === 'string'
       ? queryValue

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import * as TEST_SUBJECTS from './test_subjects';
+import { FindingsByResourceTable } from './findings_by_resource_table';
+import * as TEXT from './translations';
+import type { PropsOf } from '@elastic/eui';
+import Chance from 'chance';
+
+const chance = new Chance();
+
+const getFakeFindingsByResource = () => ({
+  resource_id: chance.guid(),
+  cluster_id: chance.guid(),
+  cis_section: chance.word(),
+  failed_findings: {
+    total: chance.integer(),
+    normalized: chance.integer({ min: 0, max: 1 }),
+  },
+});
+
+type TableProps = PropsOf<typeof FindingsByResourceTable>;
+
+describe('<FindingsByResourceTable />', () => {
+  it('renders the zero state when status success and data has a length of zero ', async () => {
+    const props: TableProps = {
+      loading: false,
+      data: { page: [], total: 0 },
+      error: null,
+    };
+
+    render(<FindingsByResourceTable {...props} />);
+
+    expect(screen.getByText(TEXT.NO_FINDINGS)).toBeInTheDocument();
+  });
+
+  it('renders the table with provided items', () => {
+    const data = Array.from({ length: 10 }, getFakeFindingsByResource);
+
+    const props: TableProps = {
+      loading: false,
+      data: { page: data, total: 10 },
+      error: null,
+    };
+
+    const { container } = render(<FindingsByResourceTable {...props} />);
+
+    data.forEach((item, i) => {
+      const row = container.querySelector<HTMLElement>(
+        `[data-test-subj="${TEST_SUBJECTS.FINDINGS_BY_RESOURCE_TABLE_ROW}"]:nth-child(${i + 1})`
+      );
+      if (!row) throw new Error('missing row');
+
+      expect(within(row).getByText(item.resource_id)).toBeInTheDocument();
+      expect(within(row).getByText(item.cluster_id)).toBeInTheDocument();
+      expect(within(row).getByText(item.cis_section)).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.test.tsx
@@ -7,10 +7,11 @@
 import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import * as TEST_SUBJECTS from './test_subjects';
-import { FindingsByResourceTable, getResourceId } from './findings_by_resource_table';
+import { FindingsByResourceTable, formatNumber, getResourceId } from './findings_by_resource_table';
 import * as TEXT from './translations';
 import type { PropsOf } from '@elastic/eui';
 import Chance from 'chance';
+import numeral from '@elastic/numeral';
 
 const chance = new Chance();
 
@@ -58,6 +59,10 @@ describe('<FindingsByResourceTable />', () => {
       expect(within(row).getByText(item.resource_id)).toBeInTheDocument();
       expect(within(row).getByText(item.cluster_id)).toBeInTheDocument();
       expect(within(row).getByText(item.cis_section)).toBeInTheDocument();
+      expect(within(row).getByText(formatNumber(item.failed_findings.total))).toBeInTheDocument();
+      expect(
+        within(row).getByText(new RegExp(numeral(item.failed_findings.normalized).format('0%')))
+      ).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.test.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import * as TEST_SUBJECTS from './test_subjects';
-import { FindingsByResourceTable } from './findings_by_resource_table';
+import { FindingsByResourceTable, getResourceId } from './findings_by_resource_table';
 import * as TEXT from './translations';
 import type { PropsOf } from '@elastic/eui';
 import Chance from 'chance';
@@ -30,7 +30,7 @@ describe('<FindingsByResourceTable />', () => {
   it('renders the zero state when status success and data has a length of zero ', async () => {
     const props: TableProps = {
       loading: false,
-      data: { page: [], total: 0 },
+      data: { page: [] },
       error: null,
     };
 
@@ -44,18 +44,17 @@ describe('<FindingsByResourceTable />', () => {
 
     const props: TableProps = {
       loading: false,
-      data: { page: data, total: 10 },
+      data: { page: data },
       error: null,
     };
 
-    const { container } = render(<FindingsByResourceTable {...props} />);
+    render(<FindingsByResourceTable {...props} />);
 
     data.forEach((item, i) => {
-      const row = container.querySelector<HTMLElement>(
-        `[data-test-subj="${TEST_SUBJECTS.FINDINGS_BY_RESOURCE_TABLE_ROW}"]:nth-child(${i + 1})`
+      const row = screen.getByTestId(
+        TEST_SUBJECTS.getFindingsByResourceTableRowTestId(getResourceId(item))
       );
-      if (!row) throw new Error('missing row');
-
+      expect(row).toBeInTheDocument();
       expect(within(row).getByText(item.resource_id)).toBeInTheDocument();
       expect(within(row).getByText(item.cluster_id)).toBeInTheDocument();
       expect(within(row).getByText(item.cis_section)).toBeInTheDocument();

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.tsx
@@ -21,7 +21,8 @@ import * as TEST_SUBJECTS from './test_subjects';
 import * as TEXT from './translations';
 import type { CspFindingsByResourceResult } from './use_findings_by_resource';
 
-const formatNumber = (value: number) => (value < 1000 ? value : numeral(value).format('0.0a'));
+export const formatNumber = (value: number) =>
+  value < 1000 ? value : numeral(value).format('0.0a');
 
 type FindingsGroupByResourceProps = CspFindingsByResourceResult;
 type CspFindingsByResource = NonNullable<CspFindingsByResourceResult['data']>['page'][number];

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.tsx
@@ -13,7 +13,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiLink,
-  EuiToolTip,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import numeral from '@elastic/numeral';
@@ -27,13 +26,16 @@ const formatNumber = (value: number) => (value < 1000 ? value : numeral(value).f
 type FindingsGroupByResourceProps = CspFindingsByResourceResult;
 type CspFindingsByResource = NonNullable<CspFindingsByResourceResult['data']>['page'][number];
 
+export const getResourceId = (resource: CspFindingsByResource) =>
+  [resource.resource_id, resource.cluster_id, resource.cis_section].join('/');
+
 const FindingsByResourceTableComponent = ({
   error,
   data,
   loading,
 }: FindingsGroupByResourceProps) => {
-  const getRowProps = () => ({
-    'data-test-subj': TEST_SUBJECTS.FINDINGS_BY_RESOURCE_TABLE_ROW,
+  const getRowProps = (row: CspFindingsByResource) => ({
+    'data-test-subj': TEST_SUBJECTS.getFindingsByResourceTableRowTestId(getResourceId(row)),
   });
 
   if (!loading && !data?.page.length)
@@ -53,18 +55,13 @@ const FindingsByResourceTableComponent = ({
 const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
   {
     field: 'resource_id',
-    truncateText: true,
     name: (
       <FormattedMessage
         id="xpack.csp.findings.groupByResourceTable.resourceIdColumnLabel"
-        defaultMessage="Resource Id"
+        defaultMessage="Resource ID"
       />
     ),
-    render: (resourceId: CspFindingsByResource['resource_id']) => (
-      <EuiToolTip position="top" content={resourceId}>
-        <EuiLink>{resourceId}</EuiLink>
-      </EuiToolTip>
-    ),
+    render: (resourceId: CspFindingsByResource['resource_id']) => <EuiLink>{resourceId}</EuiLink>,
   },
   {
     field: 'cis_section',
@@ -82,7 +79,7 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
     name: (
       <FormattedMessage
         id="xpack.csp.findings.groupByResourceTable.clusterIdColumnLabel"
-        defaultMessage="Cluster Id"
+        defaultMessage="Cluster ID"
       />
     ),
   },

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import {
+  EuiTableFieldDataColumnType,
+  EuiEmptyPrompt,
+  EuiBasicTable,
+  EuiTextColor,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiToolTip,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import numeral from '@elastic/numeral';
+import { extractErrorMessage } from '../../../common/utils/helpers';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+import type { CspFindingsByResourceResult } from './use_findings_by_resource';
+
+const formatNumber = (value: number) => (value < 1000 ? value : numeral(value).format('0.0a'));
+
+type FindingsGroupByResourceProps = CspFindingsByResourceResult;
+type CspFindingsByResource = NonNullable<CspFindingsByResourceResult['data']>['page'][number];
+
+const FindingsByResourceTableComponent = ({
+  error,
+  data,
+  loading,
+}: FindingsGroupByResourceProps) => {
+  const getRowProps = () => ({
+    'data-test-subj': TEST_SUBJECTS.FINDINGS_BY_RESOURCE_TABLE_ROW,
+  });
+
+  if (!loading && !data?.page.length)
+    return <EuiEmptyPrompt iconType="logoKibana" title={<h2>{TEXT.NO_FINDINGS}</h2>} />;
+
+  return (
+    <EuiBasicTable
+      loading={loading}
+      error={error ? extractErrorMessage(error) : undefined}
+      items={data?.page || []}
+      columns={columns}
+      rowProps={getRowProps}
+    />
+  );
+};
+
+const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
+  {
+    field: 'resource_id',
+    truncateText: true,
+    name: (
+      <FormattedMessage
+        id="xpack.csp.findings.groupByResourceTable.resourceIdColumnLabel"
+        defaultMessage="Resource ID"
+      />
+    ),
+    render: (resourceId: CspFindingsByResource['resource_id']) => (
+      <EuiToolTip position="top" content={resourceId}>
+        <EuiLink>{resourceId}</EuiLink>
+      </EuiToolTip>
+    ),
+  },
+  {
+    field: 'cis_section',
+    truncateText: true,
+    name: (
+      <FormattedMessage
+        id="xpack.csp.findings.groupByResourceTable.cisSectionColumnLabel"
+        defaultMessage="CIS Section"
+      />
+    ),
+  },
+  {
+    field: 'cluster_id',
+    truncateText: true,
+    name: (
+      <FormattedMessage
+        id="xpack.csp.findings.groupByResourceTable.clusterIdColumnLabel"
+        defaultMessage="Cluster ID"
+      />
+    ),
+  },
+  {
+    field: 'failed_findings',
+    truncateText: true,
+    name: (
+      <FormattedMessage
+        id="xpack.csp.findings.groupByResourceTable.failedFindingsColumnLabel"
+        defaultMessage="Failed Findings"
+      />
+    ),
+    render: (failedFindings: CspFindingsByResource['failed_findings']) => (
+      <EuiFlexGroup gutterSize="xs">
+        <EuiFlexItem grow={false}>
+          <EuiTextColor color="danger">{formatNumber(failedFindings.total)}</EuiTextColor>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <span>({numeral(failedFindings.normalized).format('0%')})</span>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    ),
+  },
+];
+
+export const FindingsByResourceTable = React.memo(FindingsByResourceTableComponent);

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_by_resource_table.tsx
@@ -57,7 +57,7 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
     name: (
       <FormattedMessage
         id="xpack.csp.findings.groupByResourceTable.resourceIdColumnLabel"
-        defaultMessage="Resource ID"
+        defaultMessage="Resource Id"
       />
     ),
     render: (resourceId: CspFindingsByResource['resource_id']) => (
@@ -82,7 +82,7 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
     name: (
       <FormattedMessage
         id="xpack.csp.findings.groupByResourceTable.clusterIdColumnLabel"
-        defaultMessage="Cluster ID"
+        defaultMessage="Cluster Id"
       />
     ),
   },

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_container.tsx
@@ -46,7 +46,7 @@ const getGroupByOptions = (): Array<EuiComboBoxOptionOption<FindingsBaseURLQuery
   {
     value: 'resource',
     label: i18n.translate('xpack.csp.findings.groupBySelector.groupByResourceIdLabel', {
-      defaultMessage: 'Resource ID',
+      defaultMessage: 'Resource',
     }),
   },
 ];

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_group_by_selector.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_group_by_selector.tsx
@@ -7,12 +7,12 @@
 import React from 'react';
 import { EuiComboBox, EuiFormLabel, type EuiComboBoxOptionOption } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import type { GroupBy } from './findings_container';
+import type { FindingsGroupByKind } from './types';
 
 interface Props {
-  type: GroupBy;
-  options: Array<EuiComboBoxOptionOption<GroupBy>>;
-  onChange(selectedOptions: Array<EuiComboBoxOptionOption<GroupBy>>): void;
+  type: FindingsGroupByKind;
+  options: Array<EuiComboBoxOptionOption<FindingsGroupByKind>>;
+  onChange(selectedOptions: Array<EuiComboBoxOptionOption<FindingsGroupByKind>>): void;
 }
 
 export const FindingsGroupBySelector = ({ type, options, onChange }: Props) => (

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_search_bar.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_search_bar.tsx
@@ -10,12 +10,13 @@ import { EuiThemeComputed, useEuiTheme } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { DataView } from '@kbn/data-plugin/common';
 import * as TEST_SUBJECTS from './test_subjects';
-import type { CspFindingsRequest, CspFindingsResult } from './use_findings';
+import type { CspFindingsResult } from './use_findings';
+import type { FindingsBaseURLQuery } from './types';
 import type { CspClientPluginStartDeps } from '../../types';
 import { PLUGIN_NAME } from '../../../common';
 import { FINDINGS_SEARCH_PLACEHOLDER } from './translations';
 
-type SearchBarQueryProps = Pick<CspFindingsRequest, 'query' | 'filters'>;
+type SearchBarQueryProps = Pick<FindingsBaseURLQuery, 'query' | 'filters'>;
 
 interface FindingsSearchBarProps extends SearchBarQueryProps {
   setQuery(v: Partial<SearchBarQueryProps>): void;

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
@@ -22,13 +22,11 @@ import * as TEST_SUBJECTS from './test_subjects';
 import * as TEXT from './translations';
 import type { CspFinding } from './types';
 import { CspEvaluationBadge } from '../../components/csp_evaluation_badge';
-import type { CspFindingsRequest, CspFindingsResult } from './use_findings';
+import type { FindingsGroupByNoneQuery, CspFindingsResult } from './use_findings';
 import { FindingsRuleFlyout } from './findings_flyout';
 
-type TableQueryProps = Pick<CspFindingsRequest, 'sort' | 'from' | 'size'>;
-
-interface BaseFindingsTableProps extends TableQueryProps {
-  setQuery(query: Partial<TableQueryProps>): void;
+interface BaseFindingsTableProps extends FindingsGroupByNoneQuery {
+  setQuery(query: Partial<FindingsGroupByNoneQuery>): void;
 }
 
 type FindingsTableProps = CspFindingsResult & BaseFindingsTableProps;
@@ -119,7 +117,7 @@ const getEuiPaginationFromEsSearchSource = ({
 });
 
 const getEuiSortFromEsSearchSource = (
-  sort: TableQueryProps['sort']
+  sort: FindingsGroupByNoneQuery['sort']
 ): EuiBasicTableProps<CspFinding>['sorting'] => {
   if (!sort.length) return;
 
@@ -133,7 +131,7 @@ const getEuiSortFromEsSearchSource = (
 const getEsSearchQueryFromEuiTableParams = ({
   page,
   sort,
-}: Criteria<CspFinding>): Partial<TableQueryProps> => ({
+}: Criteria<CspFinding>): Partial<FindingsGroupByNoneQuery> => ({
   ...(!!page && { from: page.index * page.size, size: page.size }),
   sort: sort ? [{ [sort.field]: SortDirection[sort.direction] }] : undefined,
 });

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/test_subjects.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/test_subjects.ts
@@ -9,4 +9,5 @@ export const FINDINGS_SEARCH_BAR = 'findings_search_bar';
 export const FINDINGS_TABLE = 'findings_table';
 export const FINDINGS_CONTAINER = 'findings_container';
 export const FINDINGS_TABLE_ZERO_STATE = 'findings_table_zero_state';
-export const FINDINGS_BY_RESOURCE_TABLE_ROW = 'findings_resource_table_row';
+export const getFindingsByResourceTableRowTestId = (id: string) =>
+  `findings_resource_table_row_${id}`;

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/test_subjects.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/test_subjects.ts
@@ -9,3 +9,4 @@ export const FINDINGS_SEARCH_BAR = 'findings_search_bar';
 export const FINDINGS_TABLE = 'findings_table';
 export const FINDINGS_CONTAINER = 'findings_container';
 export const FINDINGS_TABLE_ZERO_STATE = 'findings_table_zero_state';
+export const FINDINGS_BY_RESOURCE_TABLE_ROW = 'findings_resource_table_row';

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
@@ -4,6 +4,33 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { BoolQuery, Filter, Query } from '@kbn/es-query';
+import { UseQueryResult } from 'react-query';
+
+export type FindingsGroupByKind = 'none' | 'resource';
+
+export interface FindingsBaseURLQuery {
+  groupBy: FindingsGroupByKind;
+  query: Query;
+  filters: Filter[];
+}
+
+export interface FindingsBaseEsQuery {
+  index: string;
+  query?: {
+    bool: BoolQuery;
+  };
+}
+
+export interface FindingsQueryStatus {
+  enabled: boolean;
+}
+
+export interface FindingsQueryResult<TData = unknown, TError = unknown> {
+  loading: UseQueryResult['isLoading'];
+  error: TError;
+  data: TData;
+}
 
 // TODO: this needs to be defined in a versioned schema
 export interface CspFinding {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_by_resource.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_by_resource.ts
@@ -54,7 +54,7 @@ export const getFindingsByResourceAggQuery = ({
         composite: {
           size: 10 * 1000,
           sources: [
-            { resource_id: { terms: { field: 'resource_id' } } },
+            { resource_id: { terms: { field: 'resource_id.keyword' } } },
             { cluster_id: { terms: { field: 'cluster_id.keyword' } } },
             { cis_section: { terms: { field: 'rule.section' } } },
           ],

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_by_resource.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_by_resource.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useQuery } from 'react-query';
+import { lastValueFrom } from 'rxjs';
+import { IKibanaSearchRequest, IKibanaSearchResponse } from '@kbn/data-plugin/common';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { useKibana } from '../../common/hooks/use_kibana';
+import { showErrorToast } from './use_findings';
+import type { FindingsBaseEsQuery, FindingsQueryResult, FindingsQueryStatus } from './types';
+
+interface UseFindingsByResourceOptions extends FindingsBaseEsQuery, FindingsQueryStatus {}
+
+type FindingsAggRequest = IKibanaSearchRequest<estypes.SearchRequest>;
+type FindingsAggResponse = IKibanaSearchResponse<
+  estypes.SearchResponse<{}, FindingsByResourceAggs>
+>;
+
+export type CspFindingsByResourceResult = FindingsQueryResult<
+  ReturnType<typeof useFindingsByResource>['data'] | undefined,
+  unknown
+>;
+
+interface FindingsByResourceAggs extends estypes.AggregationsCompositeAggregate {
+  groupBy: {
+    buckets: FindingsAggBucket[];
+  };
+}
+
+interface FindingsAggBucket {
+  doc_count: number;
+  failed_findings: { doc_count: number };
+  key: {
+    resource_id: string;
+    cluster_id: string;
+    cis_section: string;
+  };
+}
+
+export const getFindingsByResourceAggQuery = ({
+  index,
+  query,
+}: Omit<UseFindingsByResourceOptions, 'enabled'>): estypes.SearchRequest => ({
+  index,
+  track_total_hits: true, // TODO: only do this for first request
+  size: 0,
+  body: {
+    query,
+    aggs: {
+      groupBy: {
+        composite: {
+          size: 10 * 1000,
+          sources: [
+            { resource_id: { terms: { field: 'resource_id' } } },
+            { cluster_id: { terms: { field: 'cluster_id.keyword' } } },
+            { cis_section: { terms: { field: 'rule.section' } } },
+          ],
+        },
+        aggs: {
+          failed_findings: {
+            filter: { term: { 'result.evaluation.keyword': 'failed' } },
+          },
+        },
+      },
+    },
+  },
+});
+
+export const useFindingsByResource = ({ enabled, index, query }: UseFindingsByResourceOptions) => {
+  const {
+    data,
+    notifications: { toasts },
+  } = useKibana().services;
+
+  return useQuery(
+    ['csp_findings_resource', { index, query }],
+    () =>
+      lastValueFrom(
+        data.search.search<FindingsAggRequest, FindingsAggResponse>({
+          params: getFindingsByResourceAggQuery({ index, query }),
+        })
+      ),
+    {
+      enabled,
+      select: ({ rawResponse }) => ({
+        total: rawResponse.hits.total as number,
+        page: rawResponse.aggregations?.groupBy.buckets.map(createFindingsByResource) || [],
+      }),
+      onError: (err) => showErrorToast(toasts, err),
+    }
+  );
+};
+
+const createFindingsByResource = (bucket: FindingsAggBucket) => ({
+  ...bucket.key,
+  failed_findings: {
+    total: bucket.failed_findings.doc_count,
+    normalized: bucket.doc_count > 0 ? bucket.failed_findings.doc_count / bucket.doc_count : 0,
+  },
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_by_resource.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_by_resource.ts
@@ -45,7 +45,6 @@ export const getFindingsByResourceAggQuery = ({
   query,
 }: Omit<UseFindingsByResourceOptions, 'enabled'>): estypes.SearchRequest => ({
   index,
-  track_total_hits: true, // TODO: only do this for first request
   size: 0,
   body: {
     query,
@@ -86,7 +85,6 @@ export const useFindingsByResource = ({ enabled, index, query }: UseFindingsByRe
     {
       enabled,
       select: ({ rawResponse }) => ({
-        total: rawResponse.hits.total as number,
         page: rawResponse.aggregations?.groupBy.buckets.map(createFindingsByResource) || [],
       }),
       onError: (err) => showErrorToast(toasts, err),

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_count.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_count.ts
@@ -10,7 +10,9 @@ import { lastValueFrom } from 'rxjs';
 import type { IKibanaSearchRequest, IKibanaSearchResponse } from '@kbn/data-plugin/public';
 import { useKibana } from '../../common/hooks/use_kibana';
 import { showErrorToast } from './use_findings';
-import type { FindingsBaseQuery } from './findings_container';
+import type { FindingsBaseEsQuery, FindingsQueryStatus } from './types';
+
+interface UseFindingsCountOptions extends FindingsBaseEsQuery, FindingsQueryStatus {}
 
 type FindingsAggRequest = IKibanaSearchRequest<estypes.SearchRequest>;
 type FindingsAggResponse = IKibanaSearchResponse<estypes.SearchResponse<{}, FindingsAggs>>;
@@ -23,7 +25,7 @@ interface FindingsAggs extends estypes.AggregationsMultiBucketAggregateBase {
   };
 }
 
-export const getFindingsCountAggQuery = ({ index, query }: Omit<FindingsBaseQuery, 'error'>) => ({
+export const getFindingsCountAggQuery = ({ index, query }: FindingsBaseEsQuery) => ({
   index,
   size: 0,
   track_total_hits: true,
@@ -33,7 +35,7 @@ export const getFindingsCountAggQuery = ({ index, query }: Omit<FindingsBaseQuer
   },
 });
 
-export const useFindingsCounter = ({ index, query, error }: FindingsBaseQuery) => {
+export const useFindingsCounter = ({ enabled, index, query }: UseFindingsCountOptions) => {
   const {
     data,
     notifications: { toasts },
@@ -48,7 +50,7 @@ export const useFindingsCounter = ({ index, query, error }: FindingsBaseQuery) =
         })
       ),
     {
-      enabled: !error,
+      enabled,
       onError: (err) => showErrorToast(toasts, err),
       select: (response) =>
         Object.fromEntries(


### PR DESCRIPTION
## Summary

this PR adds support for grouping findings by ` resource`. this includes:
 - new table - `<FindingsGroupByResourceTable>` 
 - new api hook - `useFindingsByResource` 
 - renames, type changes and minor refactoring to accommodate for adding another level to `findings` results -  `groupBy` 

## Demo 

https://user-images.githubusercontent.com/20814186/163825536-d73c9441-79af-49c7-a340-0db8fbdef49e.mov


^ sorting and pagination will be added in follow up tasks. 

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

