### PR TITLE
fix missing testing dep for windows dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -226,6 +226,7 @@
 /packages/kbn-es/ @elastic/kibana-operations
 /packages/kbn-eslint-plugin-imports/ @elastic/kibana-operations
 /packages/kbn-generate/ @elastic/kibana-operations
+/packages/kbn-import-resolver/ @elastic/kibana-operations
 /packages/kbn-optimizer/ @elastic/kibana-operations
 /packages/kbn-plugin-discovery/ @elastic/kibana-operations
 /packages/kbn-pm/ @elastic/kibana-operations

--- a/packages/kbn-import-resolver/BUILD.bazel
+++ b/packages/kbn-import-resolver/BUILD.bazel
@@ -55,6 +55,7 @@ RUNTIME_DEPS = [
 TYPES_DEPS = [
   "//packages/kbn-bazel-packages:npm_module_types",
   "//packages/kbn-utils:npm_module_types",
+  "//packages/kbn-dev-utils:npm_module_types", # needed for testing, only required for windows dev
   "//packages/kbn-synthetic-package-map:npm_module_types",
   "@npm//@types/node",
   "@npm//@types/jest",


### PR DESCRIPTION
We have a missing dependency in `@kbn/import-resolver` needed for bootstrapping on windows...