### PR TITLE
using different query for saved objects

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/debug/components/saved_objects_debugger.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/debug/components/saved_objects_debugger.tsx
@@ -25,8 +25,21 @@ import { SavedObjectNamesCombo } from './saved_object_names_combo';
 
 const fetchSavedObjects = async (type?: string, name?: string) => {
   if (!type || !name) return;
-  const path = `/.kibana/_search?q=${type}.name:${name}`;
-  const body = {};
+  const path = `/.kibana/_search`;
+  const body = {
+    query: {
+      bool: {
+        must: {
+          match: { [`${type}.name`]: name },
+        },
+        filter: {
+          term: {
+            type,
+          },
+        },
+      },
+    },
+  };
   const response = await sendRequest({
     method: 'post',
     path: `/api/console/proxy`,


### PR DESCRIPTION
## Summary

Using a different ES query to fix this issue: https://github.com/elastic/kibana/pull/131395#issuecomment-1116233127

Now `Agent policy 1 `saved object returns correctly:

<img width="944" alt="image" src="https://user-images.githubusercontent.com/90178898/166648015-c4e143dd-eb92-44ff-8272-32e824787b70.png">

