### PR TITLE
[8.3][Session View] Only render load more remaining count when value > 0

### DIFF
--- a/x-pack/plugins/session_view/public/components/process_tree_load_more_button/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_load_more_button/index.tsx
@@ -36,7 +36,7 @@ export const ProcessTreeLoadMoreButton = ({
         isLoading={isFetching}
       >
         {text}
-        {eventsRemaining !== 0 && (
+        {eventsRemaining > 0 && (
           <FormattedMessage
             id="xpack.sessionView.processTreeLoadMoreButton"
             defaultMessage=" ({count} left)"


### PR DESCRIPTION
Discussed with @codearos about UX treatment, and we agreed that we can just hide the remaining count when the total events count is above the `total` upper cap configured.