### PR TITLE
[8.2] [Osquery] Fix osquery action permission and dropdown visibility (#130944)

### DIFF
--- a/x-pack/plugins/osquery/cypress/integration/all/live_query.spec.ts
+++ b/x-pack/plugins/osquery/cypress/integration/all/live_query.spec.ts
@@ -42,10 +42,10 @@ describe('ALL - Live Query', () => {
     cy.contains('View in Lens').should('exist');
     cy.react(RESULTS_TABLE_CELL_WRRAPER, {
       props: { id: 'osquery.days.number', index: 1 },
-    });
+    }).should('exist');
     cy.react(RESULTS_TABLE_CELL_WRRAPER, {
       props: { id: 'osquery.hours.number', index: 2 },
-    });
+    }).should('exist');
 
     getAdvancedButton().click();
     typeInECSFieldInput('message{downArrow}{enter}');
@@ -58,9 +58,13 @@ describe('ALL - Live Query', () => {
     });
     cy.react(RESULTS_TABLE_CELL_WRRAPER, {
       props: { id: 'message', index: 1 },
-    });
+    }).should('exist');
     cy.react(RESULTS_TABLE_CELL_WRRAPER, {
       props: { id: 'osquery.days.number', index: 2 },
-    }).react('EuiIconIndexMapping');
+    }).within(() => {
+      cy.get('.euiToolTipAnchor').within(() => {
+        cy.get('svg').should('exist');
+      });
+    });
   });
 });

--- a/x-pack/plugins/osquery/cypress/integration/roles/alert_test.spec.ts
+++ b/x-pack/plugins/osquery/cypress/integration/roles/alert_test.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ROLES } from '../../test';
+import { ArchiverMethod, runKbnArchiverScript } from '../../tasks/archiver';
+import { login } from '../../tasks/login';
+import { findAndClickButton, findFormFieldByRowsLabelAndType } from '../../tasks/live_query';
+import { preparePack } from '../../tasks/packs';
+import { closeModalIfVisible } from '../../tasks/integrations';
+import { navigateTo } from '../../tasks/navigation';
+
+describe('Alert_Test', () => {
+  before(() => {
+    runKbnArchiverScript(ArchiverMethod.LOAD, 'pack');
+    runKbnArchiverScript(ArchiverMethod.LOAD, 'rule');
+  });
+  beforeEach(() => {
+    login(ROLES.alert_test);
+  });
+
+  after(() => {
+    runKbnArchiverScript(ArchiverMethod.UNLOAD, 'pack');
+    runKbnArchiverScript(ArchiverMethod.UNLOAD, 'rule');
+  });
+
+  it('should be able to run live query', () => {
+    const PACK_NAME = 'testpack';
+    const RULE_NAME = 'Test-rule';
+    navigateTo('/app/osquery');
+    preparePack(PACK_NAME);
+    findAndClickButton('Edit');
+    cy.contains(`Edit ${PACK_NAME}`);
+    findFormFieldByRowsLabelAndType(
+      'Scheduled agent policies (optional)',
+      'fleet server {downArrow}{enter}'
+    );
+    findAndClickButton('Update pack');
+    closeModalIfVisible();
+    cy.contains(PACK_NAME);
+    cy.visit('/app/security/rules');
+    cy.contains(RULE_NAME).click();
+    cy.wait(2000);
+    cy.getBySel('ruleSwitch').should('have.attr', 'aria-checked', 'true');
+    cy.getBySel('ruleSwitch').click();
+    cy.getBySel('ruleSwitch').should('have.attr', 'aria-checked', 'false');
+    cy.getBySel('ruleSwitch').click();
+    cy.getBySel('ruleSwitch').should('have.attr', 'aria-checked', 'true');
+    cy.visit('/app/security/alerts');
+    cy.getBySel('expand-event').first().click();
+    cy.getBySel('take-action-dropdown-btn').click();
+    cy.getBySel('osquery-action-item').click();
+
+    cy.contains('Run Osquery');
+    cy.contains('Permission denied');
+  });
+});

