### PR TITLE
[Discover] Display current interval setting

### DIFF
--- a/src/plugins/discover/public/application/main/components/chart/discover_chart.test.tsx
+++ b/src/plugins/discover/public/application/main/components/chart/discover_chart.test.tsx
@@ -103,7 +103,13 @@ async function mountComponent(isTimeBased: boolean = false) {
     savedSearchRefetch$: new Subject(),
     searchSource: searchSourceMock,
     state: { columns: [] },
-    stateContainer: {} as GetStateReturn,
+    stateContainer: {
+      appStateContainer: {
+        getState: () => ({
+          interval: 'auto',
+        }),
+      },
+    } as unknown as GetStateReturn,
     viewMode: VIEW_MODE.DOCUMENT_LEVEL,
     setDiscoverViewMode: jest.fn(),
   };

--- a/src/plugins/discover/public/application/main/components/chart/discover_chart.tsx
+++ b/src/plugins/discover/public/application/main/components/chart/discover_chart.tsx
@@ -215,6 +215,7 @@ export function DiscoverChart({
             <DiscoverHistogramMemoized
               savedSearchData$={savedSearchDataChart$}
               timefilterUpdateHandler={timefilterUpdateHandler}
+              stateContainer={stateContainer}
             />
           </section>
           <EuiSpacer size="s" />

--- a/src/plugins/discover/public/application/main/components/chart/histogram.test.tsx
+++ b/src/plugins/discover/public/application/main/components/chart/histogram.test.tsx
@@ -15,6 +15,7 @@ import { DiscoverHistogram } from './histogram';
 import React from 'react';
 import * as hooks from '../../utils/use_data_state';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { GetStateReturn } from '../../services/discover_state';
 
 const chartData = {
   xAxisOrderedValues: [
@@ -76,6 +77,13 @@ function mountComponent(fetchStatus: FetchStatus) {
   const props = {
     savedSearchData$: charts$,
     timefilterUpdateHandler,
+    stateContainer: {
+      appStateContainer: {
+        getState: () => ({
+          interval: 'auto',
+        }),
+      },
+    } as unknown as GetStateReturn,
   };
 
   return mountWithIntl(

--- a/src/plugins/discover/public/application/main/components/chart/histogram.tsx
+++ b/src/plugins/discover/public/application/main/components/chart/histogram.tsx
@@ -45,10 +45,12 @@ import { useDiscoverServices } from '../../../../utils/use_discover_services';
 import { DataCharts$, DataChartsMessage } from '../../utils/use_saved_search';
 import { FetchStatus } from '../../../types';
 import { useDataState } from '../../utils/use_data_state';
+import { GetStateReturn } from '../../services/discover_state';
 
 export interface DiscoverHistogramProps {
   savedSearchData$: DataCharts$;
   timefilterUpdateHandler: (ranges: { from: number; to: number }) => void;
+  stateContainer: GetStateReturn;
 }
 
 function getTimezone(uiSettings: IUiSettingsClient) {
@@ -64,6 +66,7 @@ function getTimezone(uiSettings: IUiSettingsClient) {
 export function DiscoverHistogram({
   savedSearchData$,
   timefilterUpdateHandler,
+  stateContainer,
 }: DiscoverHistogramProps) {
   const { data, theme, uiSettings, fieldFormats } = useDiscoverServices();
   const chartTheme = theme.useChartsTheme();
@@ -123,8 +126,20 @@ export function DiscoverHistogram({
       from: dateMath.parse(from),
       to: dateMath.parse(to, { roundUp: true }),
     };
-    return `${toMoment(timeRange.from)} - ${toMoment(timeRange.to)}`;
-  }, [from, to, toMoment]);
+    const intervalText = i18n.translate('discover.histogramTimeRangeIntervalDescription', {
+      defaultMessage: '(interval: {value})',
+      values: {
+        value: `${
+          stateContainer.appStateContainer.getState().interval === 'auto'
+            ? `${i18n.translate('discover.histogramTimeRangeIntervalAuto', {
+                defaultMessage: 'Auto',
+              })} - `
+            : ''
+        }${bucketInterval?.description}`,
+      },
+    });
+    return `${toMoment(timeRange.from)} - ${toMoment(timeRange.to)} ${intervalText}`;
+  }, [from, to, toMoment, bucketInterval, stateContainer]);
 
   if (!chartData && fetchStatus === FetchStatus.LOADING) {
     return (

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.test.tsx
@@ -145,7 +145,14 @@ function mountComponent(indexPattern: DataView, prevSidebarClosed?: boolean) {
     savedSearchRefetch$: new Subject(),
     searchSource: searchSourceMock,
     state: { columns: [] },
-    stateContainer: { setAppState: () => {} } as unknown as GetStateReturn,
+    stateContainer: {
+      setAppState: () => {},
+      appStateContainer: {
+        getState: () => ({
+          interval: 'auto',
+        }),
+      },
+    } as unknown as GetStateReturn,
     setExpandedDoc: jest.fn(),
   };
 


### PR DESCRIPTION
Addresses #122896

https://user-images.githubusercontent.com/6686189/164861587-7a3643d0-bfd7-4c98-9b6d-3071839080a0.mov

There is some weirdness in how it updates. The `from`, `to`, and `Auto` will be first and then the interval itself. One idea I had was to hide the `(interval ...)` section while the fetch status is loading but it didn't look any better.


