### PR TITLE
[preserve-symlinks] log about signals and errors, use valid code

### DIFF
--- a/src/setup_node_env/ensure_node_preserve_symlinks.js
+++ b/src/setup_node_env/ensure_node_preserve_symlinks.js
@@ -89,10 +89,18 @@
     }
 
     if (spawnResult.signal !== null) {
-      return 128 + spawnResult.signal;
+      console.log(
+        'ensure_node_preserve_symlinks wrapper: process exitted with signal',
+        spawnResult.signal
+      );
+      return 1;
     }
 
     if (spawnResult.error) {
+      console.log(
+        'ensure_node_preserve_symlinks wrapper: process exitted with error',
+        spawnResult.error
+      );
       return 1;
     }
 


### PR DESCRIPTION
The `ensure_node_preserve_symlinks` script is injected into every standard node process started in the Kibana repo in order to ensure that `--preserve-symlinks` and `--preserve-symlinks-main` are passed as node options, allowing node to resolve modules built in the bazel repo. This script runs the executed script in a sub-process if those parameters were not passed, adding them to the child processes node options. When the process exits the exit code is reflected on the parent process, but it seems like this process fails for node processes which OOM. As demonstrated in https://buildkite.com/elastic/kibana-pull-request/builds/43519#2a1ed2fb-2c4a-4651-a85e-795b95804cfb with [these changes](https://github.com/elastic/kibana/commit/b270a62918ccb9bb74e186b30eebf47822c84262) when the underlying Jest process OOMs it doesn't use a `status`, but instead it reports a `signal` which is the string `SIGABRT`. Then, the `ensure_node_preserve_symlinks` script combines that string with `128` and passes `128SIGABRT` to `process.exit()`, which doesn't do anything and unfortunately leads to node exiting with the code `0`.

This change switches strategies a little and logs the signal (or error) results if the child process doesn't exit normally with an exit code, finally exiting with code `1`.