### PR TITLE
[Controls] Remove "Set all sizes to default" checkbox in control group settings 

### DIFF
--- a/src/plugins/controls/common/control_group/control_group_constants.ts
+++ b/src/plugins/controls/common/control_group/control_group_constants.ts
@@ -8,5 +8,5 @@
 
 import { ControlStyle, ControlWidth } from '../types';
 
-export const DEFAULT_CONTROL_WIDTH: ControlWidth = 'auto';
+export const DEFAULT_CONTROL_WIDTH: ControlWidth = 'medium';
 export const DEFAULT_CONTROL_STYLE: ControlStyle = 'oneLine';

--- a/src/plugins/controls/common/control_group/control_group_persistence.ts
+++ b/src/plugins/controls/common/control_group/control_group_persistence.ts
@@ -26,6 +26,7 @@ const safeJSONParse = <OutType>(jsonString?: string): OutType | undefined => {
 export const getDefaultControlGroupInput = (): Omit<ControlGroupInput, 'id'> => ({
   panels: {},
   defaultControlWidth: DEFAULT_CONTROL_WIDTH,
+  defaultControlGrow: true,
   controlStyle: DEFAULT_CONTROL_STYLE,
   chainingSystem: 'HIERARCHICAL',
   ignoreParentSettings: {

--- a/src/plugins/controls/common/control_group/types.ts
+++ b/src/plugins/controls/common/control_group/types.ts
@@ -27,6 +27,7 @@ export interface ControlsPanels {
 export interface ControlGroupInput extends EmbeddableInput, ControlInput {
   chainingSystem: ControlGroupChainingSystem;
   defaultControlWidth?: ControlWidth;
+  defaultControlGrow: boolean;
   controlStyle: ControlStyle;
   panels: ControlsPanels;
 }

--- a/src/plugins/controls/common/control_group/types.ts
+++ b/src/plugins/controls/common/control_group/types.ts
@@ -15,6 +15,7 @@ export interface ControlPanelState<TEmbeddableInput extends ControlInput = Contr
   extends PanelState<TEmbeddableInput> {
   order: number;
   width: ControlWidth;
+  grow: boolean;
 }
 
 export type ControlGroupChainingSystem = 'HIERARCHICAL' | 'NONE';

--- a/src/plugins/controls/common/control_group/types.ts
+++ b/src/plugins/controls/common/control_group/types.ts
@@ -14,8 +14,6 @@ export const CONTROL_GROUP_TYPE = 'control_group';
 export interface ControlPanelState<TEmbeddableInput extends ControlInput = ControlInput>
   extends PanelState<TEmbeddableInput> {
   order: number;
-  width: ControlWidth;
-  grow: boolean;
 }
 
 export type ControlGroupChainingSystem = 'HIERARCHICAL' | 'NONE';

--- a/src/plugins/controls/common/control_group/types.ts
+++ b/src/plugins/controls/common/control_group/types.ts
@@ -26,7 +26,7 @@ export interface ControlsPanels {
 
 export interface ControlGroupInput extends EmbeddableInput, ControlInput {
   chainingSystem: ControlGroupChainingSystem;
-  defaultControlWidth?: ControlWidth;
+  defaultControlWidth: ControlWidth;
   defaultControlGrow: boolean;
   controlStyle: ControlStyle;
   panels: ControlsPanels;

--- a/src/plugins/controls/common/types.ts
+++ b/src/plugins/controls/common/types.ts
@@ -10,7 +10,7 @@ import { Filter, Query } from '@kbn/es-query';
 import { TimeRange } from '@kbn/data-plugin/common';
 import { EmbeddableInput } from '@kbn/embeddable-plugin/common/types';
 
-export type ControlWidth = 'auto' | 'small' | 'medium' | 'large';
+export type ControlWidth = 'small' | 'medium' | 'large';
 export type ControlStyle = 'twoLine' | 'oneLine';
 
 export interface ParentIgnoreSettings {

--- a/src/plugins/controls/common/types.ts
+++ b/src/plugins/controls/common/types.ts
@@ -25,6 +25,7 @@ export type ControlInput = EmbeddableInput & {
   filters?: Filter[];
   timeRange?: TimeRange;
   ignoreParentSettings?: ParentIgnoreSettings;
+  controlStyle?: ControlStyle;
   width?: ControlWidth;
   grow?: boolean;
 };

--- a/src/plugins/controls/common/types.ts
+++ b/src/plugins/controls/common/types.ts
@@ -24,8 +24,9 @@ export type ControlInput = EmbeddableInput & {
   query?: Query;
   filters?: Filter[];
   timeRange?: TimeRange;
-  controlStyle?: ControlStyle;
   ignoreParentSettings?: ParentIgnoreSettings;
+  width?: ControlWidth;
+  grow?: boolean;
 };
 
 export type DataControlInput = ControlInput & {

--- a/src/plugins/controls/public/__stories__/controls.stories.tsx
+++ b/src/plugins/controls/public/__stories__/controls.stories.tsx
@@ -139,7 +139,8 @@ export const ConfiguredControlGroupStory = () => (
       optionsList1: {
         type: OPTIONS_LIST_CONTROL,
         order: 1,
-        width: 'auto',
+        width: 'small',
+        grow: true,
         explicitInput: {
           title: 'Origin City',
           id: 'optionsList1',
@@ -151,7 +152,8 @@ export const ConfiguredControlGroupStory = () => (
       optionsList2: {
         type: OPTIONS_LIST_CONTROL,
         order: 2,
-        width: 'auto',
+        width: 'medium',
+        grow: true,
         explicitInput: {
           title: 'Destination City',
           id: 'optionsList2',
@@ -163,7 +165,8 @@ export const ConfiguredControlGroupStory = () => (
       optionsList3: {
         type: 'TIME_SLIDER',
         order: 3,
-        width: 'auto',
+        width: 'large',
+        grow: true,
         explicitInput: {
           title: 'Carrier',
           id: 'optionsList3',
@@ -174,7 +177,8 @@ export const ConfiguredControlGroupStory = () => (
       rangeSlider1: {
         type: RANGE_SLIDER_CONTROL,
         order: 4,
-        width: 'auto',
+        width: 'medium',
+        grow: true,
         explicitInput: {
           id: 'rangeSlider1',
           title: 'Average ticket price',
@@ -194,7 +198,8 @@ export const RangeSliderControlGroupStory = () => (
       rangeSlider1: {
         type: RANGE_SLIDER_CONTROL,
         order: 1,
-        width: 'auto',
+        width: 'medium',
+        grow: true,
         explicitInput: {
           id: 'rangeSlider1',
           title: 'Average ticket price',
@@ -207,7 +212,8 @@ export const RangeSliderControlGroupStory = () => (
       rangeSlider2: {
         type: RANGE_SLIDER_CONTROL,
         order: 2,
-        width: 'auto',
+        width: 'medium',
+        grow: true,
         explicitInput: {
           id: 'rangeSlider2',
           title: 'Total distance in miles',
@@ -220,7 +226,8 @@ export const RangeSliderControlGroupStory = () => (
       rangeSlider3: {
         type: RANGE_SLIDER_CONTROL,
         order: 3,
-        width: 'auto',
+        width: 'medium',
+        grow: true,
         explicitInput: {
           id: 'rangeSlider3',
           title: 'Flight duration in hour',

--- a/src/plugins/controls/public/__stories__/controls.stories.tsx
+++ b/src/plugins/controls/public/__stories__/controls.stories.tsx
@@ -26,6 +26,7 @@ import {
   OPTIONS_LIST_CONTROL,
   RANGE_SLIDER_CONTROL,
 } from '..';
+import { DEFAULT_CONTROL_WIDTH } from '../../common';
 
 import { decorators } from './decorators';
 import { ControlsPanels } from '../control_group/types';
@@ -91,6 +92,8 @@ export const ControlGroupStoryComponent: FC<{
       );
       const controlGroupContainerEmbeddable = await factory.create({
         controlStyle: 'oneLine',
+        defaultControlWidth: DEFAULT_CONTROL_WIDTH,
+        defaultControlGrow: true,
         chainingSystem: 'NONE', // a chaining system doesn't make sense in storybook since the controls aren't backed by elasticsearch
         panels: panels ?? {},
         id: uuid.v4(),
@@ -139,10 +142,10 @@ export const ConfiguredControlGroupStory = () => (
       optionsList1: {
         type: OPTIONS_LIST_CONTROL,
         order: 1,
-        width: 'small',
-        grow: true,
         explicitInput: {
           title: 'Origin City',
+          width: 'small',
+          grow: true,
           id: 'optionsList1',
           dataViewId: 'demoDataFlights',
           fieldName: 'OriginCityName',
@@ -152,10 +155,10 @@ export const ConfiguredControlGroupStory = () => (
       optionsList2: {
         type: OPTIONS_LIST_CONTROL,
         order: 2,
-        width: 'medium',
-        grow: true,
         explicitInput: {
           title: 'Destination City',
+          width: 'medium',
+          grow: true,
           id: 'optionsList2',
           dataViewId: 'demoDataFlights',
           fieldName: 'DestCityName',
@@ -165,10 +168,10 @@ export const ConfiguredControlGroupStory = () => (
       optionsList3: {
         type: 'TIME_SLIDER',
         order: 3,
-        width: 'large',
-        grow: true,
         explicitInput: {
           title: 'Carrier',
+          width: 'large',
+          grow: true,
           id: 'optionsList3',
           dataViewId: 'demoDataFlights',
           fieldName: 'Carrier',
@@ -177,10 +180,10 @@ export const ConfiguredControlGroupStory = () => (
       rangeSlider1: {
         type: RANGE_SLIDER_CONTROL,
         order: 4,
-        width: 'medium',
-        grow: true,
         explicitInput: {
           id: 'rangeSlider1',
+          width: 'medium',
+          grow: true,
           title: 'Average ticket price',
           dataViewId: 'demoDataFlights',
           fieldName: 'AvgTicketPrice',
@@ -198,10 +201,10 @@ export const RangeSliderControlGroupStory = () => (
       rangeSlider1: {
         type: RANGE_SLIDER_CONTROL,
         order: 1,
-        width: 'medium',
-        grow: true,
         explicitInput: {
           id: 'rangeSlider1',
+          width: 'medium',
+          grow: true,
           title: 'Average ticket price',
           dataViewId: 'demoDataFlights',
           fieldName: 'AvgTicketPrice',
@@ -212,10 +215,10 @@ export const RangeSliderControlGroupStory = () => (
       rangeSlider2: {
         type: RANGE_SLIDER_CONTROL,
         order: 2,
-        width: 'medium',
-        grow: true,
         explicitInput: {
           id: 'rangeSlider2',
+          width: 'medium',
+          grow: true,
           title: 'Total distance in miles',
           dataViewId: 'demoDataFlights',
           fieldName: 'DistanceMiles',
@@ -226,10 +229,10 @@ export const RangeSliderControlGroupStory = () => (
       rangeSlider3: {
         type: RANGE_SLIDER_CONTROL,
         order: 3,
-        width: 'medium',
-        grow: true,
         explicitInput: {
           id: 'rangeSlider3',
+          width: 'medium',
+          grow: true,
           title: 'Flight duration in hour',
           dataViewId: 'demoDataFlight',
           fieldName: 'FlightTimeHour',

--- a/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
+++ b/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
@@ -66,6 +66,7 @@ const SortableControlInner = forwardRef<
   const { panels } = useEmbeddableSelector((state) => state);
 
   const width = panels[embeddableId].width;
+  const grow = panels[embeddableId].grow;
 
   const dragHandle = (
     <button ref={dragHandleRef} {...dragHandleProps} className="controlFrame__dragHandle">
@@ -75,7 +76,7 @@ const SortableControlInner = forwardRef<
 
   return (
     <EuiFlexItem
-      grow={width === 'auto'}
+      grow={grow}
       data-control-id={embeddableId}
       data-test-subj={`control-frame`}
       data-render-complete="true"

--- a/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
+++ b/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
@@ -65,8 +65,8 @@ const SortableControlInner = forwardRef<
   const { useEmbeddableSelector } = useReduxContainerContext<ControlGroupInput>();
   const { panels } = useEmbeddableSelector((state) => state);
 
-  const width = panels[embeddableId].width;
-  const grow = panels[embeddableId].grow;
+  const width = panels[embeddableId].explicitInput.width;
+  const grow = panels[embeddableId].explicitInput.grow;
 
   const dragHandle = (
     <button ref={dragHandleRef} {...dragHandleProps} className="controlFrame__dragHandle">
@@ -109,7 +109,7 @@ export const ControlClone = ({ draggingId }: { draggingId: string }) => {
   const { useEmbeddableSelector } = useReduxContainerContext<ControlGroupInput>();
   const { panels, controlStyle } = useEmbeddableSelector((state) => state);
 
-  const width = panels[draggingId].width;
+  const width = panels[draggingId].explicitInput.width;
   const title = panels[draggingId].explicitInput.title;
   return (
     <EuiFlexItem

--- a/src/plugins/controls/public/control_group/control_group.scss
+++ b/src/plugins/controls/public/control_group/control_group.scss
@@ -18,14 +18,17 @@ $controlMinWidth: $euiSize * 14;
 
   &--small {
     width: $smallControl;
+    min-width:$smallControl;
   }
 
   &--medium {
     width: $mediumControl;
+    min-width:$mediumControl;
   }
 
   &--large {
     width: $largeControl;
+    min-width:$largeControl;
   }
 
   &--twoLine {
@@ -111,14 +114,17 @@ $controlMinWidth: $euiSize * 14;
 
   &--small {
     width: $smallControl;
+    min-width: $smallControl;
   }
 
   &--medium {
     width: $mediumControl;
+    min-width: $mediumControl;
   }
 
   &--large {
     width: $largeControl;
+    min-width: $largeControl;
   }
 
   &--insertBefore,

--- a/src/plugins/controls/public/control_group/control_group_strings.ts
+++ b/src/plugins/controls/public/control_group/control_group_strings.ts
@@ -54,7 +54,7 @@ export const ControlGroupStrings = {
       }),
     getWidthInputTitle: () =>
       i18n.translate('controls.controlGroup.manageControl.widthInputTitle', {
-        defaultMessage: 'Control size',
+        defaultMessage: 'Control width',
       }),
     getSaveChangesTitle: () =>
       i18n.translate('controls.controlGroup.manageControl.saveChangesTitle', {
@@ -63,6 +63,10 @@ export const ControlGroupStrings = {
     getCancelTitle: () =>
       i18n.translate('controls.controlGroup.manageControl.cancelTitle', {
         defaultMessage: 'Cancel',
+      }),
+    getGrowSwitchTitle: () =>
+      i18n.translate('controls.controlGroup.manageControl.growSwitchTitle', {
+        defaultMessage: 'Expand width to fit available space',
       }),
   },
   management: {
@@ -80,7 +84,7 @@ export const ControlGroupStrings = {
       }),
     getDefaultWidthTitle: () =>
       i18n.translate('controls.controlGroup.management.defaultWidthTitle', {
-        defaultMessage: 'Default size',
+        defaultMessage: 'Default width',
       }),
     getDeleteButtonTitle: () =>
       i18n.translate('controls.controlGroup.management.delete', {

--- a/src/plugins/controls/public/control_group/control_group_strings.ts
+++ b/src/plugins/controls/public/control_group/control_group_strings.ts
@@ -86,13 +86,17 @@ export const ControlGroupStrings = {
       i18n.translate('controls.controlGroup.management.defaultWidthTitle', {
         defaultMessage: 'Default width',
       }),
+    getDefaultGrowTitle: () =>
+      i18n.translate('controls.controlGroup.management.defaultWidthTitle', {
+        defaultMessage: 'Expand width to fit available space',
+      }),
     getDeleteButtonTitle: () =>
       i18n.translate('controls.controlGroup.management.delete', {
         defaultMessage: 'Delete control',
       }),
     getSetAllWidthsToDefaultTitle: () =>
       i18n.translate('controls.controlGroup.management.setAllWidths', {
-        defaultMessage: 'Set all sizes to default',
+        defaultMessage: 'Set all controls to default width',
       }),
     getDeleteAllButtonTitle: () =>
       i18n.translate('controls.controlGroup.management.deleteAll', {

--- a/src/plugins/controls/public/control_group/control_group_strings.ts
+++ b/src/plugins/controls/public/control_group/control_group_strings.ts
@@ -182,6 +182,24 @@ export const ControlGroupStrings = {
           defaultMessage: 'Cancel',
         }),
     },
+    applyDefaultSize: {
+      getTitle: () =>
+        i18n.translate('controls.controlGroup.management.applyDefaultSize.title', {
+          defaultMessage: 'Apply default size',
+        }),
+      getSubtitle: () =>
+        i18n.translate('controls.controlGroup.management.applyDefaultSize.sub', {
+          defaultMessage: 'Do you want to apply the new default to all existing controls?',
+        }),
+      getConfirm: () =>
+        i18n.translate('controls.controlGroup.management.applyDefaultSize.confirm', {
+          defaultMessage: 'Apply',
+        }),
+      getCancel: () =>
+        i18n.translate('controls.controlGroup.management.applyDefaultSize.cancel', {
+          defaultMessage: 'Skip',
+        }),
+    },
     discardNewControl: {
       getTitle: () =>
         i18n.translate('controls.controlGroup.management.deleteNew.title', {

--- a/src/plugins/controls/public/control_group/control_group_strings.ts
+++ b/src/plugins/controls/public/control_group/control_group_strings.ts
@@ -86,6 +86,10 @@ export const ControlGroupStrings = {
       i18n.translate('controls.controlGroup.management.defaultWidthTitle', {
         defaultMessage: 'Default width',
       }),
+    getAdvancedSettings: () =>
+      i18n.translate('controls.controlGroup.management.defaultWidthTitle', {
+        defaultMessage: 'Advanced settings',
+      }),
     getDefaultGrowTitle: () =>
       i18n.translate('controls.controlGroup.management.defaultWidthTitle', {
         defaultMessage: 'Expand width to fit available space',

--- a/src/plugins/controls/public/control_group/editor/control_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_editor.tsx
@@ -33,6 +33,7 @@ import {
   EuiKeyPadMenuItem,
   EuiIcon,
   EuiToolTip,
+  EuiSwitch,
 } from '@elastic/eui';
 
 import { EmbeddableFactoryDefinition } from '@kbn/embeddable-plugin/public';
@@ -54,6 +55,7 @@ interface EditControlProps {
   onSave: (type: string) => void;
   onCancel: () => void;
   removeControl?: () => void;
+  updateGrow?: (grow: boolean) => void;
   updateTitle: (title?: string) => void;
   updateWidth: (newWidth: ControlWidth) => void;
   getRelevantDataViewId?: () => string | undefined;
@@ -69,6 +71,7 @@ export const ControlEditor = ({
   onSave,
   onCancel,
   removeControl,
+  updateGrow,
   updateTitle,
   updateWidth,
   onTypeEditorChange,
@@ -84,6 +87,7 @@ export const ControlEditor = ({
   const [defaultTitle, setDefaultTitle] = useState<string>();
   const [currentTitle, setCurrentTitle] = useState(title);
   const [currentWidth, setCurrentWidth] = useState(width);
+  const [currentGrow, setCurrentGrow] = useState(true);
   const [controlEditorValid, setControlEditorValid] = useState(false);
 
   const getControlTypeEditor = (type: string) => {
@@ -180,21 +184,20 @@ export const ControlEditor = ({
                   }}
                 />
               </EuiFormRow>
+              {updateGrow ? (
+                <EuiFormRow>
+                  <EuiSwitch
+                    label={ControlGroupStrings.manageControl.getGrowSwitchTitle()}
+                    color="primary"
+                    checked={currentGrow}
+                    onChange={() => {
+                      setCurrentGrow(!currentGrow);
+                      updateGrow(!currentGrow);
+                    }}
+                  />
+                </EuiFormRow>
+              ) : null}
               <EuiSpacer size="l" />
-              {removeControl && (
-                <EuiButtonEmpty
-                  aria-label={`delete-${title}`}
-                  iconType="trash"
-                  flush="left"
-                  color="danger"
-                  onClick={() => {
-                    onCancel();
-                    removeControl();
-                  }}
-                >
-                  {ControlGroupStrings.management.getDeleteButtonTitle()}
-                </EuiButtonEmpty>
-              )}
             </>
           )}
         </EuiForm>
@@ -210,6 +213,23 @@ export const ControlEditor = ({
             >
               {ControlGroupStrings.manageControl.getCancelTitle()}
             </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow />
+          <EuiFlexItem grow={false}>
+            {removeControl && (
+              <EuiButtonEmpty
+                aria-label={`delete-${title}`}
+                iconType="trash"
+                flush="left"
+                color="danger"
+                onClick={() => {
+                  onCancel();
+                  removeControl();
+                }}
+              >
+                {ControlGroupStrings.management.getDeleteButtonTitle()}
+              </EuiButtonEmpty>
+            )}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButton

--- a/src/plugins/controls/public/control_group/editor/control_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_editor.tsx
@@ -52,6 +52,7 @@ interface EditControlProps {
   isCreate: boolean;
   title?: string;
   width: ControlWidth;
+  grow: boolean;
   onSave: (type: string) => void;
   onCancel: () => void;
   removeControl?: () => void;
@@ -68,6 +69,7 @@ export const ControlEditor = ({
   isCreate,
   title,
   width,
+  grow,
   onSave,
   onCancel,
   removeControl,
@@ -87,7 +89,7 @@ export const ControlEditor = ({
   const [defaultTitle, setDefaultTitle] = useState<string>();
   const [currentTitle, setCurrentTitle] = useState(title);
   const [currentWidth, setCurrentWidth] = useState(width);
-  const [currentGrow, setCurrentGrow] = useState(true);
+  const [currentGrow, setCurrentGrow] = useState(grow);
   const [controlEditorValid, setControlEditorValid] = useState(false);
 
   const getControlTypeEditor = (type: string) => {

--- a/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
@@ -49,28 +49,19 @@ import { pluginServices } from '../../services';
 interface EditControlGroupProps {
   initialInput: ControlGroupInput;
   controlCount: number;
-  updateInput: (input: Partial<ControlGroupInput>) => void;
   onDeleteAll: () => void;
-  onClose: () => void;
+  onClose: (newInput?: ControlGroupInput) => void;
 }
 
 type EditorControlGroupInput = ControlGroupInput &
   Required<Pick<ControlGroupInput, 'defaultControlWidth'>>;
 
-const editorControlGroupInputIsEqual = (a: ControlGroupInput, b: ControlGroupInput) =>
-  fastIsEqual(a, b);
-
 export const ControlGroupEditor = ({
   controlCount,
   initialInput,
-  updateInput,
   onDeleteAll,
   onClose,
 }: EditControlGroupProps) => {
-  const advancedSettingsAccordionId = useGeneratedHtmlId({ prefix: 'advancedSettingsAccordion' });
-  const { overlays } = pluginServices.getServices();
-  const { openConfirm } = overlays;
-
   const [controlGroupEditorState, setControlGroupEditorState] = useState<EditorControlGroupInput>({
     defaultControlWidth: DEFAULT_CONTROL_WIDTH,
     ...getDefaultControlGroupInput(),
@@ -108,30 +99,30 @@ export const ControlGroupEditor = ({
     [controlGroupEditorState]
   );
 
-  const applyChangesToInput = async () => {
-    const inputToApply = { ...controlGroupEditorState };
-    if (controlCount > 0 && inputToApply.defaultControlWidth !== initialInput.defaultControlWidth) {
-      openConfirm(ControlGroupStrings.management.applyDefaultSize.getSubtitle(), {
-        confirmButtonText: ControlGroupStrings.management.applyDefaultSize.getConfirm(),
-        cancelButtonText: ControlGroupStrings.management.applyDefaultSize.getCancel(),
-        title: ControlGroupStrings.management.applyDefaultSize.getTitle(),
-      }).then((confirmed) => {
-        if (confirmed) {
-          const newPanels = {} as ControlsPanels;
-          Object.entries(initialInput.panels).forEach(
-            ([id, panel]) =>
-              (newPanels[id] = {
-                ...panel,
-                width: inputToApply.defaultControlWidth,
-              })
-          );
-          inputToApply.panels = newPanels;
-        }
-        updateInput(inputToApply);
-      });
-    } else if (!editorControlGroupInputIsEqual(inputToApply, initialInput))
-      updateInput(inputToApply);
-  };
+  // const applyChangesToInput = async () => {
+  //   const inputToApply = { ...controlGroupEditorState };
+  //   if (controlCount > 0 && inputToApply.defaultControlWidth !== initialInput.defaultControlWidth) {
+  //     openConfirm(ControlGroupStrings.management.applyDefaultSize.getSubtitle(), {
+  //       confirmButtonText: ControlGroupStrings.management.applyDefaultSize.getConfirm(),
+  //       cancelButtonText: ControlGroupStrings.management.applyDefaultSize.getCancel(),
+  //       title: ControlGroupStrings.management.applyDefaultSize.getTitle(),
+  //     }).then((confirmed) => {
+  //       if (confirmed) {
+  //         const newPanels = {} as ControlsPanels;
+  //         Object.entries(initialInput.panels).forEach(
+  //           ([id, panel]) =>
+  //             (newPanels[id] = {
+  //               ...panel,
+  //               width: inputToApply.defaultControlWidth,
+  //             })
+  //         );
+  //         inputToApply.panels = newPanels;
+  //       }
+  //       updateInput(inputToApply);
+  //     });
+  //   } else if (!editorControlGroupInputIsEqual(inputToApply, initialInput))
+  //     updateInput(inputToApply);
+  // };
 
   return (
     <>
@@ -325,8 +316,7 @@ export const ControlGroupEditor = ({
               color="primary"
               data-test-subj="control-group-editor-save"
               onClick={() => {
-                applyChangesToInput();
-                onClose();
+                onClose({ ...controlGroupEditorState });
               }}
             >
               {ControlGroupStrings.manageControl.getSaveChangesTitle()}

--- a/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
@@ -29,7 +29,6 @@ import {
   EuiFormRow,
   EuiButtonEmpty,
   EuiSpacer,
-  EuiCheckbox,
   EuiForm,
   EuiAccordion,
   useGeneratedHtmlId,
@@ -67,7 +66,6 @@ export const ControlGroupEditor = ({
   onDeleteAll,
   onClose,
 }: EditControlGroupProps) => {
-  const [resetAllWidths, setResetAllWidths] = useState(false);
   const advancedSettingsAccordionId = useGeneratedHtmlId({ prefix: 'advancedSettingsAccordion' });
 
   const [controlGroupEditorState, setControlGroupEditorState] = useState<EditorControlGroupInput>({
@@ -109,7 +107,7 @@ export const ControlGroupEditor = ({
 
   const applyChangesToInput = useCallback(() => {
     const inputToApply = { ...controlGroupEditorState };
-    if (resetAllWidths) {
+    if (inputToApply.defaultControlWidth !== initialInput.defaultControlWidth) {
       const newPanels = {} as ControlsPanels;
       Object.entries(initialInput.panels).forEach(
         ([id, panel]) =>
@@ -122,7 +120,7 @@ export const ControlGroupEditor = ({
       inputToApply.panels = newPanels;
     }
     if (!editorControlGroupInputIsEqual(inputToApply, initialInput)) updateInput(inputToApply);
-  }, [controlGroupEditorState, resetAllWidths, initialInput, updateInput]);
+  }, [controlGroupEditorState, initialInput, updateInput]);
 
   return (
     <>
@@ -161,30 +159,6 @@ export const ControlGroupEditor = ({
                   });
                 }}
               />
-              <EuiSpacer size="s" />
-              <EuiSwitch
-                label={ControlGroupStrings.management.getDefaultGrowTitle()}
-                checked={controlGroupEditorState.defaultControlGrow}
-                onChange={() => {
-                  updateControlGroupEditorSetting({
-                    defaultControlGrow: !controlGroupEditorState.defaultControlGrow,
-                  });
-                }}
-              />
-              {controlCount > 0 && (
-                <>
-                  <EuiSpacer size="s" />
-                  <EuiCheckbox
-                    id="editControls_setAllSizesCheckbox"
-                    data-test-subj="set-all-control-sizes-checkbox"
-                    label={ControlGroupStrings.management.getSetAllWidthsToDefaultTitle()}
-                    checked={resetAllWidths}
-                    onChange={(e) => {
-                      setResetAllWidths(e.target.checked);
-                    }}
-                  />
-                </>
-              )}
             </>
           </EuiFormRow>
           <EuiHorizontalRule margin="m" />

--- a/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
@@ -174,7 +174,7 @@ export const ControlGroupEditor = ({
               {controlCount > 0 && (
                 <>
                   <EuiSpacer size="s" />
-                  <EuiSwitch
+                  <EuiCheckbox
                     id="editControls_setAllSizesCheckbox"
                     data-test-subj="set-all-control-sizes-checkbox"
                     label={ControlGroupStrings.management.getSetAllWidthsToDefaultTitle()}

--- a/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
@@ -116,6 +116,7 @@ export const ControlGroupEditor = ({
           (newPanels[id] = {
             ...panel,
             width: inputToApply.defaultControlWidth,
+            grow: inputToApply.defaultControlGrow,
           })
       );
       inputToApply.panels = newPanels;
@@ -160,10 +161,20 @@ export const ControlGroupEditor = ({
                   });
                 }}
               />
+              <EuiSpacer size="s" />
+              <EuiSwitch
+                label={ControlGroupStrings.management.getDefaultGrowTitle()}
+                checked={controlGroupEditorState.defaultControlGrow}
+                onChange={() => {
+                  updateControlGroupEditorSetting({
+                    defaultControlGrow: !controlGroupEditorState.defaultControlGrow,
+                  });
+                }}
+              />
               {controlCount > 0 && (
                 <>
                   <EuiSpacer size="s" />
-                  <EuiCheckbox
+                  <EuiSwitch
                     id="editControls_setAllSizesCheckbox"
                     data-test-subj="set-all-control-sizes-checkbox"
                     label={ControlGroupStrings.management.getSetAllWidthsToDefaultTitle()}

--- a/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
@@ -62,6 +62,8 @@ export const ControlGroupEditor = ({
   onDeleteAll,
   onClose,
 }: EditControlGroupProps) => {
+  const advancedSettingsAccordionId = useGeneratedHtmlId({ prefix: 'advancedSettingsAccordion' });
+
   const [controlGroupEditorState, setControlGroupEditorState] = useState<EditorControlGroupInput>({
     defaultControlWidth: DEFAULT_CONTROL_WIDTH,
     ...getDefaultControlGroupInput(),
@@ -98,31 +100,6 @@ export const ControlGroupEditor = ({
       ),
     [controlGroupEditorState]
   );
-
-  // const applyChangesToInput = async () => {
-  //   const inputToApply = { ...controlGroupEditorState };
-  //   if (controlCount > 0 && inputToApply.defaultControlWidth !== initialInput.defaultControlWidth) {
-  //     openConfirm(ControlGroupStrings.management.applyDefaultSize.getSubtitle(), {
-  //       confirmButtonText: ControlGroupStrings.management.applyDefaultSize.getConfirm(),
-  //       cancelButtonText: ControlGroupStrings.management.applyDefaultSize.getCancel(),
-  //       title: ControlGroupStrings.management.applyDefaultSize.getTitle(),
-  //     }).then((confirmed) => {
-  //       if (confirmed) {
-  //         const newPanels = {} as ControlsPanels;
-  //         Object.entries(initialInput.panels).forEach(
-  //           ([id, panel]) =>
-  //             (newPanels[id] = {
-  //               ...panel,
-  //               width: inputToApply.defaultControlWidth,
-  //             })
-  //         );
-  //         inputToApply.panels = newPanels;
-  //       }
-  //       updateInput(inputToApply);
-  //     });
-  //   } else if (!editorControlGroupInputIsEqual(inputToApply, initialInput))
-  //     updateInput(inputToApply);
-  // };
 
   return (
     <>
@@ -161,122 +138,142 @@ export const ControlGroupEditor = ({
                   });
                 }}
               />
-            </>
-          </EuiFormRow>
-          <EuiHorizontalRule margin="m" />
-          <EuiFlexGroup>
-            <EuiFlexItem grow={false}>
-              <EuiSpacer size="xs" />
+              <EuiSpacer size="s" />
               <EuiSwitch
-                label={ControlGroupStrings.management.querySync.getQuerySettingsTitle()}
-                data-test-subj="control-group-query-sync"
-                showLabel={false}
-                checked={fullQuerySyncActive}
-                onChange={(e) => {
-                  const newSetting = !e.target.checked;
-                  updateIgnoreSetting({
-                    ignoreFilters: newSetting,
-                    ignoreTimerange: newSetting,
-                    ignoreQuery: newSetting,
+                label={ControlGroupStrings.management.getDefaultGrowTitle()}
+                checked={controlGroupEditorState.defaultControlGrow}
+                onChange={() => {
+                  updateControlGroupEditorSetting({
+                    defaultControlGrow: !controlGroupEditorState.defaultControlGrow,
                   });
                 }}
               />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiTitle size="xxs">
-                <h3>{ControlGroupStrings.management.querySync.getQuerySettingsTitle()}</h3>
-              </EuiTitle>
-              <EuiText size="s">
-                <p>{ControlGroupStrings.management.querySync.getQuerySettingsSubtitle()}</p>
-              </EuiText>
-              <EuiSpacer size="s" />
-              <EuiAccordion
-                data-test-subj="control-group-query-sync-advanced"
-                id={advancedSettingsAccordionId}
-                initialIsOpen={!fullQuerySyncActive}
-                buttonContent={ControlGroupStrings.management.querySync.getAdvancedSettingsTitle()}
-              >
-                <EuiSpacer size="s" />
-                <EuiFormRow hasChildLabel display="columnCompressedSwitch">
+            </>
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiFormRow label={ControlGroupStrings.management.getAdvancedSettings()}>
+            <>
+              <EuiFlexGroup>
+                <EuiFlexItem grow={false}>
+                  <EuiSpacer size="xs" />
                   <EuiSwitch
-                    data-test-subj="control-group-query-sync-time-range"
-                    label={ControlGroupStrings.management.querySync.getIgnoreTimerangeTitle()}
-                    compressed
-                    checked={Boolean(controlGroupEditorState.ignoreParentSettings?.ignoreTimerange)}
-                    onChange={(e) => updateIgnoreSetting({ ignoreTimerange: e.target.checked })}
+                    label={ControlGroupStrings.management.querySync.getQuerySettingsTitle()}
+                    data-test-subj="control-group-query-sync"
+                    showLabel={false}
+                    checked={fullQuerySyncActive}
+                    onChange={(e) => {
+                      const newSetting = !e.target.checked;
+                      updateIgnoreSetting({
+                        ignoreFilters: newSetting,
+                        ignoreTimerange: newSetting,
+                        ignoreQuery: newSetting,
+                      });
+                    }}
                   />
-                </EuiFormRow>
-                <EuiFormRow hasChildLabel display="columnCompressedSwitch">
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiTitle size="xxs">
+                    <h3>{ControlGroupStrings.management.querySync.getQuerySettingsTitle()}</h3>
+                  </EuiTitle>
+                  <EuiText size="s">
+                    <p>{ControlGroupStrings.management.querySync.getQuerySettingsSubtitle()}</p>
+                  </EuiText>
+                  <EuiSpacer size="s" />
+                  <EuiAccordion
+                    data-test-subj="control-group-query-sync-advanced"
+                    id={advancedSettingsAccordionId}
+                    initialIsOpen={!fullQuerySyncActive}
+                    buttonContent={ControlGroupStrings.management.querySync.getAdvancedSettingsTitle()}
+                  >
+                    <EuiSpacer size="s" />
+                    <EuiFormRow hasChildLabel display="columnCompressedSwitch">
+                      <EuiSwitch
+                        data-test-subj="control-group-query-sync-time-range"
+                        label={ControlGroupStrings.management.querySync.getIgnoreTimerangeTitle()}
+                        compressed
+                        checked={Boolean(
+                          controlGroupEditorState.ignoreParentSettings?.ignoreTimerange
+                        )}
+                        onChange={(e) => updateIgnoreSetting({ ignoreTimerange: e.target.checked })}
+                      />
+                    </EuiFormRow>
+                    <EuiFormRow hasChildLabel display="columnCompressedSwitch">
+                      <EuiSwitch
+                        data-test-subj="control-group-query-sync-query"
+                        label={ControlGroupStrings.management.querySync.getIgnoreQueryTitle()}
+                        compressed
+                        checked={Boolean(controlGroupEditorState.ignoreParentSettings?.ignoreQuery)}
+                        onChange={(e) => updateIgnoreSetting({ ignoreQuery: e.target.checked })}
+                      />
+                    </EuiFormRow>
+                    <EuiFormRow hasChildLabel display="columnCompressedSwitch">
+                      <EuiSwitch
+                        data-test-subj="control-group-query-sync-filters"
+                        label={ControlGroupStrings.management.querySync.getIgnoreFilterPillsTitle()}
+                        compressed
+                        checked={Boolean(
+                          controlGroupEditorState.ignoreParentSettings?.ignoreFilters
+                        )}
+                        onChange={(e) => updateIgnoreSetting({ ignoreFilters: e.target.checked })}
+                      />
+                    </EuiFormRow>
+                  </EuiAccordion>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+              <EuiHorizontalRule margin="m" />
+              <EuiFlexGroup>
+                <EuiFlexItem grow={false}>
+                  <EuiSpacer size="xs" />
                   <EuiSwitch
-                    data-test-subj="control-group-query-sync-query"
-                    label={ControlGroupStrings.management.querySync.getIgnoreQueryTitle()}
-                    compressed
-                    checked={Boolean(controlGroupEditorState.ignoreParentSettings?.ignoreQuery)}
-                    onChange={(e) => updateIgnoreSetting({ ignoreQuery: e.target.checked })}
+                    data-test-subj="control-group-validate-selections"
+                    label={ControlGroupStrings.management.validateSelections.getValidateSelectionsTitle()}
+                    showLabel={false}
+                    checked={
+                      !Boolean(controlGroupEditorState.ignoreParentSettings?.ignoreValidations)
+                    }
+                    onChange={(e) => updateIgnoreSetting({ ignoreValidations: !e.target.checked })}
                   />
-                </EuiFormRow>
-                <EuiFormRow hasChildLabel display="columnCompressedSwitch">
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiTitle size="xxs">
+                    <h3>
+                      {ControlGroupStrings.management.validateSelections.getValidateSelectionsTitle()}
+                    </h3>
+                  </EuiTitle>
+                  <EuiText size="s">
+                    <p>
+                      {ControlGroupStrings.management.validateSelections.getValidateSelectionsSubTitle()}
+                    </p>
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+              <EuiHorizontalRule margin="m" />
+              <EuiFlexGroup>
+                <EuiFlexItem grow={false}>
+                  <EuiSpacer size="xs" />
                   <EuiSwitch
-                    data-test-subj="control-group-query-sync-filters"
-                    label={ControlGroupStrings.management.querySync.getIgnoreFilterPillsTitle()}
-                    compressed
-                    checked={Boolean(controlGroupEditorState.ignoreParentSettings?.ignoreFilters)}
-                    onChange={(e) => updateIgnoreSetting({ ignoreFilters: e.target.checked })}
+                    data-test-subj="control-group-chaining"
+                    label={ControlGroupStrings.management.controlChaining.getHierarchyTitle()}
+                    showLabel={false}
+                    checked={controlGroupEditorState.chainingSystem === 'HIERARCHICAL'}
+                    onChange={(e) =>
+                      updateControlGroupEditorSetting({
+                        chainingSystem: e.target.checked ? 'HIERARCHICAL' : 'NONE',
+                      })
+                    }
                   />
-                </EuiFormRow>
-              </EuiAccordion>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiHorizontalRule margin="m" />
-          <EuiFlexGroup>
-            <EuiFlexItem grow={false}>
-              <EuiSpacer size="xs" />
-              <EuiSwitch
-                data-test-subj="control-group-validate-selections"
-                label={ControlGroupStrings.management.validateSelections.getValidateSelectionsTitle()}
-                showLabel={false}
-                checked={!Boolean(controlGroupEditorState.ignoreParentSettings?.ignoreValidations)}
-                onChange={(e) => updateIgnoreSetting({ ignoreValidations: !e.target.checked })}
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiTitle size="xxs">
-                <h3>
-                  {ControlGroupStrings.management.validateSelections.getValidateSelectionsTitle()}
-                </h3>
-              </EuiTitle>
-              <EuiText size="s">
-                <p>
-                  {ControlGroupStrings.management.validateSelections.getValidateSelectionsSubTitle()}
-                </p>
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiHorizontalRule margin="m" />
-          <EuiFlexGroup>
-            <EuiFlexItem grow={false}>
-              <EuiSpacer size="xs" />
-              <EuiSwitch
-                data-test-subj="control-group-chaining"
-                label={ControlGroupStrings.management.controlChaining.getHierarchyTitle()}
-                showLabel={false}
-                checked={controlGroupEditorState.chainingSystem === 'HIERARCHICAL'}
-                onChange={(e) =>
-                  updateControlGroupEditorSetting({
-                    chainingSystem: e.target.checked ? 'HIERARCHICAL' : 'NONE',
-                  })
-                }
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiTitle size="xxs">
-                <h3>{ControlGroupStrings.management.controlChaining.getHierarchyTitle()}</h3>
-              </EuiTitle>
-              <EuiText size="s">
-                <p>{ControlGroupStrings.management.controlChaining.getHierarchySubTitle()}</p>
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiTitle size="xxs">
+                    <h3>{ControlGroupStrings.management.controlChaining.getHierarchyTitle()}</h3>
+                  </EuiTitle>
+                  <EuiText size="s">
+                    <p>{ControlGroupStrings.management.controlChaining.getHierarchySubTitle()}</p>
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </>
+          </EuiFormRow>
           {controlCount > 0 && (
             <>
               <EuiHorizontalRule margin="m" />

--- a/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
@@ -15,7 +15,6 @@
  */
 
 import { omit } from 'lodash';
-import fastIsEqual from 'fast-deep-equal';
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   EuiFlyoutHeader,
@@ -42,8 +41,7 @@ import { ControlGroupStrings } from '../control_group_strings';
 import { ControlStyle, ControlWidth } from '../../types';
 import { ParentIgnoreSettings } from '../..';
 import { ControlGroupInput } from '..';
-import { DEFAULT_CONTROL_WIDTH, getDefaultControlGroupInput } from '../../../common';
-import { pluginServices } from '../../services';
+import { getDefaultControlGroupInput } from '../../../common';
 
 interface EditControlGroupProps {
   initialInput: ControlGroupInput;

--- a/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
@@ -41,7 +41,6 @@ import { CONTROL_LAYOUT_OPTIONS, CONTROL_WIDTH_OPTIONS } from './editor_constant
 import { ControlGroupStrings } from '../control_group_strings';
 import { ControlStyle, ControlWidth } from '../../types';
 import { ParentIgnoreSettings } from '../..';
-import { ControlsPanels } from '../types';
 import { ControlGroupInput } from '..';
 import { DEFAULT_CONTROL_WIDTH, getDefaultControlGroupInput } from '../../../common';
 import { pluginServices } from '../../services';
@@ -50,7 +49,8 @@ interface EditControlGroupProps {
   initialInput: ControlGroupInput;
   controlCount: number;
   onDeleteAll: () => void;
-  onClose: (newInput?: ControlGroupInput) => void;
+  onCancel: () => void;
+  onSave: (newInput: ControlGroupInput) => void;
 }
 
 type EditorControlGroupInput = ControlGroupInput &
@@ -60,7 +60,8 @@ export const ControlGroupEditor = ({
   controlCount,
   initialInput,
   onDeleteAll,
-  onClose,
+  onCancel,
+  onSave,
 }: EditControlGroupProps) => {
   const advancedSettingsAccordionId = useGeneratedHtmlId({ prefix: 'advancedSettingsAccordion' });
 
@@ -299,7 +300,7 @@ export const ControlGroupEditor = ({
               aria-label={`cancel-editing-group`}
               iconType="cross"
               onClick={() => {
-                onClose();
+                onCancel();
               }}
             >
               {ControlGroupStrings.manageControl.getCancelTitle()}
@@ -312,7 +313,7 @@ export const ControlGroupEditor = ({
               color="primary"
               data-test-subj="control-group-editor-save"
               onClick={() => {
-                onClose({ ...controlGroupEditorState });
+                onSave({ ...controlGroupEditorState });
               }}
             >
               {ControlGroupStrings.manageControl.getSaveChangesTitle()}

--- a/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
@@ -65,7 +65,6 @@ export const ControlGroupEditor = ({
   const advancedSettingsAccordionId = useGeneratedHtmlId({ prefix: 'advancedSettingsAccordion' });
 
   const [controlGroupEditorState, setControlGroupEditorState] = useState<EditorControlGroupInput>({
-    defaultControlWidth: DEFAULT_CONTROL_WIDTH,
     ...getDefaultControlGroupInput(),
     ...initialInput,
   });

--- a/src/plugins/controls/public/control_group/editor/create_control.tsx
+++ b/src/plugins/controls/public/control_group/editor/create_control.tsx
@@ -22,6 +22,7 @@ export type CreateControlButtonTypes = 'toolbar' | 'callout';
 export interface CreateControlButtonProps {
   defaultControlWidth?: ControlWidth;
   updateDefaultWidth: (defaultControlWidth: ControlWidth) => void;
+  updateDefaultGrow: (defaultControlGrow: boolean) => void;
   addNewEmbeddable: (type: string, input: Omit<ControlInput, 'id'>) => void;
   setLastUsedDataViewId?: (newDataViewId: string) => void;
   getRelevantDataViewId?: () => string | undefined;
@@ -35,13 +36,14 @@ interface CreateControlResult {
 }
 
 export const CreateControlButton = ({
-  defaultControlWidth,
-  updateDefaultWidth,
-  addNewEmbeddable,
   buttonType,
+  defaultControlWidth,
+  addNewEmbeddable,
   closePopover,
-  setLastUsedDataViewId,
   getRelevantDataViewId,
+  setLastUsedDataViewId,
+  updateDefaultWidth,
+  updateDefaultGrow,
 }: CreateControlButtonProps) => {
   // Controls Services Context
   const { overlays, controls } = pluginServices.getServices();
@@ -83,6 +85,7 @@ export const CreateControlButton = ({
               width={defaultControlWidth ?? DEFAULT_CONTROL_WIDTH}
               updateTitle={(newTitle) => (inputToReturn.title = newTitle)}
               updateWidth={updateDefaultWidth}
+              updateGrow={updateDefaultGrow}
               onSave={(type: string) => {
                 const factory = getControlFactory(type) as IEditableControlFactory;
                 if (factory.presaveTransformFunction) {

--- a/src/plugins/controls/public/control_group/editor/create_control.tsx
+++ b/src/plugins/controls/public/control_group/editor/create_control.tsx
@@ -21,6 +21,7 @@ import { setFlyoutRef } from '../embeddable/control_group_container';
 export type CreateControlButtonTypes = 'toolbar' | 'callout';
 export interface CreateControlButtonProps {
   defaultControlWidth?: ControlWidth;
+  defaultControlGrow: boolean;
   updateDefaultWidth: (defaultControlWidth: ControlWidth) => void;
   updateDefaultGrow: (defaultControlGrow: boolean) => void;
   addNewEmbeddable: (type: string, input: Omit<ControlInput, 'id'>) => void;
@@ -38,6 +39,7 @@ interface CreateControlResult {
 export const CreateControlButton = ({
   buttonType,
   defaultControlWidth,
+  defaultControlGrow,
   addNewEmbeddable,
   closePopover,
   getRelevantDataViewId,
@@ -83,6 +85,7 @@ export const CreateControlButton = ({
               getRelevantDataViewId={getRelevantDataViewId}
               isCreate={true}
               width={defaultControlWidth ?? DEFAULT_CONTROL_WIDTH}
+              grow={defaultControlGrow ?? true}
               updateTitle={(newTitle) => (inputToReturn.title = newTitle)}
               updateWidth={updateDefaultWidth}
               updateGrow={updateDefaultGrow}

--- a/src/plugins/controls/public/control_group/editor/create_control.tsx
+++ b/src/plugins/controls/public/control_group/editor/create_control.tsx
@@ -20,10 +20,8 @@ import { setFlyoutRef } from '../embeddable/control_group_container';
 
 export type CreateControlButtonTypes = 'toolbar' | 'callout';
 export interface CreateControlButtonProps {
-  defaultControlWidth?: ControlWidth;
+  defaultControlWidth: ControlWidth;
   defaultControlGrow: boolean;
-  updateDefaultWidth: (defaultControlWidth: ControlWidth) => void;
-  updateDefaultGrow: (defaultControlGrow: boolean) => void;
   addNewEmbeddable: (type: string, input: Omit<ControlInput, 'id'>) => void;
   setLastUsedDataViewId?: (newDataViewId: string) => void;
   getRelevantDataViewId?: () => string | undefined;
@@ -44,8 +42,6 @@ export const CreateControlButton = ({
   closePopover,
   getRelevantDataViewId,
   setLastUsedDataViewId,
-  updateDefaultWidth,
-  updateDefaultGrow,
 }: CreateControlButtonProps) => {
   // Controls Services Context
   const { overlays, controls } = pluginServices.getServices();
@@ -84,11 +80,11 @@ export const CreateControlButton = ({
               setLastUsedDataViewId={setLastUsedDataViewId}
               getRelevantDataViewId={getRelevantDataViewId}
               isCreate={true}
-              width={defaultControlWidth ?? DEFAULT_CONTROL_WIDTH}
-              grow={defaultControlGrow ?? true}
+              width={defaultControlWidth}
+              grow={defaultControlGrow}
               updateTitle={(newTitle) => (inputToReturn.title = newTitle)}
-              updateWidth={updateDefaultWidth}
-              updateGrow={updateDefaultGrow}
+              updateWidth={(newWidth) => (inputToReturn.width = newWidth)}
+              updateGrow={(newGrow) => (inputToReturn.grow = newGrow)}
               onSave={(type: string) => {
                 const factory = getControlFactory(type) as IEditableControlFactory;
                 if (factory.presaveTransformFunction) {

--- a/src/plugins/controls/public/control_group/editor/create_control.tsx
+++ b/src/plugins/controls/public/control_group/editor/create_control.tsx
@@ -15,7 +15,6 @@ import { pluginServices } from '../../services';
 import { ControlEditor } from './control_editor';
 import { ControlGroupStrings } from '../control_group_strings';
 import { ControlWidth, ControlInput, IEditableControlFactory } from '../../types';
-import { DEFAULT_CONTROL_WIDTH } from '../../../common/control_group/control_group_constants';
 import { setFlyoutRef } from '../embeddable/control_group_container';
 
 export type CreateControlButtonTypes = 'toolbar' | 'callout';

--- a/src/plugins/controls/public/control_group/editor/edit_control.tsx
+++ b/src/plugins/controls/public/control_group/editor/edit_control.tsx
@@ -35,7 +35,7 @@ export const EditControlButton = ({ embeddableId }: { embeddableId: string }) =>
   >();
   const {
     containerActions: { untilEmbeddableLoaded, removeEmbeddable, updateInputForChild },
-    actions: { setControlWidth },
+    actions: { setControlWidth, setControlGrow },
     useEmbeddableSelector,
     useEmbeddableDispatch,
   } = reduxContainerContext;
@@ -97,6 +97,7 @@ export const EditControlButton = ({ embeddableId }: { embeddableId: string }) =>
           updateTitle={(newTitle) => (inputToReturn.title = newTitle)}
           setLastUsedDataViewId={(lastUsed) => controlGroup.setLastUsedDataViewId(lastUsed)}
           updateWidth={(newWidth) => dispatch(setControlWidth({ width: newWidth, embeddableId }))}
+          updateGrow={(grow) => dispatch(setControlGrow({ grow, embeddableId }))}
           onTypeEditorChange={(partialInput) =>
             (inputToReturn = { ...inputToReturn, ...partialInput })
           }

--- a/src/plugins/controls/public/control_group/editor/edit_control.tsx
+++ b/src/plugins/controls/public/control_group/editor/edit_control.tsx
@@ -35,14 +35,13 @@ export const EditControlButton = ({ embeddableId }: { embeddableId: string }) =>
   >();
   const {
     containerActions: { untilEmbeddableLoaded, removeEmbeddable, updateInputForChild },
-    actions: { setControlWidth, setControlGrow },
     useEmbeddableSelector,
-    useEmbeddableDispatch,
   } = reduxContainerContext;
-  const dispatch = useEmbeddableDispatch();
 
   // current state
-  const { panels, defaultControlGrow } = useEmbeddableSelector((state) => state);
+  const { panels, defaultControlGrow, defaultControlWidth } = useEmbeddableSelector(
+    (state) => state
+  );
 
   // keep up to date ref of latest panel state for comparison when closing editor.
   const latestPanelState = useRef(panels[embeddableId]);
@@ -64,11 +63,10 @@ export const EditControlButton = ({ embeddableId }: { embeddableId: string }) =>
     const onCancel = (ref: OverlayRef) => {
       if (
         removed ||
-        (isEqual(latestPanelState.current.explicitInput, {
+        isEqual(latestPanelState.current.explicitInput, {
           ...panel.explicitInput,
           ...inputToReturn,
-        }) &&
-          isEqual(latestPanelState.current.width, panel.width))
+        })
       ) {
         ref.close();
         return;
@@ -80,7 +78,6 @@ export const EditControlButton = ({ embeddableId }: { embeddableId: string }) =>
         buttonColor: 'danger',
       }).then((confirmed) => {
         if (confirmed) {
-          dispatch(setControlWidth({ width: panel.width, embeddableId }));
           ref.close();
         }
       });
@@ -90,15 +87,15 @@ export const EditControlButton = ({ embeddableId }: { embeddableId: string }) =>
       forwardAllContext(
         <ControlEditor
           isCreate={false}
-          width={panel.width}
-          grow={defaultControlGrow ?? true}
+          width={panel.explicitInput.width ?? defaultControlWidth}
+          grow={panel.explicitInput.grow ?? defaultControlGrow}
           embeddable={embeddable}
           title={embeddable.getTitle()}
           onCancel={() => onCancel(flyoutInstance)}
           updateTitle={(newTitle) => (inputToReturn.title = newTitle)}
+          updateWidth={(newWidth) => (inputToReturn.width = newWidth)}
+          updateGrow={(newGrow) => (inputToReturn.grow = newGrow)}
           setLastUsedDataViewId={(lastUsed) => controlGroup.setLastUsedDataViewId(lastUsed)}
-          updateWidth={(newWidth) => dispatch(setControlWidth({ width: newWidth, embeddableId }))}
-          updateGrow={(grow) => dispatch(setControlGrow({ grow, embeddableId }))}
           onTypeEditorChange={(partialInput) =>
             (inputToReturn = { ...inputToReturn, ...partialInput })
           }

--- a/src/plugins/controls/public/control_group/editor/edit_control.tsx
+++ b/src/plugins/controls/public/control_group/editor/edit_control.tsx
@@ -42,7 +42,7 @@ export const EditControlButton = ({ embeddableId }: { embeddableId: string }) =>
   const dispatch = useEmbeddableDispatch();
 
   // current state
-  const { panels } = useEmbeddableSelector((state) => state);
+  const { panels, defaultControlGrow } = useEmbeddableSelector((state) => state);
 
   // keep up to date ref of latest panel state for comparison when closing editor.
   const latestPanelState = useRef(panels[embeddableId]);
@@ -91,6 +91,7 @@ export const EditControlButton = ({ embeddableId }: { embeddableId: string }) =>
         <ControlEditor
           isCreate={false}
           width={panel.width}
+          grow={defaultControlGrow ?? true}
           embeddable={embeddable}
           title={embeddable.getTitle()}
           onCancel={() => onCancel(flyoutInstance)}

--- a/src/plugins/controls/public/control_group/editor/edit_control_group.tsx
+++ b/src/plugins/controls/public/control_group/editor/edit_control_group.tsx
@@ -73,6 +73,7 @@ export const EditControlGroup = ({
                 (newPanels[id] = {
                   ...panel,
                   width: newInput.defaultControlWidth,
+                  grow: newInput.defaultControlGrow,
                 } as ControlPanelState)
             );
             newInput.panels = newPanels;

--- a/src/plugins/controls/public/control_group/editor/edit_control_group.tsx
+++ b/src/plugins/controls/public/control_group/editor/edit_control_group.tsx
@@ -75,8 +75,11 @@ export const EditControlGroup = ({
               ([id, panel]) =>
                 (newPanels[id] = {
                   ...panel,
-                  width: newInput.defaultControlWidth,
-                  grow: newInput.defaultControlGrow,
+                  explicitInput: {
+                    ...panel.explicitInput,
+                    width: newInput.defaultControlWidth,
+                    grow: newInput.defaultControlGrow,
+                  },
                 } as ControlPanelState)
             );
             newInput.panels = newPanels;

--- a/src/plugins/controls/public/control_group/editor/edit_control_group.tsx
+++ b/src/plugins/controls/public/control_group/editor/edit_control_group.tsx
@@ -52,15 +52,18 @@ export const EditControlGroup = ({
       });
     };
 
-    const onClose = (ref: OverlayRef, newInput?: ControlGroupInput) => {
-      if (!newInput) {
-        ref.close();
-        return;
-      }
+    const onCancel = (ref: OverlayRef) => {
+      ref.close();
+    };
 
+    const onSave = (ref: OverlayRef, newInput: ControlGroupInput) => {
       const controlCount = Object.keys(controlGroupContainer.getInput().panels ?? {}).length;
       const initialInput = controlGroupContainer.getInput();
-      if (controlCount > 0 && newInput.defaultControlWidth !== initialInput.defaultControlWidth) {
+      if (
+        controlCount > 0 &&
+        (newInput.defaultControlWidth !== initialInput.defaultControlWidth ||
+          newInput.defaultControlGrow !== initialInput.defaultControlGrow)
+      ) {
         openConfirm(ControlGroupStrings.management.applyDefaultSize.getSubtitle(), {
           confirmButtonText: ControlGroupStrings.management.applyDefaultSize.getConfirm(),
           cancelButtonText: ControlGroupStrings.management.applyDefaultSize.getCancel(),
@@ -94,7 +97,8 @@ export const EditControlGroup = ({
             initialInput={controlGroupContainer.getInput()}
             controlCount={Object.keys(controlGroupContainer.getInput().panels ?? {}).length}
             onDeleteAll={() => onDeleteAll(flyoutInstance)}
-            onClose={(newInput?: ControlGroupInput) => onClose(flyoutInstance, newInput)}
+            onCancel={() => onCancel(flyoutInstance)}
+            onSave={(newInput: ControlGroupInput) => onSave(flyoutInstance, newInput)}
           />
         </PresentationUtilProvider>
       ),

--- a/src/plugins/controls/public/control_group/editor/editor_constants.ts
+++ b/src/plugins/controls/public/control_group/editor/editor_constants.ts
@@ -10,11 +10,6 @@ import { ControlGroupStrings } from '../control_group_strings';
 
 export const CONTROL_WIDTH_OPTIONS = [
   {
-    id: `auto`,
-    'data-test-subj': 'control-editor-width-auto',
-    label: ControlGroupStrings.management.controlWidth.getAutoWidthTitle(),
-  },
-  {
     id: `small`,
     'data-test-subj': 'control-editor-width-small',
     label: ControlGroupStrings.management.controlWidth.getSmallWidthTitle(),

--- a/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
+++ b/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
@@ -123,6 +123,9 @@ export class ControlGroupContainer extends Container<
         buttonType={buttonType}
         defaultControlWidth={this.getInput().defaultControlWidth}
         updateDefaultWidth={(defaultControlWidth) => this.updateInput({ defaultControlWidth })}
+        updateDefaultGrow={(defaultControlGrow: boolean) =>
+          this.updateInput({ defaultControlGrow })
+        }
         addNewEmbeddable={(type, input) => this.addNewEmbeddable(type, input)}
         closePopover={closePopover}
         getRelevantDataViewId={() => this.getMostRelevantDataViewId()}
@@ -303,6 +306,7 @@ export class ControlGroupContainer extends Container<
     return {
       order: nextOrder,
       width: this.getInput().defaultControlWidth,
+      grow: this.getInput().defaultControlGrow,
       ...panelState,
     } as ControlPanelState<TEmbeddableInput>;
   }

--- a/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
+++ b/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
@@ -123,10 +123,6 @@ export class ControlGroupContainer extends Container<
         buttonType={buttonType}
         defaultControlWidth={this.getInput().defaultControlWidth}
         defaultControlGrow={this.getInput().defaultControlGrow}
-        updateDefaultWidth={(defaultControlWidth) => this.updateInput({ defaultControlWidth })}
-        updateDefaultGrow={(defaultControlGrow: boolean) =>
-          this.updateInput({ defaultControlGrow })
-        }
         addNewEmbeddable={(type, input) => this.addNewEmbeddable(type, input)}
         closePopover={closePopover}
         getRelevantDataViewId={() => this.getMostRelevantDataViewId()}
@@ -306,8 +302,6 @@ export class ControlGroupContainer extends Container<
     }
     return {
       order: nextOrder,
-      width: this.getInput().defaultControlWidth,
-      grow: this.getInput().defaultControlGrow,
       ...panelState,
     } as ControlPanelState<TEmbeddableInput>;
   }

--- a/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
+++ b/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
@@ -122,6 +122,7 @@ export class ControlGroupContainer extends Container<
       <CreateControlButton
         buttonType={buttonType}
         defaultControlWidth={this.getInput().defaultControlWidth}
+        defaultControlGrow={this.getInput().defaultControlGrow}
         updateDefaultWidth={(defaultControlWidth) => this.updateInput({ defaultControlWidth })}
         updateDefaultGrow={(defaultControlGrow: boolean) =>
           this.updateInput({ defaultControlGrow })

--- a/src/plugins/controls/public/control_group/state/control_group_reducers.ts
+++ b/src/plugins/controls/public/control_group/state/control_group_reducers.ts
@@ -31,6 +31,12 @@ export const controlGroupReducers = {
   ) => {
     state.panels[action.payload.embeddableId].width = action.payload.width;
   },
+  setControlGrow: (
+    state: WritableDraft<ControlGroupInput>,
+    action: PayloadAction<{ grow: boolean; embeddableId: string }>
+  ) => {
+    state.panels[action.payload.embeddableId].grow = action.payload.grow;
+  },
   setControlOrders: (
     state: WritableDraft<ControlGroupInput>,
     action: PayloadAction<{ ids: string[] }>

--- a/src/plugins/controls/public/control_group/state/control_group_reducers.ts
+++ b/src/plugins/controls/public/control_group/state/control_group_reducers.ts
@@ -9,7 +9,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import { WritableDraft } from 'immer/dist/types/types-external';
 
-import { ControlWidth } from '../../types';
 import { ControlGroupInput } from '../types';
 
 export const controlGroupReducers = {
@@ -24,18 +23,6 @@ export const controlGroupReducers = {
     action: PayloadAction<ControlGroupInput['defaultControlWidth']>
   ) => {
     state.defaultControlWidth = action.payload;
-  },
-  setControlWidth: (
-    state: WritableDraft<ControlGroupInput>,
-    action: PayloadAction<{ width: ControlWidth; embeddableId: string }>
-  ) => {
-    state.panels[action.payload.embeddableId].width = action.payload.width;
-  },
-  setControlGrow: (
-    state: WritableDraft<ControlGroupInput>,
-    action: PayloadAction<{ grow: boolean; embeddableId: string }>
-  ) => {
-    state.panels[action.payload.embeddableId].grow = action.payload.grow;
   },
   setControlOrders: (
     state: WritableDraft<ControlGroupInput>,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/130702
Relies on https://github.com/elastic/kibana/pull/131769

## Summary
### Removes the "Set all sizes to default" checkbox
Our user testing showed that the old "Set all sizes to default" checkbox in the control group settings was confusing, so we chose to remove it. However, after initially implementing the behaviour discussed in the attached issue, I found that seemingly randomly changing the size was even **more** confusing - therefore, I decided to add a conformation modal to make the behaviour of overwriting the control size as explicit as possible. 
  
Essentially, when the user changes **anything** to do with the default control size (either the size itself or the "Expand width to fit available space" setting), then a confirmation modal will pop up:
  
  <img src="https://user-images.githubusercontent.com/8698078/167449276-6ef76a3c-2f90-4515-a531-4b7fa2d4da27.png" width="575px"/>
  
  - If the user chooses **skip**, then the new default size will be **saved**, but it will not overwrite the sizes of any existing controls. It will still apply other changes as expected (such as changes to the label position, if given).

     https://user-images.githubusercontent.com/8698078/167488393-2725ba72-1c7b-4a4c-ab72-14eeefbd05fc.mp4

  - If the user chooses **apply**, then the new default size will be both saved **and** it will overwrite the sizes of all existing controls to be the new default.

     https://user-images.githubusercontent.com/8698078/167487942-b92fa068-177a-41a3-b236-69666afd06e1.mp4

### Improves the default control width/grow behaviour
As part of this PR, I also made the use of the default control width more consistent. As described in [this comment](https://github.com/elastic/kibana/pull/131769#discussion_r868217858), the old behaviour was a bit confusing - to summarize this discussion, basically creating a new control with a non-default size/grow status used to change the **default** size/grow status, which doesn't make sense for what the term "default" implies. 
  
Instead, this PR makes it so the default control size **only** applies to which options are auto-selected when creating a control - creating a control has **no** impact on this default. To do this, I had to make both the control width and the control grow part of the control input rather than having them only as part of the panel state. Here is a video of the new behaviour:

https://user-images.githubusercontent.com/8698078/167497004-3ba99948-fa0a-46e6-b692-1db4d989bd71.mp4


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
