### PR TITLE
[App Search] Add missing tests for curation panel refresh buttons

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation_history.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation_history.test.tsx
@@ -9,7 +9,13 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
+import { EuiButtonEmpty } from '@elastic/eui';
+
+import { nextTick } from '@kbn/test-jest-helpers';
+
 import { EntSearchLogStream } from '../../../../shared/log_stream';
+
+import { DataPanel } from '../../data_panel';
 
 import { AutomatedCurationHistory } from './automated_curation_history';
 
@@ -19,5 +25,18 @@ describe('AutomatedCurationHistory', () => {
     expect(wrapper.find(EntSearchLogStream).prop('query')).toEqual(
       'appsearch.adaptive_relevance.query: some text and event.kind: event and event.dataset: search-relevance-suggestions and appsearch.adaptive_relevance.engine: foo and event.action: curation_suggestion and appsearch.adaptive_relevance.suggestion.new_status: automated'
     );
+  });
+
+  it('sets new endTimestamp when refresh is pressed', async () => {
+    const wrapper = shallow(<AutomatedCurationHistory engineName="foo" query="some text" />);
+    const initialTimestamp = wrapper.find(EntSearchLogStream).prop('endTimestamp');
+    await nextTick();
+
+    // Find the refresh button and click
+    shallow(wrapper.find(DataPanel).prop('title')).find(EuiButtonEmpty).simulate('click');
+
+    wrapper.update();
+
+    expect(wrapper.find(EntSearchLogStream).prop('endTimestamp')).not.toEqual(initialTimestamp);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/automated_curations_history_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/automated_curations_history_panel.test.tsx
@@ -13,6 +13,10 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
+import { EuiButtonEmpty } from '@elastic/eui';
+
+import { nextTick } from '@kbn/test-jest-helpers';
+
 import { EntSearchLogStream } from '../../../../../../shared/log_stream';
 import { DataPanel } from '../../../../data_panel';
 
@@ -31,5 +35,18 @@ describe('AutomatedCurationsHistoryPanel', () => {
     expect(wrapper.find(EntSearchLogStream).prop('query')).toEqual(
       'event.kind: event and event.dataset: search-relevance-suggestions and appsearch.adaptive_relevance.engine: some-engine and event.action: curation_suggestion and appsearch.adaptive_relevance.suggestion.new_status: automated'
     );
+  });
+
+  it('sets new endTimestamp when refresh is pressed', async () => {
+    const wrapper = shallow(<AutomatedCurationsHistoryPanel />);
+    const initialTimestamp = wrapper.find(EntSearchLogStream).prop('endTimestamp');
+    await nextTick();
+
+    // Find the refresh button and click
+    shallow(wrapper.find(DataPanel).prop('title')).find(EuiButtonEmpty).simulate('click');
+
+    wrapper.update();
+
+    expect(wrapper.find(EntSearchLogStream).prop('endTimestamp')).not.toEqual(initialTimestamp);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/ignored_queries_panel/ignored_queries_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/ignored_queries_panel/ignored_queries_panel.test.tsx
@@ -15,7 +15,9 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiBasicTable } from '@elastic/eui';
+import { EuiBasicTable, EuiButtonEmpty } from '@elastic/eui';
+
+import { DataPanel } from '../../../../../data_panel';
 
 import { IgnoredQueriesPanel } from './ignored_queries_panel';
 
@@ -90,5 +92,14 @@ describe('IgnoredQueriesPanel', () => {
     wrapper.find(EuiBasicTable).simulate('change', { page: { index: 0 } });
 
     expect(mockActions.onPaginate).toHaveBeenCalledWith(1);
+  });
+
+  it('fetches data on refresh button press', () => {
+    const wrapper = shallow(<IgnoredQueriesPanel />);
+    expect(mockActions.loadIgnoredQueries).toHaveBeenCalledTimes(1);
+
+    shallow(wrapper.find(DataPanel).prop('title')).find(EuiButtonEmpty).simulate('click');
+
+    expect(mockActions.loadIgnoredQueries).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
closes https://github.com/elastic/enterprise-search-team/issues/1035

## Summary

Add missing test for Automated curations refresh buttons.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
