### PR TITLE
Add cloud icon "ess-icon" at the end of the config keys in "alerting"…

### DIFF
--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -187,37 +187,37 @@ For example, `20m`, `24h`, `7d`, `1w`. Default: `60s`.
 [[alert-settings]]
 ==== Alerting settings
 
-`xpack.alerting.maxEphemeralActionsPerAlert`::
+`xpack.alerting.maxEphemeralActionsPerAlert` {ess-icon}::
 Sets the number of actions that will run ephemerally. To use this, enable
 ephemeral tasks in task manager first with
 <<task-manager-settings,`xpack.task_manager.ephemeral_tasks.enabled`>>
 
-`xpack.alerting.cancelAlertsOnRuleTimeout`::
+`xpack.alerting.cancelAlertsOnRuleTimeout` {ess-icon}::
 Specifies whether to skip writing alerts and scheduling actions if rule
 processing was cancelled due to a timeout. Default: `true`. This setting can be
 overridden by individual rule types.
 
-`xpack.alerting.rules.minimumScheduleInterval.value`::
+`xpack.alerting.rules.minimumScheduleInterval.value` {ess-icon}::
 Specifies the minimum schedule interval for rules. This minimum is applied to all rules created or updated after you set this value. The time is formatted as:
 +
 `<count>[s,m,h,d]` 
 +
 For example, `20m`, `24h`, `7d`. This duration cannot exceed `1d`. Default: `1m`.
 
-`xpack.alerting.rules.minimumScheduleInterval.enforce`::
+`xpack.alerting.rules.minimumScheduleInterval.enforce` {ess-icon}::
 Specifies the behavior when a new or changed rule has a schedule interval less than the value defined in `xpack.alerting.rules.minimumScheduleInterval.value`. If `false`, rules with schedules less than the interval will be created but warnings will be logged. If `true`, rules with schedules less than the interval cannot be created. Default: `false`.
 
-`xpack.alerting.rules.run.actions.max`::
+`xpack.alerting.rules.run.actions.max` {ess-icon}::
 Specifies the maximum number of actions that a rule can generate each time detection checks run.
 
-`xpack.alerting.rules.run.timeout`::
+`xpack.alerting.rules.run.timeout` {ess-icon}::
 Specifies the default timeout for tasks associated with all types of rules. The time is formatted as:
 +
 `<count>[ms,s,m,h,d,w,M,Y]`
 +
 For example, `20m`, `24h`, `7d`, `1w`. Default: `5m`.
 
-`xpack.alerting.rules.run.ruleTypeOverrides`::
+`xpack.alerting.rules.run.ruleTypeOverrides` {ess-icon}::
 Overrides the configs under `xpack.alerting.rules.run` for the rule type with the given ID. List the rule identifier and its settings in an array of objects.
 +
 For example:
@@ -230,7 +230,7 @@ xpack.alerting.rules.run:
           timeout: '15m'
 --
 
-`xpack.alerting.rules.run.actions.connectorTypeOverrides`::
+`xpack.alerting.rules.run.actions.connectorTypeOverrides` {ess-icon}::
 Overrides the configs under `xpack.alerting.rules.run.actions` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects.
 +
 For example:


### PR DESCRIPTION
Cloud icons that indicate the config key is allowed in cloud was missing in alerting documentation.
This PR adds those missing icons.
