### PR TITLE
[Expressions] Add support of deprecation flags

### DIFF
--- a/src/plugins/expressions/common/expression_functions/arguments.ts
+++ b/src/plugins/expressions/common/expression_functions/arguments.ts
@@ -54,6 +54,10 @@ type UnresolvedArrayTypeToArgumentString<T> =
 interface BaseArgumentType<T> {
   /** Alternate names for the Function valid for use in the Expression Editor */
   aliases?: string[];
+  /**
+   * The flag to mark the function parameter as deprecated.
+   */
+  deprecated?: boolean;
   /** Help text for the Argument to be displayed in the Expression Editor */
   help: string;
   /** Default options for the Argument */

--- a/src/plugins/expressions/common/expression_functions/expression_function.ts
+++ b/src/plugins/expressions/common/expression_functions/expression_function.ts
@@ -63,6 +63,12 @@ export class ExpressionFunction implements PersistableState<ExpressionAstFunctio
   inputTypes: string[] | undefined;
 
   disabled: boolean;
+
+  /**
+   * Deprecation flag.
+   */
+  deprecated: boolean;
+
   telemetry: (
     state: ExpressionAstFunction['arguments'],
     telemetryData: Record<string, unknown>
@@ -88,6 +94,7 @@ export class ExpressionFunction implements PersistableState<ExpressionAstFunctio
       inputTypes,
       context,
       disabled,
+      deprecated,
       telemetry,
       inject,
       extract,
@@ -103,6 +110,7 @@ export class ExpressionFunction implements PersistableState<ExpressionAstFunctio
     this.help = help || '';
     this.inputTypes = inputTypes || context?.types;
     this.disabled = disabled || false;
+    this.deprecated = !!deprecated;
     this.telemetry = telemetry || ((s, c) => c);
     this.inject = inject || identity;
     this.extract = extract || ((s) => ({ state: s, references: [] }));

--- a/src/plugins/expressions/common/expression_functions/expression_function_parameter.ts
+++ b/src/plugins/expressions/common/expression_functions/expression_function_parameter.ts
@@ -16,6 +16,7 @@ export class ExpressionFunctionParameter<T = unknown> {
   types: ArgumentType<T>['types'];
   default?: ArgumentType<T>['default'];
   aliases: string[];
+  deprecated: boolean;
   multi: boolean;
   resolve: boolean;
   /**
@@ -25,7 +26,7 @@ export class ExpressionFunctionParameter<T = unknown> {
   options: T[];
 
   constructor(name: string, arg: ArgumentType<T>) {
-    const { required, help, types, aliases, multi, options, resolve, strict } = arg;
+    const { required, help, types, aliases, deprecated, multi, options, resolve, strict } = arg;
 
     if (name === '_') {
       throw Error('Arg names must not be _. Use it in aliases instead.');
@@ -37,6 +38,7 @@ export class ExpressionFunctionParameter<T = unknown> {
     this.types = types || [];
     this.default = arg.default;
     this.aliases = aliases || [];
+    this.deprecated = !!deprecated;
     this.multi = !!multi;
     this.options = options || [];
     this.resolve = resolve == null ? true : resolve;

--- a/src/plugins/expressions/common/expression_functions/types.ts
+++ b/src/plugins/expressions/common/expression_functions/types.ts
@@ -40,6 +40,11 @@ export interface ExpressionFunctionDefinition<
   name: Name;
 
   /**
+   * The flag to mark the function as deprecated.
+   */
+  deprecated?: boolean;
+
+  /**
    * if set to true function will be disabled (but its migrate function will still be available)
    */
   disabled?: boolean;

--- a/src/plugins/kibana_react/public/code_editor/editor_theme.ts
+++ b/src/plugins/kibana_react/public/code_editor/editor_theme.ts
@@ -76,6 +76,8 @@ export function createTheme(
       { token: 'keyword.json', foreground: euiTheme.euiColorPrimary },
       { token: 'keyword.flow', foreground: euiTheme.euiColorWarning },
       { token: 'keyword.flow.scss', foreground: euiTheme.euiColorPrimary },
+      // Monaco editor supports strikethrough font style only starting from 0.32.0.
+      { token: 'keyword.deprecated', foreground: euiTheme.euiColorAccent },
 
       { token: 'operator.scss', foreground: euiTheme.euiColorDarkShade },
       { token: 'operator.sql', foreground: euiTheme.euiColorMediumShade },

--- a/src/plugins/presentation_util/public/components/expression_input/expression_input.stories.tsx
+++ b/src/plugins/presentation_util/public/components/expression_input/expression_input.stories.tsx
@@ -34,6 +34,7 @@ const font: ExpressionFunctionParameter<Style> = {
   help: 'The CSS font properties for the content. For example, font-family or font-weight.',
   types: ['style'],
   default: '{font}',
+  deprecated: false,
   aliases: [],
   multi: false,
   resolve: true,

--- a/src/plugins/presentation_util/public/components/expression_input/expression_input.stories.tsx
+++ b/src/plugins/presentation_util/public/components/expression_input/expression_input.stories.tsx
@@ -20,6 +20,7 @@ const content: ExpressionFunctionParameter<'string'> = {
   help: 'A string of text that contains Markdown. To concatenate, pass the `string` function multiple times.',
   types: ['string'],
   default: '',
+  deprecated: false,
   aliases: ['_', 'expression'],
   multi: true,
   resolve: false,

--- a/src/plugins/presentation_util/public/components/expression_input/language.ts
+++ b/src/plugins/presentation_util/public/components/expression_input/language.ts
@@ -17,6 +17,7 @@ import { EXPRESSIONS_LANGUAGE_ID } from '../../../common';
  */
 interface ExpressionsLanguage extends monaco.languages.IMonarchLanguage {
   keywords: string[];
+  deprecated: string[];
   symbols: RegExp;
   escapes: RegExp;
   digits: RegExp;
@@ -34,6 +35,7 @@ interface ExpressionsLanguage extends monaco.languages.IMonarchLanguage {
  */
 const expressionsLanguage: ExpressionsLanguage = {
   keywords: [],
+  deprecated: [],
 
   symbols: /[=|]/,
   escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
@@ -58,7 +60,12 @@ const expressionsLanguage: ExpressionsLanguage = {
         /[a-z_$][\w$]*/,
         {
           cases: {
-            '@keywords': 'keyword',
+            '@keywords': {
+              cases: {
+                '@deprecated': 'keyword.deprecated',
+                '@default': 'keyword',
+              },
+            },
             '@null': 'keyword',
             '@boolean': 'keyword',
             '@default': 'identifier',
@@ -107,6 +114,7 @@ const expressionsLanguage: ExpressionsLanguage = {
 
 export function registerExpressionsLanguage(functions: ExpressionFunction[]) {
   expressionsLanguage.keywords = functions.map((fn) => fn.name);
+  expressionsLanguage.deprecated = functions.filter((fn) => fn.deprecated).map((fn) => fn.name);
   monaco.languages.register({ id: EXPRESSIONS_LANGUAGE_ID });
   monaco.languages.setMonarchTokensProvider(EXPRESSIONS_LANGUAGE_ID, expressionsLanguage);
 }

--- a/x-pack/plugins/canvas/public/components/expression_input/__stories__/expression_input.stories.tsx
+++ b/x-pack/plugins/canvas/public/components/expression_input/__stories__/expression_input.stories.tsx
@@ -19,6 +19,7 @@ const content: ExpressionFunctionParameter<'string'> = {
   help: 'A string of text that contains Markdown. To concatenate, pass the `string` function multiple times.',
   types: ['string'],
   default: '',
+  deprecated: false,
   aliases: ['_', 'expression'],
   multi: true,
   resolve: false,

--- a/x-pack/plugins/canvas/public/components/expression_input/__stories__/expression_input.stories.tsx
+++ b/x-pack/plugins/canvas/public/components/expression_input/__stories__/expression_input.stories.tsx
@@ -33,6 +33,7 @@ const font: ExpressionFunctionParameter<Style> = {
   help: 'The CSS font properties for the content. For example, font-family or font-weight.',
   types: ['style'],
   default: '{font}',
+  deprecated: false,
   aliases: [],
   multi: false,
   resolve: true,


### PR DESCRIPTION
## Summary

Resolves #120066.

- Currently, there is no way to highlight deprecated function parameters in the Monaco editor. It's based on a tokenizer, but we need to know the context to implement that.
- The current version of Monaco editor (0.23) does not support strikethrough text decoration, so the deprecated functions are colored to attract the user's attention.
  <img width="538" alt="image" src="https://user-images.githubusercontent.com/15189627/168857974-48ff2932-bd7c-4520-86ef-efdf0fd433cd.png">
  _(see `mapColumn` coloring)_



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
