### PR TITLE
[8.2] [8.2.1] [Session View] Add process fields name to text to copy (#131167)

### DIFF
--- a/x-pack/plugins/session_view/public/components/detail_panel_copy/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/session_view/public/components/detail_panel_copy/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DetailPanelCopy component When DetailPanelCopy is mounted renders DetailPanelCopy correctly 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="euiText euiText--small css-dx11u5-EuiText"
+        data-test-subj="sessionView:detail-panel-list-item"
+      >
+        <span
+          class="euiToolTipAnchor"
+        >
+          <span>
+            copy component test
+          </span>
+        </span>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="euiText euiText--small css-dx11u5-EuiText"
+      data-test-subj="sessionView:detail-panel-list-item"
+    >
+      <span
+        class="euiToolTipAnchor"
+      >
+        <span>
+          copy component test
+        </span>
+      </span>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/x-pack/plugins/session_view/public/components/detail_panel_copy/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_copy/index.test.tsx
@@ -28,6 +28,7 @@ describe('DetailPanelCopy component', () => {
       );
 
       expect(renderResult.queryByText(TEST_TEXT_COPY)).toBeVisible();
+      expect(renderResult).toMatchSnapshot();
     });
   });
 });

--- a/x-pack/plugins/session_view/public/components/detail_panel_copy/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_copy/index.tsx
@@ -13,7 +13,7 @@ import { useStyles } from './styles';
 
 interface DetailPanelCopyDeps {
   children: ReactNode;
-  textToCopy: string | number | undefined;
+  textToCopy: string;
   display?: 'inlineBlock' | 'block' | undefined;
 }
 
@@ -34,7 +34,7 @@ export const DetailPanelCopy = ({
 
   const props: DetailPanelListItemProps = {
     copy: (
-      <EuiCopy textToCopy={dataOrDash(textToCopy).toString()} display={display}>
+      <EuiCopy textToCopy={textToCopy} display={display}>
         {(copy) => (
           <EuiButtonIcon
             css={styles.copyButton}

--- a/x-pack/plugins/session_view/public/components/detail_panel_host_tab/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_host_tab/index.tsx
@@ -31,7 +31,7 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>hostname</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.hostname}>
+              <DetailPanelCopy textToCopy={`host.hostname: "${dataOrDash(processHost?.hostname)}"`}>
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.hostname)}
                 </EuiTextColor>
@@ -41,7 +41,7 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>id</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.id}>
+              <DetailPanelCopy textToCopy={`host.id: "${dataOrDash(processHost?.id)}"`}>
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.id)}
                 </EuiTextColor>
@@ -51,7 +51,7 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>ip</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.ip}>
+              <DetailPanelCopy textToCopy={`host.ip: "${dataOrDash(processHost?.ip)}"`}>
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.ip)}
                 </EuiTextColor>
@@ -61,7 +61,7 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>mac</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.mac}>
+              <DetailPanelCopy textToCopy={`host.mac: "${dataOrDash(processHost?.mac)}"`}>
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.mac)}
                 </EuiTextColor>
@@ -71,7 +71,7 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>name</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.name}>
+              <DetailPanelCopy textToCopy={`host.name: "${dataOrDash(processHost?.name)}"`}>
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.name)}
                 </EuiTextColor>
@@ -87,7 +87,9 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>architecture</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.architecture}>
+              <DetailPanelCopy
+                textToCopy={`host.architecture: "${dataOrDash(processHost?.architecture)}"`}
+              >
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.architecture)}
                 </EuiTextColor>
@@ -97,7 +99,9 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>os.family</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.os?.family}>
+              <DetailPanelCopy
+                textToCopy={`host.os.family: "${dataOrDash(processHost?.os?.family)}"`}
+              >
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.os?.family)}
                 </EuiTextColor>
@@ -107,7 +111,7 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>os.full</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.os?.full}>
+              <DetailPanelCopy textToCopy={`host.os.full: "${dataOrDash(processHost?.os?.full)}"`}>
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.os?.full)}
                 </EuiTextColor>
