### PR TITLE
[Fleet] Do not compare package version in preconfiguration tests

### DIFF
--- a/x-pack/plugins/fleet/server/integration_tests/__snapshots__/cloud_preconfiguration.test.ts.snap
+++ b/x-pack/plugins/fleet/server/integration_tests/__snapshots__/cloud_preconfiguration.test.ts.snap
@@ -19,7 +19,6 @@ Object {
       "meta": Object {
         "package": Object {
           "name": "fleet_server",
-          "version": "1.1.1",
         },
       },
       "name": "Fleet Server",
@@ -115,7 +114,6 @@ Object {
       "meta": Object {
         "package": Object {
           "name": "apm",
-          "version": "8.3.0-dev1",
         },
       },
       "name": "Elastic APM",

--- a/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
@@ -142,7 +142,14 @@ describe('Fleet preconfiguration reset', () => {
           sort: 'revision_idx:desc',
         });
 
-        expect((res.hits.hits[0]._source as any)!.data).toMatchSnapshot();
+        const data = (res.hits.hits[0]._source as any)!.data;
+
+        // Remove package version to avoid upgrading this test for each new package dev version
+        data.inputs.forEach((input: any) => {
+          delete input.meta.package.version;
+        });
+
+        expect(data).toMatchSnapshot();
       });
 
       it('Create correct package policies', async () => {


### PR DESCRIPTION
## Summary

Resolve #129367

Do not include package version in preconfiguration test snapshot to make upgrading bundled package easier.

