### PR TITLE
[Visualize] Adds a deprecation warning to the timelion app

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -490,7 +490,7 @@ Used for calculating automatic intervals in visualizations, this is the number
 of buckets to try to represent.
 
 [[timelion-legacyChartsLibrary]]`timelion:legacyChartsLibrary`::
-**The legacy timelion charts are deprecated and will not be supported in a future version.**
+**The legacy timelion charts are deprecated and will not be supported as of 8.4.**
 Enables the legacy charts library for timelion charts in Visualize.
 
 

--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -490,6 +490,7 @@ Used for calculating automatic intervals in visualizations, this is the number
 of buckets to try to represent.
 
 [[timelion-legacyChartsLibrary]]`timelion:legacyChartsLibrary`::
+**The legacy timelion charts are deprecated and will not be supported in a future version.**
 Enables the legacy charts library for timelion charts in Visualize.
 
 

--- a/src/plugins/vis_types/timelion/server/ui_settings.ts
+++ b/src/plugins/vis_types/timelion/server/ui_settings.ts
@@ -23,8 +23,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
       }),
       deprecation: {
         message: i18n.translate('timelion.uiSettings.legacyChartsLibraryDeprication', {
-          defaultMessage:
-            'This setting is deprecated and will not be supported in a future version.',
+          defaultMessage: 'This setting is deprecated and will not be supported as of 8.4.',
         }),
         docLinksKey: 'timelionSettings',
       },

