### PR TITLE
[DOCS] Updates deprecation text for legacy APIs

### DIFF
--- a/docs/api/actions-and-connectors/legacy/index.asciidoc
+++ b/docs/api/actions-and-connectors/legacy/index.asciidoc
@@ -1,4 +1,4 @@
 [[actions-and-connectors-legacy-apis]]
 === Deprecated 7.x APIs
 
-These APIs are deprecated and will be removed as of 8.0.
+These APIs are deprecated and will be removed in a future release.

--- a/docs/api/alerting/legacy/index.asciidoc
+++ b/docs/api/alerting/legacy/index.asciidoc
@@ -1,7 +1,7 @@
 [[alerts-api]]
 === Deprecated 7.x APIs
 
-These APIs are deprecated and will be removed as of 8.0.
+These APIs are deprecated and will be removed in a future release.
 
 include::create.asciidoc[leveloffset=+1]
 include::delete.asciidoc[leveloffset=+1]


### PR DESCRIPTION
## Summary

This PR updates the notice in https://www.elastic.co/guide/en/kibana/7.17/alerts-api.html and https://www.elastic.co/guide/en/kibana/7.17/actions-and-connectors-legacy-apis.html since the APIs were not removed in 8.0
