### PR TITLE
Stabilize VisEditors tests by waiting for the chart to update

### DIFF
--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -787,6 +787,7 @@ export class VisualBuilderPageObject extends FtrService {
     });
 
     await this.setMetricsGroupByFiltering(filtering.include, filtering.exclude);
+    await this.header.waitUntilLoadingHasFinished();
   }
 
   public async setAnotherGroupByTermsField(field: string) {

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -787,7 +787,6 @@ export class VisualBuilderPageObject extends FtrService {
     });
 
     await this.setMetricsGroupByFiltering(filtering.include, filtering.exclude);
-    await this.header.waitUntilLoadingHasFinished();
   }
 
   public async setAnotherGroupByTermsField(field: string) {
@@ -892,6 +891,7 @@ export class VisualBuilderPageObject extends FtrService {
   }
 
   public async getChartDebugState(chartData?: DebugState) {
+    await this.header.waitUntilLoadingHasFinished();
     return chartData ?? (await this.elasticChart.getChartDebugData())!;
   }
 
@@ -909,7 +909,6 @@ export class VisualBuilderPageObject extends FtrService {
     chartData?: DebugState,
     itemType: 'areas' | 'bars' | 'annotations' = 'areas'
   ) {
-    await this.header.waitUntilLoadingHasFinished();
     return (await this.getChartDebugState(chartData))?.[itemType];
   }
 

--- a/x-pack/test/functional/apps/lens/chart_data.ts
+++ b/x-pack/test/functional/apps/lens/chart_data.ts
@@ -73,37 +73,31 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     }
 
     it('should render xy chart', async () => {
-      await PageObjects.lens.waitForVisualization('xyVisChart');
-
-      const data = await PageObjects.lens.getCurrentChartDebugState();
+      const data = await PageObjects.lens.getCurrentChartDebugState('xyVisChart');
       assertMatchesExpectedData(data!);
     });
 
     it('should render pie chart', async () => {
       await PageObjects.lens.switchToVisualization('pie');
-      await PageObjects.lens.waitForVisualization('partitionVisChart');
-      const data = await PageObjects.lens.getCurrentChartDebugState();
+      const data = await PageObjects.lens.getCurrentChartDebugState('partitionVisChart');
       assertMatchesExpectedPieData(data!);
     });
 
     it('should render donut chart', async () => {
       await PageObjects.lens.switchToVisualization('donut');
-      await PageObjects.lens.waitForVisualization('partitionVisChart');
-      const data = await PageObjects.lens.getCurrentChartDebugState();
+      const data = await PageObjects.lens.getCurrentChartDebugState('partitionVisChart');
       assertMatchesExpectedPieData(data!);
     });
 
     it('should render treemap chart', async () => {
       await PageObjects.lens.switchToVisualization('treemap', 'treemap');
-      await PageObjects.lens.waitForVisualization('partitionVisChart');
-      const data = await PageObjects.lens.getCurrentChartDebugState();
+      const data = await PageObjects.lens.getCurrentChartDebugState('partitionVisChart');
       assertMatchesExpectedPieData(data!);
     });
 
     it('should render heatmap chart', async () => {
       await PageObjects.lens.switchToVisualization('heatmap', 'heat');
-      await PageObjects.lens.waitForVisualization('heatmapChart');
-      const debugState = await PageObjects.lens.getCurrentChartDebugState();
+      const debugState = await PageObjects.lens.getCurrentChartDebugState('heatmapChart');
 
       if (!debugState) {
         throw new Error('Debug state is not available');

--- a/x-pack/test/functional/apps/lens/heatmap.ts
+++ b/x-pack/test/functional/apps/lens/heatmap.ts
@@ -38,8 +38,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should render heatmap chart with the temperature palette', async () => {
       await PageObjects.lens.switchToVisualization('heatmap', 'heat');
-      await PageObjects.lens.waitForVisualization('heatmapChart');
-      const debugState = await PageObjects.lens.getCurrentChartDebugState();
+      const debugState = await PageObjects.lens.getCurrentChartDebugState('heatmapChart');
 
       if (!debugState) {
         throw new Error('Debug state is not available');
@@ -78,9 +77,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           typeCharByChar: true,
         });
       });
