### PR TITLE
[App Search] Remove “New!” badge from Curations UI

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
@@ -98,26 +98,6 @@ describe('Curations', () => {
     expect(tabs.length).toBe(2);
   });
 
-  it('renders a New! badge  when suggestions are not active', () => {
-    setMockValues(set('engine.adaptive_relevance_suggestions_active', false, values));
-    const wrapper = shallow(<Curations />);
-
-    expect(getPageTitle(wrapper)).toEqual('Curated results');
-
-    const tabs = getPageHeaderTabs(wrapper).find(EuiTab);
-    expect(tabs.at(1).prop('append')).not.toBeUndefined();
-  });
-
-  it('hides the badge when suggestions are active', () => {
-    setMockValues(set('engine.adaptive_relevance_suggestions_active', true, values));
-    const wrapper = shallow(<Curations />);
-
-    expect(getPageTitle(wrapper)).toEqual('Curated results');
-
-    const tabs = getPageHeaderTabs(wrapper).find(EuiTab);
-    expect(tabs.at(2).prop('append')).toBeUndefined();
-  });
-
   it('renders an overview view', () => {
     setMockValues({ ...values, selectedPageTab: 'overview' });
     const wrapper = shallow(<Curations />);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
@@ -9,7 +9,6 @@ import React, { useEffect } from 'react';
 
 import { useValues, useActions } from 'kea';
 
-import { EuiBadge } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';
@@ -32,8 +31,6 @@ export const Curations: React.FC = () => {
   const {
     engine: { adaptive_relevance_suggestions_active: adaptiveRelevanceSuggestionsActive },
   } = useValues(EngineLogic);
-
-  const suggestionsEnabled = adaptiveRelevanceSuggestionsActive;
 
   const OVERVIEW_TAB = {
     label: i18n.translate(
@@ -63,13 +60,6 @@ export const Curations: React.FC = () => {
     ),
     isSelected: selectedPageTab === 'settings',
     onClick: () => onSelectPageTab('settings'),
-    append: suggestionsEnabled ? undefined : (
-      <EuiBadge color="success">
-        {i18n.translate('xpack.enterpriseSearch.appSearch.engine.curations.newBadgeLabel', {
-          defaultMessage: 'New!',
-        })}
-      </EuiBadge>
-    ),
   };
 
   const pageTabs = adaptiveRelevanceSuggestionsActive

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -10242,7 +10242,6 @@
     "xpack.enterpriseSearch.appSearch.engine.curations.manageQueryButtonLabel": "クエリを管理",
     "xpack.enterpriseSearch.appSearch.engine.curations.manageQueryDescription": "このキュレーションのクエリを編集、追加、削除します。",
     "xpack.enterpriseSearch.appSearch.engine.curations.manageQueryTitle": "クエリを管理",
-    "xpack.enterpriseSearch.appSearch.engine.curations.newBadgeLabel": "新機能！",
     "xpack.enterpriseSearch.appSearch.engine.curations.organicDocuments.description": "表示するオーガニック結果はありません。{manualDescription}",
     "xpack.enterpriseSearch.appSearch.engine.curations.organicDocuments.manualDescription": "上記のアクティブなクエリを追加または変更します。",
     "xpack.enterpriseSearch.appSearch.engine.curations.organicDocuments.title": "\"{currentQuery}\"の上位のオーガニックドキュメント",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -10261,7 +10261,6 @@
     "xpack.enterpriseSearch.appSearch.engine.curations.manageQueryButtonLabel": "管理查询",
     "xpack.enterpriseSearch.appSearch.engine.curations.manageQueryDescription": "编辑、添加或移除此策展的查询。",
     "xpack.enterpriseSearch.appSearch.engine.curations.manageQueryTitle": "管理查询",
-    "xpack.enterpriseSearch.appSearch.engine.curations.newBadgeLabel": "新！",
     "xpack.enterpriseSearch.appSearch.engine.curations.organicDocuments.description": "没有要显示的有机结果。{manualDescription}",
     "xpack.enterpriseSearch.appSearch.engine.curations.organicDocuments.manualDescription": "在上面添加或更改活动查询。",
     "xpack.enterpriseSearch.appSearch.engine.curations.organicDocuments.title": "“{currentQuery}”的排名靠前有机文档",


### PR DESCRIPTION
closes https://github.com/elastic/enterprise-search-team/issues/1770

## Summary

Removes “New!” badge from Curations UI

![image](https://user-images.githubusercontent.com/1869731/163861668-2326f378-8c65-4c04-a3e8-2830c0c92c3e.png)


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
