### PR TITLE
[Cloud Posture] Findings table columns update

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/csp_evaluation_badge.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_evaluation_badge.tsx
@@ -22,9 +22,9 @@ const getColor = (type: Props['type']): EuiBadgeProps['color'] => {
 export const CspEvaluationBadge = ({ type }: Props) => (
   <EuiBadge color={getColor(type)}>
     {type === 'failed' ? (
-      <FormattedMessage id="xpack.csp.cspEvaluationBadge.failLabel" defaultMessage="FAIL" />
+      <FormattedMessage id="xpack.csp.cspEvaluationBadge.failLabel" defaultMessage="Fail" />
     ) : (
-      <FormattedMessage id="xpack.csp.cspEvaluationBadge.passLabel" defaultMessage="PASS" />
+      <FormattedMessage id="xpack.csp.cspEvaluationBadge.passLabel" defaultMessage="Pass" />
     )}
   </EuiBadge>
 );

--- a/x-pack/plugins/cloud_security_posture/public/components/csp_evaluation_badge.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_evaluation_badge.tsx
@@ -22,9 +22,9 @@ const getColor = (type: Props['type']): EuiBadgeProps['color'] => {
 export const CspEvaluationBadge = ({ type }: Props) => (
   <EuiBadge color={getColor(type)}>
     {type === 'failed' ? (
-      <FormattedMessage id="xpack.csp.cspEvaluationBadge.failedLabel" defaultMessage="FAILED" />
+      <FormattedMessage id="xpack.csp.cspEvaluationBadge.failLabel" defaultMessage="FAIL" />
     ) : (
-      <FormattedMessage id="xpack.csp.cspEvaluationBadge.passedLabel" defaultMessage="PASSED" />
+      <FormattedMessage id="xpack.csp.cspEvaluationBadge.passLabel" defaultMessage="PASS" />
     )}
   </EuiBadge>
 );

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -165,7 +165,7 @@ const getGeneralCards = ({ rule }: CspFinding): Card[] => [
 
 const getRemediationCards = ({ result, ...rest }: CspFinding): Card[] => [
   {
-    title: TEXT.RESULT,
+    title: TEXT.RESULT_DETAILS,
     listItems: [
       [TEXT.EXPECTED, ''],
       [TEXT.EVIDENCE, <CodeBlock>{JSON.stringify(result.evidence, null, 2)}</CodeBlock>],

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
@@ -8,7 +8,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import {
   type Criteria,
   EuiToolTip,
-  EuiLink,
   EuiTableFieldDataColumnType,
   EuiEmptyPrompt,
   EuiBasicTable,
@@ -17,7 +16,6 @@ import {
 } from '@elastic/eui';
 import moment from 'moment';
 import { SortDirection } from '@kbn/data-plugin/common';
-import { ApiKey } from '@kbn/security-plugin/common';
 import { EuiTableActionsColumnType } from '@elastic/eui/src/components/basic_table/table_types';
 import { extractErrorMessage } from '../../../common/utils/helpers';
 import * as TEST_SUBJECTS from './test_subjects';
@@ -26,7 +24,6 @@ import type { CspFinding } from './types';
 import { CspEvaluationBadge } from '../../components/csp_evaluation_badge';
 import type { FindingsGroupByNoneQuery, CspFindingsResult } from './use_findings';
 import { FindingsRuleFlyout } from './findings_flyout/findings_flyout';
-import { LAST_CHECKED } from './translations';
 
 interface BaseFindingsTableProps extends FindingsGroupByNoneQuery {
   setQuery(query: Partial<FindingsGroupByNoneQuery>): void;
@@ -47,59 +44,62 @@ const FindingsTableComponent = ({
 
   const columns: Array<
     EuiTableFieldDataColumnType<CspFinding> | EuiTableActionsColumnType<CspFinding>
-  > = [
-    {
-      width: '40px',
-      actions: [
-        {
-          name: 'Expand',
-          description: 'Expand',
-          type: 'icon',
-          icon: 'expand',
-          onClick: (item) => setSelectedFinding(item),
-        },
-      ],
-    },
-    {
-      field: 'resource_id',
-      name: TEXT.RESOURCE_ID,
-      truncateText: true,
-      width: '15%',
-      sortable: true,
-      render: resourceFilenameRenderer,
-    },
-    {
-      field: 'result.evaluation',
-      name: TEXT.RESULT,
-      width: '100px',
-      sortable: true,
-      render: resultEvaluationRenderer,
-    },
-    {
-      field: 'rule.name',
-      name: TEXT.RULE_NAME,
-      truncateText: true,
-      sortable: true,
-      render: ruleNameRenderer,
-    },
-    {
-      field: 'cluster_id',
-      name: TEXT.SYSTEM_ID,
-      truncateText: true,
-    },
-    {
-      field: 'rule.section',
-      name: TEXT.RULE_SECTION,
-      truncateText: true,
-    },
-    {
-      field: '@timestamp',
-      name: TEXT.LAST_CHECKED,
-      truncateText: true,
-      sortable: true,
-      render: timestampRenderer,
-    },
-  ];
+  > = useMemo(
+    () => [
+      {
+        width: '40px',
+        actions: [
+          {
+            name: 'Expand',
+            description: 'Expand',
+            type: 'icon',
+            icon: 'expand',
+            onClick: (item) => setSelectedFinding(item),
+          },
+        ],
+      },
+      {
+        field: 'resource_id',
+        name: TEXT.RESOURCE_ID,
+        truncateText: true,
+        width: '15%',
+        sortable: true,
+        render: resourceFilenameRenderer,
+      },
+      {
+        field: 'result.evaluation',
+        name: TEXT.RESULT,
+        width: '100px',
+        sortable: true,
+        render: resultEvaluationRenderer,
+      },
+      {
+        field: 'rule.name',
+        name: TEXT.RULE_NAME,
+        truncateText: true,
+        sortable: true,
+        render: ruleNameRenderer,
+      },
+      {
+        field: 'cluster_id',
+        name: TEXT.SYSTEM_ID,
+        truncateText: true,
+      },
+      {
+        field: 'rule.section',
+        name: TEXT.RULE_SECTION,
+        truncateText: true,
+      },
+      {
+        field: '@timestamp',
+        name: TEXT.LAST_CHECKED,
+        truncateText: true,
+        sortable: true,
+        render: timestampRenderer,
+      },
+    ],
+    []
+  );
 
   const pagination = useMemo(
     () =>

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
@@ -77,7 +77,6 @@ const FindingsTableComponent = ({
         field: 'rule.name',
         name: TEXT.RULE,
         sortable: true,
-        render: ruleNameRenderer,
       },
       {
         field: 'cluster_id',
@@ -198,12 +197,6 @@ const timestampRenderer = (timestamp: string) => (
 const resourceFilenameRenderer = (filename: string) => (
   <EuiToolTip position="top" content={filename}>
     <span>{filename}</span>
-  </EuiToolTip>
-);
-
-const ruleNameRenderer = (name: string) => (
-  <EuiToolTip position="top" content={name}>
-    <span>{name}</span>
   </EuiToolTip>
 );
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
@@ -75,8 +75,7 @@ const FindingsTableComponent = ({
       },
       {
         field: 'rule.name',
-        name: TEXT.RULE_NAME,
-        truncateText: true,
+        name: TEXT.RULE,
         sortable: true,
         render: ruleNameRenderer,
       },
@@ -84,10 +83,12 @@ const FindingsTableComponent = ({
         field: 'cluster_id',
         name: TEXT.SYSTEM_ID,
         truncateText: true,
+        sortable: true,
       },
       {
         field: 'rule.section',
-        name: TEXT.RULE_SECTION,
+        name: TEXT.CIS_SECTION,
+        sortable: true,
         truncateText: true,
       },
       {
@@ -112,13 +113,6 @@ const FindingsTableComponent = ({
   );
 
   const sorting = useMemo(() => getEuiSortFromEsSearchSource(sort), [sort]);
-
-  const getCellProps = useCallback(
-    (item: CspFinding, column: EuiTableFieldDataColumnType<CspFinding>) => ({
-      onClick: column.field === 'rule.name' ? () => setSelectedFinding(item) : undefined,
-    }),
-    []
-  );
 
   const onTableChange = useCallback(
     (params: Criteria<CspFinding>) => {
@@ -149,7 +143,6 @@ const FindingsTableComponent = ({
         pagination={pagination}
         sorting={sorting}
         onChange={onTableChange}
-        cellProps={getCellProps}
         hasActions
       />
       {selectedFinding && (

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
@@ -42,6 +42,41 @@ export const RESOURCE = i18n.translate('xpack.csp.findings.resourceLabel', {
   defaultMessage: 'Resource',
 });
 
+export const RESOURCE_ID = i18n.translate(
+  'xpack.csp.findings.findingsTable.findingsTableColumn.resourceIdColumnLabel',
+  {
+    defaultMessage: 'Resource ID',
+  }
+);
+
+export const RESULT = i18n.translate(
+  'xpack.csp.findings.findingsTable.findingsTableColumn.resultColumnLabel',
+  {
+    defaultMessage: 'Result',
+  }
+);
+
+export const SYSTEM_ID = i18n.translate(
+  'xpack.csp.findings.findingsTable.findingsTableColumn.systemIdColumnLabel',
+  {
+    defaultMessage: 'System ID',
+  }
+);
+
+export const RULE_SECTION = i18n.translate(
+  'xpack.csp.findings.findingsTable.findingsTableColumn.ruleSectionColumnLabel',
+  {
+    defaultMessage: 'Rule Section',
+  }
+);
+
+export const LAST_CHECKED = i18n.translate(
+  'xpack.csp.findings.findingsTable.findingsTableColumn.lastCheckedColumnLabel',
+  {
+    defaultMessage: 'Last Checked',
+  }
+);
+
 export const FILENAME = i18n.translate('xpack.csp.findings.filenameLabel', {
   defaultMessage: 'Filename',
 });
@@ -106,7 +141,7 @@ export const AUDIT = i18n.translate('xpack.csp.findings.auditLabel', {
   defaultMessage: 'Audit',
 });
 
-export const RESULT = i18n.translate('xpack.csp.findings.resultLabel', {
+export const RESULT_DETAILS = i18n.translate('xpack.csp.findings.resultLabel', {
   defaultMessage: 'Result Details',
 });
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
@@ -63,10 +63,10 @@ export const SYSTEM_ID = i18n.translate(
   }
 );
 
-export const RULE_SECTION = i18n.translate(
+export const CIS_SECTION = i18n.translate(
   'xpack.csp.findings.findingsTable.findingsTableColumn.ruleSectionColumnLabel',
   {
-    defaultMessage: 'Rule Section',
+    defaultMessage: 'CIS Section',
   }
 );
 


### PR DESCRIPTION
## Summary

Updated findings table columns.
- [x] now displaying `resource_id` 
- [x] result tags now show `PASS` and `FAIL`
- [x] rule names are no longer clickable to open the flyout
- [x] added expand button to open the flyout
- [x] rule section column added, awaiting data
- [x] `last checked` column now displaying data in `x time ago` formart

![image](https://user-images.githubusercontent.com/51442161/165747400-94385b79-c4e4-48e0-9984-46886966d333.png)

![image](https://user-images.githubusercontent.com/51442161/165747344-053bf283-b9cd-4c5d-a161-a7b7d362d6c9.png)