### PR TITLE
[EBT] Fix flaky test for Context Providers in the browser

### DIFF
--- a/test/analytics/tests/instrumented_events/from_the_browser/core_context_providers.ts
+++ b/test/analytics/tests/instrumented_events/from_the_browser/core_context_providers.ts
@@ -15,8 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const ebtUIHelper = getService('kibana_ebt_ui');
   const { common } = getPageObjects(['common']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/131729
-  describe.skip('Core Context Providers', () => {
+  describe('Core Context Providers', () => {
     let event: Event;
     before(async () => {
       await common.navigateToApp('home');
@@ -73,7 +72,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(event.context).not.to.have.property('page'); // In the Home app it's not available.
     });
 
-    it('should have the properties provided by the "license info" context provider', () => {
+    it('should have the properties provided by the "license info" context provider', async () => {
+      await common.clickAndValidate('kibanaChrome', 'kibanaChrome');
+      [event] = await ebtUIHelper.getLastEvents(1, ['click']); // Get a later event to ensure license has been obtained already.
       expect(event.context).to.have.property('license_id');
       expect(event.context.license_id).to.be.a('string');
       expect(event.context).to.have.property('license_status');


### PR DESCRIPTION
## Summary

Resolves #131729.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/600

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
