### PR TITLE
[APM] Callout flashes on service inventory page

### DIFF
--- a/x-pack/plugins/apm/public/hooks/use_local_storage.ts
+++ b/x-pack/plugins/apm/public/hooks/use_local_storage.ts
@@ -5,38 +5,36 @@
  * 2.0.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 
 export function useLocalStorage<T>(key: string, defaultValue: T) {
-  const [item, setItem] = useState<T>(getFromStorage(key, defaultValue));
+  const [storageUpdate, setStorageUpdate] = useState(0);
 
-  const updateFromStorage = () => {
-    const storedItem = getFromStorage(key, defaultValue);
-    setItem(storedItem);
-  };
+  const item = useMemo(() => {
+    return getFromStorage(key, defaultValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, storageUpdate, defaultValue]);
 
   const saveToStorage = (value: T) => {
     if (value === undefined) {
       window.localStorage.removeItem(key);
     } else {
       window.localStorage.setItem(key, JSON.stringify(value));
-      updateFromStorage();
+      setStorageUpdate(storageUpdate + 1);
     }
   };
 
   useEffect(() => {
-    window.addEventListener('storage', (event: StorageEvent) => {
+    function onUpdate(event: StorageEvent) {
       if (event.key === key) {
-        updateFromStorage();
+        setStorageUpdate(storageUpdate + 1);
       }
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // item state must be updated with a new key or default value
-  useEffect(() => {
-    setItem(getFromStorage(key, defaultValue));
-  }, [key, defaultValue]);
+    }
+    window.addEventListener('storage', onUpdate);
+    return () => {
+      window.removeEventListener('storage', onUpdate);
+    };
+  }, [key, setStorageUpdate, storageUpdate]);
 
   return [item, saveToStorage] as const;
 }

--- a/x-pack/plugins/apm/public/hooks/use_local_storage.ts
+++ b/x-pack/plugins/apm/public/hooks/use_local_storage.ts
@@ -8,6 +8,8 @@
 import { useState, useEffect, useMemo } from 'react';
 
 export function useLocalStorage<T>(key: string, defaultValue: T) {
+  // This is necessary to fix a race condition issue.
+  // It guarantees that the latest value will be always returned after the value is updated
   const [storageUpdate, setStorageUpdate] = useState(0);
 
   const item = useMemo(() => {


### PR DESCRIPTION
fixes https://github.com/elastic/kibana/issues/130263

This explains a bit the problem we had:
<img width="976" alt="Screen Shot 2022-04-18 at 10 45 02 AM" src="https://user-images.githubusercontent.com/55978943/163853414-a7468dcd-cb34-4fa7-8aa5-45b5e6b38115.png">

Basically, the local storage hook was being called late in the render chain, because we were using `useEffect` to trigger the hook when a new key or value was given. That is proven by line 3 of the console on the image above, where the state is already updated to `noJobs` but `userHasDismissedCallout` is still `false` while it's actually `true` in the local storage value.

Credits to @dgieselaar.