### PR TITLE
[Fleet] Renable logs disabled callout for managed policies

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -84,25 +84,27 @@ const AgentPolicyLogsNotEnabledCallout: React.FunctionComponent<{ agentPolicy: A
           />
         }
       >
-        <FormattedMessage
-          id="xpack.fleet.agentLogs.logDisabledCallOutDescription"
-          defaultMessage="Update the agent's policy {settingsLink} to enable logs collection."
-          values={{
-            settingsLink: (
-              <EuiLink
-                href={getHref('policy_details', {
-                  policyId: agentPolicy.id,
-                  tabId: 'settings',
-                })}
-              >
-                <FormattedMessage
-                  id="xpack.fleet.agentLogs.settingsLink"
-                  defaultMessage="settings"
-                />
-              </EuiLink>
-            ),
-          }}
-        />
+        {agentPolicy.is_managed ? null : (
+          <FormattedMessage
+            id="xpack.fleet.agentLogs.logDisabledCallOutDescription"
+            defaultMessage="Update the agent's policy {settingsLink} to enable logs collection."
+            values={{
+              settingsLink: (
+                <EuiLink
+                  href={getHref('policy_details', {
+                    policyId: agentPolicy.id,
+                    tabId: 'settings',
+                  })}
+                >
+                  <FormattedMessage
+                    id="xpack.fleet.agentLogs.settingsLink"
+                    defaultMessage="settings"
+                  />
+                </EuiLink>
+              ),
+            }}
+          />
+        )}
       </EuiCallOut>
     </EuiFlexItem>
   );
@@ -278,9 +280,9 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(
 
     return (
       <WrapperFlexGroup direction="column" gutterSize="m">
-        {agentPolicy &&
-          !agentPolicy.monitoring_enabled?.includes('logs') &&
-          !agentPolicy.is_managed && <AgentPolicyLogsNotEnabledCallout agentPolicy={agentPolicy} />}
+        {agentPolicy && !agentPolicy.monitoring_enabled?.includes('logs') && (
+          <AgentPolicyLogsNotEnabledCallout agentPolicy={agentPolicy} />
+        )}
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="m">
             <EuiFlexItem>


### PR DESCRIPTION
## Summary
Closes #131141

In #119186 we removed the logs disabled callout for managed policies since users are not able to change the logs monitoring settings for managed policies. But this causes some confusion like #131141 as now the log stream is empty without any context.

This PR reenables the callout for managed policies, but hides the CTA advising the user to update settings.

I am backporting this pretty far since it affects the experience on Cloud.