### PR TITLE
[jest] try running unit tests in parallel

### DIFF
--- a/.buildkite/scripts/steps/test/jest_parallel.sh
+++ b/.buildkite/scripts/steps/test/jest_parallel.sh
@@ -10,10 +10,17 @@ JOB_COUNT=$BUILDKITE_PARALLEL_JOB_COUNT
 i=0
 exitCode=0
 
+# run unit tests in parallel
+if [[ "$1" == 'jest.config.js' ]]; then
+  parallelism="-w2"
+else
+  parallelism="--runInBand"
+fi
+
 while read -r config; do
   if [ "$((i % JOB_COUNT))" -eq "$JOB" ]; then
     echo "--- $ node scripts/jest --config $config"
-    node --max-old-space-size=14336 ./scripts/jest --config="$config" --runInBand --coverage=false --passWithNoTests
+    node --max-old-space-size=14336 ./scripts/jest --config="$config" "$parallelism" --coverage=false --passWithNoTests
     lastCode=$?
 
     if [ $lastCode -ne 0 ]; then

--- a/packages/kbn-cli-dev-mode/src/dev_server.test.ts
+++ b/packages/kbn-cli-dev-mode/src/dev_server.test.ts
@@ -72,6 +72,7 @@ const defaultOptions: Options = {
   processExit$,
   sigint$,
   sigterm$,
+  forceColor: true,
 };
 
 expect.addSnapshotSerializer(extendedEnvSerializer);
@@ -80,7 +81,6 @@ beforeEach(() => {
   jest.clearAllMocks();
   log.messages.length = 0;
   process.execArgv = ['--inheritted', '--exec', '--argv'];
-  process.env.FORCE_COLOR = process.env.FORCE_COLOR || '1';
   currentProc = undefined;
 });
 

--- a/packages/kbn-cli-dev-mode/src/dev_server.ts
+++ b/packages/kbn-cli-dev-mode/src/dev_server.ts
@@ -144,109 +144,107 @@ export class DevServer {
       })
     );
 
+    const serverOptions = {
+      script: this.script,
+      argv: this.argv,
+      forceColor: this.forceColor,
+    };
     const runServer = () =>
