### PR TITLE
[Workplace Search] Update object types for SharePoint Online external connector

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -28,7 +28,7 @@ export const staticExternalSourceData: SourceDataItem = {
     documentationUrl: docLinks.workplaceSearchExternalSharePointOnline,
     applicationPortalUrl: 'https://portal.azure.com/',
   },
-  objTypes: [SOURCE_OBJ_TYPES.FOLDERS, SOURCE_OBJ_TYPES.SITES, SOURCE_OBJ_TYPES.ALL_FILES],
+  objTypes: [SOURCE_OBJ_TYPES.ALL_STORED_FILES],
   features: {
     basicOrgContext: [
       FeatureIds.SyncFrequency,


### PR DESCRIPTION
## Summary

The external connector indexes different content than our internal one at the moment, we need to update the list of object types we display to the user when they're connecting a content source.

### Screenshots

![image](https://user-images.githubusercontent.com/2479295/163837088-1897d3c5-3264-4f87-97bb-31decdf6c7f6.png)

### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

