### PR TITLE
[Fleet] Remove licence check in UI for upcoming agents rolling upgrade work

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -32,7 +32,6 @@ import {
   useUrlParams,
   useLink,
   useBreadcrumbs,
-  useLicense,
   useKibanaVersion,
   useStartServices,
 } from '../../../hooks';
@@ -153,7 +152,6 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
   const { getHref } = useLink();
   const defaultKuery: string = (useUrlParams().urlParams.kuery as string) || '';
   const hasFleetAllPrivileges = useAuthz().fleet.all;
-  const isGoldPlus = useLicense().isGoldPlus();
   const kibanaVersion = useKibanaVersion();
 
   // Agent data states
@@ -667,27 +665,23 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           pageSizeOptions,
         }}
         isSelectable={true}
-        selection={
-          isGoldPlus
-            ? {
-                onSelectionChange: (newAgents: Agent[]) => {
-                  setSelectedAgents(newAgents);
-                  setSelectionMode('manual');
-                },
-                selectable: isAgentSelectable,
-                selectableMessage: (selectable, agent) => {
-                  if (selectable) return '';
-                  if (!agent.active) {
-                    return 'This agent is not active';
-                  }
-                  if (agent.policy_id && agentPoliciesIndexedById[agent.policy_id].is_managed) {
-                    return 'This action is not available for agents enrolled in an externally managed agent policy';
-                  }
-                  return '';
-                },
-              }
-            : undefined
-        }
+        selection={{
+          onSelectionChange: (newAgents: Agent[]) => {
+            setSelectedAgents(newAgents);
+            setSelectionMode('manual');
+          },
+          selectable: isAgentSelectable,
+          selectableMessage: (selectable, agent) => {
+            if (selectable) return '';
+            if (!agent.active) {
+              return 'This agent is not active';
+            }
+            if (agent.policy_id && agentPoliciesIndexedById[agent.policy_id].is_managed) {
+              return 'This action is not available for agents enrolled in an externally managed agent policy';
+            }
+            return '';
+          },
+        }}
         onChange={({ page }: { page: { index: number; size: number } }) => {
           const newPagination = {
             ...pagination,


### PR DESCRIPTION
## Summary
Part of https://github.com/elastic/kibana/issues/130259
Remove the licence check to allow bulk actions in Agent lists. 

Currently, only users with `Gold plus` licence have bulk actions in the agents list UI (in the API there's no restriction at all). This check is being removed to allow the additional work planned for the agents rolling upgrade feature.

#### Testing
- Open Fleet (a basic licence is fine, no need to change it) and enroll fleet server and an agent, you should have bulk actions available.

#### Before
![Screenshot 2022-04-26 at 15 54 34](https://user-images.githubusercontent.com/16084106/165316436-d9699783-ff87-49b9-a508-9e325d9c2b1d.png)

#### After
![Screenshot 2022-04-26 at 15 55 09](https://user-images.githubusercontent.com/16084106/165316555-0c0ee89e-679d-427b-a276-2cc81af8da21.png)


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

