### PR TITLE
[es-snapshots] Fix verify job dependencies after FTR configs change

### DIFF
--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -44,10 +44,8 @@ steps:
     agents:
       queue: kibana-default
     depends_on:
-      - default-cigroup
-      - oss-cigroup
+      - ftr-configs
       - jest-integration
-      - api-integration
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
The pipeline is currently not able to complete as the listed dependencies no longer exist.