### PR TITLE
[CI] Move detection engine create exceptions tests to ciGroup14

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/index.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/index.ts
@@ -25,7 +25,6 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
       loadTestFile(require.resolve('./create_rules_bulk'));
       loadTestFile(require.resolve('./create_ml'));
       loadTestFile(require.resolve('./create_threat_matching'));
-      loadTestFile(require.resolve('./create_exceptions'));
       loadTestFile(require.resolve('./delete_rules'));
       loadTestFile(require.resolve('./delete_rules_bulk'));
       loadTestFile(require.resolve('./export_rules'));
@@ -53,6 +52,12 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
       loadTestFile(require.resolve('./throttle'));
       loadTestFile(require.resolve('./ignore_fields'));
       loadTestFile(require.resolve('./migrations'));
+    });
+
+    describe('', function () {
+      this.tags('ciGroup14');
+
+      loadTestFile(require.resolve('./create_exceptions'));
     });
 
     // That split here enable us on using a different ciGroup to run the tests


### PR DESCRIPTION
These `create_rules_with_exceptions` tests are the slowest detection engine API tests in ciGroup11, which has gotten pretty long. Moving them to ciGroup14 to balance things out.