### PR TITLE
[CI] Move most tests from oss ciGroup6 to ciGroup5

### DIFF
--- a/test/functional/apps/dashboard/index.ts
+++ b/test/functional/apps/dashboard/index.ts
@@ -115,7 +115,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     // TODO: Remove when vislib is removed
     // https://github.com/elastic/kibana/issues/56143
     describe('new charts library', function () {
-      this.tags('ciGroup6');
+      this.tags('ciGroup5');
 
       before(async () => {
         await loadLogstash();

--- a/test/functional/apps/getting_started/index.ts
+++ b/test/functional/apps/getting_started/index.ts
@@ -13,7 +13,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
 
   describe('Getting Started ', function () {
-    this.tags(['ciGroup6']);
+    this.tags(['ciGroup5']);
 
     before(async function () {
       await browser.setWindowSize(1200, 800);

--- a/test/functional/apps/home/index.js
+++ b/test/functional/apps/home/index.js
@@ -10,7 +10,7 @@ export default function ({ getService, loadTestFile }) {
   const browser = getService('browser');
 
   describe('homepage app', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     before(function () {
       return browser.setWindowSize(1200, 800);

--- a/test/ui_capabilities/newsfeed_err/test.ts
+++ b/test/ui_capabilities/newsfeed_err/test.ts
@@ -15,7 +15,7 @@ export default function uiCapabilitiesTests({ getService, getPageObjects }: FtrP
   const PageObjects = getPageObjects(['common', 'newsfeed']);
 
   describe('Newsfeed icon button handle errors', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     before(async () => {
       await PageObjects.newsfeed.resetPage();

--- a/test/visual_regression/tests/discover/index.ts
+++ b/test/visual_regression/tests/discover/index.ts
@@ -16,7 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const browser = getService('browser');
 
   describe('discover app', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     before(function () {
       return browser.setWindowSize(SCREEN_WIDTH, 1000);

--- a/test/visual_regression/tests/vega/index.ts
+++ b/test/visual_regression/tests/vega/index.ts
@@ -16,7 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const browser = getService('browser');
 
   describe('vega app', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     before(function () {
       return browser.setWindowSize(SCREEN_WIDTH, 1000);

--- a/x-pack/test/api_integration/apis/security/security_basic.ts
+++ b/x-pack/test/api_integration/apis/security/security_basic.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security (basic license)', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
 
     // Updates here should be mirrored in `./index.js` if tests
     // should also run under a trial/platinum license.

--- a/x-pack/test/api_integration/apis/security/security_basic.ts
+++ b/x-pack/test/api_integration/apis/security/security_basic.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security (basic license)', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     // Updates here should be mirrored in `./index.js` if tests
     // should also run under a trial/platinum license.

--- a/x-pack/test/api_integration/apis/security/security_trial.ts
+++ b/x-pack/test/api_integration/apis/security/security_trial.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security (trial license)', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
 
     // THIS TEST NEEDS TO BE LAST. IT IS DESTRUCTIVE! IT REMOVES TRIAL LICENSE!!!
     loadTestFile(require.resolve('./license_downgrade'));

--- a/x-pack/test/api_integration/apis/security/security_trial.ts
+++ b/x-pack/test/api_integration/apis/security/security_trial.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security (trial license)', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     // THIS TEST NEEDS TO BE LAST. IT IS DESTRUCTIVE! IT REMOVES TRIAL LICENSE!!!
     loadTestFile(require.resolve('./license_downgrade'));

--- a/x-pack/test/functional_with_es_ssl/apps/discover/index.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/discover/index.ts
@@ -8,7 +8,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default ({ loadTestFile, getService }: FtrProviderContext) => {
   describe('Discover alerting', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
     loadTestFile(require.resolve('./search_source_alert'));
   });
 };

--- a/x-pack/test/functional_with_es_ssl/apps/discover/index.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/discover/index.ts
@@ -8,7 +8,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default ({ loadTestFile, getService }: FtrProviderContext) => {
   describe('Discover alerting', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
     loadTestFile(require.resolve('./search_source_alert'));
   });
 };

--- a/x-pack/test/functional_with_es_ssl/apps/uptime/index.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/uptime/index.ts
@@ -14,7 +14,7 @@ export default ({ getService, loadTestFile }: FtrProviderContext) => {
   const kibanaServer = getService('kibanaServer');
 
   describe('Uptime app', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
 
     describe('with real-world data', () => {
       before(async () => {

--- a/x-pack/test/functional_with_es_ssl/apps/uptime/index.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/uptime/index.ts
@@ -14,7 +14,7 @@ export default ({ getService, loadTestFile }: FtrProviderContext) => {
   const kibanaServer = getService('kibanaServer');
 
   describe('Uptime app', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     describe('with real-world data', () => {
       before(async () => {

--- a/x-pack/test/observability_functional/apps/observability/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('ObservabilityApp', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     loadTestFile(require.resolve('./alerts'));
     loadTestFile(require.resolve('./alerts/add_to_case'));

--- a/x-pack/test/observability_functional/apps/observability/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('ObservabilityApp', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
 
     loadTestFile(require.resolve('./alerts'));
     loadTestFile(require.resolve('./alerts/add_to_case'));

--- a/x-pack/test/plugin_api_integration/test_suites/event_log/index.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/event_log/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('event_log', function taskManagerSuite() {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
     loadTestFile(require.resolve('./public_api_integration'));
     loadTestFile(require.resolve('./service_api_integration'));
   });

--- a/x-pack/test/plugin_api_integration/test_suites/event_log/index.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/event_log/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('event_log', function taskManagerSuite() {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
     loadTestFile(require.resolve('./public_api_integration'));
     loadTestFile(require.resolve('./service_api_integration'));
   });

--- a/x-pack/test/security_api_integration/tests/anonymous/index.ts
+++ b/x-pack/test/security_api_integration/tests/anonymous/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Anonymous access', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
     loadTestFile(require.resolve('./login'));
     loadTestFile(require.resolve('./capabilities'));
   });

--- a/x-pack/test/security_api_integration/tests/anonymous/index.ts
+++ b/x-pack/test/security_api_integration/tests/anonymous/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Anonymous access', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
     loadTestFile(require.resolve('./login'));
     loadTestFile(require.resolve('./capabilities'));
   });

--- a/x-pack/test/security_api_integration/tests/audit/index.ts
+++ b/x-pack/test/security_api_integration/tests/audit/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Audit Log', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
     loadTestFile(require.resolve('./audit_log'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/audit/index.ts
+++ b/x-pack/test/security_api_integration/tests/audit/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Audit Log', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
     loadTestFile(require.resolve('./audit_log'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/http_bearer/index.ts
+++ b/x-pack/test/security_api_integration/tests/http_bearer/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - HTTP Bearer', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
     loadTestFile(require.resolve('./header'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/http_bearer/index.ts
+++ b/x-pack/test/security_api_integration/tests/http_bearer/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - HTTP Bearer', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
     loadTestFile(require.resolve('./header'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/http_no_auth_providers/index.ts
+++ b/x-pack/test/security_api_integration/tests/http_no_auth_providers/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - HTTP no authentication providers are enabled', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
     loadTestFile(require.resolve('./authentication'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/http_no_auth_providers/index.ts
+++ b/x-pack/test/security_api_integration/tests/http_no_auth_providers/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - HTTP no authentication providers are enabled', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
     loadTestFile(require.resolve('./authentication'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/login_selector/index.ts
+++ b/x-pack/test/security_api_integration/tests/login_selector/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Login Selector', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
     loadTestFile(require.resolve('./basic_functionality'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/login_selector/index.ts
+++ b/x-pack/test/security_api_integration/tests/login_selector/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Login Selector', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
     loadTestFile(require.resolve('./basic_functionality'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/index.ts
+++ b/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - OIDC (Authorization Code Flow)', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
     loadTestFile(require.resolve('./oidc_auth'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/index.ts
+++ b/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - OIDC (Authorization Code Flow)', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
     loadTestFile(require.resolve('./oidc_auth'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/oidc/implicit_flow/index.ts
+++ b/x-pack/test/security_api_integration/tests/oidc/implicit_flow/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - OIDC (Implicit Flow)', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
     loadTestFile(require.resolve('./oidc_auth'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/oidc/implicit_flow/index.ts
+++ b/x-pack/test/security_api_integration/tests/oidc/implicit_flow/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - OIDC (Implicit Flow)', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
     loadTestFile(require.resolve('./oidc_auth'));
   });
 }

--- a/x-pack/test/security_api_integration/tests/pki/index.ts
+++ b/x-pack/test/security_api_integration/tests/pki/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - PKI', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     loadTestFile(require.resolve('./pki_auth'));
   });

--- a/x-pack/test/security_api_integration/tests/pki/index.ts
+++ b/x-pack/test/security_api_integration/tests/pki/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - PKI', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
 
     loadTestFile(require.resolve('./pki_auth'));
   });

--- a/x-pack/test/security_api_integration/tests/session_invalidate/index.ts
+++ b/x-pack/test/security_api_integration/tests/session_invalidate/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Session Invalidate', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     loadTestFile(require.resolve('./invalidate'));
   });

--- a/x-pack/test/security_api_integration/tests/session_invalidate/index.ts
+++ b/x-pack/test/security_api_integration/tests/session_invalidate/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Session Invalidate', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
 
     loadTestFile(require.resolve('./invalidate'));
   });

--- a/x-pack/test/security_api_integration/tests/session_lifespan/index.ts
+++ b/x-pack/test/security_api_integration/tests/session_lifespan/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Session Lifespan', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
 
     loadTestFile(require.resolve('./cleanup'));
   });

--- a/x-pack/test/security_api_integration/tests/session_lifespan/index.ts
+++ b/x-pack/test/security_api_integration/tests/session_lifespan/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Session Lifespan', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
 
     loadTestFile(require.resolve('./cleanup'));
   });

--- a/x-pack/test/security_api_integration/tests/token/index.ts
+++ b/x-pack/test/security_api_integration/tests/token/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Token', function () {
-    this.tags('ciGroup5');
+    this.tags('ciGroup6');
     loadTestFile(require.resolve('./login'));
     loadTestFile(require.resolve('./logout'));
     loadTestFile(require.resolve('./header'));

--- a/x-pack/test/security_api_integration/tests/token/index.ts
+++ b/x-pack/test/security_api_integration/tests/token/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security APIs - Token', function () {
-    this.tags('ciGroup6');
+    this.tags('ciGroup5');
     loadTestFile(require.resolve('./login'));
     loadTestFile(require.resolve('./logout'));
     loadTestFile(require.resolve('./header'));


### PR DESCRIPTION
These are a lot of tests, but they actually only take up about 10 minutes. ciGroup6 is 50 minutes long, so let's move them to ciGroup5.