### PR TITLE
[ML] Data Frame Analytics creation wizard: add support for filters in saved searches

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/use_saved_search.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/use_saved_search.ts
@@ -56,8 +56,7 @@ export function useSavedSearch() {
           qry.bool.filter = qry.bool.filter === undefined ? [] : [qry.bool.filter];
         }
         if (Array.isArray(qry.bool.must_not) === false) {
-          qry.bool.must_not =
-            qry.bool.must_not === undefined ? [] : [qry.bool.must_not];
+          qry.bool.must_not = qry.bool.must_not === undefined ? [] : [qry.bool.must_not];
         }
         qry.bool.filter = [...qry.bool.filter, ...filterQuery.filter];
         qry.bool.must_not = [...qry.bool.must_not, ...filterQuery.must_not];

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/use_saved_search.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/use_saved_search.ts
@@ -7,12 +7,12 @@
 
 import { useState, useEffect } from 'react';
 import {
+  buildEsQuery,
+  buildQueryFromFilters,
   decorateQuery,
   fromKueryExpression,
-  luceneStringToDsl,
   toElasticsearchQuery,
 } from '@kbn/es-query';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { useMlContext } from '../../../../../contexts/ml';
 import { SEARCH_QUERY_LANGUAGE } from '../../../../../../../common/constants/search';
 import { getQueryFromSavedSearchObject } from '../../../../../util/index_utils';
@@ -36,19 +36,33 @@ export function useSavedSearch() {
   const { currentSavedSearch, currentDataView, kibanaConfig } = mlContext;
 
   const getQueryData = () => {
-    let qry: estypes.QueryDslQueryContainer = {};
+    let qry: any = {};
     let qryString;
 
     if (currentSavedSearch !== null) {
-      const { query } = getQueryFromSavedSearchObject(currentSavedSearch);
+      const { query, filter } = getQueryFromSavedSearchObject(currentSavedSearch);
       const queryLanguage = query.language;
       qryString = query.query;
 
       if (queryLanguage === SEARCH_QUERY_LANGUAGE.KUERY) {
         const ast = fromKueryExpression(qryString);
         qry = toElasticsearchQuery(ast, currentDataView);
+        const filterQuery = buildQueryFromFilters(filter, currentDataView);
+        if (qry.bool === undefined) {
+          qry.bool = {};
+        }
+
+        if (Array.isArray(qry.bool.filter) === false) {
+          qry.bool.filter = qry.bool.filter === undefined ? [] : [qry.bool.filter];
+        }
+        if (Array.isArray(qry.bool.must_not) === false) {
+          qry.bool.must_not =
+            qry.bool.must_not === undefined ? [] : [qry.bool.must_not];
+        }
+        qry.bool.filter = [...qry.bool.filter, ...filterQuery.filter];
+        qry.bool.must_not = [...qry.bool.must_not, ...filterQuery.must_not];
       } else {
-        qry = luceneStringToDsl(qryString);
+        qry = buildEsQuery(currentDataView, [query], filter);
         decorateQuery(qry, kibanaConfig.get('query:queryString:options'));
       }
 

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/use_saved_search.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/use_saved_search.ts
@@ -50,6 +50,16 @@ export function useSavedSearch() {
         const filterQuery = buildQueryFromFilters(filter, currentDataView);
         if (qry.bool === undefined) {
           qry.bool = {};
+          // toElasticsearchQuery may add a single match_all item to the
+          // root of its returned query, rather than putting it inside
+          // a bool.should
+          // in this case, move it to a bool.should
+          if (qry.match_all !== undefined) {
+            qry.bool.should = {
+              match_all: qry.match_all,
+            };
+            delete qry.match_all;
+          }
         }
 
         if (Array.isArray(qry.bool.filter) === false) {


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/130050

The creation wizard now supports filters in saved searches - these are now reflected in the preview table and passed through to the job config.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))


