### PR TITLE
Get mb field name

### DIFF
--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_color_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_color_property.tsx
@@ -135,7 +135,7 @@ export class DynamicColorProperty extends DynamicStyleProperty<ColorDynamicOptio
   }
 
   _getMbColor() {
-    if (!this.getMbFieldName()) {
+    if (!this.getMbPropertyName()) {
       return null;
     }
 
@@ -145,7 +145,7 @@ export class DynamicColorProperty extends DynamicStyleProperty<ColorDynamicOptio
   }
 
   _getOrdinalColorMbExpression() {
-    const targetName = this.getMbFieldName();
+    const targetName = this.getMbPropertyName();
     if (this._options.useCustomColorRamp) {
       if (!this._options.customColorRamp || !this._options.customColorRamp.length) {
         // custom color ramp config is not complete
@@ -321,7 +321,7 @@ export class DynamicColorProperty extends DynamicStyleProperty<ColorDynamicOptio
     }
 
     mbStops.push(defaultColor); // last color is default color
-    return ['match', ['to-string', ['get', this.getMbFieldName()]], ...mbStops];
+    return ['match', ['to-string', ['get', this.getMbPropertyName()]], ...mbStops];
   }
 
   _getOrdinalBreaks(symbolId?: string, svg?: string): Break[] {

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_icon_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_icon_property.tsx
@@ -22,6 +22,10 @@ import { LegendProps } from './style_property';
 import { IconDynamicOptions } from '../../../../../common/descriptor_types';
 
 export class DynamicIconProperty extends DynamicStyleProperty<IconDynamicOptions> {
+  supportsFeatureState() {
+    return false;
+  }
+
   isOrdinal() {
     return false;
   }
@@ -87,7 +91,7 @@ export class DynamicIconProperty extends DynamicStyleProperty<IconDynamicOptions
     if (fallbackSymbolId) {
       mbStops.push(fallbackSymbolId); // last item is fallback style for anything that does not match provided stops
     }
-    return ['match', ['to-string', ['get', this.getMbFieldName()]], ...mbStops];
+    return ['match', ['to-string', ['get', this.getMbPropertyName()]], ...mbStops];
   }
 
   _getMbIconAnchorExpression() {
@@ -107,7 +111,7 @@ export class DynamicIconProperty extends DynamicStyleProperty<IconDynamicOptions
     if (fallbackSymbolId) {
       mbStops.push(getMakiSymbolAnchor(fallbackSymbolId)); // last item is fallback style for anything that does not match provided stops
     }
-    return ['match', ['to-string', ['get', this.getMbFieldName()]], ...mbStops];
+    return ['match', ['to-string', ['get', this.getMbPropertyName()]], ...mbStops];
   }
 
   _isIconDynamicConfigComplete() {

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_size_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_size_property.tsx
@@ -57,7 +57,7 @@ export class DynamicSizeProperty extends DynamicStyleProperty<SizeDynamicOptions
   syncIconSizeWithMb(symbolLayerId: string, mbMap: MbMap) {
     const rangeFieldMeta = this.getRangeFieldMeta();
     if (this._isSizeDynamicConfigComplete() && rangeFieldMeta) {
-      const targetName = this.getMbFieldName();
+      const targetName = this.getMbPropertyName();
       // Using property state instead of feature-state because layout properties do not support feature-state
       mbMap.setLayoutProperty(symbolLayerId, 'icon-size', [
         'interpolate',
@@ -110,7 +110,7 @@ export class DynamicSizeProperty extends DynamicStyleProperty<SizeDynamicOptions
     }
 
     return this._getMbDataDrivenSize({
-      targetName: this.getMbFieldName(),
+      targetName: this.getMbPropertyName(),
       minSize: this._options.minSize,
       maxSize: this._options.maxSize,
       minValue: rangeFieldMeta.min,

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_style_property.tsx
@@ -43,7 +43,6 @@ export interface IDynamicStyleProperty<T> extends IStyleProperty<T> {
   getFieldMetaOptions(): FieldMetaOptions;
   getField(): IField | null;
   getFieldName(): string;
-  getMbFieldName(): string;
   getFieldOrigin(): FIELD_ORIGIN | null;
   getRangeFieldMeta(): RangeFieldMeta | null;
   getCategoryFieldMeta(): Category[];
@@ -233,10 +232,6 @@ export class DynamicStyleProperty<T>
 
   getFieldName() {
     return this._field ? this._field.getName() : '';
-  }
-
-  getMbFieldName() {
-    return this._field ? this._field.getMbFieldName() : '';
   }
 
   isDynamic() {


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/116150

> https://github.com/elastic/kibana/pull/114553 migrated from using mvt's generated by the Kibana server to mvt's generated by Elasticsearch. During this migration, some tech debt was added in order to have this feature make 8.0 FF. These need to be cleaned up in 8.1.

> Remove getMbFieldName from IDynamicStyleProperty interface. DynamicStyleProperty already has a method, getMbPropertyName, for this purpose. getMbPropertyName should be used anywhere getMbFieldName was added.