### PR TITLE
[Fleet] Moved package policy create authz check to JS service

### DIFF
--- a/x-pack/plugins/fleet/common/authz.ts
+++ b/x-pack/plugins/fleet/common/authz.ts
@@ -26,6 +26,9 @@ export interface FleetAuthz {
 
     readIntegrationPolicies: boolean;
     writeIntegrationPolicies: boolean;
+
+    writeEndpointIntegration: boolean;
+    readEndpointIntegration: boolean;
   };
 }
 
@@ -38,6 +41,8 @@ interface CalculateParams {
   integrations: {
     all: boolean;
     read: boolean;
+    writeEndpointIntegration: boolean;
+    readEndpointIntegration: boolean;
   };
 
   isSuperuser: boolean;
@@ -70,5 +75,12 @@ export const calculateAuthz = ({
 
     readIntegrationPolicies: fleet.all && (integrations.all || integrations.read),
     writeIntegrationPolicies: fleet.all && integrations.all,
+
+    writeEndpointIntegration: integrations.all || integrations.writeEndpointIntegration,
+    readEndpointIntegration:
+      integrations.all ||
+      integrations.read ||
+      integrations.readEndpointIntegration ||
+      integrations.writeEndpointIntegration,
   },
 });

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -94,13 +94,13 @@ export function Detail() {
   const { getId: getAgentPolicyId } = useAgentPolicyContext();
   const { pkgkey, panel } = useParams<DetailParams>();
   const { getHref } = useLink();
-  const canInstallPackages = useAuthz().integrations.installPackages;
+
   const canReadPackageSettings = useAuthz().integrations.readPackageSettings;
   const canReadIntegrationPolicies = useAuthz().integrations.readIntegrationPolicies;
   const permissionCheck = usePermissionCheck();
   const missingSecurityConfiguration =
     !permissionCheck.data?.success && permissionCheck.data?.error === 'MISSING_SECURITY';
-  const userCanInstallPackages = canInstallPackages && permissionCheck.data?.success;
+
   const history = useHistory();
   const { pathname, search, hash } = useLocation();
   const queryParams = useMemo(() => new URLSearchParams(search), [search]);
@@ -112,6 +112,12 @@ export function Detail() {
   const [packageInfo, setPackageInfo] = useState<PackageInfo | null>(null);
   const setPackageInstallStatus = useSetPackageInstallStatus();
   const getPackageInstallStatus = useGetPackageInstallStatus();
+
+  const authz = useAuthz();
+  const canInstallPackages =
+    authz.integrations.installPackages ||
+    (packageInfo?.name === 'endpoint' && authz.integrations.writeEndpointIntegration);
+  const userCanInstallPackages = canInstallPackages && permissionCheck.data?.success;
 
   const CustomAssets = useUIExtension(packageInfo?.name ?? '', 'package-detail-assets');
 

--- a/x-pack/plugins/fleet/public/plugin.ts
+++ b/x-pack/plugins/fleet/public/plugin.ts
@@ -286,6 +286,8 @@ export class FleetPlugin implements Plugin<FleetSetup, FleetStart, FleetSetupDep
         integrations: {
           all: capabilities.fleet.all as boolean,
           read: capabilities.fleet.read as boolean,
+          writeEndpointIntegration: capabilities.fleet.writeEndpointIntegration as boolean,
+          readEndpointIntegration: capabilities.fleet.readEndpointIntegration as boolean,
         },
         isSuperuser: false,
       }),

--- a/x-pack/plugins/fleet/server/errors/handlers.ts
+++ b/x-pack/plugins/fleet/server/errors/handlers.ts
@@ -27,6 +27,7 @@ import {
   RegistryConnectionError,
   RegistryError,
   RegistryResponseError,
+  FleetUnauthorizedError,
 } from '.';
 
 type IngestErrorHandler = (
@@ -64,6 +65,9 @@ const getHTTPResponseCode = (error: IngestManagerError): number => {
   }
   if (error instanceof AgentNotFoundError) {
     return 404;
+  }
+  if (error instanceof FleetUnauthorizedError) {
+    return 403; // Unauthorized
   }
   return 400; // Bad Request
 };

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -315,6 +315,43 @@ export class FleetPlugin
             ui: ['read'],
           },
         },
