### PR TITLE
[WIP] Unify Flyouts in Security Detections

### DIFF
--- a/x-pack/plugins/security_solution/common/ecs/agent/index.ts
+++ b/x-pack/plugins/security_solution/common/ecs/agent/index.ts
@@ -7,4 +7,5 @@
 
 export interface AgentEcs {
   type?: string[];
+  id?: string[];
 }

--- a/x-pack/plugins/security_solution/public/app/app.tsx
+++ b/x-pack/plugins/security_solution/public/app/app.tsx
@@ -15,6 +15,7 @@ import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { AppLeaveHandler, AppMountParameters } from '@kbn/core/public';
 
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
+import { FlyoutProvider } from '../detections/components/flyouts';
 import { ManageUserInfo } from '../detections/components/user_info';
 import { DEFAULT_DARK_MODE, APP_NAME, APP_ID } from '../../common/constants';
 import { ErrorToastDispatcher } from '../common/components/error_toast_dispatcher';
@@ -68,20 +69,22 @@ const StartAppComponent: FC<StartAppComponent> = ({
                 <MlCapabilitiesProvider>
                   <UserPrivilegesProvider kibanaCapabilities={capabilities}>
                     <ManageUserInfo>
-                      <ReactQueryClientProvider>
-                        <CasesContext
-                          owner={[APP_ID]}
-                          userCanCrud={casesPermissions?.crud ?? false}
-                        >
-                          <PageRouter
-                            history={history}
-                            onAppLeave={onAppLeave}
-                            setHeaderActionMenu={setHeaderActionMenu}
+                      <FlyoutProvider>
+                        <ReactQueryClientProvider>
+                          <CasesContext
+                            owner={[APP_ID]}
+                            userCanCrud={casesPermissions?.crud ?? false}
                           >
-                            {children}
-                          </PageRouter>
-                        </CasesContext>
-                      </ReactQueryClientProvider>
+                            <PageRouter
+                              history={history}
+                              onAppLeave={onAppLeave}
+                              setHeaderActionMenu={setHeaderActionMenu}
+                            >
+                              {children}
+                            </PageRouter>
+                          </CasesContext>
+                        </ReactQueryClientProvider>
+                      </FlyoutProvider>
                     </ManageUserInfo>
                   </UserPrivilegesProvider>
                 </MlCapabilitiesProvider>

--- a/x-pack/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/index.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { AppLeaveHandler, AppMountParameters } from '@kbn/core/public';
+import { useSecurityFlyout } from '../../detections/components/flyouts';
 import { DragDropContextWrapper } from '../../common/components/drag_and_drop/drag_drop_context_wrapper';
 import { SecuritySolutionAppWrapper } from '../../common/components/page';
 import { HelpMenu } from '../../common/components/help_menu';
@@ -46,7 +47,7 @@ const HomePageComponent: React.FC<HomePageProps> = ({
   // a background task solution can be built on the server side. Once a background task solution is available we
   // can remove this.
   useUpgradeSecurityPackages();
-
+  const { FlyoutComponent } = useSecurityFlyout();
   return (
     <SecuritySolutionAppWrapper className="kbnAppWrapper">
       <ConsoleManager>
@@ -57,6 +58,7 @@ const HomePageComponent: React.FC<HomePageProps> = ({
             {children}
           </SecuritySolutionTemplateWrapper>
         </DragDropContextWrapper>
+        <FlyoutComponent />
         <HelpMenu />
       </ConsoleManager>
     </SecuritySolutionAppWrapper>

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
@@ -13,7 +13,7 @@ import { connect, ConnectedProps } from 'react-redux';
 import { ExceptionListType } from '@kbn/securitysolution-io-ts-list-types';
 import { get } from 'lodash/fp';
 import { DEFAULT_ACTION_BUTTON_WIDTH } from '@kbn/timelines-plugin/public';
-import { useSecurityFlyout } from '../../flyouts';
+import { FlyoutTypes, useSecurityFlyout } from '../../flyouts';
 import { OsqueryActionItem } from '../../osquery/osquery_action_item';
 import { useRouteSpy } from '../../../../common/utils/route/use_route_spy';
 import { buildGetAlertByIdQuery } from '../../../../common/components/exceptions/helpers';
@@ -132,16 +132,17 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
   const ruleIndex =
     ecsRowData['kibana.alert.rule.parameters']?.index ?? ecsRowData?.signal?.rule?.index;
 
-  const {
-    exceptionFlyoutType,
-    onAddExceptionCancel,
-    onAddExceptionConfirm,
-    onAddExceptionTypeClick,
-    ruleIndices,
-  } = useExceptionFlyout({
+  const { onAddExceptionTypeClick } = useExceptionFlyout({
     ruleIndex,
     refetch: refetchAll,
     timelineId,
+    addExceptionModalWrapperData: {
+      ruleId,
+      ruleName,
+      alertStatus,
+      eventId: ecsRowData?._id,
+      onRuleChange,
+    },
   });
 
   const { onAddEventFilterClick } = useEventFilterModal({ ecsData: ecsRowData });
@@ -183,8 +184,8 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
       OsqueryActionItem({
         handleClick: () => {
           flyoutDispatch({
-            type: 'osquery',
-            payload: { agentId, onClose: () => flyoutDispatch({ type: null }) },
+            type: FlyoutTypes.OSQUERY,
+            payload: { agentId: agentId as string, onClose: () => flyoutDispatch({ type: null }) },
           });
           closePopover();
         },
@@ -233,22 +234,6 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
           </EventsTdContent>
         </div>
       )}
-      {exceptionFlyoutType != null &&
-        ruleId != null &&
-        ruleName != null &&
-        ecsRowData?._id != null && (
-          <AddExceptionFlyoutWrapper
-            ruleName={ruleName}
-            ruleId={ruleId}
-            ruleIndices={ruleIndices}
-            exceptionListType={exceptionFlyoutType}
-            eventId={ecsRowData?._id}
-            onCancel={onAddExceptionCancel}
-            onConfirm={onAddExceptionConfirm}
-            alertStatus={alertStatus}
-            onRuleChange={onRuleChange}
-          />
-        )}
     </>
   );
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_event_filter_modal.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_event_filter_modal.tsx
@@ -25,8 +25,9 @@ export const useEventFilterModal = (props: IProps) => {
       flyoutDispatch({
         type: FlyoutTypes.EVENT_FILTER,
         payload: {
-          closeAddEventFilterModal,
           ...props,
+          closeAddEventFilterModal,
+          ecsData: props.ecsData as Ecs,
         },
       });
     }

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_event_filter_modal.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_event_filter_modal.tsx
@@ -5,17 +5,32 @@
  * 2.0.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
+import { FlyoutTypes, useSecurityFlyout } from '../../flyouts';
+import { Ecs } from '../../../../../common/ecs';
 
-export const useEventFilterModal = () => {
-  const [isAddEventFilterModalOpen, setIsAddEventFilterModalOpen] = useState<boolean>(false);
+interface IProps extends Record<string, unknown> {
+  ecsData: Ecs | null;
+}
+
+export const useEventFilterModal = (props: IProps) => {
+  const { flyoutDispatch } = useSecurityFlyout();
+
+  const closeAddEventFilterModal = useCallback((): void => {
+    flyoutDispatch({ type: null });
+  }, [flyoutDispatch]);
 
   const onAddEventFilterClick = useCallback((): void => {
-    setIsAddEventFilterModalOpen(true);
-  }, []);
-  const closeAddEventFilterModal = useCallback((): void => {
-    setIsAddEventFilterModalOpen(false);
-  }, []);
+    if (props.ecsData != null) {
+      flyoutDispatch({
+        type: FlyoutTypes.EVENT_FILTER,
+        payload: {
+          closeAddEventFilterModal,
+          ...props,
+        },
+      });
+    }
+  }, [closeAddEventFilterModal, flyoutDispatch, props]);
 
-  return { closeAddEventFilterModal, isAddEventFilterModalOpen, onAddEventFilterClick };
+  return { onAddEventFilterClick };
 };

--- a/x-pack/plugins/security_solution/public/detections/components/flyouts/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/flyouts/index.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { noop } from 'lodash/fp';
+import React, { useReducer, Dispatch, createContext, useContext } from 'react';
+import { OsqueryFlyout } from '../osquery/osquery_flyout';
+import { EventFiltersFlyout } from '../../../management/pages/event_filters/view/components/flyout';
+import { Ecs } from '../../../../common/ecs';
+
+type FlyoutType = string;
+
+export interface State {
+  currentFlyout: FlyoutType | null;
+  payload: Record<string, unknown>;
+}
+
+export const initialState: State = {
+  currentFlyout: null,
+  payload: {},
+};
+
+export type Action =
+  | { type: null }
+  | {
+      type: FlyoutTypes.OSQUERY;
+      payload: {
+        agentId: string;
+        onClose: () => void;
+      };
+    }
+  | {
+      type: FlyoutTypes.EVENT_FILTER;
+      payload: {
+        ecsData: Ecs | null;
+        closeAddEventFilterModal: () => void;
+      };
+    };
+
+export enum FlyoutTypes {
+  OSQUERY = 'osquery',
+  EVENT_FILTER = 'event_filter',
+}
+
+export const securityFlyoutReducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case FlyoutTypes.OSQUERY: {
+      return {
+        ...state,
+        currentFlyout: FlyoutTypes.OSQUERY,
+        payload: action.payload,
+      };
+    }
+    case FlyoutTypes.EVENT_FILTER: {
+      return {
+        ...state,
+        currentFlyout: FlyoutTypes.EVENT_FILTER,
+        payload: action.payload,
+      };
+    }
+    default:
+      return {
+        currentFlyout: null,
+        payload: {},
+      };
+  }
+};
+
+const FlyoutContext = createContext<[State, Dispatch<Action>]>([initialState, () => noop]);
+
+export const useFlyoutData = () => useContext(FlyoutContext);
+
+interface ManageUserInfoProps {
+  children: React.ReactNode;
+}
+
+interface ISecurityFlyout {
+  FlyoutComponent: () => JSX.Element | null;
+  flyoutDispatch: Dispatch<Action>;
+}
+
+export const useSecurityFlyout = (): ISecurityFlyout => {
+  const [data, dispatch] = useFlyoutData();
+  const FlyoutComponent = () => {
+    switch (data.currentFlyout) {
+      case FlyoutTypes.OSQUERY:
+        const { agentId, onClose } = data.payload as { agentId: string; onClose: () => void };
+
+        return <OsqueryFlyout agentId={agentId} onClose={onClose} />;
+      case FlyoutTypes.EVENT_FILTER:
+        const { ecs, closeAddEventFilterModal, ...rest } = data.payload as {
+          ecs: Ecs;
+          closeAddEventFilterModal: () => null;
+        };
+
+        return <EventFiltersFlyout data={ecs} onCancel={closeAddEventFilterModal} {...rest} />;
+      default:
+        return null;
+    }
+  };
+  return {
+    FlyoutComponent,
+    flyoutDispatch: dispatch,
+  };
+};
+
+export const FlyoutProvider = ({ children }: ManageUserInfoProps) => (
+  <FlyoutContext.Provider value={useReducer(securityFlyoutReducer, initialState)}>
+    {children}
+  </FlyoutContext.Provider>
+);

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
@@ -223,7 +223,6 @@ export const TakeActionDropdown = React.memo(
         ...(tGridEnabled ? addToCaseActionItems : []),
         ...alertsActionItems,
         ...hostIsolationActionItems,
-        ...eventFilterActionItems,
         ...(osqueryAvailable ? [osqueryActionItem] : []),
         ...investigateInTimelineActionItems,
       ],

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
@@ -223,6 +223,7 @@ export const TakeActionDropdown = React.memo(
         ...(tGridEnabled ? addToCaseActionItems : []),
         ...alertsActionItems,
         ...hostIsolationActionItems,
+        ...eventFilterActionItems,
         ...(osqueryAvailable ? [osqueryActionItem] : []),
         ...investigateInTimelineActionItems,
       ],

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/footer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/footer.tsx
@@ -13,11 +13,12 @@ import { FlyoutTypes, useSecurityFlyout } from '../../../../detections/component
 import { TakeActionDropdown } from '../../../../detections/components/take_action_dropdown';
 import type { TimelineEventsDetailsItem } from '../../../../../common/search_strategy';
 import { TimelineId } from '../../../../../common/types';
-import { useExceptionFlyout } from '../../../../detections/components/alerts_table/timeline_actions/use_add_exception_flyout';
-import { AddExceptionFlyoutWrapper } from '../../../../detections/components/alerts_table/timeline_actions/alert_context_menu';
+import {
+  AddExceptionModalWrapperData,
+  useExceptionFlyout,
+} from '../../../../detections/components/alerts_table/timeline_actions/use_add_exception_flyout';
 import { useEventFilterModal } from '../../../../detections/components/alerts_table/timeline_actions/use_event_filter_modal';
 import { getFieldValue } from '../../../../detections/components/host_isolation/helpers';
-import { Status } from '../../../../../common/detection_engine/schemas/common/schemas';
 import { Ecs } from '../../../../../common/ecs';
 import { inputsModel, inputsSelectors, State } from '../../../../common/store';
 
@@ -35,13 +36,6 @@ interface EventDetailsFooterProps {
   onAddIsolationStatusClick: (action: 'isolateHost' | 'unisolateHost') => void;
   timelineId: string;
   refetchFlyoutData: () => Promise<void>;
-}
-
-interface AddExceptionModalWrapperData {
-  alertStatus: Status;
-  eventId: string;
-  ruleId: string;
-  ruleName: string;
 }
 
 export const EventDetailsFooterComponent = React.memo(
@@ -95,16 +89,11 @@ export const EventDetailsFooterComponent = React.memo(
       }
     }, [timelineId, globalQuery, timelineQuery]);
 
-    const {
-      exceptionFlyoutType,
-      onAddExceptionTypeClick,
-      onAddExceptionCancel,
-      onAddExceptionConfirm,
-      ruleIndices,
-    } = useExceptionFlyout({
+    const { onAddExceptionTypeClick } = useExceptionFlyout({
       ruleIndex,
       refetch: refetchAll,
       timelineId,
+      addExceptionModalWrapperData,
     });
     const { onAddEventFilterClick } = useEventFilterModal({
       ecsData: detailsEcsData,
@@ -151,20 +140,6 @@ export const EventDetailsFooterComponent = React.memo(
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlyoutFooter>
-        {/* This is still wrong to do render flyout/modal inside of the flyout
-        We need to completely refactor the EventDetails  component to be correct
-      */}
-        {exceptionFlyoutType != null &&
-          addExceptionModalWrapperData.ruleId != null &&
-          addExceptionModalWrapperData.eventId != null && (
-            <AddExceptionFlyoutWrapper
-              {...addExceptionModalWrapperData}
-              ruleIndices={ruleIndices}
-              exceptionListType={exceptionFlyoutType}
-              onCancel={onAddExceptionCancel}
-              onConfirm={onAddExceptionConfirm}
-            />
-          )}
       </>
     );
   }

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/helpers/constants.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/helpers/constants.ts
@@ -94,6 +94,7 @@ export const TIMELINE_EVENTS_FIELDS = [
   'event.timezone',
   'event.type',
   'agent.type',
+  'agent.id',
   'auditd.result',
   'auditd.session',
   'auditd.data.acct',


### PR DESCRIPTION
## Summary
Hey folks. Recently I added Osquery to take_action_dropdown in Alerts and Timelines. Later on when I realized that there is also the very similar dropdown in a context menu (each row) I found it extremely confusing to understand how the Flyouts are being handled. It seems that each flyout has its completely own and different logic, most of the times duplicated rendering logic. 

The idea behind this PR is somehow to unify this, and create one single place to handle Flyouts in Alerts view (possibly even wider). It's kind of a Proof of Concept so far, I would appreciate any feedback or any other ideas on how to tackle this if you've given it more thoughts already (I am still quite new to the project), before I invest too much time into it. Any code/solution improvements are welcome :) 

Another step would be to refactor EventDetails component.

So far useSecurityFlyout handles 3 flyouts, but I believe we can move all of them in here. 

Big thanks in advance :)



