### PR TITLE
[8.2] [Advanced settings] Fix resetting image values (#131610)

### DIFF
--- a/src/plugins/advanced_settings/public/management_app/components/field/field.test.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/field/field.test.tsx
@@ -388,7 +388,7 @@ describe('Field', () => {
           const updated = wrapper.update();
           findTestSubject(updated, `advancedSetting-resetField-${setting.name}`).simulate('click');
           expect(handleChange).toBeCalledWith(setting.name, {
-            value: getEditableValue(setting.type, setting.defVal),
+            value: getEditableValue(setting.type, setting.defVal, setting.defVal),
             changeImage: true,
           });
         });

--- a/src/plugins/advanced_settings/public/management_app/components/field/field.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/field/field.tsx
@@ -100,7 +100,7 @@ export class Field extends PureComponent<FieldProps> {
     if (type === 'image') {
       this.cancelChangeImage();
       return this.handleChange({
-        value: getEditableValue(type, defVal),
+        value: getEditableValue(type, defVal, defVal),
         changeImage: true,
       });
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Advanced settings] Fix resetting image values (#131610)](https://github.com/elastic/kibana/pull/131610)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)