### PR TITLE
[FullStory] Document browser exposed config in the test

### DIFF
--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -165,6 +165,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.cloud.deployment_url (string)',
         'xpack.cloud.full_story.enabled (boolean)',
         'xpack.cloud.full_story.org_id (any)',
+        // No PII. Just the list of event types we want to forward to FullStory.
         'xpack.cloud.full_story.eventTypesAllowlist (array)',
         'xpack.cloud.id (string)',
         'xpack.cloud.organization_url (string)',


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/131148 to address NIT comment.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
