### PR TITLE
[Cloud Posture] add resource findings table

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.tsx
@@ -7,7 +7,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   type Criteria,
-  type EuiTableFieldDataColumnType,
   EuiEmptyPrompt,
   EuiBasicTable,
   EuiBasicTableProps,

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
@@ -21,7 +21,7 @@ import { findingsNavigation } from '../../../common/navigation/constants';
 import { useCspBreadcrumbs } from '../../../common/navigation/use_csp_breadcrumbs';
 import { ResourceFindings } from './resource_findings/resource_findings_container';
 
-export const getDefaultQuery = (): FindingsBaseURLQuery => ({
+const getDefaultQuery = (): FindingsBaseURLQuery => ({
   query: { language: 'kuery', query: '' },
   filters: [],
 });
@@ -31,7 +31,7 @@ export const FindingsByResourceContainer = ({ dataView }: { dataView: DataView }
     <Route
       exact
       path={findingsNavigation.findings_by_resource.path}
-      render={() => <LatestFindingsByResourceContainer dataView={dataView} />}
+      render={() => <LatestFindingsByResource dataView={dataView} />}
     />
     <Route
       path={findingsNavigation.resource_findings.path}
@@ -40,7 +40,7 @@ export const FindingsByResourceContainer = ({ dataView }: { dataView: DataView }
   </Switch>
 );
 
-const LatestFindingsByResourceContainer = ({ dataView }: { dataView: DataView }) => {
+const LatestFindingsByResource = ({ dataView }: { dataView: DataView }) => {
   useCspBreadcrumbs([findingsNavigation.findings_by_resource]);
   const { urlQuery, setUrlQuery } = useUrlQuery(getDefaultQuery);
   const findingsGroupByResource = useFindingsByResource(

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -15,6 +15,17 @@ import * as TEST_SUBJECTS from '../../test_subjects';
 import { PageWrapper, PageTitle, PageTitleText } from '../../layout/findings_layout';
 import { useCspBreadcrumbs } from '../../../../common/navigation/use_csp_breadcrumbs';
 import { findingsNavigation } from '../../../../common/navigation/constants';
+import { useResourceFindings } from './use_resource_findings';
+import { useUrlQuery } from '../../../../common/hooks/use_url_query';
+import { FindingsBaseURLQuery } from '../../types';
+import { getBaseQuery } from '../../utils';
+import { ResourceFindingsTable } from './resource_findings_table';
+import { FindingsSearchBar } from '../../layout/findings_search_bar';
+
+export const getDefaultQuery = (): FindingsBaseURLQuery => ({
+  query: { language: 'kuery', query: '' },
+  filters: [],
+});
 
 const BackToResourcesButton = () => {
   return (
@@ -33,9 +44,22 @@ export const ResourceFindings = ({ dataView }: { dataView: DataView }) => {
   useCspBreadcrumbs([findingsNavigation.findings_default]);
   const { euiTheme } = useEuiTheme();
   const params = useParams<{ resourceId: string }>();
+  const { urlQuery, setUrlQuery } = useUrlQuery(getDefaultQuery);
+
+  const resourceFindings = useResourceFindings({
+    ...getBaseQuery({ dataView, filters: urlQuery.filters, query: urlQuery.query }),
+    resourceId: params.resourceId,
+  });
 
   return (
     <div data-test-subj={TEST_SUBJECTS.FINDINGS_CONTAINER}>
+      <FindingsSearchBar
+        dataView={dataView}
+        setQuery={setUrlQuery}
+        query={urlQuery.query}
+        filters={urlQuery.filters}
+        loading={resourceFindings.isLoading}
+      />
       <PageWrapper>
         <PageTitle>
           <BackToResourcesButton />
@@ -52,6 +76,11 @@ export const ResourceFindings = ({ dataView }: { dataView: DataView }) => {
           />
         </PageTitle>
         <EuiSpacer />
+        <ResourceFindingsTable
+          loading={resourceFindings.isLoading}
+          data={resourceFindings.data}
+          error={resourceFindings.error}
+        />
       </PageWrapper>
     </div>
   );

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -17,12 +17,12 @@ import { useCspBreadcrumbs } from '../../../../common/navigation/use_csp_breadcr
 import { findingsNavigation } from '../../../../common/navigation/constants';
 import { useResourceFindings } from './use_resource_findings';
 import { useUrlQuery } from '../../../../common/hooks/use_url_query';
-import { FindingsBaseURLQuery } from '../../types';
+import type { FindingsBaseURLQuery } from '../../types';
 import { getBaseQuery } from '../../utils';
 import { ResourceFindingsTable } from './resource_findings_table';
 import { FindingsSearchBar } from '../../layout/findings_search_bar';
 
-export const getDefaultQuery = (): FindingsBaseURLQuery => ({
+const getDefaultQuery = (): FindingsBaseURLQuery => ({
   query: { language: 'kuery', query: '' },
   filters: [],
 });

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_table.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiEmptyPrompt, EuiBasicTable } from '@elastic/eui';
+import numeral from '@elastic/numeral';
+import { extractErrorMessage } from '../../../../../common/utils/helpers';
+import * as TEST_SUBJECTS from '../../test_subjects';
+import * as TEXT from '../../translations';
+import type { ResourceFindingsResult } from './use_resource_findings';
+import { getFindingsColumns } from '../../layout/findings_layout';
+
+export const formatNumber = (value: number) =>
+  value < 1000 ? value : numeral(value).format('0.0a');
+
+type FindingsGroupByResourceProps = ResourceFindingsResult;
+type CspFindingsByResource = NonNullable<ResourceFindingsResult['data']>[number];
+
+export const getResourceId = (resource: CspFindingsByResource) =>
+  [resource.resource_id, resource.cluster_id, resource.cis_section].join('/');
+
+const columns = getFindingsColumns();
+
+const ResourceFindingsTableComponent = ({ error, data, loading }: FindingsGroupByResourceProps) => {
+  const getRowProps = (row: CspFindingsByResource) => ({
+    'data-test-subj': TEST_SUBJECTS.getFindingsByResourceTableRowTestId(getResourceId(row)),
+  });
+
+  if (!loading && !data?.page.length)
+    return <EuiEmptyPrompt iconType="logoKibana" title={<h2>{TEXT.NO_FINDINGS}</h2>} />;
+
+  return (
+    <EuiBasicTable
+      loading={loading}
+      error={error ? extractErrorMessage(error) : undefined}
+      items={data?.page || []}
+      columns={columns}
+      rowProps={getRowProps}
+    />
+  );
+};
+
+export const ResourceFindingsTable = React.memo(ResourceFindingsTableComponent);

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_table.tsx
@@ -6,29 +6,16 @@
  */
 import React from 'react';
 import { EuiEmptyPrompt, EuiBasicTable } from '@elastic/eui';
-import numeral from '@elastic/numeral';
 import { extractErrorMessage } from '../../../../../common/utils/helpers';
-import * as TEST_SUBJECTS from '../../test_subjects';
 import * as TEXT from '../../translations';
 import type { ResourceFindingsResult } from './use_resource_findings';
 import { getFindingsColumns } from '../../layout/findings_layout';
 
-export const formatNumber = (value: number) =>
-  value < 1000 ? value : numeral(value).format('0.0a');
-
 type FindingsGroupByResourceProps = ResourceFindingsResult;
-type CspFindingsByResource = NonNullable<ResourceFindingsResult['data']>[number];
-
-export const getResourceId = (resource: CspFindingsByResource) =>
-  [resource.resource_id, resource.cluster_id, resource.cis_section].join('/');
 
 const columns = getFindingsColumns();
 
 const ResourceFindingsTableComponent = ({ error, data, loading }: FindingsGroupByResourceProps) => {
-  const getRowProps = (row: CspFindingsByResource) => ({
-    'data-test-subj': TEST_SUBJECTS.getFindingsByResourceTableRowTestId(getResourceId(row)),
-  });
-
   if (!loading && !data?.page.length)
     return <EuiEmptyPrompt iconType="logoKibana" title={<h2>{TEXT.NO_FINDINGS}</h2>} />;
 
@@ -38,7 +25,6 @@ const ResourceFindingsTableComponent = ({ error, data, loading }: FindingsGroupB
       error={error ? extractErrorMessage(error) : undefined}
       items={data?.page || []}
       columns={columns}
-      rowProps={getRowProps}
     />
   );
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/use_resource_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/use_resource_findings.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useQuery } from 'react-query';
+import { lastValueFrom } from 'rxjs';
+import {
+  IEsSearchResponse,
+  IKibanaSearchRequest,
+  IKibanaSearchResponse,
+} from '@kbn/data-plugin/common';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { useKibana } from '../../../../common/hooks/use_kibana';
+import { showErrorToast } from '../../latest_findings/use_latest_findings';
+import type { CspFinding, FindingsBaseEsQuery, FindingsQueryResult } from '../../types';
+
+interface Options extends FindingsBaseEsQuery {
+  resourceId: string;
+}
+
+export type ResourceFindingsResult = FindingsQueryResult<
+  ReturnType<typeof useResourceFindings>['data'] | undefined,
+  unknown
+>;
+
+export const getResourceFindingsQuery = ({
+  index,
+  query,
+  resourceId,
+}: Options): estypes.SearchRequest => {
+  const queryWithResourceIdFilter = {
+    ...query,
+    bool: {
+      ...query?.bool,
+      filter: [...(query?.bool?.filter || []), { term: { 'resource_id.keyword': resourceId } }],
+    },
+  };
+
+  return {
+    index,
+    body: {
+      query: queryWithResourceIdFilter,
+    },
+  };
+};
+
+export const useResourceFindings = ({ index, query, resourceId }: Options) => {
+  const {
+    data,
+    notifications: { toasts },
+  } = useKibana().services;
+
+  return useQuery(
+    ['csp_resource_findings', { index, query, resourceId }],
+    () =>
+      lastValueFrom<IEsSearchResponse<CspFinding>>(
+        data.search.search({
+          params: getResourceFindingsQuery({ index, query, resourceId }),
+        })
+      ),
+    {
+      select: ({ rawResponse }) => {
+        console.log({ rawResponse });
+        const hits = rawResponse.hits;
+        return {
+          page: hits.hits.map((hit) => hit._source!),
+          total: typeof hits.total === 'number' ? hits.total : 0,
+        };
+      },
+
+      onError: (err) => showErrorToast(toasts, err),
+    }
+  );
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
@@ -90,7 +90,7 @@ export const getFindingsColumns = (): Array<EuiBasicTableColumn<CspFinding>> => 
   },
   {
     field: 'cluster_id',
-    name: TEXT.SYSTEM_ID,
+    name: TEXT.CLUSTER_ID,
     truncateText: true,
     sortable: true,
   },

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
@@ -5,8 +5,20 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiSpacer, EuiTitle, useEuiTheme } from '@elastic/eui';
+import {
+  EuiBasicTableColumn,
+  EuiSpacer,
+  EuiTableActionsColumnType,
+  EuiTitle,
+  EuiToolTip,
+  PropsOf,
+  useEuiTheme,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
+import moment from 'moment';
+import { CspEvaluationBadge } from '../../../components/csp_evaluation_badge';
+import * as TEXT from '../translations';
+import { CspFinding } from '../types';
 
 export const PageWrapper: React.FC = ({ children }) => {
   const { euiTheme } = useEuiTheme();
@@ -31,3 +43,72 @@ export const PageTitle: React.FC = ({ children }) => (
 );
 
 export const PageTitleText = ({ title }: { title: React.ReactNode }) => <h2>{title}</h2>;
+
+export const getExpandColumn = <T extends unknown>({
+  onClick,
+}: {
+  onClick(item: T): void;
+}): EuiTableActionsColumnType<T> => ({
+  width: '40px',
+  actions: [
+    {
+      name: 'Expand',
+      description: 'Expand',
+      type: 'icon',
+      icon: 'expand',
+      onClick,
+    },
+  ],
+});
+
+export const getFindingsColumns = (): Array<EuiBasicTableColumn<CspFinding>> => [
+  {
+    field: 'resource_id',
+    name: TEXT.RESOURCE_ID,
+    truncateText: true,
+    width: '15%',
+    sortable: true,
+    render: (filename: string) => (
+      <EuiToolTip position="top" content={filename}>
+        <span>{filename}</span>
+      </EuiToolTip>
+    ),
+  },
+  {
+    field: 'result.evaluation',
+    name: TEXT.RESULT,
+    width: '100px',
+    sortable: true,
+    render: (type: PropsOf<typeof CspEvaluationBadge>['type']) => (
+      <CspEvaluationBadge type={type} />
+    ),
+  },
+  {
+    field: 'rule.name',
+    name: TEXT.RULE,
+    sortable: true,
+  },
+  {
+    field: 'cluster_id',
+    name: TEXT.SYSTEM_ID,
+    truncateText: true,
+    sortable: true,
+  },
+  {
+    field: 'rule.section',
+    name: TEXT.CIS_SECTION,
+    sortable: true,
+    truncateText: true,
+  },
+  {
+    field: '@timestamp',
+    name: TEXT.LAST_CHECKED,
+    truncateText: true,
+    sortable: true,
+    render: (timestamp: number) => (
+      <EuiToolTip position="top" content={timestamp}>
+        <span>{moment(timestamp).fromNow()}</span>
+      </EuiToolTip>
+    ),
+  },
+];

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
@@ -64,10 +64,10 @@ export const RESULT = i18n.translate(
   }
 );
 
-export const SYSTEM_ID = i18n.translate(
-  'xpack.csp.findings.findingsTable.findingsTableColumn.systemIdColumnLabel',
+export const CLUSTER_ID = i18n.translate(
+  'xpack.csp.findings.findingsTable.findingsTableColumn.clusterIdColumnLabel',
   {
-    defaultMessage: 'System ID',
+    defaultMessage: 'Cluster ID',
   }
 );
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/utils.ts
@@ -7,6 +7,7 @@
 
 import { buildEsQuery } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-plugin/common';
+import type { EuiBasicTableProps } from '@elastic/eui';
 import type { FindingsBaseEsQuery, FindingsBaseURLQuery } from './types';
 
 export const getBaseQuery = ({

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/utils.ts
@@ -7,7 +7,6 @@
 
 import { buildEsQuery } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-plugin/common';
-import type { EuiBasicTableProps } from '@elastic/eui';
 import type { FindingsBaseEsQuery, FindingsBaseURLQuery } from './types';
 
 export const getBaseQuery = ({


### PR DESCRIPTION
## Summary

this PR adds the table component for the `/findings/resource/:resourceId` route. 

it includes: 
 - table component with shared columns from `group_by_none` 
 - api hook to query `es` with hidden filter for `resource_id: resourceId` 


### Demo 


https://user-images.githubusercontent.com/20814186/166258195-07c5aec7-3231-4691-85f8-3a5b23cc608d.mov


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

