### PR TITLE
[Cloud Posture] use index with keyword mapping

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings.ts
@@ -78,6 +78,7 @@ export const getFindingsQuery = ({
   from,
   sort,
 }: Omit<UseFindingsOptions, 'error'>) => ({
+  index,
   query,
   size,
   from,

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_count.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_count.ts
@@ -29,7 +29,7 @@ export const getFindingsCountAggQuery = ({ index, query }: Omit<FindingsBaseQuer
   track_total_hits: true,
   body: {
     query,
-    aggs: { count: { terms: { field: 'result.evaluation' } } },
+    aggs: { count: { terms: { field: 'result.evaluation.keyword' } } },
   },
 });
 


### PR DESCRIPTION
after merging https://github.com/elastic/kibana/pull/129639 i noticed the results are odd as the passed / failed don't add up to the total. 

this PR adds (back) the `index` to the default findings query and uses `keyword` on the count aggregation query, which fixes the issue. 
