### PR TITLE
`target_web` packages should be built as browser-agnostic ES modules

### DIFF
--- a/packages/kbn-babel-preset/BUILD.bazel
+++ b/packages/kbn-babel-preset/BUILD.bazel
@@ -10,6 +10,7 @@ SOURCE_FILES = glob([
   "istanbul_preset.js",
   "node_preset.js",
   "styled_components_files.js",
+  "web_preset.js",
   "webpack_preset.js",
 ])
 

--- a/packages/kbn-babel-preset/README.md
+++ b/packages/kbn-babel-preset/README.md
@@ -12,9 +12,11 @@ To use our presets add the following to the devDependencies section of your pack
 
 Then run `yarn kbn bootstrap` to properly link the package into your plugin/package.
 
-Finally, add either `@kbn/babel-preset/node_preset` or `@kbn/babel-preset/webpack_preset` to your babel config.
+Finally, add either `@kbn/babel-preset/node_preset`, `@kbn/babel-preset/web_preset` or `@kbn/babel-preset/webpack_preset` to your babel config.
 
-`@kbn/babel-preset/node_preset` is usually placed in a [`babel.config.js` file](https://babeljs.io/docs/en/configuration#babelconfigjs).
+`@kbn/babel-preset/node_preset` is usually placed in a [`babel.config.js` file](https://babeljs.io/docs/en/configuration#babelconfigjs) for server-side code.
+
+`@kbn/babel-preset/web_preset` is used to build browser-friendly packages that will be bundled later on by `webpack` using the `@kbn/babel-preset/webpack_preset`. Refer to [the original PR for the discussion and metrics improvements](https://github.com/elastic/kibana/pull/130904).
 
 `@kbn/babel-preset/webpack_preset` is usually placed directly in your `webpack` configuration.
 

--- a/packages/kbn-babel-preset/web_preset.js
+++ b/packages/kbn-babel-preset/web_preset.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module.exports = (_, options = {}) => {
+  return {
+    // This preset is called from the /src/dev/bazel/jsts_transpiler.bzl.
+    // Ideally, it should simply use the `webpack_preset` with some opts but, since it is called via CLI options,
+    // Babel currently does not provide a way to pass options to the presets.
+    presets: [[require('./webpack_preset'), { ...options, esmodules: true }]],
+  };
+};

--- a/packages/kbn-babel-preset/webpack_preset.js
+++ b/packages/kbn-babel-preset/webpack_preset.js
@@ -8,21 +8,18 @@
 
 const { USES_STYLED_COMPONENTS } = require('./styled_components_files');
 
-module.exports = (_, options = {}) => {
+module.exports = (_, { esmodules, ...options } = {}) => {
   return {
     presets: [
       [
         require.resolve('@babel/preset-env'),
         {
-          ...(options.esmodules === false
-            ? {}
-            : {
-                targets: {
-                  esmodules: true,
-                },
-                modules: false,
-              }),
+          // When building the @kbn web packages, we want to emit the ES modules only.
+          // However, when generating the final bundles in webpack, we want `.browserslistrc` to be applied (specifying no targets gets this effect).
+          // This optimization has proven to generate a smaller bundle sizes overall. \o/
+          ...(esmodules === true ? { targets: { esmodules: true } } : {}),
           useBuiltIns: 'entry',
+          modules: false,
           // Please read the explanation for this
           // in node_preset.js
           corejs: '3.21.1',

--- a/packages/kbn-babel-preset/webpack_preset.js
+++ b/packages/kbn-babel-preset/webpack_preset.js
@@ -14,6 +14,9 @@ module.exports = (_, options = {}) => {
       [
         require.resolve('@babel/preset-env'),
         {
+          targets: {
+            esmodules: true,
+          },
           useBuiltIns: 'entry',
           modules: false,
           // Please read the explanation for this

--- a/packages/kbn-babel-preset/webpack_preset.js
+++ b/packages/kbn-babel-preset/webpack_preset.js
@@ -14,11 +14,15 @@ module.exports = (_, options = {}) => {
       [
         require.resolve('@babel/preset-env'),
         {
-          targets: {
-            esmodules: true,
-          },
+          ...(options.esmodules === false
+            ? {}
+            : {
+                targets: {
+                  esmodules: true,
+                },
+                modules: false,
+              }),
           useBuiltIns: 'entry',
-          modules: false,
           // Please read the explanation for this
           // in node_preset.js
           corejs: '3.21.1',

--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -219,8 +219,8 @@ export function getWebpackConfig(bundle: Bundle, bundleRefs: BundleRefs, worker:
               babelrc: false,
               envName: worker.dist ? 'production' : 'development',
               presets: IS_CODE_COVERAGE
-                ? [ISTANBUL_PRESET_PATH, [BABEL_PRESET_PATH, { esmodules: false }]]
-                : [[BABEL_PRESET_PATH, { esmodules: false }]],
+                ? [ISTANBUL_PRESET_PATH, [BABEL_PRESET_PATH]]
+                : [[BABEL_PRESET_PATH]],
             },
           },
         },

--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -219,8 +219,8 @@ export function getWebpackConfig(bundle: Bundle, bundleRefs: BundleRefs, worker:
               babelrc: false,
               envName: worker.dist ? 'production' : 'development',
               presets: IS_CODE_COVERAGE
-                ? [ISTANBUL_PRESET_PATH, BABEL_PRESET_PATH]
-                : [BABEL_PRESET_PATH],
+                ? [ISTANBUL_PRESET_PATH, [BABEL_PRESET_PATH, { esmodules: false }]]
+                : [[BABEL_PRESET_PATH, { esmodules: false }]],
             },
           },
         },

--- a/src/dev/bazel/jsts_transpiler.bzl
+++ b/src/dev/bazel/jsts_transpiler.bzl
@@ -21,7 +21,7 @@ def jsts_transpiler(name, srcs, build_pkg_name, web = False, root_input_dir = "s
 
   if web:
     inline_presets += [
-      "@kbn/babel-preset/webpack_preset",
+      "@kbn/babel-preset/web_preset",
     ]
   else:
     inline_presets += [


### PR DESCRIPTION
## Summary

The Bazel step building `target_web` now uses the new preset `@kbn/babel-preset/web_preset`. The main difference with `@kbn/babel-preset/webpack_preset` is that it initially emits browser-agnostic ES modules.

### Motivation

In Kibana, when building the packages' `target_web` version, the transpiled code is not the final bundle we ship to the browsers. The final bundle is built at a later stage by Webpack in `@kbn/optimizer`.

For this reason, building a browserlist-compiled version of `target_web` creates a larger package output that will be concatenated to the code before Webpack applies the browserlist version of the final bundle. IMO, we don't need that 2-level browserlist-fy process and we can rely on the final Webpack step to do that.

Related to #88678

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
