### PR TITLE
[ML] Anomaly Detection: Adds View in Maps item to Actions menu in the anomalies table

### DIFF
--- a/x-pack/plugins/ml/common/types/anomalies.ts
+++ b/x-pack/plugins/ml/common/types/anomalies.ts
@@ -278,6 +278,11 @@ export interface AnomaliesTableRecord {
    * which can be plotted by the ML UI in an anomaly chart.
    */
   isTimeSeriesViewRecord?: boolean;
+
+  /**
+   * Returns true if the anomaly record represented by the table row can be shown in the maps plugin
+   */
+  isGeoRecord?: boolean;
 }
 
 export type PartitionFieldsType = typeof PARTITION_FIELDS[number];

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/anomalies_table_columns.js
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/anomalies_table_columns.js
@@ -18,6 +18,7 @@ import {
   formatHumanReadableDateTime,
   formatHumanReadableDateTimeSeconds,
 } from '../../../../common/util/date_utils';
+import { ML_JOB_AGGREGATION } from '../../../../common/constants/aggregation_types';
 
 import { DescriptionCell } from './description_cell';
 import { DetectorCell } from './detector_cell';
@@ -47,7 +48,8 @@ function showLinksMenuForItem(item, showViewSeriesLink) {
     canConfigureRules ||
     (showViewSeriesLink && item.isTimeSeriesViewRecord) ||
     item.entityName === 'mlcategory' ||
-    item.customUrls !== undefined
+    item.customUrls !== undefined ||
+    item.detector.includes(ML_JOB_AGGREGATION.LAT_LONG)
   );
 }
 

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/links_menu.tsx
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/links_menu.tsx
@@ -73,14 +73,17 @@ export const LinksMenuUI = (props: LinksMenuProps) => {
     services: { data, share, application },
   } = kibana;
 
