### PR TITLE
[Security Solution] Make only a single api request for exceptions when opening an alert in timeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -415,6 +415,7 @@
 /x-pack/plugins/security_solution/cypress/integration/urls @elastic/security-threat-hunting-investigations
 
 /x-pack/plugins/security_solution/public/common/components/alerts_viewer @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_action @elastic/security-threat-hunting-investigations
 /x-pack/plugins/security_solution/public/common/components/event_details @elastic/security-threat-hunting-investigations
 /x-pack/plugins/security_solution/public/common/components/events_viewer @elastic/security-threat-hunting-investigations
 /x-pack/plugins/security_solution/public/common/components/markdown_editor @elastic/security-threat-hunting-investigations

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
@@ -14,7 +14,7 @@ import { ALERT_RULE_EXCEPTIONS_LIST } from '@kbn/rule-data-utils';
 import {
   ExceptionListIdentifiers,
   ExceptionListItemSchema,
-  ReadExceptionListSchema,
+  ExceptionListTypeEnum,
 } from '@kbn/securitysolution-io-ts-list-types';
 import { useApi } from '@kbn/securitysolution-list-hooks';
 
@@ -51,48 +51,48 @@ export const useInvestigateInTimeline = ({
 
   const getExceptions = useCallback(
     async (ecsData: Ecs): Promise<ExceptionListItemSchema[]> => {
-      const exceptionsLists: ReadExceptionListSchema[] = (
-        getField(ecsData, ALERT_RULE_EXCEPTIONS_LIST) ?? []
-      )
-        .map((list: string) => JSON.parse(list))
-        .filter((list: ExceptionListIdentifiers) => list.type === 'detection');
+      const exceptionsLists = (getField(ecsData, ALERT_RULE_EXCEPTIONS_LIST) ?? []).reduce(
+        (acc: ExceptionListIdentifiers[], next: string) => {
+          const parsedList = JSON.parse(next);
+          if (parsedList.type === 'detection') {
+            const formattedList = {
+              id: parsedList.id,
+              listId: parsedList.list_id,
+              type: ExceptionListTypeEnum.DETECTION,
+              namespaceType: parsedList.namespace_type,
+            };
+            acc.push(formattedList);
+          }
+          return acc;
+        },
+        []
+      );
 
       const allExceptions: ExceptionListItemSchema[] = [];
 
       if (exceptionsLists.length > 0) {
-        for (const list of exceptionsLists) {
-          if (list.id && list.list_id && list.namespace_type) {
-            await getExceptionListsItems({
-              lists: [
-                {
-                  id: list.id,
-                  listId: list.list_id,
-                  type: 'detection',
-                  namespaceType: list.namespace_type,
-                },
-              ],
-              filterOptions: [],
-              pagination: {
-                page: 0,
-                perPage: 10000,
-                total: 10000,
-              },
-              showDetectionsListsOnly: true,
-              showEndpointListsOnly: false,
-              onSuccess: ({ exceptions }) => {
-                allExceptions.push(...exceptions);
-              },
-              onError: (err: string[]) => {
-                addError(err, {
-                  title: i18n.translate(
-                    'xpack.securitySolution.detectionEngine.alerts.fetchExceptionsFailure',
-                    { defaultMessage: 'Error fetching exceptions.' }
-                  ),
-                });
-              },
+        await getExceptionListsItems({
+          lists: exceptionsLists,
+          filterOptions: [],
+          pagination: {
+            page: 0,
+            perPage: 10000,
+            total: 10000,
+          },
+          showDetectionsListsOnly: true,
+          showEndpointListsOnly: false,
+          onSuccess: ({ exceptions }) => {
+            allExceptions.push(...exceptions);
+          },
+          onError: (err: string[]) => {
+            addError(err, {
+              title: i18n.translate(
+                'xpack.securitySolution.detectionEngine.alerts.fetchExceptionsFailure',
+                { defaultMessage: 'Error fetching exceptions.' }
+              ),
             });
-          }
-        }
+          },
+        });
       }
       return allExceptions;
     },


### PR DESCRIPTION
## Summary

The exception item api already expects the api call to be made with an array of ExceptionListIdentifiers, currently, the code is looping over these and making 1 request per item in the array, this pr changes this so that only 1 request is ever made.

![exception_once](https://user-images.githubusercontent.com/56408403/165229280-8c06bc33-1574-4e85-b6b1-930ad64b965b.gif)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



