### PR TITLE
[8.2] [ftr] handle unexpected Kibana/ES shutdowns better (#131767)

### DIFF
--- a/packages/kbn-dev-utils/src/proc_runner/proc.ts
+++ b/packages/kbn-dev-utils/src/proc_runner/proc.ts
@@ -168,5 +168,8 @@ export function startProc(name: string, options: ProcOptions, log: ToolingLog) {
     outcome$,
     outcomePromise,
     stop,
+    stopWasCalled() {
+      return stopCalled;
+    },
   };
 }

--- a/packages/kbn-dev-utils/src/proc_runner/proc_runner.ts
+++ b/packages/kbn-dev-utils/src/proc_runner/proc_runner.ts
@@ -22,6 +22,7 @@ const noop = () => {};
 interface RunOptions extends ProcOptions {
   wait: true | RegExp;
   waitTimeout?: number | false;
+  onEarlyExit?: (msg: string) => void;
 }
 
 /**
@@ -48,16 +49,6 @@ export class ProcRunner {
 
   /**
    *  Start a process, tracking it by `name`
-   *  @param  {String}  name
-   *  @param  {Object}  options
-   *  @property {String} options.cmd executable to run
-   *  @property {Array<String>?} options.args arguments to provide the executable
-   *  @property {String?} options.cwd current working directory for the process
-   *  @property {RegExp|Boolean} options.wait Should start() wait for some time? Use
-   *                                          `true` will wait until the proc exits,
-   *                                          a `RegExp` will wait until that log line
-   *                                          is found
-   *  @return {Promise<undefined>}
    */
   async run(name: string, options: RunOptions) {
     const {
@@ -67,6 +58,7 @@ export class ProcRunner {
       wait = false,
       waitTimeout = 15 * MINUTE,
       env = process.env,
+      onEarlyExit,
     } = options;
     const cmd = options.cmd === 'node' ? process.execPath : options.cmd;
 
@@ -89,6 +81,25 @@ export class ProcRunner {
       env,
       stdin,
     });
+
+    if (onEarlyExit) {
+      proc.outcomePromise
+        .then(
+          (code) => {
+            if (!proc.stopWasCalled()) {
+              onEarlyExit(`[${name}] exitted early with ${code}`);
+            }
+          },
+          (error) => {
+            if (!proc.stopWasCalled()) {
+              onEarlyExit(`[${name}] exitted early: ${error.message}`);
+            }
+          }
+        )
+        .catch((error) => {
+          throw new Error(`Error handling early exit: ${error.stack}`);
+        });
+    }
 
     try {
       if (wait instanceof RegExp) {

--- a/packages/kbn-es/src/cluster.js
+++ b/packages/kbn-es/src/cluster.js
@@ -215,6 +215,25 @@ exports.Cluster = class Cluster {
         }),
       ]);
     });
+
+    if (options.onEarlyExit) {
+      this._outcome
+        .then(
+          () => {
+            if (!this._stopCalled) {
+              options.onEarlyExit(`ES exitted unexpectedly`);
+            }
+          },
+          (error) => {
+            if (!this._stopCalled) {
+              options.onEarlyExit(`ES exitted unexpectedly: ${error.stack}`);
+            }
+          }
+        )
+        .catch((error) => {
+          throw new Error(`failure handling early exit: ${error.stack}`);
+        });
+    }
   }
 
   /**

--- a/packages/kbn-es/src/cluster_exec_options.ts
+++ b/packages/kbn-es/src/cluster_exec_options.ts
@@ -15,4 +15,5 @@ export interface EsClusterExecOptions {
   password?: string;
   skipReadyCheck?: boolean;
   readyTimeout?: number;
+  onEarlyExit?: (msg: string) => void;
 }

--- a/packages/kbn-test/src/es/test_es_cluster.ts
+++ b/packages/kbn-test/src/es/test_es_cluster.ts
@@ -145,6 +145,11 @@ export interface CreateTestEsClusterOptions {
    * defaults to the transport port from `packages/kbn-test/src/es/es_test_config.ts`
    */
   transportPort?: number | string;
+  /**
+   * Report to the creator of the es-test-cluster that the es node has exitted before stop() was called, allowing
+   * this caller to react appropriately. If this is not passed then an uncatchable exception will be thrown
+   */
+  onEarlyExit?: (msg: string) => void;
 }
 
 export function createTestEsCluster<
@@ -164,6 +169,7 @@ export function createTestEsCluster<
     clusterName: customClusterName = 'es-test-cluster',
     ssl,
     transportPort,
+    onEarlyExit,
   } = options;
 
   const clusterName = `${CI_PARALLEL_PROCESS_PREFIX}${customClusterName}`;
@@ -257,6 +263,7 @@ export function createTestEsCluster<
             // set it up after the last node is started.
             skipNativeRealmSetup: this.nodes.length > 1 && i < this.nodes.length - 1,
             skipReadyCheck: this.nodes.length > 1 && i < this.nodes.length - 1,
+            onEarlyExit,
           });
         });
       }

