### PR TITLE
[Security Solution] Removes 'usersEnabled' flag from Cypress config

### DIFF
--- a/x-pack/test/security_solution_cypress/config.ts
+++ b/x-pack/test/security_solution_cypress/config.ts
@@ -50,7 +50,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--xpack.ruleRegistry.unsafe.legacyMultiTenancy.enabled=true',
         `--xpack.securitySolution.enableExperimental=${JSON.stringify([
           'riskyHostsEnabled',
-          'usersEnabled',
           'riskyUsersEnabled',
           'ruleRegistryEnabled',
         ])}`,


### PR DESCRIPTION
## Summary

On 8.2 the new users page is enabled by default. In this PR we are removing the feature flag from the Cypress tests since it is not needed anymore.