### PR TITLE
[8.2] [Controls] Clear range/time slider selections when field changes (#129824)

### DIFF
--- a/src/plugins/controls/common/control_types/options_list/types.ts
+++ b/src/plugins/controls/common/control_types/options_list/types.ts
@@ -8,14 +8,11 @@
 
 import { BoolQuery } from '@kbn/es-query';
 import { FieldSpec } from '../../../../data_views/common';
-import { ControlInput } from '../../types';
+import { DataControlInput } from '../../types';
 
 export const OPTIONS_LIST_CONTROL = 'optionsListControl';
 
-export interface OptionsListEmbeddableInput extends ControlInput {
-  fieldName: string;
-  dataViewId: string;
-
+export interface OptionsListEmbeddableInput extends DataControlInput {
   selectedOptions?: string[];
   singleSelect?: boolean;
   loading?: boolean;

--- a/src/plugins/controls/common/control_types/range_slider/types.ts
+++ b/src/plugins/controls/common/control_types/range_slider/types.ts
@@ -6,14 +6,12 @@
  * Side Public License, v 1.
  */
 
-import { ControlInput } from '../../types';
+import { DataControlInput } from '../../types';
 
 export const RANGE_SLIDER_CONTROL = 'rangeSliderControl';
 
 export type RangeValue = [string, string];
 
-export interface RangeSliderEmbeddableInput extends ControlInput {
-  fieldName: string;
-  dataViewId: string;
+export interface RangeSliderEmbeddableInput extends DataControlInput {
   value: RangeValue;
 }

--- a/src/plugins/controls/common/control_types/time_slider/types.ts
+++ b/src/plugins/controls/common/control_types/time_slider/types.ts
@@ -6,12 +6,10 @@
  * Side Public License, v 1.
  */
 
-import { ControlInput } from '../../types';
+import { DataControlInput } from '../../types';
 
 export const TIME_SLIDER_CONTROL = 'timeSlider';
 
-export interface TimeSliderControlEmbeddableInput extends ControlInput {
-  fieldName: string;
-  dataViewId: string;
+export interface TimeSliderControlEmbeddableInput extends DataControlInput {
   value?: [number | null, number | null];
 }

--- a/src/plugins/controls/common/types.ts
+++ b/src/plugins/controls/common/types.ts
@@ -27,3 +27,8 @@ export type ControlInput = EmbeddableInput & {
   controlStyle?: ControlStyle;
   ignoreParentSettings?: ParentIgnoreSettings;
 };
+
+export type DataControlInput = ControlInput & {
+  fieldName: string;
+  dataViewId: string;
+};

--- a/src/plugins/controls/public/control_types/range_slider/range_slider.component.tsx
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider.component.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, useCallback } from 'react';
 import { BehaviorSubject } from 'rxjs';
 
 import { DataViewField } from '../../../../data_views/public';
@@ -45,16 +45,13 @@ export const RangeSliderComponent: FC<Props> = ({ componentStateSubject }) => {
     componentStateSubject.getValue()
   );
 
-  const { value = ['', ''], id, title } = useEmbeddableSelector((state) => state);
-
-  const [selectedValue, setSelectedValue] = useState<RangeValue>(value || ['', '']);
+  const { value, id, title } = useEmbeddableSelector((state) => state);
 
   const onChangeComplete = useCallback(
     (range: RangeValue) => {
       dispatch(selectRange(range));
-      setSelectedValue(range);
     },
-    [selectRange, setSelectedValue, dispatch]
+    [selectRange, dispatch]
   );
 
   return (
@@ -64,7 +61,7 @@ export const RangeSliderComponent: FC<Props> = ({ componentStateSubject }) => {
       min={min}
       max={max}
       title={title}
-      value={selectedValue}
+      value={value ?? ['', '']}
       onChange={onChangeComplete}
       fieldFormatter={fieldFormatter}
     />

--- a/src/plugins/controls/public/control_types/range_slider/range_slider_embeddable.tsx
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider_embeddable.tsx
@@ -306,7 +306,7 @@ export class RangeSliderEmbeddable extends Embeddable<RangeSliderEmbeddableInput
     this.updateOutput({ filters: [rangeFilter], dataViews: [dataView], loading: false });
   };
 
-  reload = () => {
+  public reload = () => {
     this.fetchMinMax();
   };
 

--- a/src/plugins/controls/public/control_types/range_slider/range_slider_embeddable_factory.tsx
+++ b/src/plugins/controls/public/control_types/range_slider/range_slider_embeddable_factory.tsx
@@ -37,8 +37,8 @@ export class RangeSliderEmbeddableFactory
   ) => {
     if (
       embeddable &&
-      (!deepEqual(newInput.fieldName, embeddable.getInput().fieldName) ||
-        !deepEqual(newInput.dataViewId, embeddable.getInput().dataViewId))
+      ((newInput.fieldName && !deepEqual(newInput.fieldName, embeddable.getInput().fieldName)) ||
+        (newInput.dataViewId && !deepEqual(newInput.dataViewId, embeddable.getInput().dataViewId)))
     ) {
       // if the field name or data view id has changed in this editing session, selected values are invalid, so reset them.
       newInput.value = ['', ''];

--- a/src/plugins/controls/public/control_types/time_slider/time_slider.tsx
+++ b/src/plugins/controls/public/control_types/time_slider/time_slider.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FC, useCallback, useState, useMemo } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 import { BehaviorSubject } from 'rxjs';
 import { debounce } from 'lodash';
 import { useStateObservable } from '../../hooks/use_state_observable';
@@ -59,10 +59,6 @@ export const TimeSlider: FC<TimeSliderProps> = ({
 
   const { value } = useEmbeddableSelector((state) => state);
 
-  const [selectedValue, setSelectedValue] = useState<[number | null, number | null]>(
-    value || [null, null]
-  );
-
   const dispatchChange = useCallback(
     (range: [number | null, number | null]) => {
       dispatch(selectRange(range));
@@ -75,15 +71,14 @@ export const TimeSlider: FC<TimeSliderProps> = ({
   const onChangeComplete = useCallback(
     (range: [number | null, number | null]) => {
       debouncedDispatchChange(range);
-      setSelectedValue(range);
     },
-    [setSelectedValue, debouncedDispatchChange]
+    [debouncedDispatchChange]
   );
 
   return (
     <Component
       onChange={onChangeComplete}
-      value={selectedValue}
+      value={value ?? [null, null]}
       range={[min, max]}
       dateFormat={dateFormat}
       timezone={timezone}

--- a/src/plugins/controls/public/control_types/time_slider/time_slider_embeddable_factory.tsx
+++ b/src/plugins/controls/public/control_types/time_slider/time_slider_embeddable_factory.tsx
@@ -39,8 +39,8 @@ export class TimesliderEmbeddableFactory
   ) => {
     if (
       embeddable &&
-      (!deepEqual(newInput.fieldName, embeddable.getInput().fieldName) ||
-        !deepEqual(newInput.dataViewId, embeddable.getInput().dataViewId))
+      ((newInput.fieldName && !deepEqual(newInput.fieldName, embeddable.getInput().fieldName)) ||
+        (newInput.dataViewId && !deepEqual(newInput.dataViewId, embeddable.getInput().dataViewId)))
     ) {
       // if the field name or data view id has changed in this editing session, selected options are invalid, so reset them.
       newInput.value = undefined;

--- a/src/plugins/controls/public/types.ts
+++ b/src/plugins/controls/public/types.ts
@@ -75,4 +75,4 @@ export interface ControlsPluginStartDeps {
 }
 
 // re-export from common
-export type { ControlWidth, ControlInput, ControlStyle } from '../common/types';
+export type { ControlWidth, ControlInput, DataControlInput, ControlStyle } from '../common/types';

--- a/test/functional/apps/dashboard_elements/controls/options_list.ts
+++ b/test/functional/apps/dashboard_elements/controls/options_list.ts
@@ -116,6 +116,36 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
       });
 
+      it('editing field clears selections', async () => {
+        const secondId = (await dashboardControls.getAllControlIds())[1];
+        await dashboardControls.optionsListOpenPopover(secondId);
+        await dashboardControls.optionsListPopoverSelectOption('hiss');
+        await dashboardControls.optionsListEnsurePopoverIsClosed(secondId);
+
+        await dashboardControls.editExistingControl(secondId);
+        await dashboardControls.controlsEditorSetfield('animal.keyword');
+        await dashboardControls.controlEditorSave();
+
+        const selectionString = await dashboardControls.optionsListGetSelectionsString(secondId);
+        expect(selectionString).to.be('Select...');
+      });
+
+      it('editing other control settings keeps selections', async () => {
+        const secondId = (await dashboardControls.getAllControlIds())[1];
+        await dashboardControls.optionsListOpenPopover(secondId);
+        await dashboardControls.optionsListPopoverSelectOption('dog');
+        await dashboardControls.optionsListPopoverSelectOption('cat');
+        await dashboardControls.optionsListEnsurePopoverIsClosed(secondId);
+
+        await dashboardControls.editExistingControl(secondId);
+        await dashboardControls.controlEditorSetTitle('Animal');
+        await dashboardControls.controlEditorSetWidth('large');
+        await dashboardControls.controlEditorSave();
+
+        const selectionString = await dashboardControls.optionsListGetSelectionsString(secondId);
+        expect(selectionString).to.be('dog, cat');
+      });
+
       it('deletes an existing control', async () => {
         const firstId = (await dashboardControls.getAllControlIds())[0];
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Controls] Clear range/time slider selections when field changes (#129824)](https://github.com/elastic/kibana/pull/129824)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)