--- a/packages/kbn-test/src/functional_test_runner/fake_mocha_types.ts
+++ b/packages/kbn-test/src/functional_test_runner/fake_mocha_types.ts
@@ -37,6 +37,7 @@ export interface Test {
 export interface Runner extends EventEmitter {
   abort(): void;
   failures: any[];
+  uncaught: (error: Error) => void;
 }
 
 export interface Mocha {

--- a/packages/kbn-test/src/functional_test_runner/lib/mocha/run_tests.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/mocha/run_tests.ts
@@ -7,6 +7,7 @@
  */
 
 import * as Rx from 'rxjs';
+import { take } from 'rxjs/operators';
 import { Lifecycle } from '../lifecycle';
 import { Mocha } from '../../fake_mocha_types';
 
@@ -27,7 +28,7 @@ export async function runTests(lifecycle: Lifecycle, mocha: Mocha, abortSignal?:
 
   Rx.race(
     lifecycle.cleanup.before$,
-    abortSignal ? Rx.fromEvent(abortSignal, 'abort').pipe(Rx.take(1)) : Rx.NEVER
+    abortSignal ? Rx.fromEvent(abortSignal, 'abort').pipe(take(1)) : Rx.NEVER
   ).subscribe({
     next() {
       if (!runComplete) {

--- a/packages/kbn-test/src/functional_tests/lib/run_elasticsearch.ts
+++ b/packages/kbn-test/src/functional_tests/lib/run_elasticsearch.ts
@@ -17,6 +17,7 @@ interface RunElasticsearchOptions {
   log: ToolingLog;
   esFrom?: string;
   config: Config;
+  onEarlyExit?: (msg: string) => void;
 }
 
 interface CcsConfig {
@@ -92,7 +93,8 @@ export async function runElasticsearch(
 async function startEsNode(
   log: ToolingLog,
   name: string,
-  config: EsConfig & { transportPort?: number }
+  config: EsConfig & { transportPort?: number },
+  onEarlyExit?: (msg: string) => void
 ) {
   const cluster = createTestEsCluster({
     clusterName: `cluster-${name}`,
@@ -112,6 +114,7 @@ async function startEsNode(
       },
     ],
     transportPort: config.transportPort,
+    onEarlyExit,
   });
 
   await cluster.start();

--- a/packages/kbn-test/src/functional_tests/lib/run_ftr.ts
+++ b/packages/kbn-test/src/functional_tests/lib/run_ftr.ts
@@ -81,8 +81,8 @@ async function createFtr({
   };
 }
 
-export async function assertNoneExcluded({ configPath, options }: CreateFtrParams) {
-  const { config, ftr } = await createFtr({ configPath, options });
+export async function assertNoneExcluded(params: CreateFtrParams) {
+  const { config, ftr } = await createFtr(params);
 
   if (config.get('testRunner')) {
     // tests with custom test runners are not included in this check
@@ -92,21 +92,21 @@ export async function assertNoneExcluded({ configPath, options }: CreateFtrParam
   const stats = await ftr.getTestStats();
   if (stats.testsExcludedByTag.length > 0) {
     throw new CliError(`
-      ${stats.testsExcludedByTag.length} tests in the ${configPath} config
+      ${stats.testsExcludedByTag.length} tests in the ${params.configPath} config
       are excluded when filtering by the tags run on CI. Make sure that all suites are
       tagged with one of the following tags:
 
-      ${JSON.stringify(options.suiteTags)}
+      ${JSON.stringify(params.options.suiteTags)}
 
       - ${stats.testsExcludedByTag.join('\n      - ')}
     `);
   }
 }
 
-export async function runFtr({ configPath, options }: CreateFtrParams) {
-  const { ftr } = await createFtr({ configPath, options });
+export async function runFtr(params: CreateFtrParams, signal?: AbortSignal) {
+  const { ftr } = await createFtr(params);
 
-  const failureCount = await ftr.run();
+  const failureCount = await ftr.run(signal);
   if (failureCount > 0) {
     throw new CliError(
       `${failureCount} functional test ${failureCount === 1 ? 'failure' : 'failures'}`
@@ -114,8 +114,8 @@ export async function runFtr({ configPath, options }: CreateFtrParams) {
   }
 }
 
-export async function hasTests({ configPath, options }: CreateFtrParams) {
-  const { ftr, config } = await createFtr({ configPath, options });
+export async function hasTests(params: CreateFtrParams) {
+  const { ftr, config } = await createFtr(params);
 
   if (config.get('testRunner')) {
     // configs with custom test runners are assumed to always have tests

--- a/packages/kbn-test/src/functional_tests/lib/run_kibana_server.ts
+++ b/packages/kbn-test/src/functional_tests/lib/run_kibana_server.ts
@@ -31,10 +31,12 @@ export async function runKibanaServer({
   procs,
   config,
   options,
+  onEarlyExit,
 }: {
   procs: ProcRunner;
   config: Config;
   options: { installDir?: string; extraKbnOpts?: string[] };
+  onEarlyExit?: (msg: string) => void;
 }) {
   const { installDir } = options;
   const runOptions = config.get('kbnTestServer.runOptions');
@@ -51,6 +53,7 @@ export async function runKibanaServer({
     },
     cwd: installDir || KIBANA_ROOT,
     wait: runOptions.wait,
+    onEarlyExit,
   });
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[ftr] handle unexpected Kibana/ES shutdowns better (#131767)](https://github.com/elastic/kibana/pull/131767)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)