### PR TITLE
[ci/test-groups] define scripts externally

### DIFF
--- a/.buildkite/package-lock.json
+++ b/.buildkite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kibana-buildkite",
       "version": "1.0.0",
       "dependencies": {
-        "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#f5381bea52e0a71f50a6919cb6357ff3262cf2d6"
+        "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#ef419d4f761dd256cb59bfab9b59f8b91029eb40"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -355,8 +355,8 @@
     },
     "node_modules/kibana-buildkite-library": {
       "version": "1.0.0",
-      "resolved": "git+https://git@github.com/elastic/kibana-buildkite-library.git#f5381bea52e0a71f50a6919cb6357ff3262cf2d6",
-      "integrity": "sha512-L1JP2NvXR7mhKn9JBwROPgTEV4vDr5HWwZtkdvxtHjZ/MeOnJYFSDqB4JUY/gXTz6v3CO3eUm3GQ0BP/kewoqQ==",
+      "resolved": "git+https://git@github.com/elastic/kibana-buildkite-library.git#ef419d4f761dd256cb59bfab9b59f8b91029eb40",
+      "integrity": "sha512-ou/Db/DAhyMeD0uQeLpJ/VfUCg0PGPssIYsr4gJZSTZoqxCDrMtE4nhtH8sXErHq0TaugdqergUhyhVHNBSJiA==",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.10.0",
@@ -801,9 +801,9 @@
       }
     },
     "kibana-buildkite-library": {
-      "version": "git+https://git@github.com/elastic/kibana-buildkite-library.git#f5381bea52e0a71f50a6919cb6357ff3262cf2d6",
-      "integrity": "sha512-L1JP2NvXR7mhKn9JBwROPgTEV4vDr5HWwZtkdvxtHjZ/MeOnJYFSDqB4JUY/gXTz6v3CO3eUm3GQ0BP/kewoqQ==",
-      "from": "kibana-buildkite-library@git+https://git@github.com/elastic/kibana-buildkite-library#f5381bea52e0a71f50a6919cb6357ff3262cf2d6",
+      "version": "git+https://git@github.com/elastic/kibana-buildkite-library.git#ef419d4f761dd256cb59bfab9b59f8b91029eb40",
+      "integrity": "sha512-ou/Db/DAhyMeD0uQeLpJ/VfUCg0PGPssIYsr4gJZSTZoqxCDrMtE4nhtH8sXErHq0TaugdqergUhyhVHNBSJiA==",
+      "from": "kibana-buildkite-library@git+https://git@github.com/elastic/kibana-buildkite-library#ef419d4f761dd256cb59bfab9b59f8b91029eb40",
       "requires": {
         "@octokit/rest": "^18.10.0",
         "axios": "^0.21.4",

--- a/.buildkite/package.json
+++ b/.buildkite/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#f5381bea52e0a71f50a6919cb6357ff3262cf2d6"
+    "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#ef419d4f761dd256cb59bfab9b59f8b91029eb40"
   }
 }

--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -32,6 +32,9 @@ steps:
     agents:
       queue: kibana-default
     env:
+      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
       LIMIT_CONFIG_TYPE: integration,functional
     retry:
       automatic:

--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -33,7 +33,7 @@ steps:
       queue: kibana-default
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
-      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
       FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
       LIMIT_CONFIG_TYPE: integration,functional
     retry:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -55,7 +55,7 @@ steps:
       queue: kibana-default
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
-      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
       FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -53,6 +53,10 @@ steps:
     label: 'Pick Test Group Run Order'
     agents:
       queue: kibana-default
+    env:
+      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -21,7 +21,7 @@ steps:
       queue: kibana-default
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
-      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
       FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -19,6 +19,10 @@ steps:
     label: 'Pick Test Group Run Order'
     agents:
       queue: kibana-default
+    env:
+      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
Right now the `kibana-buildkite-library` defines the scripts for the three types of pipeline steps that it uploads. For Pipelines like cloud testing and code coverage we want to be able to customize these scripts, and additionally it can be unclear that renaming these scripts requires changes in an external repository. This PR instead bumps the `kibana-buildkite-library` to a new version which requires that the `JEST_UNIT_SCRIPT`, `FTR_CONFIGS_SCRIPT`, and `JEST_INTEGRATION_SCRIPT` are defined when those steps are going to be scheduled.