+        subFeatures: [
+          {
+            name: 'Endpoint integration',
+            privilegeGroups: [
+              {
+                groupType: 'mutually_exclusive',
+                privileges: [
+                  {
+                    api: [
+                      `${INTEGRATIONS_PLUGIN_ID}-writeEndpointIntegration`,
+                      `${INTEGRATIONS_PLUGIN_ID}-readEndpointIntegration`,
+                    ],
+                    id: 'endpoint_all',
+                    includeIn: 'all',
+                    name: 'All',
+                    savedObject: {
+                      all: [],
+                      read: [],
+                    },
+                    ui: ['writeEndpointIntegration', 'readEndpointIntegration'],
+                  },
+                  {
+                    api: [`${INTEGRATIONS_PLUGIN_ID}-readEndpointIntegration`],
+                    id: 'endpoint_read',
+                    includeIn: 'read',
+                    name: 'Read',
+                    savedObject: {
+                      all: [],
+                      read: [],
+                    },
+                    ui: ['readEndpointIntegration'],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       });
     }
 

--- a/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
@@ -108,11 +108,16 @@ export const createPackagePolicyHandler: FleetRequestHandler<
     );
 
     // Create package policy
-    const packagePolicy = await packagePolicyService.create(soClient, esClient, newData, {
-      user,
-      force,
-      spaceId,
-    });
+    const packagePolicy = await fleetContext.packagePolicyService.asCurrentUser.create(
+      soClient,
+      esClient,
+      newData,
+      {
+        user,
+        force,
+        spaceId,
+      }
+    );
 
     const enrichedPackagePolicy = await packagePolicyService.runExternalCallbacks(
       'packagePolicyPostCreate',

--- a/x-pack/plugins/fleet/server/routes/package_policy/index.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/index.ts
@@ -57,9 +57,6 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
     {
       path: PACKAGE_POLICY_API_ROUTES.CREATE_PATTERN,
       validate: CreatePackagePolicyRequestSchema,
-      fleetAuthz: {
-        integrations: { writeIntegrationPolicies: true },
-      },
     },
     createPackagePolicyHandler
   );

--- a/x-pack/plugins/fleet/server/routes/security.ts
+++ b/x-pack/plugins/fleet/server/routes/security.ts
@@ -68,6 +68,8 @@ export async function getAuthzFromRequest(req: KibanaRequest): Promise<FleetAuth
         security.authz.actions.api.get(`${INTEGRATIONS_PLUGIN_ID}-all`),
         security.authz.actions.api.get(`${INTEGRATIONS_PLUGIN_ID}-read`),
         security.authz.actions.api.get('fleet-setup'),
+        security.authz.actions.api.get(`${INTEGRATIONS_PLUGIN_ID}-writeEndpointIntegration`),
+        security.authz.actions.api.get(`${INTEGRATIONS_PLUGIN_ID}-readEndpointIntegration`),
       ],
     });
     const fleetAllAuth = getAuthorizationFromPrivileges(privileges.kibana, `${PLUGIN_ID}-all`);
@@ -81,16 +83,36 @@ export async function getAuthzFromRequest(req: KibanaRequest): Promise<FleetAuth
     );
     const fleetSetupAuth = getAuthorizationFromPrivileges(privileges.kibana, 'fleet-setup');
 
+    const writeEndpointIntegrationAuth = getAuthorizationFromPrivileges(
+      privileges.kibana,
+      `${INTEGRATIONS_PLUGIN_ID}-writeEndpointIntegration`
+    );
+
+    const readEndpointIntegrationAuth = getAuthorizationFromPrivileges(
+      privileges.kibana,
+      `${INTEGRATIONS_PLUGIN_ID}-readEndpointIntegration`
+    );
+
     return calculateAuthz({
       fleet: { all: fleetAllAuth, setup: fleetSetupAuth },
-      integrations: { all: intAllAuth, read: intReadAuth },
+      integrations: {
+        all: intAllAuth,
+        read: intReadAuth,
+        writeEndpointIntegration: writeEndpointIntegrationAuth,
+        readEndpointIntegration: readEndpointIntegrationAuth,
+      },
       isSuperuser: checkSuperuser(req),
     });
   }
 
   return calculateAuthz({
     fleet: { all: false, setup: false },
-    integrations: { all: false, read: false },
+    integrations: {
+      all: false,
+      read: false,
+      writeEndpointIntegration: false,
+      readEndpointIntegration: false,
+    },
     isSuperuser: false,
   });
 }

