### PR TITLE
[artifact testing] Bump VM boot timeout

### DIFF
--- a/test/package/Vagrantfile
+++ b/test/package/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
   config.vm.synced_folder '../../target/', '/packages'
-
+  config.vm.boot_timeout = 600
   config.vm.define "deb" do |deb|
     deb.vm.provider :virtualbox do |vb|
       vb.memory = 2048


### PR DESCRIPTION
We saw a flaky `vagrant ssh` timeout in a CI run, possibly caused by a
busy host.  This doubles the VM setup timeout from 5 minutes to 10
minutes.