### PR TITLE
[7.17] [ci-stats-reporter] use v2 test group APIs (#131001)

### DIFF
--- a/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
+++ b/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
@@ -85,10 +85,8 @@ export interface CiStatsReportTestsOptions {
 }
 
 /* @internal */
-interface ReportTestsResponse {
-  buildId: string;
+interface ReportTestGroupResponse {
   groupId: string;
-  testRunCount: number;
 }
 
 /* @internal */
@@ -239,18 +237,51 @@ export class CiStatsReporter {
       );
     }
 
-    return await this.req<ReportTestsResponse>({
+    const groupResp = await this.req<ReportTestGroupResponse>({
       auth: true,
-      path: '/v1/test_group',
+      path: '/v2/test_group',
       query: {
         buildId: this.config?.buildId,
       },
-      bodyDesc: `[${group.name}/${group.type}] test groups with ${testRuns.length} tests`,
-      body: [
-        JSON.stringify({ group }),
-        ...testRuns.map((testRun) => JSON.stringify({ testRun })),
-      ].join('\n'),
+      bodyDesc: `[${group.name}/${group.type}] test group`,
+      body: group,
     });
+
+    if (!groupResp) {
+      return;
+    }
+
+    let bufferBytes = 0;
+    const buffer: string[] = [];
+    const flushBuffer = async () => {
+      await this.req<{ testRunCount: number }>({
+        auth: true,
+        path: '/v2/test_runs',
+        query: {
+          buildId: this.config?.buildId,
+          groupId: groupResp.groupId,
+          groupType: group.type,
+        },
+        bodyDesc: `[${group.name}/${group.type}] Chunk of ${bufferBytes} bytes`,
+        body: buffer.join('\n'),
+      });
+      buffer.length = 0;
+      bufferBytes = 0;
+    };
+
+    // send test runs in chunks of ~500kb
+    for (const testRun of testRuns) {
+      const json = JSON.stringify(testRun);
+      bufferBytes += json.length;
+      buffer.push(json);
+      if (bufferBytes >= 450000) {
+        await flushBuffer();
+      }
+    }
+
+    if (bufferBytes) {
+      await flushBuffer();
+    }
   }
 
   /**

--- a/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
+++ b/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
@@ -23,6 +23,8 @@ import type { CiStatsTestGroupInfo, CiStatsTestRun } from './ci_stats_test_group
 import { CiStatsMetadata } from './ci_stats_metadata';
 
 const BASE_URL = 'https://ci-stats.kibana.dev';
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
 
 /** A ci-stats metric record */
 export interface CiStatsMetric {
@@ -96,6 +98,7 @@ interface ReqOptions {
   body: any;
   bodyDesc: string;
   query?: AxiosRequestConfig['params'];
+  timeout?: number;
 }
 
 /** Object that helps report data to the ci-stats service */
@@ -264,6 +267,7 @@ export class CiStatsReporter {
         },
         bodyDesc: `[${group.name}/${group.type}] Chunk of ${bufferBytes} bytes`,
         body: buffer.join('\n'),
+        timeout: 5 * MINUTE,
       });
       buffer.length = 0;
       bufferBytes = 0;
@@ -318,7 +322,7 @@ export class CiStatsReporter {
     }
   }
 
-  private async req<T>({ auth, body, bodyDesc, path, query }: ReqOptions) {
+  private async req<T>({ auth, body, bodyDesc, path, query, timeout = 60 * SECOND }: ReqOptions) {
     let attempt = 0;
     const maxAttempts = 5;
 
@@ -343,6 +347,11 @@ export class CiStatsReporter {
           data: body,
           params: query,
           adapter: httpAdapter,
+
+          // if it can be serialized into a string, send it
+          maxBodyLength: Infinity,
+          maxContentLength: Infinity,
+          timeout,
         });
 
         return resp.data;

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -9050,6 +9050,8 @@ var _ci_stats_config = __webpack_require__(218);
  */
 // @ts-expect-error not "public", but necessary to prevent Jest shimming from breaking things
 const BASE_URL = 'https://ci-stats.kibana.dev';
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
 /** A ci-stats metric record */
 
 /** Object that helps report data to the ci-stats service */
@@ -9239,7 +9241,8 @@ class CiStatsReporter {
           groupType: group.type
         },
         bodyDesc: `[${group.name}/${group.type}] Chunk of ${bufferBytes} bytes`,
-        body: buffer.join('\n')
+        body: buffer.join('\n'),
+        timeout: 5 * MINUTE
       });
       buffer.length = 0;
       bufferBytes = 0;
@@ -9308,7 +9311,8 @@ class CiStatsReporter {
     body,
     bodyDesc,
     path,
-    query
+    query,
+    timeout = 60 * SECOND
   }) {
     let attempt = 0;
     const maxAttempts = 5;
@@ -9333,7 +9337,11 @@ class CiStatsReporter {
           headers,
           data: body,
           params: query,
-          adapter: _http.default
+          adapter: _http.default,
+          // if it can be serialized into a string, send it
+          maxBodyLength: Infinity,
+          maxContentLength: Infinity,
+          timeout
         });
         return resp.data;
       } catch (error) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci-stats-reporter] use v2 test group APIs (#131001)](https://github.com/elastic/kibana/pull/131001)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)