--- a/x-pack/plugins/osquery/cypress/integration/roles/t2_analyst.spec.ts
+++ b/x-pack/plugins/osquery/cypress/integration/roles/t2_analyst.spec.ts
@@ -74,10 +74,10 @@ describe('T2 Analyst - READ + Write Live/Saved + runSavedQueries ', () => {
     cy.contains('View in Lens').should('not.exist');
     cy.react('EuiDataGridHeaderCellWrapper', {
       props: { id: 'osquery.days.number', index: 1 },
-    });
+    }).should('exist');
     cy.react('EuiDataGridHeaderCellWrapper', {
       props: { id: 'osquery.hours.number', index: 2 },
-    });
+    }).should('exist');
 
     cy.react('EuiAccordion', { props: { buttonContent: 'Advanced' } }).click();
     typeInECSFieldInput('message{downArrow}{enter}');
@@ -87,10 +87,14 @@ describe('T2 Analyst - READ + Write Live/Saved + runSavedQueries ', () => {
     checkResults();
     cy.react('EuiDataGridHeaderCellWrapper', {
       props: { id: 'message', index: 1 },
-    });
+    }).should('exist');
     cy.react('EuiDataGridHeaderCellWrapper', {
       props: { id: 'osquery.days.number', index: 2 },
-    }).react('EuiIconIndexMapping');
+    }).within(() => {
+      cy.get('.euiToolTipAnchor').within(() => {
+        cy.get('svg').should('exist');
+      });
+    });
   });
   it('to click the edit button and edit pack', () => {
     navigateTo('/app/osquery/saved_queries');

--- a/x-pack/plugins/osquery/cypress/test/index.ts
+++ b/x-pack/plugins/osquery/cypress/test/index.ts
@@ -15,4 +15,5 @@ export enum ROLES {
   rule_author = 'rule_author',
   platform_engineer = 'platform_engineer',
   detections_admin = 'detections_admin',
+  alert_test = 'alert_test',
 }

--- a/x-pack/plugins/osquery/public/assets/use_assets_status.ts
+++ b/x-pack/plugins/osquery/public/assets/use_assets_status.ts
@@ -18,6 +18,7 @@ export const useAssetsStatus = () => {
     () => http.get('/internal/osquery/assets'),
     {
       keepPreviousData: true,
+      retry: false,
     }
   );
 };

--- a/x-pack/plugins/osquery/public/live_queries/form/index.tsx
+++ b/x-pack/plugins/osquery/public/live_queries/form/index.tsx
@@ -62,7 +62,7 @@ interface LiveQueryFormProps {
   ecsMappingField?: boolean;
   formType?: FormType;
   enabled?: boolean;
-  hideFullscreen?: true;
+  isExternal?: true;
 }
 
 const LiveQueryFormComponent: React.FC<LiveQueryFormProps> = ({
@@ -73,7 +73,7 @@ const LiveQueryFormComponent: React.FC<LiveQueryFormProps> = ({
   ecsMappingField = true,
   formType = 'steps',
   enabled = true,
-  hideFullscreen,
+  isExternal,
 }) => {
   const ecsFieldRef = useRef<ECSMappingEditorFieldRef>();
   const permissions = useKibana().services.application.capabilities.osquery;
@@ -393,10 +393,10 @@ const LiveQueryFormComponent: React.FC<LiveQueryFormProps> = ({
           actionId={actionId}
           endDate={data?.actions[0].expiration}
           agentIds={agentIds}
-          hideFullscreen={hideFullscreen}
+          isExternal={isExternal}
         />
       ) : null,
-    [actionId, agentIds, data?.actions, hideFullscreen]
+    [actionId, agentIds, data?.actions, isExternal]
   );
 
   const formSteps: EuiContainedStepProps[] = useMemo(
@@ -464,6 +464,7 @@ const LiveQueryFormComponent: React.FC<LiveQueryFormProps> = ({
       </Form>
       {showSavedQueryFlyout ? (
         <SavedQueryFlyout
+          isExternal={isExternal}
           onClose={handleCloseSaveQueryFlout}
           defaultValue={flyoutFormDefaultValue}
         />

--- a/x-pack/plugins/osquery/public/live_queries/index.tsx
+++ b/x-pack/plugins/osquery/public/live_queries/index.tsx
@@ -28,7 +28,7 @@ interface LiveQueryProps {
   ecsMappingField?: boolean;
   enabled?: boolean;
   formType?: 'steps' | 'simple';
-  hideFullscreen?: true;
+  isExternal?: true;
 }
 
 const LiveQueryComponent: React.FC<LiveQueryProps> = ({
@@ -45,7 +45,7 @@ const LiveQueryComponent: React.FC<LiveQueryProps> = ({
   ecsMappingField,
   formType,
   enabled,
-  hideFullscreen,
+  isExternal,
 }) => {
   const { data: hasActionResultsPrivileges, isLoading } = useActionResultsPrivileges();
 
@@ -115,7 +115,7 @@ const LiveQueryComponent: React.FC<LiveQueryProps> = ({
       onSuccess={onSuccess}
       formType={formType}
       enabled={enabled}
-      hideFullscreen={hideFullscreen}
+      isExternal={isExternal}
     />
   );
 };

--- a/x-pack/plugins/osquery/public/results/results_table.tsx
+++ b/x-pack/plugins/osquery/public/results/results_table.tsx
@@ -46,7 +46,7 @@ interface ResultsTableComponentProps {
   agentIds?: string[];
   endDate?: string;
   startDate?: string;
-  hideFullscreen?: true;
+  isExternal?: true;
 }
 
 const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
@@ -54,7 +54,7 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
   agentIds,
   startDate,
   endDate,
-  hideFullscreen,
+  isExternal,
 }) => {
   const [isLive, setIsLive] = useState(true);
   const { data: hasActionResultsPrivileges } = useActionResultsPrivileges();
@@ -309,7 +309,7 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
   const toolbarVisibility = useMemo(
     () => ({
       showDisplaySelector: false,
-      showFullScreenSelector: !hideFullscreen,
+      showFullScreenSelector: !isExternal,
       additionalControls: (
         <>
           <ViewResultsInDiscoverAction
@@ -327,7 +327,7 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
         </>
       ),
     }),
-    [actionId, endDate, startDate, hideFullscreen]
+    [actionId, endDate, startDate, isExternal]
   );
 
   useEffect(

--- a/x-pack/plugins/osquery/public/routes/saved_queries/edit/tabs.tsx
+++ b/x-pack/plugins/osquery/public/routes/saved_queries/edit/tabs.tsx
@@ -17,7 +17,7 @@ interface ResultTabsProps {
   agentIds?: string[];
   startDate?: string;
   endDate?: string;
-  hideFullscreen?: true;
+  isExternal?: true;
 }
 
 const ResultTabsComponent: React.FC<ResultTabsProps> = ({
@@ -25,7 +25,7 @@ const ResultTabsComponent: React.FC<ResultTabsProps> = ({
   agentIds,
   endDate,
   startDate,
-  hideFullscreen,
+  isExternal,
 }) => {
   const tabs = useMemo(
     () => [
@@ -40,7 +40,7 @@ const ResultTabsComponent: React.FC<ResultTabsProps> = ({
               agentIds={agentIds}
               startDate={startDate}
               endDate={endDate}
-              hideFullscreen={hideFullscreen}
+              isExternal={isExternal}
             />
           </>
         ),
@@ -60,7 +60,7 @@ const ResultTabsComponent: React.FC<ResultTabsProps> = ({
         ),
       },
     ],
-    [actionId, agentIds, endDate, startDate, hideFullscreen]
+    [actionId, agentIds, endDate, startDate, isExternal]
   );
 
   return (

--- a/x-pack/plugins/osquery/public/saved_queries/saved_query_flyout.tsx
+++ b/x-pack/plugins/osquery/public/saved_queries/saved_query_flyout.tsx
@@ -28,9 +28,16 @@ import { useCreateSavedQuery } from './use_create_saved_query';
 interface AddQueryFlyoutProps {
   defaultValue: unknown;
   onClose: () => void;
+  isExternal?: true;
 }
 
-const SavedQueryFlyoutComponent: React.FC<AddQueryFlyoutProps> = ({ defaultValue, onClose }) => {
+const additionalZIndexStyle = { style: 'z-index: 6000' };
+
+const SavedQueryFlyoutComponent: React.FC<AddQueryFlyoutProps> = ({
+  defaultValue,
+  onClose,
+  isExternal,
+}) => {
   const savedQueryFormRef = useRef<SavedQueryFormRefObject>(null);
   const createSavedQueryMutation = useCreateSavedQuery({ withRedirect: false });
 
@@ -53,8 +60,7 @@ const SavedQueryFlyoutComponent: React.FC<AddQueryFlyoutProps> = ({ defaultValue
         ownFocus
         onClose={onClose}
         aria-labelledby="flyoutTitle"
-        // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
-        maskProps={{ style: 'z-index: 6000' }} // For an edge case to display above the alerts flyout
+        maskProps={isExternal && additionalZIndexStyle} // For an edge case to display above the alerts flyout
       >
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="s">

--- a/x-pack/plugins/osquery/public/shared_components/osquery_action/index.tsx
+++ b/x-pack/plugins/osquery/public/shared_components/osquery_action/index.tsx
@@ -8,7 +8,13 @@
 import { EuiErrorBoundary, EuiLoadingContent, EuiEmptyPrompt, EuiCode } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { QueryClientProvider } from 'react-query';
-import { i18n } from '@kbn/i18n';
+import {
+  AGENT_STATUS_ERROR,
+  EMPTY_PROMPT,
+  NOT_AVAILABLE,
+  PERMISSION_DENIED,
+  SHORT_EMPTY_TITLE,
+} from './translations';
 import { KibanaContextProvider, useKibana } from '../../common/lib/kibana';
 
 import { LiveQuery } from '../../live_queries';
@@ -20,36 +26,19 @@ import { useIsOsqueryAvailable } from './use_is_osquery_available';
 interface OsqueryActionProps {
   agentId?: string;
   formType: 'steps' | 'simple';
-  hideFullscreen?: true;
+  isExternal?: true;
 }
 
-const OsqueryActionComponent: React.FC<OsqueryActionProps> = ({
-  agentId,
-  formType = 'simple',
-  hideFullscreen,
-}) => {
+const OsqueryActionComponent: React.FC<OsqueryActionProps> = ({ agentId, formType = 'simple' }) => {
   const permissions = useKibana().services.application.capabilities.osquery;
 
   const emptyPrompt = useMemo(
     () => (
       <EuiEmptyPrompt
         icon={<OsqueryIcon />}
-        title={
-          <h2>
-            {i18n.translate('xpack.osquery.action.shortEmptyTitle', {
-              defaultMessage: 'Osquery is not available',
-            })}
-          </h2>
-        }
+        title={<h2>{SHORT_EMPTY_TITLE}</h2>}
         titleSize="xs"
-        body={
-          <p>
-            {i18n.translate('xpack.osquery.action.empty', {
-              defaultMessage:
-                'An Elastic Agent is not installed on this host. To run queries, install Elastic Agent on the host, and then add the Osquery Manager integration to the agent policy in Fleet.',
-            })}
-          </p>
-        }
+        body={<p>{EMPTY_PROMPT}</p>}
       />
     ),
     []
@@ -61,17 +50,14 @@ const OsqueryActionComponent: React.FC<OsqueryActionProps> = ({
     return emptyPrompt;
   }
 
-  if (!(permissions.runSavedQueries || permissions.writeLiveQueries)) {
+  if (
+    (!permissions.runSavedQueries || !permissions.readSavedQueries) &&
+    !permissions.writeLiveQueries
+  ) {
     return (
       <EuiEmptyPrompt
         icon={<OsqueryIcon />}
-        title={
-          <h2>
-            {i18n.translate('xpack.osquery.action.permissionDenied', {
-              defaultMessage: 'Permission denied',
-            })}
-          </h2>
-        }
+        title={<h2>{PERMISSION_DENIED}</h2>}
         titleSize="xs"
         body={
           <p>
@@ -95,22 +81,9 @@ const OsqueryActionComponent: React.FC<OsqueryActionProps> = ({
     return (
       <EuiEmptyPrompt
         icon={<OsqueryIcon />}
-        title={
-          <h2>
-            {i18n.translate('xpack.osquery.action.shortEmptyTitle', {
-              defaultMessage: 'Osquery is not available',
-            })}
-          </h2>
-        }
+        title={<h2>{SHORT_EMPTY_TITLE}</h2>}
         titleSize="xs"
-        body={
-          <p>
-            {i18n.translate('xpack.osquery.action.unavailable', {
-              defaultMessage:
-                'The Osquery Manager integration is not added to the agent policy. To run queries on the host, add the Osquery Manager integration to the agent policy in Fleet.',
-            })}
-          </p>
-        }
+        body={<p>{NOT_AVAILABLE}</p>}
       />
     );
   }
@@ -119,38 +92,25 @@ const OsqueryActionComponent: React.FC<OsqueryActionProps> = ({
     return (
       <EuiEmptyPrompt
         icon={<OsqueryIcon />}
-        title={
-          <h2>
-            {i18n.translate('xpack.osquery.action.shortEmptyTitle', {
-              defaultMessage: 'Osquery is not available',
-            })}
-          </h2>
-        }
+        title={<h2>{SHORT_EMPTY_TITLE}</h2>}
         titleSize="xs"
-        body={
-          <p>
-            {i18n.translate('xpack.osquery.action.agentStatus', {
-              defaultMessage:
-                'To run queries on this host, the Elastic Agent must be active. Check the status of this agent in Fleet.',
-            })}
-          </p>
-        }
+        body={<p>{AGENT_STATUS_ERROR}</p>}
       />
     );
   }
 
-  return <LiveQuery formType={formType} agentId={agentId} hideFullscreen={hideFullscreen} />;
+  return <LiveQuery formType={formType} agentId={agentId} isExternal={true} />;
 };
 
-const OsqueryAction = React.memo(OsqueryActionComponent);
+export const OsqueryAction = React.memo(OsqueryActionComponent);
 
 // @ts-expect-error update types
-const OsqueryActionWrapperComponent = ({ services, agentId, formType, hideFullscreen }) => (
+const OsqueryActionWrapperComponent = ({ services, agentId, formType, isExternal }) => (
   <KibanaThemeProvider theme$={services.theme.theme$}>
     <KibanaContextProvider services={services}>
       <EuiErrorBoundary>
         <QueryClientProvider client={queryClient}>
-          <OsqueryAction agentId={agentId} formType={formType} hideFullscreen={hideFullscreen} />
+          <OsqueryAction agentId={agentId} formType={formType} isExternal={isExternal} />
         </QueryClientProvider>
       </EuiErrorBoundary>
     </KibanaContextProvider>

--- a/x-pack/plugins/osquery/public/shared_components/osquery_action/osquery_action.test.tsx
+++ b/x-pack/plugins/osquery/public/shared_components/osquery_action/osquery_action.test.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { render } from '@testing-library/react';
+import { QueryClientProvider } from 'react-query';
+
+import { OsqueryAction } from '.';
+import { queryClient } from '../../query_client';
+import * as hooks from './use_is_osquery_available';
+import { useKibana } from '../../common/lib/kibana';
+import { AGENT_STATUS_ERROR, EMPTY_PROMPT, NOT_AVAILABLE, PERMISSION_DENIED } from './translations';
+
+jest.mock('../../common/lib/kibana');
+
+const useKibanaMock = useKibana as jest.MockedFunction<typeof useKibana>;
+
+const defaultUseOsqueryAvailableResult = {
+  osqueryAvailable: true,
+  agentFetched: true,
+  isLoading: false,
+  policyFetched: true,
+  policyLoading: false,
+};
+
+const spyUseIsOsqueryAvailable = jest
+  .spyOn(hooks, 'useIsOsqueryAvailable')
+  .mockImplementation(() => ({
+    ...defaultUseOsqueryAvailableResult,
+    agentData: {},
+  }));
+
+const defaultPermissions = {
+  osquery: {
+    runSavedQueries: false,
+    readSavedQueries: false,
+  },
+};
+
+const mockKibana = (permissionType: unknown = defaultPermissions) => {
+  useKibanaMock.mockReturnValue({
+    services: {
+      application: {
+        capabilities: permissionType,
+      },
+    },
+  } as unknown as ReturnType<typeof useKibana>);
+};
+
+const spyOsquery = (data: Record<string, unknown> = {}) => {
+  spyUseIsOsqueryAvailable.mockImplementation(() => ({
+    ...defaultUseOsqueryAvailableResult,
+    ...data,
+  }));
+};
+
+const properPermissions = {
+  osquery: {
+    runSavedQueries: true,
+    writeLiveQueries: true,
+  },
+};
+
+const renderWithContext = (Element: React.ReactElement) =>
+  render(
+    <IntlProvider locale={'en'}>
+      <QueryClientProvider client={queryClient}>{Element}</QueryClientProvider>
+    </IntlProvider>
+  );
+
+describe('Osquery Action', () => {
+  it('should return empty prompt when agentFetched and no agentData', async () => {
+    spyOsquery();
+    mockKibana();
+
+    const { getByText } = renderWithContext(
+      <OsqueryAction agentId={'test'} formType={'steps'} isExternal={true} />
+    );
+    expect(getByText(EMPTY_PROMPT)).toBeInTheDocument();
+  });
+  it('should return empty prompt when no agentId', async () => {
+    spyOsquery();
+    mockKibana();
+
+    const { getByText } = renderWithContext(
+      <OsqueryAction agentId={''} formType={'steps'} isExternal={true} />
+    );
+    expect(getByText(EMPTY_PROMPT)).toBeInTheDocument();
+  });
+  it('should return permission denied when agentFetched and agentData available', async () => {
+    spyOsquery({ agentData: {} });
+    mockKibana();
+
+    const { getByText } = renderWithContext(
+      <OsqueryAction agentId={'test'} formType={'steps'} isExternal={true} />
+    );
+    expect(getByText(PERMISSION_DENIED)).toBeInTheDocument();
+  });
+  it('should return agent status error when permissions are ok and agent status is wrong', async () => {
+    spyOsquery({ agentData: {} });
+    mockKibana(properPermissions);
+    const { getByText } = renderWithContext(
+      <OsqueryAction agentId={'test'} formType={'steps'} isExternal={true} />
+    );
+    expect(getByText(AGENT_STATUS_ERROR)).toBeInTheDocument();
+  });
+  it('should return permission denied if just one permission (runSavedQueries) is available', async () => {
+    spyOsquery({ agentData: {} });
+    mockKibana({
+      osquery: {
+        runSavedQueries: true,
+      },
+    });
+    const { getByText } = renderWithContext(
+      <OsqueryAction agentId={'test'} formType={'steps'} isExternal={true} />
+    );
+    expect(getByText(PERMISSION_DENIED)).toBeInTheDocument();
+  });
+  it('should return permission denied if just one permission (readSavedQueries) is available', async () => {
+    spyOsquery({ agentData: {} });
+    mockKibana({
+      osquery: {
+        readSavedQueries: true,
+      },
+    });
+    const { getByText } = renderWithContext(
+      <OsqueryAction agentId={'test'} formType={'steps'} isExternal={true} />
+    );
+    expect(getByText(PERMISSION_DENIED)).toBeInTheDocument();
+  });
+  it('should return permission denied if no writeLiveQueries', async () => {
+    spyOsquery({ agentData: {} });
+    mockKibana({
+      osquery: {
+        writeLiveQueries: true,
+      },
+    });
+    const { getByText } = renderWithContext(
+      <OsqueryAction agentId={'test'} formType={'steps'} isExternal={true} />
+    );
+    expect(getByText(AGENT_STATUS_ERROR)).toBeInTheDocument();
+  });
+  it('should return not available prompt if osquery is not available', async () => {
+    spyOsquery({ agentData: {}, osqueryAvailable: false });
+    mockKibana({
+      osquery: {
+        writeLiveQueries: true,
+      },
+    });
+    const { getByText } = renderWithContext(
+      <OsqueryAction agentId={'test'} formType={'steps'} isExternal={true} />
+    );
+    expect(getByText(NOT_AVAILABLE)).toBeInTheDocument();
+  });
+  it('should not return any errors when all data is ok', async () => {
+    spyOsquery({ agentData: { status: 'online' } });
+    mockKibana(properPermissions);
+
+    const { queryByText } = renderWithContext(
+      <OsqueryAction agentId={'test'} formType={'steps'} isExternal={true} />
+    );
+    expect(queryByText(EMPTY_PROMPT)).not.toBeInTheDocument();
+    expect(queryByText(PERMISSION_DENIED)).not.toBeInTheDocument();
+    expect(queryByText(AGENT_STATUS_ERROR)).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/osquery/public/shared_components/osquery_action/translations.ts
+++ b/x-pack/plugins/osquery/public/shared_components/osquery_action/translations.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const SHORT_EMPTY_TITLE = i18n.translate('xpack.osquery.action.shortEmptyTitle', {
+  defaultMessage: 'Osquery is not available',
+});
+
+export const EMPTY_PROMPT = i18n.translate('xpack.osquery.action.empty', {
+  defaultMessage:
+    'An Elastic Agent is not installed on this host. To run queries, install Elastic Agent on the host, and then add the Osquery Manager integration to the agent policy in Fleet.',
+});
+export const PERMISSION_DENIED = i18n.translate('xpack.osquery.action.permissionDenied', {
+  defaultMessage: 'Permission denied',
+});
+
+export const NOT_AVAILABLE = i18n.translate('xpack.osquery.action.unavailable', {
+  defaultMessage:
+    'The Osquery Manager integration is not added to the agent policy. To run queries on the host, add the Osquery Manager integration to the agent policy in Fleet.',
+});
+export const AGENT_STATUS_ERROR = i18n.translate('xpack.osquery.action.agentStatus', {
+  defaultMessage:
+    'To run queries on this host, the Elastic Agent must be active. Check the status of this agent in Fleet.',
+});

--- a/x-pack/plugins/osquery/public/shared_components/osquery_action/use_is_osquery_available.ts
+++ b/x-pack/plugins/osquery/public/shared_components/osquery_action/use_is_osquery_available.ts
@@ -7,11 +7,24 @@
 
 import { useMemo } from 'react';
 import { find } from 'lodash';
+import { AgentStatus } from '@kbn/fleet-plugin/common';
 import { useAgentDetails } from '../../agents/use_agent_details';
 import { useAgentPolicy } from '../../agent_policies';
 import { OSQUERY_INTEGRATION_NAME } from '../../../common';
 
-export const useIsOsqueryAvailable = (agentId?: string) => {
+interface IIsOsqueryAvailable {
+  osqueryAvailable: boolean;
+  agentFetched: boolean;
+  isLoading: boolean;
+  policyFetched: boolean;
+  policyLoading: boolean;
+  agentData?: {
+    status?: AgentStatus;
+    policy_id?: string;
+  };
+}
+
+export const useIsOsqueryAvailable = (agentId?: string): IIsOsqueryAvailable => {
   const {
     data: agentData,
     isFetched: agentFetched,

--- a/x-pack/plugins/osquery/public/shared_components/osquery_action/use_is_osquery_available.ts
+++ b/x-pack/plugins/osquery/public/shared_components/osquery_action/use_is_osquery_available.ts
@@ -7,7 +7,8 @@
 
 import { useMemo } from 'react';
 import { find } from 'lodash';
-import { AgentStatus } from '@kbn/fleet-plugin/common';
+
+import { AgentStatus } from '../../../../fleet/common';
 import { useAgentDetails } from '../../agents/use_agent_details';
 import { useAgentPolicy } from '../../agent_policies';
 import { OSQUERY_INTEGRATION_NAME } from '../../../common';

--- a/x-pack/plugins/osquery/scripts/roles_users/alert_test/delete_user.sh
+++ b/x-pack/plugins/osquery/scripts/roles_users/alert_test/delete_user.sh
@@ -1,0 +1,11 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+curl -v -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+-XDELETE ${ELASTICSEARCH_URL}/_security/user/alert_test

--- a/x-pack/plugins/osquery/scripts/roles_users/alert_test/get_role.sh
+++ b/x-pack/plugins/osquery/scripts/roles_users/alert_test/get_role.sh
@@ -1,0 +1,11 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+curl -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+-XGET ${KIBANA_URL}/api/security/role/alert_test | jq -S .

--- a/x-pack/plugins/osquery/scripts/roles_users/alert_test/index.ts
+++ b/x-pack/plugins/osquery/scripts/roles_users/alert_test/index.ts
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-export * from './platform_engineer';
-export * from './reader';
-export * from './t1_analyst';
-export * from './t2_analyst';
-export * from './soc_manager';
-export * from './alert_test';
+import * as alertTestUser from './user.json';
+import * as alertTestRole from './role.json';
+
+export { alertTestUser, alertTestRole };

--- a/x-pack/plugins/osquery/scripts/roles_users/alert_test/post_role.sh
+++ b/x-pack/plugins/osquery/scripts/roles_users/alert_test/post_role.sh
@@ -1,0 +1,14 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+ROLE_CONFIG=(${@:-./detections_role.json})
+
+curl -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+-XPUT ${KIBANA_URL}/api/security/role/alert_test \
+-d @${ROLE_CONFIG}

--- a/x-pack/plugins/osquery/scripts/roles_users/alert_test/post_user.sh
+++ b/x-pack/plugins/osquery/scripts/roles_users/alert_test/post_user.sh
@@ -1,0 +1,14 @@
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+USER=(${@:-./detections_user.json})
+
+curl -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
+ -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
+ ${ELASTICSEARCH_URL}/_security/user/alert_test \
+-d @${USER}

--- a/x-pack/plugins/osquery/scripts/roles_users/alert_test/role.json
+++ b/x-pack/plugins/osquery/scripts/roles_users/alert_test/role.json
@@ -1,0 +1,33 @@
+{
+  "elasticsearch": {
+    "cluster": ["manage"],
+    "indices": [
+      {
+        "names": [".items-*", ".lists-*", ".alerts-security.alerts-*", ".siem-signals-*"],
+        "privileges": ["manage", "read", "write", "view_index_metadata", "maintenance"]
+      },
+      {
+        "names": ["*"],
+        "privileges": ["read"]
+      },
+      {
+        "names": ["logs-osquery_manager*"],
+        "privileges": ["read"]
+      }
+    ]
+  },
+  "kibana": [
+    {
+      "feature": {
+        "discover": ["read"],
+        "infrastructure": ["read"],
+        "ml": ["all"],
+        "siem": ["all"],
+        "osquery": ["read", "packs_all"],
+        "visualize": ["read"]
+      },
+      "spaces": ["*"]
+    }
+  ]
+}
+

--- a/x-pack/plugins/osquery/scripts/roles_users/alert_test/user.json
+++ b/x-pack/plugins/osquery/scripts/roles_users/alert_test/user.json
@@ -1,0 +1,6 @@
+{
+  "password": "changeme",
+  "roles": ["alert_test"],
+  "full_name": "Alert Test",
+  "email": "osquery@example.com"
+}

--- a/x-pack/plugins/security_solution/public/detections/components/osquery/osquery_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/osquery/osquery_flyout.tsx
@@ -45,7 +45,7 @@ export const OsqueryFlyout: React.FC<OsqueryFlyoutProps> = ({ agentId, onClose }
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <OsqueryActionWrapper data-test-subj="flyout-body-osquery">
-          <OsqueryAction agentId={agentId} formType="steps" hideFullscreen={true} />
+          <OsqueryAction agentId={agentId} formType="steps" />
         </OsqueryActionWrapper>
       </EuiFlyoutBody>
       <EuiFlyoutFooter>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Osquery] Fix osquery action permission and dropdown visibility (#130944)](https://github.com/elastic/kibana/pull/130944)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)