### PR TITLE
[Response Ops] Add deprecated telemetry for _mute_all

### DIFF
--- a/x-pack/plugins/alerting/server/lib/track_deprecated_route_usage.test.ts
+++ b/x-pack/plugins/alerting/server/lib/track_deprecated_route_usage.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { usageCountersServiceMock } from '@kbn/usage-collection-plugin/server/usage_counters/usage_counters_service.mock';
+import { trackDeprecatedRouteUsage } from './track_deprecated_route_usage';
+
+describe('trackDeprecatedRouteUsage', () => {
+  it('should call `usageCounter.incrementCounter`', () => {
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    trackDeprecatedRouteUsage('test', mockUsageCounter);
+    expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+      counterName: `deprecatedRoute_test`,
+      counterType: 'deprecatedApiUsage',
+      incrementBy: 1,
+    });
+  });
+
+  it('should do nothing if no usage counter is provided', () => {
+    let err;
+    try {
+      trackDeprecatedRouteUsage('test', undefined);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeUndefined();
+  });
+});

--- a/x-pack/plugins/alerting/server/lib/track_deprecated_route_usage.ts
+++ b/x-pack/plugins/alerting/server/lib/track_deprecated_route_usage.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { UsageCounter } from '@kbn/usage-collection-plugin/server';
+
+export function trackDeprecatedRouteUsage(route: string, usageCounter?: UsageCounter) {
+  if (usageCounter) {
+    usageCounter.incrementCounter({
+      counterName: `deprecatedRoute_${route}`,
+      counterType: 'deprecatedApiUsage',
+      incrementBy: 1,
+    });
+  }
+}

--- a/x-pack/plugins/alerting/server/routes/index.ts
+++ b/x-pack/plugins/alerting/server/routes/index.ts
@@ -60,7 +60,7 @@ export function defineRoutes(opts: RouteOptions) {
   getRuleStateRoute(router, licenseState);
   healthRoute(router, licenseState, encryptedSavedObjects);
   ruleTypesRoute(router, licenseState);
-  muteAllRuleRoute(router, licenseState);
+  muteAllRuleRoute(router, licenseState, usageCounter);
   muteAlertRoute(router, licenseState);
   unmuteAllRuleRoute(router, licenseState);
   unmuteAlertRoute(router, licenseState);

--- a/x-pack/plugins/alerting/server/routes/mute_all_rule.test.ts
+++ b/x-pack/plugins/alerting/server/routes/mute_all_rule.test.ts
@@ -4,17 +4,22 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { usageCountersServiceMock } from '@kbn/usage-collection-plugin/server/usage_counters/usage_counters_service.mock';
 import { muteAllRuleRoute } from './mute_all_rule';
 import { httpServiceMock } from '@kbn/core/server/mocks';
 import { licenseStateMock } from '../lib/license_state.mock';
 import { mockHandlerArguments } from './_mock_handler_arguments';
 import { rulesClientMock } from '../rules_client.mock';
 import { RuleTypeDisabledError } from '../lib/errors/rule_type_disabled';
+import { trackDeprecatedRouteUsage } from '../lib/track_deprecated_route_usage';
 
 const rulesClient = rulesClientMock.create();
 jest.mock('../lib/license_api_access', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../lib/track_deprecated_route_usage', () => ({
+  trackDeprecatedRouteUsage: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -76,5 +81,20 @@ describe('muteAllRuleRoute', () => {
     await handler(context, req, res);
 
     expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'Fail' } });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    muteAllRuleRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { params: {}, body: {} }, [
+      'ok',
+    ]);
+    await handler(context, req, res);
+    expect(trackDeprecatedRouteUsage).toHaveBeenCalledWith('muteAll', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/mute_all_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/mute_all_rule.ts
@@ -7,9 +7,11 @@
 
 import { IRouter } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { ILicenseState, RuleTypeDisabledError } from '../lib';
 import { verifyAccessAndContext } from './lib';
 import { AlertingRequestHandlerContext, BASE_ALERTING_API_PATH } from '../types';
+import { trackDeprecatedRouteUsage } from '../lib/track_deprecated_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
@@ -17,7 +19,8 @@ const paramSchema = schema.object({
 
 export const muteAllRuleRoute = (
   router: IRouter<AlertingRequestHandlerContext>,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) => {
   router.post(
     {
@@ -30,6 +33,7 @@ export const muteAllRuleRoute = (
       verifyAccessAndContext(licenseState, async function (context, req, res) {
         const rulesClient = context.alerting.getRulesClient();
         const { id } = req.params;
+        trackDeprecatedRouteUsage('muteAll', usageCounter);
         try {
           await rulesClient.muteAll({ id });
           return res.noContent();


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/126817

Similar to https://github.com/elastic/kibana/pull/111885, this PR introduces telemetry for deprecated endpoints, specifically `rule/{id}/_mute_all`

To test, visit the above url and then check telemetry stats (via https://localhost:5601/api/stats?extended):
```
"usage_counters": {
  "daily_events": [
    {
      "domain_id": "alerts",
      "counter_name": "deprecatedRoute_muteAll",
      "counter_type": "deprecatedApiUsage",
      "last_updated_at": "2022-04-18T14:30:20.278Z",
      "from_timestamp": "2022-04-18T00:00:00Z",
      "total": 1
    }
  ]
```