### PR TITLE
[Unified search] Changes the filter set to saved query

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/query_bar_menu.test.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_menu.test.tsx
@@ -120,7 +120,7 @@ describe('Querybar Menu component', () => {
     expect(component.find('[data-test-subj="queryBarMenuPanel"]')).toBeTruthy();
   });
 
-  it('should render the saved filter sets panels if the showQueryInput prop is true but disabled', async () => {
+  it('should render the saved saved queries panels if the showQueryInput prop is true but disabled', async () => {
     const newProps = {
       ...props,
       openQueryBarMenu: true,
@@ -140,7 +140,7 @@ describe('Querybar Menu component', () => {
     expect(loadFilterSetButton.first().prop('disabled')).toBe(true);
   });
 
-  it('should render the filter sets panels if the showFilterBar is true but disabled', async () => {
+  it('should render the saved queries panels if the showFilterBar is true but disabled', async () => {
     const newProps = {
       ...props,
       openQueryBarMenu: true,

--- a/src/plugins/unified_search/public/query_string_input/query_bar_menu.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_menu.tsx
@@ -94,7 +94,7 @@ export function QueryBarMenu({
   };
 
   const buttonLabel = i18n.translate('unifiedSearch.filter.options.filterSetButtonLabel', {
-    defaultMessage: 'Filter set menu',
+    defaultMessage: 'Saved query menu',
   });
 
   const button = (

--- a/src/plugins/unified_search/public/query_string_input/query_bar_menu_panels.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_menu_panels.tsx
@@ -249,10 +249,10 @@ export function QueryBarMenuPanels({
     {
       name: savedQuery
         ? i18n.translate('unifiedSearch.filter.options.loadOtherFilterSetLabel', {
-            defaultMessage: 'Load other filter set',
+            defaultMessage: 'Load other saved query',
           })
         : i18n.translate('unifiedSearch.filter.options.loadCurrentFilterSetLabel', {
-            defaultMessage: 'Load filter set',
+            defaultMessage: 'Load saved query',
           }),
       panel: 4,
       width: 350,
@@ -266,7 +266,7 @@ export function QueryBarMenuPanels({
             defaultMessage: 'Save as new',
           })
         : i18n.translate('unifiedSearch.filter.options.saveFilterSetLabel', {
-            defaultMessage: 'Save filter set',
+            defaultMessage: 'Save saved query',
           }),
       icon: 'save',
       disabled:
@@ -331,7 +331,13 @@ export function QueryBarMenuPanels({
                 size="s"
                 data-test-subj="savedQueryTitle"
               >
-                <strong>{savedQuery ? savedQuery.attributes.title : 'Filter set'}</strong>
+                <strong>
+                  {savedQuery
+                    ? savedQuery.attributes.title
+                    : i18n.translate('unifiedSearch.search.searchBar.savedQuery', {
+                        defaultMessage: 'Saved query',
+                      })}
+                </strong>
               </EuiText>
             </EuiFlexItem>
             {savedQuery && savedQueryHasChanged && Boolean(showSaveQuery) && hasFiltersOrQuery && (
@@ -397,7 +403,7 @@ export function QueryBarMenuPanels({
     {
       id: 1,
       title: i18n.translate('unifiedSearch.filter.options.saveCurrentFilterSetLabel', {
-        defaultMessage: 'Save current filter set',
+        defaultMessage: 'Save current saved query',
       }),
       disabled: !Boolean(showSaveQuery),
       content: <div style={{ padding: 16 }}>{saveAsNewQueryFormComponent}</div>,
@@ -483,7 +489,7 @@ export function QueryBarMenuPanels({
     {
       id: 4,
       title: i18n.translate('unifiedSearch.filter.options.loadCurrentFilterSetLabel', {
-        defaultMessage: 'Load filter set',
+        defaultMessage: 'Load saved query',
       }),
       width: 400,
       content: <div>{manageFilterSetComponent}</div>,

--- a/src/plugins/unified_search/public/saved_query_form/save_query_form.tsx
+++ b/src/plugins/unified_search/public/saved_query_form/save_query_form.tsx
@@ -203,7 +203,7 @@ export function SaveQueryForm({
           disabled={hasErrors}
         >
           {i18n.translate('unifiedSearch.search.searchBar.savedQueryFormSaveButtonText', {
-            defaultMessage: 'Save filter set',
+            defaultMessage: 'Save saved query',
           })}
         </EuiButton>
       </EuiFormRow>

--- a/src/plugins/unified_search/public/saved_query_management/saved_query_management_list.test.tsx
+++ b/src/plugins/unified_search/public/saved_query_management/saved_query_management_list.test.tsx
@@ -140,7 +140,7 @@ describe('Saved query management list component', () => {
         .find('[data-test-subj="saved-query-management-apply-changes-button"]')
         .first()
         .text()
-    ).toBe('Apply filter set');
+    ).toBe('Apply saved query');
 
     const newProps = {
       ...props,
@@ -153,7 +153,7 @@ describe('Saved query management list component', () => {
         .find('[data-test-subj="saved-query-management-apply-changes-button"]')
         .first()
         .text()
-    ).toBe('Replace with selected filter set');
+    ).toBe('Replace with selected saved query');
   });
 
   it('should render the modal on delete', async () => {

--- a/src/plugins/unified_search/public/saved_query_management/saved_query_management_list.tsx
+++ b/src/plugins/unified_search/public/saved_query_management/saved_query_management_list.tsx
@@ -266,7 +266,7 @@ export function SavedQueryManagementList({
                 placeholder: i18n.translate(
                   'unifiedSearch.query.queryBar.indexPattern.findFilterSet',
                   {
-                    defaultMessage: 'Find a filter set',
+                    defaultMessage: 'Find a saved query',
                   }
                 ),
               }}
@@ -323,7 +323,7 @@ export function SavedQueryManagementList({
               aria-label={i18n.translate(
                 'unifiedSearch.search.searchBar.savedQueryPopoverApplyFilterSetLabel',
                 {
-                  defaultMessage: 'Apply filter set',
+                  defaultMessage: 'Apply saved query',
                 }
               )}
               data-test-subj="saved-query-management-apply-changes-button"
@@ -332,13 +332,13 @@ export function SavedQueryManagementList({
                 ? i18n.translate(
                     'unifiedSearch.search.searchBar.savedQueryPopoverReplaceFilterSetLabel',
                     {
-                      defaultMessage: 'Replace with selected filter set',
+                      defaultMessage: 'Replace with selected saved query',
                     }
                   )
                 : i18n.translate(
                     'unifiedSearch.search.searchBar.savedQueryPopoverApplyFilterSetLabel',
                     {
-                      defaultMessage: 'Apply filter set',
+                      defaultMessage: 'Apply saved query',
                     }
                   )}
             </EuiButton>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/131648

After the discussion we had on the issue above, we decided for now to revert the Saved query term for the save capabilities of the unified search as our user testing demonstrated some confusion with the `filter set` term. This PR changes the occurrences of the filter set term to saved query.

<img width="379" alt="image" src="https://user-images.githubusercontent.com/17003240/167353613-72dd428e-7086-44a0-af5c-5a40dcc00291.png">

On the long term, we think that the correct term is `saved search` but is already used by Discover. As there are plans to change the Discover saved search to dataview, we will re-discuss it then.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios