### PR TITLE
[Fleet] Clean up unused `installed_bundled` installation status

### DIFF
--- a/x-pack/plugins/fleet/common/constants/epm.ts
+++ b/x-pack/plugins/fleet/common/constants/epm.ts
@@ -59,5 +59,4 @@ export const installationStatuses = {
   Installing: 'installing',
   InstallFailed: 'install_failed',
   NotInstalled: 'not_installed',
-  InstalledBundled: 'installed_bundled',
 } as const;

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -45,11 +45,7 @@ export interface DefaultPackagesInstallationError {
 export type InstallType = 'reinstall' | 'reupdate' | 'rollback' | 'update' | 'install' | 'unknown';
 export type InstallSource = 'registry' | 'upload' | 'bundled';
 
-export type EpmPackageInstallStatus =
-  | 'installed'
-  | 'installing'
-  | 'install_failed'
-  | 'installed_bundled';
+export type EpmPackageInstallStatus = 'installed' | 'installing' | 'install_failed';
 
 export type DetailViewPanelName = 'overview' | 'policies' | 'assets' | 'settings' | 'custom';
 export type ServiceName = 'kibana' | 'elasticsearch';
@@ -431,8 +427,7 @@ export type Installable<T> =
   | InstalledRegistry<T>
   | Installing<T>
   | NotInstalled<T>
-  | InstallFailed<T>
-  | InstalledBundled<T>;
+  | InstallFailed<T>;
 
 export type InstallStatusExcluded<T = {}> = T & {
   status: undefined;
@@ -441,10 +436,6 @@ export type InstallStatusExcluded<T = {}> = T & {
 export type InstalledRegistry<T = {}> = T & {
   status: InstallationStatus['Installed'];
   savedObject: SavedObject<Installation>;
-};
-
-export type InstalledBundled<T = {}> = T & {
-  status: InstallationStatus['InstalledBundled'];
 };
 
 export type Installing<T = {}> = T & {


### PR DESCRIPTION
## Summary

Clean up `InstalledBundled: 'installed_bundled'` package installation status, which is unused elsewhere in the code but creates a small amount of confusion. We track install source (bundled vs registry) via a different property, `install_source: bundled`.
