### PR TITLE
[Spacetime] Add integration suggestions

### DIFF
--- a/src/plugins/custom_integrations/common/index.ts
+++ b/src/plugins/custom_integrations/common/index.ts
@@ -118,6 +118,7 @@ export interface CustomIntegration {
   categories: IntegrationCategory[];
   shipper: Shipper;
   eprOverlap?: string; // name of the equivalent Elastic Agent integration in EPR. e.g. a beat module can correspond to an EPR-package, or an APM-tutorial. When completed, Integrations-UX can preferentially show the EPR-package, rather than the custom-integration
+  suggestionScore?: number;
 }
 
 export const ROUTES_APPEND_CUSTOM_INTEGRATIONS = `/internal/${PLUGIN_ID}/appendCustomIntegrations`;

--- a/x-pack/plugins/fleet/.storybook/context/fixtures/packages.ts
+++ b/x-pack/plugins/fleet/.storybook/context/fixtures/packages.ts
@@ -20,6 +20,7 @@ export const items: GetPackagesResponse['items'] = [
     id: 'ga_not_installed',
     status: 'not_installed',
     categories: ['aws', 'azure'],
+    suggestionScore: 10,
   },
   {
     name: 'ga_beats',
@@ -33,6 +34,7 @@ export const items: GetPackagesResponse['items'] = [
     id: 'ga_not_installed_beat',
     status: 'not_installed',
     categories: ['azure', 'cloud', 'config_management'],
+    suggestionScore: 5,
   },
   {
     name: 'ga_installed',
@@ -70,6 +72,7 @@ export const items: GetPackagesResponse['items'] = [
       version: 'WzczMTIsNF0=',
     },
     categories: ['cloud', 'containers'],
+    suggestionScore: 1,
   },
   {
     name: 'ga_installed_update',

--- a/x-pack/plugins/fleet/.storybook/context/index.tsx
+++ b/x-pack/plugins/fleet/.storybook/context/index.tsx
@@ -110,16 +110,15 @@ export const StorybookContext: React.FC<{ storyContext?: StoryContext }> = ({
     }),
     [isCloudEnabled]
   );
-  useEffect(() => {
-    setHttpClient(startServices.http);
-    setCustomIntegrations({
-      getAppendCustomIntegrations: async () => [],
-      getReplacementCustomIntegrations: async () => {
-        const { integrations } = await import('./fixtures/replacement_integrations');
-        return integrations;
-      },
-    });
-  }, [startServices]);
+
+  setHttpClient(startServices.http);
+  setCustomIntegrations({
+    getAppendCustomIntegrations: async () => [],
+    getReplacementCustomIntegrations: async () => {
+      const { integrations } = await import('./fixtures/replacement_integrations');
+      return integrations;
+    },
+  });
 
   const config = {
     enabled: true,

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -248,6 +248,7 @@ export type RegistrySearchResult = Pick<
   | 'data_streams'
   | 'policy_templates'
   | 'categories'
+  | 'suggestion_signals'
 >;
 
 export type ScreenshotItem = RegistryImage | PackageSpecScreenshot;

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -386,6 +386,7 @@ type Merge<FirstType, SecondType> = Omit<FirstType, Extract<keyof FirstType, key
 export type PackageList = PackageListItem[];
 export type PackageListItem = Installable<RegistrySearchResult> & {
   integration?: string;
+  suggestionScore?: number;
   id: string;
 };
 
@@ -400,6 +401,7 @@ export interface IntegrationCardItem {
   integration: string;
   id: string;
   categories: string[];
+  suggestionScore?: number;
 }
 
 export type PackagesGroupedByStatus = Record<ValueOf<InstallationStatus>, PackageList>;

--- a/x-pack/plugins/fleet/common/types/models/package_spec.ts
+++ b/x-pack/plugins/fleet/common/types/models/package_spec.ts
@@ -7,6 +7,10 @@
 
 import type { RegistryPolicyTemplate, RegistryVarsEntry } from './epm';
 
+export const SUGGESTION_SIGNAL_FIELDS = ['process.name', 'container.image.name'] as const;
+export type SuggestionSignalFields = typeof SUGGESTION_SIGNAL_FIELDS[number];
+export type SuggestionSignals = Record<SuggestionSignalFields, string[] | undefined>;
+
 // Based on https://github.com/elastic/package-spec/blob/master/versions/1/manifest.spec.yml#L8
 export interface PackageSpecManifest {
   format_version: string;
@@ -24,6 +28,7 @@ export interface PackageSpecManifest {
   policy_templates?: RegistryPolicyTemplate[];
   vars?: RegistryVarsEntry[];
   owner: { github: string };
+  suggestion_signals?: SuggestionSignals;
 }
 
 export type PackageSpecCategory =

--- a/x-pack/plugins/fleet/common/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/epm.ts
@@ -33,6 +33,7 @@ export interface GetPackagesRequest {
     category?: string;
     experimental?: boolean;
     excludeInstallStatus?: boolean;
+    includeSuggestions?: boolean;
   };
 }
 

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid.tsx
@@ -16,6 +16,10 @@ import {
   EuiTitle,
   EuiSearchBar,
   EuiText,
+  EuiIcon,
+  EuiPanel,
+  EuiSplitPanel,
+  EuiIconTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -33,6 +37,7 @@ export interface Props {
   controls?: ReactNode | ReactNode[];
   title?: string;
   list: IntegrationCardItem[];
+  suggestedList?: IntegrationCardItem[];
   featuredList?: JSX.Element | null;
   initialSearch?: string;
   setSelectedCategory: (category: string) => void;
@@ -50,6 +55,7 @@ export const PackageListGrid: FunctionComponent<Props> = ({
   onSearchChange,
   setSelectedCategory,
   showMissingIntegrationMessage = false,
+  suggestedList = [],
   featuredList = null,
   callout,
 }) => {
@@ -93,18 +99,42 @@ export const PackageListGrid: FunctionComponent<Props> = ({
   if (isLoading || !localSearchRef.current) {
     gridContent = <Loading />;
   } else {
-    const filteredList = searchTerm
-      ? list.filter((item) =>
-          (localSearchRef.current!.search(searchTerm) as IntegrationCardItem[])
-            .map((match) => match[searchIdField])
-            .includes(item[searchIdField])
-        )
-      : list;
+    const filterListBySearchTerm = (inputList: IntegrationCardItem[]) =>
+      searchTerm
+        ? inputList.filter((item) =>
+            (localSearchRef.current!.search(searchTerm) as IntegrationCardItem[])
+              .map((match) => match[searchIdField])
+              .includes(item[searchIdField])
+          )
+        : inputList;
+
+    const filteredList = filterListBySearchTerm(list);
+    const suggestedFilteredList = filterListBySearchTerm(suggestedList).slice(0, 3);
+
+    const suggestedContent = suggestedFilteredList.length ? (
+      <>
+        <EuiPanel color="subdued" hasShadow={false} hasBorder>
+          <EuiText color="subdued">
+            <h5>
+              Suggestions{' '}
+              <EuiIconTip content="Integrations that are recommended for you based on data you've collected." />
+            </h5>
+          </EuiText>
+          <EuiSpacer />
+          <GridColumn list={suggestedFilteredList} />
+        </EuiPanel>
+        <EuiSpacer />
+      </>
+    ) : null;
+
     gridContent = (
-      <GridColumn
-        list={filteredList}
-        showMissingIntegrationMessage={showMissingIntegrationMessage}
-      />
+      <>
+        {suggestedContent}
+        <GridColumn
+          list={filteredList}
+          showMissingIntegrationMessage={showMissingIntegrationMessage}
+        />
+      </>
     );
   }
 

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -26,6 +26,8 @@ import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 
 import type { CustomIntegration } from '@kbn/custom-integrations-plugin/common';
 
+import useObservable from 'react-use/lib/useObservable';
+
 import { useStartServices } from '../../../../hooks';
 
 import { pagePathGetters } from '../../../../constants';
@@ -184,8 +186,13 @@ export const AvailablePackages: React.FC = memo(() => {
   const [preference, setPreference] = useState<IntegrationPreferenceType>('recommended');
   useBreadcrumbs('integrations_all');
 
-  const { http } = useStartServices();
+  const { http, uiSettings } = useStartServices();
   const addBasePath = http.basePath.prepend;
+
+  const enableSuggestions = useObservable(
+    uiSettings.get$('integrations:enableSuggestions'),
+    uiSettings.get('integrations:enableSuggestions')
+  );
 
   const { selectedCategory, searchParam } = getParams(
     useParams<CategoryParams>(),
@@ -215,6 +222,7 @@ export const AvailablePackages: React.FC = memo(() => {
   } = useGetPackages({
     category: '',
     excludeInstallStatus: true,
+    includeSuggestions: enableSuggestions,
   });
   const eprIntegrationList = useMemo(
     () => packageListToIntegrationsList(eprPackages?.items || []),

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -309,6 +309,15 @@ export const AvailablePackages: React.FC = memo(() => {
     return c.categories.includes(selectedCategory);
   });
 
+  const suggestedCards = _.sortBy(
+    cards.filter(
+      (item) =>
+        item.suggestionScore &&
+        (selectedCategory === '' || item.categories.includes(selectedCategory))
+    ),
+    'suggestionScore'
+  ).reverse();
+
   // TODO: Remove this hard coded list of integrations with a suggestion service
   const featuredList = (
     <>
@@ -373,6 +382,7 @@ export const AvailablePackages: React.FC = memo(() => {
 
   return (
     <PackageListGrid
+      suggestedList={suggestedCards}
       featuredList={featuredList}
       isLoading={isLoadingAllPackages}
       controls={controls}

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -85,6 +85,7 @@ export const mapToCard = (
     version: 'version' in item ? item.version || '' : '',
     release,
     categories: ((item.categories || []) as string[]).filter((c: string) => !!c),
+    suggestionScore: item.suggestionScore,
   };
 };
 

--- a/x-pack/plugins/fleet/public/hooks/use_request/use_request.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/use_request.ts
@@ -44,6 +44,7 @@ export const sendRequest = <D = any, E = RequestError>(
 
 export const useRequest = <D = any, E = RequestError>(config: UseRequestConfig) => {
   if (!httpClient) {
+    // debugger;
     throw new Error('sendRequest has no http client set');
   }
   return _useRequest<D, E>(httpClient, config);

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -9,6 +9,7 @@ import type { Observable } from 'rxjs';
 import { BehaviorSubject } from 'rxjs';
 import { take } from 'rxjs/operators';
 
+import { schema } from '@kbn/config-schema';
 import { i18n } from '@kbn/i18n';
 import type {
   CoreSetup,
@@ -221,6 +222,17 @@ export class FleetPlugin
 
     registerSavedObjects(core.savedObjects, deps.encryptedSavedObjects);
     registerEncryptedSavedObjects(deps.encryptedSavedObjects);
+
+    core.uiSettings.register({
+      'integrations:enableSuggestions': {
+        schema: schema.boolean(),
+        category: ['management'],
+        name: 'Enable integration suggestions',
+        value: false,
+        description:
+          'Find related integrations to data you are ingesting. May have performance problems on larger clusters.',
+      },
+    });
 
     // Register feature
     if (deps.features) {

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -84,6 +84,10 @@ const FAKE_SIGNALS: Record<string, SuggestionSignals | undefined> = {
     'process.name': ['*postgres*'],
     'container.image.name': ['*postgres*'],
   },
+  redis: {
+    'process.name': ['*redis*'],
+    'container.image.name': ['*redis*'],
+  },
 };
 
 const appendFakeSignals = (results: RegistrySearchResults): RegistrySearchResults =>

--- a/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
@@ -19,6 +19,7 @@ export const GetPackagesRequestSchema = {
     category: schema.maybe(schema.string()),
     experimental: schema.maybe(schema.boolean()),
     excludeInstallStatus: schema.maybe(schema.boolean({ defaultValue: false })),
+    includeSuggestions: schema.maybe(schema.boolean({ defaultValue: false })),
   }),
 };
 


### PR DESCRIPTION
## Summary

This PR adds an auto-suggest feature that leverages existing integration data to suggest other packages that a user may want to install. For instance, if a user installs the generic System integration, the `process.name` fields can provide hints on other integrations that the user may be interested in.

This may be especially useful as we move Agent installation (with the System integration) to be the first step, with integration selection happening afterward.

### Screenshot

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/1813008/166691847-2294453e-2fca-4569-8088-6bb4313df832.png">


### Notes on implementation
- This currently does not actually change any package manifests to include signals, all the signals are hardcoded in Kibana for now. I didn't bother with the package aspect because it isn't particular interesting and we'd only want to do it once we decided to adopt this feature.  A hard coded list is fine for now: https://github.com/elastic/kibana/pull/131520/files#diff-fcf218bd5390498580458eeb562b2ed74a02463f3fddf280edf9545611cc57d8
- Some additional optimizations on the query may be possible. For instance, using the new random sampler agg would be a great fit for clusters with a lot of data
- It could be helpful to show the user why a package was suggested, for example showing which field matched and which data streams they were found in

### How to see it in action
1. ES from Kibana repo: `yarn es snapshot`
2. Start Kibana: `yarn start`
3. Enable the suggestions feature in Advanced Settings (behind a flag for now so we can merge and test the query first before rollout) and click save:
	<img width="1177" alt="image" src="https://user-images.githubusercontent.com/1813008/166688940-dca92408-b472-4e6c-9f75-4550c8ab07b7.png">
4. Ingest some dummy data that has some known signals. Make sure to use recent timestamps (last 24h) so the suggestions query picks these up:
    ```
    POST logs-docker.test-default/_bulk
    { "create": {} }
    { "container.image.name": "nginx", "message": "foo", "@timestamp": "2022-05-04T14:00" }
    { "create": {} }
    { "process.name": "foo-postgres-blah", "message": "foo", "@timestamp": "2022-05-04T14:00" }
    { "create": {} }
    { "container.image.name": "redis", "message": "foo", "@timestamp": "2022-05-04T14:00" }
    { "create": {} }
    { "container.image.name": "redis", "message": "foo", "@timestamp": "2022-05-04T14:00" }
    { "create": {} }
    { "container.image.name": "redis", "message": "foo", "@timestamp": "2022-05-04T14:00" }
    { "create": {} }
    { "container.image.name": "redis", "message": "foo", "@timestamp": "2022-05-04T14:00" }
    { "create": {} }
    { "container.image.name": "redis", "message": "foo", "@timestamp": "2022-05-04T14:00" }
    ```

5. Go to integrations UI and see suggestions:
    <img width="1228" alt="image" src="https://user-images.githubusercontent.com/1813008/166690425-b4479872-be61-4fa4-b978-e089180d4dd0.png">

6. View the "Data store" cateogry and note the suggestions only show if they apply to the category:
    <img width="1220" alt="image" src="https://user-images.githubusercontent.com/1813008/166690599-b461af3e-1f9d-41e9-8c6d-12185b5c0eb8.png">

7. Install one of the suggestions, for example PostgreSQL, and note the suggestion disappears:
    <img width="1265" alt="image" src="https://user-images.githubusercontent.com/1813008/166690300-4bb9f707-496e-4b14-861b-750a0e5e142f.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
