### PR TITLE
[Discover] Fix adding a filter for scripted fields via Document Explorer cell actions

### DIFF
--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.test.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.test.tsx
@@ -48,7 +48,11 @@ describe('Discover cell actions ', function () {
     );
     const button = findTestSubject(component, 'filterForButton');
     await button.simulate('click');
-    expect(contextMock.onFilter).toHaveBeenCalledWith('extension', 'jpg', '+');
+    expect(contextMock.onFilter).toHaveBeenCalledWith(
+      indexPatternMock.fields.getByName('extension'),
+      'jpg',
+      '+'
+    );
   });
   it('triggers filter function when FilterOutBtn is clicked', async () => {
     const contextMock = {
@@ -76,6 +80,10 @@ describe('Discover cell actions ', function () {
     );
     const button = findTestSubject(component, 'filterOutButton');
     await button.simulate('click');
-    expect(contextMock.onFilter).toHaveBeenCalledWith('extension', 'jpg', '-');
+    expect(contextMock.onFilter).toHaveBeenCalledWith(
+      indexPatternMock.fields.getByName('extension'),
+      'jpg',
+      '-'
+    );
   });
 });

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
@@ -11,7 +11,22 @@ import { EuiDataGridColumnCellActionProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { DataViewField } from '@kbn/data-views-plugin/public';
 import { flattenHit } from '@kbn/data-plugin/public';
-import { DiscoverGridContext } from './discover_grid_context';
+import { DiscoverGridContext, GridContext } from './discover_grid_context';
+
+function onFilterCell(
+  context: GridContext,
+  rowIndex: EuiDataGridColumnCellActionProps['rowIndex'],
+  columnId: EuiDataGridColumnCellActionProps['columnId'],
+  mode: '+' | '-'
+) {
+  const row = context.rows[rowIndex];
+  const flattened = flattenHit(row, context.indexPattern);
+  const field = context.indexPattern.fields.getByName(columnId);
+
+  if (flattened && field) {
+    context.onFilter(field, flattened[columnId], mode);
+  }
+}
 
 export const FilterInBtn = ({
   Component,
@@ -27,12 +42,7 @@ export const FilterInBtn = ({
   return (
     <Component
       onClick={() => {
-        const row = context.rows[rowIndex];
-        const flattened = flattenHit(row, context.indexPattern);
-
-        if (flattened) {
-          context.onFilter(columnId, flattened[columnId], '+');
-        }
+        onFilterCell(context, rowIndex, columnId, '+');
       }}
       iconType="plusInCircle"
       aria-label={buttonTitle}
@@ -60,12 +70,7 @@ export const FilterOutBtn = ({
   return (
     <Component
       onClick={() => {
-        const row = context.rows[rowIndex];
-        const flattened = flattenHit(row, context.indexPattern);
-
-        if (flattened) {
-          context.onFilter(columnId, flattened[columnId], '-');
-        }
+        onFilterCell(context, rowIndex, columnId, '-');
       }}
       iconType="minusInCircle"
       aria-label={buttonTitle}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/130751

## Summary

This PR fixes adding filters when user clicks on "Filter for"/"Filter out" buttons in the new Document Explorer grid. Now field types will be considered and scripted fields will be properly handled in the search request. A similar implementation for the legacy table view can be found [here](https://github.com/jughosta/kibana/blob/3730dd0779ed8efd74aee88f57422781ec1ac122/src/plugins/discover/public/components/doc_table/components/table_row.tsx#L98-L104).

![Apr-25-2022 15-13-51](https://user-images.githubusercontent.com/1415710/165096900-5238646a-8827-4227-b8a2-f7628e40039b.gif)

How to test:
1. Add a scripted field (Stack Management > Data view > Scripted fields (for a data view) > Create a scripted field) with `return "test";` value
2. Navigate back to Discover
3. Check `+`/`-` cell actions for Document Explorer and the legacy table view. It should trigger ES queries with `script` filter. Same behaviour should be for `+`/`-` in Document Explorer flyout.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
