### PR TITLE
[8.2] Make only a single api request for exceptions when opening an alert in timeline (#130941)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,638 @@
+# GitHub CODEOWNERS definition
+# Identify which groups will be pinged by changes to different parts of the codebase.
+# For more info, see https://help.github.com/articles/about-codeowners/
+
+# The #CC# prefix delineates Code Coverage,
+# used for the 'team' designator within Kibana Stats
+
+# Virtual teams
+/x-pack/plugins/rule_registry/ @elastic/rac @elastic/response-ops
+
+# Data Discovery
+/src/plugins/discover/ @elastic/kibana-data-discovery
+/x-pack/plugins/discover_enhanced/ @elastic/kibana-data-discovery
+/test/functional/apps/discover/ @elastic/kibana-data-discovery
+/x-pack/plugins/graph/ @elastic/kibana-data-discovery
+/x-pack/test/functional/apps/graph @elastic/kibana-data-discovery
+
+# Vis Editors
+/x-pack/plugins/lens/ @elastic/kibana-vis-editors
+/src/plugins/charts/ @elastic/kibana-vis-editors
+/src/plugins/vis_default_editor/ @elastic/kibana-vis-editors
+/src/plugins/vis_types/metric/ @elastic/kibana-vis-editors
+/src/plugins/vis_types/table/ @elastic/kibana-vis-editors
+/src/plugins/vis_types/tagcloud/ @elastic/kibana-vis-editors
+/src/plugins/vis_types/timelion/ @elastic/kibana-vis-editors
+/src/plugins/vis_types/timeseries/ @elastic/kibana-vis-editors
+/src/plugins/vis_types/vega/ @elastic/kibana-vis-editors
+/src/plugins/vis_types/vislib/ @elastic/kibana-vis-editors
+/src/plugins/vis_types/xy/ @elastic/kibana-vis-editors
+/src/plugins/vis_types/pie/ @elastic/kibana-vis-editors
+/src/plugins/vis_types/heatmap/ @elastic/kibana-vis-editors
+/src/plugins/visualize/ @elastic/kibana-vis-editors
+/src/plugins/visualizations/ @elastic/kibana-vis-editors
+/src/plugins/chart_expressions/expression_tagcloud/ @elastic/kibana-vis-editors
+/src/plugins/chart_expressions/expression_metric/ @elastic/kibana-vis-editors
+/src/plugins/chart_expressions/expression_heatmap/ @elastic/kibana-vis-editors
+/src/plugins/chart_expressions/expression_gauge/ @elastic/kibana-vis-editors
+/src/plugins/chart_expressions/expression_partition_vis/ @elastic/kibana-vis-editors
+/src/plugins/chart_expressions/expression_xy/ @elastic/kibana-vis-editors
+/src/plugins/url_forwarding/ @elastic/kibana-vis-editors
+/packages/kbn-tinymath/ @elastic/kibana-vis-editors
+/x-pack/test/functional/apps/lens @elastic/kibana-vis-editors
+/test/functional/apps/visualize/ @elastic/kibana-vis-editors
+
+# Application Services
+/examples/bfetch_explorer/ @elastic/kibana-app-services
+/examples/dashboard_embeddable_examples/ @elastic/kibana-app-services
+/examples/demo_search/ @elastic/kibana-app-services
+/examples/developer_examples/ @elastic/kibana-app-services
+/examples/embeddable_examples/ @elastic/kibana-app-services
+/examples/embeddable_explorer/ @elastic/kibana-app-services
+/examples/state_containers_examples/ @elastic/kibana-app-services
+/examples/ui_action_examples/ @elastic/kibana-app-services
+/examples/ui_actions_explorer/ @elastic/kibana-app-services
+/examples/field_formats_example/ @elastic/kibana-app-services
+/examples/partial_results_example/ @elastic/kibana-app-services
+/examples/search_examples/ @elastic/kibana-app-services
+/packages/kbn-datemath/ @elastic/kibana-app-services
+/packages/kbn-interpreter/ @elastic/kibana-app-services
+/packages/kbn-react-field/ @elastic/kibana-app-services
+/packages/kbn-es-query/ @elastic/kibana-app-services
+/packages/kbn-field-types/ @elastic/kibana-app-services
+/src/plugins/bfetch/ @elastic/kibana-app-services
+/src/plugins/data/ @elastic/kibana-app-services
+/src/plugins/data_views/ @elastic/kibana-app-services
+/src/plugins/embeddable/ @elastic/kibana-app-services
+/src/plugins/expressions/ @elastic/kibana-app-services
+/src/plugins/field_formats/ @elastic/kibana-app-services
+/src/plugins/data_view_editor/ @elastic/kibana-app-services
+/src/plugins/inspector/ @elastic/kibana-app-services
+/src/plugins/kibana_utils/ @elastic/kibana-app-services
+/src/plugins/navigation/ @elastic/kibana-app-services
+/src/plugins/share/ @elastic/kibana-app-services
+/src/plugins/ui_actions/ @elastic/kibana-app-services
+/src/plugins/data_view_field_editor @elastic/kibana-app-services
+/src/plugins/screenshot_mode @elastic/kibana-app-services
+/src/plugins/bfetch/ @elastic/kibana-app-services
+/src/plugins/data_view_management/ @elastic/kibana-app-services
+/src/plugins/inspector/ @elastic/kibana-app-services
+/src/plugins/unified_search/ @elastic/kibana-app-services
+/x-pack/examples/ui_actions_enhanced_examples/ @elastic/kibana-app-services
+/x-pack/plugins/data_enhanced/ @elastic/kibana-app-services
+/x-pack/plugins/embeddable_enhanced/ @elastic/kibana-app-services
+/x-pack/plugins/ui_actions_enhanced/ @elastic/kibana-app-services
+/x-pack/plugins/runtime_fields @elastic/kibana-app-services
+/x-pack/test/search_sessions_integration/ @elastic/kibana-app-services
+
+### Observability Plugins
+
+# Observability Shared
+/x-pack/plugins/observability/public/components/shared/date_picker/ @elastic/uptime
+
+# Unified Observability
+/x-pack/plugins/observability/public/components/shared/exploratory_view @elastic/unified-observability
+/x-pack/plugins/observability/public/context @elastic/unified-observability
+/x-pack/plugins/observability/public/pages/home @elastic/unified-observability
+/x-pack/plugins/observability/public/pages/landing @elastic/unified-observability
+/x-pack/plugins/observability/public/pages/overview @elastic/unified-observability
+
+# Actionable Observability
+/x-pack/plugins/observability/common/rules @elastic/actionable-observability
+/x-pack/plugins/observability/public/rules @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/alerts @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/cases  @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/rules  @elastic/actionable-observability
+
+# Infra Monitoring
+/x-pack/plugins/infra/ @elastic/infra-monitoring-ui
+/x-pack/test/functional/apps/infra @elastic/infra-monitoring-ui
+/x-pack/test/api_integration/apis/infra @elastic/infra-monitoring-ui
+
+# Elastic Stack Monitoring
+/x-pack/plugins/monitoring/ @elastic/infra-monitoring-ui
+/x-pack/test/functional/apps/monitoring @elastic/infra-monitoring-ui
+/x-pack/test/api_integration/apis/monitoring @elastic/infra-monitoring-ui
+
+# Fleet
+/fleet_packages.json @elastic/fleet
+/x-pack/plugins/fleet/ @elastic/fleet
+/x-pack/test/fleet_api_integration @elastic/fleet
+/x-pack/test/fleet_cypress @elastic/fleet
+/x-pack/test/fleet_functional @elastic/fleet
+
+# APM
+/x-pack/plugins/apm/  @elastic/apm-ui
+/x-pack/test/functional/apps/apm/  @elastic/apm-ui
+/x-pack/test/apm_api_integration/ @elastic/apm-ui
+/src/plugins/apm_oss/  @elastic/apm-ui
+/src/apm.js @elastic/kibana-core @vigneshshanmugam
+/packages/kbn-apm-config-loader/ @elastic/kibana-core @vigneshshanmugam
+/src/core/types/elasticsearch @elastic/apm-ui
+#CC# /src/plugins/apm_oss/ @elastic/apm-ui
+#CC# /x-pack/plugins/observability/ @elastic/apm-ui
+
+# Uptime
+/x-pack/plugins/synthetics @elastic/uptime
+/x-pack/plugins/ux @elastic/uptime
+/x-pack/test/functional_with_es_ssl/apps/uptime  @elastic/uptime
+/x-pack/test/functional/apps/uptime @elastic/uptime
+/x-pack/test/functional/es_archives/uptime @elastic/uptime
+/x-pack/test/functional/services/uptime @elastic/uptime
+/x-pack/test/api_integration/apis/uptime @elastic/uptime
+
+# Client Side Monitoring / Uptime (lives in APM directories but owned by Uptime)
+/x-pack/plugins/apm/public/application/uxApp.tsx @elastic/uptime
+/x-pack/plugins/apm/public/components/app/rum_dashboard @elastic/uptime
+/x-pack/plugins/apm/server/lib/rum_client @elastic/uptime
+/x-pack/plugins/apm/server/routes/rum_client.ts @elastic/uptime
+/x-pack/plugins/apm/server/projections/rum_page_load_transactions.ts @elastic/uptime
+/x-pack/test/apm_api_integration/tests/csm/ @elastic/uptime
+
+### END Observability Plugins
+
+# Presentation
+/src/plugins/dashboard/ @elastic/kibana-presentation
+/src/plugins/expression_error/ @elastic/kibana-presentation
+/src/plugins/expression_image/ @elastic/kibana-presentation
+/src/plugins/expression_metric/ @elastic/kibana-presentation
+/src/plugins/expression_repeat_image/ @elastic/kibana-presentation
+/src/plugins/expression_reveal_image/ @elastic/kibana-presentation
+/src/plugins/expression_shape/ @elastic/kibana-presentation
+/src/plugins/input_control_vis/ @elastic/kibana-presentation
+/src/plugins/vis_type_markdown/ @elastic/kibana-presentation
+/src/plugins/presentation_util/ @elastic/kibana-presentation
+/src/plugins/controls/ @elastic/kibana-presentation
+/test/functional/apps/dashboard/  @elastic/kibana-presentation
+/test/functional/apps/dashboard_elements/  @elastic/kibana-presentation
+/x-pack/plugins/canvas/  @elastic/kibana-presentation
+/x-pack/plugins/dashboard_enhanced/ @elastic/kibana-presentation
+/x-pack/test/functional/apps/canvas/  @elastic/kibana-presentation
+#CC# /src/plugins/kibana_react/public/code_editor/ @elastic/kibana-presentation
+
+# Machine Learning
+/x-pack/plugins/ml/  @elastic/ml-ui
+/x-pack/test/accessibility/apps/ml.ts  @elastic/ml-ui
+/x-pack/test/accessibility/apps/ml_embeddables_in_dashboard.ts  @elastic/ml-ui
+/x-pack/test/api_integration/apis/ml/ @elastic/ml-ui
+/x-pack/test/api_integration_basic/apis/ml/ @elastic/ml-ui
+/x-pack/test/functional/apps/ml/  @elastic/ml-ui
+/x-pack/test/functional/es_archives/ml/  @elastic/ml-ui
+/x-pack/test/functional/services/ml/  @elastic/ml-ui
+/x-pack/test/functional_basic/apps/ml/ @elastic/ml-ui
+/x-pack/test/functional_with_es_ssl/apps/ml/ @elastic/ml-ui
+/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/ml_rule_types/ @elastic/ml-ui
+/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/transform_rule_types/ @elastic/ml-ui
+/x-pack/test/screenshot_creation/apps/ml_docs @elastic/ml-ui
+/x-pack/test/screenshot_creation/services/ml_screenshots.ts @elastic/ml-ui
+
+# ML team owns and maintains the transform plugin despite it living in the Data management section.
+/x-pack/plugins/transform/  @elastic/ml-ui
+/x-pack/plugins/data_visualizer/ @elastic/ml-ui
+/x-pack/plugins/file_upload/ @elastic/ml-ui
+/x-pack/test/accessibility/apps/transform.ts  @elastic/ml-ui
+/x-pack/test/api_integration/apis/transform/ @elastic/ml-ui
+/x-pack/test/api_integration_basic/apis/transform/ @elastic/ml-ui
+/x-pack/test/functional/apps/transform/ @elastic/ml-ui
+/x-pack/test/functional/services/transform/ @elastic/ml-ui
+/x-pack/test/functional_basic/apps/transform/ @elastic/ml-ui
+
+# Maps
+#CC# /x-pack/plugins/maps/ @elastic/kibana-gis
+/x-pack/plugins/maps/ @elastic/kibana-gis
+/x-pack/test/api_integration/apis/maps/ @elastic/kibana-gis
+/x-pack/test/functional/apps/maps/ @elastic/kibana-gis
+/x-pack/test/functional/es_archives/maps/ @elastic/kibana-gis
+/x-pack/test/visual_regression/tests/maps/index.js @elastic/kibana-gis
+/x-pack/plugins/stack_alerts/server/alert_types/geo_containment @elastic/kibana-gis
+/x-pack/plugins/stack_alerts/public/alert_types/geo_containment @elastic/kibana-gis
+#CC# /x-pack/plugins/file_upload @elastic/kibana-gis
+/x-pack/plugins/file_upload @elastic/kibana-gis
+/packages/kbn-mapbox-gl @elastic/kibana-gis
+
+# Operations
+/src/dev/license_checker/config.ts @elastic/kibana-operations
+/packages/kbn-docs-utils/ @elastic/kibana-operations
+/src/dev/ @elastic/kibana-operations
+/src/setup_node_env/ @elastic/kibana-operations
+/packages/*eslint*/ @elastic/kibana-operations
+/packages/*babel*/ @elastic/kibana-operations
+/packages/kbn-ambient-ui-types/ @elastic/kibana-operations
+/packages/kbn-ambient-storybook-types/ @elastic/kibana-operations
+/packages/kbn-bazel-packages/ @elastic/kibana-operations
+/packages/kbn-bazel-runner/ @elastic/kibana-operations
+/packages/kbn-cli-dev-mode/ @elastic/kibana-operations
+/packages/kbn-dev-utils*/ @elastic/kibana-operations
+/packages/kbn-es-archiver/ @elastic/kibana-operations
+/packages/kbn-es/ @elastic/kibana-operations
+/packages/kbn-eslint-plugin-imports/ @elastic/kibana-operations
+/packages/kbn-generate/ @elastic/kibana-operations
+/packages/kbn-import-resolver/ @elastic/kibana-operations
+/packages/kbn-optimizer/ @elastic/kibana-operations
+/packages/kbn-plugin-discovery/ @elastic/kibana-operations
+/packages/kbn-pm/ @elastic/kibana-operations
+/packages/kbn-test/ @elastic/kibana-operations
+/packages/kbn-type-summarizer/ @elastic/kibana-operations
+/packages/kbn-ui-shared-deps-npm/ @elastic/kibana-operations
+/packages/kbn-ui-shared-deps-src/ @elastic/kibana-operations
+/packages/kbn-utils/ @elastic/kibana-operations
+/src/cli/keystore/ @elastic/kibana-operations
+/.ci/es-snapshots/ @elastic/kibana-operations
+/.github/workflows/ @elastic/kibana-operations
+/vars/ @elastic/kibana-operations
+/.bazelignore @elastic/kibana-operations
+/.bazeliskversion @elastic/kibana-operations
+/.bazelrc @elastic/kibana-operations
+/.bazelrc.common @elastic/kibana-operations
+/.bazelversion @elastic/kibana-operations
+/WORKSPACE.bazel @elastic/kibana-operations
+#CC# /packages/kbn-expect/ @elastic/kibana-operations
+/.buildkite/ @elastic/kibana-operations
+
+# Quality Assurance
+/src/dev/code_coverage @elastic/kibana-qa
+/vars/*Coverage.groovy @elastic/kibana-qa
+/test/functional/services/common @elastic/kibana-qa
+/test/functional/services/lib @elastic/kibana-qa
+/test/functional/services/remote @elastic/kibana-qa
+
+# Core
+/examples/hello_world/ @elastic/kibana-core
+/src/core/  @elastic/kibana-core
+/src/plugins/saved_objects_tagging_oss  @elastic/kibana-core
+/config/kibana.yml @elastic/kibana-core
+/typings/ @elastic/kibana-core
+/x-pack/plugins/banners/  @elastic/kibana-core
+/x-pack/plugins/features/  @elastic/kibana-core
+/x-pack/plugins/licensing/  @elastic/kibana-core
+/x-pack/plugins/global_search/  @elastic/kibana-core
+/x-pack/plugins/cloud/ @elastic/kibana-core
+/x-pack/plugins/saved_objects_tagging/ @elastic/kibana-core
+/x-pack/test/saved_objects_field_count/ @elastic/kibana-core
+/x-pack/test/saved_object_tagging/ @elastic/kibana-core
+/packages/analytics/ @elastic/kibana-core
+/packages/kbn-config-schema/ @elastic/kibana-core
+/packages/kbn-std/ @elastic/kibana-core
+/packages/kbn-config/ @elastic/kibana-core
+/packages/kbn-logging/ @elastic/kibana-core
+/packages/kbn-logging-mocks/ @elastic/kibana-core
+/packages/kbn-http-tools/ @elastic/kibana-core
+/src/plugins/saved_objects_management/ @elastic/kibana-core
+/src/dev/run_check_published_api_changes.ts @elastic/kibana-core
+/src/plugins/home/public @elastic/kibana-core
+/src/plugins/home/server/*.ts @elastic/kibana-core
+/src/plugins/home/server/services/ @elastic/kibana-core
+/src/plugins/kibana_overview/ @elastic/kibana-core
+/src/plugins/advanced_settings/ @elastic/kibana-core
+/x-pack/plugins/global_search_bar/ @elastic/kibana-core
+#CC# /src/core/server/csp/ @elastic/kibana-core
+#CC# /src/plugins/saved_objects/ @elastic/kibana-core
+#CC# /x-pack/plugins/cloud/ @elastic/kibana-core
+#CC# /x-pack/plugins/features/ @elastic/kibana-core
+#CC# /x-pack/plugins/global_search/ @elastic/kibana-core
+#CC# /src/plugins/newsfeed @elastic/kibana-core
+#CC# /src/plugins/home/public @elastic/kibana-core
+#CC# /src/plugins/home/server/services/ @elastic/kibana-core
+#CC# /src/plugins/home/ @elastic/kibana-core
+#CC# /x-pack/plugins/global_search_providers/ @elastic/kibana-core
+
+# Kibana Docs
+/packages/kbn-doc-links/ @elastic/kibana-docs
+
+# Kibana Telemetry
+/packages/kbn-analytics/ @elastic/kibana-core
+/packages/kbn-telemetry-tools/ @elastic/kibana-core
+/src/plugins/kibana_usage_collection/ @elastic/kibana-core
+/src/plugins/newsfeed/ @elastic/kibana-core
+/src/plugins/telemetry/ @elastic/kibana-core
+/src/plugins/telemetry_collection_manager/ @elastic/kibana-core
+/src/plugins/telemetry_management_section/ @elastic/kibana-core
+/src/plugins/usage_collection/ @elastic/kibana-core
+/x-pack/plugins/telemetry_collection_xpack/ @elastic/kibana-core
+/.telemetryrc.json @elastic/kibana-core
+/x-pack/.telemetryrc.json @elastic/kibana-core
+/src/plugins/telemetry/schema/ @elastic/kibana-core @elastic/kibana-telemetry
+/x-pack/plugins/telemetry_collection_xpack/schema/ @elastic/kibana-core @elastic/kibana-telemetry
+
+# Kibana Localization
+/src/dev/i18n/  @elastic/kibana-localization @elastic/kibana-core
+/src/core/public/i18n/  @elastic/kibana-localization @elastic/kibana-core
+/packages/kbn-i18n/  @elastic/kibana-localization @elastic/kibana-core
+#CC# /x-pack/plugins/translations/ @elastic/kibana-localization @elastic/kibana-core
+
+# Kibana Platform Security
+/packages/kbn-crypto/ @elastic/kibana-security
+/src/core/server/csp/ @elastic/kibana-security @elastic/kibana-core
+/src/plugins/interactive_setup/ @elastic/kibana-security
+/test/interactive_setup_api_integration/ @elastic/kibana-security
+/test/interactive_setup_functional/ @elastic/kibana-security
+/test/plugin_functional/test_suites/core_plugins/rendering.ts @elastic/kibana-security
+/x-pack/plugins/spaces/ @elastic/kibana-security
+/x-pack/plugins/encrypted_saved_objects/ @elastic/kibana-security
+/x-pack/plugins/security/ @elastic/kibana-security
+/x-pack/test/api_integration/apis/security/ @elastic/kibana-security
+/x-pack/test/api_integration/apis/spaces/ @elastic/kibana-security
+/x-pack/test/ui_capabilities/ @elastic/kibana-security
+/x-pack/test/encrypted_saved_objects_api_integration/ @elastic/kibana-security
+/x-pack/test/functional/apps/security/ @elastic/kibana-security
+/x-pack/test/functional/apps/spaces/ @elastic/kibana-security
+/x-pack/test/security_api_integration/ @elastic/kibana-security
+/x-pack/test/security_functional/ @elastic/kibana-security
+/x-pack/test/spaces_api_integration/ @elastic/kibana-security
+/x-pack/test/saved_object_api_integration/ @elastic/kibana-security
+/src/core/server/csp/ @elastic/kibana-security @elastic/kibana-core
+/examples/preboot_example/ @elastic/kibana-security @elastic/kibana-core
+#CC# /x-pack/plugins/security/ @elastic/kibana-security
+
+# Response Ops team
+/x-pack/plugins/alerting/ @elastic/response-ops
+/x-pack/plugins/actions/ @elastic/response-ops
+/x-pack/plugins/event_log/ @elastic/response-ops
+/x-pack/plugins/task_manager/ @elastic/response-ops
+/x-pack/test/alerting_api_integration/ @elastic/response-ops
+/x-pack/test/plugin_api_integration/test_suites/task_manager/ @elastic/response-ops
+/x-pack/plugins/triggers_actions_ui/ @elastic/response-ops
+/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/ @elastic/response-ops
+/x-pack/test/functional_with_es_ssl/fixtures/plugins/alerts/ @elastic/response-ops
+/docs/user/alerting/ @elastic/response-ops @elastic/mlr-docs
+/docs/management/connectors/ @elastic/response-ops @elastic/mlr-docs
+#CC# /x-pack/plugins/stack_alerts @elastic/response-ops
+/x-pack/plugins/cases/ @elastic/response-ops
+/x-pack/test/cases_api_integration/ @elastic/response-ops
+/x-pack/test/functional/services/cases/ @elastic/response-ops
+/x-pack/test/functional_with_es_ssl/apps/cases/ @elastic/response-ops
+
+# Enterprise Search
+/x-pack/plugins/enterprise_search @elastic/enterprise-search-frontend
+/x-pack/test/functional_enterprise_search/ @elastic/enterprise-search-frontend
+
+# Management Experience - Deployment Management
+/src/plugins/dev_tools/ @elastic/platform-deployment-management
+/src/plugins/console/  @elastic/platform-deployment-management
+/src/plugins/es_ui_shared/  @elastic/platform-deployment-management
+/src/plugins/management/ @elastic/platform-deployment-management
+/x-pack/plugins/cross_cluster_replication/  @elastic/platform-deployment-management
+/x-pack/plugins/index_lifecycle_management/  @elastic/platform-deployment-management
+/x-pack/plugins/grokdebugger/  @elastic/platform-deployment-management
+/x-pack/plugins/index_management/  @elastic/platform-deployment-management
+/x-pack/plugins/license_api_guard/  @elastic/platform-deployment-management
+/x-pack/plugins/license_management/  @elastic/platform-deployment-management
+/x-pack/plugins/painless_lab/  @elastic/platform-deployment-management
+/x-pack/plugins/remote_clusters/  @elastic/platform-deployment-management
+/x-pack/plugins/rollup/  @elastic/platform-deployment-management
+/x-pack/plugins/searchprofiler/  @elastic/platform-deployment-management
+/x-pack/plugins/snapshot_restore/  @elastic/platform-deployment-management
+/x-pack/plugins/upgrade_assistant/  @elastic/platform-deployment-management
+/x-pack/plugins/watcher/  @elastic/platform-deployment-management
+/x-pack/plugins/ingest_pipelines/  @elastic/platform-deployment-management
+/packages/kbn-ace/ @elastic/platform-deployment-management
+/packages/kbn-monaco/ @elastic/platform-deployment-management
+#CC# /x-pack/plugins/cross_cluster_replication/ @elastic/platform-deployment-management
+
+# Security Solution
+/x-pack/test/endpoint_api_integration_no_ingest/ @elastic/security-solution
+/x-pack/test/security_solution_endpoint/ @elastic/security-solution
+/x-pack/test/functional/es_archives/endpoint/ @elastic/security-solution
+/x-pack/test/plugin_functional/plugins/resolver_test/ @elastic/security-solution
+/x-pack/test/plugin_functional/test_suites/resolver/ @elastic/security-solution
+/x-pack/plugins/security_solution/ @elastic/security-solution
+/x-pack/test/detection_engine_api_integration @elastic/security-solution
+/x-pack/test/lists_api_integration @elastic/security-solution
+/x-pack/test/api_integration/apis/security_solution @elastic/security-solution
+#CC# /x-pack/plugins/security_solution/ @elastic/security-solution
+
+# Security Solution sub teams
+
+## Security Solution sub teams - Threat Hunting Investigations
+/x-pack/plugins/timelines @elastic/security-threat-hunting-investigations
+
+/x-pack/plugins/security_solution/common/search_strategy/timeline @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/common/types/timeline @elastic/security-threat-hunting-investigations
+
+/x-pack/plugins/security_solution/cypress/integration/timeline_templates @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/cypress/integration/timeline @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/cypress/integration/detection_alerts @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/cypress/integration/urls @elastic/security-threat-hunting-investigations
+
+/x-pack/plugins/security_solution/public/common/components/alerts_viewer @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_action @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/common/components/event_details @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/common/components/events_viewer @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/common/components/markdown_editor @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/detections/components/alerts_kpis @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/detections/components/alerts_table @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/detections/components/alerts_info @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/resolver @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/timelines @elastic/security-threat-hunting-investigations
+
+/x-pack/plugins/security_solution/server/lib/timeline @elastic/security-threat-hunting-investigations
+
+## Security Solution sub teams - Threat Hunting Explore
+/x-pack/plugins/security_solution/common/search_strategy/security_solution/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/common/search_strategy/security_solution/matrix_histogram @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/common/search_strategy/security_solution/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/common/search_strategy/security_solution/user @elastic/security-threat-hunting-explore
+
+/x-pack/plugins/security_solution/cypress/integration/cases @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/integration/host_details @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/integration/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/integration/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/integration/overview @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/integration/pagination @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/integration/users @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/screens/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/screens/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/tasks/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/tasks/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/upgrade_integration/threat_hunting/cases @elastic/security-threat-hunting-explore
+
+/x-pack/plugins/security_solution/public/common/components/charts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/header_page @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/header_section @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/inspect @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/last_event_time @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/links @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/matrix_histogram @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/navigation @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/news_feed @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/overview_description_list @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/paginated_table @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/sidebar_header @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/stat_items @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/tables @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/top_n @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/with_hover_actions @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/containers/hosts_risk @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/containers/matrix_histogram @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/lib/cell_actions @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/cases @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/overview @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/users @elastic/security-threat-hunting-explore
+
+/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users @elastic/security-threat-hunting-explore
+
+## Security Solution sub teams - Detections and Response Alerts
+/x-pack/plugins/security_solution/public/detections/pages/alerts @elastic/security-detections-response-alerts
+
+/x-pack/plugins/security_solution/server/lib/detection_engine/migrations @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/notifications @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/schemas @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/signals @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals @elastic/security-detections-response-alerts
+
+
+## Security Solution sub teams - Detections and Response Rules
+/x-pack/plugins/security_solution/cypress/integration/detection_rules @elastic/security-detections-response-rules
+
+/x-pack/plugins/security_solution/public/detections/components/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/components/severity @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/components/status @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/common/components/health_truncate_text @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/common/components/links_to_docs @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/common/components/callouts @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/components/callouts @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/mitre @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules @elastic/security-detections-response-rules
+
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_execution_log @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/factories @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/utils @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/tags @elastic/security-detections-response-rules
+
+## Security Solution sub teams - Security Platform
+/x-pack/plugins/lists @elastic/security-solution-platform
+
+/x-pack/plugins/security_solution/cypress/integration/data_sources @elastic/security-solution-platform
+/x-pack/plugins/security_solution/cypress/integration/exceptions @elastic/security-solution-platform
+/x-pack/plugins/security_solution/cypress/integration/value_lists @elastic/security-solution-platform
+
+/x-pack/plugins/security_solution/public/common/components/exceptions @elastic/security-solution-platform
+/x-pack/plugins/security_solution/public/exceptions @elastic/security-solution-platform
+/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists @elastic/security-solution-platform
+/x-pack/plugins/security_solution/public/common/components/sourcerer @elastic/security-solution-platform
+
+/x-pack/plugins/security_solution/server/lib/sourcerer @elastic/security-solution-platform
+/packages/kbn-securitysolution* @elastic/security-solution-platform
+
+## Security Threat Intelligence - Under Security Platform
+/x-pack/plugins/security_solution/public/common/components/threat_match @elastic/security-solution-platform
+
+## Security Solution cross teams ownership
+/x-pack/plugins/security_solution/cypress/downloads @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/fixtures @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/helpers @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/objects @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/plugins @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/support @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/urls @elastic/security-threat-hunting-investigations @elastic/security-solution-platform
+
+/x-pack/plugins/security_solution/screens/common @elastic/security-detections-response @elastic/security-threat-hunting
+
+/x-pack/plugins/security_solution/common/ecs @elastic/security-detections-response-rules @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/common/test @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
+
+/x-pack/plugins/security_solution/public/common/components/hover_actions @elastic/security-threat-hunting-explore @elastic/security-threat-hunting-investigations
+
+/x-pack/plugins/security_solution/server/routes @elastic/security-detections-response-alerts @elastic/security-detections-response-rules
+
+
+## Security Solution sub teams - security-onboarding-and-lifecycle-mgt
+/x-pack/plugins/security_solution/public/management/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/plugins/security_solution/public/common/lib/endpoint*/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/plugins/security_solution/public/common/components/endpoint/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/plugins/security_solution/common/endpoint/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/plugins/security_solution/server/endpoint/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/plugins/security_solution/server/lists_integration/endpoint/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/plugins/security_solution/server/lib/license/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/plugins/security_solution/server/fleet_integration/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/plugins/security_solution/scripts/endpoint/event_filters/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/test/security_solution_endpoint/apps/endpoint/ @elastic/security-onboarding-and-lifecycle-mgt
+/x-pack/test/security_solution_endpoint_api_int/ @elastic/security-onboarding-and-lifecycle-mgt
+
+## Security Solution sub teams - security-telemetry (Data Engineering)
+x-pack/plugins/security_solution/server/usage/ @elastic/security-telemetry
+x-pack/plugins/security_solution/server/lib/telemetry/ @elastic/security-telemetry
+
+## Security Solution sub teams - security-engineering-productivity
+x-pack/plugins/security_solution/cypress/ccs_integration @elastic/security-engineering-productivity
+x-pack/plugins/security_solution/cypress/upgrade_integration @elastic/security-engineering-productivity
+x-pack/plugins/security_solution/cypress/README.md @elastic/security-engineering-productivity
+x-pack/test/security_solution_cypress @elastic/security-engineering-productivity
+
+## Security Solution sub teams - adaptive-workload-protection
+x-pack/plugins/session_view @elastic/awp-platform
+x-pack/plugins/security_solution/public/common/components/sessions_viewer @elastic/awp-platform
+
+# Security Intelligence And Analytics
+/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules @elastic/security-intelligence-analytics
+
+
+# Security Asset Management
+/x-pack/plugins/osquery @elastic/security-asset-management
+
+# Cloud Security Posture
+/x-pack/plugins/cloud_security_posture/ @elastic/kibana-cloud-security-posture
+
+# Design (at the bottom for specificity of SASS files)
+**/*.scss  @elastic/kibana-design
+#CC# /packages/kbn-ui-framework/ @elastic/kibana-design
+
+# Observability design
+/x-pack/plugins/apm/**/*.scss @elastic/observability-design
+/x-pack/plugins/infra/**/*.scss @elastic/observability-design
+/x-pack/plugins/fleet/**/*.scss @elastic/observability-design
+/x-pack/plugins/observability/**/*.scss @elastic/observability-design
+/x-pack/plugins/monitoring/**/*.scss @elastic/observability-design
+
+# Ent. Search design
+/x-pack/plugins/enterprise_search/**/*.scss @elastic/ent-search-design
+
+# Security design
+/x-pack/plugins/endpoint/**/*.scss @elastic/security-design
+/x-pack/plugins/security_solution/**/*.scss @elastic/security-design
+
+# Logstash
+#CC# /x-pack/plugins/logstash/ @elastic/logstash
+
+# Reporting
+/x-pack/examples/reporting_example/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/examples/screenshotting_example/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/plugins/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/apps/dashboard/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/apps/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/apps/reporting_management/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/examples/screenshotting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/es_archives/lens/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/es_archives/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/fixtures/kbn_archiver/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/reporting_api_integration/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/reporting_functional/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/stack_functional_integration/apps/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/docs/user/reporting @elastic/kibana-reporting-services @elastic/kibana-app-services
+/docs/settings/reporting-settings.asciidoc @elastic/kibana-reporting-services @elastic/kibana-app-services
+/docs/setup/configuring-reporting.asciidoc @elastic/kibana-reporting-services @elastic/kibana-app-services
+#CC# /x-pack/plugins/reporting/ @elastic/kibana-reporting-services
+
+# EUI design
+/src/plugins/kibana_react/public/page_template/ @elastic/eui-design @elastic/shared-ux
+
+# Application Experience
+
+## Shared UX
+/src/plugins/shared_ux/ @elastic/shared-ux
+/packages/shared-ux/ @elastic/shared-ux
+/packages/shared-ux-*/ @elastic/shared-ux
+/src/plugins/kibana_react/ @elastic/shared-ux
+/src/plugins/kibana_react/public/code_editor @elastic/shared-ux @elastic/kibana-presentation

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
@@ -14,7 +14,7 @@ import { ALERT_RULE_EXCEPTIONS_LIST } from '@kbn/rule-data-utils';
 import {
   ExceptionListIdentifiers,
   ExceptionListItemSchema,
-  ReadExceptionListSchema,
+  ExceptionListTypeEnum,
 } from '@kbn/securitysolution-io-ts-list-types';
 import { useApi } from '@kbn/securitysolution-list-hooks';
 
@@ -51,48 +51,48 @@ export const useInvestigateInTimeline = ({
 
   const getExceptions = useCallback(
     async (ecsData: Ecs): Promise<ExceptionListItemSchema[]> => {
-      const exceptionsLists: ReadExceptionListSchema[] = (
-        getField(ecsData, ALERT_RULE_EXCEPTIONS_LIST) ?? []
-      )
-        .map((list: string) => JSON.parse(list))
-        .filter((list: ExceptionListIdentifiers) => list.type === 'detection');
+      const exceptionsLists = (getField(ecsData, ALERT_RULE_EXCEPTIONS_LIST) ?? []).reduce(
+        (acc: ExceptionListIdentifiers[], next: string) => {
+          const parsedList = JSON.parse(next);
+          if (parsedList.type === 'detection') {
+            const formattedList = {
+              id: parsedList.id,
+              listId: parsedList.list_id,
+              type: ExceptionListTypeEnum.DETECTION,
+              namespaceType: parsedList.namespace_type,
+            };
+            acc.push(formattedList);
+          }
+          return acc;
+        },
+        []
+      );
 
       const allExceptions: ExceptionListItemSchema[] = [];
 
       if (exceptionsLists.length > 0) {
-        for (const list of exceptionsLists) {
-          if (list.id && list.list_id && list.namespace_type) {
-            await getExceptionListsItems({
-              lists: [
-                {
-                  id: list.id,
-                  listId: list.list_id,
-                  type: 'detection',
-                  namespaceType: list.namespace_type,
-                },
-              ],
-              filterOptions: [],
-              pagination: {
-                page: 0,
-                perPage: 10000,
-                total: 10000,
-              },
-              showDetectionsListsOnly: true,
-              showEndpointListsOnly: false,
-              onSuccess: ({ exceptions }) => {
-                allExceptions.push(...exceptions);
-              },
-              onError: (err: string[]) => {
-                addError(err, {
-                  title: i18n.translate(
-                    'xpack.securitySolution.detectionEngine.alerts.fetchExceptionsFailure',
-                    { defaultMessage: 'Error fetching exceptions.' }
-                  ),
-                });
-              },
+        await getExceptionListsItems({
+          lists: exceptionsLists,
+          filterOptions: [],
+          pagination: {
+            page: 0,
+            perPage: 10000,
+            total: 10000,
+          },
+          showDetectionsListsOnly: true,
+          showEndpointListsOnly: false,
+          onSuccess: ({ exceptions }) => {
+            allExceptions.push(...exceptions);
+          },
+          onError: (err: string[]) => {
+            addError(err, {
+              title: i18n.translate(
+                'xpack.securitySolution.detectionEngine.alerts.fetchExceptionsFailure',
+                { defaultMessage: 'Error fetching exceptions.' }
+              ),
             });
-          }
-        }
+          },
+        });
       }
       return allExceptions;
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Make only a single api request for exceptions when opening an alert in timeline (#130941)](https://github.com/elastic/kibana/pull/130941)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)