### PR TITLE
fix(NA): update codeowners for kibana-cloud-security-posture team on cloud_security_posture plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -582,7 +582,7 @@ x-pack/plugins/security_solution/public/common/components/sessions_viewer @elast
 /x-pack/plugins/osquery @elastic/security-asset-management
 
 # Cloud Security Posture
-/x-pack/plugins/cloud_security_posture/ @elastic/cloud-security-posture-control-plane
+/x-pack/plugins/cloud_security_posture/ @elastic/kibana-cloud-security-posture
 
 # Design (at the bottom for specificity of SASS files)
 **/*.scss  @elastic/kibana-design


### PR DESCRIPTION
This PR fixes the code owners file with the correct team owners team id for the cloud_security_posture plugin.