### PR TITLE
[Cloud Posture] Display and save rules per benchmark

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
@@ -32,9 +32,17 @@ const getWrapper =
   ({ children }) =>
     <TestProvider>{children}</TestProvider>;
 
-const getRuleMock = ({ id = chance.guid(), enabled }: { id?: string; enabled: boolean }) =>
+const getRuleMock = ({
+  savedObjectId = chance.guid(),
+  id = chance.guid(),
+  enabled,
+}: {
+  savedObjectId?: string;
+  id?: string;
+  enabled: boolean;
+}) =>
   ({
-    id,
+    id: savedObjectId,
     updatedAt: chance.date().toISOString(),
     attributes: {
       id,
@@ -101,6 +109,13 @@ describe('<RulesContainer />', () => {
 
     const switchId1 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id);
     const switchId2 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule2.id);
+
+    expect(screen.getByTestId(switchId1).getAttribute('aria-checked')).toEqual(
+      rule1.attributes.enabled.toString()
+    );
+    expect(screen.getByTestId(switchId2).getAttribute('aria-checked')).toEqual(
+      rule2.attributes.enabled.toString()
+    );
 
     fireEvent.click(screen.getByTestId(switchId1));
     fireEvent.click(screen.getByTestId(switchId2));

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -16,6 +16,7 @@ import {
 import { useParams } from 'react-router-dom';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { pagePathGetters } from '@kbn/fleet-plugin/public';
+import { cspRuleAssetSavedObjectType } from '../../../common/schemas/csp_rule';
 import { extractErrorMessage, isNonNullable } from '../../../common/utils/helpers';
 import { RulesTable } from './rules_table';
 import { RulesBottomBar } from './rules_bottom_bar';
@@ -81,7 +82,7 @@ const getRulesPageData = (
     error: error ? extractErrorMessage(error) : undefined,
     all_rules: rules,
     rules_map: new Map(rules.map((rule) => [rule.id, rule])),
-    rules_page: page.map((rule) => changedRules.get(rule.attributes.id) || rule),
+    rules_page: page.map((rule) => changedRules.get(rule.id) || rule),
     total: data?.total || 0,
     lastModified: getLastModified(rules) || null,
   };
@@ -107,9 +108,15 @@ export const RulesContainer = () => {
   const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
   const [isAllSelected, setIsAllSelected] = useState<boolean>(false);
   const [visibleSelectedRulesIds, setVisibleSelectedRulesIds] = useState<string[]>([]);
-  const [rulesQuery, setRulesQuery] = useState<RulesQuery>({ page: 0, perPage: 5, search: '' });
+  const [rulesQuery, setRulesQuery] = useState<RulesQuery>({
+    filter: `${cspRuleAssetSavedObjectType}.attributes.policy_id: "${params.policyId}" and ${cspRuleAssetSavedObjectType}.attributes.package_policy_id: "${params.packagePolicyId}"`,
+    search: '',
+    page: 0,
+    perPage: 5,
+  });
 
   const { data, status, error, refetch } = useFindCspRules({
+    filter: rulesQuery.filter,
     search: getSimpleQueryString(rulesQuery.search),
     page: 1,
     perPage: MAX_ITEMS_PER_PAGE,
@@ -152,7 +159,11 @@ export const RulesContainer = () => {
 
   const toggleRule = (rule: RuleSavedObject) => toggleRules([rule], !rule.attributes.enabled);
 
-  const bulkUpdateRules = () => bulkUpdate([...changedRules].map(([, rule]) => rule.attributes));
+  const bulkUpdateRules = () =>
+    bulkUpdate({
+      savedObjectRules: [...changedRules].map(([, savedObjectRule]) => savedObjectRule),
+      packagePolicyId: params.packagePolicyId,
+    });
 
   const discardChanges = useCallback(() => setChangedRules(new Map()), []);
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_flyout.tsx
@@ -146,7 +146,7 @@ const RuleOverviewTab = ({ rule, toggleRule }: { rule: RuleSavedObject; toggleRu
             label={TEXT.ACTIVATED}
             checked={rule.attributes.enabled}
             onChange={toggleRule}
-            data-test-subj={TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule.attributes.id)}
+            data-test-subj={TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule.id)}
           />
         </EuiToolTip>
       </span>

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -148,7 +148,7 @@ const getColumns = ({
           label={enabled ? TEXT.DISABLE : TEXT.ENABLE}
           checked={enabled}
           onChange={() => toggleRule(rule)}
-          data-test-subj={TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule.attributes.id)}
+          data-test-subj={TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule.id)}
         />
       </EuiToolTip>
     ),

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
@@ -7,6 +7,7 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { FunctionKeys } from 'utility-types';
 import type { SavedObjectsFindOptions, SimpleSavedObject } from '@kbn/core/public';
+import { UPDATE_RULES_CONFIG_ROUTE_PATH } from '../../../common/constants';
 import { cspRuleAssetSavedObjectType, type CspRuleSchema } from '../../../common/schemas/csp_rule';
 import { useKibana } from '../../common/hooks/use_kibana';
 import { UPDATE_FAILED } from './translations';
@@ -16,11 +17,14 @@ export type RuleSavedObject = Omit<
   FunctionKeys<SimpleSavedObject>
 >;
 
-export type RulesQuery = Required<Pick<SavedObjectsFindOptions, 'search' | 'page' | 'perPage'>>;
+export type RulesQuery = Required<
+  Pick<SavedObjectsFindOptions, 'search' | 'page' | 'perPage' | 'filter'>
+>;
 export type RulesQueryResult = ReturnType<typeof useFindCspRules>;
 
-export const useFindCspRules = ({ search, page, perPage }: RulesQuery) => {
+export const useFindCspRules = ({ search, page, perPage, filter }: RulesQuery) => {
   const { savedObjects } = useKibana().services;
+
   return useQuery(
     [cspRuleAssetSavedObjectType, { search, page, perPage }],
     () =>
@@ -32,24 +36,37 @@ export const useFindCspRules = ({ search, page, perPage }: RulesQuery) => {
         // NOTE: 'name.raw' is a field mapping we defined on 'name'
         sortField: 'name.raw',
         perPage,
+        filter,
       }),
     { refetchOnWindowFocus: false }
   );
 };
 
 export const useBulkUpdateCspRules = () => {
-  const { savedObjects, notifications } = useKibana().services;
+  const { savedObjects, notifications, http } = useKibana().services;
   const queryClient = useQueryClient();
 
   return useMutation(
-    (rules: CspRuleSchema[]) =>
-      savedObjects.client.bulkUpdate<CspRuleSchema>(
-        rules.map((rule) => ({
+    async ({
+      savedObjectRules,
+      packagePolicyId,
+    }: {
+      savedObjectRules: RuleSavedObject[];
+      packagePolicyId: CspRuleSchema['package_policy_id'];
+    }) => {
+      await savedObjects.client.bulkUpdate<RuleSavedObject>(
+        savedObjectRules.map((savedObjectRule) => ({
           type: cspRuleAssetSavedObjectType,
-          id: rule.id,
-          attributes: rule,
+          id: savedObjectRule.id,
+          attributes: savedObjectRule.attributes,
         }))
-      ),
+      );
+      await http.post(UPDATE_RULES_CONFIG_ROUTE_PATH, {
+        body: JSON.stringify({
+          package_policy_id: packagePolicyId,
+        }),
+      });
+    },
     {
       onError: (err) => {
         if (err instanceof Error) notifications.toasts.addError(err, { title: UPDATE_FAILED });

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -106,7 +106,7 @@ export const defineUpdateRulesConfigRoute = (router: CspRouter, cspContext: CspA
   router.post(
     {
       path: UPDATE_RULES_CONFIG_ROUTE_PATH,
-      validate: { query: configurationUpdateInputSchema },
+      validate: { body: configurationUpdateInputSchema },
     },
     async (context, request, response) => {
       if (!(await context.fleet).authz.fleet.all) {
@@ -118,7 +118,7 @@ export const defineUpdateRulesConfigRoute = (router: CspRouter, cspContext: CspA
         const esClient = coreContext.elasticsearch.client.asCurrentUser;
         const soClient = coreContext.savedObjects.client;
         const packagePolicyService = cspContext.service.packagePolicyService;
-        const packagePolicyId = request.query.package_policy_id;
+        const packagePolicyId = request.body.package_policy_id;
 
         if (!packagePolicyService) {
           throw new Error(`Failed to get Fleet services`);


### PR DESCRIPTION
## Summary

- Fixed rule pages showing rules from all integrations combined
- Fixed active toggling not working
- Now also sends the active rules data to a new API that updated the `data.yml`

https://user-images.githubusercontent.com/51442161/166477862-5481461e-39fc-47af-a0f9-27499a7b1c5b.mov


