### PR TITLE
[8.2] Hide welcome page privacy statement on cloud instances (#129198)

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -170,6 +170,7 @@ kibana_vars=(
     status.v6ApiFormat
     telemetry.allowChangingOptInStatus
     telemetry.enabled
+    telemetry.hidePrivacyStatement
     telemetry.optIn
     telemetry.sendUsageTo
     telemetry.sendUsageFrom

--- a/src/plugins/telemetry/public/plugin.test.ts
+++ b/src/plugins/telemetry/public/plugin.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { TelemetryPlugin } from './plugin';
+import { coreMock } from '../../../core/public/mocks';
+import { homePluginMock } from '../../home/public/mocks';
+import { screenshotModePluginMock } from '../../screenshot_mode/public/mocks';
+import { HomePublicPluginSetup } from '../../home/public';
+import { ScreenshotModePluginSetup } from '../../screenshot_mode/public';
+
+let screenshotMode: ScreenshotModePluginSetup;
+let home: HomePublicPluginSetup;
+
+describe('TelemetryPlugin', () => {
+  beforeEach(() => {
+    screenshotMode = screenshotModePluginMock.createSetupContract();
+    home = homePluginMock.createSetupContract();
+  });
+
+  describe('setup', () => {
+    describe('when home is provided', () => {
+      describe('and hidePrivacyStatement is false (default)', () => {
+        it('registers the telemetry notice renderer and onRendered handlers', () => {
+          const initializerContext = coreMock.createPluginInitializerContext();
+
+          new TelemetryPlugin(initializerContext).setup(coreMock.createSetup(), {
+            screenshotMode,
+            home,
+          });
+
+          expect(home.welcomeScreen.registerTelemetryNoticeRenderer).toHaveBeenCalledWith(
+            expect.any(Function)
+          );
+          expect(home.welcomeScreen.registerOnRendered).toHaveBeenCalledWith(expect.any(Function));
+        });
+      });
+
+      describe('and hidePrivacyStatement is true', () => {
+        it('does not register the telemetry notice renderer and onRendered handlers', () => {
+          const initializerContext = coreMock.createPluginInitializerContext({
+            hidePrivacyStatement: true,
+          });
+
+          new TelemetryPlugin(initializerContext).setup(coreMock.createSetup(), {
+            screenshotMode,
+            home,
+          });
+
+          expect(home.welcomeScreen.registerTelemetryNoticeRenderer).not.toBeCalled();
+          expect(home.welcomeScreen.registerOnRendered).not.toBeCalled();
+        });
+      });
+    });
+  });
+});

--- a/src/plugins/telemetry/public/plugin.ts
+++ b/src/plugins/telemetry/public/plugin.ts
@@ -109,6 +109,8 @@ export interface TelemetryPluginConfig {
   telemetryNotifyUserAboutOptInDefault?: boolean;
   /** Does the user have enough privileges to change the settings? **/
   userCanChangeSettings?: boolean;
+  /** Should we hide the privacy statement notice? Useful on some environments, e.g. Cloud */
+  hidePrivacyStatement?: boolean;
 }
 
 function getTelemetryConstants(docLinks: DocLinksStart): TelemetryConstants {
@@ -155,7 +157,7 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
       await this.refreshConfig();
     });
 
-    if (home) {
+    if (home && !this.config.hidePrivacyStatement) {
       home.welcomeScreen.registerOnRendered(() => {
         if (this.telemetryService?.userCanChangeSettings) {
           this.telemetryNotifications?.setOptedInNoticeSeen();

--- a/src/plugins/telemetry/public/services/telemetry_service.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_service.test.ts
@@ -219,6 +219,19 @@ describe('TelemetryService', () => {
   });
 
   describe('getUserShouldSeeOptInNotice', () => {
+    it('should return false if the telemetry notice is hidden by config', () => {
+      const telemetryService = mockTelemetryService({
+        config: {
+          userCanChangeSettings: true,
+          telemetryNotifyUserAboutOptInDefault: true,
+          hidePrivacyStatement: true,
+        },
+      });
+      expect(telemetryService.config.userCanChangeSettings).toBe(true);
+      expect(telemetryService.userCanChangeSettings).toBe(true);
+      expect(telemetryService.getUserShouldSeeOptInNotice()).toBe(false);
+    });
+
     it('returns whether the user can update the telemetry config (has SavedObjects access)', () => {
       const telemetryService = mockTelemetryService({
         config: { userCanChangeSettings: undefined },

--- a/src/plugins/telemetry/public/services/telemetry_service.ts
+++ b/src/plugins/telemetry/public/services/telemetry_service.ts
@@ -113,7 +113,9 @@ export class TelemetryService {
    */
   public getUserShouldSeeOptInNotice(): boolean {
     return (
-      (this.config.telemetryNotifyUserAboutOptInDefault && this.config.userCanChangeSettings) ??
+      (!this.config.hidePrivacyStatement &&
+        this.config.telemetryNotifyUserAboutOptInDefault &&
+        this.config.userCanChangeSettings) ??
       false
     );
   }

--- a/src/plugins/telemetry/server/config/config.ts
+++ b/src/plugins/telemetry/server/config/config.ts
@@ -18,6 +18,7 @@ const clusterEnvSchema: [Type<'prod'>, Type<'staging'>] = [
 const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: true }),
   allowChangingOptInStatus: schema.boolean({ defaultValue: true }),
+  hidePrivacyStatement: schema.boolean({ defaultValue: false }),
   optIn: schema.conditional(
     schema.siblingRef('allowChangingOptInStatus'),
     schema.literal(false),
@@ -50,5 +51,6 @@ export const config: PluginConfigDescriptor<TelemetryConfigType> = {
     optIn: true,
     sendUsageFrom: true,
     sendUsageTo: true,
+    hidePrivacyStatement: true,
   },
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Hide welcome page privacy statement on cloud instances (#129198)](https://github.com/elastic/kibana/pull/129198)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)