### PR TITLE
[8.2] [Security Solution] fix flashing authz on endpoint integration (#130933)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/index.tsx
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiSpacer } from '@elastic/eui';
+import { EuiSpacer, EuiLoadingSpinner } from '@elastic/eui';
 import React, { memo, useMemo } from 'react';
 import { useHttp } from '../../../../../../common/lib/kibana/hooks';
 import { PackageCustomExtensionComponentProps } from '../../../../../../../../fleet/public';
@@ -99,7 +99,7 @@ export const EndpointPackageCustomExtension = memo<PackageCustomExtensionCompone
   (props) => {
     const http = useHttp();
     const canSeeHostIsolationExceptions = useCanSeeHostIsolationExceptionsMenu();
-    const { canAccessEndpointManagement } = useEndpointPrivileges();
+    const { loading, canAccessEndpointManagement } = useEndpointPrivileges();
 
     const trustedAppsApiClientInstance = useMemo(
       () => TrustedAppsApiClient.getInstance(http),
@@ -171,7 +171,13 @@ export const EndpointPackageCustomExtension = memo<PackageCustomExtensionCompone
       ]
     );
 
-    return canAccessEndpointManagement ? artifactCards : <NoPermissions />;
+    return loading ? (
+      <EuiLoadingSpinner data-test-subj="endpointExtensionLoadingSpinner" />
+    ) : canAccessEndpointManagement ? (
+      artifactCards
+    ) : (
+      <NoPermissions />
+    );
   }
 );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Security Solution] fix flashing authz on endpoint integration (#130933)](https://github.com/elastic/kibana/pull/130933)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)