### PR TITLE
[8.2] [DOCS] Fix section titles in Cases APIs (#130737)

### DIFF
--- a/docs/api/cases/cases-api-add-comment.asciidoc
+++ b/docs/api/cases/cases-api-add-comment.asciidoc
@@ -6,21 +6,20 @@
 
 Adds a comment to a case.
 
-=== Request
+=== {api-request-title}
 
 `POST <kibana host>:<port>/api/cases/<case_id>/comments`
 
 `POST <kibana host>:<port>/s/<space_id>/api/cases/<case_id>/comments`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `all` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the case you're updating.
 
-
-=== Path parameters
+=== {api-path-parms-title}
 
 `<case_id>`::
 (Required,string) The identifier for the case. To retrieve case IDs, use
@@ -30,7 +29,7 @@ You must have `all` privileges for the *Cases* feature in the *Management*,
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Request body
+=== {api-request-body-title}
 
 `alertId`::
 (Required*, string) The alert identifier. It is required only when `type` is
@@ -65,12 +64,12 @@ only when `type` is `alert`. preview:[]
 `type`::
 (Required, string) The comment type, which must be `user` or `alert`.
 
-=== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-=== Example
+=== {api-examples-title}
 
 Add a comment to case ID `293f1bc0-74f6-11ea-b83a-553aecdb28b6`:
 

--- a/docs/api/cases/cases-api-create.asciidoc
+++ b/docs/api/cases/cases-api-create.asciidoc
@@ -6,26 +6,26 @@
 
 Creates a case.
 
-=== Request
+=== {api-request-title}
 
 `POST <kibana host>:<port>/api/cases`
 
 `POST <kibana host>:<port>/s/<space_id>/api/cases`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `all` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the case you're creating.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<space_id>`::
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Request body
+=== {api-request-body-title}
 
 `connector`::
 (Required, object) An object that contains the connector configuration.
@@ -107,8 +107,8 @@ For {swimlane} connectors, specify:
 
 `id`::
 (Required, string) The identifier for the connector. To create a case without a
-connector, use `none`.
-//To retrieve connector IDs, use <<cases-api-find-connectors>>).
+connector, use `none`. To retrieve connector IDs, use
+<<cases-api-find-connectors>>.
 
 `name`::
 (Required, string) The name of the connector. To create a case without a
@@ -147,12 +147,12 @@ categorize cases. It can be an empty array.
 `title`::
 (Required, string) A title for the case.
 
-=== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-=== Example
+=== {api-examples-title}
 
 [source,sh]
 --------------------------------------------------

--- a/docs/api/cases/cases-api-delete-cases.asciidoc
+++ b/docs/api/cases/cases-api-delete-cases.asciidoc
@@ -6,26 +6,26 @@
 
 Deletes one or more cases.
 
-=== Request
+=== {api-request-title}
 
 `DELETE <kibana host>:<port>/api/cases?ids=["<case ID1>","<case ID2>"]`
 
 `DELETE <kibana host>:<port>/s/<space_id>/api/cases?ids=["<case ID1>","<case ID2>"]`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `all` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're deleting.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<space_id>`::
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Query parameters
+=== {api-query-parms-title}
 
 `ids`::
 (Required, string) The cases that you want to remove. To retrieve case IDs, use
@@ -33,12 +33,12 @@ default space is used.
 +
 NOTE: All non-ASCII characters must be URL encoded.
 
-==== Response code
+=== {api-response-codes-title}
 
 `204`::
    Indicates a successful call.
 
-=== Example
+=== {api-examples-title}
 
 Delete cases with these IDs:
 

--- a/docs/api/cases/cases-api-delete-comments.asciidoc
+++ b/docs/api/cases/cases-api-delete-comments.asciidoc
@@ -6,7 +6,7 @@
 
 Deletes one or all comments from a case.
 
-=== Request
+=== {api-request-title}
 
 `DELETE <kibana host>:<port>/api/cases/<case_id>/comments`
 
@@ -16,14 +16,14 @@ Deletes one or all comments from a case.
 
 `DELETE <kibana host>:<port>/s/<space_id>/api/cases/<case_id>/comments/<comment_id>`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `all` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're updating.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<case_id>`::
 (Required, string) The identifier for the case. To retrieve case IDs, use
@@ -38,12 +38,12 @@ comments are deleted.
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Response code
+=== {api-response-codes-title}
 
 `204`::
    Indicates a successful call.
 
-=== Example
+=== {api-examples-title}
 
 Delete all comments from case ID `9c235210-6834-11ea-a78c-6ffb38a34414`:
 

--- a/docs/api/cases/cases-api-find-cases.asciidoc
+++ b/docs/api/cases/cases-api-find-cases.asciidoc
@@ -6,26 +6,26 @@
 
 Retrieves a paginated subset of cases.
 
-=== Request
+=== {api-request-title}
 
 `GET <kibana host>:<port>/api/cases/_find`
 
 `GET <kibana host>:<port>/s/<space_id>/api/cases/_find`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `read` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're seeking.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<space_id>`::
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Query parameters
+=== {api-query-parms-title}
 
 `defaultSearchOperator`::
 (Optional, string) The default operator to use for the `simple_query_string`.
@@ -78,12 +78,12 @@ Defaults to `desc`.
 `tags`::
 (Optional, string or array of strings) Filters the returned cases by tags.
 
-=== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-=== Example
+=== {api-examples-title}
 
 Retrieve the first five cases with the `phishing` tag, in ascending order by
 last update time:

--- a/docs/api/cases/cases-api-find-connectors.asciidoc
+++ b/docs/api/cases/cases-api-find-connectors.asciidoc
@@ -10,30 +10,30 @@ In particular, only the connectors that are supported for use in cases are
 returned. Refer to the list of supported external incident management systems in
 <<add-case-connectors>>.
 
-=== Request
+=== {api-request-title}
 
 `GET <kibana host>:<port>/api/cases/configure/connectors/_find`
 
 `GET <kibana host>:<port>/s/<space_id>/api/cases/configure/connectors/_find`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `read` privileges for the *Actions and Connectors* feature in the
 *Management* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<space_id>`::
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-=== Example
+=== {api-examples-title}
 
 [source,sh]
 --------------------------------------------------

--- a/docs/api/cases/cases-api-get-alerts.asciidoc
+++ b/docs/api/cases/cases-api-get-alerts.asciidoc
@@ -36,7 +36,7 @@ default space is used.
 `200`::
    Indicates a successful call.
 
-=== {api-example-title}
+=== {api-examples-title}
 
 Return all alerts attached to case `293f1bc0-74f6-11ea-b83a-553aecdb28b6`:
 

--- a/docs/api/cases/cases-api-get-case-activity.asciidoc
+++ b/docs/api/cases/cases-api-get-case-activity.asciidoc
@@ -8,20 +8,20 @@ Returns all user activity for the specified case.
 
 deprecated::[8.1.0]
 
-=== Request
+=== {api-request-title}
 
 `GET <kibana host>:<port>/api/cases/<case ID>/user_actions`
 
 `GET <kibana host>:<port>/s/<space_id>/api/cases/<case ID>/user_actions`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `read` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're seeking.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<case_id>`::
 (Required, string) An identifier for the case to retrieve. Use 
@@ -31,12 +31,12 @@ You must have `read` privileges for the *Cases* feature in the *Management*,
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-==== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-==== Example
+=== {api-examples-title}
 
 Gets all activity for case ID `a18b38a0-71b0-11ea-a0b2-c51ea50a58e2`:
 

--- a/docs/api/cases/cases-api-get-case.asciidoc
+++ b/docs/api/cases/cases-api-get-case.asciidoc
@@ -6,20 +6,20 @@
 
 Returns a specified case.
 
-=== Request
+=== {api-request-title}
 
 `GET <kibana host>:<port>/api/cases/<case ID>`
 
 `GET <kibana host>:<port>/s/<space_id>/api/cases/<case ID>`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `read` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're seeking.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<case_id>`::
 (Required, string) An identifier for the case to retrieve. Use 
@@ -29,19 +29,18 @@ You must have `read` privileges for the *Cases* feature in the *Management*,
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Query parameters
+=== {api-query-parms-title}
 
 `includeComments`::
 (Optional, boolean) Determines whether case comments are returned. Defaults to 
 `true`. deprecated:[8.1.0, "The `includeComments` query parameter is deprecated and will be removed in a future release."]
 
-
-==== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-==== Example
+=== {api-examples-title}
 
 Returns case ID `a18b38a0-71b0-11ea-a0b2-c51ea50a58e2` without comments:
 

--- a/docs/api/cases/cases-api-get-cases-by-alert.asciidoc
+++ b/docs/api/cases/cases-api-get-cases-by-alert.asciidoc
@@ -43,7 +43,7 @@ cases that the user has access to read.
 `200`::
    Indicates a successful call.
 
-=== {api-example-title}
+=== {api-examples-title}
 
 Return cases associated with the alert ID
 `09f0c261e39e36351d75995b78bb83673774d1bc2cca9df2d15f0e5c0a99a540`:

--- a/docs/api/cases/cases-api-get-comments.asciidoc
+++ b/docs/api/cases/cases-api-get-comments.asciidoc
@@ -6,7 +6,7 @@
 
 Gets a comment or all comments for a case.
 
-=== Request
+=== {api-request-title}
 
 `GET <kibana host>:<port>/api/cases/<case ID>/comments/<comment ID>`
 
@@ -16,14 +16,14 @@ Gets a comment or all comments for a case.
 
 `GET <kibana host>:<port>/s/<space_id>/api/cases/<case_id>/comments` deprecated:[8.1.0]
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `read` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases with the comments you're seeking.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<case_id>`::
 (Required, string) The identifier for the case. To retrieve case IDs, use 
@@ -40,12 +40,12 @@ deprecated:[8.1.0,The comment identifier will no longer be optional.]
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-=== Example
+=== {api-examples-title}
 
 Retrieves comment ID `71ec1870-725b-11ea-a0b2-c51ea50a58e2` from case ID
 `a18b38a0-71b0-11ea-a0b2-c51ea50a58e2`:

--- a/docs/api/cases/cases-api-get-reporters.asciidoc
+++ b/docs/api/cases/cases-api-get-reporters.asciidoc
@@ -6,32 +6,32 @@
 
 Returns information about the users who opened cases.
 
-=== Request
+=== {api-request-title}
 
 `GET <kibana host>:<port>/api/cases/reporters`
 
 `GET <kibana host>:<port>/s/api/cases/reporters`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `read` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're seeking.
 
-=== Query parameters
+=== {api-query-parms-title}
 
 `owner`::
 (Optional, string or array of strings) A filter to limit the retrieved reporters 
 to a specific set of applications. If this parameter is omitted, the response 
 will contain all reporters from cases that the user has access to read.
 
-==== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-==== Example
+=== {api-examples-title}
 
 Returns all case reporters:
 

--- a/docs/api/cases/cases-api-get-status.asciidoc
+++ b/docs/api/cases/cases-api-get-status.asciidoc
@@ -8,26 +8,26 @@ Returns the number of cases that are open, closed, and in progress.
 
 deprecated::[8.1.0]
 
-=== Request
+=== {api-request-title}
 
 `GET <kibana host>:<port>/api/cases/status`
 
 `GET <kibana host>:<port>/s/<space_id>/api/cases/status`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `read` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're seeking.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 <space_id>::
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Query parameters
+=== {api-query-parms-title}
 
 `owner`::
 (Optional, string or array of strings) A filter to limit the retrieved case
@@ -35,12 +35,12 @@ statistics to a specific set of applications. Valid values are: `cases`,
 `observability`, and `securitySolution`. If this parameter is omitted, the
 response contains all cases that the user has access to read.
 
-=== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-=== Example
+=== {api-examples-title}
 
 [source,sh]
 --------------------------------------------------

--- a/docs/api/cases/cases-api-get-tags.asciidoc
+++ b/docs/api/cases/cases-api-get-tags.asciidoc
@@ -6,38 +6,38 @@
 
 Aggregates and returns a list of case tags.
 
-=== Request
+=== {api-request-title}
 
 `GET <kibana host>:<port>/api/cases/tags`
 
 `GET <kibana host>:<port>/s/<space_id>/api/cases/tags`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `read` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're seeking.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<space_id>`::
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Query parameters
+=== {api-query-parms-title}
 
 `owner`::
 (Optional, string or array of strings) A filter to limit the retrieved tags to a specific set of applications.
 Valid values are: `cases`, `observability`, and `securitySolution`. If this parameter is omitted, the response
 contains tags from all cases that the user has access to read.
 
-==== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-==== Example
+=== {api-examples-title}
 
 [source,sh]
 --------------------------------------------------

--- a/docs/api/cases/cases-api-push.asciidoc
+++ b/docs/api/cases/cases-api-push.asciidoc
@@ -40,7 +40,7 @@ default space is used.
 `200`::
    Indicates a successful call.
 
-=== {api-example-title}
+=== {api-examples-title}
 
 Push the case to an external service:
 

--- a/docs/api/cases/cases-api-set-configuration.asciidoc
+++ b/docs/api/cases/cases-api-set-configuration.asciidoc
@@ -99,7 +99,7 @@ An object that contains the case settings.
 `200`::
    Indicates a successful call.
 
-=== {api-example-title}
+=== {api-examples-title}
 
 Sets the closure type and default connector for cases in **{stack-manage-app}**:
 

--- a/docs/api/cases/cases-api-update-comment.asciidoc
+++ b/docs/api/cases/cases-api-update-comment.asciidoc
@@ -6,20 +6,20 @@
 
 Updates a comment in a case.
 
-=== Request
+=== {api-request-title}
 
 `PATCH <kibana host>:<port>/api/cases/<case_id>/comments`
 
 `PATCH <kibana host>:<port>/s/<space_id>/api/cases/<case_id>/comments`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `all` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the case you're updating.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<case_id>`::
 The identifier for the case. To retrieve case IDs, use
@@ -29,7 +29,7 @@ The identifier for the case. To retrieve case IDs, use
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Request body
+=== {api-request-body-title}
 
 `alertId`::
 (Required*, string) The identifier for the alert. It is required only when
@@ -40,8 +40,7 @@ default space is used.
 `user`.
 
 `id`::
-(Required, string) The identifier for the comment.
-//To retrieve comment IDs, use <<cases-api-get-all-case-comments>>.
+(Required, string) The identifier for the comment. To retrieve comment IDs, use <<cases-api-get-comments>>.
 
 `index`::
 (Required*, string) The alert index. It is required only when `type` is `alert`.
@@ -75,15 +74,14 @@ The rule that is associated with the alert. It is required only when `type` is
 NOTE: You cannot change the comment type.
 
 `version`::
-(Required, string) The current comment version.
-//To retrieve version values, use <<cases-api-get-all-case-comments>>.
+(Required, string) The current comment version. To retrieve version values, use <<cases-api-get-comments>>.
 
-=== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-=== Example
+=== {api-examples-title}
 
 Update comment ID `8af6ac20-74f6-11ea-b83a-553aecdb28b6` (associated with case
 ID `293f1bc0-74f6-11ea-b83a-553aecdb28b6`):

--- a/docs/api/cases/cases-api-update.asciidoc
+++ b/docs/api/cases/cases-api-update.asciidoc
@@ -6,26 +6,26 @@
 
 Updates one or more cases.
 
-=== Request
+=== {api-request-title}
 
 `PATCH <kibana host>:<port>/api/cases`
 
 `PATCH <kibana host>:<port>/s/<space_id>/api/cases`
 
-=== Prerequisite
+=== {api-prereq-title}
 
 You must have `all` privileges for the *Cases* feature in the *Management*,
 *{observability}*, or *Security* section of the
 <<kibana-feature-privileges,{kib} feature privileges>>, depending on the
 `owner` of the cases you're updating.
 
-=== Path parameters
+=== {api-path-parms-title}
 
 `<space_id>`::
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
-=== Request body
+=== {api-request-body-title}
 
 `cases`::
 (Required, array of objects) Array containing one or more case objects.
@@ -114,8 +114,7 @@ For {swimlane} connectors, specify:
 
 `id`::
 (Required, string) The identifier for the connector. To remove the connector,
-use `none`.
-//To retrieve connector IDs, use <<cases-api-find-connectors>>).
+use `none`. To retrieve connector IDs, use <<cases-api-find-connectors>>).
 
 `name`::
 (Required, string) The name of the connector. To remove the connector, use
@@ -159,12 +158,12 @@ and `open`.
 (Required, string) The current version of the case. To determine this value, use <<cases-api-get-case>> or <<cases-api-find-cases>>.
 ====
 
-=== Response code
+=== {api-response-codes-title}
 
 `200`::
    Indicates a successful call.
 
-=== Example
+=== {api-examples-title}
 
 Update the description, tags, and connector of case ID
 `a18b38a0-71b0-11ea-a0b2-c51ea50a58e2`:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[DOCS] Fix section titles in Cases APIs (#130737)](https://github.com/elastic/kibana/pull/130737)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)