### PR TITLE
[Workplace Search] Remove unused user filtering in groups

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
@@ -30,8 +30,6 @@ export interface Group {
   createdAt: string;
   updatedAt: string;
   contentSources: ContentSource[];
-  users: User[];
-  usersCount: number;
   color?: string;
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/__mocks__/groups_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/__mocks__/groups_logic.mock.ts
@@ -6,12 +6,11 @@
  */
 
 import { DEFAULT_META } from '../../../../shared/constants';
-import { ContentSource, User, Group } from '../../../types';
+import { ContentSource, Group } from '../../../types';
 
 export const mockGroupsValues = {
   groups: [] as Group[],
   contentSources: [] as ContentSource[],
-  users: [] as User[],
   groupsDataLoading: true,
   groupListLoading: true,
   newGroupModalOpen: false,
@@ -21,10 +20,6 @@ export const mockGroupsValues = {
   newGroupNameErrors: [],
   filterSourcesDropdownOpen: false,
   filteredSources: [],
-  filterUsersDropdownOpen: false,
-  filteredUsers: [],
-  allGroupUsersLoading: false,
-  allGroupUsers: [],
   filterValue: '',
   groupsMeta: DEFAULT_META,
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.test.tsx
@@ -91,7 +91,6 @@ describe('GroupOverview', () => {
       ...mockValues,
       group: {
         ...groups[0],
-        users: [],
         contentSources: [],
       },
     });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.tsx
@@ -28,12 +28,6 @@ export const NO_SOURCES_MESSAGE = i18n.translate(
     defaultMessage: 'No organizational content sources',
   }
 );
-export const NO_USERS_MESSAGE = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.groups.noUsersMessage',
-  {
-    defaultMessage: 'No users',
-  }
-);
 
 const dateDisplay = (date: string) =>
   moment(date).isAfter(moment().subtract(DAYS_CUTOFF, 'days'))

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
@@ -38,7 +38,6 @@ export const Groups: React.FC = () => {
       page: { total_results: numGroups },
     },
     filteredSources,
-    filteredUsers,
     filterValue,
   } = useValues(GroupsLogic);
 
