### PR TITLE
[8.2] [Discover] Fix adding/removing a filter for a scripted field in Document Explorer view (#130895)

### DIFF
--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.test.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.test.tsx
@@ -49,7 +49,11 @@ describe('Discover cell actions ', function () {
     );
     const button = findTestSubject(component, 'filterForButton');
     await button.simulate('click');
-    expect(contextMock.onFilter).toHaveBeenCalledWith('extension', 'jpg', '+');
+    expect(contextMock.onFilter).toHaveBeenCalledWith(
+      indexPatternMock.fields.getByName('extension'),
+      'jpg',
+      '+'
+    );
   });
   it('triggers filter function when FilterOutBtn is clicked', async () => {
     const contextMock = {
@@ -78,6 +82,10 @@ describe('Discover cell actions ', function () {
     );
     const button = findTestSubject(component, 'filterOutButton');
     await button.simulate('click');
-    expect(contextMock.onFilter).toHaveBeenCalledWith('extension', 'jpg', '-');
+    expect(contextMock.onFilter).toHaveBeenCalledWith(
+      indexPatternMock.fields.getByName('extension'),
+      'jpg',
+      '-'
+    );
   });
 });

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
@@ -9,9 +9,24 @@
 import React, { useContext } from 'react';
 import { EuiDataGridColumnCellActionProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { DataViewField } from '../../../../data_views/public';
-import { flattenHit } from '../../../../data/public';
-import { DiscoverGridContext } from './discover_grid_context';
+import { DataViewField } from '@kbn/data-views-plugin/public';
+import { flattenHit } from '@kbn/data-plugin/public';
+import { DiscoverGridContext, GridContext } from './discover_grid_context';
+
+function onFilterCell(
+  context: GridContext,
+  rowIndex: EuiDataGridColumnCellActionProps['rowIndex'],
+  columnId: EuiDataGridColumnCellActionProps['columnId'],
+  mode: '+' | '-'
+) {
+  const row = context.rows[rowIndex];
+  const flattened = flattenHit(row, context.indexPattern);
+  const field = context.indexPattern.fields.getByName(columnId);
+
+  if (flattened && field) {
+    context.onFilter(field, flattened[columnId], mode);
+  }
+}
 
 export const FilterInBtn = ({
   Component,
@@ -27,12 +42,7 @@ export const FilterInBtn = ({
   return (
     <Component
       onClick={() => {
-        const row = context.rows[rowIndex];
-        const flattened = flattenHit(row, context.indexPattern);
-
-        if (flattened) {
-          context.onFilter(columnId, flattened[columnId], '+');
-        }
+        onFilterCell(context, rowIndex, columnId, '+');
       }}
       iconType="plusInCircle"
       aria-label={buttonTitle}
@@ -60,12 +70,7 @@ export const FilterOutBtn = ({
   return (
     <Component
       onClick={() => {
-        const row = context.rows[rowIndex];
-        const flattened = flattenHit(row, context.indexPattern);
-
-        if (flattened) {
-          context.onFilter(columnId, flattened[columnId], '-');
-        }
+        onFilterCell(context, rowIndex, columnId, '-');
       }}
       iconType="minusInCircle"
       aria-label={buttonTitle}

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
@@ -9,8 +9,8 @@
 import React, { useContext } from 'react';
 import { EuiDataGridColumnCellActionProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { DataViewField } from '@kbn/data-views-plugin/public';
-import { flattenHit } from '@kbn/data-plugin/public';
+import { DataViewField } from '../../../../data_views/public';
+import { flattenHit } from '../../../../data/public';
 import { DiscoverGridContext, GridContext } from './discover_grid_context';
 
 function onFilterCell(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Discover] Fix adding/removing a filter for a scripted field in Document Explorer view (#130895)](https://github.com/elastic/kibana/pull/130895)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)