### PR TITLE
added orphaned policies api and to debug page

### DIFF
--- a/x-pack/plugins/fleet/common/constants/routes.ts
+++ b/x-pack/plugins/fleet/common/constants/routes.ts
@@ -54,6 +54,8 @@ export const PACKAGE_POLICY_API_ROUTES = {
   DELETE_PATTERN: `${PACKAGE_POLICY_API_ROOT}/delete`,
   UPGRADE_PATTERN: `${PACKAGE_POLICY_API_ROOT}/upgrade`,
   DRYRUN_PATTERN: `${PACKAGE_POLICY_API_ROOT}/upgrade/dryrun`,
+  ORPHANED_INTEGRATION_POLICIES: `${INTERNAL_ROOT}/orphaned_integration_policies`,
+  DELETE_ORPHANED_INTEGRATION_POLICIES: `${INTERNAL_ROOT}/orphaned_integration_policies/delete`,
 };
 
 // Agent policy API routes

--- a/x-pack/plugins/fleet/common/services/routes.ts
+++ b/x-pack/plugins/fleet/common/services/routes.ts
@@ -106,6 +106,14 @@ export const packagePolicyRouteService = {
   getDryRunPath: () => {
     return PACKAGE_POLICY_API_ROUTES.DRYRUN_PATTERN;
   },
+
+  getOrphanedIntegrationPoliciesPath: () => {
+    return PACKAGE_POLICY_API_ROUTES.ORPHANED_INTEGRATION_POLICIES;
+  },
+
+  getDeleteOrphanedIntegrationPolicyPath: () => {
+    return PACKAGE_POLICY_API_ROUTES.DELETE_ORPHANED_INTEGRATION_POLICIES;
+  },
 };
 
 export const agentPolicyRouteService = {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/debug/components/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/debug/components/index.tsx
@@ -10,3 +10,4 @@ export * from './integration_debugger';
 export * from './saved_object_debugger';
 export * from './preconfiguration_debugger';
 export * from './fleet_index_debugger';
+export * from './orphaned_integration_policies_debugger';

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/debug/components/orphaned_integration_policies_debugger.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/debug/components/orphaned_integration_policies_debugger.tsx
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiSpacer,
+  EuiText,
+  EuiFlexGroup,
+  EuiComboBox,
+  EuiFlexItem,
+  EuiButton,
+  EuiConfirmModal,
+} from '@elastic/eui';
+
+import { useMutation, useQuery } from 'react-query';
+
+import {
+  sendGetOrphanedIntegrationPolicies,
+  sendDeleteOneOrphanedIntegrationPolicy,
+  useStartServices,
+} from '../../../hooks';
+import { queryClient } from '..';
+
+import { CodeBlock } from './code_block';
+
+const fetchOrphanedPolicies = async () => {
+  const response = await sendGetOrphanedIntegrationPolicies();
+
+  if (response.error) {
+    throw new Error(response.error.message);
+  }
+
+  return response.data?.items ?? [];
+};
+
+export const OrphanedIntegrationPoliciesDebugger: React.FunctionComponent = () => {
+  const { notifications } = useStartServices();
+
+  const [selectedPolicyId, setSelectedPolicyId] = useState<string>();
+  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
+  const [isDeleteAllModalVisible, setIsDeleteAllModalVisible] = useState(false);
+
+  const { data: orphanedPolicies } = useQuery('debug-orphaned-policies', fetchOrphanedPolicies);
+
+  const comboBoxOptions =
+    orphanedPolicies?.map((policy: { id: string; name: string }) => ({
+      label: policy.name,
+      value: policy.id,
+    })) ?? [];
+
+  const selectedOptions = selectedPolicyId
+    ? [comboBoxOptions.find(({ value }: { value: string }) => value === selectedPolicyId)!]
+    : [];
+
+  const selectedPolicy = orphanedPolicies?.find(
+    (policy: { id: string }) => policy.id === selectedPolicyId
+  );
+
+  const deleteOnePolicyMutation = useMutation(async (policyId: string) => {
+    const response = await sendDeleteOneOrphanedIntegrationPolicy({
+      ids: [policyId],
+    });
+
+    if (response.error) {
+      notifications.toasts.addError(response.error, {
+        title: `Error deleting policy`,
+        toastMessage: response.error.message,
+      });
+      throw new Error(response.error.message);
+    }
+
+    notifications.toasts.addSuccess('Successfully deleted orphaned policy');
+    queryClient.invalidateQueries('debug-orphaned-policies');
+    setSelectedPolicyId(undefined);
+    setIsDeleteModalVisible(false);
+
+    return response.data;
+  });
+
+  const deleteAllPoliciesMutation = useMutation(async () => {
+    const response = await sendDeleteOneOrphanedIntegrationPolicy({
+      ids: orphanedPolicies?.map((policy: { id: string }) => policy.id),
+    });
+
+    if (response.error) {
+      notifications.toasts.addError(response.error, {
+        title: `Error deleting orphaned policies`,
+        toastMessage: response.error.message,
+      });
+      throw new Error(response.error.message);
+    }
+
+    notifications.toasts.addSuccess('Successfully deleted all orphaned policies');
+    queryClient.invalidateQueries('debug-orphaned-policies');
+    setSelectedPolicyId(undefined);
+    setIsDeleteAllModalVisible(false);
+
+    return response.data;
+  });
+
+  return (
+    <>
+      <EuiText grow={false}>
+        <p>This tool can be used to delete {'"orphaned"'} integration policies.</p>
+
+        <p>
+          You may delete a single orphaned integration policy or use the {'"Delete all"'} button to
+          delete all orphaned integration policies at once.
+        </p>
+      </EuiText>
+
+      <EuiSpacer size="m" />
+
+      <EuiFlexGroup>
+        <EuiFlexItem
+          grow={false}
+          css={`
+            min-width: 400px;
+          `}
+        >
+          <EuiComboBox
+            aria-label="Select an orphaned integration policy"
+            placeholder="Select an orphaned integration policy"
+            fullWidth
+            options={comboBoxOptions}
+            singleSelection={{ asPlainText: true }}
+            selectedOptions={selectedOptions}
+            onChange={(newSelectedOptions: any[]) => {
+              if (!newSelectedOptions.length) {
+                setSelectedPolicyId(undefined);
+              } else {
+                setSelectedPolicyId(newSelectedOptions[0].value);
+              }
+            }}
+          />
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <div>
+            <EuiButton
+              color="warning"
+              isDisabled={!selectedPolicyId}
+              onClick={() => setIsDeleteModalVisible(true)}
+            >
+              Delete
+            </EuiButton>
+          </div>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <div>
+            <EuiButton
+              color="danger"
+              isDisabled={!orphanedPolicies?.length}
+              onClick={() => setIsDeleteAllModalVisible(true)}
+            >
+              Delete all
+            </EuiButton>
+          </div>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      {isDeleteModalVisible && selectedPolicy && selectedPolicyId && (
+        <EuiConfirmModal
+          title={`Delete ${selectedPolicy.name}`}
+          onCancel={() => setIsDeleteModalVisible(false)}
+          onConfirm={() => deleteOnePolicyMutation.mutate(selectedPolicyId)}
+          isLoading={deleteOnePolicyMutation.isLoading}
+          cancelButtonText="Cancel"
+          confirmButtonText="Delete"
+        >
+          Are you sure you want to delete {selectedPolicy.name}?
+        </EuiConfirmModal>
+      )}
+
+      {isDeleteAllModalVisible && (
+        <EuiConfirmModal
+          title={`Delete all orphaned integration policies`}
+          onCancel={() => setIsDeleteAllModalVisible(false)}
+          onConfirm={() => deleteAllPoliciesMutation.mutate()}
+          isLoading={deleteAllPoliciesMutation.isLoading}
+          cancelButtonText="Cancel"
+          confirmButtonText="Delete all"
+        >
+          Are you sure you want to delete all orphaned integration policies?
+        </EuiConfirmModal>
+      )}
+
+      {selectedPolicyId && (
+        <>
+          <EuiSpacer size="m" />
+          <CodeBlock value={JSON.stringify(selectedPolicy, null, 2)} />
+        </>
+      )}
+    </>
+  );
+};

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/debug/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/debug/index.tsx
@@ -27,6 +27,7 @@ import {
   PreconfigurationDebugger,
   FleetIndexDebugger,
   SavedObjectDebugger,
+  OrphanedIntegrationPoliciesDebugger,
 } from './components';
 
 // TODO: Evaluate moving this react-query initialization up to the main Fleet app
