### PR TITLE
[ML] Functional tests - re-enable permission tests in functional_basic

### DIFF
--- a/x-pack/test/functional_basic/apps/ml/permissions/full_ml_access.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/full_ml_access.ts
@@ -20,9 +20,7 @@ export default function ({ getService }: FtrProviderContext) {
     { user: USER.ML_POWERUSER_SPACES, discoverAvailable: false },
   ];
 
-  // FLAKY: https://github.com/elastic/kibana/issues/124413
-  // FLAKY: https://github.com/elastic/kibana/issues/122838
-  describe.skip('for user with full ML access', function () {
+  describe('for user with full ML access', function () {
     for (const testUser of testUsers) {
       describe(`(${testUser.user})`, function () {
         const ecIndexPattern = 'ft_module_sample_ecommerce';


### PR DESCRIPTION
## Summary

This PR re-enables the `full_ml_access` permission tests in `functional_basic`.

Closes #122838
Closes #124413

