### PR TITLE
[ci] break out skip patterns so they can change without triggering CI

### DIFF
--- a/.buildkite/scripts/pipelines/pull_request/pipeline.js
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.js
@@ -9,20 +9,7 @@
 const execSync = require('child_process').execSync;
 const fs = require('fs');
 const { areChangesSkippable, doAnyChangesMatch } = require('kibana-buildkite-library');
-
-const SKIPPABLE_PATHS = [
-  /^docs\//,
-  /^rfcs\//,
-  /^.ci\/.+\.yml$/,
-  /^.ci\/es-snapshots\//,
-  /^.ci\/pipeline-library\//,
-  /^.ci\/Jenkinsfile_[^\/]+$/,
-  /^\.github\//,
-  /\.md$/,
-  /^\.backportrc\.json$/,
-  /^nav-kibana-dev\.docnav\.json$/,
-  /^src\/dev\/prs\/kibana_qa_pr_list\.json$/,
-];
+const { SKIPPABLE_PR_MATCHERS } = require('./skippable_pr_matchers');
 
 const REQUIRED_PATHS = [
   // this file is auto-generated and changes to it need to be validated with CI
@@ -48,7 +35,7 @@ const uploadPipeline = (pipelineContent) => {
 
 (async () => {
   try {
-    const skippable = await areChangesSkippable(SKIPPABLE_PATHS, REQUIRED_PATHS);
+    const skippable = await areChangesSkippable(SKIPPABLE_PR_MATCHERS, REQUIRED_PATHS);
 
     if (skippable) {
       console.log('All changes in PR are skippable. Skipping CI.');

--- a/.buildkite/scripts/pipelines/pull_request/skippable_pr_matchers.js
+++ b/.buildkite/scripts/pipelines/pull_request/skippable_pr_matchers.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module.exports = {
+  SKIPPABLE_PR_MATCHERS: [
+    /^docs\//,
+    /^rfcs\//,
+    /^.ci\/.+\.yml$/,
+    /^.ci\/es-snapshots\//,
+    /^.ci\/pipeline-library\//,
+    /^.ci\/Jenkinsfile_[^\/]+$/,
+    /^\.github\//,
+    /\.md$/,
+    /^\.backportrc\.json$/,
+    /^nav-kibana-dev\.docnav\.json$/,
+    /^src\/dev\/prs\/kibana_qa_pr_list\.json$/,
+    /^\.buildkite\/scripts\/pipelines\/pull_request\/skippable_pr_matchers\.js$/,
+  ],
+};


### PR DESCRIPTION
Breaks the `SKIPPABLE_PR_MATCHERS` into a separate file which is itself skippable. Changes to this file shouldn't require a full CI run, but should instead validate that the PR they are testing (assuming it changes the mentioned files) is properly skipping CI.