### PR TITLE
[Security Solution] fix flashing authz on endpoint integration

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/endpoint_package_custom_extension.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/endpoint_package_custom_extension.test.tsx
@@ -97,4 +97,16 @@ describe('When displaying the EndpointPackageCustomExtension fleet UI extension'
       expect(renderResult.queryByTestId('hostIsolationExceptions-fleetCard')).toBeNull();
     });
   });
+
+  it('should only show loading spinner if loading', () => {
+    useEndpointPrivilegesMock.mockReturnValue({
+      ...getEndpointPrivilegesInitialStateMock(),
+      loading: true,
+    });
+    render();
+
+    expect(renderResult.getByTestId('endpointExtensionLoadingSpinner')).toBeInTheDocument();
+    expect(renderResult.queryByTestId('fleetEndpointPackageCustomContent')).toBeNull();
+    expect(renderResult.queryByTestId('noIngestPermissions')).toBeNull();
+  });
 });

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/endpoint_package_custom_extension.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/endpoint_package_custom_extension.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useMemo } from 'react';
-import { EuiSpacer } from '@elastic/eui';
+import { EuiSpacer, EuiLoadingSpinner } from '@elastic/eui';
 import { PackageCustomExtensionComponentProps } from '@kbn/fleet-plugin/public';
 import { useHttp } from '../../../../../../common/lib/kibana';
 import { useCanSeeHostIsolationExceptionsMenu } from '../../../../host_isolation_exceptions/view/hooks';
@@ -34,7 +34,7 @@ export const EndpointPackageCustomExtension = memo<PackageCustomExtensionCompone
   (props) => {
     const http = useHttp();
     const canSeeHostIsolationExceptions = useCanSeeHostIsolationExceptionsMenu();
-    const { canAccessEndpointManagement } = useEndpointPrivileges();
+    const { loading, canAccessEndpointManagement } = useEndpointPrivileges();
 
     const trustedAppsApiClientInstance = useMemo(
       () => TrustedAppsApiClient.getInstance(http),
@@ -106,7 +106,13 @@ export const EndpointPackageCustomExtension = memo<PackageCustomExtensionCompone
       ]
     );
 
-    return canAccessEndpointManagement ? artifactCards : <NoPermissions />;
+    return loading ? (
+      <EuiLoadingSpinner data-test-subj="endpointExtensionLoadingSpinner" />
+    ) : canAccessEndpointManagement ? (
+      artifactCards
+    ) : (
+      <NoPermissions />
+    );
   }
 );
 


### PR DESCRIPTION
## Summary

Fix issue where no permissions message flashes on initial load of endpoint integration advanced tab
Issue: https://github.com/elastic/kibana/issues/130887

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
