### PR TITLE
[SecuritySolution][Field Browser] Improve filter selected performance

### DIFF
--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/helpers.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/helpers.tsx
@@ -6,7 +6,6 @@
  */
 
 import { EuiBadge, EuiLoadingSpinner } from '@elastic/eui';
-import { pickBy } from 'lodash/fp';
 import styled from 'styled-components';
 
 import { TimelineId } from '../../../../types';
@@ -108,27 +107,46 @@ export const filterSelectedBrowserFields = ({
 }): BrowserFields => {
   const selectedFieldIds = new Set(columnHeaders.map(({ id }) => id));
 
-  const filteredBrowserFields: BrowserFields = Object.keys(browserFields).reduce(
-    (filteredCategories, categoryId) => ({
-      ...filteredCategories,
-      [categoryId]: {
-        ...browserFields[categoryId],
-        fields: pickBy(
-          ({ name }) => name != null && selectedFieldIds.has(name),
-          browserFields[categoryId].fields
-        ),
-      },
-    }),
-    {}
-  );
+  const result: Record<string, Partial<BrowserField>> = {};
 
-  // only pick non-empty categories from the filtered browser fields
-  const nonEmptyCategories: BrowserFields = pickBy(
-    (category) => categoryHasFields(category),
-    filteredBrowserFields
-  );
+  for (const [categoryName, categoryDescriptor] of Object.entries(browserFields)) {
+    if (!categoryDescriptor.fields) {
+      // ignore any category that is missing fields. This is not expected to happen.
+      // eslint-disable-next-line no-continue
+      continue;
+    }
 
-  return nonEmptyCategories;
+    // keep track of whether this category had a selected field, if so, we should emit it into the result
+    let hadSelected = false;
+
+    // The selected fields for this `categoryName`
+    const selectedFields: Record<string, Partial<BrowserField>> = {};
+
+    for (const [fieldName, fieldDescriptor] of Object.entries(categoryDescriptor.fields)) {
+      // For historical reasons, we consider the name as it appears on the field descriptor, not the `fieldName` (attribute name) itself.
+      // It is unclear if there is any point in continuing to do this.
+      const fieldNameFromDescriptor = fieldDescriptor.name;
+
+      if (!fieldNameFromDescriptor) {
+        // Ignore any field that is missing a name in its descriptor. This is not expected to happen.
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      if (selectedFieldIds.has(fieldNameFromDescriptor)) {
+        hadSelected = true;
+        selectedFields[fieldName] = fieldDescriptor;
+      }
+    }
+
+    if (hadSelected) {
+      result[categoryName] = {
+        ...browserFields[categoryName],
+        fields: selectedFields,
+      };
+    }
+  }
+  return result;
 };
 
 export const getAlertColumnHeader = (timelineId: string, fieldId: string) =>


### PR DESCRIPTION
## Summary

Solves: https://github.com/elastic/kibana/issues/131516

Change in the `filterSelectedBrowserFields` function to create the results in a new object every iteration, instead of using the spread operator to copy objects inside each other every iteration.

The solution is based on the `filterBrowserFieldsByFieldName` improvement by @oatkiller.

Tested with +11k categories and fields:
-  The old implementation was freezing the UI for `~30s` while filtering all selected fields:
![old_version_profile](https://user-images.githubusercontent.com/17747913/166708441-b03ab848-2779-4bdf-b41c-7259704c3c08.png)

-  The new implementation takes `~200ms` to do the same:
![new_version_profile](https://user-images.githubusercontent.com/17747913/166709513-760b79b3-a86a-417d-9735-dc04c712ae86.png)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