@@ -117,7 +121,9 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>os.kernel</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.os?.kernel}>
+              <DetailPanelCopy
+                textToCopy={`host.os.kernel: "${dataOrDash(processHost?.os?.kernel)}"`}
+              >
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.os?.kernel)}
                 </EuiTextColor>
@@ -127,7 +133,7 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>os.name</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.os?.name}>
+              <DetailPanelCopy textToCopy={`host.os.name: "${dataOrDash(processHost?.os?.name)}"`}>
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.os?.name)}
                 </EuiTextColor>
@@ -137,7 +143,9 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>os.platform</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.os?.platform}>
+              <DetailPanelCopy
+                textToCopy={`host.os.platform: "${dataOrDash(processHost?.os?.platform)}"`}
+              >
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.os?.platform)}
                 </EuiTextColor>
@@ -147,7 +155,9 @@ export const DetailPanelHostTab = ({ processHost }: DetailPanelHostTabDeps) => {
           {
             title: <DetailPanelListItem>os.version</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processHost?.os?.version}>
+              <DetailPanelCopy
+                textToCopy={`host.os.version: "${dataOrDash(processHost?.os?.version)}"`}
+              >
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(processHost?.os?.version)}
                 </EuiTextColor>

--- a/x-pack/plugins/session_view/public/components/detail_panel_process_tab/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_process_tab/index.tsx
@@ -59,6 +59,14 @@ const leaderDescriptionListInfo = [
   },
 ];
 
+const PROCESS_FIELD_PREFIX = 'process';
+const LEADER_FIELD_PREFIX = [
+  `${PROCESS_FIELD_PREFIX}.entry_leader`,
+  `${PROCESS_FIELD_PREFIX}.session_leader`,
+  `${PROCESS_FIELD_PREFIX}.group_leader`,
+  `${PROCESS_FIELD_PREFIX}.parent`,
+];
+
 /**
  * Detail panel in the session view.
  */
