### PR TITLE
[generate/package] run ESLint and auto-fix generated files

### DIFF
--- a/packages/kbn-generate/src/commands/package_command.ts
+++ b/packages/kbn-generate/src/commands/package_command.ts
@@ -11,6 +11,7 @@ import Path from 'path';
 
 import normalizePath from 'normalize-path';
 import globby from 'globby';
+import { ESLint } from 'eslint';
 
 import micromatch from 'micromatch';
 import { REPO_ROOT } from '@kbn/utils';
@@ -128,6 +129,15 @@ ${BAZEL_PACKAGE_DIRS.map((dir) => `                          ./${dir}/*\n`).join
     }
 
     log.info('Wrote plugin files to', packageDir);
+
+    log.info('Linting files');
+    const eslint = new ESLint({
+      cache: false,
+      cwd: REPO_ROOT,
+      fix: true,
+      extensions: ['.js', '.mjs', '.ts', '.tsx'],
+    });
+    await ESLint.outputFixes(await eslint.lintFiles([packageDir]));
 
     const packageJsonPath = Path.resolve(REPO_ROOT, 'package.json');
     const packageJson = JSON.parse(await Fsp.readFile(packageJsonPath, 'utf8'));


### PR DESCRIPTION
When we generate packages we don't know the ESLint rules of the generated location. If packages are generated in `x-pack` then they need different license headers for instance, this PR updates the package command to run ESLint on the generated files and auto-fix all violations automatically.