### PR TITLE
Unskip flaky Saved Objects Management <> spaces test

### DIFF
--- a/x-pack/test/functional/apps/saved_objects_management/spaces_integration.ts
+++ b/x-pack/test/functional/apps/saved_objects_management/spaces_integration.ts
@@ -31,8 +31,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     return bools.every((currBool) => currBool === true);
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/115303
-  describe.skip('spaces integration', () => {
+  describe('spaces integration', () => {
     before(async () => {
       await spacesService.create({ id: spaceId, name: spaceId });
       await kibanaServer.importExport.load(


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/115303, with no code changes 😬.

I suspect that recent EUI changes improved the rendering of tables, so we aren't susceptible to the partial rendering that we were seeing in https://github.com/elastic/kibana/issues/115303.


### Flaky test runner results:
- Run 1 (100x): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/602
- Run 2 (100x): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/603