### PR TITLE
[Cloud Security] Dashboard failed findings by CIS Section

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/types.ts
+++ b/x-pack/plugins/cloud_security_posture/common/types.ts
@@ -36,7 +36,7 @@ export interface Cluster {
     lastUpdate: number; // unix epoch time
   };
   stats: Stats;
-  resourcesTypes: GroupedFindingsEvaluation[];
+  groupedFindingsEvaluation: GroupedFindingsEvaluation[];
   trend: PostureTrend[];
 }
 

--- a/x-pack/plugins/cloud_security_posture/common/types.ts
+++ b/x-pack/plugins/cloud_security_posture/common/types.ts
@@ -21,7 +21,7 @@ export interface Stats extends FindingsEvaluation {
   postureScore: Score;
 }
 
-export interface ResourceType extends FindingsEvaluation {
+export interface GroupedFindingsEvaluation extends FindingsEvaluation {
   name: string;
 }
 
@@ -36,13 +36,13 @@ export interface Cluster {
     lastUpdate: number; // unix epoch time
   };
   stats: Stats;
-  resourcesTypes: ResourceType[];
+  resourcesTypes: GroupedFindingsEvaluation[];
   trend: PostureTrend[];
 }
 
 export interface ComplianceDashboardData {
   stats: Stats;
-  resourcesTypes: ResourceType[];
+  groupedFindingsEvaluation: GroupedFindingsEvaluation[];
   clusters: Cluster[];
   trend: PostureTrend[];
 }

