### PR TITLE
[8.2] [ML] Fixing management app docs links (#130776)

### DIFF
--- a/x-pack/plugins/ml/public/application/management/jobs_list/components/jobs_list_page/jobs_list_page.tsx
+++ b/x-pack/plugins/ml/public/application/management/jobs_list/components/jobs_list_page/jobs_list_page.tsx
@@ -27,12 +27,13 @@ import type { DataPublicPluginStart } from 'src/plugins/data/public';
 import { PLUGIN_ID } from '../../../../../../common/constants/app';
 import type { ManagementAppMountParams } from '../../../../../../../../../src/plugins/management/public';
 
-import { checkGetManagementMlJobsResolver } from '../../../../capabilities/check_capabilities';
 import {
   KibanaContextProvider,
   KibanaThemeProvider,
   RedirectAppLinks,
 } from '../../../../../../../../../src/plugins/kibana_react/public';
+
+import { checkGetManagementMlJobsResolver } from '../../../../capabilities/check_capabilities';
 
 // @ts-ignore undeclared module
 import { JobsListView } from '../../../../jobs/jobs_list/components/jobs_list_view/index';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[ML] Fixing management app docs links (#130776)](https://github.com/elastic/kibana/pull/130776)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)