-  const getMapsLink = async (anomaly: any) => {
+  const getMapsLink = async (anomaly: AnomaliesTableRecord) => {
     const initialLayers = getInitialAnomaliesLayers(anomaly.jobId);
+    const anomalyBucketStart = moment(anomaly.time).toISOString();
+    const timeRange = data.query.timefilter.timefilter.getTime();
+    // Set 'from' in timeRange to start bucket time for the specific anomaly
+    timeRange.from = anomalyBucketStart;
 
     const locator = share.url.locators.get(MAPS_APP_LOCATOR);
     const location = await locator?.getLocation({
       initialLayers,
-      timeRange: data.query.timefilter.timefilter.getTime(),
-      // {from: '2022-04-14T00:04:19.000Z', to: '2022-04-28T21:46:05.000Z'}
+      timeRange,
     });
     return location;
   };

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/links_menu.tsx
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/links_menu.tsx
@@ -79,7 +79,7 @@ export const LinksMenuUI = (props: LinksMenuProps) => {
     const anomalyBucketStartMoment = moment(anomaly.time).tz(getDateFormatTz());
     const anomalyBucketStart = anomalyBucketStartMoment.toISOString();
     const anomalyBucketEnd = anomalyBucketStartMoment
-      .add(anomaly.source.bucket_span, 'seconds')
+      .add(anomaly.source.bucket_span, 'seconds').subtract(1, 'ms')
       .toISOString();
     const timeRange = data.query.timefilter.timefilter.getTime();
 

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/links_menu.tsx
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/links_menu.tsx
@@ -79,7 +79,8 @@ export const LinksMenuUI = (props: LinksMenuProps) => {
     const anomalyBucketStartMoment = moment(anomaly.time).tz(getDateFormatTz());
     const anomalyBucketStart = anomalyBucketStartMoment.toISOString();
     const anomalyBucketEnd = anomalyBucketStartMoment
-      .add(anomaly.source.bucket_span, 'seconds').subtract(1, 'ms')
+      .add(anomaly.source.bucket_span, 'seconds')
+      .subtract(1, 'ms')
       .toISOString();
     const timeRange = data.query.timefilter.timefilter.getTime();
 

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
@@ -16,7 +16,6 @@ import {
   EuiFlexItem,
   EuiIconTip,
   EuiToolTip,
-  htmlIdGenerator,
 } from '@elastic/eui';
 
 import {
@@ -36,15 +35,13 @@ import { MlTooltipComponent } from '../../components/chart_tooltip';
 import { withKibana } from '@kbn/kibana-react-plugin/public';
 import { useMlKibana } from '../../contexts/kibana';
 import { ML_JOB_AGGREGATION } from '../../../../common/constants/aggregation_types';
-import { AnomalySource } from '../../../maps/anomaly_source';
-import { CUSTOM_COLOR_RAMP } from '../../../maps/anomaly_layer_wizard_factory';
-import { LAYER_TYPE, APP_ID as MAPS_APP_ID } from '@kbn/maps-plugin/common';
+import { getInitialAnomaliesLayers } from '../../../maps/util';
+import { APP_ID as MAPS_APP_ID } from '@kbn/maps-plugin/common';
 import { MAPS_APP_LOCATOR } from '@kbn/maps-plugin/public';
 import { ExplorerChartsErrorCallOuts } from './explorer_charts_error_callouts';
 import { addItemToRecentlyAccessed } from '../../util/recently_accessed';
 import { EmbeddedMapComponentWrapper } from './explorer_chart_embedded_map';
 import { useActiveCursor } from '@kbn/charts-plugin/public';
-import { ML_ANOMALY_LAYERS } from '../../../maps/util';
 import { Chart, Settings } from '@elastic/charts';
 import useObservable from 'react-use/lib/useObservable';
 
@@ -114,59 +111,7 @@ function ExplorerChartContainer({
 
   const getMapsLink = useCallback(async () => {
     const { queryString, query } = getEntitiesQuery(series);
-    const initialLayers = [];
-    const typicalStyle = {
-      type: 'VECTOR',
-      properties: {
-        fillColor: {
-          type: 'STATIC',
-          options: {
-            color: '#98A2B2',
-          },
-        },
-        lineColor: {
-          type: 'STATIC',
-          options: {
-            color: '#fff',
-          },
-        },
-        lineWidth: {
-          type: 'STATIC',
-          options: {
-            size: 2,
-          },
-        },
-        iconSize: {
-          type: 'STATIC',
-          options: {
-            size: 6,
-          },
-        },
-      },
-    };
-
-    const style = {
-      type: 'VECTOR',
-      properties: {
-        fillColor: CUSTOM_COLOR_RAMP,
-        lineColor: CUSTOM_COLOR_RAMP,
-      },
-      isTimeAware: false,
-    };
-
-    for (const layer in ML_ANOMALY_LAYERS) {
-      if (ML_ANOMALY_LAYERS.hasOwnProperty(layer)) {
-        initialLayers.push({
-          id: htmlIdGenerator()(),
-          type: LAYER_TYPE.GEOJSON_VECTOR,
-          sourceDescriptor: AnomalySource.createDescriptor({
-            jobId: series.jobId,
-            typicalActual: ML_ANOMALY_LAYERS[layer],
-          }),
-          style: ML_ANOMALY_LAYERS[layer] === ML_ANOMALY_LAYERS.TYPICAL ? typicalStyle : style,
-        });
-      }
-    }
+    const initialLayers = getInitialAnomaliesLayers(series.jobId);
 
     const locator = share.url.locators.get(MAPS_APP_LOCATOR);
     const location = await locator.getLocation({

--- a/x-pack/plugins/ml/public/application/explorer/explorer_utils.ts
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_utils.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../common/constants/search';
 import { EntityField, getEntityFieldList } from '../../../common/util/anomaly_utils';
 import { extractErrorMessage } from '../../../common/util/errors';
+import { ML_JOB_AGGREGATION } from '../../../common/constants/aggregation_types';
 import {
   isSourceDataChartableForDetector,
   isModelPlotChartableForDetector,
@@ -495,6 +496,10 @@ export async function loadAnomaliesTableData(
           }
 
           anomaly.isTimeSeriesViewRecord = isChartable;
+
+          if (detector !== undefined && detector.function === ML_JOB_AGGREGATION.LAT_LONG) {
+            anomaly.isGeoRecord = true;
+          }
 
           if (mlJobService.customUrlsByJob[jobId] !== undefined) {
             anomaly.customUrls = mlJobService.customUrlsByJob[jobId];

--- a/x-pack/plugins/ml/public/application/explorer/explorer_utils.ts
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_utils.ts
@@ -496,7 +496,8 @@ export async function loadAnomaliesTableData(
           }
 
           anomaly.isTimeSeriesViewRecord = isChartable;
-          anomaly.isGeoRecord = detector !== undefined && detector.function === ML_JOB_AGGREGATION.LAT_LONG;
+          anomaly.isGeoRecord =
+            detector !== undefined && detector.function === ML_JOB_AGGREGATION.LAT_LONG;
 
           if (mlJobService.customUrlsByJob[jobId] !== undefined) {
             anomaly.customUrls = mlJobService.customUrlsByJob[jobId];

--- a/x-pack/plugins/ml/public/application/explorer/explorer_utils.ts
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_utils.ts
@@ -496,10 +496,7 @@ export async function loadAnomaliesTableData(
           }
 
           anomaly.isTimeSeriesViewRecord = isChartable;
-
-          if (detector !== undefined && detector.function === ML_JOB_AGGREGATION.LAT_LONG) {
-            anomaly.isGeoRecord = true;
-          }
+          anomaly.isGeoRecord = detector !== undefined && detector.function === ML_JOB_AGGREGATION.LAT_LONG;
 
           if (mlJobService.customUrlsByJob[jobId] !== undefined) {
             anomaly.customUrls = mlJobService.customUrlsByJob[jobId];

--- a/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_layer_wizard_factory.tsx
@@ -11,13 +11,13 @@ import type { StartServicesAccessor } from '@kbn/core/public';
 import { LocatorPublic } from '@kbn/share-plugin/common';
 import { SerializableRecord } from '@kbn/utility-types';
 import type { LayerWizard, RenderWizardArguments } from '@kbn/maps-plugin/public';
-import { FIELD_ORIGIN, LAYER_TYPE, STYLE_TYPE } from '@kbn/maps-plugin/common';
+import { LAYER_TYPE } from '@kbn/maps-plugin/common';
 import {
   VectorLayerDescriptor,
   VectorStylePropertiesDescriptor,
 } from '@kbn/maps-plugin/common/descriptor_types';
-import { SEVERITY_COLOR_RAMP } from '../../common';
 import { ML_APP_LOCATOR, ML_PAGES } from '../../common/constants/locator';
+import { CUSTOM_COLOR_RAMP } from './util';
 import { CreateAnomalySourceEditor } from './create_anomaly_source_editor';
 import { AnomalySource, AnomalySourceDescriptor } from './anomaly_source';
 
@@ -26,17 +26,6 @@ import type { MlPluginStart, MlStartDependencies } from '../plugin';
 import type { MlApiServices } from '../application/services/ml_api_service';
 
 export const ML_ANOMALY = 'ML_ANOMALIES';
-export const CUSTOM_COLOR_RAMP = {
-  type: STYLE_TYPE.DYNAMIC,
-  options: {
-    customColorRamp: SEVERITY_COLOR_RAMP,
-    field: {
-      name: 'record_score',
-      origin: FIELD_ORIGIN.SOURCE,
-    },
-    useCustomColorRamp: true,
-  },
-};
 
 export class AnomalyLayerWizardFactory {
   public readonly type = ML_ANOMALY;


### PR DESCRIPTION
## Summary

Related maps integration meta issue https://github.com/elastic/kibana/issues/123492
This PR adds the 'View in Maps' item to the action menu in the anomalies table for anomalies from geo jobs.

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/6446462/166078274-2fc7150a-4ebc-4760-8da1-8e2e31c37662.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))


