### PR TITLE
[Fleet] Add match_only_text and wildcard types to default fields

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.test.ts
@@ -36,6 +36,18 @@ describe('buildDefaultSettings', () => {
           name: 'field2Boolean',
           type: 'boolean',
         },
+        {
+          name: 'field3Text',
+          type: 'text',
+        },
+        {
+          name: 'field4MatchOnlyText',
+          type: 'match_only_text',
+        },
+        {
+          name: 'field5Wildcard',
+          type: 'wildcard',
+        },
       ],
     });
 
@@ -49,6 +61,9 @@ describe('buildDefaultSettings', () => {
           "query": Object {
             "default_field": Array [
               "field1Keyword",
+              "field3Text",
+              "field4MatchOnlyText",
+              "field5Wildcard",
             ],
           },
         },

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.ts
@@ -8,7 +8,7 @@
 import { appContextService } from '../../../app_context';
 import type { Field, Fields } from '../../fields/field';
 
-const QUERY_DEFAULT_FIELD_TYPES = ['keyword', 'text'];
+const QUERY_DEFAULT_FIELD_TYPES = ['keyword', 'text', 'match_only_text', 'wildcard'];
 const QUERY_DEFAULT_FIELD_LIMIT = 1024;
 
 const flattenFieldsToNameAndType = (


### PR DESCRIPTION
## Summary

Resolves #124905. Adds `match_only_text` and `wildcard` field types to be included in the list of default fields in Fleet-generated index template settings.
