### PR TITLE
[Fleet] Allow to specify an upgrade window for rolling upgrade

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3795,6 +3795,9 @@
           "source_uri": {
             "type": "string"
           },
+          "rollout_duration_seconds": {
+            "type": "number;"
+          },
           "agents": {
             "oneOf": [
               {

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3796,7 +3796,7 @@
             "type": "string"
           },
           "rollout_duration_seconds": {
-            "type": "number;"
+            "type": "number"
           },
           "agents": {
             "oneOf": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2392,7 +2392,7 @@ components:
         source_uri:
           type: string
         rollout_duration_seconds:
-          type: number;
+          type: number
         agents:
           oneOf:
             - type: array

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2391,6 +2391,8 @@ components:
           type: string
         source_uri:
           type: string
+        rollout_duration_seconds:
+          type: number;
         agents:
           oneOf:
             - type: array

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/bulk_upgrade_agents.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/bulk_upgrade_agents.yaml
@@ -6,7 +6,7 @@ properties:
   source_uri:
     type: string
   rollout_duration_seconds:
-    type: number;
+    type: number
   agents:
     oneOf:
       - type: array

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/bulk_upgrade_agents.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/bulk_upgrade_agents.yaml
@@ -5,6 +5,8 @@ properties:
     type: string
   source_uri:
     type: string
+  rollout_duration_seconds:
+    type: number;
   agents:
     oneOf:
       - type: array

--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -44,6 +44,9 @@ export interface NewAgentAction {
   agents: string[];
   created_at?: string;
   id?: string;
+  expiration?: string;
+  start_time?: string;
+  minimum_execution_duration?: number;
 }
 
 export interface AgentAction extends NewAgentAction {

--- a/x-pack/plugins/fleet/server/routes/agent/upgrade_handler.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/upgrade_handler.ts
@@ -81,7 +81,13 @@ export const postBulkAgentsUpgradeHandler: RequestHandler<
   const coreContext = await context.core;
   const soClient = coreContext.savedObjects.client;
   const esClient = coreContext.elasticsearch.client.asInternalUser;
-  const { version, source_uri: sourceUri, agents, force } = request.body;
+  const {
+    version,
+    source_uri: sourceUri,
+    agents,
+    force,
+    rollout_duration_seconds: upgradeDurationSeconds,
+  } = request.body;
   const kibanaVersion = appContextService.getKibanaVersion();
   try {
     checkVersionIsSame(version, kibanaVersion);
@@ -102,6 +108,7 @@ export const postBulkAgentsUpgradeHandler: RequestHandler<
       sourceUri,
       version,
       force,
+      upgradeDurationSeconds,
     };
     const results = await AgentService.sendUpgradeAgentsActions(soClient, esClient, upgradeOptions);
     const body = results.items.reduce<PostBulkAgentUpgradeResponse>((acc, so) => {

--- a/x-pack/plugins/fleet/server/services/agents/upgrade.ts
+++ b/x-pack/plugins/fleet/server/services/agents/upgrade.ts
@@ -6,6 +6,7 @@
  */
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+import moment from 'moment';
 
 import type { Agent, BulkActionResult } from '../../types';
 import { agentPolicyService } from '..';
@@ -27,6 +28,8 @@ import {
   getAgentPolicyForAgent,
 } from './crud';
 import { searchHitToAgent } from './helpers';
+
+const MINIMUM_EXECUTION_DURATION_SECONDS = 600; // 10m
 
 function isMgetDoc(doc?: estypes.MgetResponseItem<unknown>): doc is estypes.GetGetResult {
   return Boolean(doc && 'found' in doc);
@@ -78,6 +81,7 @@ export async function sendUpgradeAgentsActions(
     version: string;
     sourceUri?: string | undefined;
     force?: boolean;
+    upgradeDurationSeconds?: number;
   }
 ) {
   // Full set of agents
@@ -158,12 +162,21 @@ export async function sendUpgradeAgentsActions(
     source_uri: options.sourceUri,
   };
 
+  const rollingUpgradeOptions = options?.upgradeDurationSeconds
+    ? {
+        start_time: now,
+        minimum_execution_duration: MINIMUM_EXECUTION_DURATION_SECONDS,
+        expiration: moment().add(options?.upgradeDurationSeconds, 'seconds').toISOString(),
+      }
+    : {};
+
   await createAgentAction(esClient, {
     created_at: now,
     data,
     ack_data: data,
     type: 'UPGRADE',
     agents: agentsToUpdate.map((agent) => agent.id),
+    ...rollingUpgradeOptions,
   });
 
   await bulkUpdateAgents(

--- a/x-pack/plugins/fleet/server/services/agents/upgrade.ts
+++ b/x-pack/plugins/fleet/server/services/agents/upgrade.ts
@@ -29,7 +29,7 @@ import {
 } from './crud';
 import { searchHitToAgent } from './helpers';
 
-const MINIMUM_EXECUTION_DURATION_SECONDS = 600; // 10m
+const MINIMUM_EXECUTION_DURATION_SECONDS = 1800; // 30m
 
 function isMgetDoc(doc?: estypes.MgetResponseItem<unknown>): doc is estypes.GetGetResult {
   return Boolean(doc && 'found' in doc);

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -71,6 +71,7 @@ export const PostBulkAgentUpgradeRequestSchema = {
     source_uri: schema.maybe(schema.string()),
     version: schema.string(),
     force: schema.maybe(schema.boolean()),
+    rollout_duration_seconds: schema.maybe(schema.number({ min: 600 })),
   }),
 };
 

--- a/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
@@ -325,6 +325,57 @@ export default function (providerContext: FtrProviderContext) {
         expect(typeof agent2data.body.item.upgrade_started_at).to.be('undefined');
       });
 
+      it('should create a .fleet-actions document with the agents, version, and upgrade window', async () => {
+        const kibanaVersion = await kibanaServer.version.get();
+        await es.update({
+          id: 'agent1',
+          refresh: 'wait_for',
+          index: AGENTS_INDEX,
+          body: {
+            doc: {
+              local_metadata: { elastic: { agent: { upgradeable: true, version: '0.0.0' } } },
+            },
+          },
+        });
+        await es.update({
+          id: 'agent2',
+          refresh: 'wait_for',
+          index: AGENTS_INDEX,
+          body: {
+            doc: {
+              local_metadata: { elastic: { agent: { upgradeable: true, version: '0.0.0' } } },
+            },
+          },
+        });
+        await supertest
+          .post(`/api/fleet/agents/bulk_upgrade`)
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            version: kibanaVersion,
+            agents: ['agent1', 'agent2'],
+            rollout_duration_seconds: 6000,
+          })
+          .expect(200);
+
+        const actionsRes = await es.search({
+          index: '.fleet-actions',
+          body: {
+            sort: [{ '@timestamp': { order: 'desc' } }],
+          },
+        });
+
+        const action: any = actionsRes.hits.hits[0]._source;
+
+        expect(action).to.have.keys(
+          'agents',
+          'expiration',
+          'start_time',
+          'minimum_execution_duration'
+        );
+        expect(action.agents).contain('agent1');
+        expect(action.agents).contain('agent2');
+      });
+
       it('should allow to upgrade multiple upgradeable agents by kuery', async () => {
         const kibanaVersion = await kibanaServer.version.get();
         await es.update({


### PR DESCRIPTION
## Summary

Related to #130259 

Update the agent upgrade API to allow to specify an upgrade duration in seconds to progressively rollout upgrades

The bulk upgrade now support a new key `rollout_duration_seconds` 

Example:
```
POST /api/fleet/agents/bulk_upgrade
{
version: 8.2.0,
agents: ['agent1', 'agent2'],
rollout_duration_seconds: 6000,
}
```

## Tests

This is tested with an api integration tests that check we generate the correct `.fleet-actions` document.