### PR TITLE
[ML] Functional tests - re-enable data frame analytics results view tests

### DIFF
--- a/x-pack/test/functional/apps/ml/data_frame_analytics/results_view_content.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/results_view_content.ts
@@ -14,8 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/126422
-  describe.skip('results view content and total feature importance', function () {
+  describe('results view content and total feature importance', function () {
     const testDataList: Array<{
       suiteTitle: string;
       archive: string;
@@ -284,6 +283,7 @@ export default function ({ getService }: FtrProviderContext) {
         });
 
         it('should display the total feature importance in the results view', async () => {
+          await ml.dataFrameAnalyticsResults.expandFeatureImportanceSection(true);
           await ml.dataFrameAnalyticsResults.assertTotalFeatureImportanceEvaluatePanelExists();
         });
 


### PR DESCRIPTION
## Summary

This PR stabilizes and re-enables the data frame analytics results view tests.

Closes #126422