### PR TITLE
[Cases] Fix `find` method of the cases UI client. 

### DIFF
--- a/x-pack/plugins/cases/common/ui/types.ts
+++ b/x-pack/plugins/cases/common/ui/types.ts
@@ -17,6 +17,8 @@ import {
   CommentResponse,
   CaseResponse,
   CommentResponseAlertsType,
+  CasesFindResponse,
+  CasesStatusResponse,
 } from '../api';
 import { SnakeToCamelCase } from '../types';
 
@@ -61,6 +63,8 @@ export type AlertComment = SnakeToCamelCase<CommentResponseAlertsType>;
 export type CaseUserActions = SnakeToCamelCase<CaseUserActionResponse>;
 export type CaseExternalService = SnakeToCamelCase<CaseExternalServiceBasic>;
 export type Case = Omit<SnakeToCamelCase<CaseResponse>, 'comments'> & { comments: Comment[] };
+export type Cases = Omit<SnakeToCamelCase<CasesFindResponse>, 'cases'> & { cases: Case[] };
+export type CasesStatus = SnakeToCamelCase<CasesStatusResponse>;
 
 export interface ResolvedCase {
   case: Case;
@@ -82,19 +86,6 @@ export interface FilterOptions {
   tags: string[];
   reporters: User[];
   owner: string[];
-}
-
-export interface CasesStatus {
-  countClosedCases: number | null;
-  countOpenCases: number | null;
-  countInProgressCases: number | null;
-}
-
-export interface AllCases extends CasesStatus {
-  cases: Case[];
-  page: number;
-  perPage: number;
-  total: number;
 }
 
 export type SingleCaseMetrics = SingleCaseMetricsResponse;

--- a/x-pack/plugins/cases/public/api/__mocks__/index.ts
+++ b/x-pack/plugins/cases/public/api/__mocks__/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CasesFindRequest } from '../../../common/api';
+import { HTTPService } from '..';
+import { casesStatus } from '../../containers/mock';
+import { CasesStatus } from '../../containers/types';
+
+export const getCasesStatus = async ({
+  http,
+  signal,
+  query,
+}: HTTPService & { query: CasesFindRequest }): Promise<CasesStatus> => Promise.resolve(casesStatus);

--- a/x-pack/plugins/cases/public/api/decoders.ts
+++ b/x-pack/plugins/cases/public/api/decoders.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fold } from 'fp-ts/lib/Either';
+import { identity } from 'fp-ts/lib/function';
+import { pipe } from 'fp-ts/lib/pipeable';
+
+import { createToasterPlainError } from '../containers/utils';
+import { throwErrors } from '../../common';
+import { CasesFindResponse, CasesFindResponseRt } from '../../common/api';
+
+export const decodeCasesFindResponse = (respCases?: CasesFindResponse) =>
+  pipe(CasesFindResponseRt.decode(respCases), fold(throwErrors(createToasterPlainError), identity));

--- a/x-pack/plugins/cases/public/api/decoders.ts
+++ b/x-pack/plugins/cases/public/api/decoders.ts
@@ -11,7 +11,18 @@ import { pipe } from 'fp-ts/lib/pipeable';
 
 import { createToasterPlainError } from '../containers/utils';
 import { throwErrors } from '../../common';
-import { CasesFindResponse, CasesFindResponseRt } from '../../common/api';
+import {
+  CasesFindResponse,
+  CasesFindResponseRt,
+  CasesStatusResponse,
+  CasesStatusResponseRt,
+} from '../../common/api';
 
 export const decodeCasesFindResponse = (respCases?: CasesFindResponse) =>
   pipe(CasesFindResponseRt.decode(respCases), fold(throwErrors(createToasterPlainError), identity));
+
+export const decodeCasesStatusResponse = (respCase?: CasesStatusResponse) =>
+  pipe(
+    CasesStatusResponseRt.decode(respCase),
+    fold(throwErrors(createToasterPlainError), identity)
+  );

--- a/x-pack/plugins/cases/public/api/index.test.ts
+++ b/x-pack/plugins/cases/public/api/index.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServiceMock } from '@kbn/core/public/mocks';
+import { getCases } from '.';
+import { allCases, allCasesSnake } from '../containers/mock';
+
+describe('api', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCases', () => {
+    const http = httpServiceMock.createStartContract({ basePath: '' });
+    http.get.mockResolvedValue(allCasesSnake);
+
+    it('should return the correct response', async () => {
+      expect(await getCases({ http, query: { from: 'now-1d' } })).toEqual(allCases);
+    });
+
+    it('should have been called with the correct path', async () => {
+      await getCases({ http, query: { perPage: 10 } });
+      expect(http.get).toHaveBeenCalledWith('/api/cases/_find', {
+        query: { perPage: 10 },
+      });
+    });
+  });
+});

--- a/x-pack/plugins/cases/public/api/index.ts
+++ b/x-pack/plugins/cases/public/api/index.ts
@@ -6,20 +6,40 @@
  */
 
 import { HttpStart } from '@kbn/core/public';
