### PR TITLE
[8.2] [APM] set max limit back to 500 (#131160)

### DIFF
--- a/x-pack/plugins/apm/common/service_groups.ts
+++ b/x-pack/plugins/apm/common/service_groups.ts
@@ -7,7 +7,7 @@
 
 export const APM_SERVICE_GROUP_SAVED_OBJECT_TYPE = 'apm-service-group';
 export const SERVICE_GROUP_COLOR_DEFAULT = '#D1DAE7';
-export const MAX_NUMBER_OF_SERVICES_IN_GROUP = 500;
+export const MAX_NUMBER_OF_SERVICE_GROUPS = 500;
 
 export interface ServiceGroup {
   groupName: string;

--- a/x-pack/plugins/apm/server/routes/service_groups/get_service_groups.ts
+++ b/x-pack/plugins/apm/server/routes/service_groups/get_service_groups.ts
@@ -10,7 +10,7 @@ import {
   ServiceGroup,
   SavedServiceGroup,
   APM_SERVICE_GROUP_SAVED_OBJECT_TYPE,
-  MAX_NUMBER_OF_SERVICES_IN_GROUP,
+  MAX_NUMBER_OF_SERVICE_GROUPS,
 } from '../../../common/service_groups';
 
 export async function getServiceGroups({
@@ -21,7 +21,7 @@ export async function getServiceGroups({
   const result = await savedObjectsClient.find<ServiceGroup>({
     type: APM_SERVICE_GROUP_SAVED_OBJECT_TYPE,
     page: 1,
-    perPage: MAX_NUMBER_OF_SERVICES_IN_GROUP,
+    perPage: MAX_NUMBER_OF_SERVICE_GROUPS,
   });
   return result.saved_objects.map(
     ({ id, attributes, updated_at: upatedAt }) => ({

--- a/x-pack/plugins/apm/server/routes/service_groups/lookup_services.ts
+++ b/x-pack/plugins/apm/server/routes/service_groups/lookup_services.ts
@@ -14,7 +14,7 @@ import {
 import { kqlQuery, rangeQuery } from '../../../../observability/server';
 import { ProcessorEvent } from '../../../common/processor_event';
 import { Setup } from '../../lib/helpers/setup_request';
-import { MAX_NUMBER_OF_SERVICES_IN_GROUP } from '../../../common/service_groups';
+import { MAX_NUMBER_OF_SERVICE_GROUPS } from '../../../common/service_groups';
 
 export async function lookupServices({
   setup,
@@ -49,7 +49,7 @@ export async function lookupServices({
         services: {
           terms: {
             field: SERVICE_NAME,
-            size: MAX_NUMBER_OF_SERVICES_IN_GROUP,
+            size: MAX_NUMBER_OF_SERVICE_GROUPS,
           },
           aggs: {
             environments: {

--- a/x-pack/plugins/apm/server/routes/services/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/services/__snapshots__/queries.test.ts.snap
@@ -124,7 +124,7 @@ Array [
           },
           "terms": Object {
             "field": "service.name",
-            "size": 50,
+            "size": 500,
           },
         },
       },
@@ -177,7 +177,7 @@ Array [
           },
           "terms": Object {
             "field": "service.name",
-            "size": 50,
+            "size": 500,
           },
         },
       },

--- a/x-pack/plugins/apm/server/routes/services/get_services/get_services_items.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_services_items.ts
@@ -16,7 +16,7 @@ import { ServiceGroup } from '../../../../common/service_groups';
 
 export type ServicesItemsSetup = Setup;
 
-const MAX_NUMBER_OF_SERVICES = 50;
+const MAX_NUMBER_OF_SERVICES = 500;
 
 export async function getServicesItems({
   environment,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[APM] set max limit back to 500 (#131160)](https://github.com/elastic/kibana/pull/131160)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)