### PR TITLE
[storybook] Watch for changes in packages

### DIFF
--- a/packages/kbn-storybook/src/lib/default_config.ts
+++ b/packages/kbn-storybook/src/lib/default_config.ts
@@ -18,7 +18,7 @@ const toPath = (_path: string) => path.join(REPO_ROOT, _path);
 // This ignore pattern excludes all of node_modules EXCEPT for `@kbn`.  This allows for
 // changes to packages to cause a refresh in Storybook.
 const IGNORE_PATTERN =
-  '[/\\]node_modules[/\\](?!@kbn[/\\][^/\\]+[/\\](?!node_modules)([^/\\]+))([^/\\]+[/\\][^/\\]+)';
+  /[/\\]node_modules[/\\](?!@kbn[/\\][^/\\]+[/\\](?!node_modules)([^/\\]+))([^/\\]+[/\\][^/\\]+)/;
 
 export const defaultConfig: StorybookConfig = {
   addons: ['@kbn/storybook/preset', '@storybook/addon-a11y', '@storybook/addon-essentials'],

--- a/packages/kbn-storybook/src/lib/default_config.ts
+++ b/packages/kbn-storybook/src/lib/default_config.ts
@@ -14,6 +14,12 @@ import { REPO_ROOT } from './constants';
 import { default as WebpackConfig } from '../webpack.config';
 
 const toPath = (_path: string) => path.join(REPO_ROOT, _path);
+
+// This ignore pattern excludes all of node_modules EXCEPT for `@kbn`.  This allows for
+// changes to packages to cause a refresh in Storybook.
+const IGNORE_PATTERN =
+  '[/\\]node_modules[/\\](?!@kbn[/\\][^/\\]+[/\\](?!node_modules)([^/\\]+))([^/\\]+[/\\][^/\\]+)';
+
 export const defaultConfig: StorybookConfig = {
   addons: ['@kbn/storybook/preset', '@storybook/addon-a11y', '@storybook/addon-essentials'],
   stories: ['../**/*.stories.tsx', '../**/*.stories.mdx'],
@@ -45,6 +51,11 @@ export const defaultConfig: StorybookConfig = {
     }
 
     config.node = { fs: 'empty' };
+    config.watch = true;
+    config.watchOptions = {
+      ...config.watchOptions,
+      ignored: [IGNORE_PATTERN],
+    };
 
     // Remove when @storybook has moved to @emotion v11
     // https://github.com/storybookjs/storybook/issues/13145


### PR DESCRIPTION
## Summary

As titled.  This change allows Storybook to reload when a package is compiled while Storybook is running.

## To use

1. In a terminal, run `yarn kbn watch`.
2. Start Storybook.
3. Change a file in a package.
4. Storybook refreshes its page.


