### PR TITLE
[7.16] [DOCS] Reformats the DevelopAPM settings tables into definition lists (#130303)

### DIFF
--- a/docs/settings/apm-settings.asciidoc
+++ b/docs/settings/apm-settings.asciidoc
@@ -43,75 +43,73 @@ If you'd like to change any of the default values,
 copy and paste the relevant settings into your `kibana.yml` configuration file.
 Changing these settings may disable features of the APM App.
 
-[cols="2*<"]
-|===
-| `xpack.apm.enabled` {ess-icon}
-  | deprecated:[7.16.0,"In 8.0 and later, this setting will no longer be supported."]
-  Set to `false` to disable the APM app. Defaults to `true`.
+`xpack.apm.enabled` {ess-icon}::
+deprecated:[7.16.0,"In 8.0 and later, this setting will no longer be supported."]
+Set to `false` to disable the APM app. Defaults to `true`.
 
-| `xpack.apm.maxServiceEnvironments` {ess-icon}
-  | Maximum number of unique service environments recognized by the UI. Defaults to `100`.
+`xpack.apm.maxServiceEnvironments` {ess-icon}::
+Maximum number of unique service environments recognized by the UI. Defaults to `100`.
 
-| `xpack.apm.serviceMapFingerprintBucketSize` {ess-icon}
-  | Maximum number of unique transaction combinations sampled for generating service map focused on a specific service. Defaults to `100`.
+`xpack.apm.serviceMapFingerprintBucketSize` {ess-icon}::
+Maximum number of unique transaction combinations sampled for generating service map focused on a specific service. Defaults to `100`.
 
-| `xpack.apm.serviceMapFingerprintGlobalBucketSize` {ess-icon}
-  | Maximum number of unique transaction combinations sampled for generating the global service map. Defaults to `100`.
+`xpack.apm.serviceMapFingerprintGlobalBucketSize` {ess-icon}::
+Maximum number of unique transaction combinations sampled for generating the global service map. Defaults to `100`.
 
-| `xpack.apm.serviceMapEnabled` {ess-icon}
-  | Set to `false` to disable service maps. Defaults to `true`.
+`xpack.apm.serviceMapEnabled` {ess-icon}::
+Set to `false` to disable service maps. Defaults to `true`.
 
-| `xpack.apm.serviceMapTraceIdBucketSize` {ess-icon}
-  | Maximum number of trace IDs sampled for generating service map focused on a specific service. Defaults to `65`.
+`xpack.apm.serviceMapTraceIdBucketSize` {ess-icon}::
+Maximum number of trace IDs sampled for generating service map focused on a specific service. Defaults to `65`.
 
-| `xpack.apm.serviceMapTraceIdGlobalBucketSize` {ess-icon}
-  | Maximum number of trace IDs sampled for generating the global service map. Defaults to `6`.
+`xpack.apm.serviceMapTraceIdGlobalBucketSize` {ess-icon}::
+Maximum number of trace IDs sampled for generating the global service map. Defaults to `6`.
 
-| `xpack.apm.serviceMapMaxTracesPerRequest` {ess-icon}
-  | Maximum number of traces per request for generating the global service map. Defaults to `50`.
+`xpack.apm.serviceMapMaxTracesPerRequest` {ess-icon}::
+Maximum number of traces per request for generating the global service map. Defaults to `50`.
 
-| `xpack.apm.ui.enabled` {ess-icon}
-  | Set to `false` to hide the APM app from the main menu. Defaults to `true`.
+`xpack.apm.ui.enabled` {ess-icon}::
+Set to `false` to hide the APM app from the main menu. Defaults to `true`.
 
-| `xpack.apm.ui.transactionGroupBucketSize` {ess-icon}
-  | Number of top transaction groups displayed in the APM app. Defaults to `1000`.
+`xpack.apm.ui.transactionGroupBucketSize` {ess-icon}::
+Number of top transaction groups displayed in the APM app. Defaults to `1000`.
 
-| `xpack.apm.ui.maxTraceItems` {ess-icon}
-  | Maximum number of child items displayed when viewing trace details. Defaults to `1000`.
+`xpack.apm.ui.maxTraceItems` {ess-icon}::
+Maximum number of child items displayed when viewing trace details. Defaults to `1000`.
 
-| `xpack.observability.annotations.index` {ess-icon}
-  | Index name where Observability annotations are stored. Defaults to `observability-annotations`.
+`xpack.observability.annotations.index` {ess-icon}::
+Index name where Observability annotations are stored. Defaults to `observability-annotations`.
 
-| `xpack.apm.searchAggregatedTransactions` {ess-icon}
-  | experimental[] Enables Transaction histogram metrics. Defaults to `never` and aggregated transactions are not used. When set to `auto`, the UI will use metric indices over transaction indices for transactions if aggregated transactions are found. When set to `always`, additional configuration in APM Server is required.
-    See {apm-guide-ref}/transaction-metrics.html[Configure transaction metrics] for more information.
+`xpack.apm.searchAggregatedTransactions` {ess-icon}::
+Enables Transaction histogram metrics. Defaults to `auto` so the UI will use metric indices over transaction indices for transactions if aggregated transactions are found. When set to `always`, additional configuration in APM Server is required. When set to `never` and aggregated transactions are not used. 
++
+See {apm-guide-ref}/transaction-metrics.html[Configure transaction metrics] for more information.
 
-| `xpack.apm.metricsInterval` {ess-icon}
-  | Sets a `fixed_interval` for date histograms in metrics aggregations. Defaults to `30`.
+`xpack.apm.metricsInterval` {ess-icon}::
+Sets a `fixed_interval` for date histograms in metrics aggregations. Defaults to `30`.
 
-| `xpack.apm.agent.migrations.enabled` {ess-icon}
-  | Set to `false` to disable cloud APM migrations. Defaults to `true`.
+`xpack.apm.agent.migrations.enabled` {ess-icon}::
+Set to `false` to disable cloud APM migrations. Defaults to `true`.
 
-| `xpack.apm.indices.error` {ess-icon}
-  | Matcher for all error indices. Defaults to `logs-apm*,apm-*`.
+`xpack.apm.indices.error` {ess-icon}::
+Matcher for all error indices. Defaults to `logs-apm*,apm-*`.
 
-| `xpack.apm.indices.onboarding` {ess-icon}
-  | Matcher for all onboarding indices. Defaults to `apm-*`.
+`xpack.apm.indices.onboarding` {ess-icon}::
+Matcher for all onboarding indices. Defaults to `apm-*`.
 
-| `xpack.apm.indices.span` {ess-icon}
-  | Matcher for all span indices. Defaults to `traces-apm*,apm-*`.
+`xpack.apm.indices.span` {ess-icon}::
+Matcher for all span indices. Defaults to `traces-apm*,apm-*`.
 
-| `xpack.apm.indices.transaction` {ess-icon}
-  | Matcher for all transaction indices. Defaults to `traces-apm*,apm-*`.
+`xpack.apm.indices.transaction` {ess-icon}::
+Matcher for all transaction indices. Defaults to `traces-apm*,apm-*`.
 
-| `xpack.apm.indices.metric` {ess-icon}
-  | Matcher for all metrics indices. Defaults to `metrics-apm*,apm-*`.
+`xpack.apm.indices.metric` {ess-icon}::
+Matcher for all metrics indices. Defaults to `metrics-apm*,apm-*`.
 
-| `xpack.apm.indices.sourcemap` {ess-icon}
-  | Matcher for all source map indices. Defaults to `apm-*`.
+`xpack.apm.indices.sourcemap` {ess-icon}::
+Matcher for all source map indices. Defaults to `apm-*`.
 
-| `xpack.apm.autocreateApmIndexPattern` {ess-icon}
-  | Set to `false` to disable the automatic creation of the APM index pattern when the APM app is opened. Defaults to `true`.
-|===
+`xpack.apm.autocreateApmIndexPattern` {ess-icon}::
+Set to `false` to disable the automatic creation of the APM index pattern when the APM app is opened. Defaults to `true`.
 
 // end::general-apm-settings[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.16`:
 - [[DOCS] Reformats the DevelopAPM settings tables into definition lists (#130303)](https://github.com/elastic/kibana/pull/130303)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)