### PR TITLE
[Stack Monitoring] use CCS constant in place of '*' string

### DIFF
--- a/x-pack/plugins/monitoring/common/ccs_utils.test.js
+++ b/x-pack/plugins/monitoring/common/ccs_utils.test.js
@@ -6,12 +6,12 @@
  */
 
 import expect from '@kbn/expect';
-import { parseCrossClusterPrefix, prefixIndexPattern } from './ccs_utils';
+import { parseCrossClusterPrefix, prefixIndexPatternWithCcs } from './ccs_utils';
 
 // TODO: tests were not running and are not updated.
 // They need to be changed to run.
 describe.skip('ccs_utils', () => {
-  describe('prefixIndexPattern', () => {
+  describe('prefixIndexPatternWithCcs', () => {
     const indexPattern = '.monitoring-xyz-1-*,.monitoring-xyz-2-*';
 
     it('returns the index pattern if ccs is not enabled', () => {
@@ -19,8 +19,8 @@ describe.skip('ccs_utils', () => {
       const config = { ui: { css: { enabled: false } } };
 
       // falsy string values should be ignored
-      const allPattern = prefixIndexPattern(config, indexPattern, '*');
-      const onePattern = prefixIndexPattern(config, indexPattern, 'do_not_use_me');
+      const allPattern = prefixIndexPatternWithCcs(config, indexPattern, '*');
+      const onePattern = prefixIndexPatternWithCcs(config, indexPattern, 'do_not_use_me');
 
       expect(allPattern).to.be(indexPattern);
       expect(onePattern).to.be(indexPattern);
@@ -31,9 +31,9 @@ describe.skip('ccs_utils', () => {
       const config = { ui: { css: { enabled: true } } };
 
       // falsy string values should be ignored
-      const undefinedPattern = prefixIndexPattern(config, indexPattern);
-      const nullPattern = prefixIndexPattern(config, indexPattern, null);
-      const blankPattern = prefixIndexPattern(config, indexPattern, '');
+      const undefinedPattern = prefixIndexPatternWithCcs(config, indexPattern);
+      const nullPattern = prefixIndexPatternWithCcs(config, indexPattern, null);
+      const blankPattern = prefixIndexPatternWithCcs(config, indexPattern, '');
 
       expect(undefinedPattern).to.be(indexPattern);
       expect(nullPattern).to.be(indexPattern);
@@ -44,8 +44,8 @@ describe.skip('ccs_utils', () => {
       // TODO apply as MonitoringConfig during typescript conversion
       const config = { ui: { css: { enabled: true } } };
 
-      const abcPattern = prefixIndexPattern(config, indexPattern, 'aBc');
-      const underscorePattern = prefixIndexPattern(config, indexPattern, 'cluster_one');
+      const abcPattern = prefixIndexPatternWithCcs(config, indexPattern, 'aBc');
+      const underscorePattern = prefixIndexPatternWithCcs(config, indexPattern, 'cluster_one');
 
       expect(abcPattern).to.eql(
         'aBc:.monitoring-xyz-1-*,aBc:.monitoring-xyz-2-*,aBc:monitoring-xyz-1-*,aBc:monitoring-xyz-2-*'
@@ -59,7 +59,7 @@ describe.skip('ccs_utils', () => {
       // TODO apply as MonitoringConfig during typescript conversion
       const config = { ui: { css: { enabled: true } } };
 
-      const pattern = prefixIndexPattern(config, indexPattern, '*');
+      const pattern = prefixIndexPatternWithCcs(config, indexPattern, '*');
 
       // it should have BOTH patterns so that it searches all CCS clusters and the local cluster
       expect(pattern).to.eql(

--- a/x-pack/plugins/monitoring/common/ccs_utils.ts
+++ b/x-pack/plugins/monitoring/common/ccs_utils.ts
@@ -19,7 +19,11 @@ import type { MonitoringConfig } from '../server/config';
  * @param  {String} ccs The optional cluster-prefix to prepend.
  * @return {String} The index pattern with the {@code cluster} prefix appropriately prepended.
  */
-export function prefixIndexPattern(config: MonitoringConfig, indexPattern: string, ccs?: string) {
+export function prefixIndexPatternWithCcs(
+  config: MonitoringConfig,
+  indexPattern: string,
+  ccs?: string
+) {
   const ccsEnabled = config.ui.ccs.enabled;
   if (!ccsEnabled || !ccs) {
     return indexPattern;

--- a/x-pack/plugins/monitoring/common/ccs_utils.ts
+++ b/x-pack/plugins/monitoring/common/ccs_utils.ts
@@ -8,10 +8,6 @@
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import type { MonitoringConfig } from '../server/config';
 
-export function getConfigCcs(config: MonitoringConfig): boolean {
-  // TODO: (Mat) this function can probably be removed in favor of direct config access where it's used.
-  return config.ui.ccs.enabled;
-}
 /**
  * Prefix all comma separated index patterns within the original {@code indexPattern}.
  *
@@ -24,7 +20,7 @@ export function getConfigCcs(config: MonitoringConfig): boolean {
  * @return {String} The index pattern with the {@code cluster} prefix appropriately prepended.
  */
 export function prefixIndexPattern(config: MonitoringConfig, indexPattern: string, ccs?: string) {
-  const ccsEnabled = getConfigCcs(config);
+  const ccsEnabled = config.ui.ccs.enabled;
   if (!ccsEnabled || !ccs) {
     return indexPattern;
   }

--- a/x-pack/plugins/monitoring/common/constants.ts
+++ b/x-pack/plugins/monitoring/common/constants.ts
@@ -123,6 +123,7 @@ export const CLUSTER_ALERTS_ADDRESS_CONFIG_KEY = 'cluster_alerts.email_notificat
 
 export const STANDALONE_CLUSTER_CLUSTER_UUID = '__standalone_cluster__';
 
+export const CCS_REMOTE_PATTERN = '*';
 export const INDEX_PATTERN = '.monitoring-*';
 export const INDEX_PATTERN_KIBANA = '.monitoring-kibana-*';
 export const INDEX_PATTERN_LOGSTASH = '.monitoring-logstash-*';

--- a/x-pack/plugins/monitoring/public/alerts/components/param_details_form/use_derived_index_pattern.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/components/param_details_form/use_derived_index_pattern.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import { DataViewsPublicPluginStart, DataView } from '@kbn/data-views-plugin/public';
 import { prefixIndexPattern } from '../../../../common/ccs_utils';
 import {
+  CCS_REMOTE_PATTERN,
   INDEX_PATTERN_BEATS,
   INDEX_PATTERN_ELASTICSEARCH,
   INDEX_PATTERN_KIBANA,
@@ -22,7 +23,11 @@ export const useDerivedIndexPattern = (
   dataViews: DataViewsPublicPluginStart,
   config?: MonitoringConfig
 ): { loading: boolean; derivedIndexPattern?: DataView } => {
-  const indexPattern = prefixIndexPattern(config || ({} as MonitoringConfig), INDEX_PATTERNS, '*');
+  const indexPattern = prefixIndexPattern(
+    config || ({} as MonitoringConfig),
+    INDEX_PATTERNS,
+    CCS_REMOTE_PATTERN
+  );
   const [loading, setLoading] = useState<boolean>(true);
   const [dataView, setDataView] = useState<DataView>();
   useEffect(() => {

--- a/x-pack/plugins/monitoring/public/alerts/components/param_details_form/use_derived_index_pattern.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/components/param_details_form/use_derived_index_pattern.tsx
@@ -7,7 +7,7 @@
 
 import { useEffect, useState } from 'react';
 import { DataViewsPublicPluginStart, DataView } from '@kbn/data-views-plugin/public';
-import { prefixIndexPattern } from '../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../common/ccs_utils';
 import {
   CCS_REMOTE_PATTERN,
   INDEX_PATTERN_BEATS,
@@ -23,7 +23,7 @@ export const useDerivedIndexPattern = (
   dataViews: DataViewsPublicPluginStart,
   config?: MonitoringConfig
 ): { loading: boolean; derivedIndexPattern?: DataView } => {
-  const indexPattern = prefixIndexPattern(
+  const indexPattern = prefixIndexPatternWithCcs(
     config || ({} as MonitoringConfig),
     INDEX_PATTERNS,
     CCS_REMOTE_PATTERN

--- a/x-pack/plugins/monitoring/server/kibana_monitoring/collectors/lib/fetch_stack_product_usage.ts
+++ b/x-pack/plugins/monitoring/server/kibana_monitoring/collectors/lib/fetch_stack_product_usage.ts
@@ -9,8 +9,6 @@ import { get } from 'lodash';
 import { ElasticsearchClient } from '@kbn/core/server';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { MonitoringConfig } from '../../../config';
-// @ts-ignore
-import { prefixIndexPattern } from '../../../../common/ccs_utils';
 import { StackProductUsage } from '../types';
 
 interface ESResponse {

--- a/x-pack/plugins/monitoring/server/kibana_monitoring/collectors/lib/get_stack_products_usage.ts
+++ b/x-pack/plugins/monitoring/server/kibana_monitoring/collectors/lib/get_stack_products_usage.ts
@@ -9,10 +9,6 @@ import { ElasticsearchClient } from '@kbn/core/server';
 import { MonitoringClusterStackProductUsage } from '../types';
 import { fetchESUsage } from './fetch_es_usage';
 import { MonitoringConfig } from '../../../config';
-// @ts-ignore
-import { getIndexPatterns } from '../../../lib/cluster/get_index_patterns';
-// @ts-ignore
-import { prefixIndexPattern } from '../../../../common/ccs_utils';
 import {
   INDEX_PATTERN_ELASTICSEARCH,
   INDEX_PATTERN_KIBANA,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.ts
@@ -7,11 +7,11 @@
 
 import { ElasticsearchClient } from '@kbn/core/server';
 import { get } from 'lodash';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { CCRReadExceptionsStats } from '../../../common/types/alerts';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 
 export async function fetchCCRReadExceptions(
   esClient: ElasticsearchClient,
@@ -24,7 +24,7 @@ export async function fetchCCRReadExceptions(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'ccr',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_cluster_health.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_cluster_health.ts
@@ -9,8 +9,8 @@ import { AlertCluster, AlertClusterHealth } from '../../../common/types/alerts';
 import { ElasticsearchSource } from '../../../common/types/es';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 
 export async function fetchClusterHealth(
   esClient: ElasticsearchClient,
@@ -21,7 +21,7 @@ export async function fetchClusterHealth(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'cluster_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.ts
@@ -11,7 +11,7 @@ import { AlertCluster } from '../../../common/types/alerts';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 
 interface RangeFilter {
   [field: string]: {
@@ -28,7 +28,7 @@ export async function fetchClusters(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'cluster_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_cpu_usage_node_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_cpu_usage_node_stats.ts
@@ -13,7 +13,7 @@ import { AlertCluster, AlertCpuUsageNodeStats } from '../../../common/types/aler
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 
 interface NodeBucketESResponse {
   key: string;
@@ -43,7 +43,7 @@ export async function fetchCpuUsageNodeStats(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_disk_usage_node_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_disk_usage_node_stats.ts
@@ -10,7 +10,7 @@ import { get } from 'lodash';
 import { AlertCluster, AlertDiskUsageNodeStats } from '../../../common/types/alerts';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 export async function fetchDiskUsageNodeStats(
@@ -25,7 +25,7 @@ export async function fetchDiskUsageNodeStats(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_elasticsearch_versions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_elasticsearch_versions.ts
@@ -9,7 +9,7 @@ import { AlertCluster, AlertVersions } from '../../../common/types/alerts';
 import { ElasticsearchSource } from '../../../common/types/es';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 export async function fetchElasticsearchVersions(
@@ -22,7 +22,7 @@ export async function fetchElasticsearchVersions(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'cluster_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_index_shard_size.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_index_shard_size.ts
@@ -11,7 +11,7 @@ import { ElasticsearchIndexStats, ElasticsearchResponseHit } from '../../../comm
 import { ESGlobPatterns, RegExPatterns } from '../../../common/es_glob_patterns';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 type TopHitType = ElasticsearchResponseHit & {
@@ -40,7 +40,7 @@ export async function fetchIndexShardSize(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'index',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_kibana_versions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_kibana_versions.ts
@@ -9,7 +9,7 @@ import { get } from 'lodash';
 import { AlertCluster, AlertVersions } from '../../../common/types/alerts';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 interface ESAggResponse {
@@ -26,7 +26,7 @@ export async function fetchKibanaVersions(
     config: Globals.app.config,
     moduleType: 'kibana',
     dataset: 'stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_licenses.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_licenses.ts
@@ -9,7 +9,7 @@ import { AlertLicense, AlertCluster } from '../../../common/types/alerts';
 import { ElasticsearchSource } from '../../../common/types/es';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 export async function fetchLicenses(
@@ -21,7 +21,7 @@ export async function fetchLicenses(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'cluster_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_logstash_versions.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_logstash_versions.ts
@@ -9,7 +9,7 @@ import { get } from 'lodash';
 import { AlertCluster, AlertVersions } from '../../../common/types/alerts';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 interface ESAggResponse {
@@ -26,7 +26,7 @@ export async function fetchLogstashVersions(
     config: Globals.app.config,
     moduleType: 'logstash',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_memory_usage_node_stats.ts
@@ -10,7 +10,7 @@ import { get } from 'lodash';
 import { AlertCluster, AlertMemoryUsageNodeStats } from '../../../common/types/alerts';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 export async function fetchMemoryUsageNodeStats(
@@ -26,7 +26,7 @@ export async function fetchMemoryUsageNodeStats(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_missing_monitoring_data.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_missing_monitoring_data.ts
@@ -9,7 +9,7 @@ import { ElasticsearchClient } from '@kbn/core/server';
 import { get } from 'lodash';
 import { AlertCluster, AlertMissingData } from '../../../common/types/alerts';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 import { createDatasetFilter } from './create_dataset_query_filter';
 
@@ -59,7 +59,7 @@ export async function fetchMissingMonitoringData(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_nodes_from_cluster_stats.ts
@@ -9,7 +9,7 @@ import { AlertCluster, AlertClusterStatsNodes } from '../../../common/types/aler
 import { ElasticsearchSource } from '../../../common/types/es';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 function formatNode(
@@ -36,7 +36,7 @@ export async function fetchNodesFromClusterStats(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'cluster_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_thread_pool_rejections_stats.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_thread_pool_rejections_stats.ts
@@ -10,7 +10,7 @@ import { get } from 'lodash';
 import { AlertCluster, AlertThreadPoolRejectionsStats } from '../../../common/types/alerts';
 import { createDatasetFilter } from './create_dataset_query_filter';
 import { Globals } from '../../static_globals';
-import { getConfigCcs } from '../../../common/ccs_utils';
+import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import { getNewIndexPatterns } from '../cluster/get_index_patterns';
 
 const invalidNumberValue = (value: number) => {
@@ -52,7 +52,7 @@ export async function fetchThreadPoolRejectionStats(
     config: Globals.app.config,
     moduleType: 'elasticsearch',
     dataset: 'node_stats',
-    ccs: getConfigCcs(Globals.app.config) ? '*' : undefined,
+    ccs: CCS_REMOTE_PATTERN,
   });
   const params = {
     index: indexPatterns,

--- a/x-pack/plugins/monitoring/server/lib/cluster/get_clusters_from_request.ts
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_clusters_from_request.ts
@@ -28,6 +28,7 @@ import {
   CODE_PATH_BEATS,
   CODE_PATH_APM,
   CODE_PATH_ENTERPRISE_SEARCH,
+  CCS_REMOTE_PATTERN,
 } from '../../../common/constants';
 
 import { getApmsForClusters } from '../apm/get_apms_for_clusters';
@@ -62,11 +63,11 @@ export async function getClustersFromRequest(
     clusters.push(getStandaloneClusterDefinition());
   } else {
     // get clusters with stats and cluster state
-    clusters = await getClustersStats(req, clusterUuid, '*');
+    clusters = await getClustersStats(req, clusterUuid, CCS_REMOTE_PATTERN);
   }
 
   if (!clusterUuid && !isStandaloneCluster) {
-    if (await hasStandaloneClusters(req, '*')) {
+    if (await hasStandaloneClusters(req, CCS_REMOTE_PATTERN)) {
       clusters.push(getStandaloneClusterDefinition());
     }
   }
@@ -90,7 +91,7 @@ export async function getClustersFromRequest(
 
     // add ml jobs and alerts data
     const mlJobs = isInCodePath(codePaths, [CODE_PATH_ML])
-      ? await getMlJobsForCluster(req, cluster, '*')
+      ? await getMlJobsForCluster(req, cluster, CCS_REMOTE_PATTERN)
       : null;
     if (mlJobs !== null) {
       cluster.ml = { jobs: mlJobs };
@@ -113,7 +114,7 @@ export async function getClustersFromRequest(
     }
 
     // update clusters with license check results
-    const getSupportedClusters = flagSupportedClusters(req, '*');
+    const getSupportedClusters = flagSupportedClusters(req, CCS_REMOTE_PATTERN);
     clusters = await getSupportedClusters(clusters);
 
     // add alerts data
@@ -169,7 +170,7 @@ export async function getClustersFromRequest(
   // add kibana data
   const kibanas =
     isInCodePath(codePaths, [CODE_PATH_KIBANA]) && !isStandaloneCluster
-      ? await getKibanasForClusters(req, clusters, '*')
+      ? await getKibanasForClusters(req, clusters, CCS_REMOTE_PATTERN)
       : [];
   // add the kibana data to each cluster
   kibanas.forEach((kibana) => {
@@ -182,8 +183,13 @@ export async function getClustersFromRequest(
 
   // add logstash data
   if (isInCodePath(codePaths, [CODE_PATH_LOGSTASH])) {
-    const logstashes = await getLogstashForClusters(req, clusters, '*');
-    const pipelines = await getLogstashPipelineIds({ req, clusterUuid, size: 1, ccs: '*' });
+    const logstashes = await getLogstashForClusters(req, clusters, CCS_REMOTE_PATTERN);
+    const pipelines = await getLogstashPipelineIds({
+      req,
+      clusterUuid,
+      size: 1,
+      ccs: CCS_REMOTE_PATTERN,
+    });
     logstashes.forEach((logstash) => {
       const clusterIndex = clusters.findIndex(
         (cluster) =>
@@ -199,7 +205,7 @@ export async function getClustersFromRequest(
 
   // add beats data
   const beatsByCluster = isInCodePath(codePaths, [CODE_PATH_BEATS])
-    ? await getBeatsForClusters(req, clusters, '*')
+    ? await getBeatsForClusters(req, clusters, CCS_REMOTE_PATTERN)
     : [];
   beatsByCluster.forEach((beats) => {
     const clusterIndex = clusters.findIndex(
@@ -211,7 +217,7 @@ export async function getClustersFromRequest(
 
   // add apm data
   const apmsByCluster = isInCodePath(codePaths, [CODE_PATH_APM])
-    ? await getApmsForClusters(req, clusters, '*')
+    ? await getApmsForClusters(req, clusters, CCS_REMOTE_PATTERN)
     : [];
   apmsByCluster.forEach((apm) => {
     const clusterIndex = clusters.findIndex(
@@ -229,7 +235,7 @@ export async function getClustersFromRequest(
 
   // add Enterprise Search data
   const enterpriseSearchByCluster = isInCodePath(codePaths, [CODE_PATH_ENTERPRISE_SEARCH])
-    ? await getEnterpriseSearchForClusters(req, clusters, '*')
+    ? await getEnterpriseSearchForClusters(req, clusters, CCS_REMOTE_PATTERN)
     : [];
   enterpriseSearchByCluster.forEach((entSearch) => {
     const clusterIndex = clusters.findIndex(
@@ -244,7 +250,7 @@ export async function getClustersFromRequest(
   });
 
   // check ccr configuration
-  const isCcrEnabled = await checkCcrEnabled(req, '*');
+  const isCcrEnabled = await checkCcrEnabled(req, CCS_REMOTE_PATTERN);
 
   const kibanaUuid = req.server.instanceUuid;
 

--- a/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.ts
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.ts
@@ -18,13 +18,14 @@ import {
   DS_INDEX_PATTERN_METRICS,
   INDEX_PATTERN_TYPES,
   INDEX_PATTERN_ENTERPRISE_SEARCH,
+  CCS_REMOTE_PATTERN,
 } from '../../../common/constants';
 import { MonitoringConfig } from '../..';
 
 export function getIndexPatterns(
   server: LegacyServer,
   additionalPatterns: Record<string, string> = {},
-  ccs: string = '*'
+  ccs: string = CCS_REMOTE_PATTERN
 ) {
   const config = server.config;
   const esIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_ELASTICSEARCH, ccs);

--- a/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.ts
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_index_patterns.ts
@@ -6,7 +6,7 @@
  */
 
 import { LegacyServer } from '../../types';
-import { prefixIndexPattern } from '../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../common/ccs_utils';
 import {
   INDEX_PATTERN_ELASTICSEARCH,
   INDEX_PATTERN_ELASTICSEARCH_ECS,
@@ -28,13 +28,13 @@ export function getIndexPatterns(
   ccs: string = CCS_REMOTE_PATTERN
 ) {
   const config = server.config;
-  const esIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
-  const kbnIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_KIBANA, ccs);
-  const lsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_LOGSTASH, ccs);
-  const beatsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
-  const apmIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
-  const alertsIndex = prefixIndexPattern(config, INDEX_ALERTS, ccs);
-  const enterpriseSearchIndexPattern = prefixIndexPattern(
+  const esIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
+  const kbnIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_KIBANA, ccs);
+  const lsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_LOGSTASH, ccs);
+  const beatsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
+  const apmIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
+  const alertsIndex = prefixIndexPatternWithCcs(config, INDEX_ALERTS, ccs);
+  const enterpriseSearchIndexPattern = prefixIndexPatternWithCcs(
     config,
     INDEX_PATTERN_ENTERPRISE_SEARCH,
     ccs
@@ -50,7 +50,7 @@ export function getIndexPatterns(
     ...Object.keys(additionalPatterns).reduce((accum, varName) => {
       return {
         ...accum,
-        [varName]: prefixIndexPattern(config, additionalPatterns[varName], ccs),
+        [varName]: prefixIndexPatternWithCcs(config, additionalPatterns[varName], ccs),
       };
     }, {}),
   };
@@ -89,7 +89,7 @@ export function getLegacyIndexPattern({
     default:
       throw new Error(`invalid module type to create index pattern: ${moduleType}`);
   }
-  return prefixIndexPattern(config, indexPattern, ccs);
+  return prefixIndexPatternWithCcs(config, indexPattern, ccs);
 }
 
 export function getDsIndexPattern({
@@ -113,7 +113,7 @@ export function getDsIndexPattern({
   } else {
     datasetsPattern = `${moduleType}.*`;
   }
-  return prefixIndexPattern(config, `${type}-${datasetsPattern}-${namespace}`, ccs);
+  return prefixIndexPatternWithCcs(config, `${type}-${datasetsPattern}-${namespace}`, ccs);
 }
 
 export function getNewIndexPatterns({

--- a/x-pack/plugins/monitoring/server/lib/logs/init_infra_source.ts
+++ b/x-pack/plugins/monitoring/server/lib/logs/init_infra_source.ts
@@ -7,13 +7,13 @@
 
 // @ts-ignore
 import { InfraPluginSetup } from '@kbn/infra-plugin/server';
-import { prefixIndexPattern } from '../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../common/ccs_utils';
 import { CCS_REMOTE_PATTERN, INFRA_SOURCE_ID } from '../../../common/constants';
 import { MonitoringConfig } from '../../config';
 
 export const initInfraSource = (config: MonitoringConfig, infraPlugin: InfraPluginSetup) => {
   if (infraPlugin) {
-    const filebeatIndexPattern = prefixIndexPattern(
+    const filebeatIndexPattern = prefixIndexPatternWithCcs(
       config,
       config.ui.logs.index,
       CCS_REMOTE_PATTERN

--- a/x-pack/plugins/monitoring/server/lib/logs/init_infra_source.ts
+++ b/x-pack/plugins/monitoring/server/lib/logs/init_infra_source.ts
@@ -8,12 +8,16 @@
 // @ts-ignore
 import { InfraPluginSetup } from '@kbn/infra-plugin/server';
 import { prefixIndexPattern } from '../../../common/ccs_utils';
-import { INFRA_SOURCE_ID } from '../../../common/constants';
+import { CCS_REMOTE_PATTERN, INFRA_SOURCE_ID } from '../../../common/constants';
 import { MonitoringConfig } from '../../config';
 
 export const initInfraSource = (config: MonitoringConfig, infraPlugin: InfraPluginSetup) => {
   if (infraPlugin) {
-    const filebeatIndexPattern = prefixIndexPattern(config, config.ui.logs.index, '*');
+    const filebeatIndexPattern = prefixIndexPattern(
+      config,
+      config.ui.logs.index,
+      CCS_REMOTE_PATTERN
+    );
     infraPlugin.defineInternalSourceConfiguration(INFRA_SOURCE_ID, {
       name: 'Elastic Stack Logs',
       logIndices: {

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/instance.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/instance.js
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { metricSet } from './metric_set_instance';
 import { handleError } from '../../../../lib/errors';
@@ -37,7 +37,7 @@ export function apmInstanceRoute(server) {
       const config = server.config;
       const clusterUuid = req.params.clusterUuid;
       const ccs = req.payload.ccs;
-      const apmIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
+      const apmIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
 
       const showCgroupMetrics = config.ui.container.apm.enabled;
       if (showCgroupMetrics) {

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/instances.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/instances.js
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { getStats, getApms } from '../../../../lib/apm';
 import { handleError } from '../../../../lib/errors';
 import { INDEX_PATTERN_BEATS } from '../../../../../common/constants';
@@ -33,7 +33,7 @@ export function apmInstancesRoute(server) {
       const config = server.config;
       const ccs = req.payload.ccs;
       const clusterUuid = req.params.clusterUuid;
-      const apmIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
+      const apmIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
 
       try {
         const [stats, apms] = await Promise.all([

--- a/x-pack/plugins/monitoring/server/routes/api/v1/beats/beat_detail.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/beats/beat_detail.js
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { getBeatSummary } from '../../../../lib/beats';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { handleError } from '../../../../lib/errors';
@@ -37,7 +37,7 @@ export function beatsDetailRoute(server) {
       const beatUuid = req.params.beatUuid;
       const config = server.config;
       const ccs = req.payload.ccs;
-      const beatsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
+      const beatsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
 
       const summaryOptions = {
         clusterUuid,

--- a/x-pack/plugins/monitoring/server/routes/api/v1/beats/beats.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/beats/beats.js
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { getStats, getBeats } from '../../../../lib/beats';
 import { handleError } from '../../../../lib/errors';
 import { INDEX_PATTERN_BEATS } from '../../../../../common/constants';
@@ -33,7 +33,7 @@ export function beatsListingRoute(server) {
       const config = server.config;
       const ccs = req.payload.ccs;
       const clusterUuid = req.params.clusterUuid;
-      const beatsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
+      const beatsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
 
       try {
         const [stats, listing] = await Promise.all([

--- a/x-pack/plugins/monitoring/server/routes/api/v1/beats/overview.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/beats/overview.js
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { getLatestStats, getStats } from '../../../../lib/beats';
 import { handleError } from '../../../../lib/errors';
@@ -35,7 +35,7 @@ export function beatsOverviewRoute(server) {
       const config = server.config;
       const ccs = req.payload.ccs;
       const clusterUuid = req.params.clusterUuid;
-      const beatsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_BEATS, ccs);
+      const beatsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_BEATS, ccs);
 
       try {
         const [latest, stats, metrics] = await Promise.all([

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/ccr.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/ccr.ts
@@ -11,7 +11,7 @@ import { get, groupBy } from 'lodash';
 // @ts-ignore
 import { handleError } from '../../../../lib/errors/handle_error';
 // @ts-ignore
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { INDEX_PATTERN_ELASTICSEARCH } from '../../../../../common/constants';
 import {
   ElasticsearchResponse,
@@ -216,7 +216,7 @@ export function ccrRoute(server: { route: (p: any) => void; config: MonitoringCo
     async handler(req: LegacyRequest) {
       const config = server.config;
       const ccs = req.payload.ccs;
-      const esIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
+      const esIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
 
       try {
         const { callWithRequest } = req.server.plugins.elasticsearch.getCluster('monitoring');

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/ccr_shard.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/ccr_shard.ts
@@ -10,7 +10,7 @@ import { schema } from '@kbn/config-schema';
 // @ts-ignore
 import { handleError } from '../../../../lib/errors/handle_error';
 // @ts-ignore
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 // @ts-ignore
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { ElasticsearchResponse } from '../../../../../common/types/es';

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/index_detail.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/index_detail.js
@@ -12,7 +12,7 @@ import { getIndexSummary } from '../../../../lib/elasticsearch/indices';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { getShardAllocation, getShardStats } from '../../../../lib/elasticsearch/shards';
 import { handleError } from '../../../../lib/errors/handle_error';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { metricSet } from './metric_set_index_detail';
 import { getLogs } from '../../../../lib/logs/get_logs';
 import { CCS_REMOTE_PATTERN } from '../../../../../common/constants';
@@ -46,7 +46,7 @@ export function esIndexRoute(server) {
         const indexUuid = req.params.id;
         const start = req.payload.timeRange.min;
         const end = req.payload.timeRange.max;
-        const filebeatIndexPattern = prefixIndexPattern(
+        const filebeatIndexPattern = prefixIndexPatternWithCcs(
           config,
           config.ui.logs.index,
           CCS_REMOTE_PATTERN

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/index_detail.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/index_detail.js
@@ -15,6 +15,7 @@ import { handleError } from '../../../../lib/errors/handle_error';
 import { prefixIndexPattern } from '../../../../../common/ccs_utils';
 import { metricSet } from './metric_set_index_detail';
 import { getLogs } from '../../../../lib/logs/get_logs';
+import { CCS_REMOTE_PATTERN } from '../../../../../common/constants';
 
 const { advanced: metricSetAdvanced, overview: metricSetOverview } = metricSet;
 
@@ -45,7 +46,11 @@ export function esIndexRoute(server) {
         const indexUuid = req.params.id;
         const start = req.payload.timeRange.min;
         const end = req.payload.timeRange.max;
-        const filebeatIndexPattern = prefixIndexPattern(config, config.ui.logs.index, '*');
+        const filebeatIndexPattern = prefixIndexPattern(
+          config,
+          config.ui.logs.index,
+          CCS_REMOTE_PATTERN
+        );
         const isAdvanced = req.payload.is_advanced;
         const metricSet = isAdvanced ? metricSetAdvanced : metricSetOverview;
 

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/node_detail.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/node_detail.js
@@ -15,6 +15,7 @@ import { handleError } from '../../../../lib/errors/handle_error';
 import { prefixIndexPattern } from '../../../../../common/ccs_utils';
 import { metricSets } from './metric_set_node_detail';
 import { getLogs } from '../../../../lib/logs/get_logs';
+import { CCS_REMOTE_PATTERN } from '../../../../../common/constants';
 
 const { advanced: metricSetAdvanced, overview: metricSetOverview } = metricSets;
 
@@ -47,7 +48,11 @@ export function esNodeRoute(server) {
       const nodeUuid = req.params.nodeUuid;
       const start = req.payload.timeRange.min;
       const end = req.payload.timeRange.max;
-      const filebeatIndexPattern = prefixIndexPattern(config, config.ui.logs.index, '*');
+      const filebeatIndexPattern = prefixIndexPattern(
+        config,
+        config.ui.logs.index,
+        CCS_REMOTE_PATTERN
+      );
       const isAdvanced = req.payload.is_advanced;
 
       let metricSet;

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/node_detail.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/node_detail.js
@@ -12,7 +12,7 @@ import { getNodeSummary } from '../../../../lib/elasticsearch/nodes';
 import { getShardStats, getShardAllocation } from '../../../../lib/elasticsearch/shards';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { handleError } from '../../../../lib/errors/handle_error';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { metricSets } from './metric_set_node_detail';
 import { getLogs } from '../../../../lib/logs/get_logs';
 import { CCS_REMOTE_PATTERN } from '../../../../../common/constants';
@@ -48,7 +48,7 @@ export function esNodeRoute(server) {
       const nodeUuid = req.params.nodeUuid;
       const start = req.payload.timeRange.min;
       const end = req.payload.timeRange.max;
-      const filebeatIndexPattern = prefixIndexPattern(
+      const filebeatIndexPattern = prefixIndexPatternWithCcs(
         config,
         config.ui.logs.index,
         CCS_REMOTE_PATTERN

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
@@ -15,6 +15,7 @@ import { prefixIndexPattern } from '../../../../../common/ccs_utils';
 import { metricSet } from './metric_set_overview';
 import { getLogs } from '../../../../lib/logs';
 import { getIndicesUnassignedShardStats } from '../../../../lib/elasticsearch/shards/get_indices_unassigned_shard_stats';
+import { CCS_REMOTE_PATTERN } from '../../../../../common/constants';
 
 export function esOverviewRoute(server) {
   server.route({
@@ -37,7 +38,11 @@ export function esOverviewRoute(server) {
     async handler(req) {
       const config = server.config;
       const clusterUuid = req.params.clusterUuid;
-      const filebeatIndexPattern = prefixIndexPattern(config, config.ui.logs.index, '*');
+      const filebeatIndexPattern = prefixIndexPattern(
+        config,
+        config.ui.logs.index,
+        CCS_REMOTE_PATTERN
+      );
 
       const start = req.payload.timeRange.min;
       const end = req.payload.timeRange.max;

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch/overview.js
@@ -11,7 +11,7 @@ import { getClusterStatus } from '../../../../lib/cluster/get_cluster_status';
 import { getLastRecovery } from '../../../../lib/elasticsearch/get_last_recovery';
 import { getMetrics } from '../../../../lib/details/get_metrics';
 import { handleError } from '../../../../lib/errors/handle_error';
-import { prefixIndexPattern } from '../../../../../common/ccs_utils';
+import { prefixIndexPatternWithCcs } from '../../../../../common/ccs_utils';
 import { metricSet } from './metric_set_overview';
 import { getLogs } from '../../../../lib/logs';
 import { getIndicesUnassignedShardStats } from '../../../../lib/elasticsearch/shards/get_indices_unassigned_shard_stats';
@@ -38,7 +38,7 @@ export function esOverviewRoute(server) {
     async handler(req) {
       const config = server.config;
       const clusterUuid = req.params.clusterUuid;
-      const filebeatIndexPattern = prefixIndexPattern(
+      const filebeatIndexPattern = prefixIndexPatternWithCcs(
         config,
         config.ui.logs.index,
         CCS_REMOTE_PATTERN

--- a/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch_settings/check/internal_monitoring.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/elasticsearch_settings/check/internal_monitoring.ts
@@ -13,9 +13,7 @@ import {
   INDEX_PATTERN_KIBANA,
   INDEX_PATTERN_LOGSTASH,
 } from '../../../../../../common/constants';
-// @ts-ignore
-import { prefixIndexPattern } from '../../../../../../common/ccs_utils';
-// @ts-ignore
+import { prefixIndexPatternWithCcs } from '../../../../../../common/ccs_utils';
 import { handleError } from '../../../../../lib/errors';
 import { RouteDependencies, LegacyServer } from '../../../../../types';
 
@@ -89,9 +87,9 @@ export function internalMonitoringCheckRoute(server: LegacyServer, npRoute: Rout
 
         const config = server.config;
         const { ccs } = request.body;
-        const esIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
-        const kbnIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_KIBANA, ccs);
-        const lsIndexPattern = prefixIndexPattern(config, INDEX_PATTERN_LOGSTASH, ccs);
+        const esIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_ELASTICSEARCH, ccs);
+        const kbnIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_KIBANA, ccs);
+        const lsIndexPattern = prefixIndexPatternWithCcs(config, INDEX_PATTERN_LOGSTASH, ccs);
         const indexCounts = await Promise.all([
           checkLatestMonitoringIsLegacy(context, esIndexPattern),
           checkLatestMonitoringIsLegacy(context, kbnIndexPattern),


### PR DESCRIPTION
As part of https://github.com/elastic/kibana/issues/120384#issuecomment-1099573270, instead of making CCS remotes customizable via kibana config we will continue to use '*', but place it in a constant.  See https://github.com/elastic/kibana/pull/129806 for original PR using kibana config.  Also adds some other cleanup changes

-  Replace usage of `*` with `CCS_REMOTE_PATTERN`.  This is used by rule executors and getting initial cluster information from the UI to check for remote clusters.
- Remove getConfigCcs and directly access config.  We don't need to check of ccs is enabled before using the ccs string value of the remote name/pattern because that already happens in `prefixIndexPattern`
- change `prefixIndexPattern` to `prefixIndexPatternWithCcs`.  Previously this was used to also append `metricbeat-*` to the index but now only handles CCS