### PR TITLE
[Lens] Stabilize a11y test

### DIFF
--- a/x-pack/test/accessibility/apps/lens.ts
+++ b/x-pack/test/accessibility/apps/lens.ts
@@ -123,7 +123,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.waitForSearchInputValue('line');
       await a11y.testAppSnapshot();
       await testSubjects.click('lnsChartSwitchPopover_line');
-      await PageObjects.header.waitUntilLoadingHasFinished();
     });
 
     it('change chart type via suggestions', async () => {

--- a/x-pack/test/accessibility/apps/lens.ts
+++ b/x-pack/test/accessibility/apps/lens.ts
@@ -119,8 +119,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('change chart type', async () => {
-      await PageObjects.lens.switchToVisualization('line');
+      await PageObjects.lens.openChartSwitchPopover();
+      await PageObjects.lens.waitForSearchInputValue('line');
       await a11y.testAppSnapshot();
+      await testSubjects.click('lnsChartSwitchPopover_line');
+      await PageObjects.header.waitUntilLoadingHasFinished();
     });
 
     it('change chart type via suggestions', async () => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/88927

By opening the chart switcher, then running the a11y check, then clicking the targeted value afterwards.