### PR TITLE
[Data Visualizer] Removing saved object client from file data visualizer

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/file_data_visualizer_view/file_data_visualizer_view.js
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/file_data_visualizer_view/file_data_visualizer_view.js
@@ -65,7 +65,6 @@ export class FileDataVisualizerView extends Component {
       linesToSample: DEFAULT_LINES_TO_SAMPLE,
     };
 
-    this.savedObjectsClient = props.savedObjectsClient;
     this.maxFileUploadBytes = props.fileUpload.getMaxBytes();
   }
 
@@ -367,7 +366,6 @@ export class FileDataVisualizerView extends Component {
               dataViewsContract={this.props.dataViewsContract}
               showBottomBar={this.showBottomBar}
               hideBottomBar={this.hideBottomBar}
-              savedObjectsClient={this.savedObjectsClient}
               fileUpload={this.props.fileUpload}
               getAdditionalLinks={this.props.getAdditionalLinks}
               capabilities={this.props.capabilities}

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_view/import_view.js
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_view/import_view.js
@@ -77,7 +77,7 @@ export class ImportView extends Component {
     super(props);
 
     this.state = getDefaultState(DEFAULT_STATE, this.props.results, this.props.capabilities);
-    this.savedObjectsClient = props.savedObjectsClient;
+    this.dataViewsContract = props.dataViewsContract;
   }
 
   componentDidMount() {
@@ -417,14 +417,7 @@ export class ImportView extends Component {
 
   async loadDataViewNames() {
     try {
-      const dataViewNames = (
-        await this.savedObjectsClient.find({
-          type: 'index-pattern',
-          fields: ['title'],
-          perPage: 10000,
-        })
-      ).savedObjects.map(({ attributes }) => attributes && attributes.title);
-
+      const dataViewNames = await this.dataViewsContract.getTitles();
       this.setState({ dataViewNames });
     } catch (error) {
       console.error('failed to load data views', error);

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/file_data_visualizer.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/file_data_visualizer.tsx
@@ -42,7 +42,6 @@ export const FileDataVisualizer: FC<Props> = ({ getAdditionalLinks }) => {
         <CloudContext>
           <FileDataVisualizerView
             dataViewsContract={data.dataViews}
-            savedObjectsClient={coreStart.savedObjects.client}
             http={coreStart.http}
             fileUpload={fileUpload}
             getAdditionalLinks={getAdditionalLinks}


### PR DESCRIPTION
Removing saved object client and using data view client for loading data view titles.

To test, when creating a data view to match the new index, try adding a data view name that already exists. 

Fixes https://github.com/elastic/kibana/issues/131903
