### PR TITLE
[7.17] [ML] Functional tests - re-enable import jobs tests

### DIFF
--- a/x-pack/test/functional/apps/ml/stack_management_jobs/import_jobs.ts
+++ b/x-pack/test/functional/apps/ml/stack_management_jobs/import_jobs.ts
@@ -32,8 +32,7 @@ export default function ({ getService }: FtrProviderContext) {
     },
   ];
 
-  // Failing: See https://github.com/elastic/kibana/issues/124747
-  describe.skip('import jobs', function () {
+  describe('import jobs', function () {
     this.tags(['mlqa']);
     before(async () => {
       await ml.api.cleanMlIndices();


### PR DESCRIPTION
## Summary

This PR re-enables the import jobs tests.

The fix was delivered some time ago in #124328, but tests have been skipped before the fix backport was merged.

Closes #124747
