### PR TITLE
Fix overlooked term "execution" in kibana-docker allowed list

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -200,12 +200,12 @@ kibana_vars=(
     xpack.alerting.invalidateApiKeysTask.interval
     xpack.alerting.invalidateApiKeysTask.removalDelay
     xpack.alerting.defaultRuleTaskTimeout
-    xpack.alerting.rules.execution.timeout
-    xpack.alerting.rules.execution.ruleTypeOverrides
+    xpack.alerting.rules.run.timeout
+    xpack.alerting.rules.run.ruleTypeOverrides
     xpack.alerting.cancelAlertsOnRuleTimeout
     xpack.alerting.rules.minimumScheduleInterval.value
     xpack.alerting.rules.minimumScheduleInterval.enforce
-    xpack.alerting.rules.execution.actions.max
+    xpack.alerting.rules.run.actions.max
     xpack.alerts.healthCheck.interval
     xpack.alerts.invalidateApiKeysTask.interval
     xpack.alerts.invalidateApiKeysTask.removalDelay


### PR DESCRIPTION
We forgot to rename the term "execution" to "run" in kibana-docker allowed list.
This PR fixes that
