### PR TITLE
[Fleet] Fix aligment logstash copy API key tooltip

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/logstash_instructions/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/logstash_instructions/index.tsx
@@ -111,10 +111,11 @@ const LogstashInstructionSteps = () => {
               <EuiCodeBlock paddingSize="m">
                 <h5>API Key</h5>
                 {logstashApiKey.apiKey}
-                <EuiCopy textToCopy={logstashApiKey.apiKey}>
-                  {(copy) => (
-                    <div className="euiCodeBlock__controls">
-                      <div className="euiCodeBlock__copyButton">
+
+                <div className="euiCodeBlock__controls">
+                  <div className="euiCodeBlock__copyButton">
+                    <EuiCopy textToCopy={logstashApiKey.apiKey}>
+                      {(copy) => (
                         <EuiButtonIcon
                           onClick={copy}
                           iconType="copyClipboard"
@@ -126,10 +127,10 @@ const LogstashInstructionSteps = () => {
                             }
                           )}
                         />
-                      </div>
-                    </div>
-                  )}
-                </EuiCopy>
+                      )}
+                    </EuiCopy>
+                  </div>
+                </div>
               </EuiCodeBlock>
             ) : (
               <EuiButton


### PR DESCRIPTION
## Summary

Resolve #130780

The tooltip `Copied` when copying the logstash API key was not correctly aligned.

### UI Changes

<img width="590" alt="Screen Shot 2022-04-21 at 1 15 39 PM" src="https://user-images.githubusercontent.com/1336873/164515377-eb9c2dd3-d70f-44eb-bb9c-5435690d84ca.png">
