### PR TITLE
[ci] include test_group_env in more ci scripts

### DIFF
--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -101,3 +101,8 @@ export DISABLE_BOOTSTRAP_VALIDATION=true
 
 # Prevent Browserlist from logging on CI about outdated database versions
 export BROWSERSLIST_IGNORE_OLD_DATA=true
+
+# keys used to associate test group data in ci-stats with Jest execution order
+export TEST_GROUP_TYPE_UNIT="Jest Unit Tests"
+export TEST_GROUP_TYPE_INTEGRATION="Jest Integration Tests"
+export TEST_GROUP_TYPE_FUNCTIONAL="Functional Tests"

--- a/.buildkite/scripts/saved_object_field_metrics.sh
+++ b/.buildkite/scripts/saved_object_field_metrics.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
-source .buildkite/scripts/steps/test/test_group_env.sh
 
 echo '--- Default Saved Object Field Metrics'
 checks-reporter-with-killswitch "Capture Kibana Saved Objects field count metrics" \

--- a/.buildkite/scripts/saved_object_field_metrics.sh
+++ b/.buildkite/scripts/saved_object_field_metrics.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
+source .buildkite/scripts/steps/test/test_group_env.sh
 
 echo '--- Default Saved Object Field Metrics'
 checks-reporter-with-killswitch "Capture Kibana Saved Objects field count metrics" \

--- a/.buildkite/scripts/steps/functional/performance_playwright.sh
+++ b/.buildkite/scripts/steps/functional/performance_playwright.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
+source .buildkite/scripts/steps/test/test_group_env.sh
 
 .buildkite/scripts/bootstrap.sh
 .buildkite/scripts/download_build_artifacts.sh

--- a/.buildkite/scripts/steps/functional/performance_playwright.sh
+++ b/.buildkite/scripts/steps/functional/performance_playwright.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
-source .buildkite/scripts/steps/test/test_group_env.sh
 
 .buildkite/scripts/bootstrap.sh
 .buildkite/scripts/download_build_artifacts.sh

--- a/.buildkite/scripts/steps/on_merge_build_and_metrics.sh
+++ b/.buildkite/scripts/steps/on_merge_build_and_metrics.sh
@@ -7,6 +7,4 @@ set -euo pipefail
 .buildkite/scripts/build_kibana_plugins.sh
 .buildkite/scripts/post_build_kibana_plugins.sh
 .buildkite/scripts/post_build_kibana.sh
-
-source ".buildkite/scripts/steps/test/test_group_env.sh"
 .buildkite/scripts/saved_object_field_metrics.sh

--- a/.buildkite/scripts/steps/test/ftr_configs.sh
+++ b/.buildkite/scripts/steps/test/ftr_configs.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 source .buildkite/scripts/steps/functional/common.sh
-source .buildkite/scripts/steps/test/test_group_env.sh
 
 export JOB_NUM=$BUILDKITE_PARALLEL_JOB
 export JOB=ftr-configs-${JOB_NUM}

--- a/.buildkite/scripts/steps/test/jest_parallel.sh
+++ b/.buildkite/scripts/steps/test/jest_parallel.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-source .buildkite/scripts/steps/test/test_group_env.sh
-
 export JOB=$BUILDKITE_PARALLEL_JOB
 
 # a jest failure will result in the script returning an exit code of 10

--- a/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
+++ b/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
-source .buildkite/scripts/steps/test/test_group_env.sh
 
 echo '--- Pick Test Group Run Order'
 node "$(dirname "${0}")/pick_test_group_run_order.js"

--- a/.buildkite/scripts/steps/test/test_group_env.sh
+++ b/.buildkite/scripts/steps/test/test_group_env.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-# keys used to associate test group data in ci-stats with Jest execution order
-export TEST_GROUP_TYPE_UNIT="Jest Unit Tests"
-export TEST_GROUP_TYPE_INTEGRATION="Jest Integration Tests"
-export TEST_GROUP_TYPE_FUNCTIONAL="Functional Tests"


### PR DESCRIPTION
Rather than adding test_group_env.sh to each script which needs these vars, just expose them globally via the `.buildkite/scripts/common/env.sh`