### PR TITLE
[DOCS] Remove field settings that were removed from the `infra` plugin's config schema

### DIFF
--- a/docs/settings/general-infra-logs-ui-settings.asciidoc
+++ b/docs/settings/general-infra-logs-ui-settings.asciidoc
@@ -1,27 +1,6 @@
 
-`xpack.infra.sources.default.logAlias`::
-Index pattern for matching indices that contain log data. Defaults to `filebeat-*,kibana_sample_data_logs*`. To match multiple wildcard patterns, use a comma to separate the names, with no space after the comma. For example, `logstash-app1-*,default-logs-*`.
-
-`xpack.infra.sources.default.metricAlias`::
-Index pattern for matching indices that contain Metricbeat data. Defaults to `metricbeat-*`. To match multiple wildcard patterns, use a comma to separate the names, with no space after the comma. For example, `logstash-app1-*,default-logs-*`.
-
-`xpack.infra.sources.default.fields.timestamp`::
-Timestamp used to sort log entries. Defaults to `@timestamp`.
-
 `xpack.infra.sources.default.fields.message`::
 Fields used to display messages in the Logs app. Defaults to `['message', '@message']`.
-
-`xpack.infra.sources.default.fields.tiebreaker`::
-Field used to break ties between two entries with the same timestamp. Defaults to `_doc`.
-
-`xpack.infra.sources.default.fields.host`::
-Field used to identify hosts. Defaults to `host.name`.
-
-`xpack.infra.sources.default.fields.container`::
-Field used to identify Docker containers. Defaults to `container.id`.
-
-`xpack.infra.sources.default.fields.pod`::
-Field used to identify Kubernetes pods. Defaults to `kubernetes.pod.uid`.
 
 `xpack.infra.alerting.inventory_threshold.group_by_page_size`::
 Controls the size of the composite aggregations used by the Inventory Threshold to retrieve all the hosts. Defaults to `10_000`.


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/130673

## Summary

Remove field settings that were removed from the `infra` plugin's config schema as listed in https://github.com/elastic/kibana/issues/130673. 

cc @elastic/obs-docs @smith 