### PR TITLE
[8.2.1] [Session view] Add loading state for session view when fetching events and alerts

### DIFF
--- a/x-pack/plugins/session_view/public/components/session_view/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.test.tsx
@@ -35,6 +35,24 @@ describe('SessionView component', () => {
         });
       });
 
+      it('should show loading state while retrieving empty data and hide it when settled', async () => {
+        let releaseApiResponse: (value?: unknown) => void;
+
+        // make the request wait
+        mockedApi.mockReturnValue(new Promise((resolve) => (releaseApiResponse = resolve)));
+        render();
+        await waitForApiCall();
+
+        // see if loader is present
+        expect(renderResult.getByTestId('sectionLoading')).toBeTruthy();
+
+        // release the request
+        releaseApiResponse!(mockedApi);
+
+        //  check the loader is gone
+        await waitForElementToBeRemoved(renderResult.getByTestId('sectionLoading'));
+      });
+
       it('should show the Empty message', async () => {
         render();
         await waitForApiCall();
@@ -55,7 +73,7 @@ describe('SessionView component', () => {
         mockedApi.mockResolvedValue(sessionViewProcessEventsMock);
       });
 
-      it('should show loading indicator while retrieving data and hide it when it gets it', async () => {
+      it('should show loading state while retrieving data and hide it when settled', async () => {
         let releaseApiResponse: (value?: unknown) => void;
 
         // make the request wait
@@ -64,13 +82,13 @@ describe('SessionView component', () => {
         await waitForApiCall();
 
         // see if loader is present
-        expect(renderResult.getByText('Loading session…')).toBeTruthy();
+        expect(renderResult.getByTestId('sectionLoading')).toBeTruthy();
 
         // release the request
         releaseApiResponse!(mockedApi);
 
         //  check the loader is gone
-        await waitForElementToBeRemoved(renderResult.getByText('Loading session…'));
+        await waitForElementToBeRemoved(renderResult.getByTestId('sectionLoading'));
       });
 
       it('should display the search bar', async () => {

--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -9,7 +9,6 @@ import {
   EuiEmptyPrompt,
   EuiButton,
   EuiFlexItem,
-  EuiLoadingSpinner,
   EuiResizableContainer,
   EuiPanel,
   EuiHorizontalRule,
@@ -157,9 +156,12 @@ export const SessionView = ({
 
   if (renderIsLoading) {
     return (
-      <div css={styles.loadingStateContainer}>
-        <EuiLoadingSpinner size="xl" />
-      </div>
+      <SectionLoading css={styles.loadingStateContainer}>
+        <FormattedMessage
+          id="xpack.sessionView.loadingProcessTree"
+          defaultMessage="Loading session…"
+        />
+      </SectionLoading>
     );
   }
 
@@ -236,15 +238,6 @@ export const SessionView = ({
                 minSize="60%"
                 paddingSize="none"
               >
-                {renderIsLoading && (
-                  <SectionLoading>
-                    <FormattedMessage
-                      id="xpack.sessionView.loadingProcessTree"
-                      defaultMessage="Loading session…"
-                    />
-                  </SectionLoading>
-                )}
-
                 {hasError && (
                   <EuiEmptyPrompt
                     iconType="alert"

--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -156,7 +156,7 @@ export const SessionView = ({
 
   if (renderIsLoading) {
     return (
-      <SectionLoading css={styles.loadingStateContainer}>
+      <SectionLoading>
         <FormattedMessage
           id="xpack.sessionView.loadingProcessTree"
           defaultMessage="Loading session…"

--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -9,6 +9,7 @@ import {
   EuiEmptyPrompt,
   EuiButton,
   EuiFlexItem,
+  EuiLoadingSpinner,
   EuiResizableContainer,
   EuiPanel,
   EuiHorizontalRule,
@@ -115,7 +116,7 @@ export const SessionView = ({
 
   const hasData = alerts && data && data.pages?.[0].events.length > 0;
   const hasError = error || alertsError;
-  const renderIsLoading = (isFetching || alertsFetching) && !data;
+  const renderIsLoading = (isFetching || alertsFetching) && !(data && alerts);
   const renderDetails = isDetailOpen && selectedProcess;
   const { data: newUpdatedAlertsStatus } = useFetchAlertStatus(
     updatedAlertsStatus,
@@ -154,7 +155,15 @@ export const SessionView = ({
     [setDisplayOptions]
   );
 
-  if (!isFetching && !hasData) {
+  if (renderIsLoading) {
+    return (
+      <div css={styles.loadingStateContainer}>
+        <EuiLoadingSpinner size="xl" />
+      </div>
+    );
+  }
+
+  if (!hasData) {
     return (
       <EuiEmptyPrompt
         data-test-subj="sessionView:sessionViewProcessEventsEmpty"

--- a/x-pack/plugins/session_view/public/components/session_view/styles.ts
+++ b/x-pack/plugins/session_view/public/components/session_view/styles.ts
@@ -25,6 +25,14 @@ export const useStyles = ({ height = 500, isFullScreen }: StylesDeps) => {
       height: `${isFullScreen ? 'calc(100vh - 118px)' : height + 'px'}`,
     };
 
+    const loadingStateContainer: CSSObject = {
+      height: '100%',
+      minHeight: '250px',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    };
+
     const processTree: CSSObject = {
       ...sessionView,
       position: 'relative',
@@ -71,6 +79,7 @@ export const useStyles = ({ height = 500, isFullScreen }: StylesDeps) => {
       buttonsEyeDetail,
       sessionViewerComponent,
       toolBar,
+      loadingStateContainer,
     };
   }, [euiTheme, isFullScreen, height]);
 

--- a/x-pack/plugins/session_view/public/components/session_view/styles.ts
+++ b/x-pack/plugins/session_view/public/components/session_view/styles.ts
@@ -25,14 +25,6 @@ export const useStyles = ({ height = 500, isFullScreen }: StylesDeps) => {
       height: `${isFullScreen ? 'calc(100vh - 118px)' : height + 'px'}`,
     };
 
-    const loadingStateContainer: CSSObject = {
-      height: '100%',
-      minHeight: '250px',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-    };
-
     const processTree: CSSObject = {
       ...sessionView,
       position: 'relative',
@@ -79,7 +71,6 @@ export const useStyles = ({ height = 500, isFullScreen }: StylesDeps) => {
       buttonsEyeDetail,
       sessionViewerComponent,
       toolBar,
-      loadingStateContainer,
     };
   }, [euiTheme, isFullScreen, height]);
 


### PR DESCRIPTION
## Summary

Add loading state to session view when fetching events and alerts


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/16872649/163894054-f55ebe6d-3286-4af5-bf8b-340bf700580a.png">

