### PR TITLE
[MetricVis] Fix single color palette configuration for Lens

### DIFF
--- a/src/plugins/chart_expressions/expression_metric/public/components/metric_component.tsx
+++ b/src/plugins/chart_expressions/expression_metric/public/components/metric_component.tsx
@@ -81,7 +81,7 @@ class MetricVisComponent extends Component<MetricVisComponentProps> {
             title = `${bucketValue} - ${title}`;
           }
 
-          const shouldBrush = stops.length > 1 && shouldApplyColor(color ?? '');
+          const shouldBrush = shouldApplyColor(color ?? '');
           return {
             label: title,
             value: formattedValue,

--- a/src/plugins/vis_types/metric/public/to_ast.ts
+++ b/src/plugins/vis_types/metric/public/to_ast.ts
@@ -83,7 +83,7 @@ export const toExpressionAst: VisToExpressionAst<VisParams> = (vis, params) => {
     )
   );
 
-  if (colorsRange && colorsRange.length) {
+  if (colorsRange && colorsRange.length > 1) {
     const stopsWithColors = getStopsWithColorsFromRanges(colorsRange, colorSchema, invertColors);
     const palette = buildExpressionFunction('palette', {
       ...stopsWithColors,


### PR DESCRIPTION
## Summary
Closes: https://github.com/elastic/kibana/issues/131038

## Before [Lens]:
<img width="886" alt="Screenshot 2022-04-28 at 12 02 18" src="https://user-images.githubusercontent.com/22456368/165717461-bc602c7d-a313-4e9c-95cb-ed7125a2b67a.png">

## After [Lens]:
<img width="886" alt="Screenshot 2022-04-28 at 12 03 07" src="https://user-images.githubusercontent.com/22456368/165717630-4750abb9-4e8b-4bd9-9793-b174c13ce855.png">


## Before [VisTypes]:
<img width="979" alt="Screenshot 2022-04-28 at 12 05 54" src="https://user-images.githubusercontent.com/22456368/165718190-bb85108c-9e06-4e4c-9bcd-402a6567cb01.png">


## After [VisTypes]:
<img width="979" alt="Screenshot 2022-04-28 at 12 09 36" src="https://user-images.githubusercontent.com/22456368/165718917-e994e2ff-e3d1-4a44-8bcc-5d194a260aea.png">

