### PR TITLE
[Security Solutions] Fix wrong deep link key on hosts by risk

### DIFF
--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -230,7 +230,7 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
             path: `${HOSTS_PATH}/externalAlerts`,
           },
           {
-            id: SecurityPageName.usersRisk,
+            id: SecurityPageName.hostsRisk,
             title: i18n.translate('xpack.securitySolution.search.hosts.risk', {
               defaultMessage: 'Hosts by risk',
             }),


### PR DESCRIPTION

## Summary

Fix config mistake. I couldn't find any broken feature caused by this mistake.
