### PR TITLE
[Infra Monitoring]: add rac to feature privileges for logs and metrics

### DIFF
--- a/x-pack/plugins/infra/server/features.ts
+++ b/x-pack/plugins/infra/server/features.ts
@@ -33,7 +33,7 @@ export const METRICS_FEATURE = {
     all: {
       app: ['infra', 'metrics', 'kibana'],
       catalogue: ['infraops', 'metrics'],
-      api: ['infra'],
+      api: ['infra', 'rac'],
       savedObject: {
         all: ['infrastructure-ui-source'],
         read: ['index-pattern'],
@@ -54,7 +54,7 @@ export const METRICS_FEATURE = {
     read: {
       app: ['infra', 'metrics', 'kibana'],
       catalogue: ['infraops', 'metrics'],
-      api: ['infra'],
+      api: ['infra', 'rac'],
       savedObject: {
         all: [],
         read: ['infrastructure-ui-source', 'index-pattern'],
@@ -92,7 +92,7 @@ export const LOGS_FEATURE = {
     all: {
       app: ['infra', 'logs', 'kibana'],
       catalogue: ['infralogging', 'logs'],
-      api: ['infra'],
+      api: ['infra', 'rac'],
       savedObject: {
         all: [infraSourceConfigurationSavedObjectName, logViewSavedObjectName],
         read: [],
@@ -113,7 +113,7 @@ export const LOGS_FEATURE = {
     read: {
       app: ['infra', 'logs', 'kibana'],
       catalogue: ['infralogging', 'logs'],
-      api: ['infra'],
+      api: ['infra', 'rac'],
       alerting: {
         rule: {
           read: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/130761

<img width="1184" alt="Screenshot 2022-04-20 at 21 03 51" src="https://user-images.githubusercontent.com/2852703/164375278-0e57b49f-9770-4f1d-a61c-7b2fc5cab4d8.png">

### Notes for the reviewer
- The user would get a `Forbidden error` when they had the option to Update the `workflow_status` in the Alerts Page https://github.com/elastic/sdh-kibana/issues/2798. 
- Current fix has already been applied https://github.com/elastic/kibana/pull/130609 in `7.17.4`   
- Since worflow_status filtering and `Mark as acknowledged` and `Mark as closed` options have been removed from the alerts view in 8.0 https://github.com/elastic/kibana/pull/118723, you won't be able to reproduce the bug on main, but still rac privileges need to be present to avoid any future privilege related bugs

### Question
Shall we backport this fix to releases previous to `7.17.4` as well? 
Update: Based on https://github.com/elastic/kibana/pull/111296, RAC feature flags were disabled by default for 7.15 and 7.16, so I would say we don't need to backport at all?