### PR TITLE
[8.2] Make only a single api request for exceptions when opening an alert in timeline (#130941)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
@@ -14,7 +14,7 @@ import { ALERT_RULE_EXCEPTIONS_LIST } from '@kbn/rule-data-utils';
 import {
   ExceptionListIdentifiers,
   ExceptionListItemSchema,
-  ReadExceptionListSchema,
+  ExceptionListTypeEnum,
 } from '@kbn/securitysolution-io-ts-list-types';
 import { useApi } from '@kbn/securitysolution-list-hooks';
 
@@ -51,48 +51,48 @@ export const useInvestigateInTimeline = ({
 
   const getExceptions = useCallback(
     async (ecsData: Ecs): Promise<ExceptionListItemSchema[]> => {
-      const exceptionsLists: ReadExceptionListSchema[] = (
-        getField(ecsData, ALERT_RULE_EXCEPTIONS_LIST) ?? []
-      )
-        .map((list: string) => JSON.parse(list))
-        .filter((list: ExceptionListIdentifiers) => list.type === 'detection');
+      const exceptionsLists = (getField(ecsData, ALERT_RULE_EXCEPTIONS_LIST) ?? []).reduce(
+        (acc: ExceptionListIdentifiers[], next: string) => {
+          const parsedList = JSON.parse(next);
+          if (parsedList.type === 'detection') {
+            const formattedList = {
+              id: parsedList.id,
+              listId: parsedList.list_id,
+              type: ExceptionListTypeEnum.DETECTION,
+              namespaceType: parsedList.namespace_type,
+            };
+            acc.push(formattedList);
+          }
+          return acc;
+        },
+        []
+      );
 
       const allExceptions: ExceptionListItemSchema[] = [];
 
       if (exceptionsLists.length > 0) {
-        for (const list of exceptionsLists) {
-          if (list.id && list.list_id && list.namespace_type) {
-            await getExceptionListsItems({
-              lists: [
-                {
-                  id: list.id,
-                  listId: list.list_id,
-                  type: 'detection',
-                  namespaceType: list.namespace_type,
-                },
-              ],
-              filterOptions: [],
-              pagination: {
-                page: 0,
-                perPage: 10000,
-                total: 10000,
-              },
-              showDetectionsListsOnly: true,
-              showEndpointListsOnly: false,
-              onSuccess: ({ exceptions }) => {
-                allExceptions.push(...exceptions);
-              },
-              onError: (err: string[]) => {
-                addError(err, {
-                  title: i18n.translate(
-                    'xpack.securitySolution.detectionEngine.alerts.fetchExceptionsFailure',
-                    { defaultMessage: 'Error fetching exceptions.' }
-                  ),
-                });
-              },
+        await getExceptionListsItems({
+          lists: exceptionsLists,
+          filterOptions: [],
+          pagination: {
+            page: 0,
+            perPage: 10000,
+            total: 10000,
+          },
+          showDetectionsListsOnly: true,
+          showEndpointListsOnly: false,
+          onSuccess: ({ exceptions }) => {
+            allExceptions.push(...exceptions);
+          },
+          onError: (err: string[]) => {
+            addError(err, {
+              title: i18n.translate(
+                'xpack.securitySolution.detectionEngine.alerts.fetchExceptionsFailure',
+                { defaultMessage: 'Error fetching exceptions.' }
+              ),
             });
-          }
-        }
+          },
+        });
       }
       return allExceptions;
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Make only a single api request for exceptions when opening an alert in timeline (#130941)](https://github.com/elastic/kibana/pull/130941)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)