### PR TITLE
[Stack Monitoring] Fix node type detection for external collection

### DIFF
--- a/x-pack/plugins/monitoring/common/types/es.ts
+++ b/x-pack/plugins/monitoring/common/types/es.ts
@@ -412,6 +412,7 @@ export interface ElasticsearchIndexRecoveryShard {
 export interface ElasticsearchMetricbeatNode {
   name?: string;
   stats?: ElasticsearchNodeStats;
+  master: boolean;
 }
 
 export interface ElasticsearchMetricbeatSource {

--- a/x-pack/plugins/monitoring/server/lib/elasticsearch/nodes/get_node_type_class_label.ts
+++ b/x-pack/plugins/monitoring/server/lib/elasticsearch/nodes/get_node_type_class_label.ts
@@ -21,11 +21,27 @@ export function getNodeTypeClassLabel(
   node: ElasticsearchLegacySource['source_node'] | ElasticsearchMetricbeatNode,
   type: keyof typeof nodeTypeLabel
 ) {
-  const nodeType = node && 'master' in node ? 'master' : type;
+  let nodeType = null;
+  if (isElasticsearchMetricbeatNode(node)) {
+    nodeType = node.master ? 'master' : type;
+  } else {
+    nodeType = type;
+  }
+
   const returnObj = {
     nodeType,
     nodeTypeLabel: nodeTypeLabel[nodeType],
     nodeTypeClass: nodeTypeClass[nodeType],
   };
   return returnObj;
+}
+
+function isElasticsearchMetricbeatNode(
+  node: ElasticsearchLegacySource['source_node'] | ElasticsearchMetricbeatNode
+): node is ElasticsearchMetricbeatNode {
+  if (!node) {
+    return false;
+  }
+
+  return 'master' in node;
 }


### PR DESCRIPTION
Fixes #126557

The Metricbeat documents always contain the field `master` but the code only checked for existence of the field, not whether it was true or false. 

https://www.elastic.co/guide/en/beats/metricbeat/current/exported-fields-elasticsearch.html (search for elasticsearch.node.master)