-      await PageObjects.lens.waitForVisualization('heatmapChart');
-
-      const debugState = await PageObjects.lens.getCurrentChartDebugState();
+      const debugState = await PageObjects.lens.getCurrentChartDebugState('heatmapChart');
 
       if (!debugState) {
         throw new Error('Debug state is not available');
@@ -98,9 +95,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should not change when passing from percentage to number', async () => {
       await testSubjects.click('lnsPalettePanel_dynamicColoring_rangeType_groups_number');
-      await PageObjects.lens.waitForVisualization('heatmapChart');
-
-      const debugState = await PageObjects.lens.getCurrentChartDebugState();
+      const debugState = await PageObjects.lens.getCurrentChartDebugState('heatmapChart');
 
       if (!debugState) {
         throw new Error('Debug state is not available');
@@ -124,9 +119,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.setValue('lnsPalettePanel_dynamicColoring_range_value_0', '0', {
         clearWithKeyboard: true,
       });
-      await PageObjects.lens.waitForVisualization('heatmapChart');
 
-      const debugState = await PageObjects.lens.getCurrentChartDebugState();
+      const debugState = await PageObjects.lens.getCurrentChartDebugState('heatmapChart');
 
       if (!debugState) {
         throw new Error('Debug state is not available');
@@ -144,9 +138,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should reset stop numbers when changing palette', async () => {
       await PageObjects.lens.changePaletteTo('status');
-      await PageObjects.lens.waitForVisualization('heatmapChart');
 
-      const debugState = await PageObjects.lens.getCurrentChartDebugState();
+      const debugState = await PageObjects.lens.getCurrentChartDebugState('heatmapChart');
 
       if (!debugState) {
         throw new Error('Debug state is not available');
@@ -164,9 +157,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should not change when passing from number to percent', async () => {
       await testSubjects.click('lnsPalettePanel_dynamicColoring_rangeType_groups_percent');
-      await PageObjects.lens.waitForVisualization('heatmapChart');
 
-      const debugState = await PageObjects.lens.getCurrentChartDebugState();
+      const debugState = await PageObjects.lens.getCurrentChartDebugState('heatmapChart');
 
       if (!debugState) {
         throw new Error('Debug state is not available');

--- a/x-pack/test/functional/apps/lens/multi_terms.ts
+++ b/x-pack/test/functional/apps/lens/multi_terms.ts
@@ -50,7 +50,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'Top values of geo.src + 2 others'
       );
 
-      const data = await PageObjects.lens.getCurrentChartDebugState();
+      const data = await PageObjects.lens.getCurrentChartDebugState('xyVisChart');
       expect(data!.bars![0].bars[0].x).to.eql('PE › US › 19,986');
     });
 
@@ -75,7 +75,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await PageObjects.lens.closeDimensionEditor();
 
-      const data = await PageObjects.lens.getCurrentChartDebugState();
+      const data = await PageObjects.lens.getCurrentChartDebugState('xyVisChart');
       expect(data?.bars?.[0]?.name).to.eql('PE › US › 19,986');
     });
 

--- a/x-pack/test/functional/apps/lens/smokescreen.ts
+++ b/x-pack/test/functional/apps/lens/smokescreen.ts
@@ -240,14 +240,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       await PageObjects.lens.changeAxisSide('right');
-      await PageObjects.lens.waitForVisualization('xyVisChart');
-      let data = await PageObjects.lens.getCurrentChartDebugState();
+      let data = await PageObjects.lens.getCurrentChartDebugState('xyVisChart');
       expect(data?.axes?.y.length).to.eql(2);
       expect(data?.axes?.y.some(({ position }) => position === 'right')).to.eql(true);
 
       await PageObjects.lens.changeAxisSide('left');
-      await PageObjects.lens.waitForVisualization('xyVisChart');
-      data = await PageObjects.lens.getCurrentChartDebugState();
+      data = await PageObjects.lens.getCurrentChartDebugState('xyVisChart');
       expect(data?.axes?.y.length).to.eql(1);
       expect(data?.axes?.y.some(({ position }) => position === 'right')).to.eql(false);
 
@@ -262,18 +260,15 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.openVisualOptions();
       await testSubjects.click('lns_valueLabels_inside');
 
-      await PageObjects.lens.waitForVisualization('xyVisChart');
-
       // check for value labels
-      let data = await PageObjects.lens.getCurrentChartDebugState();
+      let data = await PageObjects.lens.getCurrentChartDebugState('xyVisChart');
       expect(data?.bars?.[0].labels).not.to.eql(0);
 
       // switch to stacked bar chart
       await PageObjects.lens.switchToVisualization('bar_stacked');
-      await PageObjects.lens.waitForVisualization('xyVisChart');
 
       // check for value labels
-      data = await PageObjects.lens.getCurrentChartDebugState();
+      data = await PageObjects.lens.getCurrentChartDebugState('xyVisChart');
       expect(data?.bars?.[0].labels.length).to.eql(0);
     });
 
@@ -283,16 +278,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.setValue('lnsyLeftAxisTitle', axisTitle, {
         clearWithKeyboard: true,
       });
-      await PageObjects.lens.waitForVisualization('xyVisChart');
 
-      let data = await PageObjects.lens.getCurrentChartDebugState();
+      let data = await PageObjects.lens.getCurrentChartDebugState('xyVisChart');
       expect(data?.axes?.y?.[0].title).to.eql(axisTitle);
 
       // hide the gridlines
       await testSubjects.click('lnsshowyLeftAxisGridlines');
-      await PageObjects.lens.waitForVisualization('xyVisChart');
 
-      data = await PageObjects.lens.getCurrentChartDebugState();
+      data = await PageObjects.lens.getCurrentChartDebugState('xyVisChart');
       expect(data?.axes?.y?.[0].gridlines.length).to.eql(0);
     });
 

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -907,6 +907,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     },
 
     async getCurrentChartDebugState() {
+      await this.waitForVisualization();
       return await elasticChart.getChartDebugData('lnsWorkspace');
     },
 

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -906,8 +906,8 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       );
     },
 
-    async getCurrentChartDebugState() {
-      await this.waitForVisualization();
+    async getCurrentChartDebugState(visType: string) {
+      await this.waitForVisualization(visType);
       return await elasticChart.getChartDebugData('lnsWorkspace');
     },
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/131107
Fixes https://github.com/elastic/kibana/issues/131092
Fixes https://github.com/elastic/kibana/issues/131087

VisEditors test got reshuffled recently which changed some timings and a few tests that worked by chance previously got a little flaky - this PR makes sure to wait for the loading to finish before fetching the current chart state for Lens and TSVB