### PR TITLE
[Exploratory view] Increase chart height and reduce paddings

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/contexts/exploratory_view_config.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/contexts/exploratory_view_config.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 import { AppMountParameters } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import type { AppDataType, ConfigProps, ReportViewType, SeriesConfig } from '../types';
@@ -22,6 +22,8 @@ interface ExploratoryViewContextValue {
   reportConfigMap: ReportConfigMap;
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
   theme$: AppMountParameters['theme$'];
+  isEditMode?: boolean;
+  setIsEditMode?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const ExploratoryViewContext = createContext<ExploratoryViewContextValue>({
@@ -37,6 +39,8 @@ export function ExploratoryViewContextProvider({
   setHeaderActionMenu,
   theme$,
 }: { children: JSX.Element } & ExploratoryViewContextValue) {
+  const [isEditMode, setIsEditMode] = useState(false);
+
   const value = {
     reportTypes,
     dataTypes,
@@ -44,6 +48,8 @@ export function ExploratoryViewContextProvider({
     reportConfigMap,
     setHeaderActionMenu,
     theme$,
+    isEditMode,
+    setIsEditMode,
   };
 
   return (

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.tsx
@@ -29,6 +29,7 @@ import { EmptyView } from './components/empty_view';
 import { ChartTimeRange, LastUpdated } from './header/last_updated';
 import { useExpViewTimeRange } from './hooks/use_time_range';
 import { ExpViewActionMenu } from './components/action_menu';
+import { useExploratoryView } from './contexts/exploratory_view_config';
 
 export type PanelId = 'seriesPanel' | 'chartPanel';
 
@@ -45,6 +46,8 @@ export function ExploratoryView({
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   const [height, setHeight] = useState<string>('100vh');
+
+  const { isEditMode } = useExploratoryView();
 
   const [chartTimeRangeContext, setChartTimeRangeContext] = useState<ChartTimeRange | undefined>();
 
@@ -112,9 +115,10 @@ export function ExploratoryView({
 
             return (
               <>
-                <EuiFlexGroup alignItems="center">
+                <EuiFlexGroup alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
                     <EuiButtonEmpty
+                      size="xs"
                       {...(hiddenPanel === 'chartPanel'
                         ? { iconType: 'arrowRight' }
                         : { iconType: 'arrowDown' })}
@@ -129,7 +133,11 @@ export function ExploratoryView({
                         <LastUpdated chartTimeRange={chartTimeRangeContext} />
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
-                        <EuiButton iconType="refresh" onClick={() => setLastRefresh(Date.now())}>
+                        <EuiButton
+                          iconType="refresh"
+                          onClick={() => setLastRefresh(Date.now())}
+                          size="s"
+                        >
                           {REFRESH_LABEL}
                         </EuiButton>
                       </EuiFlexItem>
@@ -138,10 +146,11 @@ export function ExploratoryView({
                 </EuiFlexGroup>
 
                 <EuiResizablePanel
-                  initialSize={40}
+                  initialSize={isEditMode ? 40 : 60}
                   minSize={'30%'}
                   mode={'collapsible'}
                   id="chartPanel"
+                  paddingSize="s"
                 >
                   {lensAttributes ? (
                     <LensEmbeddable
@@ -154,7 +163,7 @@ export function ExploratoryView({
                 </EuiResizablePanel>
 
                 <EuiResizablePanel
-                  initialSize={60}
+                  initialSize={isEditMode ? 60 : 40}
                   minSize="10%"
                   mode={'main'}
                   id="seriesPanel"
@@ -196,6 +205,11 @@ const ResizableContainer = styled(EuiResizableContainer)`
   height: 100%;
   &&& .paddingTopSmall {
     padding-top: 8px;
+  }
+  #chartPanel {
+    > .euiPanel {
+      padding-bottom: 0;
+    }
   }
 `;
 

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series.tsx
@@ -56,7 +56,7 @@ export function Series({ item, isExpanded, toggleExpanded }: Props) {
   }, [isExpanded]);
 
   return (
-    <EuiPanel hasBorder={true} data-test-subj={`exploratoryViewSeriesPanel${0}`}>
+    <EuiPanel hasBorder={true} data-test-subj={`exploratoryViewSeriesPanel${0}`} paddingSize="s">
       <StyledAccordion
         id={`exploratoryViewSeriesAccordion${id}`}
         forceState={isExpanded ? 'open' : 'closed'}

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
@@ -63,7 +63,7 @@ export const SeriesEditor = React.memo(function () {
 
   const { loading, dataViews } = useAppDataViewContext();
 
-  const { reportConfigMap } = useExploratoryView();
+  const { reportConfigMap, setIsEditMode } = useExploratoryView();
 
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<Record<string, true>>({});
 
@@ -73,6 +73,10 @@ export const SeriesEditor = React.memo(function () {
   }>({
     curCount: allSeries.length,
   });
+
+  useEffect(() => {
+    setIsEditMode?.(Object.keys(itemIdToExpandedRowMap).length > 0);
+  }, [itemIdToExpandedRowMap, setIsEditMode]);
 
   useEffect(() => {
     setSeriesCount((oldParams) => ({ prevCount: oldParams.curCount, curCount: allSeries.length }));
@@ -141,14 +145,14 @@ export const SeriesEditor = React.memo(function () {
       </StickyFlexGroup>
 
       <EditorRowsWrapper>
-        {editorItems.map((item) => (
+        {editorItems.map((item, index) => (
           <div key={item.id}>
             <Series
               item={item}
               toggleExpanded={() => toggleDetails(item)}
               isExpanded={itemIdToExpandedRowMap[item.id]}
             />
-            <EuiSpacer size="s" />
+            {index + 1 !== editorItems.length && <EuiSpacer size="s" />}
           </div>
         ))}
       </EditorRowsWrapper>


### PR DESCRIPTION
## Summary

Chart height is too small in the exploratory view, this PR does few things to improve the situation

Following things has been done to improve chart height

- Increase chart height in case no series is expanded.
- Reduce padding around series header
- Reduce paddings above/below chart
- Reduce Button sizes 

After:

<img width="1788" alt="image" src="https://user-images.githubusercontent.com/3505601/164191619-29c3a74c-885d-438c-9dab-860138d4df78.png">

Before:
<img width="1570" alt="image" src="https://user-images.githubusercontent.com/3505601/164201216-147f4926-31e6-4182-8628-6a71530e4a4a.png">
