### PR TITLE
Unskip flaky Enter Space test

### DIFF
--- a/x-pack/test/functional/apps/spaces/enter_space.ts
+++ b/x-pack/test/functional/apps/spaces/enter_space.ts
@@ -14,9 +14,7 @@ export default function enterSpaceFunctonalTests({
   const esArchiver = getService('esArchiver');
   const PageObjects = getPageObjects(['security', 'spaceSelector']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/99879
-  describe.skip('Enter Space', function () {
-    // FLAKY: https://github.com/elastic/kibana/issues/100570
+  describe('Enter Space', function () {
     // These tests fail very intermittently in Firefox. Skip Firefox testing until resolved.
     // this.tags('includeFirefox');
     before(async () => {

--- a/x-pack/test/functional/apps/spaces/enter_space.ts
+++ b/x-pack/test/functional/apps/spaces/enter_space.ts
@@ -15,8 +15,7 @@ export default function enterSpaceFunctonalTests({
   const PageObjects = getPageObjects(['security', 'spaceSelector']);
 
   describe('Enter Space', function () {
-    // These tests fail very intermittently in Firefox. Skip Firefox testing until resolved.
-    // this.tags('includeFirefox');
+    this.tags('includeFirefox');
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/spaces/enter_space');
       await PageObjects.security.forceLogout();

--- a/x-pack/test/functional/page_objects/space_selector_page.ts
+++ b/x-pack/test/functional/page_objects/space_selector_page.ts
@@ -50,7 +50,7 @@ export class SpaceSelectorPageObject extends FtrService {
     this.log.debug('openSpacesNav()');
     return await this.retry.try(async () => {
       await this.testSubjects.click('spacesNavSelector');
-      await this.find.byCssSelector('#headerSpacesMenuContent')
+      await this.find.byCssSelector('#headerSpacesMenuContent');
     });
   }
 

--- a/x-pack/test/functional/page_objects/space_selector_page.ts
+++ b/x-pack/test/functional/page_objects/space_selector_page.ts
@@ -48,7 +48,10 @@ export class SpaceSelectorPageObject extends FtrService {
 
   async openSpacesNav() {
     this.log.debug('openSpacesNav()');
-    return await this.testSubjects.click('spacesNavSelector');
+    return await this.retry.try(async () => {
+      await this.testSubjects.click('spacesNavSelector');
+      await this.find.byCssSelector('#headerSpacesMenuContent')
+    });
   }
 
   async clickManageSpaces() {


### PR DESCRIPTION
Unskips the "Enter Space" test suite, by improving the resiliency of the function responsible for opening the spaces nav.

Resolves https://github.com/elastic/kibana/issues/100570

### Flaky Test Runs
- Original (before fix): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/577 ⛔ 
- Run 1: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/579 ✅ 
- Run 2: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/580 ✅ 
- Run 3: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/581 ✅ 
- Run 4: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/582 ✅ 
- Run 5: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/585 ✅ 
- Run 6: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/586 ✅ 

### Result
- This test failed twice during the original flaky test runner job (before the fix)
- This test passed 300 times during the subsequent flaky test runner jobs (after the fix)