### PR TITLE
[8.2] [ILM] Fixing missing documentation link(#131750)

### DIFF
--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/phases/shared_fields/snapshot_policies_field.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/phases/shared_fields/snapshot_policies_field.tsx
@@ -159,7 +159,7 @@ export const SnapshotPoliciesField: React.FunctionComponent = () => {
             id="xpack.indexLifecycleMgmt.editPolicy.deletePhase.waitForSnapshotDescription"
             defaultMessage="Specify a snapshot policy to be executed before the deletion of the index. This ensures that a snapshot of the deleted index is available."
           />{' '}
-          <LearnMoreLink docPath={docLinks.links.alerting.ilmWaitForSnapshot} />
+          <LearnMoreLink docPath={docLinks.links.elasticsearch.ilmWaitForSnapshot} />
         </>
       }
       titleSize="xs"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[ILM] Fixing missing documentation link(#131750)](https://github.com/elastic/kibana/pull/131750)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)