-import { Cases } from '../../common/ui';
-import { CASE_FIND_URL } from '../../common/constants';
-import { CasesFindRequest, CasesFindResponse } from '../../common/api';
-import { convertAllCasesToCamel } from './utils';
-import { decodeCasesFindResponse } from './decoders';
+import { Cases, CasesStatus } from '../../common/ui';
+import { CASE_FIND_URL, CASE_STATUS_URL } from '../../common/constants';
+import {
+  CasesFindRequest,
+  CasesFindResponse,
+  CasesStatusRequest,
+  CasesStatusResponse,
+} from '../../common/api';
+import { convertAllCasesToCamel, convertToCamelCase } from './utils';
+import { decodeCasesFindResponse, decodeCasesStatusResponse } from './decoders';
 
-interface HTTPService {
+export interface HTTPService {
   http: HttpStart;
+  signal?: AbortSignal;
 }
 
 export const getCases = async ({
   http,
+  signal,
   query,
 }: HTTPService & { query: CasesFindRequest }): Promise<Cases> => {
-  const res = await http.get<CasesFindResponse>(CASE_FIND_URL, { query });
+  const res = await http.get<CasesFindResponse>(CASE_FIND_URL, { query, signal });
   return convertAllCasesToCamel(decodeCasesFindResponse(res));
+};
+
+export const getCasesStatus = async ({
+  http,
+  signal,
+  query,
+}: HTTPService & { query: CasesStatusRequest }): Promise<CasesStatus> => {
+  const response = await http.get<CasesStatusResponse>(CASE_STATUS_URL, {
+    signal,
+    query,
+  });
+
+  return convertToCamelCase<CasesStatusResponse, CasesStatus>(decodeCasesStatusResponse(response));
 };

--- a/x-pack/plugins/cases/public/api/index.ts
+++ b/x-pack/plugins/cases/public/api/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { HttpStart } from '@kbn/core/public';
+import { Cases } from '../../common/ui';
+import { CASE_FIND_URL } from '../../common/constants';
+import { CasesFindRequest, CasesFindResponse } from '../../common/api';
+import { convertAllCasesToCamel } from './utils';
+import { decodeCasesFindResponse } from './decoders';
+
+interface HTTPService {
+  http: HttpStart;
+}
+
+export const getCases = async ({
+  http,
+  query,
+}: HTTPService & { query: CasesFindRequest }): Promise<Cases> => {
+  const res = await http.get<CasesFindResponse>(CASE_FIND_URL, { query });
+  return convertAllCasesToCamel(decodeCasesFindResponse(res));
+};

--- a/x-pack/plugins/cases/public/api/utils.test.ts
+++ b/x-pack/plugins/cases/public/api/utils.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { allCases, allCasesSnake } from '../containers/mock';
+import { convertAllCasesToCamel, convertArrayToCamelCase, convertToCamelCase } from './utils';
+
+describe('utils', () => {
+  describe('convertArrayToCamelCase', () => {
+    it('converts an array of items to camel case correctly', () => {
+      const items = [
+        { foo_bar: [{ bar_foo: '1' }], test_bar: '2', obj_pros: { is_valid: true } },
+        { bar_test: [{ baz_foo: '1' }], test_bar: '2', obj_pros: { is_valid: true } },
+      ];
+      expect(convertArrayToCamelCase(items)).toEqual([
+        { fooBar: [{ barFoo: '1' }], testBar: '2', objPros: { isValid: true } },
+        { barTest: [{ bazFoo: '1' }], testBar: '2', objPros: { isValid: true } },
+      ]);
+    });
+  });
+
+  describe('convertToCamelCase', () => {
+    it('converts the object to camel case correctly', () => {
+      const obj = { bar_test: [{ baz_foo: '1' }], test_bar: '2', obj_pros: { is_valid: true } };
+
+      expect(convertToCamelCase(obj)).toEqual({
+        barTest: [{ bazFoo: '1' }],
+        testBar: '2',
+        objPros: { isValid: true },
+      });
+    });
+  });
+
+  describe('convertAllCasesToCamel', () => {
+    it('converts the find response to camel case', () => {
+      expect(convertAllCasesToCamel(allCasesSnake)).toEqual(allCases);
+    });
+  });
+});

--- a/x-pack/plugins/cases/public/api/utils.test.ts
+++ b/x-pack/plugins/cases/public/api/utils.test.ts
@@ -23,7 +23,7 @@ describe('utils', () => {
   });
 
   describe('convertToCamelCase', () => {
-    it('converts the object to camel case correctly', () => {
+    it('converts an object to camel case correctly', () => {
       const obj = { bar_test: [{ baz_foo: '1' }], test_bar: '2', obj_pros: { is_valid: true } };
 
       expect(convertToCamelCase(obj)).toEqual({

--- a/x-pack/plugins/cases/public/api/utils.ts
+++ b/x-pack/plugins/cases/public/api/utils.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isArray, set, camelCase, isObject } from 'lodash';
+import { CasesFindResponse, CaseResponse } from '../../common/api';
+import { Cases, Case } from '../containers/types';
+
+export const convertArrayToCamelCase = (arrayOfSnakes: unknown[]): unknown[] =>
+  arrayOfSnakes.reduce((acc: unknown[], value) => {
+    if (isArray(value)) {
+      return [...acc, convertArrayToCamelCase(value)];
+    } else if (isObject(value)) {
+      return [...acc, convertToCamelCase(value)];
+    } else {
+      return [...acc, value];
+    }
+  }, []);
+
+export const convertToCamelCase = <T, U extends {}>(obj: T): U =>
+  Object.entries(obj).reduce((acc, [key, value]) => {
+    if (isArray(value)) {
+      set(acc, camelCase(key), convertArrayToCamelCase(value));
+    } else if (isObject(value)) {
+      set(acc, camelCase(key), convertToCamelCase(value));
+    } else {
+      set(acc, camelCase(key), value);
+    }
+    return acc;
+  }, {} as U);
+
+export const convertAllCasesToCamel = (snakeCases: CasesFindResponse): Cases => ({
+  cases: snakeCases.cases.map((theCase) => convertToCamelCase<CaseResponse, Case>(theCase)),
+  countOpenCases: snakeCases.count_open_cases,
+  countInProgressCases: snakeCases.count_in_progress_cases,
+  countClosedCases: snakeCases.count_closed_cases,
+  page: snakeCases.page,
+  perPage: snakeCases.per_page,
+  total: snakeCases.total,
+});

--- a/x-pack/plugins/cases/public/client/api/index.test.ts
+++ b/x-pack/plugins/cases/public/client/api/index.test.ts
@@ -7,7 +7,7 @@
 
 import { httpServiceMock } from '@kbn/core/public/mocks';
 import { createClientAPI } from '.';
-import { allCases, casesStatus } from '../../containers/mock';
+import { allCases, casesStatus, allCasesSnake } from '../../containers/mock';
 
 describe('createClientAPI', () => {
   beforeEach(() => {
@@ -48,7 +48,7 @@ describe('createClientAPI', () => {
     describe('find', () => {
       const http = httpServiceMock.createStartContract({ basePath: '' });
       const api = createClientAPI({ http });
-      http.get.mockResolvedValue(allCases);
+      http.get.mockResolvedValue(allCasesSnake);
 
       it('should return the correct response', async () => {
         expect(await api.cases.find({ from: 'now-1d' })).toEqual(allCases);

--- a/x-pack/plugins/cases/public/client/api/index.ts
+++ b/x-pack/plugins/cases/public/client/api/index.ts
@@ -11,11 +11,12 @@ import {
   CasesByAlertIDRequest,
   CasesFindRequest,
   getCasesFromAlertsUrl,
-  CasesResponse,
   CasesStatusRequest,
   CasesStatusResponse,
 } from '../../../common/api';
-import { CASE_FIND_URL, CASE_STATUS_URL } from '../../../common/constants';
+import { CASE_STATUS_URL } from '../../../common/constants';
+import { Cases } from '../../../common/ui';
+import { getCases } from '../../api';
 import { CasesUiStart } from '../../types';
 
 export const createClientAPI = ({ http }: { http: HttpStart }): CasesUiStart['api'] => {
@@ -26,8 +27,7 @@ export const createClientAPI = ({ http }: { http: HttpStart }): CasesUiStart['ap
     ): Promise<CasesByAlertId> =>
       http.get<CasesByAlertId>(getCasesFromAlertsUrl(alertId), { query }),
     cases: {
-      find: (query: CasesFindRequest): Promise<CasesResponse> =>
-        http.get<CasesResponse>(CASE_FIND_URL, { query }),
+      find: (query: CasesFindRequest): Promise<Cases> => getCases({ http, query }),
       getAllCasesMetrics: (query: CasesStatusRequest): Promise<CasesStatusResponse> =>
         http.get<CasesStatusResponse>(CASE_STATUS_URL, { query }),
     },

--- a/x-pack/plugins/cases/public/client/api/index.ts
+++ b/x-pack/plugins/cases/public/client/api/index.ts
@@ -15,8 +15,8 @@ import {
   CasesStatusResponse,
 } from '../../../common/api';
 import { CASE_STATUS_URL } from '../../../common/constants';
-import { Cases } from '../../../common/ui';
-import { getCases } from '../../api';
+import { Cases, CasesStatus } from '../../../common/ui';
+import { getCases, getCasesStatus } from '../../api';
 import { CasesUiStart } from '../../types';
 
 export const createClientAPI = ({ http }: { http: HttpStart }): CasesUiStart['api'] => {
@@ -27,9 +27,12 @@ export const createClientAPI = ({ http }: { http: HttpStart }): CasesUiStart['ap
     ): Promise<CasesByAlertId> =>
       http.get<CasesByAlertId>(getCasesFromAlertsUrl(alertId), { query }),
     cases: {
-      find: (query: CasesFindRequest): Promise<Cases> => getCases({ http, query }),
+      find: (query: CasesFindRequest, signal?: AbortSignal): Promise<Cases> =>
+        getCases({ http, query, signal }),
       getAllCasesMetrics: (query: CasesStatusRequest): Promise<CasesStatusResponse> =>
         http.get<CasesStatusResponse>(CASE_STATUS_URL, { query }),
+      getCasesStatus: (query: CasesStatusRequest, signal?: AbortSignal): Promise<CasesStatus> =>
+        getCasesStatus({ http, query, signal }),
     },
   };
 };

--- a/x-pack/plugins/cases/public/common/lib/kibana/hooks.ts
+++ b/x-pack/plugins/cases/public/common/lib/kibana/hooks.ts
@@ -12,12 +12,12 @@ import { i18n } from '@kbn/i18n';
 
 import { AuthenticatedUser } from '@kbn/security-plugin/common/model';
 import { NavigateToAppOptions } from '@kbn/core/public';
+import { convertToCamelCase } from '../../../api/utils';
 import {
   FEATURE_ID,
   DEFAULT_DATE_FORMAT,
   DEFAULT_DATE_FORMAT_TZ,
 } from '../../../../common/constants';
-import { convertToCamelCase } from '../../../containers/utils';
 import { StartServices } from '../../../types';
 import { useUiSetting, useKibana } from './kibana_react';
 

--- a/x-pack/plugins/cases/public/components/all_cases/table.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table.tsx
@@ -19,13 +19,13 @@ import styled from 'styled-components';
 
 import { CasesTableUtilityBar } from './utility_bar';
 import { LinkButton } from '../links';
-import { AllCases, Case, FilterOptions } from '../../../common/ui/types';
+import { Cases, Case, FilterOptions } from '../../../common/ui/types';
 import * as i18n from './translations';
 import { useCreateCaseNavigation } from '../../common/navigation';
 
 interface CasesTableProps {
   columns: EuiBasicTableProps<Case>['columns'];
-  data: AllCases;
+  data: Cases;
   filterOptions: FilterOptions;
   goToCreateCase?: () => void;
   handleIsLoading: (a: boolean) => void;

--- a/x-pack/plugins/cases/public/components/all_cases/utility_bar.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/utility_bar.tsx
@@ -15,14 +15,14 @@ import {
   UtilityBarText,
 } from '../utility_bar';
 import * as i18n from './translations';
-import { AllCases, Case, DeleteCase, FilterOptions } from '../../../common/ui/types';
+import { Cases, Case, DeleteCase, FilterOptions } from '../../../common/ui/types';
 import { getBulkItems } from '../bulk_actions';
 import { useDeleteCases } from '../../containers/use_delete_cases';
 import { ConfirmDeleteCaseModal } from '../confirm_delete_case';
 import { useUpdateCases } from '../../containers/use_bulk_update_case';
 
 interface OwnProps {
-  data: AllCases;
+  data: Cases;
   enableBulkActions: boolean;
   filterOptions: FilterOptions;
   handleIsLoading: (a: boolean) => void;

--- a/x-pack/plugins/cases/public/containers/__mocks__/api.ts
+++ b/x-pack/plugins/cases/public/containers/__mocks__/api.ts
@@ -7,7 +7,7 @@
 
 import {
   ActionLicense,
-  AllCases,
+  Cases,
   BulkUpdateStatus,
   Case,
   CasesStatus,
@@ -84,7 +84,7 @@ export const getCases = async ({
     sortOrder: 'desc',
   },
   signal,
-}: FetchCasesProps): Promise<AllCases> => Promise.resolve(allCases);
+}: FetchCasesProps): Promise<Cases> => Promise.resolve(allCases);
 
 export const postCase = async (newCase: CasePostRequest, signal: AbortSignal): Promise<Case> =>
   Promise.resolve(basicCasePost);

--- a/x-pack/plugins/cases/public/containers/api.ts
+++ b/x-pack/plugins/cases/public/containers/api.ts
@@ -6,15 +6,19 @@
  */
 
 import { omit } from 'lodash';
-
-import { StatusAll, ResolvedCase } from '../../common/ui/types';
+import {
+  Cases,
+  FetchCasesProps,
+  ResolvedCase,
+  SortFieldCase,
+  StatusAll,
+} from '../../common/ui/types';
 import {
   BulkCreateCommentRequest,
   CasePatchRequest,
   CasePostRequest,
   CaseResponse,
   CaseResolveResponse,
-  CasesFindResponse,
   CasesResponse,
   CasesStatusResponse,
   CaseUserActionsResponse,
@@ -28,6 +32,7 @@ import {
   User,
   getCaseCommentDeleteUrl,
   SingleCaseMetricsResponse,
+  CasesFindResponse,
 } from '../../common/api';
 import {
   CASE_REPORTERS_URL,
@@ -40,31 +45,27 @@ import { getAllConnectorTypesUrl } from '../../common/utils/connectors_api';
 
 import { KibanaServices } from '../common/lib/kibana';
 
+import { convertAllCasesToCamel, convertToCamelCase, convertArrayToCamelCase } from '../api/utils';
+
 import {
   ActionLicense,
-  AllCases,
   BulkUpdateStatus,
   Case,
   SingleCaseMetrics,
   SingleCaseMetricsFeature,
   CasesStatus,
-  FetchCasesProps,
-  SortFieldCase,
   CaseUserActions,
 } from './types';
 
 import {
-  convertToCamelCase,
-  convertAllCasesToCamel,
-  convertArrayToCamelCase,
   decodeCaseResponse,
   decodeCasesResponse,
-  decodeCasesFindResponse,
   decodeCasesStatusResponse,
   decodeCaseUserActionsResponse,
   decodeCaseResolveResponse,
   decodeSingleCaseMetricsResponse,
 } from './utils';
+import { decodeCasesFindResponse } from '../api/decoders';
 
 export const getCase = async (
   caseId: string,
@@ -176,7 +177,7 @@ export const getCases = async ({
     sortOrder: 'desc',
   },
   signal,
-}: FetchCasesProps): Promise<AllCases> => {
+}: FetchCasesProps): Promise<Cases> => {
   const query = {
     reporters: filterOptions.reporters.map((r) => r.username ?? '').filter((r) => r !== ''),
     tags: filterOptions.tags,
@@ -185,11 +186,13 @@ export const getCases = async ({
     ...(filterOptions.owner.length > 0 ? { owner: filterOptions.owner } : {}),
     ...queryParams,
   };
+
   const response = await KibanaServices.get().http.fetch<CasesFindResponse>(`${CASES_URL}/_find`, {
     method: 'GET',
     query: query.status === StatusAll ? omit(query, ['status']) : query,
     signal,
   });
+
   return convertAllCasesToCamel(decodeCasesFindResponse(response));
 };
 

--- a/x-pack/plugins/cases/public/containers/api.ts
+++ b/x-pack/plugins/cases/public/containers/api.ts
@@ -20,7 +20,6 @@ import {
   CaseResponse,
   CaseResolveResponse,
   CasesResponse,
-  CasesStatusResponse,
   CaseUserActionsResponse,
   CommentRequest,
   CommentType,
@@ -36,7 +35,6 @@ import {
 } from '../../common/api';
 import {
   CASE_REPORTERS_URL,
-  CASE_STATUS_URL,
   CASE_TAGS_URL,
   CASES_URL,
   INTERNAL_BULK_CREATE_ATTACHMENTS_URL,
@@ -53,14 +51,12 @@ import {
   Case,
   SingleCaseMetrics,
   SingleCaseMetricsFeature,
-  CasesStatus,
   CaseUserActions,
 } from './types';
 
 import {
   decodeCaseResponse,
   decodeCasesResponse,
-  decodeCasesStatusResponse,
   decodeCaseUserActionsResponse,
   decodeCaseResolveResponse,
   decodeSingleCaseMetricsResponse,
@@ -98,18 +94,6 @@ export const resolveCase = async (
     }
   );
   return convertToCamelCase<CaseResolveResponse, ResolvedCase>(decodeCaseResolveResponse(response));
-};
-
-export const getCasesStatus = async (
-  signal: AbortSignal,
-  owner: string[]
-): Promise<CasesStatus> => {
-  const response = await KibanaServices.get().http.fetch<CasesStatusResponse>(CASE_STATUS_URL, {
-    method: 'GET',
-    signal,
-    query: { ...(owner.length > 0 ? { owner } : {}) },
-  });
-  return convertToCamelCase<CasesStatusResponse, CasesStatus>(decodeCasesStatusResponse(response));
 };
 
 export const getTags = async (signal: AbortSignal, owner: string[]): Promise<string[]> => {

--- a/x-pack/plugins/cases/public/containers/configure/api.ts
+++ b/x-pack/plugins/cases/public/containers/configure/api.ts
@@ -18,14 +18,9 @@ import {
 } from '../../../common/api';
 import { CASE_CONFIGURE_CONNECTORS_URL, CASE_CONFIGURE_URL } from '../../../common/constants';
 import { KibanaServices } from '../../common/lib/kibana';
-
+import { convertToCamelCase, convertArrayToCamelCase } from '../../api/utils';
 import { ApiProps } from '../types';
-import {
-  convertArrayToCamelCase,
-  convertToCamelCase,
-  decodeCaseConfigurationsResponse,
-  decodeCaseConfigureResponse,
-} from '../utils';
+import { decodeCaseConfigurationsResponse, decodeCaseConfigureResponse } from '../utils';
 import { CaseConfigure } from './types';
 
 export const fetchConnectors = async ({ signal }: ApiProps): Promise<ActionConnector[]> => {

--- a/x-pack/plugins/cases/public/containers/mock.ts
+++ b/x-pack/plugins/cases/public/containers/mock.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ActionLicense, AllCases, Case, CasesStatus, CaseUserActions, Comment } from './types';
+import { ActionLicense, Cases, Case, CasesStatus, CaseUserActions, Comment } from './types';
 
 import type {
   ResolvedCase,
@@ -330,7 +330,7 @@ export const cases: Case[] = [
   caseWithAlertsSyncOff,
 ];
 
-export const allCases: AllCases = {
+export const allCases: Cases = {
   cases,
   page: 1,
   perPage: 5,

--- a/x-pack/plugins/cases/public/containers/use_get_cases.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_cases.tsx
@@ -8,7 +8,7 @@
 import { useCallback, useEffect, useReducer, useRef } from 'react';
 import { DEFAULT_TABLE_ACTIVE_PAGE, DEFAULT_TABLE_LIMIT } from './constants';
 import {
-  AllCases,
+  Cases,
   Case,
   FilterOptions,
   QueryParams,
@@ -21,7 +21,7 @@ import * as i18n from './translations';
 import { getCases, patchCase } from './api';
 
 export interface UseGetCasesState {
-  data: AllCases;
+  data: Cases;
   filterOptions: FilterOptions;
   isError: boolean;
   loading: string[];
@@ -39,7 +39,7 @@ export type Action =
   | { type: 'FETCH_INIT'; payload: string }
   | {
       type: 'FETCH_CASES_SUCCESS';
-      payload: AllCases;
+      payload: Cases;
     }
   | { type: 'FETCH_FAILURE'; payload: string }
   | { type: 'FETCH_UPDATE_CASE_SUCCESS' }
@@ -114,11 +114,11 @@ export const DEFAULT_QUERY_PARAMS: QueryParams = {
   sortOrder: 'desc',
 };
 
-export const initialData: AllCases = {
+export const initialData: Cases = {
   cases: [],
-  countClosedCases: null,
-  countInProgressCases: null,
-  countOpenCases: null,
+  countClosedCases: 0,
+  countInProgressCases: 0,
+  countOpenCases: 0,
   page: 0,
   perPage: 0,
   total: 0,

--- a/x-pack/plugins/cases/public/containers/use_get_cases_status.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_cases_status.test.tsx
@@ -9,11 +9,11 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useGetCasesStatus, UseGetCasesStatus } from './use_get_cases_status';
 import { casesStatus } from './mock';
-import * as api from './api';
+import * as api from '../api';
 import { TestProviders } from '../common/mock';
 import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 
-jest.mock('./api');
+jest.mock('../api');
 jest.mock('../common/lib/kibana');
 
 describe('useGetCasesStatus', () => {
@@ -49,12 +49,17 @@ describe('useGetCasesStatus', () => {
           wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
         }
       );
+
       await waitForNextUpdate();
-      expect(spyOnGetCasesStatus).toBeCalledWith(abortCtrl.signal, [SECURITY_SOLUTION_OWNER]);
+      expect(spyOnGetCasesStatus).toBeCalledWith({
+        http: expect.anything(),
+        signal: abortCtrl.signal,
+        query: { owner: [SECURITY_SOLUTION_OWNER] },
+      });
     });
   });
 
-  it('fetch reporters', async () => {
+  it('fetch statuses', async () => {
     await act(async () => {
       const { result, waitForNextUpdate } = renderHook<string, UseGetCasesStatus>(
         () => useGetCasesStatus(),
@@ -62,6 +67,7 @@ describe('useGetCasesStatus', () => {
           wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
         }
       );
+
       await waitForNextUpdate();
       expect(result.current).toEqual({
         countClosedCases: casesStatus.countClosedCases,

--- a/x-pack/plugins/cases/public/containers/use_get_cases_status.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_cases_status.test.tsx
@@ -30,9 +30,9 @@ describe('useGetCasesStatus', () => {
 
     await act(async () => {
       expect(result.current).toEqual({
-        countClosedCases: null,
-        countOpenCases: null,
-        countInProgressCases: null,
+        countClosedCases: 0,
+        countOpenCases: 0,
+        countInProgressCases: 0,
         isLoading: true,
         isError: false,
         fetchCasesStatus: result.current.fetchCasesStatus,

--- a/x-pack/plugins/cases/public/containers/use_get_cases_status.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_cases_status.tsx
@@ -19,9 +19,9 @@ interface CasesStatusState extends CasesStatus {
 }
 
 const initialData: CasesStatusState = {
-  countClosedCases: null,
-  countInProgressCases: null,
-  countOpenCases: null,
+  countClosedCases: 0,
+  countInProgressCases: 0,
+  countOpenCases: 0,
   isLoading: true,
   isError: false,
 };

--- a/x-pack/plugins/cases/public/containers/use_get_cases_status.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_cases_status.tsx
@@ -8,10 +8,10 @@
 import { useCallback, useEffect, useState, useRef } from 'react';
 
 import { useCasesContext } from '../components/cases_context/use_cases_context';
-import { getCasesStatus } from './api';
 import * as i18n from './translations';
 import { CasesStatus } from './types';
-import { useToasts } from '../common/lib/kibana';
+import { useHttp, useToasts } from '../common/lib/kibana';
+import { getCasesStatus } from '../api';
 
 interface CasesStatusState extends CasesStatus {
   isLoading: boolean;
@@ -31,6 +31,7 @@ export interface UseGetCasesStatus extends CasesStatusState {
 }
 
 export const useGetCasesStatus = (): UseGetCasesStatus => {
+  const http = useHttp();
   const { owner } = useCasesContext();
   const [casesStatusState, setCasesStatusState] = useState<CasesStatusState>(initialData);
   const toasts = useToasts();
@@ -47,7 +48,11 @@ export const useGetCasesStatus = (): UseGetCasesStatus => {
         isLoading: true,
       });
 
-      const response = await getCasesStatus(abortCtrlRef.current.signal, owner);
+      const response = await getCasesStatus({
+        http,
+        signal: abortCtrlRef.current.signal,
+        query: { owner },
+      });
 
       if (!isCancelledRef.current) {
         setCasesStatusState({

--- a/x-pack/plugins/cases/public/containers/utils.ts
+++ b/x-pack/plugins/cases/public/containers/utils.ts
@@ -5,16 +5,13 @@
  * 2.0.
  */
 
-import { set } from '@elastic/safer-lodash-set';
-import { camelCase, isArray, isObject, transform, snakeCase } from 'lodash';
+import { isObject, transform, snakeCase } from 'lodash';
 import { fold } from 'fp-ts/lib/Either';
 import { identity } from 'fp-ts/lib/function';
 import { pipe } from 'fp-ts/lib/pipeable';
 
 import { ToastInputFields } from '@kbn/core/public';
 import {
-  CasesFindResponse,
-  CasesFindResponseRt,
   CaseResponse,
   CaseResponseRt,
   CasesResponse,
@@ -35,7 +32,7 @@ import {
   SingleCaseMetricsResponse,
   SingleCaseMetricsResponseRt,
 } from '../../common/api';
-import { AllCases, Case, UpdateByKey } from './types';
+import { Case, UpdateByKey } from './types';
 import * as i18n from './translations';
 
 export const getTypedPayload = <T>(a: unknown): T => a as T;
@@ -45,39 +42,6 @@ export const covertToSnakeCase = (obj: Record<string, unknown>) =>
     const camelKey = Array.isArray(target) ? key : snakeCase(key);
     acc[camelKey] = isObject(value) ? covertToSnakeCase(value as Record<string, unknown>) : value;
   });
-
-export const convertArrayToCamelCase = (arrayOfSnakes: unknown[]): unknown[] =>
-  arrayOfSnakes.reduce((acc: unknown[], value) => {
-    if (isArray(value)) {
-      return [...acc, convertArrayToCamelCase(value)];
-    } else if (isObject(value)) {
-      return [...acc, convertToCamelCase(value)];
-    } else {
-      return [...acc, value];
-    }
-  }, []);
-
-export const convertToCamelCase = <T, U extends {}>(obj: T): U =>
-  Object.entries(obj).reduce((acc, [key, value]) => {
-    if (isArray(value)) {
-      set(acc, camelCase(key), convertArrayToCamelCase(value));
-    } else if (isObject(value)) {
-      set(acc, camelCase(key), convertToCamelCase(value));
-    } else {
-      set(acc, camelCase(key), value);
-    }
-    return acc;
-  }, {} as U);
-
-export const convertAllCasesToCamel = (snakeCases: CasesFindResponse): AllCases => ({
-  cases: snakeCases.cases.map((theCase) => convertToCamelCase<CaseResponse, Case>(theCase)),
-  countOpenCases: snakeCases.count_open_cases,
-  countInProgressCases: snakeCases.count_in_progress_cases,
-  countClosedCases: snakeCases.count_closed_cases,
-  page: snakeCases.page,
-  perPage: snakeCases.per_page,
-  total: snakeCases.total,
-});
 
 export const decodeCasesStatusResponse = (respCase?: CasesStatusResponse) =>
   pipe(
@@ -104,9 +68,6 @@ export const decodeSingleCaseMetricsResponse = (respCase?: SingleCaseMetricsResp
 
 export const decodeCasesResponse = (respCase?: CasesResponse) =>
   pipe(CasesResponseRt.decode(respCase), fold(throwErrors(createToasterPlainError), identity));
-
-export const decodeCasesFindResponse = (respCases?: CasesFindResponse) =>
-  pipe(CasesFindResponseRt.decode(respCases), fold(throwErrors(createToasterPlainError), identity));
 
 export const decodeCaseConfigurationsResponse = (respCase?: CasesConfigurationsResponse) => {
   return pipe(

--- a/x-pack/plugins/cases/public/containers/utils.ts
+++ b/x-pack/plugins/cases/public/containers/utils.ts
@@ -16,8 +16,6 @@ import {
   CaseResponseRt,
   CasesResponse,
   CasesResponseRt,
-  CasesStatusResponseRt,
-  CasesStatusResponse,
   throwErrors,
   CasesConfigurationsResponse,
   CaseConfigurationsResponseRt,
@@ -42,12 +40,6 @@ export const covertToSnakeCase = (obj: Record<string, unknown>) =>
     const camelKey = Array.isArray(target) ? key : snakeCase(key);
     acc[camelKey] = isObject(value) ? covertToSnakeCase(value as Record<string, unknown>) : value;
   });
-
-export const decodeCasesStatusResponse = (respCase?: CasesStatusResponse) =>
-  pipe(
-    CasesStatusResponseRt.decode(respCase),
-    fold(throwErrors(createToasterPlainError), identity)
-  );
 
 export const createToasterPlainError = (message: string) => new ToasterError([message]);
 

--- a/x-pack/plugins/cases/public/mocks.ts
+++ b/x-pack/plugins/cases/public/mocks.ts
@@ -10,7 +10,7 @@ import { CasesUiStart } from './types';
 
 const apiMock: jest.Mocked<CasesUiStart['api']> = {
   getRelatedCases: jest.fn(),
-  cases: { find: jest.fn(), getAllCasesMetrics: jest.fn() },
+  cases: { find: jest.fn(), getAllCasesMetrics: jest.fn(), getCasesStatus: jest.fn() },
 };
 
 const uiMock: jest.Mocked<CasesUiStart['ui']> = {

--- a/x-pack/plugins/cases/public/types.ts
+++ b/x-pack/plugins/cases/public/types.ts
@@ -21,7 +21,6 @@ import {
   CasesByAlertId,
   CasesByAlertIDRequest,
   CasesFindRequest,
-  CasesResponse,
   CasesStatusRequest,
   CasesStatusResponse,
   CommentRequestAlertType,
@@ -36,6 +35,7 @@ import type { GetCasesProps } from './client/ui/get_cases';
 import { GetAllCasesSelectorModalProps } from './client/ui/get_all_cases_selector_modal';
 import { GetCreateCaseFlyoutProps } from './client/ui/get_create_case_flyout';
 import { GetRecentCasesProps } from './client/ui/get_recent_cases';
+import { Cases } from '../common/ui';
 
 export interface CasesPluginSetup {
   security: SecurityPluginSetup;
@@ -76,7 +76,7 @@ export interface CasesUiStart {
   api: {
     getRelatedCases: (alertId: string, query: CasesByAlertIDRequest) => Promise<CasesByAlertId>;
     cases: {
-      find: (query: CasesFindRequest) => Promise<CasesResponse>;
+      find: (query: CasesFindRequest) => Promise<Cases>;
       getAllCasesMetrics: (query: CasesStatusRequest) => Promise<CasesStatusResponse>;
     };
   };

--- a/x-pack/plugins/cases/public/types.ts
+++ b/x-pack/plugins/cases/public/types.ts
@@ -35,7 +35,7 @@ import type { GetCasesProps } from './client/ui/get_cases';
 import { GetAllCasesSelectorModalProps } from './client/ui/get_all_cases_selector_modal';
 import { GetCreateCaseFlyoutProps } from './client/ui/get_create_case_flyout';
 import { GetRecentCasesProps } from './client/ui/get_recent_cases';
-import { Cases } from '../common/ui';
+import { Cases, CasesStatus } from '../common/ui';
 
 export interface CasesPluginSetup {
   security: SecurityPluginSetup;
@@ -76,8 +76,9 @@ export interface CasesUiStart {
   api: {
     getRelatedCases: (alertId: string, query: CasesByAlertIDRequest) => Promise<CasesByAlertId>;
     cases: {
-      find: (query: CasesFindRequest) => Promise<Cases>;
+      find: (query: CasesFindRequest, signal?: AbortSignal) => Promise<Cases>;
       getAllCasesMetrics: (query: CasesStatusRequest) => Promise<CasesStatusResponse>;
+      getCasesStatus: (query: CasesStatusRequest, signal?: AbortSignal) => Promise<CasesStatus>;
     };
   };
   ui: {

--- a/x-pack/plugins/security_solution/public/overview/components/detection_response/cases_by_status/use_cases_by_status.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/detection_response/cases_by_status/use_cases_by_status.test.tsx
@@ -28,16 +28,17 @@ jest.mock('../../../../common/containers/use_global_time', () => {
 });
 jest.mock('../../../../common/lib/kibana');
 
-const mockGetAllCasesMetrics = jest.fn();
-mockGetAllCasesMetrics.mockResolvedValue({
-  count_open_cases: 1,
-  count_in_progress_cases: 2,
-  count_closed_cases: 3,
+const mockGetCasesStatus = jest.fn();
+mockGetCasesStatus.mockResolvedValue({
+  countOpenCases: 1,
+  countInProgressCases: 2,
+  countClosedCases: 3,
 });
-mockGetAllCasesMetrics.mockResolvedValueOnce({
-  count_open_cases: 0,
-  count_in_progress_cases: 0,
-  count_closed_cases: 0,
+
+mockGetCasesStatus.mockResolvedValueOnce({
+  countOpenCases: 0,
+  countInProgressCases: 0,
+  countClosedCases: 0,
 });
 
 const mockUseKibana = {
@@ -46,7 +47,7 @@ const mockUseKibana = {
       ...mockCasesContract(),
       api: {
         cases: {
-          getAllCasesMetrics: mockGetAllCasesMetrics,
+          getCasesStatus: mockGetCasesStatus,
         },
       },
     },


### PR DESCRIPTION
## Summary

The `find` method of the cases UI client has the wrong TS return type. It also does not convert the response of the server, which is in snake case, to camel case. This PR fixes these two issues. It also introduces and applies the same fixes to `getCasesStatus`. The `getAllCasesMetrics` will be substituted by a following PR to introduce the `mttr` metric.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
