### PR TITLE
Add a note that if list pipelines exceeds 10k, Kibana faces performan…

### DIFF
--- a/docs/api/logstash-configuration-management/list-pipeline.asciidoc
+++ b/docs/api/logstash-configuration-management/list-pipeline.asciidoc
@@ -6,10 +6,7 @@
 
 experimental[] List all centrally-managed Logstash pipelines.
 
-[IMPORTANT]
-====
-Limit your number of pipelines to 10k or fewer. When the number of pipelines surpasses 10k, you may see performance issues on Kibana.
-====
+IMPORTANT: Limit the number of pipelines to 10k or fewer. As the number of pipelines nears and surpasses 10k, you may see performance issues on Kibana.
 
 [[logstash-configuration-management-api-list-request]]
 ==== Request

--- a/docs/api/logstash-configuration-management/list-pipeline.asciidoc
+++ b/docs/api/logstash-configuration-management/list-pipeline.asciidoc
@@ -6,6 +6,11 @@
 
 experimental[] List all centrally-managed Logstash pipelines.
 
+[IMPORTANT]
+====
+Limit your number of pipelines to 10k or fewer. When the number of pipelines surpasses 10k, you may see performance issues on Kibana.
+====
+
 [[logstash-configuration-management-api-list-request]]
 ==== Request
 

--- a/docs/api/logstash-configuration-management/list-pipeline.asciidoc
+++ b/docs/api/logstash-configuration-management/list-pipeline.asciidoc
@@ -6,7 +6,7 @@
 
 experimental[] List all centrally-managed Logstash pipelines.
 
-IMPORTANT: Limit the number of pipelines to 10k or fewer. As the number of pipelines nears and surpasses 10k, you may see performance issues on Kibana.
+IMPORTANT: Limit the number of pipelines to 10k or fewer. As the number of pipelines nears and surpasses 10k, you may see performance issues on {kib}.
 
 [[logstash-configuration-management-api-list-request]]
 ==== Request


### PR DESCRIPTION
Recently, Logstash team proceeded quick performance test on `fetching pipelines API` and found Kibana is paginating Logstash pipelines on frontend. Displaying large scale pipelines on Kibana UI makes slow, especially when pipelines reach 10k, UI responses significantly slow. Note that, although we don't have (statistics) customers who are using more that 1k pipelines, it is good to mark this performance because there is a possibility customers may automate pipelines.

## Summary

Adds a note about pipelines management performance on Kibana.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation]

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
