### PR TITLE
[DOCS] Fixes security link in 8.1.3 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,7 +33,7 @@ Review the following information about the {kib} 8.1.3 release.
 [[security-update-v8.1.3]]
 === Security update
 
-The 8.1.3 release contains a fix to a potential security vulnerability. For more information, check link:https://ela.st/esa-2022-051[Security Announcements].
+The 8.1.3 release contains a fix to a potential security vulnerability. For more information, check link:https://discuss.elastic.co/t/kibana-7-17-3-and-8-1-3-security-update/302826[Security Announcements].
 
 [float]
 [[breaking-changes-8.1.3]]


### PR DESCRIPTION
## Summary

Fixes the security update link in the 8.1.3 release notes.