### PR TITLE
[Actionable Observability] use shareable tags component in o11y rules page

### DIFF
--- a/x-pack/plugins/observability/public/observability_public_plugins_start.mock.ts
+++ b/x-pack/plugins/observability/public/observability_public_plugins_start.mock.ts
@@ -36,6 +36,7 @@ const triggersActionsUiStartMock = {
   createStart() {
     return {
       getAddAlertFlyout: jest.fn(),
+      getRuleTagBadge: jest.fn(),
       ruleTypeRegistry: {
         has: jest.fn(),
         register: jest.fn(),

--- a/x-pack/plugins/observability/public/pages/rules/index.tsx
+++ b/x-pack/plugins/observability/public/pages/rules/index.tsx
@@ -180,7 +180,7 @@ export function RulesPage() {
         'data-test-subj': 'rulesTableCell-tagsPopover',
         render: (tags: string[], item: RuleTableItem) => {
           return tags.length > 0
-            ? triggersActionsUi.getRuleTagsBadge({
+            ? triggersActionsUi.getRuleTagBadge({
                 isOpen: tagPopoverOpenIndex === item.index,
                 tags,
                 onClick: () => setTagPopoverOpenIndex(item.index),

--- a/x-pack/plugins/observability/public/pages/rules/index.tsx
+++ b/x-pack/plugins/observability/public/pages/rules/index.tsx
@@ -96,6 +96,7 @@ export function RulesPage() {
   const [currentRuleToEdit, setCurrentRuleToEdit] = useState<RuleTableItem | null>(null);
   const [rulesToDelete, setRulesToDelete] = useState<string[]>([]);
   const [createRuleFlyoutVisibility, setCreateRuleFlyoutVisibility] = useState(false);
+  const [tagPopoverOpenIndex, setTagPopoverOpenIndex] = useState<number>(-1);
 
   const isRuleTypeEditableInContext = (ruleTypeId: string) =>
     ruleTypeRegistry.has(ruleTypeId) ? !ruleTypeRegistry.get(ruleTypeId).requiresAppContext : false;
@@ -170,6 +171,23 @@ export function RulesPage() {
         width: '30%',
         'data-test-subj': 'rulesTableCell-name',
         render: (name: string, rule: RuleTableItem) => <Name name={name} rule={rule} />,
+      },
+      {
+        field: 'tags',
+        name: '',
+        sortable: false,
+        width: '50px',
+        'data-test-subj': 'rulesTableCell-tagsPopover',
+        render: (tags: string[], item: RuleTableItem) => {
+          return tags.length > 0
+            ? triggersActionsUi.getRuleTagsBadge({
+                isOpen: tagPopoverOpenIndex === item.index,
+                tags,
+                onClick: () => setTagPopoverOpenIndex(item.index),
+                onClose: () => setTagPopoverOpenIndex(-1),
+              })
+            : null;
+        },
       },
       {
         field: 'executionStatus.lastExecutionDate',


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/127702
Depends on https://github.com/elastic/kibana/pull/130721. Once dependent ticket is merged I can open up this PR for review. cc @JiaweiWu

<img width="1367" alt="Screenshot 2022-04-21 at 14 58 45" src="https://user-images.githubusercontent.com/2852703/164466077-f91046f1-6b26-45cb-98b1-fa45a60d2bd5.png">

