### PR TITLE
[Uptime] monitor management - adjust sort field map for inline monitor errors

### DIFF
--- a/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_inline_errors.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_inline_errors.ts
@@ -19,6 +19,7 @@ import { SYNTHETICS_INDEX_PATTERN } from '../../../../common/constants';
 const sortFieldMap: Record<string, string> = {
   ['name.keyword']: 'monitor.name',
   ['urls.keyword']: 'url.full',
+  ['type.keyword']: 'monitor.type',
   '@timestamp': '@timestamp',
 };
 

--- a/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_inline_errors.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/hooks/use_inline_errors.ts
@@ -17,8 +17,8 @@ import { useInlineErrorsCount } from './use_inline_errors_count';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../common/constants';
 
 const sortFieldMap: Record<string, string> = {
-  name: 'monitor.name',
-  urls: 'url.full',
+  ['name.keyword']: 'monitor.name',
+  ['urls.keyword']: 'url.full',
   '@timestamp': '@timestamp',
 };
 


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/130433 we implemented multi fields for some of our monitor saved object properties and implemented sorting based on the `.keyword` field mapped to `type: keyword`. This PR adjusts the `sortFieldMap` to reflect those changes. Without this change, inline monitor errors is broken and monitors will never appear as invalid.

Testing
--
1. Add the following keys to Kibana.yml https://p.elstc.co/paste/1wHk4Wyl#TsgkPH0nf0Km5FUl0-W2SxbU9WHzIRa2+THKNfyMpar
2. Navigate to Monitor Management. Click Add Monitor
3. Add a browser monitor with the following script 
```
step('Go to https://www.elastic.co/', async () => {
  await page.goto('https://www.elastic.co/');
};
```
4. Navigate to Uptime. Wait for the monitor result to come back in.
5. Navigate back to Monitor Management. You should see 1 invalid monitor 
<img width="1414" alt="Screen Shot 2022-04-19 at 3 57 16 PM" src="https://user-images.githubusercontent.com/11356435/164085465-ed456ce3-caf0-4784-ba93-f383f74b0a4e.png">