### PR TITLE
[7.12] [DOCS] Reformats the Fleet settings tables into definition lists (#130301)

### DIFF
--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -15,37 +15,27 @@ See the {fleet-guide}/index.html[{fleet}] docs for more information.
 [[general-fleet-settings-kb]]
 ==== General {fleet} settings
 
-[cols="2*<"]
-|===
-| `xpack.fleet.enabled` {ess-icon}
-  | Set to `true` (default) to enable {fleet}. 
-| `xpack.fleet.agents.enabled` {ess-icon}
-  | Set to `true` (default) to enable {fleet}. 
-|===
+`xpack.fleet.enabled` {ess-icon}::
+Set to `true` (default) to enable {fleet}. 
+
+`xpack.fleet.agents.enabled` {ess-icon}::
+Set to `true` (default) to enable {fleet}.
 
 [[fleet-data-visualizer-settings]]
 
 ==== {package-manager} settings
 
-[cols="2*<"]
-|===
-| `xpack.fleet.registryUrl`
-  | The address to use to reach {package-manager} registry.
-|===
+`xpack.fleet.registryUrl`::
+The address to use to reach {package-manager} registry.
 
 ==== {fleet} settings
+`xpack.fleet.agents.kibana.host`::
+The hostname used by {agent} for accessing {kib}.
 
-[cols="2*<"]
-|===
-| `xpack.fleet.agents.kibana.host`
-  | The hostname used by {agent} for accessing {kib}.
-| `xpack.fleet.agents.elasticsearch.host`
-  | The hostname used by {agent} for accessing {es}.
-| `xpack.fleet.agents.tlsCheckDisabled`
-  | Set to `true` to allow {fleet} to run on a {kib} instance without TLS enabled.
-|===
+`xpack.fleet.agents.elasticsearch.host`::
+The hostname used by {agent} for accessing {es}.
 
-[NOTE]
-====
-In {ecloud}, {fleet} flags are already configured.
-====
+`xpack.fleet.agents.tlsCheckDisabled`::
+Set to `true` to allow {fleet} to run on a {kib} instance without TLS enabled.
+
+NOTE: In {ecloud}, {fleet} flags are already configured.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.12`:
 - [[DOCS] Reformats the Fleet settings tables into definition lists (#130301)](https://github.com/elastic/kibana/pull/130301)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)