### PR TITLE
[8.2] [Uptime] Synthetics tests - close Monitor Management tour (#130490)

### DIFF
--- a/x-pack/plugins/uptime/e2e/journeys/alerts/default_email_settings.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/alerts/default_email_settings.ts
@@ -13,13 +13,7 @@
  */
 
 import { journey, step, before } from '@elastic/synthetics';
-import {
-  assertNotText,
-  assertText,
-  byTestId,
-  loginToKibana,
-  waitForLoadingToFinish,
-} from '../utils';
+import { assertNotText, assertText, byTestId, waitForLoadingToFinish } from '../utils';
 import { settingsPageProvider } from '../../page_objects/settings';
 
 journey('DefaultEmailSettings', async ({ page, params }) => {
@@ -40,7 +34,7 @@ journey('DefaultEmailSettings', async ({ page, params }) => {
     await page.goto(`${baseUrl}?${queryParams}`, {
       waitUntil: 'networkidle',
     });
-    await loginToKibana({ page });
+    await settings.loginToKibana();
   });
 
   step('clear existing settings', async () => {

--- a/x-pack/plugins/uptime/e2e/journeys/alerts/status_alert_flyouts_in_alerting_app.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/alerts/status_alert_flyouts_in_alerting_app.ts
@@ -6,9 +6,11 @@
  */
 
 import { journey, step, expect, before } from '@elastic/synthetics';
-import { assertText, byTestId, loginToKibana, waitForLoadingToFinish } from '../utils';
+import { assertText, byTestId, waitForLoadingToFinish } from '../utils';
+import { loginPageProvider } from '../../page_objects/login';
 
 journey('StatusFlyoutInAlertingApp', async ({ page, params }) => {
+  const login = loginPageProvider({ page });
   before(async () => {
     await waitForLoadingToFinish({ page });
   });
@@ -19,7 +21,7 @@ journey('StatusFlyoutInAlertingApp', async ({ page, params }) => {
     await page.goto(`${baseUrl}`, {
       waitUntil: 'networkidle',
     });
-    await loginToKibana({ page });
+    await login.loginToKibana();
   });
 
   step('Open monitor status flyout', async () => {

--- a/x-pack/plugins/uptime/e2e/journeys/alerts/tls_alert_flyouts_in_alerting_app.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/alerts/tls_alert_flyouts_in_alerting_app.ts
@@ -6,9 +6,11 @@
  */
 
 import { journey, step, before } from '@elastic/synthetics';
-import { assertText, byTestId, loginToKibana, waitForLoadingToFinish } from '../utils';
+import { assertText, byTestId, waitForLoadingToFinish } from '../utils';
+import { loginPageProvider } from '../../page_objects/login';
 
 journey('TlsFlyoutInAlertingApp', async ({ page, params }) => {
+  const login = loginPageProvider({ page });
   before(async () => {
     await waitForLoadingToFinish({ page });
   });
@@ -19,7 +21,7 @@ journey('TlsFlyoutInAlertingApp', async ({ page, params }) => {
     await page.goto(`${baseUrl}`, {
       waitUntil: 'networkidle',
     });
-    await loginToKibana({ page });
+    await login.loginToKibana();
   });
 
   step('Open tls alert flyout', async () => {

--- a/x-pack/plugins/uptime/e2e/journeys/data_view_permissions.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/data_view_permissions.ts
@@ -6,10 +6,12 @@
  */
 
 import { journey, step, expect, before } from '@elastic/synthetics';
-import { byTestId, loginToKibana, waitForLoadingToFinish } from './utils';
 import { callKibana } from '../../../apm/scripts/create_apm_users_and_roles/helpers/call_kibana';
+import { byTestId, waitForLoadingToFinish } from './utils';
+import { loginPageProvider } from '../page_objects/login';
 
 journey('DataViewPermissions', async ({ page, params }) => {
+  const login = loginPageProvider({ page });
   before(async () => {
     await waitForLoadingToFinish({ page });
     try {
@@ -36,7 +38,7 @@ journey('DataViewPermissions', async ({ page, params }) => {
     await page.goto(`${baseUrl}?${queryParams}`, {
       waitUntil: 'networkidle',
     });
-    await loginToKibana({ page, user: { username: 'obs_read_user', password: 'changeme' } });
+    await login.loginToKibana('obs_read_user', 'changeme');
   });
 
   step('Click explore data button', async () => {

--- a/x-pack/plugins/uptime/e2e/journeys/step_duration.journey.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/step_duration.journey.ts
@@ -6,9 +6,11 @@
  */
 
 import { journey, step, expect, before } from '@elastic/synthetics';
-import { loginToKibana, waitForLoadingToFinish } from './utils';
+import { waitForLoadingToFinish } from './utils';
+import { loginPageProvider } from '../page_objects/login';
 
 journey('StepsDuration', async ({ page, params }) => {
+  const login = loginPageProvider({ page });
   before(async () => {
     await waitForLoadingToFinish({ page });
   });
@@ -24,7 +26,7 @@ journey('StepsDuration', async ({ page, params }) => {
     await page.goto(`${baseUrl}?${queryParams}`, {
       waitUntil: 'networkidle',
     });
-    await loginToKibana({ page });
+    await login.loginToKibana();
   });
 
   step('Go to monitor details', async () => {

--- a/x-pack/plugins/uptime/e2e/journeys/utils.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/utils.ts
@@ -30,6 +30,8 @@ export async function loginToKibana({
   await page.click('[data-test-subj=loginSubmit]');
 
   await waitForLoadingToFinish({ page });
+  // Close Monitor Management tour added in 8.2.0
+  await page.click('text=Close tour');
 }
 
 export const byTestId = (testId: string) => {

--- a/x-pack/plugins/uptime/e2e/page_objects/login.tsx
+++ b/x-pack/plugins/uptime/e2e/page_objects/login.tsx
@@ -36,6 +36,12 @@ export function loginPageProvider({
       await page.click('[data-test-subj=loginSubmit]');
 
       await this.waitForLoadingToFinish();
+      // Close Monitor Management tour added in 8.2.0
+      try {
+        await page.click('text=Close tour');
+      } catch (e) {
+        return;
+      }
     },
   };
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Uptime] Synthetics tests - close Monitor Management tour (#130490)](https://github.com/elastic/kibana/pull/130490)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)