### PR TITLE
[Discover] Monospace font in Document Explorer

### DIFF
--- a/src/plugins/discover/public/components/discover_grid/constants.ts
+++ b/src/plugins/discover/public/components/discover_grid/constants.ts
@@ -19,7 +19,7 @@ export const GRID_STYLE = {
 
 export const pageSizeArr = [25, 50, 100, 250];
 export const defaultPageSize = 100;
-export const defaultTimeColumnWidth = 190;
+export const defaultTimeColumnWidth = 200;
 export const toolbarVisibility = {
   showColumnSelector: {
     allowHide: false,

--- a/src/plugins/discover/public/components/discover_grid/constants.ts
+++ b/src/plugins/discover/public/components/discover_grid/constants.ts
@@ -19,7 +19,7 @@ export const GRID_STYLE = {
 
 export const pageSizeArr = [25, 50, 100, 250];
 export const defaultPageSize = 100;
-export const defaultTimeColumnWidth = 200;
+export const defaultTimeColumnWidth = 210;
 export const toolbarVisibility = {
   showColumnSelector: {
     allowHide: false,

--- a/src/plugins/discover/public/components/discover_grid/discover_grid.scss
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid.scss
@@ -34,6 +34,11 @@
   font-family: $euiCodeFontFamily;
 }
 
+.dscDiscoverGrid__cellPopoverValue {
+  font-family: $euiCodeFontFamily;
+  font-size: $euiFontSizeXS;
+}
+
 .dscDiscoverGrid__footer {
   background-color: $euiColorLightShade;
   padding: $euiSize / 2 $euiSize;

--- a/src/plugins/discover/public/components/discover_grid/discover_grid.scss
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid.scss
@@ -30,6 +30,10 @@
   }
 }
 
+.dscDiscoverGrid__cellValue {
+  font-family: $euiCodeFontFamily;
+}
+
 .dscDiscoverGrid__footer {
   background-color: $euiColorLightShade;
   padding: $euiSize / 2 $euiSize;

--- a/src/plugins/discover/public/components/discover_grid/discover_grid.scss
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid.scss
@@ -36,7 +36,7 @@
 
 .dscDiscoverGrid__cellPopoverValue {
   font-family: $euiCodeFontFamily;
-  font-size: $euiFontSizeXS;
+  font-size: $euiFontSizeS;
 }
 
 .dscDiscoverGrid__footer {

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_columns.test.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_columns.test.tsx
@@ -207,7 +207,7 @@ describe('Discover grid columns', function () {
             />
           </React.Fragment>,
           "id": "timestamp",
-          "initialWidth": 190,
+          "initialWidth": 200,
           "isSortable": true,
           "schema": "datetime",
         },

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_columns.test.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_columns.test.tsx
@@ -207,7 +207,7 @@ describe('Discover grid columns', function () {
             />
           </React.Fragment>,
           "id": "timestamp",
-          "initialWidth": 200,
+          "initialWidth": 210,
           "isSortable": true,
           "schema": "datetime",
         },

--- a/src/plugins/discover/public/components/discover_grid/get_render_cell_value.test.tsx
+++ b/src/plugins/discover/public/components/discover_grid/get_render_cell_value.test.tsx
@@ -92,7 +92,9 @@ describe('Discover grid cell rendering', function () {
         setCellProps={jest.fn()}
       />
     );
-    expect(component.html()).toMatchInlineSnapshot(`"<span>100</span>"`);
+    expect(component.html()).toMatchInlineSnapshot(
+      `"<span class=\\"dscDiscoverGrid__cellValue\\">100</span>"`
+    );
   });
 
   it('renders bytes column correctly using _source when details is true', () => {

--- a/src/plugins/discover/public/components/discover_grid/get_render_cell_value.test.tsx
+++ b/src/plugins/discover/public/components/discover_grid/get_render_cell_value.test.tsx
@@ -118,7 +118,7 @@ describe('Discover grid cell rendering', function () {
       />
     );
     expect(component.html()).toMatchInlineSnapshot(
-      `"<span class=\\"dscDiscoverGrid__cellValue\\">100</span>"`
+      `"<span class=\\"dscDiscoverGrid__cellPopoverValue\\">100</span>"`
     );
   });
 
@@ -143,7 +143,7 @@ describe('Discover grid cell rendering', function () {
       />
     );
     expect(component.html()).toMatchInlineSnapshot(
-      `"<span class=\\"dscDiscoverGrid__cellValue\\">100</span>"`
+      `"<span class=\\"dscDiscoverGrid__cellPopoverValue\\">100</span>"`
     );
   });
 
@@ -730,7 +730,7 @@ describe('Discover grid cell rendering', function () {
     );
     expect(componentWithDetails).toMatchInlineSnapshot(`
       <span
-        className="dscDiscoverGrid__cellValue"
+        className="dscDiscoverGrid__cellPopoverValue"
         dangerouslySetInnerHTML={
           Object {
             "__html": Array [

--- a/src/plugins/discover/public/components/discover_grid/get_render_cell_value.test.tsx
+++ b/src/plugins/discover/public/components/discover_grid/get_render_cell_value.test.tsx
@@ -117,7 +117,9 @@ describe('Discover grid cell rendering', function () {
         setCellProps={jest.fn()}
       />
     );
-    expect(component.html()).toMatchInlineSnapshot(`"<span>100</span>"`);
+    expect(component.html()).toMatchInlineSnapshot(
+      `"<span class=\\"dscDiscoverGrid__cellValue\\">100</span>"`
+    );
   });
 
   it('renders bytes column correctly using fields when details is true', () => {
@@ -140,7 +142,9 @@ describe('Discover grid cell rendering', function () {
         setCellProps={jest.fn()}
       />
     );
-    expect(component.html()).toMatchInlineSnapshot(`"<span>100</span>"`);
+    expect(component.html()).toMatchInlineSnapshot(
+      `"<span class=\\"dscDiscoverGrid__cellValue\\">100</span>"`
+    );
   });
 
   it('renders _source column correctly', () => {
@@ -165,7 +169,7 @@ describe('Discover grid cell rendering', function () {
     );
     expect(component).toMatchInlineSnapshot(`
       <EuiDescriptionList
-        className="dscDiscoverGrid__descriptionList"
+        className="dscDiscoverGrid__descriptionList dscDiscoverGrid__cellValue"
         compressed={true}
         type="inline"
       >
@@ -282,7 +286,7 @@ describe('Discover grid cell rendering', function () {
     );
     expect(component).toMatchInlineSnapshot(`
       <EuiDescriptionList
-        className="dscDiscoverGrid__descriptionList"
+        className="dscDiscoverGrid__descriptionList dscDiscoverGrid__cellValue"
         compressed={true}
         type="inline"
       >
@@ -361,7 +365,7 @@ describe('Discover grid cell rendering', function () {
     );
     expect(component).toMatchInlineSnapshot(`
       <EuiDescriptionList
-        className="dscDiscoverGrid__descriptionList"
+        className="dscDiscoverGrid__descriptionList dscDiscoverGrid__cellValue"
         compressed={true}
         type="inline"
       >
@@ -487,7 +491,7 @@ describe('Discover grid cell rendering', function () {
     );
     expect(component).toMatchInlineSnapshot(`
       <EuiDescriptionList
-        className="dscDiscoverGrid__descriptionList"
+        className="dscDiscoverGrid__descriptionList dscDiscoverGrid__cellValue"
         compressed={true}
         type="inline"
       >
@@ -529,7 +533,7 @@ describe('Discover grid cell rendering', function () {
     );
     expect(component).toMatchInlineSnapshot(`
       <EuiDescriptionList
-        className="dscDiscoverGrid__descriptionList"
+        className="dscDiscoverGrid__descriptionList dscDiscoverGrid__cellValue"
         compressed={true}
         type="inline"
       >
@@ -605,6 +609,7 @@ describe('Discover grid cell rendering', function () {
     );
     expect(component).toMatchInlineSnapshot(`
       <span
+        className="dscDiscoverGrid__cellValue"
         dangerouslySetInnerHTML={
           Object {
             "__html": Array [
@@ -636,7 +641,9 @@ describe('Discover grid cell rendering', function () {
         setCellProps={jest.fn()}
       />
     );
-    expect(component.html()).toMatchInlineSnapshot(`"<span>-</span>"`);
+    expect(component.html()).toMatchInlineSnapshot(
+      `"<span class=\\"dscDiscoverGrid__cellValue\\">-</span>"`
+    );
   });
 
   it('renders correctly when invalid column is given', () => {
@@ -659,7 +666,9 @@ describe('Discover grid cell rendering', function () {
         setCellProps={jest.fn()}
       />
     );
-    expect(component.html()).toMatchInlineSnapshot(`"<span>-</span>"`);
+    expect(component.html()).toMatchInlineSnapshot(
+      `"<span class=\\"dscDiscoverGrid__cellValue\\">-</span>"`
+    );
   });
 
   it('renders unmapped fields correctly', () => {
@@ -697,6 +706,7 @@ describe('Discover grid cell rendering', function () {
     );
     expect(component).toMatchInlineSnapshot(`
       <span
+        className="dscDiscoverGrid__cellValue"
         dangerouslySetInnerHTML={
           Object {
             "__html": Array [
@@ -720,6 +730,7 @@ describe('Discover grid cell rendering', function () {
     );
     expect(componentWithDetails).toMatchInlineSnapshot(`
       <span
+        className="dscDiscoverGrid__cellValue"
         dangerouslySetInnerHTML={
           Object {
             "__html": Array [

--- a/src/plugins/discover/public/components/discover_grid/get_render_cell_value.tsx
+++ b/src/plugins/discover/public/components/discover_grid/get_render_cell_value.tsx
@@ -9,6 +9,7 @@
 import React, { Fragment, useContext, useEffect, useMemo } from 'react';
 import { euiLightVars as themeLight, euiDarkVars as themeDark } from '@kbn/ui-theme';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
+import classnames from 'classnames';
 import {
   EuiDataGridCellValueElementProps,
   EuiDescriptionList,
@@ -25,6 +26,8 @@ import { formatHit } from '../../utils/format_hit';
 import { ElasticSearchHit } from '../../types';
 import { useDiscoverServices } from '../../utils/use_discover_services';
 import { MAX_DOC_FIELDS_DISPLAYED } from '../../../common';
+
+const CELL_CLASS = 'dscDiscoverGrid__cellValue';
 
 export const getRenderCellValueFn =
   (
@@ -67,7 +70,7 @@ export const getRenderCellValueFn =
     }, [ctx, row, setCellProps]);
 
     if (typeof row === 'undefined' || typeof rowFlattened === 'undefined') {
-      return <span>-</span>;
+      return <span className={CELL_CLASS}>-</span>;
     }
 
     /**
@@ -102,7 +105,11 @@ export const getRenderCellValueFn =
         : formatHit(row, dataView, fieldsToShow, maxEntries, fieldFormats);
 
       return (
-        <EuiDescriptionList type="inline" compressed className="dscDiscoverGrid__descriptionList">
+        <EuiDescriptionList
+          type="inline"
+          compressed
+          className={classnames('dscDiscoverGrid__descriptionList', CELL_CLASS)}
+        >
           {pairs.map(([key, value]) => (
             <Fragment key={key}>
               <EuiDescriptionListTitle>{key}</EuiDescriptionListTitle>
@@ -118,6 +125,7 @@ export const getRenderCellValueFn =
 
     return (
       <span
+        className={CELL_CLASS}
         // formatFieldValue guarantees sanitized values
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{
@@ -170,6 +178,7 @@ function renderPopoverContent({
 
   return (
     <span
+      className={CELL_CLASS}
       // formatFieldValue guarantees sanitized values
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{

--- a/src/plugins/discover/public/components/discover_grid/get_render_cell_value.tsx
+++ b/src/plugins/discover/public/components/discover_grid/get_render_cell_value.tsx
@@ -178,7 +178,7 @@ function renderPopoverContent({
 
   return (
     <span
-      className={CELL_CLASS}
+      className="dscDiscoverGrid__cellPopoverValue"
       // formatFieldValue guarantees sanitized values
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{

--- a/src/plugins/discover/public/components/discover_grid/get_render_cell_value.tsx
+++ b/src/plugins/discover/public/components/discover_grid/get_render_cell_value.tsx
@@ -7,9 +7,9 @@
  */
 
 import React, { Fragment, useContext, useEffect, useMemo } from 'react';
+import classnames from 'classnames';
 import { euiLightVars as themeLight, euiDarkVars as themeDark } from '@kbn/ui-theme';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
-import classnames from 'classnames';
 import {
   EuiDataGridCellValueElementProps,
   EuiDescriptionList,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/130402

## Summary

This PR changes the default font to Monospace for Document Explorer. It also changes font family and reduces font size in cells popover.

<img width="1385" alt="Screenshot 2022-05-05 at 13 49 47" src="https://user-images.githubusercontent.com/1415710/166919749-f9292588-76dd-4ac3-9c35-6863f678f32f.png">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)