### PR TITLE
[ML] Data Frame Analytics: ensure page header updates with selection

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/page.tsx
@@ -108,7 +108,7 @@ export const Page: FC<{
         />
       ) : null}
       {jobIdToUse !== undefined && (
-        <MlPageHeader>
+        <MlPageHeader key={`${jobIdToUse}-id`}>
           <FormattedMessage
             id="xpack.ml.dataframe.analyticsExploration.titleWithId"
             defaultMessage="Explore results for job ID {id}"

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -120,7 +120,7 @@ export const Page: FC = () => {
         </MlPageHeader>
       ) : null}
       {jobId !== undefined ? (
-        <MlPageHeader>
+        <MlPageHeader key={`${jobId}-id`}>
           <FormattedMessage
             data-test-subj="mlPageDataFrameAnalyticsMapTitle"
             id="xpack.ml.dataframe.analyticsMap.analyticsIdTitle"

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -145,10 +145,11 @@ export const Page: FC = () => {
       <SavedObjectsWarning onCloseFlyout={refresh} />
       <UpgradeWarning />
 
-      {mapJobId || mapModelId || analyticsId ? (
+      {jobId || modelId ? (
         <JobMap
-          analyticsId={mapJobId || analyticsId?.job_id}
-          modelId={mapModelId || analyticsId?.model_id}
+          key={`${jobId || modelId}-id`}
+          analyticsId={jobId}
+          modelId={modelId}
           forceRefresh={isLoading}
         />
       ) : (

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -102,7 +102,7 @@ export const Page: FC = () => {
     <>
       <AnalyticsIdSelectorControls
         setIsIdSelectorFlyoutVisible={setIsIdSelectorFlyoutVisible}
-        selectedId={jobId || modelId}
+        selectedId={jobId ?? modelId}
       />
       {isIdSelectorFlyoutVisible ? (
         <AnalyticsIdSelector
@@ -145,9 +145,9 @@ export const Page: FC = () => {
       <SavedObjectsWarning onCloseFlyout={refresh} />
       <UpgradeWarning />
 
-      {jobId || modelId ? (
+      {jobId ?? modelId ? (
         <JobMap
-          key={`${jobId || modelId}-id`}
+          key={`${jobId ?? modelId}-id`}
           analyticsId={jobId}
           modelId={modelId}
           forceRefresh={isLoading}


### PR DESCRIPTION
## Summary

This fixes the issue where the page header would not update with the newly selected analytics id.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

