### PR TITLE
[Fleet] fixed window code block max width

### DIFF
--- a/x-pack/plugins/fleet/public/components/platform_selector.tsx
+++ b/x-pack/plugins/fleet/public/components/platform_selector.tsx
@@ -50,6 +50,21 @@ export const PlatformSelector: React.FunctionComponent<Props> = ({
     />
   );
 
+  const getCommandByPlatform = (plat: PLATFORM_TYPE) => {
+    switch (plat) {
+      case 'linux':
+        return linuxCommand;
+      case 'mac':
+        return macCommand;
+      case 'windows':
+        return windowsCommand;
+      case 'deb':
+        return linuxDebCommand;
+      case 'rpm':
+        return linuxRpmCommand;
+    }
+  };
+
   return (
     <>
       {isK8s ? (
@@ -67,39 +82,22 @@ export const PlatformSelector: React.FunctionComponent<Props> = ({
             })}
           />
           <EuiSpacer size="s" />
-          {platform === 'linux' && (
-            <EuiCodeBlock fontSize="m" isCopyable={true} paddingSize="m">
-              <CommandCode>{linuxCommand}</CommandCode>
-            </EuiCodeBlock>
-          )}
-          {platform === 'mac' && (
-            <EuiCodeBlock fontSize="m" isCopyable={true} paddingSize="m">
-              <CommandCode>{macCommand}</CommandCode>
-            </EuiCodeBlock>
-          )}
-          {platform === 'windows' && (
-            <EuiCodeBlock fontSize="m" isCopyable={true} paddingSize="m">
-              <CommandCode>{windowsCommand}</CommandCode>
-            </EuiCodeBlock>
-          )}
-          {platform === 'deb' && (
+          {(platform === 'deb' || platform === 'rpm') && (
             <>
               {systemPackageCallout}
               <EuiSpacer size="m" />
-              <EuiCodeBlock fontSize="m" isCopyable={true} paddingSize="m">
-                <CommandCode>{linuxDebCommand}</CommandCode>
-              </EuiCodeBlock>
             </>
           )}
-          {platform === 'rpm' && (
-            <>
-              {systemPackageCallout}
-              <EuiSpacer size="m" />
-              <EuiCodeBlock fontSize="m" isCopyable={true} paddingSize="m">
-                <CommandCode>{linuxRpmCommand}</CommandCode>
-              </EuiCodeBlock>
-            </>
-          )}
+          <EuiCodeBlock
+            fontSize="m"
+            isCopyable={true}
+            paddingSize="m"
+            css={`
+              max-width: 1100px;
+            `}
+          >
+            <CommandCode>{getCommandByPlatform(platform)}</CommandCode>
+          </EuiCodeBlock>
         </>
       )}
     </>

--- a/x-pack/plugins/fleet/public/components/platform_selector.tsx
+++ b/x-pack/plugins/fleet/public/components/platform_selector.tsx
@@ -50,19 +50,12 @@ export const PlatformSelector: React.FunctionComponent<Props> = ({
     />
   );
 
-  const getCommandByPlatform = (plat: PLATFORM_TYPE) => {
-    switch (plat) {
-      case 'linux':
-        return linuxCommand;
-      case 'mac':
-        return macCommand;
-      case 'windows':
-        return windowsCommand;
-      case 'deb':
-        return linuxDebCommand;
-      case 'rpm':
-        return linuxRpmCommand;
-    }
+  const commandsByPlatform: Record<PLATFORM_TYPE, string> = {
+    linux: linuxCommand,
+    mac: macCommand,
+    windows: windowsCommand,
+    deb: linuxDebCommand,
+    rpm: linuxRpmCommand,
   };
 
   return (
@@ -96,7 +89,7 @@ export const PlatformSelector: React.FunctionComponent<Props> = ({
               max-width: 1100px;
             `}
           >
-            <CommandCode>{getCommandByPlatform(platform)}</CommandCode>
+            <CommandCode>{commandsByPlatform[platform]}</CommandCode>
           </EuiCodeBlock>
         </>
       )}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/131217

Added max width for code block so that it doesn't expand too wide.

<img width="1122" alt="image" src="https://user-images.githubusercontent.com/90178898/167615126-6ddb05bc-9172-4cc1-9efc-1bde35ecd366.png">
 