### PR TITLE
chore(NA): include @kbn/synthetic-package-map/synthetic-packages.json on .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,4 +98,4 @@ elastic-agent-*
 fleet-server-*
 elastic-agent.yml
 fleet-server.yml
-
+/packages/kbn-synthetic-package-map/synthetic-packages.jsongi


### PR DESCRIPTION
I've realised when switching branches from `main` is easy to commit that file by mistake. That PR just adds a simple line on `.gitignore` for it.