### PR TITLE
Optimize package installation performance, phase 2

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/index.ts
@@ -5,6 +5,6 @@
  * 2.0.
  */
 
-export { installPipelines, isTopLevelPipeline } from './install';
+export { prepareToInstallPipelines, isTopLevelPipeline } from './install';
 
 export { deletePreviousPipelines, deletePipeline } from './remove';

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/install.ts
@@ -12,7 +12,6 @@ import { ElasticsearchAssetType } from '../../../../types';
 import type { EsAssetReference, RegistryDataStream, InstallablePackage } from '../../../../types';
 import { getAsset, getPathParts } from '../../archive';
 import type { ArchiveEntry } from '../../archive';
-import { updateEsAssetReferences } from '../../packages/install';
 import {
   FLEET_FINAL_PIPELINE_CONTENT,
   FLEET_FINAL_PIPELINE_ID,
@@ -48,11 +47,12 @@ export const installPipelines = async (
   // it can be created pointing to the new template, without removing the old one and effecting data
   // so do not remove the currently installed pipelines here
   const dataStreams = installablePackage.data_streams;
-  const { name: pkgName, version: pkgVersion } = installablePackage;
+  const { version: pkgVersion } = installablePackage;
   const pipelinePaths = paths.filter((path) => isPipeline(path));
   const topLevelPipelinePaths = paths.filter((path) => isTopLevelPipeline(path));
 
-  if (!dataStreams?.length && topLevelPipelinePaths.length === 0) return [];
+  if (!dataStreams?.length && topLevelPipelinePaths.length === 0)
+    return { assetsToAdd: [], assetsToRemove: [] };
 
   // get and save pipeline refs before installing pipelines
   let pipelineRefs = dataStreams
@@ -85,10 +85,6 @@ export const installPipelines = async (
 
   pipelineRefs = [...pipelineRefs, ...topLevelPipelineRefs];
 
-  esReferences = await updateEsAssetReferences(savedObjectsClient, pkgName, esReferences, {
-    assetsToAdd: pipelineRefs,
-  });
-
   const pipelines = dataStreams
     ? dataStreams.reduce<Array<Promise<EsAssetReference[]>>>((acc, dataStream) => {
         if (dataStream.ingest_pipeline) {
@@ -119,7 +115,9 @@ export const installPipelines = async (
   }
 
   await Promise.all(pipelines);
-  return esReferences;
+  return {
+    assetsToAdd: pipelineRefs,
+  };
 };
 
 export function rewriteIngestPipeline(

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.test.ts
@@ -4,30 +4,19 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { loggerMock } from '@kbn/logging-mocks';
-
 import { createAppContextStartContractMock } from '../../../../mocks';
 import { appContextService } from '../../..';
 
 import type { RegistryDataStream } from '../../../../types';
-import type { Field } from '../../fields/field';
 
-import { installTemplate } from './install';
+import { prepareTemplate } from './install';
 
-describe('EPM install', () => {
+describe('EPM index template install', () => {
   beforeEach(async () => {
     appContextService.start(createAppContextStartContractMock());
   });
 
-  it('tests installPackage to use correct priority and index_patterns for data stream with dataset_is_prefix not set', async () => {
-    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
-    esClient.indices.getIndexTemplate.mockImplementation(() =>
-      elasticsearchServiceMock.createSuccessTransportRequestPromise({ index_templates: [] })
-    );
-
-    const fields: Field[] = [];
+  it('tests prepareTemplate to use correct priority and index_patterns for data stream with dataset_is_prefix not set', async () => {
     const dataStreamDatasetIsPrefixUnset = {
       type: 'metrics',
       dataset: 'package.dataset',
@@ -43,29 +32,14 @@ describe('EPM install', () => {
     };
     const templateIndexPatternDatasetIsPrefixUnset = 'metrics-package.dataset-*';
     const templatePriorityDatasetIsPrefixUnset = 200;
-    await installTemplate({
-      esClient,
-      logger: loggerMock.create(),
-      fields,
-      dataStream: dataStreamDatasetIsPrefixUnset,
-      packageVersion: pkg.version,
-      packageName: pkg.name,
-    });
-
-    const sentTemplate = (
-      esClient.indices.putIndexTemplate.mock.calls[0][0] as estypes.IndicesPutIndexTemplateRequest
-    ).body;
-
-    expect(sentTemplate).toBeDefined();
-    expect(sentTemplate?.priority).toBe(templatePriorityDatasetIsPrefixUnset);
-    expect(sentTemplate?.index_patterns).toEqual([templateIndexPatternDatasetIsPrefixUnset]);
+    const {
+      indexTemplate: { indexTemplate },
+    } = prepareTemplate({ pkg, dataStream: dataStreamDatasetIsPrefixUnset });
+    expect(indexTemplate.priority).toBe(templatePriorityDatasetIsPrefixUnset);
+    expect(indexTemplate.index_patterns).toEqual([templateIndexPatternDatasetIsPrefixUnset]);
   });
 
-  it('tests installPackage to use correct priority and index_patterns for data stream with dataset_is_prefix set to false', async () => {
-    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
-    esClient.indices.getIndexTemplate.mockResponse({ index_templates: [] });
-
-    const fields: Field[] = [];
+  it('tests prepareTemplate to use correct priority and index_patterns for data stream with dataset_is_prefix set to false', async () => {
     const dataStreamDatasetIsPrefixFalse = {
       type: 'metrics',
       dataset: 'package.dataset',
@@ -82,29 +56,15 @@ describe('EPM install', () => {
     };
     const templateIndexPatternDatasetIsPrefixFalse = 'metrics-package.dataset-*';
     const templatePriorityDatasetIsPrefixFalse = 200;
-    await installTemplate({
-      esClient,
-      logger: loggerMock.create(),
-      fields,
-      dataStream: dataStreamDatasetIsPrefixFalse,
-      packageVersion: pkg.version,
-      packageName: pkg.name,
-    });
+    const {
+      indexTemplate: { indexTemplate },
+    } = prepareTemplate({ pkg, dataStream: dataStreamDatasetIsPrefixFalse });
 
-    const sentTemplate = (
-      esClient.indices.putIndexTemplate.mock.calls[0][0] as estypes.IndicesPutIndexTemplateRequest
-    ).body;
-
-    expect(sentTemplate).toBeDefined();
-    expect(sentTemplate?.priority).toBe(templatePriorityDatasetIsPrefixFalse);
-    expect(sentTemplate?.index_patterns).toEqual([templateIndexPatternDatasetIsPrefixFalse]);
+    expect(indexTemplate.priority).toBe(templatePriorityDatasetIsPrefixFalse);
+    expect(indexTemplate.index_patterns).toEqual([templateIndexPatternDatasetIsPrefixFalse]);
   });
 
-  it('tests installPackage to use correct priority and index_patterns for data stream with dataset_is_prefix set to true', async () => {
-    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
-    esClient.indices.getIndexTemplate.mockResponse({ index_templates: [] });
-
-    const fields: Field[] = [];
+  it('tests prepareTemplate to use correct priority and index_patterns for data stream with dataset_is_prefix set to true', async () => {
     const dataStreamDatasetIsPrefixTrue = {
       type: 'metrics',
       dataset: 'package.dataset',
@@ -121,71 +81,11 @@ describe('EPM install', () => {
     };
     const templateIndexPatternDatasetIsPrefixTrue = 'metrics-package.dataset.*-*';
     const templatePriorityDatasetIsPrefixTrue = 150;
-    await installTemplate({
-      esClient,
-      logger: loggerMock.create(),
-      fields,
-      dataStream: dataStreamDatasetIsPrefixTrue,
-      packageVersion: pkg.version,
-      packageName: pkg.name,
-    });
+    const {
+      indexTemplate: { indexTemplate },
+    } = prepareTemplate({ pkg, dataStream: dataStreamDatasetIsPrefixTrue });
 
-    const sentTemplate = (
-      esClient.indices.putIndexTemplate.mock.calls[0][0] as estypes.IndicesPutIndexTemplateRequest
-    ).body;
-
-    expect(sentTemplate).toBeDefined();
-    expect(sentTemplate?.priority).toBe(templatePriorityDatasetIsPrefixTrue);
-    expect(sentTemplate?.index_patterns).toEqual([templateIndexPatternDatasetIsPrefixTrue]);
-  });
-
-  it('tests installPackage remove the aliases property if the property existed', async () => {
-    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
-
-    esClient.indices.getIndexTemplate.mockResponse({
-      index_templates: [
-        {
-          name: 'metrics-package.dataset',
-          // @ts-expect-error not full interface
-          index_template: {
-            index_patterns: ['metrics-package.dataset-*'],
-            template: { aliases: {} },
-          },
-        },
-      ],
-    });
-
-    const fields: Field[] = [];
-    const dataStreamDatasetIsPrefixUnset = {
-      type: 'metrics',
-      dataset: 'package.dataset',
-      title: 'test data stream',
-      release: 'experimental',
-      package: 'package',
-      path: 'path',
-      ingest_pipeline: 'default',
-    } as RegistryDataStream;
-    const pkg = {
-      name: 'package',
-      version: '0.0.1',
-    };
-    const templateIndexPatternDatasetIsPrefixUnset = 'metrics-package.dataset-*';
-    const templatePriorityDatasetIsPrefixUnset = 200;
-    await installTemplate({
-      esClient,
-      logger: loggerMock.create(),
-      fields,
-      dataStream: dataStreamDatasetIsPrefixUnset,
-      packageVersion: pkg.version,
-      packageName: pkg.name,
-    });
-
-    const sentTemplate = (
-      esClient.indices.putIndexTemplate.mock.calls[0][0] as estypes.IndicesPutIndexTemplateRequest
-    ).body;
-    expect(sentTemplate).toBeDefined();
-    expect(sentTemplate?.template?.aliases).not.toBeDefined();
-    expect(sentTemplate?.priority).toBe(templatePriorityDatasetIsPrefixUnset);
-    expect(sentTemplate?.index_patterns).toEqual([templateIndexPatternDatasetIsPrefixUnset]);
+    expect(indexTemplate.priority).toBe(templatePriorityDatasetIsPrefixTrue);
+    expect(indexTemplate.index_patterns).toEqual([templateIndexPatternDatasetIsPrefixTrue]);
   });
 });

--- a/x-pack/plugins/fleet/server/services/epm/fields/field.ts
+++ b/x-pack/plugins/fleet/server/services/epm/fields/field.ts
@@ -261,12 +261,12 @@ const isFields = (path: string) => {
  * Gets all field files, optionally filtered by dataset, extracts .yml files, merges them together
  */
 
-export const loadFieldsFromYaml = async (
+export const loadFieldsFromYaml = (
   pkg: Pick<PackageInfo, 'version' | 'name'>,
   datasetName?: string
-): Promise<Field[]> => {
+): Field[] => {
   // Fetch all field definition files
-  const fieldDefinitionFiles = await getAssetsData(pkg, isFields, datasetName);
+  const fieldDefinitionFiles = getAssetsData(pkg, isFields, datasetName);
   return fieldDefinitionFiles.reduce<Field[]>((acc, file) => {
     // Make sure it is defined as it is optional. Should never happen.
     if (file.buffer) {

--- a/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
@@ -267,6 +267,7 @@ export async function installKibanaSavedObjects({
         overwrite: true,
         readStream: createListStream(toBeSavedObjects),
         createNewCopies: false,
+        refresh: false,
       })
     );
 

--- a/x-pack/plugins/fleet/server/services/epm/packages/_install_package.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/_install_package.ts
@@ -22,10 +22,10 @@ import {
 import type { InstallablePackage, InstallSource, PackageAssetReference } from '../../../../common';
 import { PACKAGES_SAVED_OBJECT_TYPE } from '../../../constants';
 import type { AssetReference, Installation, InstallType } from '../../../types';
-import { installTemplates } from '../elasticsearch/template/install';
+import { prepareToInstallTemplates } from '../elasticsearch/template/install';
 import { removeLegacyTemplates } from '../elasticsearch/template/remove_legacy';
 import {
-  installPipelines,
+  prepareToInstallPipelines,
   isTopLevelPipeline,
   deletePreviousPipelines,
 } from '../elasticsearch/ingest_pipeline';
@@ -146,28 +146,45 @@ export async function _installPackage({
       installMlModel(packageInfo, paths, esClient, savedObjectsClient, logger, esReferences)
     );
 
-    // Install index templates and ingest pipelines in parallel since they typically take the longest
-    const [ingestRefs, templateResults] = await Promise.all([
-      // installs versionized pipelines without removing currently installed ones
-      withPackageSpan('Install ingest pipelines', () =>
-        installPipelines(packageInfo, paths, esClient, savedObjectsClient, logger, esReferences)
-      ),
-      withPackageSpan('Install index templates', () =>
-        installTemplates(packageInfo, esClient, logger, paths, esReferences)
-      ),
-    ]);
+    /**
+     * In order to install assets in parallel, we need to split the preparation step from the installation step. This
+     * allows us to know which asset references are going to be installed so that we can save them on the packages
+     * SO before installation begins. In the case of a failure during installing any individual asset, we'll have the
+     * references necessary to remove any assets in that were successfully installed during the rollback phase.
+     *
+     * This split of prepare/install could be extended to all asset types. Besides performance, it also allows us to
+     * more easily write unit tests against the asset generation code without needing to mock ES responses.
+     */
+    const preparedIngestPipelines = prepareToInstallPipelines(packageInfo, paths);
+    const preparedIndexTemplates = prepareToInstallTemplates(packageInfo, paths, esReferences);
 
     // Update the references for the templates and ingest pipelines together. Need to be done togther to avoid race
     // conditions on updating the installed_es field at the same time
+    // These must be saved before we actually attempt to install the templates or pipelines so that we know what to
+    // cleanup in the case that a single asset fails to install.
     esReferences = await updateEsAssetReferences(
       savedObjectsClient,
       packageInfo.name,
       esReferences,
       {
-        assetsToRemove: templateResults.esReferences.assetsToRemove,
-        assetsToAdd: [...ingestRefs.assetsToAdd, ...templateResults.esReferences.assetsToAdd],
+        assetsToRemove: preparedIndexTemplates.assetsToRemove,
+        assetsToAdd: [
+          ...preparedIngestPipelines.assetsToAdd,
+          ...preparedIndexTemplates.assetsToAdd,
+        ],
       }
     );
+
+    // Install index templates and ingest pipelines in parallel since they typically take the longest
+    const [installedTemplates] = await Promise.all([
+      withPackageSpan('Install index templates', () =>
+        preparedIndexTemplates.install(esClient, logger)
+      ),
+      // installs versionized pipelines without removing currently installed ones
+      withPackageSpan('Install ingest pipelines', () =>
+        preparedIngestPipelines.install(esClient, logger)
+      ),
+    ]);
 
     try {
       await removeLegacyTemplates({ packageInfo, esClient, logger });
@@ -177,7 +194,7 @@ export async function _installPackage({
 
     // update current backing indices of each data stream
     await withPackageSpan('Update write indices', () =>
-      updateCurrentWriteIndices(esClient, logger, templateResults.installedTemplates)
+      updateCurrentWriteIndices(esClient, logger, installedTemplates)
     );
 
     ({ esReferences } = await withPackageSpan('Install transforms', () =>

--- a/x-pack/plugins/fleet/server/services/epm/packages/_install_package.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/_install_package.ts
@@ -164,10 +164,7 @@ export async function _installPackage({
       packageInfo.name,
       esReferences,
       {
-        assetsToRemove: [
-          ...ingestRefs.assetsToRemove,
-          ...templateResults.esReferences.assetsToRemove,
-        ],
+        assetsToRemove: templateResults.esReferences.assetsToRemove,
         assetsToAdd: [...ingestRefs.assetsToAdd, ...templateResults.esReferences.assetsToAdd],
       }
     );

--- a/x-pack/plugins/fleet/server/services/epm/packages/assets.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/assets.ts
@@ -51,11 +51,11 @@ export function getAssets(
 
 // ASK: Does getAssetsData need an installSource now?
 // if so, should it be an Installation vs InstallablePackage or add another argument?
-export async function getAssetsData(
+export function getAssetsData(
   packageInfo: Pick<PackageInfo, 'version' | 'name'>,
   filter = (path: string): boolean => true,
   datasetName?: string
-): Promise<ArchiveEntry[]> {
+): ArchiveEntry[] {
   // Gather all asset data
   const assets = getAssets(packageInfo, filter, datasetName);
   const entries: ArchiveEntry[] = assets.map((path) => {

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -616,7 +616,7 @@ export async function createInstallation(options: {
       install_source: installSource,
       keep_policies_up_to_date: defaultKeepPoliciesUpToDate,
     },
-    { id: pkgName, overwrite: true }
+    { id: pkgName, overwrite: true, refresh: false }
   );
 
   return created;

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -616,7 +616,7 @@ export async function createInstallation(options: {
       install_source: installSource,
       keep_policies_up_to_date: defaultKeepPoliciesUpToDate,
     },
-    { id: pkgName, overwrite: true, refresh: false }
+    { id: pkgName, overwrite: true }
   );
 
   return created;


### PR DESCRIPTION
## Summary

Follow up from https://github.com/elastic/kibana/pull/130906
Closes https://github.com/elastic/kibana/issues/110500

This makes two additional performance improvements to shave off several more seconds from the installation process:
- Set `refresh: false` on the Saved Object import of Kibana assets
- Execute ingest pipeline and index template installation in parallel
	- Since we don't rollover the data streams until after both of these operations are done, this should be 100% safe to do.