### PR TITLE
[Dev Tools] Fix cat APIs returning as escaped string

### DIFF
--- a/src/plugins/console/public/application/hooks/use_send_current_request_to_es/send_request_to_es.test.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request_to_es/send_request_to_es.test.ts
@@ -98,4 +98,36 @@ describe('sendRequestToES', () => {
       expect(mockedSendRequestToES).toHaveBeenCalledTimes(1);
     }
   });
+  describe('successful response value', () => {
+    describe('with text', () => {
+      it('should return value with lines separated', async () => {
+        mockedSendRequestToES.mockResolvedValue('\ntest_index-1    [] \ntest_index-2    []\n');
+        const response = await sendRequestToES({
+          http: mockContextValue.services.http,
+          requests: [{ method: 'GET', url: 'test-1', data: [] }],
+        });
+
+        expect(response).toMatchInlineSnapshot(`
+          "
+          test_index-1    [] 
+          test_index-2    []
+          "
+        `);
+        expect(mockedSendRequestToES).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('with parsed json', () => {
+      it('should stringify value', async () => {
+        mockedSendRequestToES.mockResolvedValue(JSON.stringify({ test: 'some value' }));
+        const response = await sendRequestToES({
+          http: mockContextValue.services.http,
+          requests: [{ method: 'GET', url: 'test-2', data: [] }],
+        });
+
+        expect(typeof response).toBe('string');
+        expect(mockedSendRequestToES).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
 });

--- a/src/plugins/console/public/application/hooks/use_send_current_request_to_es/send_request_to_es.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request_to_es/send_request_to_es.ts
@@ -93,7 +93,7 @@ export function sendRequestToES(args: EsRequestArgs): Promise<ESRequestResult[]>
             if (body instanceof ArrayBuffer) {
               value = body;
             } else {
-              value = JSON.stringify(body, null, 2);
+              value = typeof body === 'string' ? body : JSON.stringify(body, null, 2);
             }
 
             const warnings = response.headers.get('warning');


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/130635
Closes https://github.com/elastic/kibana/issues/130518

## Summary

Fixes escaped strings for `text/plain` in editor output

## Testing

`GET _cat/templates`

## Output
<img width="950" alt="Capture" src="https://user-images.githubusercontent.com/53621505/164178960-21c53e49-32d9-4ba1-bed9-8ac1e9739a6f.PNG">

