### PR TITLE
[Cloud Posture] add resource findings page

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
@@ -28,4 +28,5 @@ export const allNavigationItems: Record<CspPage, CspNavigationItem> = {
 export const findingsNavigation = {
   findings_default: { name: TEXT.FINDINGS, path: '/findings/default' },
   findings_by_resource: { name: TEXT.FINDINGS, path: '/findings/resource' },
+  resource_findings: { name: TEXT.FINDINGS, path: '/findings/resource/:resourceId' },
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
@@ -8,6 +8,7 @@ import React, { useMemo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import type { DataView } from '@kbn/data-plugin/common';
 import { SortDirection } from '@kbn/data-plugin/common';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { FindingsTable } from './latest_findings_table';
 import { FindingsSearchBar } from '../layout/findings_search_bar';
 import * as TEST_SUBJECTS from '../test_subjects';
@@ -22,7 +23,6 @@ import { PageWrapper, PageTitle, PageTitleText } from '../layout/findings_layout
 import { FindingsGroupBySelector } from '../layout/findings_group_by_selector';
 import { useCspBreadcrumbs } from '../../../common/navigation/use_csp_breadcrumbs';
 import { findingsNavigation } from '../../../common/navigation/constants';
-import { FormattedMessage } from '@kbn/i18n-react';
 
 export const getDefaultQuery = (): FindingsBaseURLQuery & FindingsGroupByNoneQuery => ({
   query: { language: 'kuery', query: '' },

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
@@ -18,10 +18,11 @@ import type { FindingsBaseURLQuery } from '../types';
 import { useFindingsCounter } from '../use_findings_count';
 import { FindingsDistributionBar } from '../layout/findings_distribution_bar';
 import { getBaseQuery } from '../utils';
-import { PageWrapper } from '../layout/findings_layout';
+import { PageWrapper, PageTitle, PageTitleText } from '../layout/findings_layout';
 import { FindingsGroupBySelector } from '../layout/findings_group_by_selector';
 import { useCspBreadcrumbs } from '../../../common/navigation/use_csp_breadcrumbs';
 import { findingsNavigation } from '../../../common/navigation/constants';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 export const getDefaultQuery = (): FindingsBaseURLQuery & FindingsGroupByNoneQuery => ({
   query: { language: 'kuery', query: '' },
@@ -57,6 +58,13 @@ export const LatestFindingsContainer = ({ dataView }: { dataView: DataView }) =>
         loading={findingsGroupByNone.isLoading}
       />
       <PageWrapper>
+        <PageTitle>
+          <PageTitleText
+            title={
+              <FormattedMessage id="xpack.csp.findings.findingsTitle" defaultMessage="Findings" />
+            }
+          />
+        </PageTitle>
         <FindingsGroupBySelector type="default" />
         <FindingsDistributionBar
           total={findingsGroupByNone.data?.total || 0}

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
@@ -6,6 +6,8 @@
  */
 import React from 'react';
 import type { DataView } from '@kbn/data-plugin/common';
+import { Route, Switch } from 'react-router-dom';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { FindingsSearchBar } from '../layout/findings_search_bar';
 import * as TEST_SUBJECTS from '../test_subjects';
 import { useUrlQuery } from '../../../common/hooks/use_url_query';
@@ -13,17 +15,32 @@ import type { FindingsBaseURLQuery } from '../types';
 import { useFindingsByResource } from './use_findings_by_resource';
 import { FindingsByResourceTable } from './findings_by_resource_table';
 import { getBaseQuery } from '../utils';
-import { PageWrapper } from '../layout/findings_layout';
+import { PageTitle, PageTitleText, PageWrapper } from '../layout/findings_layout';
 import { FindingsGroupBySelector } from '../layout/findings_group_by_selector';
 import { findingsNavigation } from '../../../common/navigation/constants';
 import { useCspBreadcrumbs } from '../../../common/navigation/use_csp_breadcrumbs';
+import { ResourceFindings } from './resource_findings/resource_findings_container';
 
 export const getDefaultQuery = (): FindingsBaseURLQuery => ({
   query: { language: 'kuery', query: '' },
   filters: [],
 });
 
-export const FindingsByResourceContainer = ({ dataView }: { dataView: DataView }) => {
+export const FindingsByResourceContainer = ({ dataView }: { dataView: DataView }) => (
+  <Switch>
+    <Route
+      exact
+      path={findingsNavigation.findings_by_resource.path}
+      render={() => <LatestFindingsByResourceContainer dataView={dataView} />}
+    />
+    <Route
+      path={findingsNavigation.resource_findings.path}
+      render={() => <ResourceFindings dataView={dataView} />}
+    />
+  </Switch>
+);
+
+export const FindingsByResourceContainer1 = ({ dataView }: { dataView: DataView }) => {
   useCspBreadcrumbs([findingsNavigation.findings_by_resource]);
   const { urlQuery, setUrlQuery } = useUrlQuery(getDefaultQuery);
   const findingsGroupByResource = useFindingsByResource(
@@ -40,6 +57,52 @@ export const FindingsByResourceContainer = ({ dataView }: { dataView: DataView }
         loading={findingsGroupByResource.isLoading}
       />
       <PageWrapper>
+        <PageTitle>
+          <PageTitleText
+            title={
+              <FormattedMessage
+                id="xpack.csp.findings.findingsByResourceTitle"
+                defaultMessage="Findings"
+              />
+            }
+          />
+        </PageTitle>
+        <FindingsGroupBySelector type="resource" />
+        <FindingsByResourceTable
+          data={findingsGroupByResource.data}
+          error={findingsGroupByResource.error}
+          loading={findingsGroupByResource.isLoading}
+        />
+      </PageWrapper>
+    </div>
+  );
+};
+
+const LatestFindingsByResourceContainer = ({ dataView }: { dataView: DataView }) => {
+  useCspBreadcrumbs([findingsNavigation.findings_by_resource]);
+  const { urlQuery, setUrlQuery } = useUrlQuery(getDefaultQuery);
+  const findingsGroupByResource = useFindingsByResource(
+    getBaseQuery({ dataView, filters: urlQuery.filters, query: urlQuery.query })
+  );
+
+  return (
+    <div data-test-subj={TEST_SUBJECTS.FINDINGS_CONTAINER}>
+      <FindingsSearchBar
+        dataView={dataView}
+        setQuery={setUrlQuery}
+        query={urlQuery.query}
+        filters={urlQuery.filters}
+        loading={findingsGroupByResource.isLoading}
+      />
+      <PageWrapper>
+        <PageTitle
+          title={
+            <FormattedMessage
+              id="xpack.csp.findings.findingsByResourceTitle"
+              defaultMessage="Findings"
+            />
+          }
+        />
         <FindingsGroupBySelector type="resource" />
         <FindingsByResourceTable
           data={findingsGroupByResource.data}

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
@@ -95,14 +95,16 @@ const LatestFindingsByResourceContainer = ({ dataView }: { dataView: DataView })
         loading={findingsGroupByResource.isLoading}
       />
       <PageWrapper>
-        <PageTitle
-          title={
-            <FormattedMessage
-              id="xpack.csp.findings.findingsByResourceTitle"
-              defaultMessage="Findings"
-            />
-          }
-        />
+        <PageTitle>
+          <PageTitleText
+            title={
+              <FormattedMessage
+                id="xpack.csp.findings.findingsByResourceTitle"
+                defaultMessage="Findings"
+              />
+            }
+          />
+        </PageTitle>
         <FindingsGroupBySelector type="resource" />
         <FindingsByResourceTable
           data={findingsGroupByResource.data}

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
@@ -40,44 +40,6 @@ export const FindingsByResourceContainer = ({ dataView }: { dataView: DataView }
   </Switch>
 );
 
-export const FindingsByResourceContainer1 = ({ dataView }: { dataView: DataView }) => {
-  useCspBreadcrumbs([findingsNavigation.findings_by_resource]);
-  const { urlQuery, setUrlQuery } = useUrlQuery(getDefaultQuery);
-  const findingsGroupByResource = useFindingsByResource(
-    getBaseQuery({ dataView, filters: urlQuery.filters, query: urlQuery.query })
-  );
-
-  return (
-    <div data-test-subj={TEST_SUBJECTS.FINDINGS_CONTAINER}>
-      <FindingsSearchBar
-        dataView={dataView}
-        setQuery={setUrlQuery}
-        query={urlQuery.query}
-        filters={urlQuery.filters}
-        loading={findingsGroupByResource.isLoading}
-      />
-      <PageWrapper>
-        <PageTitle>
-          <PageTitleText
-            title={
-              <FormattedMessage
-                id="xpack.csp.findings.findingsByResourceTitle"
-                defaultMessage="Findings"
-              />
-            }
-          />
-        </PageTitle>
-        <FindingsGroupBySelector type="resource" />
-        <FindingsByResourceTable
-          data={findingsGroupByResource.data}
-          error={findingsGroupByResource.error}
-          loading={findingsGroupByResource.isLoading}
-        />
-      </PageWrapper>
-    </div>
-  );
-};
-
 const LatestFindingsByResourceContainer = ({ dataView }: { dataView: DataView }) => {
   useCspBreadcrumbs([findingsNavigation.findings_by_resource]);
   const { urlQuery, setUrlQuery } = useUrlQuery(getDefaultQuery);

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
@@ -62,7 +62,10 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
         defaultMessage="Resource ID"
       />
     ),
-    render: (resourceId: CspFindingsByResource['resource_id']) => <EuiLink>{resourceId}</EuiLink>,
+    render: (resourceId: CspFindingsByResource['resource_id']) => (
+      // TODO: get link
+      <EuiLink href={`/lfe/app/csp/findings/resource/${resourceId}`}>{resourceId}</EuiLink>
+    ),
   },
   {
     field: 'cis_section',

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
@@ -12,14 +12,15 @@ import {
   EuiTextColor,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiLink,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import numeral from '@elastic/numeral';
+import { Link, generatePath } from 'react-router-dom';
 import { extractErrorMessage } from '../../../../common/utils/helpers';
 import * as TEST_SUBJECTS from '../test_subjects';
 import * as TEXT from '../translations';
 import type { CspFindingsByResourceResult } from './use_findings_by_resource';
+import { findingsNavigation } from '../../../common/navigation/constants';
 
 export const formatNumber = (value: number) =>
   value < 1000 ? value : numeral(value).format('0.0a');
@@ -63,8 +64,9 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
       />
     ),
     render: (resourceId: CspFindingsByResource['resource_id']) => (
-      // TODO: get link
-      <EuiLink href={`/lfe/app/csp/findings/resource/${resourceId}`}>{resourceId}</EuiLink>
+      <Link to={generatePath(findingsNavigation.resource_findings.path, { resourceId })}>
+        {resourceId}
+      </Link>
     ),
   },
   {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -7,32 +7,26 @@
 import React from 'react';
 import { EuiSpacer, EuiButtonEmpty } from '@elastic/eui';
 import type { DataView } from '@kbn/data-plugin/common';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useEuiTheme } from '@elastic/eui';
+import { generatePath } from 'react-router-dom';
 import * as TEST_SUBJECTS from '../../test_subjects';
 import { PageWrapper, PageTitle, PageTitleText } from '../../layout/findings_layout';
 import { useCspBreadcrumbs } from '../../../../common/navigation/use_csp_breadcrumbs';
 import { findingsNavigation } from '../../../../common/navigation/constants';
-import { useKibana } from '../../../../common/hooks/use_kibana';
-import { PLUGIN_ID } from '../../../../../common';
 
 const BackToResourcesButton = () => {
-  const { application } = useKibana().services;
-
   return (
-    <EuiButtonEmpty
-      iconType={'arrowLeft'}
-      href={application.getUrlForApp(PLUGIN_ID, {
-        path: findingsNavigation.findings_by_resource.path,
-      })}
-    >
-      <FormattedMessage
-        id="xpack.csp.findings.resourceFindings.backToResourcesPageButtonLabel"
-        defaultMessage=" Back to group by resource view"
-      />
-      Back to group by resource view
-    </EuiButtonEmpty>
+    <Link to={generatePath(findingsNavigation.findings_by_resource.path)}>
+      <EuiButtonEmpty iconType={'arrowLeft'}>
+        <FormattedMessage
+          id="xpack.csp.findings.resourceFindings.backToResourcesPageButtonLabel"
+          defaultMessage=" Back to group by resource view"
+        />
+        Back to group by resource view
+      </EuiButtonEmpty>
+    </Link>
   );
 };
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiSpacer, EuiButtonEmpty } from '@elastic/eui';
+import type { DataView } from '@kbn/data-plugin/common';
+import { useParams } from 'react-router-dom';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useEuiTheme } from '@elastic/eui';
+import * as TEST_SUBJECTS from '../../test_subjects';
+import { PageWrapper, PageTitle, PageTitleText } from '../../layout/findings_layout';
+import { useCspBreadcrumbs } from '../../../../common/navigation/use_csp_breadcrumbs';
+import { findingsNavigation } from '../../../../common/navigation/constants';
+import { useKibana } from '../../../../common/hooks/use_kibana';
+import { PLUGIN_ID } from '../../../../../common';
+
+const BackToResourcesButton = () => {
+  const { application } = useKibana().services;
+
+  return (
+    <EuiButtonEmpty
+      iconType={'arrowLeft'}
+      href={application.getUrlForApp(PLUGIN_ID, {
+        path: findingsNavigation.findings_by_resource.path,
+      })}
+    >
+      <FormattedMessage
+        id="xpack.csp.findings.resourceFindings.backToResourcesPageButtonLabel"
+        defaultMessage=" Back to group by resource view"
+      />
+      Back to group by resource view
+    </EuiButtonEmpty>
+  );
+};
+
+export const ResourceFindings = ({ dataView }: { dataView: DataView }) => {
+  useCspBreadcrumbs([findingsNavigation.findings_default]);
+  const { euiTheme } = useEuiTheme();
+  const params = useParams<{ resourceId: string }>();
+
+  return (
+    <div data-test-subj={TEST_SUBJECTS.FINDINGS_CONTAINER}>
+      <PageWrapper>
+        <PageTitle>
+          <BackToResourcesButton />
+          <PageTitleText
+            title={
+              <div style={{ padding: euiTheme.size.s }}>
+                <FormattedMessage
+                  id="xpack.csp.findings.resourceFindingsTitle"
+                  defaultMessage="{resourceId} - Findings"
+                  values={{ resourceId: params.resourceId }}
+                />
+              </div>
+            }
+          />
+        </PageTitle>
+        <EuiSpacer />
+      </PageWrapper>
+    </div>
+  );
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -22,9 +22,8 @@ const BackToResourcesButton = () => {
       <EuiButtonEmpty iconType={'arrowLeft'}>
         <FormattedMessage
           id="xpack.csp.findings.resourceFindings.backToResourcesPageButtonLabel"
-          defaultMessage=" Back to group by resource view"
+          defaultMessage="Back to group by resource view"
         />
-        Back to group by resource view
       </EuiButtonEmpty>
     </Link>
   );

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
@@ -7,16 +7,8 @@
 import React from 'react';
 import { EuiSpacer, EuiTitle, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { FormattedMessage } from '@kbn/i18n-react';
 
-interface Props {
-  title?: string;
-}
-
-export const PageWrapper: React.FC<Props> = ({
-  children,
-  title = <FormattedMessage id="xpack.csp.findings.findingsTitle" defaultMessage="Findings" />,
-}) => {
+export const PageWrapper: React.FC = ({ children }) => {
   const { euiTheme } = useEuiTheme();
   return (
     <div
@@ -24,11 +16,18 @@ export const PageWrapper: React.FC<Props> = ({
         padding: ${euiTheme.size.l};
       `}
     >
-      <EuiTitle size="l">
-        <h2>{title}</h2>
-      </EuiTitle>
-      <EuiSpacer />
       {children}
     </div>
   );
 };
+
+export const PageTitle: React.FC = ({ children }) => (
+  <EuiTitle size="l">
+    <div>
+      {children}
+      <EuiSpacer />
+    </div>
+  </EuiTitle>
+);
+
+export const PageTitleText = ({ title }: { title: React.ReactNode }) => <h2>{title}</h2>;


### PR DESCRIPTION
## Summary

this PR adds a new URL route to `/findings/resource/:resourceId` and its matching placeholder component.

we then use the `resourceId` param to: 
- show it in the page title 
- later on use to query elastic when populating the table

## Demo 


https://user-images.githubusercontent.com/20814186/166242139-fee1f47a-2735-4a15-bb15-1cb9eac3b64f.mov


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

