### PR TITLE
[ci-stats/test-groups] report overall result of test group

### DIFF
--- a/packages/kbn-ci-stats-reporter/src/ci_stats_test_group_types.ts
+++ b/packages/kbn-ci-stats-reporter/src/ci_stats_test_group_types.ts
@@ -84,6 +84,10 @@ export interface CiStatsTestGroupInfo {
    */
   name: string;
   /**
+   * Overall result of this test group
+   */
+  result: 'fail' | 'pass' | 'skip';
+  /**
    * Arbitrary metadata associated with this group. We currently look for a ciGroup metadata property for highlighting that when appropriate
    */
   meta: CiStatsMetadata;

--- a/packages/kbn-test/src/functional_test_runner/lib/mocha/reporter/ci_stats_ftr_reporter.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/mocha/reporter/ci_stats_ftr_reporter.ts
@@ -80,6 +80,7 @@ export function setupCiStatsFtrTestGroupReporter({
     durationMs: 0,
     type: config.path.startsWith('x-pack') ? 'X-Pack Functional Tests' : 'Functional Tests',
     name: Path.relative(REPO_ROOT, config.path),
+    result: 'skip',
     meta: {
       ciGroup: config.get('suiteTags.include').find((t: string) => t.startsWith('ciGroup')),
       tags: [
@@ -117,6 +118,11 @@ export function setupCiStatsFtrTestGroupReporter({
     errors.set(test, error);
   });
 
+  let passCount = 0;
+  let failCount = 0;
+  runner.on('pass', () => (passCount += 1));
+  runner.on('fail', () => (failCount += 1));
+
   runner.on('hook end', (hook: Runnable) => {
     if (hook.isFailed()) {
       const error = errors.get(hook);
@@ -150,6 +156,7 @@ export function setupCiStatsFtrTestGroupReporter({
 
     // update the durationMs
     group.durationMs = Date.now() - startMs;
+    group.result = failCount ? 'fail' : passCount ? 'pass' : 'skip';
   });
 
   lifecycle.cleanup.add(async () => {


### PR DESCRIPTION
Provide ci-stats with an overall result for a test group.