### PR TITLE
[Enterprise Search] Add documentation link for BYOEI

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -96,6 +96,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       crawlRules: `${APP_SEARCH_DOCS}crawl-web-content.html#crawl-web-content-manage-crawl-rules`,
       curations: `${APP_SEARCH_DOCS}curations-guide.html`,
       duplicateDocuments: `${APP_SEARCH_DOCS}web-crawler-reference.html#web-crawler-reference-content-deduplication`,
+      elasticsearchIndexedEngines: `${APP_SEARCH_DOCS}elasticsearch-engines.html`,
       entryPoints: `${APP_SEARCH_DOCS}crawl-web-content.html#crawl-web-content-manage-entry-points`,
       guide: `${APP_SEARCH_DOCS}index.html`,
       indexingDocuments: `${APP_SEARCH_DOCS}indexing-documents-guide.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -82,6 +82,7 @@ export interface DocLinks {
     readonly crawlRules: string;
     readonly curations: string;
     readonly duplicateDocuments: string;
+    readonly elasticsearchIndexedEngines: string;
     readonly entryPoints: string;
     readonly guide: string;
     readonly indexingDocuments: string;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation.tsx
@@ -33,6 +33,7 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
+import { docLinks } from '../../../shared/doc_links';
 import { parseQueryParams } from '../../../shared/query_params';
 import { ENGINES_TITLE } from '../engines';
 import { AppSearchPageTemplate } from '../layout';
@@ -212,7 +213,10 @@ export const EngineCreation: React.FC = () => {
                             </p>
                             <p>
                               <small>
-                                <EuiLink href="#" target="_blank">
+                                <EuiLink
+                                  href={docLinks.appSearchElasticsearchIndexedEngines}
+                                  target="_blank"
+                                >
                                   {i18n.translate(
                                     'xpack.enterpriseSearch.engineCreation.elasticsearchIndexedLink',
                                     {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -16,6 +16,7 @@ class DocLinks {
   public appSearchCurations: string;
   public appSearchDuplicateDocuments: string;
   public appSearchEntryPoints: string;
+  public appSearchElasticsearchIndexedEngines: string;
   public appSearchGuide: string;
   public appSearchIndexingDocs: string;
   public appSearchIndexingDocsSchema: string;
@@ -95,6 +96,7 @@ class DocLinks {
     this.appSearchCurations = '';
     this.appSearchDuplicateDocuments = '';
     this.appSearchEntryPoints = '';
+    this.appSearchElasticsearchIndexedEngines = '';
     this.appSearchGuide = '';
     this.appSearchIndexingDocs = '';
     this.appSearchIndexingDocsSchema = '';
@@ -174,6 +176,8 @@ class DocLinks {
     this.appSearchCrawlRules = docLinks.links.appSearch.crawlRules;
     this.appSearchCurations = docLinks.links.appSearch.curations;
     this.appSearchDuplicateDocuments = docLinks.links.appSearch.duplicateDocuments;
+    this.appSearchElasticsearchIndexedEngines =
+      docLinks.links.appSearch.elasticsearchIndexedEngines;
     this.appSearchEntryPoints = docLinks.links.appSearch.entryPoints;
     this.appSearchGuide = docLinks.links.appSearch.guide;
     this.appSearchIndexingDocs = docLinks.links.appSearch.indexingDocuments;


### PR DESCRIPTION
closes https://github.com/elastic/enterprise-search-team/issues/1680

## Summary

Add documentation link for the bring you own elasticsearch index (BYOEI) feature for 8.2

![link](https://user-images.githubusercontent.com/1869731/163856239-4010a9d3-9c21-4193-bea5-956e239f6298.gif)

