### PR TITLE
[7.17] chore(NA): include @kbn/synthetic-package-map/synthetic-packages.json on .gitignore (#131524)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ report.asciidoc
 
 # Exclude renovate config file (we only need it on master)
 renovate.json5
+/packages/kbn-synthetic-package-map/synthetic-packages.json


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.2` to `7.17`:
 - [chore(NA): include @kbn/synthetic-package-map/synthetic-packages.json on .gitignore (#131524)](https://github.com/elastic/kibana/pull/131524)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)