### PR TITLE
[Cloud Posture] add pagination to findings by resource

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
@@ -12,18 +12,20 @@ import { FindingsSearchBar } from '../layout/findings_search_bar';
 import * as TEST_SUBJECTS from '../test_subjects';
 import { useUrlQuery } from '../../../common/hooks/use_url_query';
 import type { FindingsBaseURLQuery } from '../types';
-import { useFindingsByResource } from './use_findings_by_resource';
+import { FindingsByResourceQuery, useFindingsByResource } from './use_findings_by_resource';
 import { FindingsByResourceTable } from './findings_by_resource_table';
-import { getBaseQuery } from '../utils';
+import { getBaseQuery, getPaginationQuery, getPaginationTableParams } from '../utils';
 import { PageTitle, PageTitleText, PageWrapper } from '../layout/findings_layout';
 import { FindingsGroupBySelector } from '../layout/findings_group_by_selector';
 import { findingsNavigation } from '../../../common/navigation/constants';
 import { useCspBreadcrumbs } from '../../../common/navigation/use_csp_breadcrumbs';
 import { ResourceFindings } from './resource_findings/resource_findings_container';
 
-const getDefaultQuery = (): FindingsBaseURLQuery => ({
+const getDefaultQuery = (): FindingsBaseURLQuery & FindingsByResourceQuery => ({
   query: { language: 'kuery', query: '' },
   filters: [],
+  pageIndex: 0,
+  pageSize: 10,
 });
 
 export const FindingsByResourceContainer = ({ dataView }: { dataView: DataView }) => (
@@ -43,9 +45,10 @@ export const FindingsByResourceContainer = ({ dataView }: { dataView: DataView }
 const LatestFindingsByResource = ({ dataView }: { dataView: DataView }) => {
   useCspBreadcrumbs([findingsNavigation.findings_by_resource]);
   const { urlQuery, setUrlQuery } = useUrlQuery(getDefaultQuery);
-  const findingsGroupByResource = useFindingsByResource(
-    getBaseQuery({ dataView, filters: urlQuery.filters, query: urlQuery.query })
-  );
+  const findingsGroupByResource = useFindingsByResource({
+    ...getBaseQuery({ dataView, filters: urlQuery.filters, query: urlQuery.query }),
+    ...getPaginationQuery(urlQuery),
+  });
 
   return (
     <div data-test-subj={TEST_SUBJECTS.FINDINGS_CONTAINER}>
@@ -72,6 +75,14 @@ const LatestFindingsByResource = ({ dataView }: { dataView: DataView }) => {
           data={findingsGroupByResource.data}
           error={findingsGroupByResource.error}
           loading={findingsGroupByResource.isLoading}
+          pagination={getPaginationTableParams({
+            pageSize: urlQuery.pageSize,
+            pageIndex: urlQuery.pageIndex,
+            totalItemCount: findingsGroupByResource.data?.total || 0,
+          })}
+          setTableOptions={({ page }) =>
+            setUrlQuery({ pageIndex: page.index, pageSize: page.size })
+          }
         />
       </PageWrapper>
     </div>

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.test.tsx
@@ -7,7 +7,12 @@
 import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import * as TEST_SUBJECTS from '../test_subjects';
-import { FindingsByResourceTable, formatNumber, getResourceId } from './findings_by_resource_table';
+import {
+  FindingsByResourceTable,
+  formatNumber,
+  getResourceId,
+  type CspFindingsByResource,
+} from './findings_by_resource_table';
 import * as TEXT from '../translations';
 import type { PropsOf } from '@elastic/eui';
 import Chance from 'chance';
@@ -16,10 +21,9 @@ import { TestProvider } from '../../../test/test_provider';
 
 const chance = new Chance();
 
-const getFakeFindingsByResource = () => ({
+const getFakeFindingsByResource = (): CspFindingsByResource => ({
   resource_id: chance.guid(),
-  cluster_id: chance.guid(),
-  cis_section: chance.word(),
+  cis_sections: [chance.word(), chance.word()],
   failed_findings: {
     total: chance.integer(),
     normalized: chance.integer({ min: 0, max: 1 }),
@@ -32,8 +36,10 @@ describe('<FindingsByResourceTable />', () => {
   it('renders the zero state when status success and data has a length of zero ', async () => {
     const props: TableProps = {
       loading: false,
-      data: { page: [] },
+      data: { page: [], total: 0 },
       error: null,
+      pagination: { pageIndex: 0, pageSize: 10, totalItemCount: 0 },
+      setTableOptions: jest.fn(),
     };
 
     render(
@@ -50,8 +56,10 @@ describe('<FindingsByResourceTable />', () => {
 
     const props: TableProps = {
       loading: false,
-      data: { page: data },
+      data: { page: data, total: data.length },
       error: null,
+      pagination: { pageIndex: 0, pageSize: 10, totalItemCount: 0 },
+      setTableOptions: jest.fn(),
     };
 
     render(
@@ -66,8 +74,7 @@ describe('<FindingsByResourceTable />', () => {
       );
       expect(row).toBeInTheDocument();
       expect(within(row).getByText(item.resource_id)).toBeInTheDocument();
-      expect(within(row).getByText(item.cluster_id)).toBeInTheDocument();
-      expect(within(row).getByText(item.cis_section)).toBeInTheDocument();
+      expect(within(row).getByText(item.cis_sections.join(', '))).toBeInTheDocument();
       expect(within(row).getByText(formatNumber(item.failed_findings.total))).toBeInTheDocument();
       expect(
         within(row).getByText(new RegExp(numeral(item.failed_findings.normalized).format('0%')))

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
@@ -27,7 +27,9 @@ import { findingsNavigation } from '../../../common/navigation/constants';
 export const formatNumber = (value: number) =>
   value < 1000 ? value : numeral(value).format('0.0a');
 
-type CspFindingsByResource = NonNullable<CspFindingsByResourceResult['data']>['page'][number];
+export type CspFindingsByResource = NonNullable<
+  CspFindingsByResourceResult['data']
+>['page'][number];
 
 interface Props extends CspFindingsByResourceResult {
   pagination: Pagination;
@@ -35,7 +37,7 @@ interface Props extends CspFindingsByResourceResult {
 }
 
 export const getResourceId = (resource: CspFindingsByResource) =>
-  [resource.resource_id, resource.cluster_id, resource.cis_section].join('/');
+  [resource.resource_id, ...resource.cis_sections].join('/');
 
 const FindingsByResourceTableComponent = ({
   error,
@@ -80,7 +82,7 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
     ),
   },
   {
-    field: 'cis_section',
+    field: 'cis_sections',
     truncateText: true,
     name: (
       <FormattedMessage
@@ -88,6 +90,7 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
         defaultMessage="CIS Section"
       />
     ),
+    render: (sections: string[]) => sections.join(', '),
   },
   {
     field: 'failed_findings',

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
@@ -6,12 +6,14 @@
  */
 import React from 'react';
 import {
-  EuiTableFieldDataColumnType,
   EuiEmptyPrompt,
   EuiBasicTable,
   EuiTextColor,
   EuiFlexGroup,
   EuiFlexItem,
+  type EuiTableFieldDataColumnType,
+  type CriteriaWithPagination,
+  type Pagination,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import numeral from '@elastic/numeral';
@@ -25,8 +27,12 @@ import { findingsNavigation } from '../../../common/navigation/constants';
 export const formatNumber = (value: number) =>
   value < 1000 ? value : numeral(value).format('0.0a');
 
-type FindingsGroupByResourceProps = CspFindingsByResourceResult;
 type CspFindingsByResource = NonNullable<CspFindingsByResourceResult['data']>['page'][number];
+
+interface Props extends CspFindingsByResourceResult {
+  pagination: Pagination;
+  setTableOptions(options: CriteriaWithPagination<CspFindingsByResource>): void;
+}
 
 export const getResourceId = (resource: CspFindingsByResource) =>
   [resource.resource_id, resource.cluster_id, resource.cis_section].join('/');
@@ -35,7 +41,9 @@ const FindingsByResourceTableComponent = ({
   error,
   data,
   loading,
-}: FindingsGroupByResourceProps) => {
+  pagination,
+  setTableOptions,
+}: Props) => {
   const getRowProps = (row: CspFindingsByResource) => ({
     'data-test-subj': TEST_SUBJECTS.getFindingsByResourceTableRowTestId(getResourceId(row)),
   });
@@ -50,6 +58,8 @@ const FindingsByResourceTableComponent = ({
       items={data?.page || []}
       columns={columns}
       rowProps={getRowProps}
+      pagination={pagination}
+      onChange={setTableOptions}
     />
   );
 };
@@ -76,16 +86,6 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
       <FormattedMessage
         id="xpack.csp.findings.groupByResourceTable.cisSectionColumnLabel"
         defaultMessage="CIS Section"
-      />
-    ),
-  },
-  {
-    field: 'cluster_id',
-    truncateText: true,
-    name: (
-      <FormattedMessage
-        id="xpack.csp.findings.groupByResourceTable.clusterIdColumnLabel"
-        defaultMessage="Cluster ID"
       />
     ),
   },

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/use_findings_by_resource.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/use_findings_by_resource.ts
@@ -71,7 +71,13 @@ export const getFindingsByResourceAggQuery = ({
             bucket_sort: {
               from,
               size,
-              sort: [{ 'failed_findings>_count': { order: 'desc' } }],
+              sort: [
+                {
+                  'failed_findings>_count': { order: 'desc' },
+                  _count: { order: 'desc' },
+                  _key: { order: 'asc' },
+                },
+              ],
             },
           },
         },

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/use_findings_by_resource.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/use_findings_by_resource.ts
@@ -121,9 +121,9 @@ export const useFindingsByResource = ({ index, query, from, size }: UseResourceF
 
 const createFindingsByResource = (bucket: FindingsAggBucket) => ({
   resource_id: bucket.key,
-  cis_section: (bucket.cis_sections.buckets as estypes.AggregationsStringRareTermsBucketKeys[]).map(
-    (v) => v.key
-  ),
+  cis_sections: (
+    bucket.cis_sections.buckets as estypes.AggregationsStringRareTermsBucketKeys[]
+  ).map((v) => v.key),
   failed_findings: {
     total: bucket.doc_count,
     normalized: bucket.doc_count > 0 ? bucket.failed_findings.doc_count / bucket.doc_count : 0,

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/use_findings_by_resource.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/use_findings_by_resource.ts
@@ -8,9 +8,20 @@ import { useQuery } from 'react-query';
 import { lastValueFrom } from 'rxjs';
 import { IKibanaSearchRequest, IKibanaSearchResponse } from '@kbn/data-plugin/common';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { Pagination } from '@elastic/eui';
 import { useKibana } from '../../../common/hooks/use_kibana';
 import { showErrorToast } from '../latest_findings/use_latest_findings';
 import type { FindingsBaseEsQuery, FindingsQueryResult } from '../types';
+
+interface UseResourceFindingsOptions extends FindingsBaseEsQuery {
+  from: NonNullable<estypes.SearchRequest['from']>;
+  size: NonNullable<estypes.SearchRequest['size']>;
+}
+
+export interface FindingsByResourceQuery {
+  pageIndex: Pagination['pageIndex'];
+  pageSize: Pagination['pageSize'];
+}
 
 type FindingsAggRequest = IKibanaSearchRequest<estypes.SearchRequest>;
 type FindingsAggResponse = IKibanaSearchResponse<
@@ -22,43 +33,57 @@ export type CspFindingsByResourceResult = FindingsQueryResult<
   unknown
 >;
 
-interface FindingsByResourceAggs extends estypes.AggregationsCompositeAggregate {
-  groupBy: {
-    buckets: FindingsAggBucket[];
-  };
+interface FindingsByResourceAggs {
+  resources: estypes.AggregationsMultiBucketAggregateBase<FindingsAggBucket>;
+  resource_total: estypes.AggregationsCardinalityAggregate;
 }
 
-interface FindingsAggBucket {
-  doc_count: number;
-  failed_findings: { doc_count: number };
-  key: {
-    resource_id: string;
-    cluster_id: string;
-    cis_section: string;
-  };
+interface FindingsAggBucket extends estypes.AggregationsStringRareTermsBucketKeys {
+  failed_findings: estypes.AggregationsMultiBucketBase;
+  cis_sections: estypes.AggregationsMultiBucketAggregateBase<estypes.AggregationsStringRareTermsBucketKeys>;
+  name: estypes.AggregationsMultiBucketAggregateBase<estypes.AggregationsStringRareTermsBucketKeys>;
+  type: estypes.AggregationsMultiBucketAggregateBase<estypes.AggregationsStringRareTermsBucketKeys>;
 }
 
 export const getFindingsByResourceAggQuery = ({
   index,
   query,
-}: FindingsBaseEsQuery): estypes.SearchRequest => ({
+  from,
+  size,
+}: UseResourceFindingsOptions): estypes.SearchRequest => ({
   index,
-  size: 0,
   body: {
     query,
+    size: 0,
     aggs: {
-      groupBy: {
-        composite: {
-          size: 10 * 1000,
-          sources: [
-            { resource_id: { terms: { field: 'resource_id.keyword' } } },
-            { cluster_id: { terms: { field: 'cluster_id.keyword' } } },
-            { cis_section: { terms: { field: 'rule.section.keyword' } } },
-          ],
-        },
+      resource_total: { cardinality: { field: 'resource.id.keyword' } },
+      resources: {
+        terms: { field: 'resource.id.keyword', size: 1000000 },
         aggs: {
+          cis_sections: {
+            terms: { field: 'rule.section.keyword', size, order: { _key: 'asc' } },
+          },
+          name: {
+            terms: { field: 'resource.name.keyword', size: 1, order: { _key: 'asc' } },
+          },
+          type: {
+            terms: { field: 'resource.sub_type.keyword', size: 1, order: { _key: 'asc' } },
+          },
           failed_findings: {
             filter: { term: { 'result.evaluation.keyword': 'failed' } },
+          },
+          sort_failed_findings: {
+            bucket_sort: {
+              from,
+              size,
+              sort: [
+                {
+                  'failed_findings>_count': { order: 'desc' },
+                  _count: { order: 'desc' },
+                  _key: { order: 'asc' },
+                },
+              ],
+            },
           },
         },
       },
@@ -66,23 +91,28 @@ export const getFindingsByResourceAggQuery = ({
   },
 });
 
-export const useFindingsByResource = ({ index, query }: FindingsBaseEsQuery) => {
+export const useFindingsByResource = ({ index, query, from, size }: UseResourceFindingsOptions) => {
   const {
     data,
     notifications: { toasts },
   } = useKibana().services;
 
   return useQuery(
-    ['csp_findings_resource', { index, query }],
+    ['csp_findings_resource', { index, query, size, from }],
     () =>
       lastValueFrom(
         data.search.search<FindingsAggRequest, FindingsAggResponse>({
-          params: getFindingsByResourceAggQuery({ index, query }),
+          params: getFindingsByResourceAggQuery({ index, query, from, size }),
         })
       ),
     {
+      keepPreviousData: true,
+      refetchOnWindowFocus: false,
       select: ({ rawResponse }) => ({
-        page: rawResponse.aggregations?.groupBy.buckets.map(createFindingsByResource) || [],
+        page: ((rawResponse.aggregations?.resources.buckets as FindingsAggBucket[]) || []).map(
+          createFindingsByResource
+        ),
+        total: rawResponse.aggregations?.resource_total.value,
       }),
       onError: (err) => showErrorToast(toasts, err),
     }
@@ -90,9 +120,12 @@ export const useFindingsByResource = ({ index, query }: FindingsBaseEsQuery) => 
 };
 
 const createFindingsByResource = (bucket: FindingsAggBucket) => ({
-  ...bucket.key,
+  resource_id: bucket.key,
+  cis_section: (bucket.cis_sections.buckets as estypes.AggregationsStringRareTermsBucketKeys[]).map(
+    (v) => v.key
+  ),
   failed_findings: {
-    total: bucket.failed_findings.doc_count,
+    total: bucket.doc_count,
     normalized: bucket.doc_count > 0 ? bucket.failed_findings.doc_count / bucket.doc_count : 0,
   },
 });


### PR DESCRIPTION
## Summary

adds pagination to `group-by-resource` table


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

