### PR TITLE
[8.1] [Reporting/Docs] User guidance to enable reporting on Cloud (memory constraints) (#129989)

### DIFF
--- a/docs/user/reporting/index.asciidoc
+++ b/docs/user/reporting/index.asciidoc
@@ -27,6 +27,10 @@ You access the options from the *Share* menu in the toolbar. The sharing options
 
 * *Embed code* &mdash; Embed a fully interactive dashboard or visualization as an iframe on a web page.
 
+[[reporting-on-cloud-resource-requirements]]
+NOTE: On Elastic Cloud, Kibana requires a minimum of 2GB RAM to generate PDF or PNG reports. To edit Kibana deployments,
+use {ess-console}[Cloud Management].
+
 [float]
 [[manually-generate-reports]]
 == Create reports


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[Reporting/Docs] User guidance to enable reporting on Cloud (memory constraints) (#129989)](https://github.com/elastic/kibana/pull/129989)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)