--- a/x-pack/plugins/fleet/server/routes/security.ts
+++ b/x-pack/plugins/fleet/server/routes/security.ts
@@ -117,7 +117,7 @@ function containsRequirement(authz: Authz, requirements: DeepPartialTruthy<Authz
   return true;
 }
 
-function hasRequiredFleetAuthzPrivilege(
+export function hasRequiredFleetAuthzPrivilege(
   authz: FleetAuthz,
   { fleetAuthz }: { fleetAuthz?: FleetAuthzRequirements }
 ): boolean {
@@ -145,7 +145,7 @@ type FleetAuthzRouteRegistrar<
   handler: RequestHandler<P, Q, B, Context, Method>
 ) => void;
 
-interface FleetAuthzRouteConfig {
+export interface FleetAuthzRouteConfig {
   fleetAuthz?: FleetAuthzRequirements;
 }
 

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -1011,11 +1011,23 @@ class PackagePolicyClientWithAuthz extends PackagePolicyClientImpl {
       overwrite?: boolean;
     }
   ): Promise<PackagePolicy> {
-    await this.#runPreflight({
-      fleetAuthz: {
-        integrations: { writeIntegrationPolicies: true },
-      },
-    });
+    try {
+      await this.#runPreflight({
+        fleetAuthz: {
+          integrations: { writeIntegrationPolicies: true },
+        },
+      });
+    } catch (error) {
+      if (packagePolicy.package?.name === 'endpoint') {
+        await this.#runPreflight({
+          fleetAuthz: {
+            integrations: { writeEndpointIntegration: true },
+          },
+        });
+      } else {
+        throw error;
+      }
+    }
 
     return super.create(soClient, esClient, packagePolicy, options);
   }