--- a/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
@@ -18,7 +18,7 @@ const getFindingsQuery = (queryValue: Query['query']): Pick<FindingsBaseURLQuery
       : // TODO: use a tested query builder instead ASAP
         Object.entries(queryValue)
           .reduce<string[]>((a, [key, value]) => {
-            a.push(`${key} : "${value}"`);
+            a.push(`${key}: "${value}"`);
             return a;
           }, [])
           .join(' and ');

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/risks_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/risks_table.tsx
@@ -66,10 +66,10 @@ export interface RisksTableProps {
 }
 
 export const getTopRisks = (
-  resourcesTypes: ComplianceDashboardData['groupedFindingsEvaluation'],
+  groupedFindingsEvaluation: ComplianceDashboardData['groupedFindingsEvaluation'],
   maxItems: number
 ) => {
-  const filtered = resourcesTypes.filter((x) => x.totalFailed > 0);
+  const filtered = groupedFindingsEvaluation.filter((x) => x.totalFailed > 0);
   const sorted = filtered.slice().sort((first, second) => second.totalFailed - first.totalFailed);
 
   return sorted.slice(0, maxItems);

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/risks_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/risks_table.tsx
@@ -14,7 +14,7 @@ import {
   EuiLink,
   EuiText,
 } from '@elastic/eui';
-import { ComplianceDashboardData, ResourceType } from '../../../../common/types';
+import { ComplianceDashboardData, GroupedFindingsEvaluation } from '../../../../common/types';
 import { CompactFormattedNumber } from '../../../components/compact_formatted_number';
 import * as TEXT from '../translations';
 import { INTERNAL_FEATURE_FLAGS } from '../../../../common/constants';
@@ -59,14 +59,14 @@ const mockData = [
 ];
 
 export interface RisksTableProps {
-  data: ComplianceDashboardData['resourcesTypes'];
+  data: ComplianceDashboardData['groupedFindingsEvaluation'];
   maxItems: number;
-  onCellClick: (resourceTypeName: string) => void;
+  onCellClick: (name: string) => void;
   onViewAllClick: () => void;
 }
 
 export const getTopRisks = (
-  resourcesTypes: ComplianceDashboardData['resourcesTypes'],
+  resourcesTypes: ComplianceDashboardData['groupedFindingsEvaluation'],
   maxItems: number
 ) => {
   const filtered = resourcesTypes.filter((x) => x.totalFailed > 0);
@@ -85,15 +85,18 @@ export const RisksTable = ({
     () => [
       {
         field: 'name',
-        name: TEXT.RESOURCE_TYPE,
-        render: (resourceTypeName: ResourceType['name']) => (
-          <EuiLink onClick={() => onCellClick(resourceTypeName)}>{resourceTypeName}</EuiLink>
+        name: TEXT.CIS_SECTION,
+        render: (name: GroupedFindingsEvaluation['name']) => (
+          <EuiLink onClick={() => onCellClick(name)}>{name}</EuiLink>
         ),
       },
       {
         field: 'totalFailed',
         name: TEXT.FINDINGS,
-        render: (totalFailed: ResourceType['totalFailed'], resource: ResourceType) => (
+        render: (
+          totalFailed: GroupedFindingsEvaluation['totalFailed'],
+          resource: GroupedFindingsEvaluation
+        ) => (
           <>
             <EuiText size="s" color="danger">
               <CompactFormattedNumber number={resource.totalFailed} />
@@ -114,7 +117,7 @@ export const RisksTable = ({
   return (
     <EuiFlexGroup direction="column" justifyContent="spaceBetween" gutterSize="s">
       <EuiFlexItem>
-        <EuiBasicTable<ResourceType>
+        <EuiBasicTable<GroupedFindingsEvaluation>
           rowHeader="name"
           items={INTERNAL_FEATURE_FLAGS.showRisksMock ? getTopRisks(mockData, maxItems) : items}
           columns={columns}

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -110,7 +110,7 @@ export const BenchmarksSection = ({
                 <EuiFlexItem grow={4}>
                   <ChartPanel title={TEXT.RISKS} hasBorder={false}>
                     <RisksTable
-                      data={cluster.resourcesTypes}
+                      data={cluster.groupedFindingsEvaluation}
                       maxItems={3}
                       onCellClick={(resourceTypeName) =>
                         handleCellClick(cluster.meta.clusterId, resourceTypeName)

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -42,19 +42,19 @@ export const BenchmarksSection = ({
     const [layerValue] = element;
     const evaluation = layerValue[0].groupByRollup as Evaluation;
 
-    navToFindings({ cluster_id: clusterId, 'result.evaluation': evaluation });
+    navToFindings({ 'cluster_id.keyword': clusterId, 'result.evaluation.keyword': evaluation });
   };
 
-  const handleCellClick = (clusterId: string, resourceTypeName: string) => {
+  const handleCellClick = (clusterId: string, ruleSection: string) => {
     navToFindings({
-      cluster_id: clusterId,
-      'resource.type': resourceTypeName,
-      'result.evaluation': RULE_FAILED,
+      'cluster_id.keyword': clusterId,
+      'rule.section.keyword': ruleSection,
+      'result.evaluation.keyword': RULE_FAILED,
     });
   };
 
   const handleViewAllClick = (clusterId: string) => {
-    navToFindings({ cluster_id: clusterId, 'result.evaluation': RULE_FAILED });
+    navToFindings({ 'cluster_id.keyword': clusterId, 'result.evaluation.keyword': RULE_FAILED });
   };
 
   return (

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
@@ -61,7 +61,7 @@ export const SummarySection = ({ complianceData }: { complianceData: ComplianceD
       <EuiFlexItem>
         <ChartPanel title={TEXT.RISKS}>
           <RisksTable
-            data={complianceData.resourcesTypes}
+            data={complianceData.groupedFindingsEvaluation}
             maxItems={5}
             onCellClick={handleCellClick}
             onViewAllClick={handleViewAllClick}

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
@@ -32,15 +32,18 @@ export const SummarySection = ({ complianceData }: { complianceData: ComplianceD
     const [layerValue] = element;
     const evaluation = layerValue[0].groupByRollup as Evaluation;
 
-    navToFindings({ 'result.evaluation': evaluation });
+    navToFindings({ 'result.evaluation.keyword': evaluation });
   };
 
-  const handleCellClick = (resourceTypeName: string) => {
-    navToFindings({ 'resource.type': resourceTypeName, 'result.evaluation': RULE_FAILED });
+  const handleCellClick = (ruleSection: string) => {
+    navToFindings({
+      'rule.section.keyword': ruleSection,
+      'result.evaluation.keyword': RULE_FAILED,
+    });
   };
 
   const handleViewAllClick = () => {
-    navToFindings({ 'result.evaluation': RULE_FAILED });
+    navToFindings({ 'result.evaluation.keyword': RULE_FAILED });
   };
 
   return (

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/translations.ts
@@ -75,8 +75,8 @@ export const VIEW_ALL_FAILED_FINDINGS = i18n.translate('xpack.csp.view_all_faile
   defaultMessage: 'View all failed findings',
 });
 
-export const RESOURCE_TYPE = i18n.translate('xpack.csp.resource_type', {
-  defaultMessage: 'Resource Type',
+export const RESOURCE_TYPE = i18n.translate('xpack.csp.cis_section', {
+  defaultMessage: 'CIS Section',
 });
 
 export const FINDINGS = i18n.translate('xpack.csp.findings', {

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/translations.ts
@@ -75,7 +75,7 @@ export const VIEW_ALL_FAILED_FINDINGS = i18n.translate('xpack.csp.view_all_faile
   defaultMessage: 'View all failed findings',
 });
 
-export const RESOURCE_TYPE = i18n.translate('xpack.csp.cis_section', {
+export const CIS_SECTION = i18n.translate('xpack.csp.cis_section', {
   defaultMessage: 'CIS Section',
 });
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/translations.ts
@@ -75,7 +75,7 @@ export const VIEW_ALL_FAILED_FINDINGS = i18n.translate('xpack.csp.view_all_faile
   defaultMessage: 'View all failed findings',
 });
 
-export const CIS_SECTION = i18n.translate('xpack.csp.cis_section', {
+export const CIS_SECTION = i18n.translate('xpack.csp.dashboard.risksTable.cisSectionColumnLabel', {
   defaultMessage: 'CIS Section',
 });
 

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.ts
@@ -10,7 +10,7 @@ import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/type
 import type { ComplianceDashboardData } from '../../../common/types';
 import { LATEST_FINDINGS_INDEX_PATTERN, STATS_ROUTE_PATH } from '../../../common/constants';
 import { CspAppContext } from '../../plugin';
-import { getResourcesTypes } from './get_resources_types';
+import { getGroupedFindingsEvaluation } from './get_grouped_findings_evaluation';
 import { ClusterWithoutTrend, getClusters } from './get_clusters';
 import { getStats } from './get_stats';
 import { CspRouter } from '../../types';
@@ -55,12 +55,14 @@ export const defineGetComplianceDashboardRoute = (
           match_all: {},
         };
 
-        const [stats, resourcesTypes, clustersWithoutTrends, trends] = await Promise.all([
-          getStats(esClient, query, pitId),
-          getResourcesTypes(esClient, query, pitId),
-          getClusters(esClient, query, pitId),
-          getTrends(esClient),
-        ]);
+        const [stats, groupedFindingsEvaluation, clustersWithoutTrends, trends] = await Promise.all(
+          [
+            getStats(esClient, query, pitId),
+            getGroupedFindingsEvaluation(esClient, query, pitId),
+            getClusters(esClient, query, pitId),
+            getTrends(esClient),
+          ]
+        );
 
         // Try closing the PIT, if it fails we can safely ignore the error since it closes itself after the keep alive
         //   ends. Not waiting on the promise returned from the `closePointInTime` call to avoid delaying the request
@@ -73,7 +75,7 @@ export const defineGetComplianceDashboardRoute = (
 
         const body: ComplianceDashboardData = {
           stats,
-          resourcesTypes,
+          groupedFindingsEvaluation,
           clusters,
           trend,
         };

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.test.ts
@@ -66,7 +66,7 @@ describe('getClustersFromAggs', () => {
           totalPassed: 6,
           postureScore: 50.0,
         },
-        resourcesTypes: [
+        groupedFindingsEvaluation: [
           {
             name: 'foo_type',
             totalFindings: 6,

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
@@ -12,8 +12,11 @@ import type {
   SearchRequest,
 } from '@elastic/elasticsearch/lib/api/types';
 import { Cluster } from '../../../common/types';
-import { getFailedFindingsFromAggs, failedFindingsAggQuery } from './get_resources_types';
-import type { FailedFindingsQueryResult } from './get_resources_types';
+import {
+  getFailedFindingsFromAggs,
+  failedFindingsAggQuery,
+} from './get_grouped_findings_evaluation';
+import type { FailedFindingsQueryResult } from './get_grouped_findings_evaluation';
 import { findingsEvaluationAggsQuery, getStatsFromFindingsEvaluationsAggs } from './get_stats';
 import { KeyDocCount } from './compliance_dashboard';
 

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
@@ -12,14 +12,14 @@ import type {
   SearchRequest,
 } from '@elastic/elasticsearch/lib/api/types';
 import { Cluster } from '../../../common/types';
-import { getResourceTypeFromAggs, resourceTypeAggQuery } from './get_resources_types';
-import type { ResourceTypeQueryResult } from './get_resources_types';
+import { getFailedFindingsFromAggs, failedFindingsAggQuery } from './get_resources_types';
+import type { FailedFindingsQueryResult } from './get_resources_types';
 import { findingsEvaluationAggsQuery, getStatsFromFindingsEvaluationsAggs } from './get_stats';
 import { KeyDocCount } from './compliance_dashboard';
 
 type UnixEpochTime = number;
 
-export interface ClusterBucket extends ResourceTypeQueryResult, KeyDocCount {
+export interface ClusterBucket extends FailedFindingsQueryResult, KeyDocCount {
   failed_findings: {
     doc_count: number;
   };
@@ -59,7 +59,7 @@ export const getClustersQuery = (query: QueryDslQueryContainer, pitId: string): 
             },
           },
         },
-        ...resourceTypeAggQuery,
+        ...failedFindingsAggQuery,
         ...findingsEvaluationAggsQuery,
       },
     },
@@ -92,7 +92,7 @@ export const getClustersFromAggs = (clusters: ClusterBucket[]): ClusterWithoutTr
     const resourcesTypesAggs = cluster.aggs_by_resource_type.buckets;
     if (!Array.isArray(resourcesTypesAggs))
       throw new Error('missing aggs by resource type per cluster');
-    const resourcesTypes = getResourceTypeFromAggs(resourcesTypesAggs);
+    const resourcesTypes = getFailedFindingsFromAggs(resourcesTypesAggs);
 
     return {
       meta,

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
@@ -95,12 +95,12 @@ export const getClustersFromAggs = (clusters: ClusterBucket[]): ClusterWithoutTr
     const resourcesTypesAggs = cluster.aggs_by_resource_type.buckets;
     if (!Array.isArray(resourcesTypesAggs))
       throw new Error('missing aggs by resource type per cluster');
-    const resourcesTypes = getFailedFindingsFromAggs(resourcesTypesAggs);
+    const groupedFindingsEvaluation = getFailedFindingsFromAggs(resourcesTypesAggs);
 
     return {
       meta,
       stats,
-      resourcesTypes,
+      groupedFindingsEvaluation,
     };
   });
 

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_grouped_findings_evaluation.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_grouped_findings_evaluation.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getFailedFindingsFromAggs, FailedFindingsBucket } from './get_resources_types';
+import { getFailedFindingsFromAggs, FailedFindingsBucket } from './get_grouped_findings_evaluation';
 
 const resourceTypeBuckets: FailedFindingsBucket[] = [
   {

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_grouped_findings_evaluation.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_grouped_findings_evaluation.ts
@@ -54,7 +54,7 @@ export const getRisksEsQuery = (query: QueryDslQueryContainer, pitId: string): S
 
 export const getFailedFindingsFromAggs = (
   queryResult: FailedFindingsBucket[]
-): ComplianceDashboardData['resourcesTypes'] =>
+): ComplianceDashboardData['groupedFindingsEvaluation'] =>
   queryResult.map((bucket) => ({
     name: bucket.key,
     totalFindings: bucket.doc_count,
@@ -62,11 +62,11 @@ export const getFailedFindingsFromAggs = (
     totalPassed: bucket.passed_findings.doc_count || 0,
   }));
 
-export const getResourcesTypes = async (
+export const getGroupedFindingsEvaluation = async (
   esClient: ElasticsearchClient,
   query: QueryDslQueryContainer,
   pitId: string
-): Promise<ComplianceDashboardData['resourcesTypes']> => {
+): Promise<ComplianceDashboardData['groupedFindingsEvaluation']> => {
   const resourceTypesQueryResult = await esClient.search<unknown, FailedFindingsQueryResult>(
     getRisksEsQuery(query, pitId)
   );

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_resources_types.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_resources_types.test.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { getResourceTypeFromAggs, ResourceTypeBucket } from './get_resources_types';
+import { getFailedFindingsFromAggs, FailedFindingsBucket } from './get_resources_types';
 
-const resourceTypeBuckets: ResourceTypeBucket[] = [
+const resourceTypeBuckets: FailedFindingsBucket[] = [
   {
     key: 'foo_type',
     doc_count: 41,
@@ -30,9 +30,9 @@ const resourceTypeBuckets: ResourceTypeBucket[] = [
   },
 ];
 
-describe('getResourceTypeFromAggs', () => {
+describe('getFailedFindingsFromAggs', () => {
   it('should return value matching ComplianceDashboardData["resourcesTypes"]', async () => {
-    const resourceTypes = getResourceTypeFromAggs(resourceTypeBuckets);
+    const resourceTypes = getFailedFindingsFromAggs(resourceTypeBuckets);
     expect(resourceTypes).toEqual([
       {
         name: 'foo_type',

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -10042,7 +10042,6 @@
     "xpack.csp.passed": "Approuvé",
     "xpack.csp.posture_score": "Score du niveau",
     "xpack.csp.posture_score_trend": "Tendance du score du niveau",
-    "xpack.csp.resource_type": "Type de ressource",
     "xpack.csp.rules.activateAllButtonLabel": "Activer {count, plural, one {# règle} other {# règles}}",
     "xpack.csp.rules.bulkActionsButtonLabel": "Actions groupées",
     "xpack.csp.rules.cancelButtonLabel": "Annuler",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -10139,7 +10139,6 @@
     "xpack.csp.passed": "合格",
     "xpack.csp.posture_score": "態勢スコア",
     "xpack.csp.posture_score_trend": "態勢スコア傾向",
-    "xpack.csp.resource_type": "リソースタイプ",
     "xpack.csp.rules.activateAllButtonLabel": "{count, plural, other {#個のルール}}をアクティブ化",
     "xpack.csp.rules.activatedLabel": "有効化",
     "xpack.csp.rules.activateLabel": "有効化",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -10160,7 +10160,6 @@
     "xpack.csp.passed": "通过",
     "xpack.csp.posture_score": "态势分数",
     "xpack.csp.posture_score_trend": "态势分数趋势",
-    "xpack.csp.resource_type": "资源类型",
     "xpack.csp.rules.activateAllButtonLabel": "激活 {count, plural, other {# 个规则}}",
     "xpack.csp.rules.activatedLabel": "已激活",
     "xpack.csp.rules.activateLabel": "激活",


### PR DESCRIPTION
## Summary

Changes the dashboard to show the failed findings by the rule.section field instead of resource.type

![Screen Shot 2022-04-28 at 15 19 24](https://user-images.githubusercontent.com/61654899/165751878-efd2a6ae-d65c-4665-b640-d5e0cf2e6ec0.png)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
