### PR TITLE
[7.17] [ML] Functional tests - stabilize outlier saved search tests (#131225)

### DIFF
--- a/x-pack/test/accessibility/apps/ml.ts
+++ b/x-pack/test/accessibility/apps/ml.ts
@@ -261,8 +261,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.dataFrameAnalyticsCreation.selectJobType(dfaJobType);
           await ml.testExecution.logTestStep('displays the source data preview');
           await ml.dataFrameAnalyticsCreation.assertSourceDataPreviewExists();
-          await ml.testExecution.logTestStep('enables the source data preview histogram charts');
-          await ml.dataFrameAnalyticsCreation.enableSourceDataPreviewHistogramCharts(true);
+          await ml.dataFrameAnalyticsCreation.assertSourceDataPreviewHistogramChartEnabled(true);
           await ml.testExecution.logTestStep('displays the include fields selection');
           await ml.dataFrameAnalyticsCreation.assertIncludeFieldsSelectionExists();
           await a11y.testAppSnapshot();

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation.ts
@@ -162,12 +162,10 @@ export default function ({ getService }: FtrProviderContext) {
 
           await ml.testExecution.logTestStep('displays the source data preview');
           await ml.dataFrameAnalyticsCreation.assertSourceDataPreviewExists();
-
-          await ml.testExecution.logTestStep('enables the source data preview histogram charts');
-          await ml.dataFrameAnalyticsCreation.enableSourceDataPreviewHistogramCharts(true);
+          await ml.dataFrameAnalyticsCreation.assertSourceDataPreviewHistogramChartEnabled(true);
 
           await ml.testExecution.logTestStep('displays the source data preview histogram charts');
-          await ml.dataFrameAnalyticsCreation.assertSourceDataPreviewHistogramCharts(
+          await ml.dataFrameAnalyticsCreation.enableAndAssertSourceDataPreviewHistogramCharts(
             testData.expected.histogramCharts
           );
 

--- a/x-pack/test/functional/services/ml/data_frame_analytics_creation.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics_creation.ts
@@ -49,6 +49,7 @@ export function MachineLearningDataFrameAnalyticsCreationProvider(
       const jobTypeAttribute = `mlAnalyticsCreation-${jobType}-option`;
       await testSubjects.click(jobTypeAttribute);
       await this.assertJobTypeSelection(jobTypeAttribute);
+      await headerPage.waitUntilLoadingHasFinished();
     },
 
     async assertAdvancedEditorSwitchExists() {
@@ -127,29 +128,41 @@ export function MachineLearningDataFrameAnalyticsCreationProvider(
       await testSubjects.existOrFail('mlAnalyticsCreationDataGridHistogramButton');
     },
 
-    async enableSourceDataPreviewHistogramCharts(expectedDefaultButtonState: boolean) {
-      await this.assertSourceDataPreviewHistogramChartButtonCheckState(expectedDefaultButtonState);
-      if (expectedDefaultButtonState === false) {
+    async enableSourceDataPreviewHistogramCharts(shouldBeEnabled: boolean) {
+      const isEnabled = await this.getSourceDataPreviewHistogramChartButtonCheckState();
+      if (isEnabled !== shouldBeEnabled) {
         await testSubjects.click('mlAnalyticsCreationDataGridHistogramButton');
-        await this.assertSourceDataPreviewHistogramChartButtonCheckState(true);
+        await this.assertSourceDataPreviewHistogramChartEnabled(shouldBeEnabled);
       }
     },
 
-    async assertSourceDataPreviewHistogramChartButtonCheckState(expectedCheckState: boolean) {
-      const actualCheckState =
+    async assertSourceDataPreviewHistogramChartEnabled(shouldBeEnabled: boolean) {
+      const isEnabled = await this.getSourceDataPreviewHistogramChartButtonCheckState();
+      expect(isEnabled).to.eql(
+        shouldBeEnabled,
+        `Source data preview histogram charts should be '${
+          shouldBeEnabled ? 'enabled' : 'disabled'
+        }' (got '${isEnabled ? 'enabled' : 'disabled'}')`
+      );
+    },
+
+    async getSourceDataPreviewHistogramChartButtonCheckState(): Promise<boolean> {
+      return (
         (await testSubjects.getAttribute(
           'mlAnalyticsCreationDataGridHistogramButton',
           'aria-pressed'
-        )) === 'true';
-      expect(actualCheckState).to.eql(
-        expectedCheckState,
-        `Chart histogram button check state should be '${expectedCheckState}' (got '${actualCheckState}')`
+        )) === 'true'
       );
+    },
+
+    async scrollSourceDataPreviewIntoView() {
+      await testSubjects.scrollIntoView('mlAnalyticsCreationDataGrid loaded');
     },
 
     async assertSourceDataPreviewHistogramCharts(
       expectedHistogramCharts: Array<{ chartAvailable: boolean; id: string; legend: string }>
     ) {
+      await this.scrollSourceDataPreviewIntoView();
       // For each chart, get the content of each header cell and assert
       // the legend text and column id and if the chart should be present or not.
       await retry.tryForTime(5000, async () => {
@@ -175,6 +188,17 @@ export function MachineLearningDataFrameAnalyticsCreationProvider(
             `Id text for column '${id}' should be '${expected.id}' (got '${actualId}')`
           );
         }
+      });
+    },
+
+    async enableAndAssertSourceDataPreviewHistogramCharts(
+      expectedHistogramCharts: Array<{ chartAvailable: boolean; id: string; legend: string }>
+    ) {
+      await retry.tryForTime(20 * 1000, async () => {
+        // turn histogram charts off and on before checking
+        await this.enableSourceDataPreviewHistogramCharts(false);
+        await this.enableSourceDataPreviewHistogramCharts(true);
+        await this.assertSourceDataPreviewHistogramCharts(expectedHistogramCharts);
       });
     },
 


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #131225

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
