### PR TITLE
[ML] Functional tests - re-enable trained models tests

### DIFF
--- a/x-pack/test/functional/apps/ml/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/model_management/model_list.ts
@@ -10,8 +10,7 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
 
-  // Failing: See https://github.com/elastic/kibana/issues/125455
-  describe.skip('trained models', function () {
+  describe('trained models', function () {
     before(async () => {
       await ml.trainedModels.createTestTrainedModels('classification', 15, true);
       await ml.trainedModels.createTestTrainedModels('regression', 15);


### PR DESCRIPTION
## Summary

This PR re-enables the trained models functional tests.

Closes #125455