### PR TITLE
[Visualize] Adds a functional test for datatable partial rows

### DIFF
--- a/test/functional/apps/visualize/_data_table.ts
+++ b/test/functional/apps/visualize/_data_table.ts
@@ -93,6 +93,31 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
+    it('should show correct data when partial rows is on', async () => {
+      const expectedChartData = [
+        ['0B', '2,088'],
+        ['1.953KB', '2,748'],
+        ['3.906KB', '2,707'],
+        ['5.859KB', '2,876'],
+        ['7.813KB', '2,863'],
+        ['9.766KB', '147'],
+        ['11.719KB', '148'],
+        ['13.672KB', '129'],
+        ['15.625KB', '161'],
+        ['17.578KB', '137'],
+      ];
+      await PageObjects.visEditor.clickOptionsTab();
+      await PageObjects.visEditor.checkSwitch('showPartialRows');
+      await PageObjects.visEditor.clickGo();
+
+      return retry.try(async function () {
+        await inspector.open();
+        await inspector.expectTableData(expectedChartData);
+        await inspector.close();
+        await PageObjects.visEditor.uncheckSwitch('showPartialRows');
+      });
+    });
+
     it('should show percentage columns', async () => {
       async function expectValidTableData() {
         const data = await PageObjects.visChart.getTableVisContent();


### PR DESCRIPTION
## Summary

Follow up of this comment https://github.com/elastic/kibana/pull/124677#issuecomment-1101714963

Adding a functional test to check that the inspector data received when the partial rows setting is on, are the correct one.

Runner 50 times https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/479

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios