### PR TITLE
[Cases] Escape KQL in range queries

### DIFF
--- a/x-pack/plugins/cases/server/client/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/utils.test.ts
@@ -117,18 +117,6 @@ describe('utils', () => {
       expect(node).toBeFalsy();
     });
 
-    it('returns undefined if the from is malformed', () => {
-      expect(() => buildRangeFilter({ from: '<' })).toThrowError(
-        'Invalid "from" and/or "to" query parameters'
-      );
-    });
-
-    it('returns undefined if the to is malformed', () => {
-      expect(() => buildRangeFilter({ to: '<' })).toThrowError(
-        'Invalid "from" and/or "to" query parameters'
-      );
-    });
-
     it('creates a range filter with only the from correctly', () => {
       const node = buildRangeFilter({ from: 'now-1M' });
       expect(toElasticsearchQuery(node!)).toMatchInlineSnapshot(`
@@ -216,6 +204,7 @@ describe('utils', () => {
         field: 'test',
         savedObjectType: 'test-type',
       });
+
       expect(toElasticsearchQuery(node!)).toMatchInlineSnapshot(`
         Object {
           "bool": Object {
@@ -242,6 +231,52 @@ describe('utils', () => {
                       "range": Object {
                         "test-type.attributes.test": Object {
                           "lte": "now",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        }
+      `);
+    });
+
+    it('escapes the query correctly', () => {
+      const node = buildRangeFilter({
+        from: '2022-04-27T12:55:47.576Z',
+        to: '2022-04-27T12:56:47.576Z',
+        field: '<weird field)',
+        savedObjectType: '.weird SO)',
+      });
+
+      expect(toElasticsearchQuery(node!)).toMatchInlineSnapshot(`
+        Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "bool": Object {
+                  "minimum_should_match": 1,
+                  "should": Array [
+                    Object {
+                      "range": Object {
+                        ".weird SO).attributes.<weird field)": Object {
+                          "gte": "2022-04-27T12:55:47.576Z",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+              Object {
+                "bool": Object {
+                  "minimum_should_match": 1,
+                  "should": Array [
+                    Object {
+                      "range": Object {
+                        ".weird SO).attributes.<weird field)": Object {
+                          "lte": "2022-04-27T12:56:47.576Z",
                         },
                       },
                     },

--- a/x-pack/plugins/cases/server/client/utils.ts
+++ b/x-pack/plugins/cases/server/client/utils.ts
@@ -12,7 +12,7 @@ import { fold } from 'fp-ts/lib/Either';
 import { identity } from 'fp-ts/lib/function';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { nodeBuilder, fromKueryExpression, KueryNode } from '@kbn/es-query';
+import { nodeBuilder, fromKueryExpression, KueryNode, escapeKuery } from '@kbn/es-query';
 import { CASE_SAVED_OBJECT } from '../../common/constants';
 import {
   OWNER_FIELD,
@@ -199,8 +199,14 @@ export const buildRangeFilter = ({
   }
 
   try {
-    const fromKQL = from != null ? `${savedObjectType}.attributes.${field} >= ${from}` : undefined;
-    const toKQL = to != null ? `${savedObjectType}.attributes.${field} <= ${to}` : undefined;
+    const fromKQL =
+      from != null
+        ? `${escapeKuery(savedObjectType)}.attributes.${escapeKuery(field)} >= ${escapeKuery(from)}`
+        : undefined;
+    const toKQL =
+      to != null
+        ? `${escapeKuery(savedObjectType)}.attributes.${escapeKuery(field)} <= ${escapeKuery(to)}`
+        : undefined;
 
     const rangeKQLQuery = `${fromKQL != null ? fromKQL : ''} ${
       fromKQL != null && toKQL != null ? 'and' : ''

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/find_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/find_cases.ts
@@ -517,8 +517,15 @@ export default ({ getService }: FtrProviderContext): void => {
         }
       });
 
-      it('returns a bad request on malformed parameter', async () => {
-        await findCases({ supertest, query: { from: '<' }, expectedHttpCode: 400 });
+      it('escapes correctly', async () => {
+        const cases = await findCases({
+          supertest,
+          query: { from: '2022-03-15T10:16:56.252Z', to: '2022-03-20T10:16:56.252' },
+        });
+
+        expect(cases.total).to.be(2);
+        expect(cases.count_open_cases).to.be(2);
+        expect(cases.cases.length).to.be(2);
       });
     });
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/status/get_status.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/status/get_status.ts
@@ -113,8 +113,17 @@ export default ({ getService }: FtrProviderContext): void => {
         }
       });
 
-      it('returns a bad request on malformed parameter', async () => {
-        await getAllCasesStatuses({ supertest, query: { from: '<' }, expectedHttpCode: 400 });
+      it('escapes correctly', async () => {
+        const statuses = await getAllCasesStatuses({
+          supertest,
+          query: { from: '2022-03-15T10:16:56.252Z', to: '2022-03-20T10:16:56.252' },
+        });
+
+        expect(statuses).to.eql({
+          count_open_cases: 2,
+          count_closed_cases: 0,
+          count_in_progress_cases: 0,
+        });
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/130979

## Testing

Do the following API requests. It should not return an error.

Find cases: `/api/cases/_find?status=open&from=2022-04-27T12:50:47.576Z&to=2022-04-27T12:55:47.576Z`
Get status: `/api/cases/status?from=2022-04-27T12:50:47.576Z&to=2022-04-27T12:55:47.576Z`

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