@@ -58,6 +59,11 @@ const panels = [
     title: 'Preconfiguration Debugger',
     id: 'preconfigurationDebugger',
     component: <PreconfigurationDebugger />,
+  },
+  {
+    title: 'Orphaned Integration Policies Debugger',
+    id: 'orphanedIntegrationPoliciesDebugger',
+    component: <OrphanedIntegrationPoliciesDebugger />,
   },
 ];
 

--- a/x-pack/plugins/fleet/public/hooks/use_request/package_policy.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/package_policy.ts
@@ -109,3 +109,18 @@ export function sendUpgradePackagePolicy(packagePolicyIds: string[]) {
     }),
   });
 }
+
+export function sendGetOrphanedIntegrationPolicies() {
+  return sendRequest({
+    path: packagePolicyRouteService.getOrphanedIntegrationPoliciesPath(),
+    method: 'get',
+  });
+}
+
+export function sendDeleteOneOrphanedIntegrationPolicy(body: { ids: string[] }) {
+  return sendRequest({
+    path: packagePolicyRouteService.getDeleteOrphanedIntegrationPolicyPath(),
+    method: 'post',
+    body: JSON.stringify(body),
+  });
+}

--- a/x-pack/plugins/fleet/server/routes/package_policy/index.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/index.ts
@@ -14,6 +14,7 @@ import {
   DeletePackagePoliciesRequestSchema,
   UpgradePackagePoliciesRequestSchema,
   DryRunPackagePoliciesRequestSchema,
+  DeleteOrphanedIntegrationPoliciesRequestSchema,
 } from '../../types';
 import type { FleetAuthzRouter } from '../security';
 
@@ -25,6 +26,8 @@ import {
   deletePackagePolicyHandler,
   upgradePackagePolicyHandler,
   dryRunUpgradePackagePolicyHandler,
+  getOrphanedPackagePolicies,
+  deleteOrphanedIntegrationPolicyHandler,
 } from './handlers';
 
 export const registerRoutes = (router: FleetAuthzRouter) => {
@@ -50,6 +53,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       },
     },
     getOnePackagePolicyHandler
+  );
+
+  router.get(
+    {
+      path: PACKAGE_POLICY_API_ROUTES.ORPHANED_INTEGRATION_POLICIES,
+      validate: {},
+      fleetAuthz: {
+        integrations: { readIntegrationPolicies: true },
+      },
+    },
+    getOrphanedPackagePolicies
+  );
+
+  router.post(
+    {
+      path: PACKAGE_POLICY_API_ROUTES.DELETE_ORPHANED_INTEGRATION_POLICIES,
+      validate: DeleteOrphanedIntegrationPoliciesRequestSchema,
+      fleetAuthz: {
+        integrations: { writeIntegrationPolicies: true },
+      },
+    },
+    deleteOrphanedIntegrationPolicyHandler
   );
 
   // Create

--- a/x-pack/plugins/fleet/server/types/rest_spec/package_policy.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/package_policy.ts
@@ -52,3 +52,9 @@ export const DryRunPackagePoliciesRequestSchema = {
     packageVersion: schema.maybe(schema.string()),
   }),
 };
+
+export const DeleteOrphanedIntegrationPoliciesRequestSchema = {
+  body: schema.object({
+    ids: schema.arrayOf(schema.string()),
+  }),
+};


### PR DESCRIPTION
## Summary

Added API to find and delete orphaned integration policies.
Added UI to debug page to display and delete.

```
GET kbn:/internal/fleet/orphaned_integration_policies

POST kbn:/internal/fleet/orphaned_integration_policies/delete
{
  ids: ['policy_id']
}
```

Tested by simulating orphaned integration policies.
Done this by commenting out code that deletes package policies when deleting agent policies.

<img width="752" alt="image" src="https://user-images.githubusercontent.com/90178898/167102047-d979a7f0-72d8-42b1-9e4d-54c18786482c.png">
<img width="1757" alt="image" src="https://user-images.githubusercontent.com/90178898/167102145-b6d3a463-de45-4397-8a0d-829d0999c023.png">
<img width="870" alt="image" src="https://user-images.githubusercontent.com/90178898/167102191-1b162c48-b41f-4fe8-a02c-ea31f7d76e18.png">
<img width="612" alt="image" src="https://user-images.githubusercontent.com/90178898/167102234-0d42e85b-f77a-47be-b2eb-54c393a40c17.png">
<img width="1761" alt="image" src="https://user-images.githubusercontent.com/90178898/167102342-b2bd5218-ef1c-4b7a-85f1-e1b4c6ee3fc2.png">



