### PR TITLE
[Spacetime] Make share menu clearer

### DIFF
--- a/src/plugins/share/public/components/share_context_menu.tsx
+++ b/src/plugins/share/public/components/share_context_menu.tsx
@@ -109,7 +109,7 @@ export class ShareContextMenu extends Component<ShareContextMenuProps> {
         topLevelMenu.push(panel);
       });
       topLevelMenu.push(exportPanel);
-    } else {
+    } else if (this.props.shareMenuItems.length === 1) {
       const { shareMenuItem, panel } = this.props.shareMenuItems[0];
       menuItems.push({ ...shareMenuItem, panel: panel.id });
       topLevelMenu.push(panel);

--- a/src/plugins/share/public/components/share_context_menu.tsx
+++ b/src/plugins/share/public/components/share_context_menu.tsx
@@ -36,26 +36,52 @@ export interface ShareContextMenuProps {
 
 export class ShareContextMenu extends Component<ShareContextMenuProps> {
   public render() {
-    const { panels, initialPanelId } = this.getPanels();
+    const panels = this.getPanels();
     return (
       <I18nProvider>
-        <EuiContextMenu
-          initialPanelId={initialPanelId}
-          panels={panels}
-          data-test-subj="shareContextMenu"
-        />
+        <EuiContextMenu initialPanelId={0} panels={panels} data-test-subj="shareContextMenu" />
       </I18nProvider>
     );
   }
 
   private getPanels = () => {
-    const panels: EuiContextMenuPanelDescriptor[] = [];
-    const menuItems: ShareContextMenuPanelItem[] = [];
+    const topLevelMenu: EuiContextMenuPanelDescriptor[] = [
+      {
+        id: 0,
+        title: i18n.translate('share.contextMenuTitle', {
+          defaultMessage: 'Share the {objectType}',
+          values: {
+            objectType: this.props.objectType,
+          },
+        }),
+        items: [],
+      },
+    ];
+    let menuItems: ShareContextMenuPanelItem[] = [];
+
+    menuItems.push(
+      {
+        name: i18n.translate('share.contextMenu.permalinksLabel', {
+          defaultMessage: 'Get link',
+        }),
+        icon: 'link',
+        panel: 'permaLinksPanel',
+        sortOrder: 0,
+      },
+      {
+        name: i18n.translate('share.contextMenu.exportLabel', {
+          defaultMessage: 'Export',
+        }),
+        icon: 'exportAction',
+        panel: 'exportActionPanel',
+        sortOrder: 2,
+      }
+    );
 
     const permalinkPanel = {
-      id: panels.length + 1,
+      id: 'permaLinksPanel',
       title: i18n.translate('share.contextMenu.permalinkPanelTitle', {
-        defaultMessage: 'Permalink',
+        defaultMessage: 'Get link',
       }),
       content: (
         <UrlPanelContent
@@ -69,19 +95,33 @@ export class ShareContextMenu extends Component<ShareContextMenuProps> {
         />
       ),
     };
-    menuItems.push({
-      name: i18n.translate('share.contextMenu.permalinksLabel', {
-        defaultMessage: 'Permalinks',
+    topLevelMenu.push(permalinkPanel);
+
+    const exportPanel = {
+      id: 'exportActionPanel',
+      title: i18n.translate('share.contextMenu.exportPanelTitle', {
+        defaultMessage: 'Export',
       }),
-      icon: 'link',
-      panel: permalinkPanel.id,
-      sortOrder: 0,
+      items: [] as ShareContextMenuPanelItem[],
+    };
+    this.props.shareMenuItems.forEach(({ shareMenuItem, panel }) => {
+      exportPanel.items.push({ ...shareMenuItem, panel: panel.id });
+      topLevelMenu.push(panel);
     });
-    panels.push(permalinkPanel);
+    topLevelMenu.push(exportPanel);
 
     if (this.props.allowEmbed) {
+      menuItems.push({
+        name: i18n.translate('share.contextMenu.embedCodeLabel', {
+          defaultMessage: 'Embed code',
+        }),
+        icon: 'console',
+        panel: 'embedCodePanel',
+        sortOrder: 1,
+      });
+
       const embedPanel = {
-        id: panels.length + 1,
+        id: 'embedCodePanel',
         title: i18n.translate('share.contextMenu.embedCodePanelTitle', {
           defaultMessage: 'Embed Code',
         }),
@@ -99,65 +139,33 @@ export class ShareContextMenu extends Component<ShareContextMenuProps> {
           />
         ),
       };
-      panels.push(embedPanel);
-      menuItems.push({
-        name: i18n.translate('share.contextMenu.embedCodeLabel', {
-          defaultMessage: 'Embed code',
-        }),
-        icon: 'console',
-        panel: embedPanel.id,
-        sortOrder: 0,
-      });
+      topLevelMenu.push(embedPanel);
     }
-
-    this.props.shareMenuItems.forEach(({ shareMenuItem, panel }) => {
-      const panelId = panels.length + 1;
-      panels.push({
-        ...panel,
-        id: panelId,
-      });
-      menuItems.push({
-        ...shareMenuItem,
-        panel: panelId,
-      });
-    });
 
     if (menuItems.length > 1) {
-      const topLevelMenuPanel = {
-        id: panels.length + 1,
-        title: i18n.translate('share.contextMenuTitle', {
-          defaultMessage: 'Share this {objectType}',
-          values: {
-            objectType: this.props.objectType,
-          },
-        }),
-        items: menuItems
-          // Sorts ascending on sort order first and then ascending on name
-          .sort((a, b) => {
-            const aSortOrder = a.sortOrder || 0;
-            const bSortOrder = b.sortOrder || 0;
-            if (aSortOrder > bSortOrder) {
-              return 1;
-            }
-            if (aSortOrder < bSortOrder) {
-              return -1;
-            }
-            if (a.name.toLowerCase().localeCompare(b.name.toLowerCase()) > 0) {
-              return 1;
-            }
-            return -1;
-          })
-          .map((menuItem) => {
-            menuItem['data-test-subj'] = `sharePanel-${menuItem.name.replace(' ', '')}`;
-            delete menuItem.sortOrder;
-            return menuItem;
-          }),
-      };
-      panels.push(topLevelMenuPanel);
+      // Sorts ascending on sort order first and then ascending on name
+      menuItems = menuItems.sort((a, b) => {
+        const aSortOrder = a.sortOrder || 0;
+        const bSortOrder = b.sortOrder || 0;
+        if (aSortOrder > bSortOrder) {
+          return 1;
+        }
+        if (aSortOrder < bSortOrder) {
+          return -1;
+        }
+        if (a.name.toLowerCase().localeCompare(b.name.toLowerCase()) > 0) {
+          return 1;
+        }
+        return -1;
+      });
     }
+    menuItems.map((menuItem) => {
+      menuItem['data-test-subj'] = `sharePanel-${menuItem.name.replace(' ', '')}`;
+      delete menuItem.sortOrder;
+      return menuItem;
+    });
+    topLevelMenu[0].items = menuItems;
 
-    const lastPanelIndex = panels.length - 1;
-    const initialPanelId = panels[lastPanelIndex].id;
-    return { panels, initialPanelId };
+    return topLevelMenu;
   };
 }

--- a/src/plugins/share/public/components/share_context_menu.tsx
+++ b/src/plugins/share/public/components/share_context_menu.tsx
@@ -59,25 +59,15 @@ export class ShareContextMenu extends Component<ShareContextMenuProps> {
     ];
     let menuItems: ShareContextMenuPanelItem[] = [];
 
-    menuItems.push(
-      {
-        name: i18n.translate('share.contextMenu.permalinksLabel', {
-          defaultMessage: 'Get link',
-        }),
-        icon: 'link',
-        panel: 'permaLinksPanel',
-        sortOrder: 0,
-      },
-      {
-        name: i18n.translate('share.contextMenu.exportLabel', {
-          defaultMessage: 'Export',
-        }),
-        icon: 'exportAction',
-        panel: 'exportActionPanel',
-        sortOrder: 2,
-      }
-    );
-
+    /** Get link **/
+    menuItems.push({
+      name: i18n.translate('share.contextMenu.permalinksLabel', {
+        defaultMessage: 'Get link',
+      }),
+      icon: 'link',
+      panel: 'permaLinksPanel',
+      sortOrder: 0,
+    });
     const permalinkPanel = {
       id: 'permaLinksPanel',
       title: i18n.translate('share.contextMenu.permalinkPanelTitle', {
@@ -97,19 +87,35 @@ export class ShareContextMenu extends Component<ShareContextMenuProps> {
     };
     topLevelMenu.push(permalinkPanel);
 
-    const exportPanel = {
-      id: 'exportActionPanel',
-      title: i18n.translate('share.contextMenu.exportPanelTitle', {
-        defaultMessage: 'Export',
-      }),
-      items: [] as ShareContextMenuPanelItem[],
-    };
-    this.props.shareMenuItems.forEach(({ shareMenuItem, panel }) => {
-      exportPanel.items.push({ ...shareMenuItem, panel: panel.id });
+    /** Export **/
+    if (this.props.shareMenuItems.length > 1) {
+      menuItems.push({
+        name: i18n.translate('share.contextMenu.exportLabel', {
+          defaultMessage: 'Export',
+        }),
+        icon: 'exportAction',
+        panel: 'exportActionPanel',
+        sortOrder: 2,
+      });
+      const exportPanel = {
+        id: 'exportActionPanel',
+        title: i18n.translate('share.contextMenu.exportPanelTitle', {
+          defaultMessage: 'Export',
+        }),
+        items: [] as ShareContextMenuPanelItem[],
+      };
+      this.props.shareMenuItems.forEach(({ shareMenuItem, panel }) => {
+        exportPanel.items.push({ ...shareMenuItem, panel: panel.id });
+        topLevelMenu.push(panel);
+      });
+      topLevelMenu.push(exportPanel);
+    } else {
+      const { shareMenuItem, panel } = this.props.shareMenuItems[0];
+      menuItems.push({ ...shareMenuItem, panel: panel.id });
       topLevelMenu.push(panel);
-    });
-    topLevelMenu.push(exportPanel);
+    }
 
+    /** Embed code **/
     if (this.props.allowEmbed) {
       menuItems.push({
         name: i18n.translate('share.contextMenu.embedCodeLabel', {

--- a/src/plugins/share/public/components/share_context_menu.tsx
+++ b/src/plugins/share/public/components/share_context_menu.tsx
@@ -129,7 +129,7 @@ export class ShareContextMenu extends Component<ShareContextMenuProps> {
       const embedPanel = {
         id: 'embedCodePanel',
         title: i18n.translate('share.contextMenu.embedCodePanelTitle', {
-          defaultMessage: 'Embed Code',
+          defaultMessage: 'Embed code',
         }),
         content: (
           <UrlPanelContent

--- a/x-pack/plugins/canvas/public/components/workpad_header/share_menu/share_menu.component.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/share_menu/share_menu.component.tsx
@@ -43,7 +43,7 @@ const strings = {
     }),
   getShareWebsiteTitle: () =>
     i18n.translate('xpack.canvas.workpadHeaderShareMenu.shareWebsiteTitle', {
-      defaultMessage: 'Share on a website',
+      defaultMessage: 'Embed code',
     }),
   getShareWorkpadMessage: () =>
     i18n.translate('xpack.canvas.workpadHeaderShareMenu.shareWorkpadMessage', {
@@ -82,17 +82,17 @@ export const ShareMenu = ({ ReportingComponent, onExport }: Props) => {
         title: strings.getShareWorkpadMessage(),
         items: [
           {
-            name: strings.getExportTitle(),
-            icon: <EuiIcon type="exportAction" size="m" />,
-            panel: 1,
-          },
-          {
             name: strings.getShareWebsiteTitle(),
-            icon: <EuiIcon type="globe" size="m" />,
+            icon: <EuiIcon type="console" size="m" />,
             onClick: () => {
               setShowFlyout(true);
               closePopover();
             },
+          },
+          {
+            name: strings.getExportTitle(),
+            icon: <EuiIcon type="exportAction" size="m" />,
+            panel: 1,
           },
         ],
       },

--- a/x-pack/plugins/canvas/public/components/workpad_header/share_menu/share_menu.component.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/share_menu/share_menu.component.tsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import {
   EuiButtonEmpty,
   EuiContextMenu,
-  EuiContextMenuPanel,
   EuiContextMenuPanelDescriptor,
   EuiIcon,
 } from '@elastic/eui';
@@ -18,7 +17,6 @@ import { i18n } from '@kbn/i18n';
 import { PDF, JSON } from '../../../../i18n/constants';
 import { ClosePopoverFn, Popover } from '../../popover';
 import { ShareWebsiteFlyout } from './flyout';
-import { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
 
 const strings = {
   getExportTitle: () =>

--- a/x-pack/plugins/reporting/public/share_context_menu/register_csv_reporting.tsx
+++ b/x-pack/plugins/reporting/public/share_context_menu/register_csv_reporting.tsx
@@ -63,7 +63,7 @@ export const reportingCsvShareProvider = ({
 
     if (licenseHasCsvReporting && capabilityHasCsvReporting) {
       const panelTitle = i18n.translate('xpack.reporting.shareContextMenu.csvReportsButtonLabel', {
-        defaultMessage: 'CSV Reports',
+        defaultMessage: 'Export to CSV',
       });
 
       shareActions.push({

--- a/x-pack/plugins/reporting/public/share_context_menu/register_pdf_png_reporting.tsx
+++ b/x-pack/plugins/reporting/public/share_context_menu/register_pdf_png_reporting.tsx
@@ -112,7 +112,7 @@ export const reportingScreenshotShareProvider = ({
     const shareActions = [];
 
     const pngPanelTitle = i18n.translate('xpack.reporting.shareContextMenu.pngReportsButtonLabel', {
-      defaultMessage: 'PNG Reports',
+      defaultMessage: 'Export to PNG',
     });
 
     const jobProviderOptions: JobParamsProviderOptions = {
@@ -156,7 +156,7 @@ export const reportingScreenshotShareProvider = ({
     };
 
     const pdfPanelTitle = i18n.translate('xpack.reporting.shareContextMenu.pdfReportsButtonLabel', {
-      defaultMessage: 'PDF Reports',
+      defaultMessage: 'Export to PDF',
     });
 
     const pdfReportType = isV2Job ? 'printablePdfV2' : 'printablePdf';


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-team/issues/499

## Summary

As part of a Spacetime project, the HELP! team wanted to make the share menu that is used throughout Kibana easier to understand. A summary of the changed menus are as follows:

| Application | Old share menu | New share menu |
|--------------| ------------------ | ------------------ |
| Dashboard | <img src="https://user-images.githubusercontent.com/8698078/165853689-7ebc8cc8-f05d-4913-9d1e-453a0220c0d9.png"  width='272px' height='264px'> | ![Dashboard-New](https://user-images.githubusercontent.com/8698078/165852928-cd201813-43b3-42d4-864d-00c9e46e30ad.gif) |
| Canvas | <img src="https://user-images.githubusercontent.com/8698078/165854329-b2148f9b-d2a3-4a96-8ae3-66a8f13590b8.png"  width='272px' height='184px'> | ![Canvas-New2](https://user-images.githubusercontent.com/8698078/165993820-f51f0979-ed59-4488-aac5-69545dd15a97.gif) |  
| Discover | <img src="https://user-images.githubusercontent.com/8698078/165855278-09abaa1b-9bd8-41e2-aaeb-262545824f2e.png" width='272px' height='185px'> | ![Discover-New](https://user-images.githubusercontent.com/8698078/165855157-1d1e8898-50ed-4a9c-a279-b3a40571211d.gif) |  

**Summary of Changes**
- `"PDF/PNG/CSV Reports" -> "Export > Export to PDF/PNG/CSV"`
    - Note that, if there is **only on option**, then we do not show the outer `"Export"` menu - i.e. rather than showing `"Export > Export to CSV"` in Discover, since `"Export to CSV"` is the only export option, we flatten the menu and only show `"Export to CSV"` directly.
    - Specifically for Canvas, `"Download as JSON" -> "Export > Export to JSON"`
- `"Permalinks" -> "Get link"`
- Specifically for Canvas, `"Share on a website" -> "Embed code"`

### ⚠️ Note about Functional Tests
If we wanted to actually get this merged in, we would have to fix a lot of functional tests to use the new menu scheme - for example, since all exports are now gathered under the `Export` label, any functional tests that expected `Export PDF` to be in the **first** menu panel would fail.

### Collaborators

- @andreadelrio 
- @gchaps
- @KOTungseth 
- @teresaalvarezsoler 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)