-      usingServerProcess(
-        {
-          script: this.script,
-          argv: this.argv,
-          forceColor: this.forceColor,
-        },
-        (proc) => {
-          this.phase$.next('starting');
-          this.ready$.next(false);
+      usingServerProcess(serverOptions, (proc) => {
+        this.phase$.next('starting');
+        this.ready$.next(false);
 
-          // observable which emits devServer states containing lines
-          // logged to stdout/stderr, completes when stdio streams complete
-          const log$ = Rx.merge(observeLines(proc.stdout!), observeLines(proc.stderr!)).pipe(
-            tap((observedLine) => {
-              const line = this.mapLogLine ? this.mapLogLine(observedLine) : observedLine;
-              if (line !== null) {
-                this.log.write(line);
+        // observable which emits devServer states containing lines
+        // logged to stdout/stderr, completes when stdio streams complete
+        const log$ = Rx.merge(observeLines(proc.stdout!), observeLines(proc.stderr!)).pipe(
+          tap((observedLine) => {
+            const line = this.mapLogLine ? this.mapLogLine(observedLine) : observedLine;
+            if (line !== null) {
+              this.log.write(line);
+            }
+          })
+        );
+
+        // observable which emits exit states and is the switch which
+        // ends all other merged observables
+        const exit$ = Rx.fromEvent<[number]>(proc, 'exit').pipe(
+          tap(([code]) => {
+            this.ready$.next(false);
+
+            if (code != null && code !== 0) {
+              this.phase$.next('fatal exit');
+              if (this.watcher.enabled) {
+                this.log.bad(`server crashed`, 'with status code', code);
+              } else {
+                throw new Error(`server crashed with exit code [${code}]`);
               }
-            })
-          );
+            }
+          }),
+          take(1),
+          share()
+        );
 
-          // observable which emits exit states and is the switch which
-          // ends all other merged observables
-          const exit$ = Rx.fromEvent<[number]>(proc, 'exit').pipe(
-            tap(([code]) => {
-              this.ready$.next(false);
+        // throw errors if spawn fails
+        const error$ = Rx.fromEvent<Error>(proc, 'error').pipe(
+          map((error) => {
+            throw error;
+          }),
+          takeUntil(exit$)
+        );
 
-              if (code != null && code !== 0) {
-                this.phase$.next('fatal exit');
-                if (this.watcher.enabled) {
-                  this.log.bad(`server crashed`, 'with status code', code);
-                } else {
-                  throw new Error(`server crashed with exit code [${code}]`);
-                }
-              }
-            }),
-            take(1),
-            share()
-          );
+        // handles messages received from the child process
+        const msg$ = Rx.fromEvent<[any]>(proc, 'message').pipe(
+          tap(([received]) => {
+            if (!Array.isArray(received)) {
+              return;
+            }
 
-          // throw errors if spawn fails
-          const error$ = Rx.fromEvent<Error>(proc, 'error').pipe(
-            map((error) => {
-              throw error;
-            }),
-            takeUntil(exit$)
-          );
+            const msg = received[0];
 
-          // handles messages received from the child process
-          const msg$ = Rx.fromEvent<[any]>(proc, 'message').pipe(
-            tap(([received]) => {
-              if (!Array.isArray(received)) {
-                return;
-              }
+            if (msg === 'SERVER_LISTENING') {
+              this.phase$.next('listening');
+              this.ready$.next(true);
+            }
 
-              const msg = received[0];
+            // TODO: remove this once Pier is done migrating log rotation to KP
+            if (msg === 'RELOAD_LOGGING_CONFIG_FROM_SERVER_WORKER') {
+              // When receive that event from server worker
+              // forward a reloadLoggingConfig message to parent
+              // and child proc. This is only used by LogRotator service
+              // when the cluster mode is enabled
+              process.emit('message' as any, { reloadLoggingConfig: true } as any);
+              proc.send({ reloadLoggingConfig: true });
+            }
+          }),
+          takeUntil(exit$)
+        );
 
-              if (msg === 'SERVER_LISTENING') {
-                this.phase$.next('listening');
-                this.ready$.next(true);
-              }
+        // handle graceful shutdown requests
+        const triggerGracefulShutdown$ = gracefulShutdown$.pipe(
+          mergeMap(() => {
+            // signal to the process that it should exit
+            proc.kill('SIGINT');
 
-              // TODO: remove this once Pier is done migrating log rotation to KP
-              if (msg === 'RELOAD_LOGGING_CONFIG_FROM_SERVER_WORKER') {
-                // When receive that event from server worker
-                // forward a reloadLoggingConfig message to parent
-                // and child proc. This is only used by LogRotator service
-                // when the cluster mode is enabled
-                process.emit('message' as any, { reloadLoggingConfig: true } as any);
-                proc.send({ reloadLoggingConfig: true });
-              }
-            }),
-            takeUntil(exit$)
-          );
+            // if the timer fires before exit$ we will send SIGINT
+            return Rx.timer(this.gracefulTimeout).pipe(
+              tap(() => {
+                this.log.warn(
+                  `server didnt exit`,
+                  `sent [SIGINT] to the server but it didn't exit within ${this.gracefulTimeout}ms, killing with SIGKILL`
+                );
 
-          // handle graceful shutdown requests
-          const triggerGracefulShutdown$ = gracefulShutdown$.pipe(
-            mergeMap(() => {
-              // signal to the process that it should exit
-              proc.kill('SIGINT');
+                proc.kill('SIGKILL');
+              })
+            );
+          }),
 
-              // if the timer fires before exit$ we will send SIGINT
-              return Rx.timer(this.gracefulTimeout).pipe(
-                tap(() => {
-                  this.log.warn(
-                    `server didnt exit`,
-                    `sent [SIGINT] to the server but it didn't exit within ${this.gracefulTimeout}ms, killing with SIGKILL`
-                  );
+          // if exit$ emits before the gracefulTimeout then this
+          // will unsub and cancel the timer
+          takeUntil(exit$)
+        );
 
-                  proc.kill('SIGKILL');
-                })
-              );
-            }),
-
-            // if exit$ emits before the gracefulTimeout then this
-            // will unsub and cancel the timer
-            takeUntil(exit$)
-          );
-
-          return Rx.merge(log$, exit$, error$, msg$, triggerGracefulShutdown$);
-        }
-      );
+        return Rx.merge(log$, exit$, error$, msg$, triggerGracefulShutdown$);
+      });
 
     subscriber.add(
       Rx.concat([undefined], this.watcher.serverShouldRestart$())

--- a/packages/kbn-cli-dev-mode/src/using_server_process.ts
+++ b/packages/kbn-cli-dev-mode/src/using_server_process.ts
@@ -18,14 +18,19 @@ interface ProcResource extends Rx.Unsubscribable {
   unsubscribe(): void;
 }
 
+interface Options {
+  script: string;
+  argv: string[];
+  forceColor: boolean;
+}
+
 export function usingServerProcess<T>(
-  script: string,
-  argv: string[],
+  options: Options,
   fn: (proc: execa.ExecaChildProcess) => Rx.Observable<T>
 ) {
   return Rx.using(
     (): ProcResource => {
-      const proc = execa.node(script, argv, {
+      const proc = execa.node(options.script, options.argv, {
         stdio: 'pipe',
         nodeOptions: [
           ...process.execArgv,
@@ -36,7 +41,7 @@ export function usingServerProcess<T>(
           NODE_OPTIONS: process.env.NODE_OPTIONS,
           isDevCliChild: 'true',
           ELASTIC_APM_SERVICE_NAME: 'kibana',
-          ...(process.stdout.isTTY ? { FORCE_COLOR: 'true' } : {}),
+          ...(options.forceColor ? { FORCE_COLOR: 'true' } : {}),
         },
       });
 

--- a/src/cli_encryption_keys/encryption_config.test.js
+++ b/src/cli_encryption_keys/encryption_config.test.js
@@ -14,7 +14,7 @@ describe('encryption key configuration', () => {
   let encryptionConfig = null;
 
   beforeEach(() => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue('xpack.security.encryptionKey: foo');
+    jest.spyOn(fs, 'readFileSync').mockReturnValueOnce('xpack.security.encryptionKey: foo');
     jest.spyOn(crypto, 'randomBytes').mockReturnValue('random-key');
     encryptionConfig = new EncryptionConfig();
   });


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/128700 slowed down Jest tests a little, leading them to be the longest part of the build. This PR re-enables Jest workers, running two tests at a time so that we can utilize more of the cores available on the worker. Reducing the worker size to 2 cores extends the job time substantially, so we are sticking with n2-4 machines. Running two workers at a time reduces the Jest execution time to about 42 minutes which leaves plenty of time for other tasks to be the slowest.