### PR TITLE
[CI] Move apps functional tests from ciGroup1 to ciGroup28

### DIFF
--- a/x-pack/test/functional/apps/monitoring/index.js
+++ b/x-pack/test/functional/apps/monitoring/index.js
@@ -7,7 +7,7 @@
 
 export default function ({ loadTestFile }) {
   describe('Monitoring app', function () {
-    this.tags('ciGroup1');
+    this.tags('ciGroup28');
     loadTestFile(require.resolve('./feature_controls'));
 
     loadTestFile(require.resolve('./cluster/list'));

--- a/x-pack/test/functional/apps/rollup_job/index.js
+++ b/x-pack/test/functional/apps/rollup_job/index.js
@@ -7,7 +7,7 @@
 
 export default function ({ loadTestFile }) {
   describe('rollup app', function () {
-    this.tags('ciGroup1');
+    this.tags('ciGroup28');
 
     loadTestFile(require.resolve('./rollup_jobs'));
     loadTestFile(require.resolve('./hybrid_index_pattern'));

--- a/x-pack/test/functional/apps/watcher/index.js
+++ b/x-pack/test/functional/apps/watcher/index.js
@@ -7,7 +7,7 @@
 
 export default function ({ loadTestFile }) {
   describe('watcher app', function () {
-    this.tags(['ciGroup1', 'includeFirefox']);
+    this.tags(['ciGroup28', 'includeFirefox']);
 
     loadTestFile(require.resolve('./watcher_test'));
   });


### PR DESCRIPTION
Moves 20min worth of tests out one of the longest CI Groups to the shortest one.