### PR TITLE
[8.2] [ML] Fixing management app docs links (#130776)

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -384,6 +384,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       regressionEvaluation: `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/ml-dfa-regression.html#ml-dfanalytics-regression-evaluation`,
       classificationAucRoc: `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/ml-dfa-classification.html#ml-dfanalytics-class-aucroc`,
       setUpgradeMode: `${ELASTICSEARCH_DOCS}ml-set-upgrade-mode.html`,
+      trainedModels: `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/ml-trained-models.html`,
     },
     transforms: {
       guide: `${ELASTICSEARCH_DOCS}transforms.html`,

--- a/x-pack/plugins/ml/public/application/management/breadcrumbs.ts
+++ b/x-pack/plugins/ml/public/application/management/breadcrumbs.ts
@@ -11,8 +11,8 @@ import { JOBS_LIST_PATH } from './management_urls';
 export function getJobsListBreadcrumbs() {
   return [
     {
-      text: i18n.translate('xpack.ml.jobsList.breadcrumb', {
-        defaultMessage: 'Jobs',
+      text: i18n.translate('xpack.ml.management.breadcrumb', {
+        defaultMessage: 'Machine Learning',
       }),
       href: `#${JOBS_LIST_PATH}`,
     },

--- a/x-pack/plugins/ml/public/application/management/jobs_list/components/jobs_list_page/jobs_list_page.tsx
+++ b/x-pack/plugins/ml/public/application/management/jobs_list/components/jobs_list_page/jobs_list_page.tsx
@@ -34,7 +34,6 @@ import {
   RedirectAppLinks,
 } from '../../../../../../../../../src/plugins/kibana_react/public';
 
-import { getDocLinks } from '../../../../util/dependency_cache';
 // @ts-ignore undeclared module
 import { JobsListView } from '../../../../jobs/jobs_list/components/jobs_list_view/index';
 import { DataFrameAnalyticsList } from '../../../../data_frame_analytics/pages/analytics_management/components/analytics_list';
@@ -54,6 +53,7 @@ import { getDefaultDFAListState } from '../../../../data_frame_analytics/pages/a
 import { ExportJobsFlyout, ImportJobsFlyout } from '../../../../components/import_export_jobs';
 import type { JobType, MlSavedObjectType } from '../../../../../../common/types/saved_objects';
 import type { FieldFormatsStart } from '../../../../../../../../../src/plugins/field_formats/public';
+import { useMlKibana } from '../../../../contexts/kibana';
 
 interface Tab extends EuiTabbedContentTab {
   'data-test-subj': string;
@@ -201,30 +201,6 @@ export const JobsListPage: FC<{
     return null;
   }
 
-  const anomalyDetectionJobsUrl = getDocLinks().links.ml.anomalyDetectionJobs;
-  const dataFrameAnalyticsUrl = getDocLinks().links.ml.dataFrameAnalytics;
-
-  const anomalyDetectionDocsLabel = i18n.translate(
-    'xpack.ml.management.jobsList.anomalyDetectionDocsLabel',
-    {
-      defaultMessage: 'Anomaly detection jobs docs',
-    }
-  );
-  const analyticsDocsLabel = i18n.translate('xpack.ml.management.jobsList.analyticsDocsLabel', {
-    defaultMessage: 'Analytics jobs docs',
-  });
-
-  const docsLink = (
-    <EuiButtonEmpty
-      href={currentTabId === 'anomaly-detector' ? anomalyDetectionJobsUrl : dataFrameAnalyticsUrl}
-      target="_blank"
-      iconType="help"
-      data-test-subj="documentationLink"
-    >
-      {currentTabId === 'anomaly-detector' ? anomalyDetectionDocsLabel : analyticsDocsLabel}
-    </EuiButtonEmpty>
-  );
-
   function renderTabs() {
     return (
       <EuiTabbedContent
@@ -280,7 +256,7 @@ export const JobsListPage: FC<{
                       defaultMessage="View, export, and import machine learning analytics and anomaly detection items."
                     />
                   }
-                  rightSideItems={[docsLink]}
+                  rightSideItems={[<DocsLink currentTabId={currentTabId} />]}
                   bottomBorder
                 />
 
@@ -327,5 +303,37 @@ export const JobsListPage: FC<{
         </KibanaThemeProvider>
       </I18nContext>
     </RedirectAppLinks>
+  );
+};
+
+const DocsLink: FC<{ currentTabId: MlSavedObjectType }> = ({ currentTabId }) => {
+  const {
+    services: {
+      docLinks: {
+        links: { ml },
+      },
+    },
+  } = useMlKibana();
+
+  let href = ml.anomalyDetectionJobs;
+  let linkLabel = i18n.translate('xpack.ml.management.jobsList.anomalyDetectionDocsLabel', {
+    defaultMessage: 'Anomaly detection jobs docs',
+  });
+
+  if (currentTabId === 'data-frame-analytics') {
+    href = ml.dataFrameAnalytics;
+    linkLabel = i18n.translate('xpack.ml.management.jobsList.analyticsDocsLabel', {
+      defaultMessage: 'Analytics jobs docs',
+    });
+  } else if (currentTabId === 'trained-model') {
+    href = ml.trainedModels;
+    linkLabel = i18n.translate('xpack.ml.management.jobsList.trainedModelsDocsLabel', {
+      defaultMessage: 'Trained models docs',
+    });
+  }
+  return (
+    <EuiButtonEmpty href={href} target="_blank" iconType="help" data-test-subj="documentationLink">
+      {linkLabel}
+    </EuiButtonEmpty>
   );
 };

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -18717,7 +18717,6 @@
     "xpack.ml.jobsList.alertingRules.tooltipContent": "La tâche a {rulesCount} {rulesCount, plural, one { règle d'alerte associée} other { règles d'alerte associées}}",
     "xpack.ml.jobsList.analyticsSpacesLabel": "Espaces",
     "xpack.ml.jobsList.auditMessageColumn.screenReaderDescription": "Cette colonne affiche des icônes lorsque des erreurs ou des avertissements pour la tâche ont été signalé(e)s au cours des dernières 24 heures",
-    "xpack.ml.jobsList.breadcrumb": "Tâches",
     "xpack.ml.jobsList.cannotSelectRowForJobMessage": "Impossible de sélectionner l'ID de tâche {jobId}",
     "xpack.ml.jobsList.cloneJobErrorMessage": "Impossible de cloner {jobId}. La tâche est introuvable",
     "xpack.ml.jobsList.closeActionStatusText": "fermer",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -18863,7 +18863,6 @@
     "xpack.ml.jobsList.alertingRules.tooltipContent": "ジョブ{rulesCount}はアラート{rulesCount, plural, other  { ルール}}に関連付けられています",
     "xpack.ml.jobsList.analyticsSpacesLabel": "スペース",
     "xpack.ml.jobsList.auditMessageColumn.screenReaderDescription": "この列は、過去24時間にエラーまたは警告があった場合にアイコンを表示します",
-    "xpack.ml.jobsList.breadcrumb": "ジョブ",
     "xpack.ml.jobsList.cannotSelectRowForJobMessage": "ジョブID {jobId}を選択できません",
     "xpack.ml.jobsList.cloneJobErrorMessage": "{jobId} のクローンを作成できませんでした。ジョブが見つかりませんでした",
     "xpack.ml.jobsList.closeActionStatusText": "閉じる",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -18890,7 +18890,6 @@
     "xpack.ml.jobsList.alertingRules.tooltipContent": "作业具有 {rulesCount} 个关联的告警{rulesCount, plural, other {规则}}",
     "xpack.ml.jobsList.analyticsSpacesLabel": "工作区",
     "xpack.ml.jobsList.auditMessageColumn.screenReaderDescription": "过去 24 小时里该作业有错误或警告时，此列显示图标",
-    "xpack.ml.jobsList.breadcrumb": "作业",
     "xpack.ml.jobsList.cannotSelectRowForJobMessage": "无法选择作业 ID {jobId}",
     "xpack.ml.jobsList.cloneJobErrorMessage": "无法克隆 {jobId}。找不到作业",
     "xpack.ml.jobsList.closeActionStatusText": "关闭",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[ML] Fixing management app docs links (#130776)](https://github.com/elastic/kibana/pull/130776)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)