### PR TITLE
[DOCS] Removes coming tag from 8.1.3 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -27,8 +27,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.1.3]]
 == {kib} 8.1.3
 
-coming::[8.1.3]
-
 Review the following information about the {kib} 8.1.3 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes `coming` tag from the 8.1.3 release notes.