### PR TITLE
[Cloud Posture] General and Remediation tabs updates

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -169,7 +169,7 @@ const getRemediationCards = ({ result, ...rest }: CspFinding): Card[] => [
         : ['', ''],
       [TEXT.EVIDENCE, <CodeBlock>{JSON.stringify(result.evidence, null, 2)}</CodeBlock>],
       [
-        TEXT.TIMESTAMP,
+        TEXT.RULE_EVALUATED_AT,
         <span>{moment(rest['@timestamp']).format('MMMM D, YYYY @ HH:mm:ss.SSS')}</span>,
       ],
     ],

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -26,7 +26,6 @@ import {
 } from '@elastic/eui';
 import { assertNever } from '@kbn/std';
 import moment from 'moment';
-import { CSP_LATEST_FINDINGS_DATA_VIEW } from '../../../../common/constants';
 import type { CspFinding } from '../types';
 import { CspEvaluationBadge } from '../../../components/csp_evaluation_badge';
 import * as TEXT from '../translations';
@@ -133,7 +132,6 @@ const getGeneralCards = ({ rule, ...rest }: CspFinding): Card[] => [
   {
     title: TEXT.RULE,
     listItems: [
-      [TEXT.INDEX, CSP_LATEST_FINDINGS_DATA_VIEW],
       [TEXT.RULE_EVALUATED_AT, moment(rest['@timestamp']).format('MMMM D, YYYY @ HH:mm:ss.SSS')],
       [
         TEXT.FRAMEWORK_SOURCES,

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -23,8 +23,10 @@ import {
   EuiFlexGroup,
   EuiIcon,
   type PropsOf,
+  EuiMarkdownFormat,
 } from '@elastic/eui';
 import { assertNever } from '@kbn/std';
+import moment from 'moment';
 import type { CspFinding } from '../types';
 import { CspEvaluationBadge } from '../../../components/csp_evaluation_badge';
 import * as TEXT from '../translations';
@@ -33,10 +35,10 @@ import k8sLogoIcon from '../../../assets/icons/k8s_logo.svg';
 import { ResourceTab } from './resource_tab';
 import { JsonTab } from './json_tab';
 
-const tabs = ['remediation', 'resource', 'general', 'json'] as const;
+const tabs = ['Remediation', 'Resource', 'General', 'JSON'] as const;
 
 const CodeBlock: React.FC<PropsOf<typeof EuiCodeBlock>> = (props) => (
-  <EuiCodeBlock {...props} isCopyable paddingSize="s" />
+  <EuiCodeBlock {...props} isCopyable paddingSize="s" overflowHeight={300} />
 );
 
 type FindingsTab = typeof tabs[number];
@@ -75,13 +77,13 @@ const Cards = ({ data }: { data: Card[] }) => (
 
 const FindingsTab = ({ tab, findings }: { findings: CspFinding; tab: FindingsTab }) => {
   switch (tab) {
-    case 'remediation':
+    case 'Remediation':
       return <Cards data={getRemediationCards(findings)} />;
-    case 'resource':
+    case 'Resource':
       return <ResourceTab data={findings} />;
-    case 'general':
+    case 'General':
       return <Cards data={getGeneralCards(findings)} />;
-    case 'json':
+    case 'JSON':
       return <JsonTab data={findings} />;
     default:
       assertNever(tab);
@@ -89,7 +91,7 @@ const FindingsTab = ({ tab, findings }: { findings: CspFinding; tab: FindingsTab
 };
 
 export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) => {
-  const [tab, setTab] = useState<FindingsTab>('remediation');
+  const [tab, setTab] = useState<FindingsTab>('Remediation');
 
   return (
     <EuiFlyout onClose={onClose}>
@@ -109,12 +111,7 @@ export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) =>
         <EuiSpacer />
         <EuiTabs>
           {tabs.map((v) => (
-            <EuiTab
-              key={v}
-              isSelected={tab === v}
-              onClick={() => setTab(v)}
-              style={{ textTransform: 'capitalize' }}
-            >
+            <EuiTab key={v} isSelected={tab === v} onClick={() => setTab(v)}>
               {v}
             </EuiTab>
           ))}
@@ -167,18 +164,23 @@ const getRemediationCards = ({ result, ...rest }: CspFinding): Card[] => [
   {
     title: TEXT.RESULT_DETAILS,
     listItems: [
-      [TEXT.EXPECTED, ''],
+      result.expected
+        ? [TEXT.EXPECTED, <CodeBlock>{JSON.stringify(result.expected, null, 2)}</CodeBlock>]
+        : ['', ''],
       [TEXT.EVIDENCE, <CodeBlock>{JSON.stringify(result.evidence, null, 2)}</CodeBlock>],
-      [TEXT.TIMESTAMP, <CodeBlock>{rest['@timestamp']}</CodeBlock>],
+      [
+        TEXT.TIMESTAMP,
+        <span>{moment(rest['@timestamp']).format('MMMM D, YYYY @ HH:mm:ss.SSS')}</span>,
+      ],
     ],
   },
   {
     title: TEXT.REMEDIATION,
     listItems: [
-      ['', <CodeBlock>{rest.rule.remediation}</CodeBlock>],
-      [TEXT.IMPACT, rest.rule.impact],
-      [TEXT.DEFAULT_VALUE, ''],
-      [TEXT.RATIONALE, ''],
+      ['', <EuiMarkdownFormat>{rest.rule.remediation}</EuiMarkdownFormat>],
+      [TEXT.IMPACT, <EuiMarkdownFormat>{rest.rule.impact}</EuiMarkdownFormat>],
+      [TEXT.DEFAULT_VALUE, <EuiMarkdownFormat>{rest.rule.default_value}</EuiMarkdownFormat>],
+      [TEXT.RATIONALE, <EuiMarkdownFormat>{rest.rule.rationale}</EuiMarkdownFormat>],
     ],
   },
 ];

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -23,6 +23,7 @@ import {
   EuiIcon,
   type PropsOf,
   EuiMarkdownFormat,
+  useEuiTheme,
 } from '@elastic/eui';
 import { assertNever } from '@kbn/std';
 import moment from 'moment';
@@ -38,11 +39,15 @@ const tabs = [
   { title: TEXT.REMEDIATION, id: 'remediation' },
   { title: TEXT.RESOURCE, id: 'resource' },
   { title: TEXT.GENERAL, id: 'general' },
-  { title: 'JSON', id: 'json' },
+  { title: TEXT.JSON, id: 'json' },
 ] as const;
 
 const CodeBlock: React.FC<PropsOf<typeof EuiCodeBlock>> = (props) => (
-  <EuiCodeBlock {...props} isCopyable paddingSize="s" overflowHeight={300} />
+  <EuiCodeBlock isCopyable paddingSize="s" overflowHeight={300} {...props} />
+);
+
+const Markdown: React.FC<PropsOf<typeof EuiMarkdownFormat>> = (props) => (
+  <EuiMarkdownFormat textSize="s" {...props} />
 );
 
 type FindingsTab = typeof tabs[number];
@@ -59,25 +64,29 @@ interface FindingFlyoutProps {
   findings: CspFinding;
 }
 
-const Cards = ({ data }: { data: Card[] }) => (
-  <EuiFlexGrid direction="column" gutterSize={'l'}>
-    {data.map((card) => (
-      <EuiFlexItem key={card.title} style={{ display: 'block' }}>
-        <EuiCard textAlign="left" title={card.title} hasBorder>
-          <EuiDescriptionList
-            compressed={false}
-            type="column"
-            listItems={card.listItems.map((v) => ({ title: v[0], description: v[1] }))}
-            style={{ flexFlow: 'column' }}
-            descriptionProps={{
-              style: { width: '100%' },
-            }}
-          />
-        </EuiCard>
-      </EuiFlexItem>
-    ))}
-  </EuiFlexGrid>
-);
+const Cards = ({ data }: { data: Card[] }) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiFlexGrid direction="column" gutterSize={'l'}>
+      {data.map((card) => (
+        <EuiFlexItem key={card.title} style={{ display: 'block' }}>
+          <EuiCard textAlign="left" title={card.title} hasBorder>
+            <EuiDescriptionList
+              compressed={false}
+              type="column"
+              listItems={card.listItems.map((v) => ({ title: v[0], description: v[1] }))}
+              style={{ flexFlow: 'column' }}
+              descriptionProps={{
+                style: { width: '100%' },
+              }}
+            />
+          </EuiCard>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGrid>
+  );
+};
 
 const FindingsTab = ({ tab, findings }: { findings: CspFinding; tab: FindingsTab }) => {
   switch (tab.id) {
@@ -145,15 +154,12 @@ const getGeneralCards = ({ rule, ...rest }: CspFinding): Card[] => [
         </EuiFlexGroup>,
       ],
       [TEXT.CIS_SECTION, rule.section],
-      [
-        TEXT.PROFILE_APPLICABILITY,
-        <EuiMarkdownFormat>{rule.profile_applicability}</EuiMarkdownFormat>,
-      ],
+      [TEXT.PROFILE_APPLICABILITY, <Markdown>{rule.profile_applicability}</Markdown>],
       [TEXT.BENCHMARK, rule.benchmark.name],
       [TEXT.NAME, rule.name],
-      [TEXT.DESCRIPTION, <EuiMarkdownFormat>{rule.description}</EuiMarkdownFormat>],
-      [TEXT.AUDIT, <EuiMarkdownFormat>{rule.audit}</EuiMarkdownFormat>],
-      [TEXT.REFERENCES, <EuiMarkdownFormat>{rule.references}</EuiMarkdownFormat>],
+      [TEXT.DESCRIPTION, <Markdown>{rule.description}</Markdown>],
+      [TEXT.AUDIT, <Markdown>{rule.audit}</Markdown>],
+      [TEXT.REFERENCES, <Markdown>{rule.references}</Markdown>],
     ],
   },
 ];
@@ -175,10 +181,10 @@ const getRemediationCards = ({ result, rule, ...rest }: CspFinding): Card[] => [
   {
     title: TEXT.REMEDIATION,
     listItems: [
-      ['', <EuiMarkdownFormat>{rule.remediation}</EuiMarkdownFormat>],
-      [TEXT.IMPACT, <EuiMarkdownFormat>{rule.impact}</EuiMarkdownFormat>],
-      [TEXT.DEFAULT_VALUE, <EuiMarkdownFormat>{rule.default_value}</EuiMarkdownFormat>],
-      [TEXT.RATIONALE, <EuiMarkdownFormat>{rule.rationale}</EuiMarkdownFormat>],
+      ['', <Markdown>{rule.remediation}</Markdown>],
+      [TEXT.IMPACT, <Markdown>{rule.impact}</Markdown>],
+      [TEXT.DEFAULT_VALUE, <Markdown>{rule.default_value}</Markdown>],
+      [TEXT.RATIONALE, <Markdown>{rule.rationale}</Markdown>],
     ],
   },
 ];

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -34,6 +34,7 @@ import cisLogoIcon from '../../../assets/icons/cis_logo.svg';
 import k8sLogoIcon from '../../../assets/icons/k8s_logo.svg';
 import { ResourceTab } from './resource_tab';
 import { JsonTab } from './json_tab';
+import { REFERENCES } from '../translations';
 
 const tabs = ['Remediation', 'Resource', 'General', 'JSON'] as const;
 
@@ -124,13 +125,12 @@ export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) =>
   );
 };
 
-const getGeneralCards = ({ rule }: CspFinding): Card[] => [
+const getGeneralCards = ({ rule, ...rest }: CspFinding): Card[] => [
   {
     title: TEXT.RULE,
     listItems: [
-      [TEXT.SEVERITY, ''],
-      [TEXT.INDEX, ''],
-      [TEXT.RULE_EVALUATED_AT, ''],
+      [TEXT.INDEX, 'rule._index'],
+      [TEXT.RULE_EVALUATED_AT, moment(rest['@timestamp']).format('MMMM D, YYYY @ HH:mm:ss.SSS')],
       [
         TEXT.FRAMEWORK_SOURCES,
         <EuiFlexGroup gutterSize="s">
@@ -142,25 +142,21 @@ const getGeneralCards = ({ rule }: CspFinding): Card[] => [
           </EuiFlexItem>
         </EuiFlexGroup>,
       ],
-      [TEXT.SECTION, ''],
-      [TEXT.PROFILE_APPLICABILITY, ''],
-      [TEXT.AUDIT, ''],
+      [TEXT.CIS_SECTION, rule.section],
+      [
+        TEXT.PROFILE_APPLICABILITY,
+        <EuiMarkdownFormat>{rule.profile_applicability}</EuiMarkdownFormat>,
+      ],
       [TEXT.BENCHMARK, rule.benchmark.name],
       [TEXT.NAME, rule.name],
-      [TEXT.DESCRIPTION, rule.description],
-      [
-        TEXT.TAGS,
-        rule.tags.map((t) => (
-          <EuiBadge key={t} color="default">
-            {t}
-          </EuiBadge>
-        )),
-      ],
+      [TEXT.DESCRIPTION, <EuiMarkdownFormat>{rule.description}</EuiMarkdownFormat>],
+      [TEXT.AUDIT, <EuiMarkdownFormat>{rule.audit}</EuiMarkdownFormat>],
+      [TEXT.REFERENCES, <EuiMarkdownFormat>{rule.references}</EuiMarkdownFormat>],
     ],
   },
 ];
 
-const getRemediationCards = ({ result, ...rest }: CspFinding): Card[] => [
+const getRemediationCards = ({ result, rule, ...rest }: CspFinding): Card[] => [
   {
     title: TEXT.RESULT_DETAILS,
     listItems: [
@@ -177,10 +173,10 @@ const getRemediationCards = ({ result, ...rest }: CspFinding): Card[] => [
   {
     title: TEXT.REMEDIATION,
     listItems: [
-      ['', <EuiMarkdownFormat>{rest.rule.remediation}</EuiMarkdownFormat>],
-      [TEXT.IMPACT, <EuiMarkdownFormat>{rest.rule.impact}</EuiMarkdownFormat>],
-      [TEXT.DEFAULT_VALUE, <EuiMarkdownFormat>{rest.rule.default_value}</EuiMarkdownFormat>],
-      [TEXT.RATIONALE, <EuiMarkdownFormat>{rest.rule.rationale}</EuiMarkdownFormat>],
+      ['', <EuiMarkdownFormat>{rule.remediation}</EuiMarkdownFormat>],
+      [TEXT.IMPACT, <EuiMarkdownFormat>{rule.impact}</EuiMarkdownFormat>],
+      [TEXT.DEFAULT_VALUE, <EuiMarkdownFormat>{rule.default_value}</EuiMarkdownFormat>],
+      [TEXT.RATIONALE, <EuiMarkdownFormat>{rule.rationale}</EuiMarkdownFormat>],
     ],
   },
 ];

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -15,7 +15,6 @@ import {
   EuiFlyoutHeader,
   EuiTitle,
   EuiFlyoutBody,
-  EuiBadge,
   EuiTabs,
   EuiTab,
   EuiFlexGrid,
@@ -27,6 +26,7 @@ import {
 } from '@elastic/eui';
 import { assertNever } from '@kbn/std';
 import moment from 'moment';
+import { CSP_LATEST_FINDINGS_DATA_VIEW } from '../../../../common/constants';
 import type { CspFinding } from '../types';
 import { CspEvaluationBadge } from '../../../components/csp_evaluation_badge';
 import * as TEXT from '../translations';
@@ -34,9 +34,13 @@ import cisLogoIcon from '../../../assets/icons/cis_logo.svg';
 import k8sLogoIcon from '../../../assets/icons/k8s_logo.svg';
 import { ResourceTab } from './resource_tab';
 import { JsonTab } from './json_tab';
-import { REFERENCES } from '../translations';
 
-const tabs = ['Remediation', 'Resource', 'General', 'JSON'] as const;
+const tabs = [
+  { title: TEXT.REMEDIATION, id: 'remediation' },
+  { title: TEXT.RESOURCE, id: 'resource' },
+  { title: TEXT.GENERAL, id: 'general' },
+  { title: 'JSON', id: 'json' },
+] as const;
 
 const CodeBlock: React.FC<PropsOf<typeof EuiCodeBlock>> = (props) => (
   <EuiCodeBlock {...props} isCopyable paddingSize="s" overflowHeight={300} />
@@ -77,14 +81,14 @@ const Cards = ({ data }: { data: Card[] }) => (
 );
 
 const FindingsTab = ({ tab, findings }: { findings: CspFinding; tab: FindingsTab }) => {
-  switch (tab) {
-    case 'Remediation':
+  switch (tab.id) {
+    case 'remediation':
       return <Cards data={getRemediationCards(findings)} />;
-    case 'Resource':
+    case 'resource':
       return <ResourceTab data={findings} />;
-    case 'General':
+    case 'general':
       return <Cards data={getGeneralCards(findings)} />;
-    case 'JSON':
+    case 'json':
       return <JsonTab data={findings} />;
     default:
       assertNever(tab);
@@ -92,7 +96,7 @@ const FindingsTab = ({ tab, findings }: { findings: CspFinding; tab: FindingsTab
 };
 
 export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) => {
-  const [tab, setTab] = useState<FindingsTab>('Remediation');
+  const [tab, setTab] = useState<FindingsTab>(tabs[0]);
 
   return (
     <EuiFlyout onClose={onClose}>
@@ -112,8 +116,8 @@ export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) =>
         <EuiSpacer />
         <EuiTabs>
           {tabs.map((v) => (
-            <EuiTab key={v} isSelected={tab === v} onClick={() => setTab(v)}>
-              {v}
+            <EuiTab key={v.id} isSelected={tab.id === v.id} onClick={() => setTab(v)}>
+              {v.title}
             </EuiTab>
           ))}
         </EuiTabs>
@@ -129,7 +133,7 @@ const getGeneralCards = ({ rule, ...rest }: CspFinding): Card[] => [
   {
     title: TEXT.RULE,
     listItems: [
-      [TEXT.INDEX, 'rule._index'],
+      [TEXT.INDEX, CSP_LATEST_FINDINGS_DATA_VIEW],
       [TEXT.RULE_EVALUATED_AT, moment(rest['@timestamp']).format('MMMM D, YYYY @ HH:mm:ss.SSS')],
       [
         TEXT.FRAMEWORK_SOURCES,

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -23,7 +23,6 @@ import {
   EuiIcon,
   type PropsOf,
   EuiMarkdownFormat,
-  useEuiTheme,
 } from '@elastic/eui';
 import { assertNever } from '@kbn/std';
 import moment from 'moment';
@@ -64,29 +63,25 @@ interface FindingFlyoutProps {
   findings: CspFinding;
 }
 
-const Cards = ({ data }: { data: Card[] }) => {
-  const { euiTheme } = useEuiTheme();
-
-  return (
-    <EuiFlexGrid direction="column" gutterSize={'l'}>
-      {data.map((card) => (
-        <EuiFlexItem key={card.title} style={{ display: 'block' }}>
-          <EuiCard textAlign="left" title={card.title} hasBorder>
-            <EuiDescriptionList
-              compressed={false}
-              type="column"
-              listItems={card.listItems.map((v) => ({ title: v[0], description: v[1] }))}
-              style={{ flexFlow: 'column' }}
-              descriptionProps={{
-                style: { width: '100%' },
-              }}
-            />
-          </EuiCard>
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGrid>
-  );
-};
+const Cards = ({ data }: { data: Card[] }) => (
+  <EuiFlexGrid direction="column" gutterSize={'l'}>
+    {data.map((card) => (
+      <EuiFlexItem key={card.title} style={{ display: 'block' }}>
+        <EuiCard textAlign="left" title={card.title} hasBorder>
+          <EuiDescriptionList
+            compressed={false}
+            type="column"
+            listItems={card.listItems.map((v) => ({ title: v[0], description: v[1] }))}
+            style={{ flexFlow: 'column' }}
+            descriptionProps={{
+              style: { width: '100%' },
+            }}
+          />
+        </EuiCard>
+      </EuiFlexItem>
+    ))}
+  </EuiFlexGrid>
+);
 
 const FindingsTab = ({ tab, findings }: { findings: CspFinding; tab: FindingsTab }) => {
   switch (tab.id) {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.test.tsx
@@ -17,6 +17,9 @@ const chance = new Chance();
 const getFakeFindings = (name: string): CspFinding & { id: string } => ({
   id: chance.word(),
   result: {
+    expected: {
+      source: {},
+    },
     evaluation: chance.weighted(['passed', 'failed'], [0.5, 0.5]),
     evidence: {
       filemode: chance.word(),
@@ -31,6 +34,12 @@ const getFakeFindings = (name: string): CspFinding & { id: string } => ({
       name: 'CIS Kubernetes',
       version: '1.6.0',
     },
+    section: chance.sentence(),
+    audit: chance.paragraph(),
+    references: chance.paragraph(),
+    profile_applicability: chance.sentence(),
+    rationale: chance.paragraph(),
+    default_value: chance.sentence(),
     tags: [],
   },
   agent: {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
@@ -42,6 +42,10 @@ export const RESOURCE = i18n.translate('xpack.csp.findings.resourceLabel', {
   defaultMessage: 'Resource',
 });
 
+export const GENERAL = i18n.translate('xpack.csp.findings.findingsFlyout.generalTabLabel', {
+  defaultMessage: 'General',
+});
+
 export const RESOURCE_ID = i18n.translate(
   'xpack.csp.findings.findingsTable.findingsTableColumn.resourceIdColumnLabel',
   {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
@@ -141,6 +141,13 @@ export const AUDIT = i18n.translate('xpack.csp.findings.auditLabel', {
   defaultMessage: 'Audit',
 });
 
+export const REFERENCES = i18n.translate(
+  'xpack.csp.findings.findingsFlyout.generalTab.referencesLabel',
+  {
+    defaultMessage: 'References',
+  }
+);
+
 export const RESULT_DETAILS = i18n.translate('xpack.csp.findings.resultLabel', {
   defaultMessage: 'Result Details',
 });

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
@@ -46,6 +46,10 @@ export const GENERAL = i18n.translate('xpack.csp.findings.findingsFlyout.general
   defaultMessage: 'General',
 });
 
+export const JSON = i18n.translate('xpack.csp.findings.findingsFlyout.jsonTabLabel', {
+  defaultMessage: 'JSON',
+});
+
 export const RESOURCE_ID = i18n.translate(
   'xpack.csp.findings.findingsTable.findingsTableColumn.resourceIdColumnLabel',
   {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
@@ -50,6 +50,8 @@ interface CspRule {
   benchmark: { name: string; version: string };
   description: string;
   impact: string;
+  default_value: string;
+  rationale: string;
   name: string;
   remediation: string;
   tags: string[];
@@ -57,6 +59,7 @@ interface CspRule {
 
 interface CspFindingResult {
   evaluation: 'passed' | 'failed';
+  expected: Record<string, unknown>;
   evidence: {
     filemode: string;
   };

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
@@ -48,6 +48,10 @@ export interface CspFinding {
 
 interface CspRule {
   benchmark: { name: string; version: string };
+  section: string;
+  audit: string;
+  references: string;
+  profile_applicability: string;
   description: string;
   impact: string;
   default_value: string;

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
@@ -63,10 +63,8 @@ interface CspRule {
 
 interface CspFindingResult {
   evaluation: 'passed' | 'failed';
-  expected: Record<string, unknown>;
-  evidence: {
-    filemode: string;
-  };
+  expected?: Record<string, unknown>;
+  evidence: Record<string, unknown>;
 }
 
 interface CspFindingResource {


### PR DESCRIPTION
## Summary

Updated for both `General` and `Remediation` tabs in findings flyout

NOTE: `index` is removed in the final version
![image](https://user-images.githubusercontent.com/51442161/166220026-b5131f21-8165-46ff-9226-fd46e98fbf5e.png)

![image](https://user-images.githubusercontent.com/51442161/166219973-8e0d489e-30d4-4317-82eb-074eab719857.png)