### PR TITLE
[cft] Bump Kibana memory to 2GB

### DIFF
--- a/.buildkite/scripts/steps/cloud/deploy.json
+++ b/.buildkite/scripts/steps/cloud/deploy.json
@@ -207,7 +207,7 @@
               "zone_count": 1,
               "size": {
                 "resource": "memory",
-                "value": 1024
+                "value": 2048
               }
             }
           ],


### PR DESCRIPTION
When https://github.com/elastic/kibana/pull/130020 is merged reporting
will be disabled on 1GB Kibana instances.  This bumps our CI deployed
instances to 2GB to support manual and automated testing of reporting.