### PR TITLE
Add SecuritySolutionLinkButton and withSecuritySolutionLink

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/links/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/links/index.test.tsx
@@ -24,12 +24,15 @@ import {
   PortOrServiceNameLink,
   DEFAULT_NUMBER_OF_LINK,
   ExternalLink,
+  SecuritySolutionLinkButton,
 } from '.';
+import { SecurityPageName } from '../../../app/types';
 
 jest.mock('../link_to');
 
 jest.mock('../../../overview/components/events_by_dataset');
 
+const mockNavigateTo = jest.fn();
 jest.mock('../../lib/kibana', () => {
   return {
     useUiSetting$: jest.fn(),
@@ -39,6 +42,9 @@ jest.mock('../../lib/kibana', () => {
           navigateToApp: jest.fn(),
         },
       },
+    }),
+    useNavigation: () => ({
+      navigateTo: mockNavigateTo,
     }),
   };
 });
@@ -578,6 +584,29 @@ describe('Custom Links', () => {
       expect(wrapper.find('a').prop('href')).toEqual(
         "https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=%3Cscript%3Ealert('XSS')%3C%2Fscript%3E"
       );
+    });
+  });
+
+  describe('SecuritySolutionLinkButton', () => {
+    it('injects href prop with hosts page path', () => {
+      const path = 'testTabPath';
+
+      const wrapper = mount(
+        <SecuritySolutionLinkButton deepLinkId={SecurityPageName.hosts} path={path} />
+      );
+
+      expect(wrapper.find('LinkButton').prop('href')).toEqual(path);
+    });
+
+    it('injects onClick prop that calls navigateTo', () => {
+      const path = 'testTabPath';
+
+      const wrapper = mount(
+        <SecuritySolutionLinkButton deepLinkId={SecurityPageName.hosts} path={path} />
+      );
+      wrapper.find('LinkButton').simulate('click');
+
+      expect(mockNavigateTo).toHaveBeenLastCalledWith({ url: path });
     });
   });
 });


### PR DESCRIPTION
## Summary

Creates a HOC that wraps any Link component and makes it a Security solutions internal navigation Link.
It injects `onClick` and 'href' into the Link component calculated based on the` deepLinkId` and `path` parameters.

Ex:
```js
  export const SecuritySolutionLinkButton = withSecuritySolutionLink(LinkButton);
  const example = () => <SecuritySolutionLinkButton deepLinkId={SecurityPageName.hosts} />;`
```

It also exports `SecuritySolutionLinkButton` by default to simplify the usage.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

