### PR TITLE
[8.2] [Security solution][Endpoint] Disable add endpoint event filter when not in host events page (#131705)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
@@ -13,6 +13,10 @@ import React from 'react';
 import { Ecs } from '../../../../../common/ecs';
 import { mockTimelines } from '../../../../common/mock/mock_timelines_plugin';
 import { mockCasesContract } from '../../../../../../cases/public/mocks';
+import { initialUserPrivilegesState as mockInitialUserPrivilegesState } from '../../../../common/components/user_privileges/user_privileges_context';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
+
+jest.mock('../../../../common/components/user_privileges');
 
 const ecsRowData: Ecs = {
   _id: '1',
@@ -74,6 +78,7 @@ const addToNewCaseButton = '[data-test-subj="add-to-new-case-action"]';
 const markAsOpenButton = '[data-test-subj="open-alert-status"]';
 const markAsAcknowledgedButton = '[data-test-subj="acknowledged-alert-status"]';
 const markAsClosedButton = '[data-test-subj="close-alert-status"]';
+const addEndpointEventFilterButton = '[data-test-subj="add-event-filter-menu-item"]';
 
 describe('InvestigateInResolverAction', () => {
   test('it render AddToCase context menu item if timelineId === TimelineId.detectionsPage', () => {
@@ -110,12 +115,7 @@ describe('InvestigateInResolverAction', () => {
   });
 
   test('it does NOT render AddToCase context menu item when timelineId is not in the allowed list', () => {
-    // In order to enable alert context menu without a timelineId, event needs to be event.kind === 'event' and agent.type === 'endpoint'
-    const customProps = {
-      ...props,
-      ecsRowData: { ...ecsRowData, agent: { type: ['endpoint'] }, event: { kind: ['event'] } },
-    };
-    const wrapper = mount(<AlertContextMenu {...customProps} timelineId="timeline-test" />, {
+    const wrapper = mount(<AlertContextMenu {...props} timelineId="timeline-test" />, {
       wrappingComponent: TestProviders,
     });
     wrapper.find(actionMenuButton).simulate('click');
@@ -133,5 +133,85 @@ describe('InvestigateInResolverAction', () => {
     expect(wrapper.find(markAsOpenButton).first().exists()).toEqual(false);
     expect(wrapper.find(markAsAcknowledgedButton).first().exists()).toEqual(true);
     expect(wrapper.find(markAsClosedButton).first().exists()).toEqual(true);
+  });
+
+  describe('AddEndpointEventFilter', () => {
+    const endpointEventProps = {
+      ...props,
+      ecsRowData: { ...ecsRowData, agent: { type: ['endpoint'] }, event: { kind: ['event'] } },
+    };
+
+    describe('when users can access endpoint management', () => {
+      beforeEach(() => {
+        (useUserPrivileges as jest.Mock).mockReturnValue({
+          ...mockInitialUserPrivilegesState(),
+          endpointPrivileges: { loading: false, canAccessEndpointManagement: true },
+        });
+      });
+
+      test('it disables AddEndpointEventFilter when timeline id is not host events page', () => {
+        const wrapper = mount(
+          <AlertContextMenu {...endpointEventProps} timelineId={TimelineId.active} />,
+          {
+            wrappingComponent: TestProviders,
+          }
+        );
+
+        wrapper.find(actionMenuButton).simulate('click');
+        expect(wrapper.find(addEndpointEventFilterButton).first().exists()).toEqual(true);
+        expect(wrapper.find(addEndpointEventFilterButton).first().props().disabled).toEqual(true);
+      });
+
+      test('it enables AddEndpointEventFilter when timeline id is host events page', () => {
+        const wrapper = mount(
+          <AlertContextMenu {...endpointEventProps} timelineId={TimelineId.hostsPageEvents} />,
+          {
+            wrappingComponent: TestProviders,
+          }
+        );
+
+        wrapper.find(actionMenuButton).simulate('click');
+        expect(wrapper.find(addEndpointEventFilterButton).first().exists()).toEqual(true);
+        expect(wrapper.find(addEndpointEventFilterButton).first().props().disabled).toEqual(false);
+      });
+
+      test('it disables AddEndpointEventFilter when timeline id is host events page but is not from endpoint', () => {
+        const customProps = {
+          ...props,
+          ecsRowData: { ...ecsRowData, agent: { type: ['other'] }, event: { kind: ['event'] } },
+        };
+        const wrapper = mount(
+          <AlertContextMenu {...customProps} timelineId={TimelineId.hostsPageEvents} />,
+          {
+            wrappingComponent: TestProviders,
+          }
+        );
+
+        wrapper.find(actionMenuButton).simulate('click');
+        expect(wrapper.find(addEndpointEventFilterButton).first().exists()).toEqual(true);
+        expect(wrapper.find(addEndpointEventFilterButton).first().props().disabled).toEqual(true);
+      });
+    });
+    describe('when users can NOT access endpoint management', () => {
+      beforeEach(() => {
+        (useUserPrivileges as jest.Mock).mockReturnValue({
+          ...mockInitialUserPrivilegesState(),
+          endpointPrivileges: { loading: false, canAccessEndpointManagement: false },
+        });
+      });
+
+      test('it disables AddEndpointEventFilter when timeline id is host events page but cannot acces endpoint management', () => {
+        const wrapper = mount(
+          <AlertContextMenu {...endpointEventProps} timelineId={TimelineId.hostsPageEvents} />,
+          {
+            wrappingComponent: TestProviders,
+          }
+        );
+
+        wrapper.find(actionMenuButton).simulate('click');
+        expect(wrapper.find(addEndpointEventFilterButton).first().exists()).toEqual(true);
+        expect(wrapper.find(addEndpointEventFilterButton).first().props().disabled).toEqual(true);
+      });
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
@@ -88,6 +88,9 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
   const alertStatus = get(0, ecsRowData?.kibana?.alert?.workflow_status) as Status | undefined;
 
   const isEvent = useMemo(() => indexOf(ecsRowData.event?.kind, 'event') !== -1, [ecsRowData]);
+  const isAgentEndpoint = useMemo(() => ecsRowData.agent?.type?.includes('endpoint'), [ecsRowData]);
+
+  const isEndpointEvent = useMemo(() => isEvent && isAgentEndpoint, [isEvent, isAgentEndpoint]);
 
   const onButtonClick = useCallback(() => {
     setPopover(!isPopoverOpen);
@@ -173,7 +176,14 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
   });
   const { eventFilterActionItems } = useEventFilterAction({
     onAddEventFilterClick: handleOnAddEventFilterClick,
-    disabled: !isEvent || !canCreateEndpointEventFilters,
+    disabled:
+      !isEndpointEvent ||
+      !canCreateEndpointEventFilters ||
+      timelineId !== TimelineId.hostsPageEvents,
+    tooltipMessage:
+      timelineId !== TimelineId.hostsPageEvents
+        ? i18n.ACTION_ADD_EVENT_FILTER_DISABLED_TOOLTIP
+        : undefined,
   });
   const items: React.ReactElement[] = useMemo(
     () =>

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_event_filter_action.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_event_filter_action.tsx
@@ -12,9 +12,11 @@ import { ACTION_ADD_EVENT_FILTER } from '../translations';
 export const useEventFilterAction = ({
   onAddEventFilterClick,
   disabled = false,
+  tooltipMessage,
 }: {
   onAddEventFilterClick: () => void;
   disabled?: boolean;
+  tooltipMessage?: string;
 }) => {
   const eventFilterActionItems = useMemo(
     () => [
@@ -23,11 +25,12 @@ export const useEventFilterAction = ({
         data-test-subj="add-event-filter-menu-item"
         onClick={onAddEventFilterClick}
         disabled={disabled}
+        toolTipContent={tooltipMessage}
       >
         {ACTION_ADD_EVENT_FILTER}
       </EuiContextMenuItem>,
     ],
-    [onAddEventFilterClick, disabled]
+    [onAddEventFilterClick, disabled, tooltipMessage]
   );
   return { eventFilterActionItems };
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/translations.ts
@@ -185,6 +185,14 @@ export const ACTION_ADD_EVENT_FILTER = i18n.translate(
   }
 );
 
+export const ACTION_ADD_EVENT_FILTER_DISABLED_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.detectionEngine.alerts.actions.addEventFilter.disabled.tooltip',
+  {
+    defaultMessage:
+      'Endpoint event filters can be created from the Events section of the Hosts page.',
+  }
+);
+
 export const ACTION_ADD_ENDPOINT_EXCEPTION = i18n.translate(
   'xpack.securitySolution.detectionEngine.alerts.actions.addEndpointException',
   {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Security solution][Endpoint] Disable add endpoint event filter when not in host events page (#131705)](https://github.com/elastic/kibana/pull/131705)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)