### PR TITLE
[Unified search] Fix uptime css problem

### DIFF
--- a/src/plugins/unified_search/public/search_bar/index.tsx
+++ b/src/plugins/unified_search/public/search_bar/index.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { injectI18n } from '@kbn/i18n-react';
 import { withKibana } from '@kbn/kibana-react-plugin/public';
 import type { SearchBarProps } from './search_bar';
+import '../index.scss';
 
 const Fallback = () => <div />;
 

--- a/src/plugins/unified_search/public/search_bar/search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/search_bar.tsx
@@ -31,8 +31,6 @@ import QueryBarTopRow from '../query_string_input/query_bar_top_row';
 import { FilterBar, FilterItems } from '../filter_bar';
 import { searchBarStyles } from './search_bar.styles';
 
-import '../index.scss';
-
 export interface SearchBarInjectedDeps {
   kibana: KibanaReactContextValue<IDataPluginServices>;
   intl: InjectedIntl;


### PR DESCRIPTION
## Summary

Fixes the css problem on Uptime and other applications that use only the QueryStringInput component and not the SearchBar.

<img width="545" alt="image" src="https://user-images.githubusercontent.com/17003240/167150391-4b520954-e129-4cb5-a499-41910d376588.png">


There will be a follow-up PR to lazy load some of the CSS files (and other cleanups) to decrease the bundle size of the unified search plugin but let's fix the problem first.