### PR TITLE
[Workplace Search] Fix broken feedback link

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/save_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/save_custom.tsx
@@ -19,11 +19,12 @@ import {
   EuiTitle,
   EuiPanel,
   EuiCallOut,
+  EuiLink,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { EuiButtonTo, EuiLinkTo } from '../../../../../../shared/react_router_helpers';
+import { EuiButtonTo } from '../../../../../../shared/react_router_helpers';
 import { AppLogic } from '../../../../../app_logic';
 import { SOURCES_PATH, getSourcesPath } from '../../../../../routes';
 
@@ -104,13 +105,13 @@ export const SaveCustom: React.FC = () => {
                 heading="h3"
                 size="s"
                 title={
-                  <EuiLinkTo target="_blank" to={'https://www.elastic.co/kibana/feedback'}>
+                  <EuiLink href={'https://www.elastic.co/kibana/feedback'} external>
                     <FormattedMessage
                       id="xpack.enterpriseSearch.workplaceSearch.sources.feedbackLinkLabel"
                       defaultMessage="Have feedback about deploying a {name} connector? Let us know."
                       values={{ name }}
                     />
-                  </EuiLinkTo>
+                  </EuiLink>
                 }
                 iconType="email"
               />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/save_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/save_custom.tsx
@@ -105,7 +105,7 @@ export const SaveCustom: React.FC = () => {
                 heading="h3"
                 size="s"
                 title={
-                  <EuiLink href={'https://www.elastic.co/kibana/feedback'} external>
+                  <EuiLink href="https://www.elastic.co/kibana/feedback" external>
                     <FormattedMessage
                       id="xpack.enterpriseSearch.workplaceSearch.sources.feedbackLinkLabel"
                       defaultMessage="Have feedback about deploying a {name} connector? Let us know."


### PR DESCRIPTION
## Summary

This needed to be an `<EuiLink external />` not a `<EuiLinkTo target="_blank" />` 


### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
