### PR TITLE
[8.2.1][Security Solution][Session view] fix full screen session view margin

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
@@ -59,7 +59,8 @@ const StyledResolver = styled(Resolver)`
 `;
 
 const ScrollableFlexItem = styled(EuiFlexItem)`
-  ${({ theme }) => `margin: 0 ${theme.eui.euiSizeM};`}
+  ${({ theme }) => `padding: 0 ${theme.eui.euiSizeM};
+  background-color: ${theme.eui.euiColorEmptyShade};`}
   overflow: hidden;
   width: 100%;
 `;

--- a/x-pack/plugins/session_view/public/components/session_view_detail_panel/styles.ts
+++ b/x-pack/plugins/session_view/public/components/session_view_detail_panel/styles.ts
@@ -12,11 +12,11 @@ import { CSSObject } from '@emotion/react';
 export const useStyles = () => {
   const { euiTheme } = useEuiTheme();
   const cached = useMemo(() => {
-    const { border, colors } = euiTheme;
+    const { border } = euiTheme;
 
     const detailsPanel: CSSObject = {
       borderLeft: border.thin,
-      backgroundColor: colors.emptyShade,
+      height: '100%',
     };
 
     return {


### PR DESCRIPTION
Issue: https://github.com/elastic/kibana/issues/130369

- Use padding instead of margin for full screen session view spacing, so that session view detail panel accordions expand icons will show without being truncated
<img width="1353" alt="image" src="https://user-images.githubusercontent.com/16872649/163858092-3cef1a3b-05fa-4704-8a0d-35992b647bbd.png">

- Also to fix that session view details panel should have full height so border will display properly on the edges