### PR TITLE
[Lens] Fixes flakiness on the visualization switcher

### DIFF
--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -720,11 +720,20 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
      */
     async switchToVisualization(subVisualizationId: string, searchTerm?: string) {
       await this.openChartSwitchPopover();
-      const searchInput = await testSubjects.find('lnsChartSwitchSearch');
-      await searchInput.focus();
-      await this.searchOnChartSwitch(subVisualizationId, searchTerm);
+      await this.waitForSearchInputValue(subVisualizationId, searchTerm);
       await testSubjects.click(`lnsChartSwitchPopover_${subVisualizationId}`);
       await PageObjects.header.waitUntilLoadingHasFinished();
+    },
+    async waitForSearchInputValue(subVisualizationId: string, searchTerm?: string) {
+      await retry.try(async () => {
+        await this.searchOnChartSwitch(subVisualizationId, searchTerm);
+        await PageObjects.common.sleep(1000); // give time for the value to be typed
+        const searchInputValue = await testSubjects.getAttribute('lnsChartSwitchSearch', 'value');
+        const queryTerm = searchTerm ?? subVisualizationId.substring(subVisualizationId.length - 3);
+        if (searchInputValue !== queryTerm) {
+          throw new Error('Search input value is not the expected value');
+        }
+      });
     },
 
     async openChartSwitchPopover() {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/130757

This is a second attempt to fix the flakiness on the visualization switcher function used on Lens functional tests.

Runner (100) https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/501#5fd067e6-592e-44de-b1fb-139c0bfe8b04

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios