### PR TITLE
[Cloud Security] fetch all rules templates

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.test.ts
@@ -66,6 +66,24 @@ describe('create CSP rules with post package create callback', () => {
     ]);
   });
 
+  it('validate that all rules templates are fetched', async () => {
+    const mockPackagePolicy = createPackagePolicyMock();
+    mockPackagePolicy.package!.name = CLOUD_SECURITY_POSTURE_PACKAGE_NAME;
+    mockSoClient.find.mockResolvedValueOnce({
+      saved_objects: [
+        {
+          type: 'csp-rule-template',
+          id: 'csp_rule_template-41308bcdaaf665761478bb6f0d745a5c',
+          attributes: { ...ruleAttributes },
+        },
+      ],
+      pit_id: undefined,
+    } as unknown as SavedObjectsFindResponse);
+    await onPackagePolicyPostCreateCallback(logger, mockPackagePolicy, mockSoClient);
+
+    expect(mockSoClient.find.mock.calls[0][0]).toMatchObject({ perPage: 1000 });
+  });
+
   it('should not create rules when the package policy is not csp package', async () => {
     const mockPackagePolicy = createPackagePolicyMock();
     mockPackagePolicy.package!.name = 'not_csp_package';

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.test.ts
@@ -81,7 +81,7 @@ describe('create CSP rules with post package create callback', () => {
     } as unknown as SavedObjectsFindResponse);
     await onPackagePolicyPostCreateCallback(logger, mockPackagePolicy, mockSoClient);
 
-    expect(mockSoClient.find.mock.calls[0][0]).toMatchObject({ perPage: 1000 });
+    expect(mockSoClient.find.mock.calls[0][0]).toMatchObject({ perPage: 10000 });
   });
 
   it('should not create rules when the package policy is not csp package', async () => {

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
@@ -46,7 +46,10 @@ export const onPackagePolicyPostCreateCallback = async (
   }
   // Create csp-rules from the generic asset
   const existingRuleTemplates: SavedObjectsFindResponse<CloudSecurityPostureRuleTemplateSchema> =
-    await savedObjectsClient.find({ type: cloudSecurityPostureRuleTemplateSavedObjectType });
+    await savedObjectsClient.find({
+      type: cloudSecurityPostureRuleTemplateSavedObjectType,
+      perPage: 1000,
+    });
 
   if (existingRuleTemplates.total === 0) {
     return;

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
@@ -48,7 +48,7 @@ export const onPackagePolicyPostCreateCallback = async (
   const existingRuleTemplates: SavedObjectsFindResponse<CloudSecurityPostureRuleTemplateSchema> =
     await savedObjectsClient.find({
       type: cloudSecurityPostureRuleTemplateSavedObjectType,
-      perPage: 1000,
+      perPage: 10000,
     });
 
   if (existingRuleTemplates.total === 0) {


### PR DESCRIPTION
When adding a Cloud Security integration with over 20 `csp_rule_template` it seems to create only 20 csp-rule objects for that integration, this PR solves this bug and fetches all the rules.