@@ -90,7 +98,9 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
       {
         title: <DetailPanelListItem>entity_id</DetailPanelListItem>,
         description: (
-          <DetailPanelCopy textToCopy={id}>
+          <DetailPanelCopy
+            textToCopy={`${LEADER_FIELD_PREFIX[idx]}.entity_id: "${dataOrDash(id)}"`}
+          >
             <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
               {dataOrDash(id)}
             </EuiTextColor>
@@ -99,12 +109,18 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
       },
       {
         title: <DetailPanelListItem>args</DetailPanelListItem>,
-        description: <DetailPanelCopy textToCopy={leaderArgs}>{leaderArgs}</DetailPanelCopy>,
+        description: (
+          <DetailPanelCopy textToCopy={`${LEADER_FIELD_PREFIX[idx]}.args: "${leaderArgs}"`}>
+            {leaderArgs}
+          </DetailPanelCopy>
+        ),
       },
       {
         title: <DetailPanelListItem>interactive</DetailPanelListItem>,
         description: (
-          <DetailPanelCopy textToCopy={isLeaderInteractive}>
+          <DetailPanelCopy
+            textToCopy={`${LEADER_FIELD_PREFIX[idx]}.interactive: "${isLeaderInteractive}"`}
+          >
             <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
               {isLeaderInteractive}
             </EuiTextColor>
@@ -114,7 +130,11 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
       {
         title: <DetailPanelListItem>working_directory</DetailPanelListItem>,
         description: (
-          <DetailPanelCopy textToCopy={workingDirectory}>
+          <DetailPanelCopy
+            textToCopy={`${LEADER_FIELD_PREFIX[idx]}.working_directory: "${dataOrDash(
+              workingDirectory
+            )}"`}
+          >
             <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
               {dataOrDash(workingDirectory)}
             </EuiTextColor>
@@ -124,7 +144,7 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
       {
         title: <DetailPanelListItem>pid</DetailPanelListItem>,
         description: (
-          <DetailPanelCopy textToCopy={pid}>
+          <DetailPanelCopy textToCopy={`${LEADER_FIELD_PREFIX[idx]}.pid: "${dataOrDash(pid)}"`}>
             <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
               {dataOrDash(pid)}
             </EuiTextColor>
@@ -133,16 +153,26 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
       },
       {
         title: <DetailPanelListItem>start</DetailPanelListItem>,
-        description: <DetailPanelCopy textToCopy={start}>{dataOrDash(start)}</DetailPanelCopy>,
+        description: (
+          <DetailPanelCopy textToCopy={`${LEADER_FIELD_PREFIX[idx]}.start: "${dataOrDash(start)}"`}>
+            {dataOrDash(start)}
+          </DetailPanelCopy>
+        ),
       },
       {
         title: <DetailPanelListItem>end</DetailPanelListItem>,
-        description: <DetailPanelCopy textToCopy={end ?? ''}>{dataOrDash(end)}</DetailPanelCopy>,
+        description: (
+          <DetailPanelCopy textToCopy={`${LEADER_FIELD_PREFIX[idx]}.end: "${dataOrDash(end)}"`}>
+            {dataOrDash(end)}
+          </DetailPanelCopy>
+        ),
       },
       {
         title: <DetailPanelListItem>exit_code</DetailPanelListItem>,
         description: (
-          <DetailPanelCopy textToCopy={exitCode ?? ''}>
+          <DetailPanelCopy
+            textToCopy={`${LEADER_FIELD_PREFIX[idx]}.exit_code: "${dataOrDash(exitCode)}"`}
+          >
             <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
               {dataOrDash(exitCode)}
             </EuiTextColor>
@@ -152,13 +182,21 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
       {
         title: <DetailPanelListItem>user.name</DetailPanelListItem>,
         description: (
-          <DetailPanelCopy textToCopy={userName}>{dataOrDash(userName)}</DetailPanelCopy>
+          <DetailPanelCopy
+            textToCopy={`${LEADER_FIELD_PREFIX[idx]}.user.name: "${dataOrDash(userName)}"`}
+          >
+            {dataOrDash(userName)}
+          </DetailPanelCopy>
         ),
       },
       {
         title: <DetailPanelListItem>group.name</DetailPanelListItem>,
         description: (
-          <DetailPanelCopy textToCopy={groupName}>{dataOrDash(groupName)}</DetailPanelCopy>
+          <DetailPanelCopy
+            textToCopy={`${LEADER_FIELD_PREFIX[idx]}.group.name: "${dataOrDash(groupName)}"`}
+          >
+            {dataOrDash(groupName)}
+          </DetailPanelCopy>
         ),
       },
     ];
@@ -168,7 +206,11 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
         {
           title: <DetailPanelListItem>entry_meta.type</DetailPanelListItem>,
           description: (
-            <DetailPanelCopy textToCopy={entryMetaType}>
+            <DetailPanelCopy
+              textToCopy={`${LEADER_FIELD_PREFIX[idx]}.entry_meta.type: "${dataOrDash(
+                entryMetaType
+              )}"`}
+            >
               <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                 {dataOrDash(entryMetaType)}
               </EuiTextColor>
@@ -178,7 +220,11 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
         {
           title: <DetailPanelListItem>entry_meta.source.ip</DetailPanelListItem>,
           description: (
-            <DetailPanelCopy textToCopy={entryMetaSourceIp}>
+            <DetailPanelCopy
+              textToCopy={`${LEADER_FIELD_PREFIX[idx]}.entry_meta.source.ip: "${dataOrDash(
+                entryMetaSourceIp
+              )}"`}
+            >
               {dataOrDash(entryMetaSourceIp)}
             </DetailPanelCopy>
           ),
@@ -217,7 +263,9 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
           {
             title: <DetailPanelListItem>entity_id</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={id}>
+              <DetailPanelCopy
+                textToCopy={`${PROCESS_FIELD_PREFIX}.entity_id: "${dataOrDash(id)}"`}
+              >
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(id)}
                 </EuiTextColor>
@@ -226,13 +274,19 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
           },
           {
             title: <DetailPanelListItem>args</DetailPanelListItem>,
-            description: <DetailPanelCopy textToCopy={processArgs}>{processArgs}</DetailPanelCopy>,
+            description: (
+              <DetailPanelCopy textToCopy={`${PROCESS_FIELD_PREFIX}.args: "${processArgs}"`}>
+                {processArgs}
+              </DetailPanelCopy>
+            ),
           },
           {
             title: <DetailPanelListItem>executable</DetailPanelListItem>,
             description: (
               <DetailPanelCopy
-                textToCopy={getProcessExecutableCopyText(executable)}
+                textToCopy={`${PROCESS_FIELD_PREFIX}.executable: "${getProcessExecutableCopyText(
+                  executable
+                )}"`}
                 display="block"
               >
                 {executable.map((execTuple, idx) => {
@@ -254,7 +308,9 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
           {
             title: <DetailPanelListItem>interactive</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={isInteractive}>
+              <DetailPanelCopy
+                textToCopy={`${PROCESS_FIELD_PREFIX}.interactive: "${isInteractive}"`}
+              >
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {isInteractive}
                 </EuiTextColor>
@@ -264,7 +320,11 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
           {
             title: <DetailPanelListItem>working_directory</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={workingDirectory}>
+              <DetailPanelCopy
+                textToCopy={`${PROCESS_FIELD_PREFIX}.working_directory: "${dataOrDash(
+                  workingDirectory
+                )}"`}
+              >
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(workingDirectory)}
                 </EuiTextColor>
@@ -274,7 +334,7 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
           {
             title: <DetailPanelListItem>pid</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={pid}>
+              <DetailPanelCopy textToCopy={`${PROCESS_FIELD_PREFIX}.pid: "${dataOrDash(pid)}"`}>
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(pid)}
                 </EuiTextColor>
@@ -283,16 +343,26 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
           },
           {
             title: <DetailPanelListItem>start</DetailPanelListItem>,
-            description: <DetailPanelCopy textToCopy={start}>{dataOrDash(start)}</DetailPanelCopy>,
+            description: (
+              <DetailPanelCopy textToCopy={`${PROCESS_FIELD_PREFIX}.start: "${dataOrDash(start)}"`}>
+                {dataOrDash(start)}
+              </DetailPanelCopy>
+            ),
           },
           {
             title: <DetailPanelListItem>end</DetailPanelListItem>,
-            description: <DetailPanelCopy textToCopy={end}>{dataOrDash(end)}</DetailPanelCopy>,
+            description: (
+              <DetailPanelCopy textToCopy={`${PROCESS_FIELD_PREFIX}.end: "${dataOrDash(end)}"`}>
+                {dataOrDash(end)}
+              </DetailPanelCopy>
+            ),
           },
           {
             title: <DetailPanelListItem>exit_code</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={exitCode}>
+              <DetailPanelCopy
+                textToCopy={`${PROCESS_FIELD_PREFIX}.exit_code: "${dataOrDash(exitCode)}"`}
+              >
                 <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
                   {dataOrDash(exitCode)}
                 </EuiTextColor>
@@ -302,13 +372,21 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
           {
             title: <DetailPanelListItem>user.name</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={userName}>{dataOrDash(userName)}</DetailPanelCopy>
+              <DetailPanelCopy
+                textToCopy={`${PROCESS_FIELD_PREFIX}.user.name: "${dataOrDash(userName)}"`}
+              >
+                {dataOrDash(userName)}
+              </DetailPanelCopy>
             ),
           },
           {
             title: <DetailPanelListItem>group.name</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={groupName}>{dataOrDash(groupName)}</DetailPanelCopy>
+              <DetailPanelCopy
+                textToCopy={`${PROCESS_FIELD_PREFIX}.group.name: "${dataOrDash(groupName)}"`}
+              >
+                {dataOrDash(groupName)}
+              </DetailPanelCopy>
             ),
           },
         ]}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[8.2.1] [Session View] Add process fields name to text to copy (#131167)](https://github.com/elastic/kibana/pull/131167)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)