@@ -47,7 +46,7 @@ export const Groups: React.FC = () => {
   useEffect(() => {
     getSearchResults(true);
     return resetGroups;
-  }, [filteredSources, filteredUsers, filterValue]);
+  }, [filteredSources, filterValue]);
 
   if (newGroup && hasMessages) {
     messages[0].description = (

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.test.ts
@@ -12,7 +12,6 @@ import {
 } from '../../../__mocks__/kea_logic';
 import { contentSources } from '../../__mocks__/content_sources.mock';
 import { groups } from '../../__mocks__/groups.mock';
-import { users } from '../../__mocks__/users.mock';
 import { mockGroupsValues } from './__mocks__/groups_logic.mock';
 
 import { nextTick } from '@kbn/test-jest-helpers';
@@ -49,13 +48,12 @@ describe('GroupsLogic', () => {
   describe('actions', () => {
     describe('onInitializeGroups', () => {
       it('sets reducers', () => {
-        GroupsLogic.actions.onInitializeGroups({ contentSources, users });
+        GroupsLogic.actions.onInitializeGroups({ contentSources });
 
         expect(GroupsLogic.values).toEqual({
           ...mockGroupsValues,
           groupsDataLoading: false,
           contentSources,
-          users,
         });
       });
     });
@@ -103,59 +101,6 @@ describe('GroupsLogic', () => {
       });
     });
 
-    describe('addFilteredUser', () => {
-      it('sets reducers', () => {
-        GroupsLogic.actions.addFilteredUser('foo');
-        GroupsLogic.actions.addFilteredUser('bar');
-        GroupsLogic.actions.addFilteredUser('baz');
-
-        expect(GroupsLogic.values).toEqual({
-          ...mockGroupsValues,
-          hasFiltersSet: true,
-          filteredUsers: ['bar', 'baz', 'foo'],
-        });
-      });
-    });
-
-    describe('removeFilteredUser', () => {
-      it('sets reducers', () => {
-        GroupsLogic.actions.addFilteredUser('foo');
-        GroupsLogic.actions.addFilteredUser('bar');
-        GroupsLogic.actions.addFilteredUser('baz');
-        GroupsLogic.actions.removeFilteredUser('foo');
-
-        expect(GroupsLogic.values).toEqual({
-          ...mockGroupsValues,
-          hasFiltersSet: true,
-          filteredUsers: ['bar', 'baz'],
-        });
-      });
-    });
-
-    describe('setGroupUsers', () => {
-      it('sets reducers', () => {
-        GroupsLogic.actions.setGroupUsers(users);
-
-        expect(GroupsLogic.values).toEqual({
-          ...mockGroupsValues,
-          allGroupUsersLoading: false,
-          allGroupUsers: users,
-        });
-      });
-    });
-
-    describe('setAllGroupLoading', () => {
-      it('sets reducer', () => {
-        GroupsLogic.actions.setAllGroupLoading(true);
-
-        expect(GroupsLogic.values).toEqual({
-          ...mockGroupsValues,
-          allGroupUsersLoading: true,
-          allGroupUsers: [],
-        });
-      });
-    });
-
     describe('setFilterValue', () => {
       it('sets reducer', () => {
         GroupsLogic.actions.setFilterValue('foo');
@@ -190,7 +135,6 @@ describe('GroupsLogic', () => {
           newGroup: groups[0],
           newGroupNameErrors: [],
           filteredSources: [],
-          filteredUsers: [],
           groupsMeta: DEFAULT_META,
         });
       });
@@ -230,19 +174,6 @@ describe('GroupsLogic', () => {
         expect(GroupsLogic.values).toEqual({
           ...mockGroupsValues,
           filterSourcesDropdownOpen: false,
-        });
-      });
-    });
-
-    describe('closeFilterUsersDropdown', () => {
-      it('sets reducer', () => {
-        // Open dropdown first
-        GroupsLogic.actions.toggleFilterUsersDropdown();
-        GroupsLogic.actions.closeFilterUsersDropdown();
-
-        expect(GroupsLogic.values).toEqual({
-          ...mockGroupsValues,
-          filterUsersDropdownOpen: false,
         });
       });
     });
@@ -294,7 +225,6 @@ describe('GroupsLogic', () => {
       const search = {
         query: '',
         content_source_ids: [],
-        user_ids: [],
       };
 
       const payload = {
@@ -349,22 +279,6 @@ describe('GroupsLogic', () => {
         await nextTick();
 
         expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-      });
-    });
-
-    describe('fetchGroupUsers', () => {
-      it('calls API and sets values', async () => {
-        const setGroupUsersSpy = jest.spyOn(GroupsLogic.actions, 'setGroupUsers');
-        http.get.mockReturnValue(Promise.resolve(users));
-
-        GroupsLogic.actions.fetchGroupUsers('123');
-        expect(http.get).toHaveBeenCalledWith('/internal/workplace_search/groups/123/group_users');
-        await nextTick();
-        expect(setGroupUsersSpy).toHaveBeenCalledWith(users);
-      });
-
-      itShowsServerErrorAsFlashMessage(http.get, () => {
-        GroupsLogic.actions.fetchGroupUsers('123');
       });
     });
 
@@ -430,7 +344,6 @@ describe('GroupsLogic', () => {
         expect(GroupsLogic.values).toEqual({
           ...mockGroupsValues,
           filteredSources: [],
-          filteredUsers: [],
           filterValue: '',
           groupsMeta: DEFAULT_META,
         });
@@ -445,18 +358,6 @@ describe('GroupsLogic', () => {
         expect(GroupsLogic.values).toEqual({
           ...mockGroupsValues,
           filterSourcesDropdownOpen: true,
-        });
-        expect(clearFlashMessages).toHaveBeenCalled();
-      });
-    });
-
-    describe('toggleFilterUsersDropdown', () => {
-      it('sets reducer and clears flash messages', () => {
-        GroupsLogic.actions.toggleFilterUsersDropdown();
-
-        expect(GroupsLogic.values).toEqual({
-          ...mockGroupsValues,
-          filterUsersDropdownOpen: true,
         });
         expect(clearFlashMessages).toHaveBeenCalled();
       });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.ts
@@ -18,13 +18,12 @@ import {
   flashSuccessToast,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
-import { ContentSource, Group, User } from '../../types';
+import { ContentSource, Group } from '../../types';
 
 export const MAX_NAME_LENGTH = 40;
 
 interface GroupsServerData {
   contentSources: ContentSource[];
-  users: User[];
 }
 
 interface GroupsSearchResponse {
@@ -37,10 +36,6 @@ interface GroupsActions {
   setSearchResults(data: GroupsSearchResponse): GroupsSearchResponse;
   addFilteredSource(sourceId: string): string;
   removeFilteredSource(sourceId: string): string;
-  addFilteredUser(userId: string): string;
-  removeFilteredUser(userId: string): string;
-  setGroupUsers(allGroupUsers: User[]): User[];
-  setAllGroupLoading(allGroupUsersLoading: boolean): boolean;
   setFilterValue(filterValue: string): string;
   setActivePage(activePage: number): number;
   setNewGroupName(newGroupName: string): string;
@@ -49,22 +44,18 @@ interface GroupsActions {
   openNewGroupModal(): void;
   closeNewGroupModal(): void;
   closeFilterSourcesDropdown(): void;
-  closeFilterUsersDropdown(): void;
   toggleFilterSourcesDropdown(): void;
-  toggleFilterUsersDropdown(): void;
   setGroupsLoading(): void;
   resetGroupsFilters(): void;
   resetGroups(): void;
   initializeGroups(): void;
   getSearchResults(resetPagination?: boolean): { resetPagination: boolean | undefined };
-  fetchGroupUsers(groupId: string): { groupId: string };
   saveNewGroup(): void;
 }
 
 interface GroupsValues {
   groups: Group[];
   contentSources: ContentSource[];
-  users: User[];
   groupsDataLoading: boolean;
   groupListLoading: boolean;
   newGroupModalOpen: boolean;
@@ -73,10 +64,6 @@ interface GroupsValues {
   newGroupNameErrors: string[];
   filterSourcesDropdownOpen: boolean;
   filteredSources: string[];
-  filterUsersDropdownOpen: boolean;
-  filteredUsers: string[];
-  allGroupUsersLoading: boolean;
-  allGroupUsers: User[];
   filterValue: string;
   groupsMeta: Meta;
   hasFiltersSet: boolean;
@@ -89,10 +76,6 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
     setSearchResults: (data) => data,
     addFilteredSource: (sourceId) => sourceId,
     removeFilteredSource: (sourceId) => sourceId,
-    addFilteredUser: (userId) => userId,
-    removeFilteredUser: (userId) => userId,
-    setGroupUsers: (allGroupUsers) => allGroupUsers,
-    setAllGroupLoading: (allGroupUsersLoading: boolean) => allGroupUsersLoading,
     setFilterValue: (filterValue) => filterValue,
     setActivePage: (activePage) => activePage,
     setNewGroupName: (newGroupName) => newGroupName,
@@ -101,15 +84,12 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
     openNewGroupModal: () => true,
     closeNewGroupModal: () => true,
     closeFilterSourcesDropdown: () => true,
-    closeFilterUsersDropdown: () => true,
     toggleFilterSourcesDropdown: () => true,
-    toggleFilterUsersDropdown: () => true,
     setGroupsLoading: () => true,
     resetGroupsFilters: () => true,
     resetGroups: () => true,
     initializeGroups: () => true,
     getSearchResults: (resetPagination) => ({ resetPagination }),
-    fetchGroupUsers: (groupId) => ({ groupId }),
     saveNewGroup: () => true,
   },
   reducers: {
@@ -123,12 +103,6 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
       [],
       {
         onInitializeGroups: (_, { contentSources }) => contentSources,
-      },
-    ],
-    users: [
-      [],
-      {
-        onInitializeGroups: (_, { users }) => users,
       },
     ],
     groupsDataLoading: [
@@ -193,36 +167,6 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
         removeFilteredSource: (state, sourceId) => state.filter((id) => id !== sourceId),
       },
     ],
-    filterUsersDropdownOpen: [
-      false,
-      {
-        toggleFilterUsersDropdown: (state) => !state,
-        closeFilterUsersDropdown: () => false,
-      },
-    ],
-    filteredUsers: [
-      [],
-      {
-        resetGroupsFilters: () => [],
-        setNewGroup: () => [],
-        addFilteredUser: (state, userId) => [...state, userId].sort(),
-        removeFilteredUser: (state, userId) => state.filter((id) => id !== userId),
-      },
-    ],
-    allGroupUsersLoading: [
-      false,
-      {
-        setAllGroupLoading: (_, allGroupUsersLoading) => allGroupUsersLoading,
-        setGroupUsers: () => false,
-      },
-    ],
-    allGroupUsers: [
-      [],
-      {
-        setGroupUsers: (_, allGroupUsers) => allGroupUsers,
-        setAllGroupLoading: () => [],
-      },
-    ],
     filterValue: [
       '',
       {
@@ -248,8 +192,8 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
   },
   selectors: ({ selectors }) => ({
     hasFiltersSet: [
-      () => [selectors.filteredUsers, selectors.filteredSources],
-      (filteredUsers, filteredSources) => filteredUsers.length > 0 || filteredSources.length > 0,
+      () => [selectors.filteredSources],
+      (filteredSources) => filteredSources.length > 0,
     ],
   }),
   listeners: ({ actions, values }) => ({
@@ -275,7 +219,6 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
         },
         filterValue,
         filteredSources,
-        filteredUsers,
       } = values;
 
       // Is the user changes the query while on a different page, we want to start back over at 1.
@@ -286,7 +229,6 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
       const search = {
         query: filterValue,
         content_source_ids: filteredSources,
-        user_ids: filteredUsers,
       };
 
       try {
@@ -302,17 +244,6 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
         );
 
         actions.setSearchResults(response);
-      } catch (e) {
-        flashAPIErrors(e);
-      }
-    },
-    fetchGroupUsers: async ({ groupId }) => {
-      actions.setAllGroupLoading(true);
-      try {
-        const response = await HttpLogic.values.http.get<User[]>(
-          `/internal/workplace_search/groups/${groupId}/group_users`
-        );
-        actions.setGroupUsers(response);
       } catch (e) {
         flashAPIErrors(e);
       }
@@ -352,9 +283,6 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
       clearFlashMessages();
     },
     toggleFilterSourcesDropdown: () => {
-      clearFlashMessages();
-    },
-    toggleFilterUsersDropdown: () => {
       clearFlashMessages();
     },
   }),

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
@@ -107,7 +107,6 @@ describe('groups routes', () => {
             search: {
               query: 'foo',
               content_source_ids: ['123', '234'],
-              user_ids: ['345', '456'],
             },
           },
         };

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.ts
@@ -51,7 +51,6 @@ export function registerSearchGroupsRoute({
           search: schema.object({
             query: schema.string(),
             content_source_ids: schema.arrayOf(schema.string()),
-            user_ids: schema.arrayOf(schema.string()),
           }),
         }),
       },

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -11925,7 +11925,6 @@
     "xpack.enterpriseSearch.workplaceSearch.groups.newGroup.action": "Gérer le groupe",
     "xpack.enterpriseSearch.workplaceSearch.groups.newGroupSavedSuccess": "{groupName} créé avec succès",
     "xpack.enterpriseSearch.workplaceSearch.groups.noSourcesMessage": "Aucune source de contenu organisationnelle",
-    "xpack.enterpriseSearch.workplaceSearch.groups.noUsersMessage": "Aucun utilisateur",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmRemoveButtonText": "Supprimer {name}",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmRemoveDescription": "Votre groupe sera supprimé de Workplace Search. Voulez-vous vraiment supprimer {name} ?",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmTitleText": "Confirmer",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -11926,7 +11926,6 @@
     "xpack.enterpriseSearch.workplaceSearch.groups.newGroup.action": "グループを管理",
     "xpack.enterpriseSearch.workplaceSearch.groups.newGroupSavedSuccess": "{groupName}が正常に作成されました",
     "xpack.enterpriseSearch.workplaceSearch.groups.noSourcesMessage": "組織コンテンツソースがありません",
-    "xpack.enterpriseSearch.workplaceSearch.groups.noUsersMessage": "ユーザーがありません",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmRemoveButtonText": "{name}を削除",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmRemoveDescription": "グループはWorkplace Searchから削除されます。{name}を削除してよろしいですか？",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmTitleText": "確認",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -11948,7 +11948,6 @@
     "xpack.enterpriseSearch.workplaceSearch.groups.newGroup.action": "管理组",
     "xpack.enterpriseSearch.workplaceSearch.groups.newGroupSavedSuccess": "已成功创建 {groupName}",
     "xpack.enterpriseSearch.workplaceSearch.groups.noSourcesMessage": "无组织内容源",
-    "xpack.enterpriseSearch.workplaceSearch.groups.noUsersMessage": "无用户",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmRemoveButtonText": "删除 {name}",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmRemoveDescription": "您的组将从 Workplace Search 中删除。确定要移除 {name}？",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmTitleText": "确认",


### PR DESCRIPTION
## Summary

following up on https://github.com/elastic/kibana/pull/104734

removes unused logic for filtering groups by users

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
