### PR TITLE
[ftr] improve --config error handling and remove default

### DIFF
--- a/packages/kbn-es-archiver/src/cli.ts
+++ b/packages/kbn-es-archiver/src/cli.ts
@@ -33,7 +33,7 @@ export function runCli() {
       string: ['es-url', 'kibana-url', 'config', 'es-ca', 'kibana-ca'],
       help: `
         --config           path to an FTR config file that sets --es-url and --kibana-url
-                             default: ${defaultConfigPath}
+                             default: ${Path.relative(process.cwd(), defaultConfigPath)}
         --es-url           url for Elasticsearch, prefer the --config flag
         --kibana-url       url for Kibana, prefer the --config flag
         --kibana-ca        if Kibana url points to https://localhost we default to the CA from @kbn/dev-utils, customize the CA with this flag

--- a/packages/kbn-test/src/functional_test_runner/cli.ts
+++ b/packages/kbn-test/src/functional_test_runner/cli.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { resolve } from 'path';
+import Path from 'path';
 import { inspect } from 'util';
 
 import { run, createFlagError, Flags } from '@kbn/dev-utils';
@@ -16,7 +16,7 @@ import exitHook from 'exit-hook';
 
 import { FunctionalTestRunner } from './functional_test_runner';
 
-const makeAbsolutePath = (v: string) => resolve(process.cwd(), v);
+const makeAbsolutePath = (v: string) => Path.resolve(process.cwd(), v);
 const toArray = (v: string | string[]) => ([] as string[]).concat(v || []);
 const parseInstallDir = (flags: Flags) => {
   const flag = flags['kibana-install-dir'];
@@ -42,9 +42,14 @@ export function runFtrCli() {
         throw createFlagError('expected --es-version to be a string');
       }
 
+      const configRel = flags.config;
+      if (typeof configRel !== 'string') {
+        throw createFlagError('--config is required');
+      }
+
       const functionalTestRunner = new FunctionalTestRunner(
         log,
-        makeAbsolutePath(flags.config as string),
+        makeAbsolutePath(configRel),
         {
           mochaOpts: {
             bail: flags.bail,
@@ -149,9 +154,6 @@ export function runFtrCli() {
           'headless',
           'dry-run',
         ],
-        default: {
-          config: 'test/functional/config.js',
-        },
         help: `
           --config=path      path to a config file
           --bail             stop tests after the first failure

--- a/packages/kbn-test/src/functional_test_runner/cli.ts
+++ b/packages/kbn-test/src/functional_test_runner/cli.ts
@@ -43,13 +43,14 @@ export function runFtrCli() {
       }
 
       const configRel = flags.config;
-      if (typeof configRel !== 'string') {
+      if (typeof configRel !== 'string' || !configRel) {
         throw createFlagError('--config is required');
       }
+      const configPath = makeAbsolutePath(configRel);
 
       const functionalTestRunner = new FunctionalTestRunner(
         log,
-        makeAbsolutePath(configRel),
+        configPath,
         {
           mochaOpts: {
             bail: flags.bail,
@@ -73,6 +74,8 @@ export function runFtrCli() {
         },
         esVersion
       );
+
+      await functionalTestRunner.readConfigFile();
 
       if (flags.throttle) {
         process.env.TEST_THROTTLE_NETWORK = '1';

--- a/packages/kbn-test/src/functional_test_runner/functional_test_runner.ts
+++ b/packages/kbn-test/src/functional_test_runner/functional_test_runner.ts
@@ -219,12 +219,7 @@ export class FunctionalTestRunner {
     const lifecycle = new Lifecycle(this.log);
 
     try {
-      const config = await readConfigFile(
-        this.log,
-        this.esVersion,
-        this.configFile,
-        this.configOverrides
-      );
+      const config = await this.readConfigFile();
       this.log.debug('Config loaded');
 
       if (
@@ -266,6 +261,10 @@ export class FunctionalTestRunner {
         }
       }
     }
+  }
+
+  public async readConfigFile() {
+    return await readConfigFile(this.log, this.esVersion, this.configFile, this.configOverrides);
   }
 
   simulateMochaDryRun(mocha: any) {

--- a/packages/kbn-test/src/functional_test_runner/lib/config/read_config_file.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/config/read_config_file.ts
@@ -10,6 +10,7 @@ import Path from 'path';
 import { ToolingLog } from '@kbn/tooling-log';
 import { defaultsDeep } from 'lodash';
 import { createFlagError } from '@kbn/dev-utils';
+import { REPO_ROOT } from '@kbn/utils';
 
 import { Config } from './config';
 import { EsVersion } from '../es_version';
@@ -26,21 +27,33 @@ async function getSettingsFromFile(
     primary: boolean;
   }
 ) {
+  let resolvedPath;
+  try {
+    resolvedPath = require.resolve(options.path);
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      throw createFlagError(`Unable to find config file [${options.path}]`);
+    }
+
+    throw error;
+  }
+
   if (
     options.primary &&
-    !FTR_CONFIGS_MANIFEST_PATHS.includes(options.path) &&
-    !options.path.includes(`${Path.sep}__fixtures__${Path.sep}`)
+    !FTR_CONFIGS_MANIFEST_PATHS.includes(resolvedPath) &&
+    !resolvedPath.includes(`${Path.sep}__fixtures__${Path.sep}`)
   ) {
+    const rel = Path.relative(REPO_ROOT, resolvedPath);
     throw createFlagError(
-      `Refusing to load FTR Config which is not listed in [${FTR_CONFIGS_MANIFEST_REL}]. All FTR Config files must be listed there, use the "enabled" key if the FTR Config should be run on automatically on PR CI, or the "disabled" key if it is run manually or by a special job.`
+      `Refusing to load FTR Config at [${rel}] which is not listed in [${FTR_CONFIGS_MANIFEST_REL}]. All FTR Config files must be listed there, use the "enabled" key if the FTR Config should be run on automatically on PR CI, or the "disabled" key if it is run manually or by a special job.`
     );
   }
 
-  const configModule = require(options.path); // eslint-disable-line @typescript-eslint/no-var-requires
+  const configModule = require(resolvedPath); // eslint-disable-line @typescript-eslint/no-var-requires
   const configProvider = configModule.__esModule ? configModule.default : configModule;
 
   if (!cache.has(configProvider)) {
-    log.debug('Loading config file from %j', options.path);
+    log.debug('Loading config file from %j', resolvedPath);
     cache.set(
       configProvider,
       configProvider({

--- a/packages/kbn-test/src/functional_tests/lib/index.ts
+++ b/packages/kbn-test/src/functional_tests/lib/index.ts
@@ -10,5 +10,5 @@ export { runKibanaServer } from './run_kibana_server';
 export { runElasticsearch } from './run_elasticsearch';
 export type { CreateFtrOptions, CreateFtrParams } from './run_ftr';
 export { runFtr, hasTests, assertNoneExcluded } from './run_ftr';
-export { KIBANA_ROOT, KIBANA_FTR_SCRIPT, FUNCTIONAL_CONFIG_PATH, API_CONFIG_PATH } from './paths';
+export { KIBANA_ROOT, KIBANA_FTR_SCRIPT } from './paths';
 export { runCli } from './run_cli';

--- a/packages/kbn-test/src/functional_tests/lib/paths.ts
+++ b/packages/kbn-test/src/functional_tests/lib/paths.ts
@@ -19,6 +19,3 @@ export const KIBANA_EXEC = 'node';
 export const KIBANA_EXEC_PATH = resolveRelative('scripts/kibana');
 export const KIBANA_ROOT = REPO_ROOT;
 export const KIBANA_FTR_SCRIPT = resolve(KIBANA_ROOT, 'scripts/functional_test_runner');
-export const PROJECT_ROOT = resolve(__dirname, '../../../../../../');
-export const FUNCTIONAL_CONFIG_PATH = resolve(KIBANA_ROOT, 'test/functional/config');
-export const API_CONFIG_PATH = resolve(KIBANA_ROOT, 'test/api_integration/config');


### PR DESCRIPTION
We've received some feedback about the updated FTR Config handling, specifically the result of running `node scripts/functional_test_runner` without any args. This results in:

```
node ../scripts/functional_test_runner
 debg KIBANA_CI_STATS_CONFIG environment variable not found, disabling CiStatsReporter
ERROR Error: Refusing to load FTR Config which is not listed in [.buildkite/ftr_configs.yml]. All FTR Config files must be listed there, use the "enabled" key if the FTR Config should be run on automatically on PR CI, or the "disabled" key if it is run manually or by a special job.
          at createFailError ...
```

This is because the `--config` flag in the functional_test_runner CLI defaults to `$(pwd)/test/functional/config`, which doesn't exist and also isn't listed in the `.buildkite/ftr_configs.yml`. To improve this situation calling `node scripts/functional_test_runner` will now show:

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/1329312/167471932-e83d4b27-b8a8-453a-a3c4-4c0488d17126.png">

This is because we've removed the default value for `--config`, since there doesn't seem to be a good default option anymore. There are dozens of config files and any user might want to have their own default, which I'd suggest they do with bash aliases.

Then, if you pass an invalid `--config` path you'll see:
```
ERROR Unable to find config file [/Users/spalger/kbn-dev/main/kibana/invalid/path.js]
```