### PR TITLE
[ML] Transforms: Use data views service for loading data views

### DIFF
--- a/x-pack/plugins/transform/kibana.json
+++ b/x-pack/plugins/transform/kibana.json
@@ -5,6 +5,7 @@
   "ui": true,
   "requiredPlugins": [
     "data",
+    "dataViews",
     "home",
     "licensing",
     "management",

--- a/x-pack/plugins/transform/public/app/hooks/use_delete_transform.tsx
+++ b/x-pack/plugins/transform/public/app/hooks/use_delete_transform.tsx
@@ -23,7 +23,7 @@ import { indexService } from '../services/es_index_service';
 export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
   const {
     http,
-    data: { dataViews },
+    data: { dataViews: dataViewsContract },
     ml: { extractErrorMessage },
     application: { capabilities },
   } = useAppDependencies();
@@ -46,7 +46,7 @@ export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
   const checkDataViewExists = useCallback(
     async (indexName: string) => {
       try {
-        const dvExists = await indexService.dataViewExists(dataViews, indexName);
+        const dvExists = await indexService.dataViewExists(dataViewsContract, indexName);
         setDataViewExists(dvExists);
       } catch (e) {
         const error = extractErrorMessage(e);
@@ -62,7 +62,7 @@ export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
         );
       }
     },
-    [dataViews, toastNotifications, extractErrorMessage]
+    [dataViewsContract, toastNotifications, extractErrorMessage]
   );
 
   const checkUserIndexPermission = useCallback(async () => {

--- a/x-pack/plugins/transform/public/app/hooks/use_delete_transform.tsx
+++ b/x-pack/plugins/transform/public/app/hooks/use_delete_transform.tsx
@@ -23,7 +23,7 @@ import { indexService } from '../services/es_index_service';
 export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
   const {
     http,
-    savedObjects,
+    data: { dataViews },
     ml: { extractErrorMessage },
     application: { capabilities },
   } = useAppDependencies();
@@ -46,9 +46,8 @@ export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
   const checkDataViewExists = useCallback(
     async (indexName: string) => {
       try {
-        if (await indexService.dataViewExists(savedObjects.client, indexName)) {
-          setDataViewExists(true);
-        }
+        const dvExists = await indexService.dataViewExists(dataViews, indexName);
+        setDataViewExists(dvExists);
       } catch (e) {
         const error = extractErrorMessage(e);
 
@@ -63,7 +62,7 @@ export const useDeleteIndexAndTargetIndex = (items: TransformListRow[]) => {
         );
       }
     },
-    [savedObjects.client, toastNotifications, extractErrorMessage]
+    [dataViews, toastNotifications, extractErrorMessage]
   );
 
   const checkUserIndexPermission = useCallback(async () => {

--- a/x-pack/plugins/transform/public/app/hooks/use_search_items/common.ts
+++ b/x-pack/plugins/transform/public/app/hooks/use_search_items/common.ts
@@ -6,9 +6,9 @@
  */
 
 import { buildEsQuery } from '@kbn/es-query';
-import { SavedObjectsClientContract, SimpleSavedObject, IUiSettingsClient } from '@kbn/core/public';
+import { IUiSettingsClient } from '@kbn/core/public';
 import { getEsQueryConfig } from '@kbn/data-plugin/public';
-import { DataView, DataViewAttributes, DataViewsContract } from '@kbn/data-views-plugin/public';
+import { DataView, DataViewsContract } from '@kbn/data-views-plugin/public';
 
 import { matchAllQuery } from '../../common';
 
@@ -16,57 +16,20 @@ import { isDataView } from '../../../../common/types/data_view';
 
 export type SavedSearchQuery = object;
 
-type DataViewId = string;
-
-let dataViewCache: Array<SimpleSavedObject<Record<string, any>>> = [];
-let fullDataViews;
-let currentDataView = null;
+let dataViewCache: DataView[] = [];
 
 export let refreshDataViews: () => Promise<unknown>;
 
-export function loadDataViews(
-  savedObjectsClient: SavedObjectsClientContract,
-  dataViews: DataViewsContract
-) {
-  fullDataViews = dataViews;
-  return savedObjectsClient
-    .find<DataViewAttributes>({
-      type: 'index-pattern',
-      fields: ['id', 'title', 'type', 'fields'],
-      perPage: 10000,
-    })
-    .then((response) => {
-      dataViewCache = response.savedObjects;
-
-      if (refreshDataViews === null) {
-        refreshDataViews = () => {
-          return new Promise((resolve, reject) => {
-            loadDataViews(savedObjectsClient, dataViews)
-              .then((resp) => {
-                resolve(resp);
-              })
-              .catch((error) => {
-                reject(error);
-              });
-          });
-        };
-      }
-
-      return dataViewCache;
-    });
+export async function loadDataViews(dataViewsContract: DataViewsContract) {
+  dataViewCache = await dataViewsContract.find('*', 10000);
+  return dataViewCache;
 }
 
 export function getDataViewIdByTitle(dataViewTitle: string): string | undefined {
-  return dataViewCache.find((d) => d?.attributes?.title === dataViewTitle)?.id;
+  return dataViewCache.find(({ title }) => title === dataViewTitle)?.id;
 }
 
 type CombinedQuery = Record<'bool', any> | object;
-
-export function loadCurrentDataView(dataViews: DataViewsContract, dataViewId: DataViewId) {
-  fullDataViews = dataViews;
-  currentDataView = fullDataViews.get(dataViewId);
-  return currentDataView;
-}
 
 export interface SearchItems {
   dataView: DataView;

--- a/x-pack/plugins/transform/public/app/hooks/use_search_items/common.ts
+++ b/x-pack/plugins/transform/public/app/hooks/use_search_items/common.ts
@@ -6,9 +6,9 @@
  */
 
 import { buildEsQuery } from '@kbn/es-query';
-import { IUiSettingsClient } from '@kbn/core/public';
+import type { IUiSettingsClient } from '@kbn/core/public';
 import { getEsQueryConfig } from '@kbn/data-plugin/public';
-import { DataView, DataViewsContract } from '@kbn/data-views-plugin/public';
+import type { DataView, DataViewsContract } from '@kbn/data-views-plugin/public';
 
 import { matchAllQuery } from '../../common';
 

--- a/x-pack/plugins/transform/public/app/hooks/use_search_items/use_search_items.ts
+++ b/x-pack/plugins/transform/public/app/hooks/use_search_items/use_search_items.ts
@@ -15,33 +15,24 @@ import { getSavedSearch, getSavedSearchUrlConflictMessage } from '../../../share
 
 import { useAppDependencies } from '../../app_dependencies';
 
-import {
-  createSearchItems,
-  getDataViewIdByTitle,
-  loadCurrentDataView,
-  loadDataViews,
-  SearchItems,
-} from './common';
+import { createSearchItems, getDataViewIdByTitle, loadDataViews, SearchItems } from './common';
 
 export const useSearchItems = (defaultSavedObjectId: string | undefined) => {
   const [savedObjectId, setSavedObjectId] = useState(defaultSavedObjectId);
   const [error, setError] = useState<string | undefined>();
 
   const appDeps = useAppDependencies();
-  const dataViews = appDeps.data.dataViews;
+  const dataViewsContract = appDeps.data.dataViews;
   const uiSettings = appDeps.uiSettings;
-  const savedObjectsClient = appDeps.savedObjects.client;
 
   const [searchItems, setSearchItems] = useState<SearchItems | undefined>(undefined);
 
   async function fetchSavedObject(id: string) {
-    await loadDataViews(savedObjectsClient, dataViews);
-
     let fetchedDataView;
     let fetchedSavedSearch;
 
     try {
-      fetchedDataView = await loadCurrentDataView(dataViews, id);
+      fetchedDataView = await dataViewsContract.get(id);
     } catch (e) {
       // Just let fetchedDataView stay undefined in case it doesn't exist.
     }

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/action_clone/use_clone_action.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/action_clone/use_clone_action.tsx
@@ -21,8 +21,7 @@ export type CloneAction = ReturnType<typeof useCloneAction>;
 export const useCloneAction = (forceDisable: boolean, transformNodes: number) => {
   const history = useHistory();
   const appDeps = useAppDependencies();
-  const savedObjectsClient = appDeps.savedObjects.client;
-  const dataViews = appDeps.data.dataViews;
+  const dataViewsContract = appDeps.data.dataViews;
   const toastNotifications = useToastNotifications();
 
   const { getDataViewIdByTitle, loadDataViews } = useSearchItems(undefined);
@@ -32,7 +31,7 @@ export const useCloneAction = (forceDisable: boolean, transformNodes: number) =>
   const clickHandler = useCallback(
     async (item: TransformListRow) => {
       try {
-        await loadDataViews(savedObjectsClient, dataViews);
+        await loadDataViews(dataViewsContract);
         const dataViewTitle = Array.isArray(item.config.source.index)
           ? item.config.source.index.join(',')
           : item.config.source.index;
@@ -57,14 +56,7 @@ export const useCloneAction = (forceDisable: boolean, transformNodes: number) =>
         });
       }
     },
-    [
-      history,
-      savedObjectsClient,
-      dataViews,
-      toastNotifications,
-      loadDataViews,
-      getDataViewIdByTitle,
-    ]
+    [history, dataViewsContract, toastNotifications, loadDataViews, getDataViewIdByTitle]
   );
 
   const action: TransformListAction = useMemo(

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/action_discover/use_action_discover.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/action_discover/use_action_discover.tsx
@@ -25,10 +25,12 @@ const getDataViewTitleFromTargetIndex = (item: TransformListRow) =>
 
 export type DiscoverAction = ReturnType<typeof useDiscoverAction>;
 export const useDiscoverAction = (forceDisable: boolean) => {
-  const appDeps = useAppDependencies();
-  const { share } = appDeps;
-  const dataViewsContract = appDeps.data.dataViews;
-  const isDiscoverAvailable = !!appDeps.application.capabilities.discover?.show;
+  const {
+    share,
+    data: { dataViews: dataViewsContract },
+    application: { capabilities },
+  } = useAppDependencies();
+  const isDiscoverAvailable = !!capabilities.discover?.show;
 
   const { getDataViewIdByTitle, loadDataViews } = useSearchItems(undefined);
 

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/action_discover/use_action_discover.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/action_discover/use_action_discover.tsx
@@ -27,8 +27,7 @@ export type DiscoverAction = ReturnType<typeof useDiscoverAction>;
 export const useDiscoverAction = (forceDisable: boolean) => {
   const appDeps = useAppDependencies();
   const { share } = appDeps;
-  const savedObjectsClient = appDeps.savedObjects.client;
-  const dataViews = appDeps.data.dataViews;
+  const dataViewsContract = appDeps.data.dataViews;
   const isDiscoverAvailable = !!appDeps.application.capabilities.discover?.show;
 
   const { getDataViewIdByTitle, loadDataViews } = useSearchItems(undefined);
@@ -37,12 +36,12 @@ export const useDiscoverAction = (forceDisable: boolean) => {
 
   useEffect(() => {
     async function checkDataViewAvailability() {
-      await loadDataViews(savedObjectsClient, dataViews);
+      await loadDataViews(dataViewsContract);
       setDataViewsLoaded(true);
     }
 
     checkDataViewAvailability();
-  }, [dataViews, loadDataViews, savedObjectsClient]);
+  }, [loadDataViews, dataViewsContract]);
 
   const clickHandler = useCallback(
     (item: TransformListRow) => {

--- a/x-pack/plugins/transform/public/app/services/es_index_service.ts
+++ b/x-pack/plugins/transform/public/app/services/es_index_service.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { HttpSetup, SavedObjectsClientContract } from '@kbn/core/public';
-import { DataView } from '@kbn/data-views-plugin/public';
+import { HttpSetup } from '@kbn/core/public';
+import { DataViewsContract } from '@kbn/data-views-plugin/public';
 import { API_BASE_PATH } from '../../../common/constants';
 
 export class IndexService {
@@ -18,16 +18,9 @@ export class IndexService {
     return privilege.hasAllPrivileges;
   }
 
-  async dataViewExists(savedObjectsClient: SavedObjectsClientContract, indexName: string) {
-    const response = await savedObjectsClient.find<DataView>({
-      type: 'index-pattern',
-      perPage: 1,
-      search: `"${indexName}"`,
-      searchFields: ['title'],
-      fields: ['title'],
-    });
-    const ip = response.savedObjects.find((obj) => obj.attributes.title === indexName);
-    return ip !== undefined;
+  async dataViewExists(dataViewsContract: DataViewsContract, indexName: string) {
+    const dv = (await dataViewsContract.find(indexName)).find(({ title }) => title === indexName);
+    return dv !== undefined;
   }
 }
 

--- a/x-pack/plugins/transform/public/app/services/es_index_service.ts
+++ b/x-pack/plugins/transform/public/app/services/es_index_service.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { HttpSetup } from '@kbn/core/public';
-import { DataViewsContract } from '@kbn/data-views-plugin/public';
+import type { HttpSetup } from '@kbn/core/public';
+import type { DataViewsContract } from '@kbn/data-views-plugin/public';
 import { API_BASE_PATH } from '../../../common/constants';
 
 export class IndexService {
@@ -19,8 +19,7 @@ export class IndexService {
   }
 
   async dataViewExists(dataViewsContract: DataViewsContract, indexName: string) {
-    const dv = (await dataViewsContract.find(indexName)).find(({ title }) => title === indexName);
-    return dv !== undefined;
+    return (await dataViewsContract.find(indexName)).some(({ title }) => title === indexName);
   }
 }
 

--- a/x-pack/plugins/transform/public/plugin.ts
+++ b/x-pack/plugins/transform/public/plugin.ts
@@ -9,6 +9,7 @@ import { i18n as kbnI18n } from '@kbn/i18n';
 
 import type { CoreSetup } from '@kbn/core/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import type { SavedObjectsStart } from '@kbn/saved-objects-plugin/public';
 import type { ManagementSetup } from '@kbn/management-plugin/public';
@@ -21,6 +22,7 @@ import { getTransformHealthRuleType } from './alerting';
 
 export interface PluginsDependencies {
   data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
   management: ManagementSetup;
   home: HomePublicPluginSetup;
   savedObjects: SavedObjectsStart;

--- a/x-pack/plugins/transform/public/plugin.ts
+++ b/x-pack/plugins/transform/public/plugin.ts
@@ -9,7 +9,7 @@ import { i18n as kbnI18n } from '@kbn/i18n';
 
 import type { CoreSetup } from '@kbn/core/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import type { SavedObjectsStart } from '@kbn/saved-objects-plugin/public';
 import type { ManagementSetup } from '@kbn/management-plugin/public';

--- a/x-pack/plugins/transform/server/plugin.ts
+++ b/x-pack/plugins/transform/server/plugin.ts
@@ -10,7 +10,7 @@ import { CoreSetup, CoreStart, Plugin, Logger, PluginInitializerContext } from '
 
 import { LicenseType } from '@kbn/licensing-plugin/common/types';
 
-import { Dependencies, PluginStartContract } from './types';
+import { PluginSetupDependencies, PluginStartDependencies } from './types';
 import { ApiRoutes } from './routes';
 import { License } from './services';
 import { registerTransformHealthRuleType } from './lib/alerting';
@@ -38,8 +38,8 @@ export class TransformServerPlugin implements Plugin<{}, void, any, any> {
   }
 
   setup(
-    { http, getStartServices, elasticsearch }: CoreSetup<PluginStartContract>,
-    { licensing, features, alerting }: Dependencies
+    { http, getStartServices, elasticsearch }: CoreSetup<PluginStartDependencies>,
+    { licensing, features, alerting }: PluginSetupDependencies
   ): {} {
     const router = http.createRouter();
 
@@ -84,7 +84,7 @@ export class TransformServerPlugin implements Plugin<{}, void, any, any> {
     return {};
   }
 
-  start(core: CoreStart, plugins: PluginStartContract) {}
+  start(core: CoreStart, plugins: PluginStartDependencies) {}
 
   stop() {}
 }

--- a/x-pack/plugins/transform/server/plugin.ts
+++ b/x-pack/plugins/transform/server/plugin.ts
@@ -6,11 +6,11 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { CoreSetup, Plugin, Logger, PluginInitializerContext } from '@kbn/core/server';
+import { CoreSetup, CoreStart, Plugin, Logger, PluginInitializerContext } from '@kbn/core/server';
 
 import { LicenseType } from '@kbn/licensing-plugin/common/types';
 
-import { Dependencies } from './types';
+import { Dependencies, PluginStartContract } from './types';
 import { ApiRoutes } from './routes';
 import { License } from './services';
 import { registerTransformHealthRuleType } from './lib/alerting';
@@ -38,7 +38,7 @@ export class TransformServerPlugin implements Plugin<{}, void, any, any> {
   }
 
   setup(
-    { http, getStartServices, elasticsearch }: CoreSetup,
+    { http, getStartServices, elasticsearch }: CoreSetup<PluginStartContract>,
     { licensing, features, alerting }: Dependencies
   ): {} {
     const router = http.createRouter();
@@ -74,6 +74,7 @@ export class TransformServerPlugin implements Plugin<{}, void, any, any> {
     this.apiRoutes.setup({
       router,
       license: this.license,
+      getStartServices,
     });
 
     if (alerting) {
@@ -83,7 +84,7 @@ export class TransformServerPlugin implements Plugin<{}, void, any, any> {
     return {};
   }
 
-  start() {}
+  start(core: CoreStart, plugins: PluginStartContract) {}
 
   stop() {}
 }

--- a/x-pack/plugins/transform/server/types.ts
+++ b/x-pack/plugins/transform/server/types.ts
@@ -12,18 +12,18 @@ import { PluginSetupContract as FeaturesPluginSetup } from '@kbn/features-plugin
 import type { AlertingPlugin } from '@kbn/alerting-plugin/server';
 import { License } from './services';
 
-export interface Dependencies {
+export interface PluginSetupDependencies {
   licensing: LicensingPluginSetup;
   features: FeaturesPluginSetup;
   alerting?: AlertingPlugin['setup'];
 }
 
+export interface PluginStartDependencies {
+  dataViews: DataViewsServerPluginStart;
+}
+
 export interface RouteDependencies {
   router: IRouter;
   license: License;
-  getStartServices: CoreSetup<PluginStartContract>['getStartServices'];
-}
-
-export interface PluginStartContract {
-  dataViews: DataViewsServerPluginStart;
+  getStartServices: CoreSetup<PluginStartDependencies>['getStartServices'];
 }

--- a/x-pack/plugins/transform/server/types.ts
+++ b/x-pack/plugins/transform/server/types.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { IRouter } from '@kbn/core/server';
+import { IRouter, CoreSetup } from '@kbn/core/server';
+import { PluginStart as DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import { LicensingPluginSetup } from '@kbn/licensing-plugin/server';
 import { PluginSetupContract as FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type { AlertingPlugin } from '@kbn/alerting-plugin/server';
@@ -20,4 +21,9 @@ export interface Dependencies {
 export interface RouteDependencies {
   router: IRouter;
   license: License;
+  getStartServices: CoreSetup<PluginStartContract>['getStartServices'];
+}
+
+export interface PluginStartContract {
+  dataViews: DataViewsServerPluginStart;
 }


### PR DESCRIPTION
## Summary

Replaces all uses of the saved object client for loading and deleting data views with the data views service from the `data-views-plugin`. 

Part of https://github.com/elastic/kibana/issues/91715

Closes #124381
