### PR TITLE
[ML] Removing alerting_rules from general job list items

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/extract_job_details.js
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/extract_job_details.js
@@ -99,6 +99,14 @@ export function extractJobDetails(job, basePath, refreshJobList) {
       return ['', <EditAlertRule initialAlert={v} onSave={refreshJobList} />];
     }),
   };
+  if (job.alerting_rules) {
+    // remove the alerting_rules list from the general section
+    // so not to show it twice.
+    const i = general.items.findIndex((item) => item[0] === 'alerting_rules');
+    if (i >= 0) {
+      general.items.splice(i, 1);
+    }
+  }
 
   const detectors = {
     id: 'detectors',


### PR DESCRIPTION
`alerting_rules` should not be listed in the general section of the anomaly detection job as it has it's own section.

![image](https://user-images.githubusercontent.com/22172091/167657994-8e40e912-eba5-40a6-8c07-af1fef45c478.png)

