### PR TITLE
[Reporting] Fix reporting job completion toast to not disappear

### DIFF
--- a/x-pack/plugins/reporting/public/lib/__snapshots__/stream_handler.test.ts.snap
+++ b/x-pack/plugins/reporting/public/lib/__snapshots__/stream_handler.test.ts.snap
@@ -188,42 +188,40 @@ Array [
 `;
 
 exports[`stream handler showNotifications show success 1`] = `
-Array [
-  Object {
-    "color": "success",
-    "data-test-subj": "completeReportSuccess",
-    "text": MountPoint {
-      "reactNode": <React.Fragment>
-        <p>
-          <ReportLink
-            getUrl={[Function]}
-          />
-        </p>
-        <DownloadButton
+Object {
+  "color": "success",
+  "data-test-subj": "completeReportSuccess",
+  "text": MountPoint {
+    "reactNode": <React.Fragment>
+      <p>
+        <ReportLink
           getUrl={[Function]}
-          job={
-            Object {
-              "id": "yas1",
-              "jobtype": "yas",
-              "status": "completed",
-              "title": "Yas",
-            }
-          }
         />
-      </React.Fragment>,
-    },
-    "title": MountPoint {
-      "reactNode": <FormattedMessage
-        defaultMessage="{reportType} created for '{reportObjectTitle}'"
-        id="xpack.reporting.publicNotifier.successfullyCreatedReportNotificationTitle"
-        values={
+      </p>
+      <DownloadButton
+        getUrl={[Function]}
+        job={
           Object {
-            "reportObjectTitle": "Yas",
-            "reportType": "yas",
+            "id": "yas1",
+            "jobtype": "yas",
+            "status": "completed",
+            "title": "Yas",
           }
         }
-      />,
-    },
+      />
+    </React.Fragment>,
   },
-]
+  "title": MountPoint {
+    "reactNode": <FormattedMessage
+      defaultMessage="{reportType} created for '{reportObjectTitle}'"
+      id="xpack.reporting.publicNotifier.successfullyCreatedReportNotificationTitle"
+      values={
+        Object {
+          "reportObjectTitle": "Yas",
+          "reportType": "yas",
+        }
+      }
+    />,
+  },
+}
 `;

--- a/x-pack/plugins/reporting/public/lib/stream_handler.test.ts
+++ b/x-pack/plugins/reporting/public/lib/stream_handler.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { omit } from 'lodash';
 import sinon, { stub } from 'sinon';
 import { NotificationsStart } from '@kbn/core/public';
 import { coreMock, themeServiceMock, docLinksServiceMock } from '@kbn/core/public/mocks';
@@ -123,7 +124,7 @@ describe('stream handler', () => {
         expect(mockShowDanger.callCount).toBe(0);
         expect(mockShowSuccess.callCount).toBe(1);
         expect(mockShowWarning.callCount).toBe(0);
-        expect(mockShowSuccess.args[0]).toMatchSnapshot();
+        expect(omit(mockShowSuccess.args[0][0], 'toastLifeTimeMs')).toMatchSnapshot();
         done();
       });
     });

--- a/x-pack/plugins/reporting/public/notifier/job_success.tsx
+++ b/x-pack/plugins/reporting/public/notifier/job_success.tsx
@@ -37,5 +37,12 @@ export const getSuccessToast = (
     </>,
     { theme$: theme.theme$ }
   ),
+  /**
+   * If timeout is an Infinity value, a Not-a-Number (NaN) value, or negative, then timeout will be zero.
+   * And we cannot use `Number.MAX_SAFE_INTEGER` because EUI's Timer implementation
+   * subtracts it from the current time to evaluate the remainder.
+   * @see https://www.w3.org/TR/2011/WD-html5-20110525/timers.html
+   */
+  toastLifeTimeMs: Number.MAX_SAFE_INTEGER - Date.now(),
   'data-test-subj': 'completeReportSuccess',
 });

--- a/x-pack/test/functional/apps/discover/reporting.ts
+++ b/x-pack/test/functional/apps/discover/reporting.ts
@@ -270,6 +270,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await setupPage();
       });
 
+      afterEach(async () => {
+        await PageObjects.reporting.checkForReportingToasts();
+      });
+
       it('generates a report with data', async () => {
         await PageObjects.discover.loadSavedSearch('Ecommerce Data');
         await retry.try(async () => {


### PR DESCRIPTION
## Summary

Resolves #128316.

## Release Note
Added a fix that makes reporting job notification messages not auto-dismiss.