### PR TITLE
[7.17][elastic-charts] Fix rendering outside small multiple charts 

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@elastic/apm-rum": "^5.9.1",
     "@elastic/apm-rum-react": "^1.3.1",
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
-    "@elastic/charts": "40.3.0",
+    "@elastic/charts": "40.3.1",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^7.16.0-canary.7",
     "@elastic/ems-client": "7.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,10 +1520,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@40.3.0":
-  version "40.3.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-40.3.0.tgz#f7e8fb0e7770251484807b33dae01e36ff336b89"
-  integrity sha512-ZY5PQiwmsMaJo2u9h7XbrGcuV8A3yO7pdgbSne8nICIaOfEz3qpH6JjGXxOXerb0els/Y9nTyYh/i1mQd8S/dA==
+"@elastic/charts@40.3.1":
+  version "40.3.1"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-40.3.1.tgz#ff3888ea3e306b1087ea15cc3a224570a53a7aaa"
+  integrity sha512-jjTuBpStv+kjp+G0bEZb+7HYn/GsbKbPrdCl0NVhfZFyUtDgr/0jzPhMmFDn9Ivx+X+W6MIZCrE2O4bCV0/HVw==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"


### PR DESCRIPTION
## Summary

This PR backports the fix https://github.com/elastic/elastic-charts/pull/1651 where charts can render outside their small multiple panels under some circumstances (for example when filtering the domain of a log scale). The fix is already available on `main` thanks to https://github.com/elastic/kibana/pull/130571

The fix in elastic-charts enables clipping at each panel level of small multiple avoiding possible overflows of charts.

See elastic-charts reported issue: https://github.com/elastic/elastic-charts/issues/1650
