### PR TITLE
[8.2] [Reporting] Reporting info panel touch ups (#120617)

### DIFF
--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -22777,7 +22777,6 @@
     "xpack.reporting.listing.infoPanel.contentTypeInfo": "コンテンツタイプ",
     "xpack.reporting.listing.infoPanel.cpuInfo": "CPU 使用状況",
     "xpack.reporting.listing.infoPanel.createdAtInfo": "作成日時：",
-<<<<<<< HEAD
     "xpack.reporting.listing.infoPanel.csvRows": "CSV行",
     "xpack.reporting.listing.infoPanel.dimensionsInfoHeight": "ピクセル単位の高さ",
     "xpack.reporting.listing.infoPanel.dimensionsInfoWidth": "ピクセル単位の幅",
@@ -22786,18 +22785,13 @@
     "xpack.reporting.listing.infoPanel.notApplicableLabel": "N/A",
     "xpack.reporting.listing.infoPanel.outputSectionTitle": "アウトプット",
     "xpack.reporting.listing.infoPanel.pdfPagesInfo": "ページ数",
-=======
->>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.infoPanel.processedByInfo": "処理方法",
     "xpack.reporting.listing.infoPanel.sizeInfo": "サイズ（バイト）",
     "xpack.reporting.listing.infoPanel.space": "Kibanaスペース",
     "xpack.reporting.listing.infoPanel.startedAtInfo": "開始日時",
     "xpack.reporting.listing.infoPanel.statusInfo": "ステータス",
     "xpack.reporting.listing.infoPanel.timeoutInfo": "タイムアウト（ms）",
-<<<<<<< HEAD
     "xpack.reporting.listing.infoPanel.timestampSectionTitle": "タイムスタンプ",
-=======
->>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.infoPanel.tzInfo": "タイムゾーン",
     "xpack.reporting.listing.infoPanel.unknownLabel": "不明",
     "xpack.reporting.listing.reports.ilmPolicyLinkText": "レポートILMポリシーを編集",
@@ -22816,12 +22810,9 @@
     "xpack.reporting.listing.table.downloadReportDescription": "このレポートを新しいタブでダウンロードします。",
     "xpack.reporting.listing.table.loadingReportsDescription": "レポートを読み込み中です",
     "xpack.reporting.listing.table.noCreatedReportsDescription": "レポートが作成されていません",
-<<<<<<< HEAD
     "xpack.reporting.listing.table.noTitleLabel": "無題",
     "xpack.reporting.listing.table.openInKibanaAppDescription": "このレポートが生成されたKibanaアプリを開きます。",
     "xpack.reporting.listing.table.openInKibanaAppLabel": "Kibanaで開く",
-=======
->>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.table.reportInfoAndErrorButtonTooltip": "レポート情報とエラーメッセージを参照してください。",
     "xpack.reporting.listing.table.reportInfoAndWarningsButtonTooltip": "レポート情報と警告を参照してください。",
     "xpack.reporting.listing.table.reportInfoButtonTooltip": "レポート情報を参照してください。",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -22777,6 +22777,7 @@
     "xpack.reporting.listing.infoPanel.contentTypeInfo": "コンテンツタイプ",
     "xpack.reporting.listing.infoPanel.cpuInfo": "CPU 使用状況",
     "xpack.reporting.listing.infoPanel.createdAtInfo": "作成日時：",
+<<<<<<< HEAD
     "xpack.reporting.listing.infoPanel.csvRows": "CSV行",
     "xpack.reporting.listing.infoPanel.dimensionsInfoHeight": "ピクセル単位の高さ",
     "xpack.reporting.listing.infoPanel.dimensionsInfoWidth": "ピクセル単位の幅",
@@ -22785,13 +22786,18 @@
     "xpack.reporting.listing.infoPanel.notApplicableLabel": "N/A",
     "xpack.reporting.listing.infoPanel.outputSectionTitle": "アウトプット",
     "xpack.reporting.listing.infoPanel.pdfPagesInfo": "ページ数",
+=======
+>>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.infoPanel.processedByInfo": "処理方法",
     "xpack.reporting.listing.infoPanel.sizeInfo": "サイズ（バイト）",
     "xpack.reporting.listing.infoPanel.space": "Kibanaスペース",
     "xpack.reporting.listing.infoPanel.startedAtInfo": "開始日時",
     "xpack.reporting.listing.infoPanel.statusInfo": "ステータス",
     "xpack.reporting.listing.infoPanel.timeoutInfo": "タイムアウト（ms）",
+<<<<<<< HEAD
     "xpack.reporting.listing.infoPanel.timestampSectionTitle": "タイムスタンプ",
+=======
+>>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.infoPanel.tzInfo": "タイムゾーン",
     "xpack.reporting.listing.infoPanel.unknownLabel": "不明",
     "xpack.reporting.listing.reports.ilmPolicyLinkText": "レポートILMポリシーを編集",
@@ -22810,9 +22816,12 @@
     "xpack.reporting.listing.table.downloadReportDescription": "このレポートを新しいタブでダウンロードします。",
     "xpack.reporting.listing.table.loadingReportsDescription": "レポートを読み込み中です",
     "xpack.reporting.listing.table.noCreatedReportsDescription": "レポートが作成されていません",
+<<<<<<< HEAD
     "xpack.reporting.listing.table.noTitleLabel": "無題",
     "xpack.reporting.listing.table.openInKibanaAppDescription": "このレポートが生成されたKibanaアプリを開きます。",
     "xpack.reporting.listing.table.openInKibanaAppLabel": "Kibanaで開く",
+=======
+>>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.table.reportInfoAndErrorButtonTooltip": "レポート情報とエラーメッセージを参照してください。",
     "xpack.reporting.listing.table.reportInfoAndWarningsButtonTooltip": "レポート情報と警告を参照してください。",
     "xpack.reporting.listing.table.reportInfoButtonTooltip": "レポート情報を参照してください。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -22809,7 +22809,6 @@
     "xpack.reporting.listing.infoPanel.contentTypeInfo": "内容类型",
     "xpack.reporting.listing.infoPanel.cpuInfo": "CPU 使用",
     "xpack.reporting.listing.infoPanel.createdAtInfo": "创建于",
-<<<<<<< HEAD
     "xpack.reporting.listing.infoPanel.csvRows": "CSV 行",
     "xpack.reporting.listing.infoPanel.dimensionsInfoHeight": "高（像素）",
     "xpack.reporting.listing.infoPanel.dimensionsInfoWidth": "宽（像素）",
@@ -22818,18 +22817,13 @@
     "xpack.reporting.listing.infoPanel.notApplicableLabel": "不可用",
     "xpack.reporting.listing.infoPanel.outputSectionTitle": "输出",
     "xpack.reporting.listing.infoPanel.pdfPagesInfo": "页面计数",
-=======
->>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.infoPanel.processedByInfo": "处理者",
     "xpack.reporting.listing.infoPanel.sizeInfo": "大小（字节）",
     "xpack.reporting.listing.infoPanel.space": "Kibana 工作区",
     "xpack.reporting.listing.infoPanel.startedAtInfo": "启动时间",
     "xpack.reporting.listing.infoPanel.statusInfo": "状态",
     "xpack.reporting.listing.infoPanel.timeoutInfo": "超时",
-<<<<<<< HEAD
     "xpack.reporting.listing.infoPanel.timestampSectionTitle": "时间戳",
-=======
->>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.infoPanel.tzInfo": "时区",
     "xpack.reporting.listing.infoPanel.unknownLabel": "未知",
     "xpack.reporting.listing.reports.ilmPolicyLinkText": "编辑报告 ILM 策略",
@@ -22848,12 +22842,9 @@
     "xpack.reporting.listing.table.downloadReportDescription": "在新选项卡中下载此报告。",
     "xpack.reporting.listing.table.loadingReportsDescription": "正在载入报告",
     "xpack.reporting.listing.table.noCreatedReportsDescription": "未创建任何报告",
-<<<<<<< HEAD
     "xpack.reporting.listing.table.noTitleLabel": "未命名",
     "xpack.reporting.listing.table.openInKibanaAppDescription": "打开生成此报告的 Kibana 应用。",
     "xpack.reporting.listing.table.openInKibanaAppLabel": "在 Kibana 中打开",
-=======
->>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.table.reportInfoAndErrorButtonTooltip": "查看报告信息和错误消息。",
     "xpack.reporting.listing.table.reportInfoAndWarningsButtonTooltip": "查看报告信息和警告。",
     "xpack.reporting.listing.table.reportInfoButtonTooltip": "查看报告信息。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -22809,6 +22809,7 @@
     "xpack.reporting.listing.infoPanel.contentTypeInfo": "内容类型",
     "xpack.reporting.listing.infoPanel.cpuInfo": "CPU 使用",
     "xpack.reporting.listing.infoPanel.createdAtInfo": "创建于",
+<<<<<<< HEAD
     "xpack.reporting.listing.infoPanel.csvRows": "CSV 行",
     "xpack.reporting.listing.infoPanel.dimensionsInfoHeight": "高（像素）",
     "xpack.reporting.listing.infoPanel.dimensionsInfoWidth": "宽（像素）",
@@ -22817,13 +22818,18 @@
     "xpack.reporting.listing.infoPanel.notApplicableLabel": "不可用",
     "xpack.reporting.listing.infoPanel.outputSectionTitle": "输出",
     "xpack.reporting.listing.infoPanel.pdfPagesInfo": "页面计数",
+=======
+>>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.infoPanel.processedByInfo": "处理者",
     "xpack.reporting.listing.infoPanel.sizeInfo": "大小（字节）",
     "xpack.reporting.listing.infoPanel.space": "Kibana 工作区",
     "xpack.reporting.listing.infoPanel.startedAtInfo": "启动时间",
     "xpack.reporting.listing.infoPanel.statusInfo": "状态",
     "xpack.reporting.listing.infoPanel.timeoutInfo": "超时",
+<<<<<<< HEAD
     "xpack.reporting.listing.infoPanel.timestampSectionTitle": "时间戳",
+=======
+>>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.infoPanel.tzInfo": "时区",
     "xpack.reporting.listing.infoPanel.unknownLabel": "未知",
     "xpack.reporting.listing.reports.ilmPolicyLinkText": "编辑报告 ILM 策略",
@@ -22842,9 +22848,12 @@
     "xpack.reporting.listing.table.downloadReportDescription": "在新选项卡中下载此报告。",
     "xpack.reporting.listing.table.loadingReportsDescription": "正在载入报告",
     "xpack.reporting.listing.table.noCreatedReportsDescription": "未创建任何报告",
+<<<<<<< HEAD
     "xpack.reporting.listing.table.noTitleLabel": "未命名",
     "xpack.reporting.listing.table.openInKibanaAppDescription": "打开生成此报告的 Kibana 应用。",
     "xpack.reporting.listing.table.openInKibanaAppLabel": "在 Kibana 中打开",
+=======
+>>>>>>> d213263ea33 ([Reporting] Reporting info panel touch ups (#120617))
     "xpack.reporting.listing.table.reportInfoAndErrorButtonTooltip": "查看报告信息和错误消息。",
     "xpack.reporting.listing.table.reportInfoAndWarningsButtonTooltip": "查看报告信息和警告。",
     "xpack.reporting.listing.table.reportInfoButtonTooltip": "查看报告信息。",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Reporting] Reporting info panel touch ups (#120617)](https://github.com/elastic/kibana/pull/120617)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)