### PR TITLE
[Cases] Export `getCasesMetrics` from the cases UI client

### DIFF
--- a/x-pack/plugins/cases/common/api/metrics/case.ts
+++ b/x-pack/plugins/cases/common/api/metrics/case.ts
@@ -184,6 +184,9 @@ export const SingleCaseMetricsResponseRt = rt.partial(
 
 export const CasesMetricsResponseRt = rt.partial(
   rt.type({
+    /**
+     * The average resolve time of all cases in seconds
+     */
     mttr: rt.number,
   }).props
 );

--- a/x-pack/plugins/cases/common/ui/types.ts
+++ b/x-pack/plugins/cases/common/ui/types.ts
@@ -19,6 +19,7 @@ import {
   CommentResponseAlertsType,
   CasesFindResponse,
   CasesStatusResponse,
+  CasesMetricsResponse,
 } from '../api';
 import { SnakeToCamelCase } from '../types';
 
@@ -65,6 +66,7 @@ export type CaseExternalService = SnakeToCamelCase<CaseExternalServiceBasic>;
 export type Case = Omit<SnakeToCamelCase<CaseResponse>, 'comments'> & { comments: Comment[] };
 export type Cases = Omit<SnakeToCamelCase<CasesFindResponse>, 'cases'> & { cases: Case[] };
 export type CasesStatus = SnakeToCamelCase<CasesStatusResponse>;
+export type CasesMetrics = SnakeToCamelCase<CasesMetricsResponse>;
 
 export interface ResolvedCase {
   case: Case;

--- a/x-pack/plugins/cases/public/api/decoders.ts
+++ b/x-pack/plugins/cases/public/api/decoders.ts
@@ -16,6 +16,8 @@ import {
   CasesFindResponseRt,
   CasesStatusResponse,
   CasesStatusResponseRt,
+  CasesMetricsResponse,
+  CasesMetricsResponseRt,
 } from '../../common/api';
 
 export const decodeCasesFindResponse = (respCases?: CasesFindResponse) =>
@@ -24,5 +26,11 @@ export const decodeCasesFindResponse = (respCases?: CasesFindResponse) =>
 export const decodeCasesStatusResponse = (respCase?: CasesStatusResponse) =>
   pipe(
     CasesStatusResponseRt.decode(respCase),
+    fold(throwErrors(createToasterPlainError), identity)
+  );
+
+export const decodeCasesMetricsResponse = (metrics?: CasesMetricsResponse) =>
+  pipe(
+    CasesMetricsResponseRt.decode(metrics),
     fold(throwErrors(createToasterPlainError), identity)
   );

--- a/x-pack/plugins/cases/public/api/index.test.ts
+++ b/x-pack/plugins/cases/public/api/index.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { httpServiceMock } from '@kbn/core/public/mocks';
-import { getCases } from '.';
+import { getCases, getCasesMetrics } from '.';
 import { allCases, allCasesSnake } from '../containers/mock';
 
 describe('api', () => {
@@ -26,6 +26,24 @@ describe('api', () => {
       await getCases({ http, query: { perPage: 10 } });
       expect(http.get).toHaveBeenCalledWith('/api/cases/_find', {
         query: { perPage: 10 },
+      });
+    });
+  });
+
+  describe('getCasesMetrics', () => {
+    const http = httpServiceMock.createStartContract({ basePath: '' });
+    http.get.mockResolvedValue({ mttr: 0 });
+
+    it('should return the correct response', async () => {
+      expect(
+        await getCasesMetrics({ http, query: { features: ['mttr'], from: 'now-1d' } })
+      ).toEqual({ mttr: 0 });
+    });
+
+    it('should have been called with the correct path', async () => {
+      await getCasesMetrics({ http, query: { features: ['mttr'], to: 'now-1d' } });
+      expect(http.get).toHaveBeenCalledWith('/api/cases/metrics', {
+        query: { features: ['mttr'], to: 'now-1d' },
       });
     });
   });

--- a/x-pack/plugins/cases/public/api/index.ts
+++ b/x-pack/plugins/cases/public/api/index.ts
@@ -6,16 +6,22 @@
  */
 
 import { HttpStart } from '@kbn/core/public';
-import { Cases, CasesStatus } from '../../common/ui';
-import { CASE_FIND_URL, CASE_STATUS_URL } from '../../common/constants';
+import { Cases, CasesStatus, CasesMetrics } from '../../common/ui';
+import { CASE_FIND_URL, CASE_METRICS_URL, CASE_STATUS_URL } from '../../common/constants';
 import {
   CasesFindRequest,
   CasesFindResponse,
+  CasesMetricsRequest,
+  CasesMetricsResponse,
   CasesStatusRequest,
   CasesStatusResponse,
 } from '../../common/api';
 import { convertAllCasesToCamel, convertToCamelCase } from './utils';
-import { decodeCasesFindResponse, decodeCasesStatusResponse } from './decoders';
+import {
+  decodeCasesFindResponse,
+  decodeCasesMetricsResponse,
+  decodeCasesStatusResponse,
+} from './decoders';
 
 export interface HTTPService {
   http: HttpStart;
@@ -42,4 +48,12 @@ export const getCasesStatus = async ({
   });
 
   return convertToCamelCase<CasesStatusResponse, CasesStatus>(decodeCasesStatusResponse(response));
+};
+
+export const getCasesMetrics = async ({
+  http,
+  query,
+}: HTTPService & { query: CasesMetricsRequest }): Promise<CasesMetrics> => {
+  const res = await http.get<CasesMetricsResponse>(CASE_METRICS_URL, { query });
+  return convertToCamelCase(decodeCasesMetricsResponse(res));
 };

--- a/x-pack/plugins/cases/public/api/index.ts
+++ b/x-pack/plugins/cases/public/api/index.ts
@@ -52,8 +52,9 @@ export const getCasesStatus = async ({
 
 export const getCasesMetrics = async ({
   http,
+  signal,
   query,
 }: HTTPService & { query: CasesMetricsRequest }): Promise<CasesMetrics> => {
-  const res = await http.get<CasesMetricsResponse>(CASE_METRICS_URL, { query });
+  const res = await http.get<CasesMetricsResponse>(CASE_METRICS_URL, { signal, query });
   return convertToCamelCase(decodeCasesMetricsResponse(res));
 };

--- a/x-pack/plugins/cases/public/client/api/index.test.ts
+++ b/x-pack/plugins/cases/public/client/api/index.test.ts
@@ -7,7 +7,7 @@
 
 import { httpServiceMock } from '@kbn/core/public/mocks';
 import { createClientAPI } from '.';
-import { allCases, casesStatus, allCasesSnake } from '../../containers/mock';
+import { allCases, allCasesSnake } from '../../containers/mock';
 
 describe('createClientAPI', () => {
   beforeEach(() => {
@@ -62,19 +62,21 @@ describe('createClientAPI', () => {
       });
     });
 
-    describe('getAllCasesMetrics', () => {
+    describe('getCasesMetrics', () => {
       const http = httpServiceMock.createStartContract({ basePath: '' });
       const api = createClientAPI({ http });
-      http.get.mockResolvedValue(casesStatus);
+      http.get.mockResolvedValue({ mttr: 0 });
 
       it('should return the correct response', async () => {
-        expect(await api.cases.getAllCasesMetrics({ from: 'now-1d' })).toEqual(casesStatus);
+        expect(await api.cases.getCasesMetrics({ features: ['mttr'], from: 'now-1d' })).toEqual({
+          mttr: 0,
+        });
       });
 
       it('should have been called with the correct path', async () => {
-        await api.cases.getAllCasesMetrics({ from: 'now-1d' });
-        expect(http.get).toHaveBeenCalledWith('/api/cases/status', {
-          query: { from: 'now-1d' },
+        await api.cases.getCasesMetrics({ features: ['mttr'], from: 'now-1d' });
+        expect(http.get).toHaveBeenCalledWith('/api/cases/metrics', {
+          query: { features: ['mttr'], from: 'now-1d' },
         });
       });
     });

--- a/x-pack/plugins/cases/public/client/api/index.ts
+++ b/x-pack/plugins/cases/public/client/api/index.ts
@@ -12,11 +12,10 @@ import {
   CasesFindRequest,
   getCasesFromAlertsUrl,
   CasesStatusRequest,
-  CasesStatusResponse,
+  CasesMetricsRequest,
 } from '../../../common/api';
-import { CASE_STATUS_URL } from '../../../common/constants';
-import { Cases, CasesStatus } from '../../../common/ui';
-import { getCases, getCasesStatus } from '../../api';
+import { Cases, CasesStatus, CasesMetrics } from '../../../common/ui';
+import { getCases, getCasesMetrics, getCasesStatus } from '../../api';
 import { CasesUiStart } from '../../types';
 
 export const createClientAPI = ({ http }: { http: HttpStart }): CasesUiStart['api'] => {
@@ -29,10 +28,10 @@ export const createClientAPI = ({ http }: { http: HttpStart }): CasesUiStart['ap
     cases: {
       find: (query: CasesFindRequest, signal?: AbortSignal): Promise<Cases> =>
         getCases({ http, query, signal }),
-      getAllCasesMetrics: (query: CasesStatusRequest): Promise<CasesStatusResponse> =>
-        http.get<CasesStatusResponse>(CASE_STATUS_URL, { query }),
       getCasesStatus: (query: CasesStatusRequest, signal?: AbortSignal): Promise<CasesStatus> =>
         getCasesStatus({ http, query, signal }),
+      getCasesMetrics: (query: CasesMetricsRequest): Promise<CasesMetrics> =>
+        getCasesMetrics({ http, query }),
     },
   };
 };

--- a/x-pack/plugins/cases/public/client/api/index.ts
+++ b/x-pack/plugins/cases/public/client/api/index.ts
@@ -30,8 +30,8 @@ export const createClientAPI = ({ http }: { http: HttpStart }): CasesUiStart['ap
         getCases({ http, query, signal }),
       getCasesStatus: (query: CasesStatusRequest, signal?: AbortSignal): Promise<CasesStatus> =>
         getCasesStatus({ http, query, signal }),
-      getCasesMetrics: (query: CasesMetricsRequest): Promise<CasesMetrics> =>
-        getCasesMetrics({ http, query }),
+      getCasesMetrics: (query: CasesMetricsRequest, signal?: AbortSignal): Promise<CasesMetrics> =>
+        getCasesMetrics({ http, signal, query }),
     },
   };
 };

--- a/x-pack/plugins/cases/public/mocks.ts
+++ b/x-pack/plugins/cases/public/mocks.ts
@@ -10,7 +10,7 @@ import { CasesUiStart } from './types';
 
 const apiMock: jest.Mocked<CasesUiStart['api']> = {
   getRelatedCases: jest.fn(),
-  cases: { find: jest.fn(), getAllCasesMetrics: jest.fn(), getCasesStatus: jest.fn() },
+  cases: { find: jest.fn(), getCasesMetrics: jest.fn(), getCasesStatus: jest.fn() },
 };
 
 const uiMock: jest.Mocked<CasesUiStart['ui']> = {

--- a/x-pack/plugins/cases/public/types.ts
+++ b/x-pack/plugins/cases/public/types.ts
@@ -78,7 +78,7 @@ export interface CasesUiStart {
     cases: {
       find: (query: CasesFindRequest, signal?: AbortSignal) => Promise<Cases>;
       getCasesStatus: (query: CasesStatusRequest, signal?: AbortSignal) => Promise<CasesStatus>;
-      getCasesMetrics: (query: CasesMetricsRequest) => Promise<CasesMetrics>;
+      getCasesMetrics: (query: CasesMetricsRequest, signal?: AbortSignal) => Promise<CasesMetrics>;
     };
   };
   ui: {

--- a/x-pack/plugins/cases/public/types.ts
+++ b/x-pack/plugins/cases/public/types.ts
@@ -21,8 +21,8 @@ import {
   CasesByAlertId,
   CasesByAlertIDRequest,
   CasesFindRequest,
+  CasesMetricsRequest,
   CasesStatusRequest,
-  CasesStatusResponse,
   CommentRequestAlertType,
   CommentRequestUserType,
 } from '../common/api';
@@ -35,7 +35,7 @@ import type { GetCasesProps } from './client/ui/get_cases';
 import { GetAllCasesSelectorModalProps } from './client/ui/get_all_cases_selector_modal';
 import { GetCreateCaseFlyoutProps } from './client/ui/get_create_case_flyout';
 import { GetRecentCasesProps } from './client/ui/get_recent_cases';
-import { Cases, CasesStatus } from '../common/ui';
+import { Cases, CasesStatus, CasesMetrics } from '../common/ui';
 
 export interface CasesPluginSetup {
   security: SecurityPluginSetup;
@@ -77,8 +77,8 @@ export interface CasesUiStart {
     getRelatedCases: (alertId: string, query: CasesByAlertIDRequest) => Promise<CasesByAlertId>;
     cases: {
       find: (query: CasesFindRequest, signal?: AbortSignal) => Promise<Cases>;
-      getAllCasesMetrics: (query: CasesStatusRequest) => Promise<CasesStatusResponse>;
       getCasesStatus: (query: CasesStatusRequest, signal?: AbortSignal) => Promise<CasesStatus>;
+      getCasesMetrics: (query: CasesMetricsRequest) => Promise<CasesMetrics>;
     };
   };
   ui: {

--- a/x-pack/plugins/cases/server/routes/api/metrics/get_case_metrics.ts
+++ b/x-pack/plugins/cases/server/routes/api/metrics/get_case_metrics.ts
@@ -19,17 +19,22 @@ export const getCaseMetricRoute = createCasesRoute({
       case_id: schema.string({ minLength: 1 }),
     }),
     query: schema.object({
-      features: schema.arrayOf(schema.string({ minLength: 1 })),
+      features: schema.oneOf([
+        schema.arrayOf(schema.string({ minLength: 1 })),
+        schema.string({ minLength: 1 }),
+      ]),
     }),
   },
   handler: async ({ context, request, response }) => {
     try {
       const caseContext = await context.cases;
       const client = await caseContext.getCasesClient();
+      const { features } = request.query;
+
       return response.ok({
         body: await client.metrics.getCaseMetrics({
           caseId: request.params.case_id,
-          features: request.query.features,
+          features: Array.isArray(features) ? features : [features],
         }),
       });
     } catch (error) {

--- a/x-pack/plugins/cases/server/routes/api/metrics/get_cases_metrics.ts
+++ b/x-pack/plugins/cases/server/routes/api/metrics/get_cases_metrics.ts
@@ -16,7 +16,10 @@ export const getCasesMetricRoute = createCasesRoute({
   path: CASE_METRICS_URL,
   params: {
     query: schema.object({
-      features: schema.arrayOf(schema.string({ minLength: 1 })),
+      features: schema.oneOf([
+        schema.arrayOf(schema.string({ minLength: 1 })),
+        schema.string({ minLength: 1 }),
+      ]),
       owner: schema.maybe(schema.oneOf([schema.arrayOf(schema.string()), schema.string()])),
       from: schema.maybe(schema.string()),
       to: schema.maybe(schema.string()),
@@ -26,9 +29,11 @@ export const getCasesMetricRoute = createCasesRoute({
     try {
       const caseContext = await context.cases;
       const client = await caseContext.getCasesClient();
+      const { features } = request.query;
+
       return response.ok({
         body: await client.metrics.getCasesMetrics({
-          ...request.query,
+          features: Array.isArray(features) ? features : [features],
         }),
       });
     } catch (error) {

--- a/x-pack/plugins/cases/server/routes/api/metrics/get_cases_metrics.ts
+++ b/x-pack/plugins/cases/server/routes/api/metrics/get_cases_metrics.ts
@@ -33,6 +33,7 @@ export const getCasesMetricRoute = createCasesRoute({
 
       return response.ok({
         body: await client.metrics.getCasesMetrics({
+          ...request.query,
           features: Array.isArray(features) ? features : [features],
         }),
       });

--- a/x-pack/plugins/security_solution/public/cases/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/pages/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { CaseViewRefreshPropInterface } from '@kbn/cases-plugin/common';
 import { TimelineId } from '../../../common/types/timeline';
@@ -94,10 +94,6 @@ const CaseContainerComponent: React.FC = () => {
   }, [dispatch]);
 
   const refreshRef = useRef<CaseViewRefreshPropInterface>(null);
-
-  useEffect(() => {
-    cases.api.cases.getCasesMetrics({ features: ['mttr'] }).then(console.log);
-  });
 
   return (
     <SecuritySolutionPageWrapper noPadding>

--- a/x-pack/plugins/security_solution/public/cases/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/pages/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { CaseViewRefreshPropInterface } from '@kbn/cases-plugin/common';
 import { TimelineId } from '../../../common/types/timeline';
@@ -94,6 +94,10 @@ const CaseContainerComponent: React.FC = () => {
   }, [dispatch]);
 
   const refreshRef = useRef<CaseViewRefreshPropInterface>(null);
+
+  useEffect(() => {
+    cases.api.cases.getCasesMetrics({ features: ['mttr'] }).then(console.log);
+  });
 
   return (
     <SecuritySolutionPageWrapper noPadding>

--- a/x-pack/test/cases_api_integration/common/lib/utils.ts
+++ b/x-pack/test/cases_api_integration/common/lib/utils.ts
@@ -1010,13 +1010,13 @@ export const getCaseMetrics = async ({
 }: {
   supertest: SuperTest.SuperTest<SuperTest.Test>;
   caseId: string;
-  features: string[];
+  features: string[] | string;
   expectedHttpCode?: number;
   auth?: { user: User; space: string | null };
 }): Promise<SingleCaseMetricsResponse> => {
   const { body: metricsResponse } = await supertest
     .get(`${getSpaceUrlPrefix(auth?.space)}${CASES_URL}/metrics/${caseId}`)
-    .query({ features: JSON.stringify(features) })
+    .query({ features })
     .auth(auth.user.username, auth.user.password)
     .expect(expectedHttpCode);
 
@@ -1277,14 +1277,14 @@ export const getCasesMetrics = async ({
   auth = { user: superUser, space: null },
 }: {
   supertest: SuperTest.SuperTest<SuperTest.Test>;
-  features: string[];
+  features: string[] | string;
   query?: Record<string, unknown>;
   expectedHttpCode?: number;
   auth?: { user: User; space: string | null };
 }): Promise<CasesMetricsResponse> => {
   const { body: metricsResponse } = await supertest
     .get(`${getSpaceUrlPrefix(auth?.space)}${CASES_URL}/metrics`)
-    .query({ features: JSON.stringify(features), ...query })
+    .query({ features, ...query })
     .auth(auth.user.username, auth.user.password)
     .expect(expectedHttpCode);
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/metrics/get_case_metrics.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/metrics/get_case_metrics.ts
@@ -30,6 +30,24 @@ export default ({ getService }: FtrProviderContext): void => {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
   describe('case metrics', () => {
+    it('accepts the features as string', async () => {
+      const newCase = await createCase(supertest, getPostCaseRequest());
+
+      const metrics = await getCaseMetrics({
+        supertest,
+        caseId: newCase.id,
+        features: 'connectors',
+      });
+
+      expect(metrics).to.eql({
+        connectors: {
+          total: 0,
+        },
+      });
+
+      await deleteAllCaseItems(es);
+    });
+
     describe('closed case from kbn archive', () => {
       const closedCaseId = 'e49ad6e0-cf9d-11eb-a603-13e7747d215z';
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/metrics/get_cases_metrics.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/metrics/get_cases_metrics.ts
@@ -34,6 +34,17 @@ export default ({ getService }: FtrProviderContext): void => {
   const kibanaServer = getService('kibanaServer');
 
   describe('all cases metrics', () => {
+    it('accepts the features as string', async () => {
+      const metrics = await getCasesMetrics({
+        supertest,
+        features: 'mttr',
+      });
+
+      expect(metrics).to.eql({ mttr: 0 });
+
+      await deleteAllCaseItems(es);
+    });
+
     describe('MTTR', () => {
       it('responses with zero if there are no cases', async () => {
         const metrics = await getCasesMetrics({


### PR DESCRIPTION
## Summary

This PR exposes the `getCasesMetrics` in the UI client.

Depends on: https://github.com/elastic/kibana/pull/131407

## Usage

```
await casesClient.api.cases.getCasesMetrics({ features: ['mttr'], from, to, owner });
```

Respose:

```
{
   // Average resolve time in seconds of all cases 
    mttr: 0
}
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
