### PR TITLE
[Timelion] fix requesting not permitted or used data views

### DIFF
--- a/src/plugins/vis_types/timelion/public/helpers/arg_value_suggestions.ts
+++ b/src/plugins/vis_types/timelion/public/helpers/arg_value_suggestions.ts
@@ -24,7 +24,7 @@ export function getArgValueSuggestions() {
     }
     const indexPatternTitle = get(indexPatternArg, 'value.text');
 
-    return (await indexPatterns.find(indexPatternTitle)).find(
+    return (await indexPatterns.find(indexPatternTitle, 1)).find(
       (index) => index.title === indexPatternTitle
     );
   }

--- a/src/plugins/vis_types/timelion/public/timelion_vis_type.tsx
+++ b/src/plugins/vis_types/timelion/public/timelion_vis_type.tsx
@@ -57,7 +57,7 @@ export function getTimelionVisDefinition(dependencies: TimelionVisDependencies) 
         );
 
         if (indexArg?.value.text) {
-          return getIndexPatterns().find(indexArg.value.text);
+          return getIndexPatterns().find(indexArg.value.text, 1);
         }
       } catch {
         // timelion expression is invalid

--- a/src/plugins/vis_types/timelion/server/series_functions/es/index.js
+++ b/src/plugins/vis_types/timelion/server/series_functions/es/index.js
@@ -104,7 +104,7 @@ export default new Datasource('es', {
       fit: 'nearest',
     });
     const indexPatternsService = tlConfig.getIndexPatternsService();
-    const indexPatternSpec = (await indexPatternsService.find(config.index)).find(
+    const indexPatternSpec = (await indexPatternsService.find(config.index, 1)).find(
       (index) => index.title === config.index
     );
 


### PR DESCRIPTION
## Summary
Analogical solution to the TSVB https://github.com/elastic/kibana/issues/130033
Steps to reproduce:
1. Create an index by dev tools:
```
PUT /kibana_sample_data_flights2
```

3.  Open a Timelion visualization based on `kibana_sample_data_flights`. In the network tab, you'll see a request also to `kibana_sample_data_flights2`.

Expected behavior: Only exact match should be taken into account. This PR fixes it.