### PR TITLE
[CI] Split default ciGroup24 up a bit

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/index.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/index.ts
@@ -22,13 +22,23 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
     describe('', function () {
       this.tags('ciGroup24');
 
-      loadTestFile(require.resolve('./ip'));
-      loadTestFile(require.resolve('./ip_array'));
       loadTestFile(require.resolve('./keyword'));
       loadTestFile(require.resolve('./keyword_array'));
       loadTestFile(require.resolve('./long'));
       loadTestFile(require.resolve('./text'));
       loadTestFile(require.resolve('./text_array'));
+    });
+
+    describe('', function () {
+      this.tags('ciGroup16');
+
+      loadTestFile(require.resolve('./ip'));
+    });
+
+    describe('', function () {
+      this.tags('ciGroup21');
+
+      loadTestFile(require.resolve('./ip_array'));
     });
   });
 };


### PR DESCRIPTION
This is the slowest test suite. #130591 actually greatly improves the execution time without moving any tests around, but I think it might take a while to get approved. So, I'm doing this split in the meantime.