### PR TITLE
[jest] disable synthetic package transform, use custom resolver

### DIFF
--- a/packages/kbn-babel-preset/common_preset.js
+++ b/packages/kbn-babel-preset/common_preset.js
@@ -47,7 +47,7 @@ module.exports = (_, options = {}) => ({
           },
         ],
 
-        ...(options['kibana/syntheticModules'] !== false
+        ...(options['kibana/syntheticPackages'] !== false
           ? [[require.resolve('@kbn/babel-plugin-synthetic-packages'), options]]
           : []),
       ],

--- a/packages/kbn-babel-preset/common_preset.js
+++ b/packages/kbn-babel-preset/common_preset.js
@@ -47,7 +47,9 @@ module.exports = (_, options = {}) => ({
           },
         ],
 
-        [require.resolve('@kbn/babel-plugin-synthetic-packages'), options],
+        ...(options['kibana/syntheticModules'] !== false
+          ? [[require.resolve('@kbn/babel-plugin-synthetic-packages'), options]]
+          : []),
       ],
     },
 

--- a/packages/kbn-import-resolver/src/import_resolver.ts
+++ b/packages/kbn-import-resolver/src/import_resolver.ts
@@ -37,6 +37,7 @@ export class ImportResolver {
 
   private baseResolveOpts = {
     extensions: ['.js', '.json', '.ts', '.tsx', '.d.ts'],
+    preserveSymlinks: true,
     isFile: (path: string) => !!this.safeStat(path)?.isFile(),
     isDirectory: (path: string) => !!this.safeStat(path)?.isDirectory(),
     readFileSync: memoize(readFileSync),

--- a/packages/kbn-import-resolver/src/resolve_result.ts
+++ b/packages/kbn-import-resolver/src/resolve_result.ts
@@ -10,7 +10,7 @@
  * Resolution result indicating that the import request resolves to a built-in node library
  */
 export interface BuiltInResult {
-  type: 'built-in';
+  readonly type: 'built-in';
 }
 
 /**
@@ -18,7 +18,7 @@ export interface BuiltInResult {
  * currently installed so assumed to be optional
  */
 export interface OptionalDepResult {
-  type: 'optional-and-missing';
+  readonly type: 'optional-and-missing';
 }
 
 /**
@@ -28,7 +28,7 @@ export interface OptionalDepResult {
  * can be trusted to exist after the build it complete or in their used location.
  */
 export interface IgnoreResult {
-  type: 'ignore';
+  readonly type: 'ignore';
 }
 
 /**
@@ -38,8 +38,8 @@ export interface IgnoreResult {
  * end up in the build or running code.
  */
 export interface TypesResult {
-  type: '@types';
-  module: string;
+  readonly type: '@types';
+  readonly module: string;
 }
 
 /**
@@ -47,11 +47,11 @@ export interface TypesResult {
  * the path of that file and the name of the nodeModule if applicable
  */
 export interface FileResult {
-  type: 'file';
-  absolute: string;
-  nodeModule?: string;
-  prefix?: string;
-  postfix?: string;
+  readonly type: 'file';
+  readonly absolute: string;
+  readonly nodeModule?: string;
+  readonly prefix?: string;
+  readonly postfix?: string;
 }
 
 /**

--- a/packages/kbn-test/src/jest/babel_transform.js
+++ b/packages/kbn-test/src/jest/babel_transform.js
@@ -11,7 +11,12 @@ const babelJest = require('babel-jest');
 module.exports = babelJest.createTransformer({
   presets: [
     [
-      require.resolve('@kbn/babel-preset/node_preset'),
+      [
+        require.resolve('@kbn/babel-preset/node_preset'),
+        {
+          'kibana/syntheticModules': false,
+        },
+      ],
       {
         '@babel/preset-env': {
           // disable built-in filtering, which is more performant but strips the import of `regenerator-runtime` required by EUI

--- a/packages/kbn-test/src/jest/babel_transform.js
+++ b/packages/kbn-test/src/jest/babel_transform.js
@@ -11,13 +11,9 @@ const babelJest = require('babel-jest');
 module.exports = babelJest.createTransformer({
   presets: [
     [
-      [
-        require.resolve('@kbn/babel-preset/node_preset'),
-        {
-          'kibana/syntheticModules': false,
-        },
-      ],
+      require.resolve('@kbn/babel-preset/node_preset'),
       {
+        'kibana/syntheticPackages': false,
         '@babel/preset-env': {
           // disable built-in filtering, which is more performant but strips the import of `regenerator-runtime` required by EUI
           useBuiltIns: false,

--- a/packages/kbn-test/src/jest/setup/preserve_symlinks_resolver.js
+++ b/packages/kbn-test/src/jest/setup/preserve_symlinks_resolver.js
@@ -8,7 +8,9 @@
 
 const { ImportResolver } = require('@kbn/import-resolver');
 const { REPO_ROOT } = require('@kbn/utils');
-const resolver = ImportResolver.create(REPO_ROOT);
+const resolver = ImportResolver.create(REPO_ROOT, {
+  disableTypesFallback: true,
+});
 
 module.exports = (request, options) => {
   const result = resolver.resolve(request, options.basedir);

--- a/packages/kbn-test/src/jest/setup/preserve_symlinks_resolver.js
+++ b/packages/kbn-test/src/jest/setup/preserve_symlinks_resolver.js
@@ -18,6 +18,7 @@ module.exports = (request, options) => {
   if (result?.type === 'built-in') {
     return request;
   }
+
   if (result?.type === 'file') {
     return result.absolute;
   }


### PR DESCRIPTION
Attempts to recover from a Jest performance issue that @brianseeders noticed caused by https://github.com/elastic/kibana/pull/128700.

The idea here is to disable the syntheticModules transform and switch to a custom import resolver which Jest can use to understand the weird require statements we are using.