### PR TITLE
[Fleet] Add support for allow_routing data streams option

### DIFF
--- a/x-pack/plugins/fleet/common/services/package_to_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/package_to_package_policy.ts
@@ -25,7 +25,7 @@ import {
 } from './policy_template';
 
 type PackagePolicyStream = RegistryStream & { release?: 'beta' | 'experimental' | 'ga' } & {
-  data_stream: { type: string; dataset: string };
+  data_stream: { type: string; dataset: string; allow_routing?: boolean };
 };
 
 export const getStreamsForInputType = (
@@ -47,6 +47,7 @@ export const getStreamsForInputType = (
           data_stream: {
             type: dataStream.type,
             dataset: dataStream.dataset,
+            allow_routing: dataStream.allow_routing,
           },
           release: dataStream.release,
         });

--- a/x-pack/plugins/fleet/common/types/models/data_stream.ts
+++ b/x-pack/plugins/fleet/common/types/models/data_stream.ts
@@ -10,6 +10,7 @@ export interface DataStream {
   dataset: string;
   namespace: string;
   type: string;
+  allow_routing: boolean;
   package: string;
   package_version: string;
   last_activity_ms: number;

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -328,10 +328,11 @@ export enum RegistryDataStreamKeys {
   ingest_pipeline = 'ingest_pipeline',
   elasticsearch = 'elasticsearch',
   dataset_is_prefix = 'dataset_is_prefix',
+  allow_routing = 'allow_routing',
 }
 
 export interface RegistryDataStream {
-  [key: string]: any;
+  [key: string]: unknown;
   [RegistryDataStreamKeys.type]: string;
   [RegistryDataStreamKeys.ilm_policy]?: string;
   [RegistryDataStreamKeys.hidden]?: boolean;
@@ -344,6 +345,7 @@ export interface RegistryDataStream {
   [RegistryDataStreamKeys.ingest_pipeline]?: string;
   [RegistryDataStreamKeys.elasticsearch]?: RegistryElasticsearch;
   [RegistryDataStreamKeys.dataset_is_prefix]?: boolean;
+  [RegistryDataStreamKeys.allow_routing]?: boolean;
 }
 
 export interface RegistryElasticsearch {

--- a/x-pack/plugins/fleet/common/types/models/package_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/package_policy.ts
@@ -29,6 +29,7 @@ export interface NewPackagePolicyInputStream {
   data_stream: {
     dataset: string;
     type: string;
+    allow_routing?: boolean;
     elasticsearch?: {
       privileges?: {
         indices?: string[];

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -99,6 +99,7 @@ export async function storedPackagePoliciesToAgentPermissions(
                     type: stream.data_stream.type,
                     dataset:
                       stream.compiled_stream?.data_stream?.dataset ?? stream.data_stream.dataset,
+                    allow_routing: stream.data_stream.allow_routing,
                   };
 
                   if (stream.data_stream.elasticsearch) {
@@ -140,6 +141,7 @@ interface DataStreamMeta {
   dataset: string;
   dataset_is_prefix?: boolean;
   hidden?: boolean;
+  allow_routing?: boolean;
   elasticsearch?: {
     privileges?: RegistryDataStreamPrivileges;
   };
@@ -157,6 +159,10 @@ export function getDataStreamPrivileges(dataStream: DataStreamMeta, namespace: s
   }
 
   index += `-${namespace}`;
+
+  if (dataStream.allow_routing) {
+    index = `${dataStream.type}-*-*`;
+  }
 
   const privileges = dataStream?.elasticsearch?.privileges?.indices?.length
     ? dataStream.elasticsearch.privileges.indices

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/datastreams/0.2.0/data_stream/test_logs/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/datastreams/0.2.0/data_stream/test_logs/manifest.yml
@@ -2,6 +2,8 @@ title: Test Dataset
 
 type: logs
 
+allow_routing: true
+
 elasticsearch:
   index_template.mappings:
     dynamic: true


### PR DESCRIPTION
## Summary

Explores adding support for https://github.com/elastic/package-spec/pull/327, but it turns out we need to do https://github.com/elastic/kibana/issues/115032 first.

Doesn't work yet.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
