### PR TITLE
[DOCS] Fix broken blob attributes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -11,7 +11,6 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 :docker-image:    {docker-repo}:{version}
 :es-docker-repo:  docker.elastic.co/elasticsearch/elasticsearch
 :es-docker-image: {es-docker-repo}:{version}
-:blob:            {kib-repo}blob/{branch}/
 :security-ref:    https://www.elastic.co/community/security/
 :Data-source:     Data view
 :data-source:     data view
@@ -19,6 +18,8 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 :a-data-source:   a data view
 
 include::{docs-root}/shared/attributes.asciidoc[]
+
+:blob: {kib-repo}blob/{branch}/
 
 include::user/index.asciidoc[]
 


### PR DESCRIPTION
## Summary

Per https://github.com/elastic/kibana/pull/130983/files?show-deleted-files=true&show-viewed-files=true&file-filters%5B%5D=#r864297066, there are broken links in https://www.elastic.co/guide/en/kibana/7.17/development-tests.html#development-functional-tests and https://www.elastic.co/guide/en/kibana/master/external-plugin-localization.html.

The "blob" attribute is defined in https://github.com/elastic/kibana/blob/main/docs/index.asciidoc, but it embeds the "kib-repo" attribute, which is not yet defined at that point. The {kib-repo} attribute is defined in https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc, so I've swapped the order in which they're defined.

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/26471269/166806983-e936828c-ba21-4d72-bceb-7b14e13f4ee3.png)

![image](https://user-images.githubusercontent.com/26471269/166811890-4cd3508a-2c64-41f5-b941-3a686e14fee3.png)

### Preview

https://kibana_131563.docs-preview.app.elstc.co/guide/en/kibana/master/development-tests.html#development-functional-tests

https://kibana_131563.docs-preview.app.elstc.co/guide/en/kibana/master/external-plugin-localization.html