### PR TITLE
[CI] Use spot instances for default cigroups in PR CI

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -25,6 +25,8 @@ steps:
     key: default-cigroup
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1
 

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -19,7 +19,7 @@ steps:
     label: 'Default CI Group'
     parallelism: 29
     agents:
-      queue: n2-4
+      queue: n2-4-spot-2
     depends_on: build
     timeout_in_minutes: 150
     key: default-cigroup


### PR DESCRIPTION
I'm using `n2-4-spot-2` as opposed to `n2-4-spot` so that we can instantly scale back our spot instance usage, without taking it all the way to 0, by just editing the `n2-4-spot-2` agent type in the JSON config. So, if there's an issue, we can undo it without needing to update all PRs with a code change.