### PR TITLE
[Security Solution][Endpoint] Fix error while checking `agent.version` compatibility for host Isolation that causes Security Solution app to crash

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/service/host_isolation/utils.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/host_isolation/utils.test.ts
@@ -24,7 +24,7 @@ describe('Host Isolation utils isVersionSupported', () => {
     ${'8.0.0-SNAPSHOT'}       | ${'7.14.0'}        | ${true}
     ${'8.0.0'}                | ${'7.14.0'}        | ${true}
     ${'7.15.0.8295.0'}        | ${'7.14.0'}        | ${false}
-    ${'NOTE_SEMVER'}          | ${'7.14.0'}        | ${false}
+    ${'NOT_SEMVER'}           | ${'7.14.0'}        | ${false}
   `(
     'should validate that version $a is compatible($expected) to $b',
     ({ currentVersion, minVersionRequired, expected }) => {

--- a/x-pack/plugins/security_solution/common/endpoint/service/host_isolation/utils.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/host_isolation/utils.test.ts
@@ -8,6 +8,7 @@
 import { isVersionSupported, isOsSupported, isIsolationSupported } from './utils';
 
 describe('Host Isolation utils isVersionSupported', () => {
+  // NOTE: the `7.15.0.8295.0` and the text current versions are invalid.
   test.each`
     currentVersion            | minVersionRequired | expected
     ${'8.14.0'}               | ${'7.13.0'}        | ${true}
@@ -22,6 +23,8 @@ describe('Host Isolation utils isVersionSupported', () => {
     ${'7.14.0-alpha'}         | ${'7.14.0'}        | ${true}
     ${'8.0.0-SNAPSHOT'}       | ${'7.14.0'}        | ${true}
     ${'8.0.0'}                | ${'7.14.0'}        | ${true}
+    ${'7.15.0.8295.0'}        | ${'7.14.0'}        | ${false}
+    ${'NOTE_SEMVER'}          | ${'7.14.0'}        | ${false}
   `(
     'should validate that version $a is compatible($expected) to $b',
     ({ currentVersion, minVersionRequired, expected }) => {

--- a/x-pack/plugins/security_solution/common/endpoint/service/host_isolation/utils.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/host_isolation/utils.ts
@@ -26,8 +26,20 @@ export const isVersionSupported = ({
   currentVersion: string;
   minVersionRequired?: string;
 }) => {
-  const parsedCurrentVersion = parseSemver(currentVersion);
-  return semverLte(minVersionRequired, parsedCurrentVersion);
+  // `parseSemver()` will throw if the version provided is not a valid semver value.
+  // If that happens, then just return false from this function
+  try {
+    const parsedCurrentVersion = parseSemver(currentVersion);
+    return semverLte(minVersionRequired, parsedCurrentVersion);
+  } catch (e) {
+    // If running in the browser, log to console
+    if (window && window.console) {
+      window.console.warn(
+        `SecuritySolution: isVersionSupported(): Unable to determine if current version [${currentVersion}] meets minimum version [${minVersionRequired}]. Error: ${e.message}`
+      );
+    }
+    return false;
+  }
 };
 
 export const isOsSupported = ({

--- a/x-pack/plugins/security_solution/public/detections/components/host_isolation/use_host_isolation_action.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/host_isolation/use_host_isolation_action.tsx
@@ -56,11 +56,15 @@ export const useHostIsolationAction = ({
     agentId,
   });
 
-  const isolationSupported = isIsolationSupported({
-    osName: hostOsFamily,
-    version: agentVersion,
-    capabilities,
-  });
+  const isolationSupported = useMemo(() => {
+    return isEndpointAlert
+      ? isIsolationSupported({
+          osName: hostOsFamily,
+          version: agentVersion,
+          capabilities,
+        })
+      : false;
+  }, [agentVersion, capabilities, hostOsFamily, isEndpointAlert]);
 
   const isIsolationAllowed = useUserPrivileges().endpointPrivileges.canIsolateHost;
 


### PR DESCRIPTION
## Summary

- Fixes an issue in an utility function that checks `agent.version` supports a minimum version, which was causing the Kibana Security Solution app to crash when attempting to view an alert that had a value that did not meet semantic version format.

If an invalid version is used, the utility will now return `false` and also log the follwoing to the browser console: 

```
SecuritySolution: isVersionSupported(): Unable to determine if current version [7.15.0.8295.0] meets minimum version [7.14.0]. Invalid Version: 7.15.0.8295.0
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



