### PR TITLE
[es-snapshots] Fix promotion not triggering due to missing dependency

### DIFF
--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -79,7 +79,6 @@ steps:
       queue: kibana-default
     depends_on:
       - default-cigroup
-      - default-cigroup-docker
       - oss-cigroup
       - jest-integration
       - api-integration


### PR DESCRIPTION
The `default-cigroup-docker` step was removed, so promotion can no longer trigger.