### PR TITLE
[Security Solution][Detections] Fix rule creation/editing forms

### DIFF
--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
@@ -660,6 +660,15 @@ export function useForm<T extends FormData = FormData, I extends FormData = T>(
   // -- EFFECTS
   // ----------------------------------
   useEffect(() => {
+    if (!isMounted.current) {
+      return;
+    }
+
+    // Whenever the "defaultValue" prop changes, reinitialize our ref
+    defaultValueDeserialized.current = defaultValueInitialized;
+  }, [defaultValueInitialized]);
+
+  useEffect(() => {
     isMounted.current = true;
 
     return () => {

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
@@ -26,12 +26,12 @@ import {
   SHOWING_RULES_TEXT,
 } from '../../screens/alerts_detection_rules';
 import {
-  // ABOUT_CONTINUE_BTN,
-  // ABOUT_EDIT_BUTTON,
+  ABOUT_CONTINUE_BTN,
+  ABOUT_EDIT_BUTTON,
   ACTIONS_THROTTLE_INPUT,
   CUSTOM_QUERY_INPUT,
-  // DEFINE_CONTINUE_BUTTON,
-  // DEFINE_EDIT_BUTTON,
+  DEFINE_CONTINUE_BUTTON,
+  DEFINE_EDIT_BUTTON,
   DEFINE_INDEX_INPUT,
   DEFAULT_RISK_SCORE_INPUT,
   RULE_DESCRIPTION_INPUT,
@@ -134,7 +134,6 @@ describe('Custom query rules', () => {
       fillAboutRuleAndContinue(this.rule);
       fillScheduleRuleAndContinue(this.rule);
 
-      /* Commenting this piece of code due to the following issue: https://github.com/elastic/kibana/issues/130767
       // expect define step to repopulate
       cy.get(DEFINE_EDIT_BUTTON).click();
       cy.get(CUSTOM_QUERY_INPUT).should('have.value', this.rule.customQuery);
@@ -145,7 +144,7 @@ describe('Custom query rules', () => {
       cy.get(ABOUT_EDIT_BUTTON).click();
       cy.get(RULE_NAME_INPUT).invoke('val').should('eql', this.rule.name);
       cy.get(ABOUT_CONTINUE_BTN).should('exist').click({ force: true });
-      cy.get(ABOUT_CONTINUE_BTN).should('not.exist');  */
+      cy.get(ABOUT_CONTINUE_BTN).should('not.exist');
 
       createAndEnableRule();
 

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
@@ -178,13 +178,11 @@ describe('indicator match', () => {
           selectIndicatorMatchType();
         });
 
-        // Unskip once https://github.com/elastic/kibana/issues/130770 is fixed
-        it.skip('Has a default set of *:*', () => {
+        it('Has a default set of *:*', () => {
           getCustomQueryInput().should('have.text', '*:*');
         });
 
-        // Unskip once https://github.com/elastic/kibana/issues/1307707 is fixed
-        it.skip('Shows invalidation text if text is removed', () => {
+        it('Shows invalidation text if text is removed', () => {
           getCustomQueryInput().type('{selectall}{del}');
           getCustomQueryInvalidationText().should('exist');
         });
@@ -401,8 +399,7 @@ describe('indicator match', () => {
       });
 
       describe('Schedule', () => {
-        // Unskip once https://github.com/elastic/kibana/issues/1307707 is fixed
-        it.skip('IM rule has 1h time interval and lookback by default', () => {
+        it('IM rule has 1h time interval and lookback by default', () => {
           visitWithoutDateRange(RULE_CREATION);
           selectIndicatorMatchType();
           fillDefineIndicatorMatchRuleAndContinue(getNewThreatIndicatorRule());
@@ -421,8 +418,7 @@ describe('indicator match', () => {
         deleteAlertsAndRules();
       });
 
-      // Unskip once https://github.com/elastic/kibana/issues/1307707 is fixed
-      it.skip('Creates and enables a new Indicator Match rule', () => {
+      it('Creates and enables a new Indicator Match rule', () => {
         visitWithoutDateRange(RULE_CREATION);
         selectIndicatorMatchType();
         fillDefineIndicatorMatchRuleAndContinue(getNewThreatIndicatorRule());

--- a/x-pack/plugins/security_solution/public/detections/components/rules/eql_query_bar/eql_query_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/eql_query_bar/eql_query_bar.tsx
@@ -94,6 +94,7 @@ export const EqlQueryBar: FC<EqlQueryBarProps> = ({
           query: newQuery,
           language: 'eql',
         },
+        saved_id: null,
       });
     },
     [setValue, onValiditingChange]

--- a/x-pack/plugins/security_solution/public/detections/components/rules/query_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/query_bar/index.tsx
@@ -29,7 +29,7 @@ import * as i18n from './translations';
 export interface FieldValueQueryBar {
   filters: Filter[];
   query: Query;
-  saved_id?: string;
+  saved_id: string | null;
 }
 interface QueryBarDefineRuleProps {
   browserFields: BrowserFields;
@@ -176,7 +176,7 @@ export const QueryBarDefineRule = ({
               query: '',
               language: 'kuery',
             },
-            saved_id: undefined,
+            saved_id: null,
           });
         }
       }
@@ -210,7 +210,7 @@ export const QueryBarDefineRule = ({
             ? [...newFilters, getDataProviderFilter(dataProvidersDsl)]
             : newFilters,
         query: newQuery,
-        saved_id: undefined,
+        saved_id: null,
       });
     },
     [browserFields, indexPattern, setFieldValue]

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/helpers.test.ts
@@ -75,7 +75,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -91,7 +91,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -107,7 +107,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -123,7 +123,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -137,7 +137,7 @@ describe('query_preview/helpers', () => {
         threatIndex: ['threat-*'],
         threatMapping: [],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -151,7 +151,7 @@ describe('query_preview/helpers', () => {
         threatIndex: ['threat-*'],
         threatMapping: [],
         machineLearningJobId: [],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -165,7 +165,7 @@ describe('query_preview/helpers', () => {
         threatIndex: ['threat-*'],
         threatMapping: [],
         machineLearningJobId: [],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -181,7 +181,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(false);
     });
@@ -195,7 +195,11 @@ describe('query_preview/helpers', () => {
         threatIndex: ['threat-*'],
         threatMapping: [],
         machineLearningJobId: [],
-        queryBar: { filters: [], query: { query: 'any where true', language: 'testlang' } },
+        queryBar: {
+          filters: [],
+          query: { query: 'any where true', language: 'testlang' },
+          saved_id: null,
+        },
       });
       expect(isDisabled).toEqual(false);
     });
@@ -234,6 +238,7 @@ describe('query_preview/helpers', () => {
         {
           query: { query: 'host.name:*', language: 'kuery' },
           filters: [{ meta: { alias: '', disabled: false, negate: false } }],
+          saved_id: null,
         },
         ['foo-*'],
         'query'
@@ -260,6 +265,7 @@ describe('query_preview/helpers', () => {
         {
           query: { query: 'host.name:*', language: 'kuery' },
           filters: [{ meta: { alias: '', disabled: false, negate: false } }],
+          saved_id: null,
         },
         ['foo-*'],
         'saved_query'
@@ -286,6 +292,7 @@ describe('query_preview/helpers', () => {
         {
           query: { query: 'host.name:*', language: 'kuery' },
           filters: [{ meta: { alias: '', disabled: false, negate: false } }],
+          saved_id: null,
         },
         ['foo-*'],
         'threshold'
@@ -312,6 +319,7 @@ describe('query_preview/helpers', () => {
         {
           query: { query: 'file where true', language: 'eql' },
           filters: [{ meta: { alias: '', disabled: false, negate: false } }],
+          saved_id: null,
         },
         ['foo-*'],
         'eql'
@@ -329,6 +337,7 @@ describe('query_preview/helpers', () => {
         {
           query: { query: 'host.name:', language: 'kuery' },
           filters: [{ meta: { alias: '', disabled: false, negate: false } }],
+          saved_id: null,
         },
         ['foo-*'],
         'threshold'

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.test.tsx
@@ -40,10 +40,12 @@ const defaultProps: RulePreviewProps = {
   query: {
     filters: [],
     query: { query: 'file.hash.md5:*', language: 'kuery' },
+    saved_id: null,
   },
   threatQuery: {
     filters: [],
     query: { query: 'threat.indicator.file.hash.md5:*', language: 'kuery' },
+    saved_id: null,
   },
   threshold: {
     field: ['agent.hostname'],

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -57,6 +57,7 @@ import { ThreatMatchInput } from '../threatmatch_input';
 import { BrowserField, BrowserFields, useFetchIndex } from '../../../../common/containers/source';
 import { RulePreview } from '../rule_preview';
 import { getIsRulePreviewDisabled } from '../rule_preview/helpers';
+import { usePrevious } from './use_previous';
 
 const CommonUseField = getUseField({ component: Field });
 
@@ -106,6 +107,11 @@ export const stepDefineDefaultValue: DefineStepRule = {
 const threatQueryBarDefaultValue: DefineStepRule['queryBar'] = {
   ...stepDefineDefaultValue.queryBar,
   query: { ...stepDefineDefaultValue.queryBar.query, query: '*:*' },
+};
+
+const defaultCustomQuery = {
+  forNormalRules: stepDefineDefaultValue.queryBar,
+  forThreatMatchRules: threatQueryBarDefaultValue,
 };
 
 export const MyLabelButton = styled(EuiButtonEmpty)`
@@ -192,6 +198,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
   const machineLearningJobId = formMachineLearningJobId ?? initialState.machineLearningJobId;
   const anomalyThreshold = formAnomalyThreshold ?? initialState.anomalyThreshold;
   const ruleType = formRuleType || initialState.ruleType;
+  const previousRuleType = usePrevious(ruleType);
   const [indexPatternsLoading, { browserFields, indexPatterns }] = useFetchIndex(index);
   const fields: Readonly<BrowserFields> = aggregatableFields(browserFields);
 
@@ -214,36 +221,57 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
   }, [threatIndex, threatIndicesConfig]);
 
   /**
-   * When a rule type is changed to or from a threat match this will modify the
-   * default query string to either:
-   *   * from the empty string '' to '*:*' if the rule type is "threatMatchRule"
-   *   * from '*:*' back to the empty string '' if the rule type is not "threatMatchRule"
-   * This calls queryBar.reset() in both cases to not trigger validation errors as
-   * the user has not entered data into those areas yet.
-   * If the user has entered data then through reference compares we can detect reliably if
-   * the user has changed data.
-   *   * queryBar.value === defaultQueryBar (Has the user changed the input of '' yet?)
-   *   * queryBar.value === threatQueryBarDefaultValue (Has the user changed the input of '*:*' yet?)
-   * This is a stronger guarantee than "isPristine" off of the forms as that value can be reset
-   * if you go to step 2) and then back to step 1) or the form is reset in another way. Using
-   * the reference compare we know factually if the data is changed as the references must change
-   * in the form libraries form the initial defaults.
+   * When the user changes rule type to or from "threat_match" this will modify the
+   * default "Custom query" string to either:
+   *   * from '' to '*:*' if the type is switched to "threat_match"
+   *   * from '*:*' back to '' if the type is switched back from "threat_match" to another one
    */
   useEffect(() => {
     const { queryBar } = getFields();
-    if (queryBar != null) {
-      const { queryBar: defaultQueryBar } = stepDefineDefaultValue;
-      if (isThreatMatchRule(ruleType) && queryBar.value === defaultQueryBar) {
+    if (queryBar == null) {
+      return;
+    }
+
+    // NOTE: Below this code does two things that are worth commenting.
+
+    // 1. If the user enters some text in the "Custom query" form field, we want
+    // to keep it even if the user switched to another rule type. So we want to
+    // be able to figure out if the field has been modified.
+    // - The forms library provides properties (isPristine, isModified, isDirty)
+    //   for that but they can't be used in our case: their values can be reset
+    //   if you go to step 2 and then back to step 1 or the form is reset in another way.
+    // - That's why we compare the actual value of the field with default ones.
+    //   NOTE: It's important to do a deep object comparison by value.
+    //   Don't do it by reference because the forms lib can change it internally.
+
+    // 2. We call queryBar.reset() in both cases to not trigger validation errors
+    // as the user has not entered data into those areas yet.
+
+    // If the user switched rule type to "threat_match" from any other one,
+    // but hasn't changed the custom query used for normal rules (''),
+    // we reset the custom query to the default used for "threat_match" rules ('*:*').
+    if (isThreatMatchRule(ruleType) && !isThreatMatchRule(previousRuleType)) {
+      if (isEqual(queryBar.value, defaultCustomQuery.forNormalRules)) {
+        console.log(`StepDefineRuleComponent :: switchedToThreatMatchType`);
         queryBar.reset({
-          defaultValue: threatQueryBarDefaultValue,
+          defaultValue: defaultCustomQuery.forThreatMatchRules,
         });
-      } else if (queryBar.value === threatQueryBarDefaultValue) {
+        return;
+      }
+    }
+
+    // If the user switched rule type from "threat_match" to any other one,
+    // but hasn't changed the custom query used for "threat_match" rules ('*:*'),
+    // we reset the custom query to another default value ('').
+    if (!isThreatMatchRule(ruleType) && isThreatMatchRule(previousRuleType)) {
+      if (isEqual(queryBar.value, defaultCustomQuery.forThreatMatchRules)) {
+        console.log(`StepDefineRuleComponent :: switchedFromThreatMatchType`);
         queryBar.reset({
-          defaultValue: defaultQueryBar,
+          defaultValue: defaultCustomQuery.forNormalRules,
         });
       }
     }
-  }, [ruleType, getFields]);
+  }, [ruleType, previousRuleType, getFields]);
 
   const handleSubmit = useCallback(() => {
     if (onSubmit) {

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -252,7 +252,6 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
     // we reset the custom query to the default used for "threat_match" rules ('*:*').
     if (isThreatMatchRule(ruleType) && !isThreatMatchRule(previousRuleType)) {
       if (isEqual(queryBar.value, defaultCustomQuery.forNormalRules)) {
-        console.log(`StepDefineRuleComponent :: switchedToThreatMatchType`);
         queryBar.reset({
           defaultValue: defaultCustomQuery.forThreatMatchRules,
         });
@@ -265,7 +264,6 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
     // we reset the custom query to another default value ('').
     if (!isThreatMatchRule(ruleType) && isThreatMatchRule(previousRuleType)) {
       if (isEqual(queryBar.value, defaultCustomQuery.forThreatMatchRules)) {
-        console.log(`StepDefineRuleComponent :: switchedFromThreatMatchType`);
         queryBar.reset({
           defaultValue: defaultCustomQuery.forNormalRules,
         });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -73,12 +73,12 @@ export const stepDefineDefaultValue: DefineStepRule = {
   queryBar: {
     query: { query: '', language: 'kuery' },
     filters: [],
-    saved_id: undefined,
+    saved_id: null,
   },
   threatQueryBar: {
     query: { query: DEFAULT_THREAT_MATCH_QUERY, language: 'kuery' },
     filters: [],
-    saved_id: undefined,
+    saved_id: null,
   },
   requiredFields: [],
   relatedIntegrations: [],

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/use_previous.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/use_previous.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef } from 'react';
+
+export const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+};

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.test.ts
@@ -330,6 +330,7 @@ describe('helpers', () => {
         threatQueryBar: {
           query: { language: 'kql', query: 'threat_host: *' },
           filters: threatFilters,
+          saved_id: null,
         },
         threatMapping,
       };

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.ts
@@ -227,7 +227,7 @@ export const formatDefineStepData = (defineStepData: DefineStepRule): DefineStep
         filters: ruleFields.queryBar?.filters,
         language: ruleFields.queryBar?.query?.language,
         query: ruleFields.queryBar?.query?.query as string,
-        saved_id: ruleFields.queryBar?.saved_id,
+        saved_id: ruleFields.queryBar?.saved_id ?? undefined,
         ...(ruleType === 'threshold' && {
           threshold: {
             field: ruleFields.threshold?.field ?? [],
@@ -251,7 +251,7 @@ export const formatDefineStepData = (defineStepData: DefineStepRule): DefineStep
         filters: ruleFields.queryBar?.filters,
         language: ruleFields.queryBar?.query?.language,
         query: ruleFields.queryBar?.query?.query as string,
-        saved_id: ruleFields.queryBar?.saved_id,
+        saved_id: ruleFields.queryBar?.saved_id ?? undefined,
         threat_index: ruleFields.threatIndex,
         threat_query: ruleFields.threatQueryBar?.query?.query as string,
         threat_filters: ruleFields.threatQueryBar?.filters,
@@ -263,7 +263,7 @@ export const formatDefineStepData = (defineStepData: DefineStepRule): DefineStep
         filters: ruleFields.queryBar?.filters,
         language: ruleFields.queryBar?.query?.language,
         query: ruleFields.queryBar?.query?.query as string,
-        saved_id: ruleFields.queryBar?.saved_id,
+        saved_id: ruleFields.queryBar?.saved_id ?? undefined,
         ...(ruleType === 'query' &&
           ruleFields.queryBar?.saved_id && { type: 'saved_query' as Type }),
       };

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.test.tsx
@@ -99,7 +99,7 @@ describe('rule helpers', () => {
             language: '',
           },
           filters: [],
-          saved_id: undefined,
+          saved_id: null,
         },
         timeline: {
           id: '86aa74d0-2136-11ea-9864-ebc8cc1cb8c2',
@@ -231,7 +231,7 @@ describe('rule helpers', () => {
             language: '',
           },
           filters: [],
-          saved_id: undefined,
+          saved_id: null,
         },
         timeline: {
           id: '86aa74d0-2136-11ea-9864-ebc8cc1cb8c2',
@@ -259,7 +259,7 @@ describe('rule helpers', () => {
             language: 'kuery',
           },
           filters: [],
-          saved_id: undefined,
+          saved_id: null,
         },
         relatedIntegrations: [],
         requiredFields: [],
@@ -275,7 +275,7 @@ describe('rule helpers', () => {
             language: '',
           },
           filters: [],
-          saved_id: undefined,
+          saved_id: null,
         },
         timeline: {
           id: '86aa74d0-2136-11ea-9864-ebc8cc1cb8c2',

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.tsx
@@ -87,13 +87,13 @@ export const getDefineStepsData = (rule: Rule): DefineStepRule => ({
   threatQueryBar: {
     query: { query: rule.threat_query ?? '', language: rule.threat_language ?? '' },
     filters: (rule.threat_filters ?? []) as Filter[],
-    saved_id: undefined,
+    saved_id: null,
   },
   threatMapping: rule.threat_mapping ?? [],
   queryBar: {
     query: { query: rule.query ?? '', language: rule.language ?? '' },
     filters: (rule.filters ?? []) as Filter[],
-    saved_id: rule.saved_id,
+    saved_id: rule.saved_id ?? null,
   },
   relatedIntegrations: rule.related_integrations ?? [],
   requiredFields: rule.required_fields ?? [],

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
@@ -37,7 +37,7 @@ const defaultValues = {
   eqlQueryBar: {
     query: { query: '', language: 'eql' },
     filters: [],
-    saved_id: undefined,
+    saved_id: null,
   },
 };
 


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/130767, https://github.com/elastic/kibana/issues/130770
**Related to:** https://github.com/elastic/kibana/pull/130771

## Summary

A bug in the forms library presumably introduced in https://github.com/elastic/kibana/pull/130544 broke Rule Creation and Editing pages in Security Solution in the `main` branch. Cypress tests haven't been run in this PR, so it was merged which caused Cypress tests in `main` to start failing. @MadameSheema skipped those failing tests in https://github.com/elastic/kibana/pull/130771.

This PR:

- Fixes the forms library by returning back the effect in the `useForm` hook which has been deleted in https://github.com/elastic/kibana/pull/130544.
- Fixes the way rule creation/editing forms use the library and handle the rule type selection. Please check the commits for details.
- Recovers Cypress tests skipped in https://github.com/elastic/kibana/pull/130771.

## Changes in `src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts`

@elastic/platform-deployment-management @sebelga @yuliacech please review the commit `Fix 1: get back the deleted effect in useForm`.

In Security Solution, we have multiple forms on the same rule creation/editing page for every step of the creation/editing process. We show or hide the forms depending on which step is currently active, so only one of the forms is visible at the same time. Without the effect that was deleted previously in https://github.com/elastic/kibana/pull/130544, it seems the `useForm` hook doesn't work on the mentioned pages.