### PR TITLE
[CI] Move some test suites out of ciGroup4

### DIFF
--- a/x-pack/test/functional/apps/spaces/index.ts
+++ b/x-pack/test/functional/apps/spaces/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function spacesApp({ loadTestFile }: FtrProviderContext) {
   describe('Spaces app', function spacesAppTestSuite() {
-    this.tags('ciGroup4');
+    this.tags('ciGroup9');
 
     loadTestFile(require.resolve('./copy_saved_objects'));
     loadTestFile(require.resolve('./feature_controls/spaces_security'));

--- a/x-pack/test/functional/apps/visualize/index.ts
+++ b/x-pack/test/functional/apps/visualize/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function visualize({ loadTestFile }: FtrProviderContext) {
   describe('Visualize', function visualizeTestSuite() {
-    this.tags(['ciGroup4', 'skipFirefox']);
+    this.tags(['ciGroup30', 'skipFirefox']);
 
     loadTestFile(require.resolve('./feature_controls/visualize_security'));
     loadTestFile(require.resolve('./feature_controls/visualize_spaces'));


### PR DESCRIPTION
Moves about 15min worth of tests to shorter CI Groups.