--- a/x-pack/plugins/fleet/server/services/package_policy_service.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy_service.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type {
+  ElasticsearchClient,
+  RequestHandlerContext,
+  SavedObjectsClientContract,
+} from '@kbn/core/server';
+import type { AuthenticatedUser } from '@kbn/security-plugin/server';
+
+import type {
+  DeletePackagePoliciesResponse,
+  UpgradePackagePolicyResponse,
+  PackageInfo,
+  ListWithKuery,
+  ListResult,
+  UpgradePackagePolicyDryRunResponseItem,
+} from '../../common';
+import type { NewPackagePolicy, UpdatePackagePolicy, PackagePolicy } from '../types';
+import type { ExternalCallback } from '..';
+
+export interface PackagePolicyService {
+  asScoped(request: KibanaRequest): PackagePolicyClient;
+  get asInternalUser(): PackagePolicyClient;
+}
+
+export interface PackagePolicyClient {
+  create(
+    soClient: SavedObjectsClientContract,
+    esClient: ElasticsearchClient,
+    packagePolicy: NewPackagePolicy,
+    options?: {
+      spaceId?: string;
+      id?: string;
+      user?: AuthenticatedUser;
+      bumpRevision?: boolean;
+      force?: boolean;
+      skipEnsureInstalled?: boolean;
+      skipUniqueNameVerification?: boolean;
+      overwrite?: boolean;
+    }
+  ): Promise<PackagePolicy>;
+
+  bulkCreate(
+    soClient: SavedObjectsClientContract,
+    esClient: ElasticsearchClient,
+    packagePolicies: NewPackagePolicy[],
+    agentPolicyId: string,
+    options?: { user?: AuthenticatedUser; bumpRevision?: boolean }
+  ): Promise<PackagePolicy[]>;
+
+  get(soClient: SavedObjectsClientContract, id: string): Promise<PackagePolicy | null>;
+
+  getByIDs(soClient: SavedObjectsClientContract, ids: string[]): Promise<PackagePolicy[] | null>;
+
+  list(
+    soClient: SavedObjectsClientContract,
+    options: ListWithKuery
+  ): Promise<ListResult<PackagePolicy>>;
+
+  listIds(
+    soClient: SavedObjectsClientContract,
+    options: ListWithKuery
+  ): Promise<ListResult<string>>;
+
+  update(
+    soClient: SavedObjectsClientContract,
+    esClient: ElasticsearchClient,
+    id: string,
+    packagePolicyUpdate: UpdatePackagePolicy,
+    options?: { user?: AuthenticatedUser; force?: boolean },
+    currentVersion?: string
+  ): Promise<PackagePolicy>;
+
+  delete(
+    soClient: SavedObjectsClientContract,
+    esClient: ElasticsearchClient,
+    ids: string[],
+    options?: { user?: AuthenticatedUser; skipUnassignFromAgentPolicies?: boolean; force?: boolean }
+  ): Promise<DeletePackagePoliciesResponse>;
+
+  upgrade(
+    soClient: SavedObjectsClientContract,
+    esClient: ElasticsearchClient,
+    ids: string[],
+    options?: { user?: AuthenticatedUser },
+    packagePolicy?: PackagePolicy,
+    pkgVersion?: string
+  ): Promise<UpgradePackagePolicyResponse>;
+
+  getUpgradeDryRunDiff(
+    soClient: SavedObjectsClientContract,
+    id: string,
+    packagePolicy?: PackagePolicy,
+    pkgVersion?: string
+  ): Promise<UpgradePackagePolicyDryRunResponseItem>;
+
+  enrichPolicyWithDefaultsFromPackage(
+    soClient: SavedObjectsClientContract,
+    newPolicy: NewPackagePolicy
+  ): Promise<NewPackagePolicy>;
+
+  buildPackagePolicyFromPackage(
+    soClient: SavedObjectsClientContract,
+    pkgName: string
+  ): Promise<NewPackagePolicy | undefined>;
+
+  runExternalCallbacks<A extends ExternalCallback[0]>(
+    externalCallbackType: A,
+    packagePolicy: A extends 'postPackagePolicyDelete'
+      ? DeletePackagePoliciesResponse
+      : A extends 'packagePolicyPostCreate'
+      ? PackagePolicy
+      : NewPackagePolicy,
+    context: RequestHandlerContext,
+    request: KibanaRequest
+  ): Promise<
+    A extends 'postPackagePolicyDelete'
+      ? void
+      : A extends 'packagePolicyPostCreate'
+      ? PackagePolicy
+      : NewPackagePolicy
+  >;
+
+  runDeleteExternalCallbacks(deletedPackagePolicies: DeletePackagePoliciesResponse): Promise<void>;
+
+  getUpgradePackagePolicyInfo(
+    soClient: SavedObjectsClientContract,
+    id: string
+  ): Promise<{ packagePolicy: PackagePolicy; packageInfo: PackageInfo }>;
+}

--- a/x-pack/plugins/fleet/server/types/request_context.ts
+++ b/x-pack/plugins/fleet/server/types/request_context.ts
@@ -16,6 +16,7 @@ import type {
 
 import type { FleetAuthz } from '../../common/authz';
 import type { AgentClient } from '../services';
+import type { PackagePolicyClient } from '../services/package_policy';
 
 /** @internal */
 export type FleetRequestHandlerContext = CustomRequestHandlerContext<{
@@ -26,6 +27,10 @@ export type FleetRequestHandlerContext = CustomRequestHandlerContext<{
     agentClient: {
       asCurrentUser: AgentClient;
       asInternalUser: AgentClient;
+    };
+    packagePolicyService: {
+      asCurrentUser: PackagePolicyClient;
+      asInternalUser: PackagePolicyClient;
     };
     epm: {
       /**


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/130112
Related to https://github.com/elastic/security-team/issues/3355
Focusing on Security endpoint use case in Phase 1:
- RBAC controls for managing Endpoint Policies (specific Integration Policy management)

Moved package policy create authz check to JS service to demonstrate how it can be used from security.

Added an example subFeature to Integrations privileges to write/read endpoint integration using the existing privilege model (phase 1).


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
