### PR TITLE
[7.17][Security Solution][Endpoint] Fix artifact `path` file name checking utility

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.test.ts
@@ -574,7 +574,9 @@ describe('Executable filenames with wildcard PATHS', () => {
       hasSimpleExecutableName({
         os: OperatingSystem.WINDOWS,
         type: 'match',
-        value: 'c:\\folder\\one.exe',
+        // Long path below is on purpose due to an issue found in the field
+        value:
+          'C:\\ProgramData\\Package Cache\\sdjfhwojvmlowhnknblkm\\658945C6D1 992AD 576CCC0F43728A9 E60A8908A2\\658945C6D1992AD576CCC0F43728A9E60A8908A2\\Installers\\WimMountAdkSetupAmd64.exe',
       })
     ).toEqual(true);
   });

--- a/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.test.ts
@@ -558,4 +558,24 @@ describe('Executable filenames with wildcard PATHS', () => {
       })
     ).toEqual(false);
   });
+
+  it('should return FALSE when WINDOWS wildcards paths do not have a file name', () => {
+    expect(
+      hasSimpleExecutableName({
+        os: OperatingSystem.WINDOWS,
+        type: 'wildcard',
+        value: 'c:\\folder\\',
+      })
+    ).toEqual(false);
+  });
+
+  it('should TRUE when WINDOWS wildcards paths `type` is not `wildcard`', () => {
+    expect(
+      hasSimpleExecutableName({
+        os: OperatingSystem.WINDOWS,
+        type: 'match',
+        value: 'c:\\folder\\one.exe',
+      })
+    ).toEqual(true);
+  });
 });

--- a/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.ts
@@ -61,7 +61,7 @@ export const hasSimpleExecutableName = ({
     return false;
   }
 
-  return /[\*\?]/.test(lastString) === false;
+  return (lastString.split('*').length || lastString.split('?').length) === 1;
 };
 
 export const isPathValid = ({

--- a/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/trusted_apps/validations.ts
@@ -34,20 +34,13 @@ export const getDuplicateFields = (entries: ConditionEntry[]) => {
     .map((entry) => entry[0]);
 };
 
-/*
- * regex to match executable names
- * starts matching from the eol of the path
- * file names with a single or multiple spaces (for spaced names)
- * and hyphens and combinations of these that produce complex names
- * such as:
- * c:\home\lib\dmp.dmp
- * c:\home\lib\my-binary-app-+/ some/  x/ dmp.dmp
- * /home/lib/dmp.dmp
- * /home/lib/my-binary-app+-\ some\  x\ dmp.dmp
+/**
+ * checks if the filename of a given path (if any) is a simple executable (does NOT have the
+ * wildcards supported by endpoing (`*` and `?`))
+ * @param os
+ * @param type
+ * @param value
  */
-const WIN_EXEC_PATH = /\\(\w+|\w*[\w+|-]+\/ +)+\w+[\w+|-]+\.*\w+$/i;
-const UNIX_EXEC_PATH = /(\/|\w*[\w+|-]+\\ +)+\w+[\w+|-]+\.*\w*$/i;
-
 export const hasSimpleExecutableName = ({
   os,
   type,
@@ -57,10 +50,18 @@ export const hasSimpleExecutableName = ({
   type: TrustedAppEntryTypes;
   value: string;
 }): boolean => {
-  if (type === 'wildcard') {
-    return os === OperatingSystem.WINDOWS ? WIN_EXEC_PATH.test(value) : UNIX_EXEC_PATH.test(value);
+  if (type !== 'wildcard') {
+    return true;
   }
-  return true;
+
+  const separator = os === OperatingSystem.WINDOWS ? '\\' : '/';
+  const lastString = value.split(separator).pop();
+
+  if (!lastString) {
+    return false;
+  }
+
+  return /[\*\?]/.test(lastString) === false;
 };
 
 export const isPathValid = ({


### PR DESCRIPTION
## Summary

- Fixes a bug in the `RegExp` of the `hasSimpleExecutableName()` utility that was causing an infinite loop when used from Artifact Manifest manager and in turn preventing access to the entire Kibana system.

### About the bug:

With long paths defined with the `matches` operator defined for a Trusted App, **BUT** having no wildcards in the path, the artifact builder task does not complete and causes a Kibana TLS handshake timeout.



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


