### PR TITLE
[Docs] Fix typo in curl examples

### DIFF
--- a/docs/api/index-patterns/update-fields.asciidoc
+++ b/docs/api/index-patterns/update-fields.asciidoc
@@ -46,7 +46,7 @@ Set popularity `count` for field `foo`:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/index_patterns/index-pattern/my-pattern/fields
+$ curl -X POST api/index_patterns/index_pattern/<id>/fields
 {
     "fields": {
         "foo": {
@@ -61,7 +61,7 @@ Update multiple metadata fields in one request:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/index_patterns/index-pattern/my-pattern/fields
+$ curl -X POST api/index_patterns/index_pattern/<id>/fields
 {
     "fields": {
         "foo": {
@@ -79,7 +79,7 @@ $ curl -X POST api/index_patterns/index-pattern/my-pattern/fields
 Use `null` value to delete metadata:
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/index_patterns/index-pattern/my-pattern/fields
+$ curl -X POST api/index_patterns/index_pattern/<id>/fields
 {
     "fields": {
         "foo": {


### PR DESCRIPTION
Fix typo in curl examples (index-pattern -> index_pattern), make id example consistent with documentation above.

## Summary

Update curl examples.


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
