### PR TITLE
[App Search] Fix outcome field on Audit log modal.

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/audit_logs_modal/audit_logs_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/audit_logs_modal/audit_logs_modal.tsx
@@ -101,7 +101,8 @@ export const AuditLogsModal: React.FC = () => {
               ),
             },
             {
-              type: 'message',
+              type: 'field',
+              field: 'message',
               width: '50%',
             },
           ]}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/audit_logs_modal/audit_logs_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/audit_logs_modal/audit_logs_modal.tsx
@@ -92,7 +92,7 @@ export const AuditLogsModal: React.FC = () => {
             },
             {
               type: 'field',
-              field: 'outcome',
+              field: 'event.outcome',
               header: i18n.translate(
                 'xpack.enterpriseSearch.appSearch.engines.auditLogsModal.headers.outcome',
                 {


### PR DESCRIPTION
linked to https://github.com/elastic/enterprise-search-team/issues/1882

## Summary

![Screenshot 2022-04-27 at 15 53 56](https://user-images.githubusercontent.com/1410658/165534853-3ac8c5ef-ebf2-4603-a9f9-457394749f3d.png)

Fixes outcome column on audit log modal by changing field type to event.outcome
Fixes message column on audit log modal by changing it to a field.
