### PR TITLE
[8.2] [Uptime] Update monitor saved object mappings (#130433)

### DIFF
--- a/x-pack/plugins/uptime/e2e/config.ts
+++ b/x-pack/plugins/uptime/e2e/config.ts
@@ -26,7 +26,7 @@ async function config({ readConfigFile }: FtrConfigProviderContext) {
 
   const manifestUrl = process.env.SYNTHETICS_SERVICE_MANIFEST ?? kibanaConfig[MANIFEST_KEY];
   const serviceUsername = process.env.SYNTHETICS_SERVICE_USERNAME ?? kibanaConfig[SERVICE_USERNAME];
-  const servicPassword = process.env.SYNTHETICS_SERVICE_PASSWORD ?? kibanaConfig[SERVICE_PASSWORD];
+  const servicePassword = process.env.SYNTHETICS_SERVICE_PASSWORD ?? kibanaConfig[SERVICE_PASSWORD];
 
   return {
     ...kibanaCommonTestsConfig.getAll(),
@@ -62,7 +62,7 @@ async function config({ readConfigFile }: FtrConfigProviderContext) {
             ? serviceUsername
             : 'localKibanaIntegrationTestsUser'
         }`,
-        `--xpack.uptime.service.password=${servicPassword}`,
+        `--xpack.uptime.service.password=${servicePassword}`,
       ],
     },
   };

--- a/x-pack/plugins/uptime/e2e/journeys/monitor_details.journey.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/monitor_details.journey.ts
@@ -11,15 +11,20 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import { journey, step, expect, before, Page } from '@elastic/synthetics';
+import uuid from 'uuid';
+import { journey, step, expect, after, before, Page } from '@elastic/synthetics';
 import { monitorManagementPageProvider } from '../page_objects/monitor_management';
 
 journey('MonitorDetails', async ({ page, params }: { page: Page; params: any }) => {
   const uptime = monitorManagementPageProvider({ page, kibanaUrl: params.kibanaUrl });
+  const name = `Test monitor ${uuid.v4()}`;
 
   before(async () => {
     await uptime.waitForLoadingToFinish();
+  });
+
+  after(async () => {
+    await uptime.enableMonitorManagement(false);
   });
 
   step('Go to monitor-management', async () => {
@@ -32,13 +37,31 @@ journey('MonitorDetails', async ({ page, params }: { page: Page; params: any }) 
     expect(await invalid.isVisible()).toBeFalsy();
   });
 
+  step('create basic monitor', async () => {
+    await uptime.enableMonitorManagement();
+    await uptime.clickAddMonitor();
+    await uptime.createBasicMonitorDetails({
+      name,
+      locations: ['US Central'],
+      apmServiceName: 'synthetics',
+    });
+    await uptime.fillByTestSubj('syntheticsUrlField', 'https://www.google.com');
+    await uptime.confirmAndSave();
+  });
+
   step('navigate to monitor details page', async () => {
-    await uptime.assertText({ text: 'Test Monitor' });
-    await Promise.all([page.waitForNavigation(), page.click('text="Test Monitor"')]);
-    await uptime.assertText({ text: 'Test Monitor' });
+    await uptime.assertText({ text: name });
+    await Promise.all([page.waitForNavigation(), page.click(`text=${name}`)]);
+    await uptime.assertText({ text: name });
     const url = await page.textContent('[data-test-subj="monitor-page-url"]');
     const type = await page.textContent('[data-test-subj="monitor-page-type"]');
     expect(url).toEqual('https://www.google.com(opens in a new tab or window)');
     expect(type).toEqual('HTTP');
+  });
+
+  step('delete monitor', async () => {
+    await uptime.navigateToMonitorManagement();
+    const isSuccessful = await uptime.deleteMonitors();
+    expect(isSuccessful).toBeTruthy();
   });
 });

--- a/x-pack/plugins/uptime/e2e/journeys/monitor_name.journey.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/monitor_name.journey.ts
@@ -11,13 +11,23 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import uuid from 'uuid';
 import { journey, step, expect, before, Page } from '@elastic/synthetics';
 import { monitorManagementPageProvider } from '../page_objects/monitor_management';
 import { byTestId } from './utils';
 
 journey(`MonitorName`, async ({ page, params }: { page: Page; params: any }) => {
+  const name = `Test monitor ${uuid.v4()}`;
   const uptime = monitorManagementPageProvider({ page, kibanaUrl: params.kibanaUrl });
+
+  const createBasicMonitor = async () => {
+    await uptime.createBasicMonitorDetails({
+      name,
+      locations: ['US Central'],
+      apmServiceName: 'synthetics',
+    });
+    await uptime.fillByTestSubj('syntheticsUrlField', 'https://www.google.com');
+  };
 
   before(async () => {
     await uptime.waitForLoadingToFinish();
@@ -33,11 +43,17 @@ journey(`MonitorName`, async ({ page, params }: { page: Page; params: any }) => 
     expect(await invalid.isVisible()).toBeFalsy();
   });
 
-  step(`shows error if name already exists`, async () => {
+  step('create basic monitor', async () => {
     await uptime.enableMonitorManagement();
     await uptime.clickAddMonitor();
+    await createBasicMonitor();
+    await uptime.confirmAndSave();
+  });
+
+  step(`shows error if name already exists`, async () => {
+    await uptime.navigateToAddMonitor();
     await uptime.createBasicMonitorDetails({
-      name: 'Test monitor',
+      name,
       locations: ['US Central'],
       apmServiceName: 'synthetics',
     });

--- a/x-pack/plugins/uptime/e2e/playwright_start.ts
+++ b/x-pack/plugins/uptime/e2e/playwright_start.ts
@@ -13,7 +13,6 @@ import { esArchiverLoad, esArchiverUnload } from './tasks/es_archiver';
 
 import './journeys';
 import { createApmAndObsUsersAndRoles } from '../../apm/scripts/create_apm_users_and_roles/create_apm_users_and_roles';
-import { importMonitors } from './tasks/import_monitors';
 
 export function playwrightRunTests({ headless, match }: { headless: boolean; match?: string }) {
   return async ({ getService }: any) => {
@@ -43,8 +42,6 @@ async function playwrightStart(getService: any, headless = true, match?: string)
     hostname: config.get('servers.kibana.hostname'),
     port: config.get('servers.kibana.port'),
   });
-
-  await importMonitors({ kibanaUrl });
 
   await createApmAndObsUsersAndRoles({
     elasticsearch: { username: 'elastic', password: 'changeme' },

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_config/use_monitor_name.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_config/use_monitor_name.test.tsx
@@ -18,7 +18,9 @@ describe('useMonitorName', () => {
     expect(result.current).toStrictEqual({ nameAlreadyExists: false, validName: '' });
     expect(defaultCore.savedObjects.client.find).toHaveBeenCalledWith({
       aggs: {
-        monitorNames: { terms: { field: 'synthetics-monitor.attributes.name', size: 10000 } },
+        monitorNames: {
+          terms: { field: 'synthetics-monitor.attributes.name.keyword', size: 10000 },
+        },
       },
       perPage: 0,
       type: 'synthetics-monitor',

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_config/use_monitor_name.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_config/use_monitor_name.ts
@@ -30,7 +30,7 @@ export const useMonitorName = ({ search = '' }: { search?: string }) => {
     const aggs = {
       monitorNames: {
         terms: {
-          field: `${syntheticsMonitorType}.attributes.name`,
+          field: `${syntheticsMonitorType}.attributes.name.keyword`,
           size: 10000,
         },
       },

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/list_tabs.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/list_tabs.test.tsx
@@ -28,7 +28,7 @@ describe('<MonitorListTabs />', () => {
     expect(onPageStateChange).toHaveBeenCalledWith({
       pageIndex: 1,
       pageSize: 10,
-      sortField: 'name',
+      sortField: 'name.keyword',
       sortOrder: 'asc',
     });
   });

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/list_tabs.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/list_tabs.tsx
@@ -39,7 +39,12 @@ export const MonitorListTabs = ({
 
   useEffect(() => {
     setSelectedTabId(viewType);
-    onPageStateChange({ pageIndex: 1, pageSize: 10, sortOrder: 'asc', sortField: ConfigKey.NAME });
+    onPageStateChange({
+      pageIndex: 1,
+      pageSize: 10,
+      sortOrder: 'asc',
+      sortField: `${ConfigKey.NAME}.keyword`,
+    });
   }, [viewType, onPageStateChange]);
 
   const tabs = [

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.test.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.test.tsx
@@ -72,7 +72,7 @@ describe('<MonitorManagementList />', () => {
   const pageState: MonitorManagementListPageState = {
     pageIndex: 1,
     pageSize: 10,
-    sortField: ConfigKey.NAME,
+    sortField: `${ConfigKey.NAME}.keyword`,
     sortOrder: 'asc',
   };
 

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list.tsx
@@ -20,7 +20,6 @@ import {
   ConfigKey,
   FetchMonitorManagementListQueryArgs,
   ICMPSimpleFields,
-  MonitorFields,
   Ping,
   ServiceLocations,
   EncryptedSyntheticsMonitorWithId,
@@ -39,7 +38,10 @@ import { useKibana } from '../../../../../../../src/plugins/kibana_react/public'
 export interface MonitorManagementListPageState {
   pageIndex: number;
   pageSize: number;
-  sortField: keyof MonitorFields;
+  sortField:
+    | `${ConfigKey.URLS}.keyword`
+    | `${ConfigKey.NAME}.keyword`
+    | `${ConfigKey.MONITOR_TYPE}.keyword`;
   sortOrder: NonNullable<FetchMonitorManagementListQueryArgs['sortOrder']>;
 }
 
@@ -86,7 +88,7 @@ export const MonitorManagementList = ({
       onPageStateChange({
         pageIndex: index + 1, // page index for Saved Objects is base 1
         pageSize: size,
-        sortField: field as keyof MonitorFields,
+        sortField: `${field}.keyword` as MonitorManagementListPageState['sortField'],
         sortOrder: direction,
       });
     },
@@ -102,7 +104,7 @@ export const MonitorManagementList = ({
 
   const sorting: EuiTableSortingType<EncryptedSyntheticsMonitorWithId> = {
     sort: {
-      field: sortField as keyof EncryptedSyntheticsMonitorWithId,
+      field: sortField.replace('.keyword', '') as keyof EncryptedSyntheticsMonitorWithId,
       direction: sortOrder,
     },
   };

--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list_container.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/monitor_list_container.tsx
@@ -27,7 +27,7 @@ export const MonitorListContainer: React.FC = () => {
       pageIndex: 1, // saved objects page index is base 1
       pageSize: 10,
       sortOrder: 'asc',
-      sortField: ConfigKey.NAME,
+      sortField: `${ConfigKey.NAME}.keyword`,
     }
   );
 

--- a/x-pack/plugins/uptime/public/pages/monitor_management/monitor_management.tsx
+++ b/x-pack/plugins/uptime/public/pages/monitor_management/monitor_management.tsx
@@ -46,7 +46,7 @@ export const MonitorManagementPage: React.FC = () => {
           page: 1, // saved objects page index is base 1
           perPage: 10,
           sortOrder: 'asc',
-          sortField: ConfigKey.NAME,
+          sortField: `${ConfigKey.NAME}.keyword`,
         })
       );
     }

--- a/x-pack/plugins/uptime/server/lib/saved_objects/synthetics_monitor.ts
+++ b/x-pack/plugins/uptime/server/lib/saved_objects/synthetics_monitor.ts
@@ -18,27 +18,36 @@ export const syntheticsMonitor: SavedObjectsType = {
     dynamic: false,
     properties: {
       name: {
-        type: 'keyword',
-      },
-      id: {
-        type: 'keyword',
+        type: 'text',
+        fields: {
+          keyword: {
+            type: 'keyword',
+            ignore_above: 256,
+          },
+        },
       },
       type: {
-        type: 'keyword',
+        type: 'text',
+        fields: {
+          keyword: {
+            type: 'keyword',
+            ignore_above: 256,
+          },
+        },
       },
       urls: {
-        type: 'keyword',
-      },
-      tags: {
-        type: 'keyword',
-      },
-      secrets: {
         type: 'text',
+        fields: {
+          keyword: {
+            type: 'keyword',
+            ignore_above: 256,
+          },
+        },
       },
     },
   },
   management: {
-    importableAndExportable: true,
+    importableAndExportable: false,
     icon: 'uptimeApp',
     getTitle: (savedObject) =>
       savedObject.attributes.name +


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Uptime] Update monitor saved object mappings (#130433)](https://github.com/elastic/kibana/pull/130433)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)