### PR TITLE
[TSVB] Fix percentile rank math

### DIFF
--- a/src/plugins/vis_types/timeseries/server/lib/vis_data/response_processors/series/math.js
+++ b/src/plugins/vis_types/timeseries/server/lib/vis_data/response_processors/series/math.js
@@ -14,6 +14,7 @@ const percentileValueMatch = /\[([0-9\.]+)\]$/;
 import { startsWith, flatten, values, first, last } from 'lodash';
 import { getDefaultDecoration, getSiblingAggValue, getSplits, mapEmptyToZero } from '../../helpers';
 import { evaluate } from '@kbn/tinymath';
+import { TSVB_METRIC_TYPES } from '../../../../../common/enums';
 
 export function mathAgg(resp, panel, series, meta, extractFields) {
   return (next) => async (results) => {
@@ -42,7 +43,13 @@ export function mathAgg(resp, panel, series, meta, extractFields) {
             });
           } else {
             const percentileMatch = v.field.match(percentileValueMatch);
-            const m = percentileMatch ? { ...metric, percent: percentileMatch[1] } : { ...metric };
+            const m = percentileMatch
+              ? {
+                  ...metric,
+                  [metric.type === TSVB_METRIC_TYPES.PERCENTILE ? 'percent' : 'value']:
+                    percentileMatch[1],
+                }
+              : { ...metric };
             acc[v.name] = mapEmptyToZero(m, split.timeseries.buckets);
           }
           return acc;

--- a/src/plugins/vis_types/timeseries/server/lib/vis_data/response_processors/series/math.test.js
+++ b/src/plugins/vis_types/timeseries/server/lib/vis_data/response_processors/series/math.test.js
@@ -108,6 +108,64 @@ describe('math(resp, panel, series)', () => {
     });
   });
 
+  test('works with percentiles and percentile rank', async () => {
+    series.metrics = [
+      {
+        id: 'percentile_cpu',
+        type: 'percentile',
+        field: 'cpu',
+        percentiles: [{ value: 50, id: 'p50' }],
+      },
+      {
+        id: 'rank_cpu',
+        type: 'percentile_rank',
+        field: 'cpu',
+        percentiles: [{ value: 500, id: 'p500' }],
+      },
+      {
+        id: 'mathagg',
+        type: 'math',
+        script: 'divide(params.a, params.b)',
+        variables: [
+          { name: 'a', field: 'percentile_cpu[50.0]' },
+          { name: 'b', field: 'rank_cpu[500.0]' },
+        ],
+      },
+    ];
+    resp.aggregations.test.buckets[0].timeseries.buckets[0].percentile_cpu = {
+      values: { '50.0': 0.25 },
+    };
+    resp.aggregations.test.buckets[0].timeseries.buckets[0].rank_cpu = {
+      values: { '500.0': 0.125 },
+    };
+    resp.aggregations.test.buckets[0].timeseries.buckets[1].percentile_cpu = {
+      values: { '50.0': 0.25 },
+    };
+    resp.aggregations.test.buckets[0].timeseries.buckets[1].rank_cpu = {
+      values: { '500.0': 0.25 },
+    };
+
+    const next = await mathAgg(resp, panel, series)((results) => results);
+    const results = await stdMetric(resp, panel, series)(next)([]);
+
+    expect(results).toHaveLength(1);
+
+    expect(results[0]).toEqual({
+      id: 'test╰┄►example-01',
+      label: 'example-01',
+      color: 'rgb(255, 0, 0)',
+      stack: false,
+      seriesId: 'test',
+      lines: { show: true, fill: 0, lineWidth: 1, steps: false },
+      points: { show: true, radius: 1, lineWidth: 1 },
+      bars: { fill: 0, lineWidth: 1, show: false },
+      data: [
+        [1, 2],
+        [2, 1],
+      ],
+    });
+  });
+
   test('handles math even if there is a series agg', async () => {
     series.metrics.push({
       id: 'myid',


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/131901

The code mapping series to variables for the math operation is assuming a percentile variable if `percentileValueMatch` matches the field name: https://github.com/elastic/kibana/blob/2a0366a986597a7ef082caf672a1e2ba41643cd7/src/plugins/vis_types/timeseries/server/lib/vis_data/response_processors/series/math.js#L45

But it can actually be either percentile or percentile rank.

This PR adds a condition for these two cases and makes sure the downstream code receives the structure it expects.