--- a/src/plugins/visualizations/public/visualize_app/components/visualize_editor_common.test.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_editor_common.test.tsx
@@ -42,7 +42,11 @@ jest.mock('@kbn/kibana-react-plugin/public', () => ({
 
 jest.mock('../../services', () => ({
   getUISettings: jest.fn(() => ({
-    get: jest.fn((token) => Boolean(token === 'visualization:visualize:legacyPieChartsLibrary')),
+    get: jest.fn(
+      (token) =>
+        Boolean(token === 'visualization:visualize:legacyPieChartsLibrary') ||
+        Boolean(token === 'timelion:legacyChartsLibrary')
+    ),
   })),
 }));
 
@@ -224,6 +228,47 @@ describe('VisualizeEditorCommon', () => {
               type: {
                 title: 'pie',
                 name: 'pie',
+              },
+              data: {
+                aggs: {
+                  aggs: [
+                    {
+                      schema: 'buckets',
+                    },
+                  ],
+                },
+              },
+            },
+          } as unknown as VisualizeEditorVisInstance
+        }
+      />
+    );
+    expect(wrapper.find(VizChartWarning).length).toBe(1);
+  });
+
+  it('should display a warning callout for old timelion implementation', async () => {
+    const wrapper = shallowWithIntl(
+      <VisualizeEditorCommon
+        appState={null}
+        hasUnsavedChanges={false}
+        setHasUnsavedChanges={() => {}}
+        hasUnappliedChanges={false}
+        isEmbeddableRendered={false}
+        onAppLeave={() => {}}
+        visEditorRef={React.createRef()}
+        visInstance={
+          {
+            savedVis: {
+              id: 'test',
+              sharingSavedObjectProps: {
+                outcome: 'conflict',
+                aliasTargetId: 'alias_id',
+              },
+            },
+            vis: {
+              type: {
+                title: 'timelion',
+                name: 'timelion',
               },
               data: {
                 aggs: {

--- a/src/plugins/visualizations/public/visualize_app/components/viz_chart_warning.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/viz_chart_warning.tsx
@@ -136,7 +136,7 @@ const TimelionWarningFormatMessage: FC<WarningMessageProps> = (props) => {
   return (
     <FormattedMessage
       id="visualizations.oldTimelionChart.notificationMessage"
-      defaultMessage="You are using the legacy charts library, which will be removed in a future version. {conditionalMessage}"
+      defaultMessage="You are using the legacy charts library, which will be removed in 8.4. {conditionalMessage}"
       values={{
         conditionalMessage: (
           <>

--- a/src/plugins/visualizations/public/visualize_app/components/viz_chart_warning.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/viz_chart_warning.tsx
@@ -132,10 +132,28 @@ const PieWarningFormatMessage: FC<WarningMessageProps> = (props) => {
   );
 };
 
+const TimelionWarningFormatMessage: FC<WarningMessageProps> = (props) => {
+  return (
+    <FormattedMessage
+      id="visualizations.oldTimelionChart.notificationMessage"
+      defaultMessage="You are using the legacy charts library, which will be removed in a future version. {conditionalMessage}"
+      values={{
+        conditionalMessage: (
+          <>
+            <SwitchToOldLibraryMessage {...props} />
+            <ContactAdminMessage {...props} />
+          </>
+        ),
+      }}
+    />
+  );
+};
+
 const warningMessages = {
   [CHARTS_WITHOUT_SMALL_MULTIPLES.heatmap]: HeatmapWarningFormatMessage,
   [CHARTS_WITHOUT_SMALL_MULTIPLES.gauge]: GaugeWarningFormatMessage,
   [CHARTS_TO_BE_DEPRECATED.pie]: PieWarningFormatMessage,
+  [CHARTS_TO_BE_DEPRECATED.timelion]: TimelionWarningFormatMessage,
 };
 
 export const VizChartWarning: FC<Props> = ({ chartType, chartConfigToken, mode }) => {

--- a/src/plugins/visualizations/public/visualize_app/constants.ts
+++ b/src/plugins/visualizations/public/visualize_app/constants.ts
@@ -9,3 +9,4 @@
 export const NEW_HEATMAP_CHARTS_LIBRARY = 'visualization:visualize:legacyHeatmapChartsLibrary';
 export const NEW_GAUGE_CHARTS_LIBRARY = 'visualization:visualize:legacyGaugeChartsLibrary';
 export const NEW_PIE_CHARTS_LIBRARY = 'visualization:visualize:legacyPieChartsLibrary';
+export const NEW_TIMELION_CHARTS_LIBRARY = 'timelion:legacyChartsLibrary';

--- a/src/plugins/visualizations/public/visualize_app/utils/split_chart_warning_helpers.ts
+++ b/src/plugins/visualizations/public/visualize_app/utils/split_chart_warning_helpers.ts
@@ -12,6 +12,7 @@ import {
   NEW_HEATMAP_CHARTS_LIBRARY,
   NEW_GAUGE_CHARTS_LIBRARY,
   NEW_PIE_CHARTS_LIBRARY,
+  NEW_TIMELION_CHARTS_LIBRARY,
 } from '../constants';
 
 export const CHARTS_WITHOUT_SMALL_MULTIPLES = {
@@ -21,6 +22,7 @@ export const CHARTS_WITHOUT_SMALL_MULTIPLES = {
 
 export const CHARTS_TO_BE_DEPRECATED = {
   pie: 'pie',
+  timelion: 'timelion',
 } as const;
 
 export type CHARTS_WITHOUT_SMALL_MULTIPLES = $Values<typeof CHARTS_WITHOUT_SMALL_MULTIPLES>;
@@ -30,6 +32,7 @@ export const CHARTS_CONFIG_TOKENS = {
   [CHARTS_WITHOUT_SMALL_MULTIPLES.heatmap]: NEW_HEATMAP_CHARTS_LIBRARY,
   [CHARTS_WITHOUT_SMALL_MULTIPLES.gauge]: NEW_GAUGE_CHARTS_LIBRARY,
   [CHARTS_TO_BE_DEPRECATED.pie]: NEW_PIE_CHARTS_LIBRARY,
+  [CHARTS_TO_BE_DEPRECATED.timelion]: NEW_TIMELION_CHARTS_LIBRARY,
 } as const;
 
 export const isSplitChart = (chartType: string | undefined, aggs?: AggConfigs) => {


### PR DESCRIPTION
## Summary
Part of https://github.com/elastic/kibana/issues/116915

It adds a deprecation message to :

- the docs advanced settings section
- the visualize app if the user works with the legacy timelion library
- the advanced settings deprecation tooltip

<img width="1222" alt="image" src="https://user-images.githubusercontent.com/17003240/163952421-406cbf20-16a5-48db-bac3-d457443cf52d.png">

<img width="930" alt="image" src="https://user-images.githubusercontent.com/17003240/163952830-b1234b48-388f-4ae9-81c2-5e81235ddd83.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios