### PR TITLE
[Discover] Fix Document Explorer infinite height growth

### DIFF
--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
@@ -156,9 +156,9 @@ function DiscoverDocumentsComponent({
         </>
       )}
       {!isLegacy && (
-        <div className="dscDiscoverGrid">
-          <>
-            <DocumentExplorerUpdateCallout />
+        <>
+          <DocumentExplorerUpdateCallout />
+          <div className="dscDiscoverGrid">
             <DataGridMemoized
               ariaLabelledBy="documentsAriaLabel"
               columns={columns}
@@ -183,8 +183,8 @@ function DiscoverDocumentsComponent({
               rowHeightState={state.rowHeight}
               onUpdateRowHeight={onUpdateRowHeight}
             />
-          </>
-        </div>
+          </div>
+        </>
       )}
     </EuiFlexItem>
   );

--- a/src/plugins/discover/public/components/discover_grid/discover_grid.scss
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid.scss
@@ -1,7 +1,7 @@
 .dscDiscoverGrid {
   width: 100%;
   max-width: 100%;
-  height: 100%;
+  min-height: 100%;
   overflow: hidden;
 
   .euiDataGrid__controls {

--- a/src/plugins/discover/public/components/discover_grid/discover_grid.scss
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid.scss
@@ -1,7 +1,7 @@
 .dscDiscoverGrid {
   width: 100%;
   max-width: 100%;
-  min-height: 100%;
+  height: 100%;
   overflow: hidden;
 
   .euiDataGrid__controls {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/131719

## Summary

This PR fixes the issue with grid growing indefinitely for smaller screen sizes.


### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
