### PR TITLE
[8.2] [ci] validate that all tests are in a ciGroup (#131173)

### DIFF
--- a/.buildkite/scripts/steps/checks.sh
+++ b/.buildkite/scripts/steps/checks.sh
@@ -8,6 +8,7 @@ export DISABLE_BOOTSTRAP_VALIDATION=false
 .buildkite/scripts/steps/checks/commit/commit.sh
 .buildkite/scripts/steps/checks/bazel_packages.sh
 .buildkite/scripts/steps/checks/telemetry.sh
+.buildkite/scripts/steps/checks/validate_ci_groups.sh
 .buildkite/scripts/steps/checks/ts_projects.sh
 .buildkite/scripts/steps/checks/jest_configs.sh
 .buildkite/scripts/steps/checks/doc_api_changes.sh

--- a/.buildkite/scripts/steps/checks/validate_ci_groups.sh
+++ b/.buildkite/scripts/steps/checks/validate_ci_groups.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+
+echo --- Ensure that all tests are in a CI Group
+checks-reporter-with-killswitch "Ensure that all tests are in a CI Group" \
+  node scripts/ensure_all_tests_in_ci_group

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/index.ts
@@ -11,7 +11,9 @@ import { setupSpacesAndUsers, tearDown } from '..';
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile, getService }: FtrProviderContext) {
   describe('Alerts', () => {
-    describe('legacy alerts', () => {
+    describe('legacy alerts', function () {
+      this.tags('ciGroup17');
+
       before(async () => {
         await setupSpacesAndUsers(getService);
       });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[ci] validate that all tests are in a ciGroup (#131173)](https://github.com/elastic/kibana/pull/131173)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)