### PR TITLE
[x-pack/functional] restore and fix home tests

### DIFF
--- a/x-pack/test/functional/apps/home/feature_controls/home_security.ts
+++ b/x-pack/test/functional/apps/home/feature_controls/home_security.ts
@@ -78,7 +78,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       it('shows the "Manage" action item', async () => {
-        await testSubjects.existOrFail('homManagementActionItem', {
+        await testSubjects.existOrFail('homeManage', {
           timeout: 2000,
         });
       });
@@ -128,7 +128,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       it('does not show the "Manage" action item', async () => {
-        await testSubjects.missingOrFail('homManagementActionItem', {
+        await testSubjects.missingOrFail('homeManage', {
           timeout: 2000,
         });
       });

--- a/x-pack/test/functional/config.js
+++ b/x-pack/test/functional/config.js
@@ -30,6 +30,7 @@ export default async function ({ readConfigFile }) {
   return {
     // list paths to the files that contain your plugins tests
     testFiles: [
+      resolve(__dirname, './apps/home'),
       resolve(__dirname, './apps/advanced_settings'),
       resolve(__dirname, './apps/canvas'),
       resolve(__dirname, './apps/graph'),


### PR DESCRIPTION
I'm playing around with functional tests and realized that the `x-pack/test/functional/app/home` tests weren't listed in the test files for the functional config and therefore weren't running. The test subjects needed a minor update, but they seem to be good to re-add.