### PR TITLE
[QA][Code Coverage] Print out some of the ingestion payload

### DIFF
--- a/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
@@ -42,13 +42,13 @@ for x in functional jest; do
   head -50 ${COVERAGE_SUMMARY_FILE}
   # running in background to speed up ingestion
   COVERAGE_PEEK=true \
-  COVERAGE_PEEK_SIZE=4 \
-  CI_STATS_DISABLED=true \
-  node scripts/ingest_coverage.js \
-  --verbose
-  --path ${COVERAGE_SUMMARY_FILE} \
-  --vcsInfoPath ./VCS_INFO.txt \
-  --teamAssignmentsPath $TEAM_ASSIGN_PATH > ${x}-ingestion.txt &
+    COVERAGE_PEEK_SIZE=4 \
+    CI_STATS_DISABLED=true \
+    node scripts/ingest_coverage.js \
+      --verbose \
+      --path ${COVERAGE_SUMMARY_FILE} \
+      --vcsInfoPath ./VCS_INFO.txt \
+      --teamAssignmentsPath $TEAM_ASSIGN_PATH > ${x}-ingestion.txt &
 done
 wait
 

--- a/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
@@ -40,9 +40,22 @@ for x in functional jest; do
   echo "### Ingesting coverage for ${x}"
   COVERAGE_SUMMARY_FILE=target/kibana-coverage/${x}-combined/coverage-summary.json
   # running in background to speed up ingestion
-  CI_STATS_DISABLED=true node scripts/ingest_coverage.js --path ${COVERAGE_SUMMARY_FILE} --vcsInfoPath ./VCS_INFO.txt --teamAssignmentsPath $TEAM_ASSIGN_PATH &
+  COVERAGE_PEEK=true \
+  COVERAGE_PEEK_SIZE=4 \
+  CI_STATS_DISABLED=true \
+  node scripts/ingest_coverage.js \
+  --path ${COVERAGE_SUMMARY_FILE} \
+  --vcsInfoPath ./VCS_INFO.txt \
+  --teamAssignmentsPath $TEAM_ASSIGN_PATH > ${x}-ingestion.txt &
 done
 wait
 
-echo "###  Ingesting Code Coverage - Complete"
+for x in functional jest; do
+  echo "### ${x}-ingestion.txt Contents:"
+  cat ${x}-ingestion.txt
+  echo ""
+done
+
+
+echo "### Ingesting Code Coverage - Complete"
 echo ""

--- a/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
@@ -39,11 +39,13 @@ CI_STATS_DISABLED=true node scripts/generate_team_assignments.js --verbose --src
 for x in functional jest; do
   echo "### Ingesting coverage for ${x}"
   COVERAGE_SUMMARY_FILE=target/kibana-coverage/${x}-combined/coverage-summary.json
+  head -50 ${COVERAGE_SUMMARY_FILE}
   # running in background to speed up ingestion
   COVERAGE_PEEK=true \
   COVERAGE_PEEK_SIZE=4 \
   CI_STATS_DISABLED=true \
   node scripts/ingest_coverage.js \
+  --verbose
   --path ${COVERAGE_SUMMARY_FILE} \
   --vcsInfoPath ./VCS_INFO.txt \
   --teamAssignmentsPath $TEAM_ASSIGN_PATH > ${x}-ingestion.txt &


### PR DESCRIPTION
## Summary

Add ability to peek into the data being sent to the cluster.

By adding `COVERAGE_PEEK` & `COVERAGE_PEEK_SIZE` to the ingestion
command, we can see some of the data now.

Default size to 4, which shows 2 records, due to the format of the bulk requests.
_What this really does is not only print out records_, but also show **which indexes** are used

Turn on the peeking.

Since the ingestion runs are backgrounded, log the output to files.
Print out the files after ingestion is over.

Drop an unused fn.  _It was a custom streaming fn, but we dont need it with bulk requests._