### PR TITLE
[7.17] fix(NA): removes carriage return character when reading bazel tools cersion file on Windows (#130572)

### DIFF
--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -52652,7 +52652,7 @@ __webpack_require__.r(__webpack_exports__);
 
 
 async function readBazelToolsVersionFile(repoRootPath, versionFilename) {
-  const version = (await Object(_fs__WEBPACK_IMPORTED_MODULE_3__["readFile"])(Object(path__WEBPACK_IMPORTED_MODULE_1__["resolve"])(repoRootPath, versionFilename))).toString().split('\n')[0];
+  const version = (await Object(_fs__WEBPACK_IMPORTED_MODULE_3__["readFile"])(Object(path__WEBPACK_IMPORTED_MODULE_1__["resolve"])(repoRootPath, versionFilename))).toString().trim();
 
   if (!version) {
     throw new Error(`[bazel_tools] Failed on reading bazel tools versions\n ${versionFilename} file do not contain any version set`);

--- a/packages/kbn-pm/src/utils/bazel/install_tools.ts
+++ b/packages/kbn-pm/src/utils/bazel/install_tools.ts
@@ -13,9 +13,7 @@ import { readFile } from '../fs';
 import { log } from '../log';
 
 async function readBazelToolsVersionFile(repoRootPath: string, versionFilename: string) {
-  const version = (await readFile(resolve(repoRootPath, versionFilename)))
-    .toString()
-    .split('\n')[0];
+  const version = (await readFile(resolve(repoRootPath, versionFilename))).toString().trim();
 
   if (!version) {
     throw new Error(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [fix(NA): removes carriage return character when reading bazel tools cersion file on Windows (#130572)](https://github.com/elastic/kibana/pull/130572)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)