### PR TITLE
[Security Solution][Exceptions] - Add pagination icon

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/exceptions/viewer/exceptions_pagination.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/viewer/exceptions_pagination.tsx
@@ -53,8 +53,8 @@ const ExceptionsViewerPaginationComponent = ({
   const items = useMemo((): ReactElement[] => {
     return pagination.pageSizeOptions.map((rows) => (
       <EuiContextMenuItem
+        icon={rows === pagination.pageSize ? 'check' : 'empty'}
         key={rows}
-        icon="empty"
         onClick={() => {
           onPaginationChange({
             pagination: {


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/106212

Very minor UX inconsistency where the checkmark was not shown in exceptions pagination as it is in other paginated views. Now checkmark appears:

<img width="232" alt="Screen Shot 2022-05-10 at 1 27 39 PM" src="https://user-images.githubusercontent.com/10927944/167716551-97846066-7204-4003-a784-7ea1dc7d2e31.png">


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))