### PR TITLE
[Uptime] add monitor management docs link

### DIFF
--- a/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/enablement_empty_state.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor_management/monitor_list/enablement_empty_state.tsx
@@ -75,7 +75,10 @@ export const EnablementEmptyState = ({ focusButton }: { focusButton: boolean }) 
           <EuiTitle size="xxs">
             <h3>{LEARN_MORE_LABEL}</h3>
           </EuiTitle>
-          <EuiLink href="#" target="_blank">
+          <EuiLink
+            href="https://docs.google.com/document/d/1hkzFibu9LggPWXQqfbAd0mMlV75wCME7_BebXlEH-oI"
+            target="_blank"
+          >
             {DOCS_LABEL}
           </EuiLink>
         </>
@@ -102,7 +105,7 @@ const MONITOR_MANAGEMENT_ENABLEMENT_MESSAGE = i18n.translate(
   'xpack.uptime.monitorManagement.emptyState.enablement',
   {
     defaultMessage:
-      'Enable Monitor Management to run lightweight checks and real-browser monitors from hosted testing locations around the world. Enabling Monitor Management will generate an API key to allow the Synthetics Service to write back to your Elasticsearch cluster.',
+      'Enable Monitor Management to run lightweight and real-browser monitors from hosted testing locations around the world. Enabling Monitor Management will generate an API key to allow the Synthetics Service to write back to your Elasticsearch cluster.',
   }
 );
 
@@ -110,7 +113,7 @@ const MONITOR_MANAGEMENT_DISABLED_MESSAGE = i18n.translate(
   'xpack.uptime.monitorManagement.emptyState.enablement.disabledDescription',
   {
     defaultMessage:
-      'Monitor Management is currently disabled. Monitor Management allows you to run lightweight checks and real-browser monitors from hosted testing locations around the world. To enable Monitor Management, please contact an administrator.',
+      'Monitor Management is currently disabled. Monitor Management allows you to run lightweight and real-browser monitors from hosted testing locations around the world. To enable Monitor Management, please contact an administrator.',
   }
 );
 


### PR DESCRIPTION
Fixes: https://github.com/elastic/uptime/issues/468

Monitor Management
--
Updates the `Read the docs` link to point to the WIP Synthetics Private Beta docs.

<img width="1435" alt="Screen Shot 2022-04-19 at 9 23 46 AM" src="https://user-images.githubusercontent.com/11356435/164014205-278cdd9e-e2a7-48eb-b255-a21f48976cdf.png">
<img width="1431" alt="Screen Shot 2022-04-19 at 9 22 32 AM" src="https://user-images.githubusercontent.com/11356435/164014208-4bd47175-76f2-4738-9fba-139194462ab5.png">
<img width="1516" alt="Screen Shot 2022-04-19 at 9 24 01 AM" src="https://user-images.githubusercontent.com/11356435/164014221-7a56a7f6-68a3-4933-9772-f2bc6ab148ef.png">
