### PR TITLE
[TSVB] Wait for viz to be stabilized after changing the timerange mode

### DIFF
--- a/test/functional/apps/visualize/group4/_tsvb_chart.ts
+++ b/test/functional/apps/visualize/group4/_tsvb_chart.ts
@@ -84,7 +84,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await visualBuilder.clickPanelOptions('metric');
         await visualBuilder.setMetricsDataTimerangeMode('Entire time range');
-        await visChart.waitForVisualizationRenderingStabilized();
 
         const value = await visualBuilder.getMetricValue();
         expect(value).to.eql('13,492');
@@ -120,7 +119,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visualBuilder.clickPanelOptions('metric');
         await visualBuilder.setMetricsDataTimerangeMode('Entire time range');
         await visualBuilder.clickDataTab('metric');
-        await visChart.waitForVisualizationRenderingStabilized();
         await visualBuilder.checkInvalidAggComponentIsPresent();
         const error = await visualBuilder.getVisualizeError();
 
@@ -208,7 +206,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visualBuilder.clickPanelOptions('gauge');
         await visualBuilder.setMetricsDataTimerangeMode('Entire time range');
         await visualBuilder.clickDataTab('gauge');
-        await visChart.waitForVisualizationRenderingStabilized();
         await visualBuilder.checkInvalidAggComponentIsPresent();
         const error = await visualBuilder.getVisualizeError();
 
@@ -331,7 +328,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visualBuilder.changeDataFormatter('number');
         await visualBuilder.clickPanelOptions('topN');
         await visualBuilder.setMetricsDataTimerangeMode('Entire time range');
-        await visChart.waitForVisualizationRenderingStabilized();
 
         const topNLabel = await visualBuilder.getTopNLabel();
         const topNCount = await visualBuilder.getTopNCount();
@@ -367,7 +363,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visualBuilder.clickPanelOptions('topN');
         await visualBuilder.setMetricsDataTimerangeMode('Entire time range');
         await visualBuilder.clickDataTab('topN');
-        await visChart.waitForVisualizationRenderingStabilized();
         await visualBuilder.checkInvalidAggComponentIsPresent();
         const error = await visualBuilder.getVisualizeError();
 

--- a/test/functional/apps/visualize/group4/_tsvb_chart.ts
+++ b/test/functional/apps/visualize/group4/_tsvb_chart.ts
@@ -84,6 +84,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await visualBuilder.clickPanelOptions('metric');
         await visualBuilder.setMetricsDataTimerangeMode('Entire time range');
+        await visChart.waitForVisualizationRenderingStabilized();
 
         const value = await visualBuilder.getMetricValue();
         expect(value).to.eql('13,492');
@@ -119,6 +120,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visualBuilder.clickPanelOptions('metric');
         await visualBuilder.setMetricsDataTimerangeMode('Entire time range');
         await visualBuilder.clickDataTab('metric');
+        await visChart.waitForVisualizationRenderingStabilized();
         await visualBuilder.checkInvalidAggComponentIsPresent();
         const error = await visualBuilder.getVisualizeError();
 
@@ -206,6 +208,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visualBuilder.clickPanelOptions('gauge');
         await visualBuilder.setMetricsDataTimerangeMode('Entire time range');
         await visualBuilder.clickDataTab('gauge');
+        await visChart.waitForVisualizationRenderingStabilized();
         await visualBuilder.checkInvalidAggComponentIsPresent();
         const error = await visualBuilder.getVisualizeError();
 
@@ -328,6 +331,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visualBuilder.changeDataFormatter('number');
         await visualBuilder.clickPanelOptions('topN');
         await visualBuilder.setMetricsDataTimerangeMode('Entire time range');
+        await visChart.waitForVisualizationRenderingStabilized();
 
         const topNLabel = await visualBuilder.getTopNLabel();
         const topNCount = await visualBuilder.getTopNCount();
@@ -363,6 +367,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visualBuilder.clickPanelOptions('topN');
         await visualBuilder.setMetricsDataTimerangeMode('Entire time range');
         await visualBuilder.clickDataTab('topN');
+        await visChart.waitForVisualizationRenderingStabilized();
         await visualBuilder.checkInvalidAggComponentIsPresent();
         const error = await visualBuilder.getVisualizeError();
 

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -374,11 +374,13 @@ export class VisualBuilderPageObject extends FtrService {
   }
 
   public async getTopNLabel() {
+    await this.visChart.waitForVisualizationRenderingStabilized();
     const topNLabel = await this.find.byCssSelector('.tvbVisTopN__label');
     return await topNLabel.getVisibleText();
   }
 
   public async getTopNCount() {
+    await this.visChart.waitForVisualizationRenderingStabilized();
     const gaugeCount = await this.find.byCssSelector('.tvbVisTopN__value');
     return await gaugeCount.getVisibleText();
   }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/131679

I added the `waitForVisualizationRenderingStabilized` every time we are changing the timerange mode in the tsvb test to ensure that the viz has been rendered before the assertion is made.

50 times runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/564

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios