### PR TITLE
[Unified Search] Provide an option to hide specified filter actions from SearchBar filter panels

### DIFF
--- a/src/plugins/unified_search/public/__stories__/search_bar.stories.tsx
+++ b/src/plugins/unified_search/public/__stories__/search_bar.stories.tsx
@@ -428,4 +428,35 @@ storiesOf('SearchBar', module)
       showQueryInput: true,
       showSubmitButton: false,
     } as SearchBarProps)
+  )
+  .add('with filter bar on but pinning option is hidden from menus', () =>
+    wrapSearchBarInContext({
+      showDatePicker: false,
+      showFilterBar: true,
+      showQueryInput: true,
+      hiddenFilterPanelOptions: ['pinFilter'],
+      filters: [
+        {
+          meta: {
+            index: '1234',
+            alias: null,
+            negate: false,
+            disabled: false,
+            type: 'phrase',
+            key: 'category.keyword',
+            params: {
+              query: "Men's Accessories",
+            },
+          },
+          query: {
+            match_phrase: {
+              'category.keyword': "Men's Accessories",
+            },
+          },
+          $state: {
+            store: 'appState',
+          },
+        },
+      ],
+    } as unknown as SearchBarProps)
   );

--- a/src/plugins/unified_search/public/filter_bar/filter_bar.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_bar.tsx
@@ -11,7 +11,7 @@ import { InjectedIntl, injectI18n } from '@kbn/i18n-react';
 import type { Filter } from '@kbn/es-query';
 import React, { useRef } from 'react';
 import { DataView } from '@kbn/data-views-plugin/public';
-import FilterItems from './filter_item/filter_items';
+import FilterItems, { Props as FilterItemsProps } from './filter_item/filter_items';
 
 import { filterBarStyles } from './filter_bar.styles';
 
@@ -22,6 +22,7 @@ export interface Props {
   indexPatterns: DataView[];
   intl: InjectedIntl;
   timeRangeForSuggestionsOverride?: boolean;
+  hiddenPanelOptions?: FilterItemsProps['hiddenPanelOptions'];
   /**
    * Applies extra styles necessary when coupled with the query bar
    */
@@ -48,6 +49,7 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
         onFiltersUpdated={props.onFiltersUpdated}
         indexPatterns={props.indexPatterns!}
         timeRangeForSuggestionsOverride={props.timeRangeForSuggestionsOverride}
+        hiddenPanelOptions={props.hiddenPanelOptions}
       />
     </EuiFlexGroup>
   );

--- a/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.tsx
@@ -29,8 +29,7 @@ import {
 import { FilterEditor } from '../filter_editor';
 import { FilterView } from '../filter_view';
 import { getIndexPatterns } from '../../services';
-
-type PanelOptions = 'pinFilter' | 'editFilter' | 'negateFilter' | 'disableFilter' | 'deleteFilter';
+import { FilterPanelOption } from '../../types';
 
 export interface FilterItemProps {
   id: string;
@@ -41,7 +40,7 @@ export interface FilterItemProps {
   onRemove: () => void;
   intl: InjectedIntl;
   uiSettings: IUiSettingsClient;
-  hiddenPanelOptions?: PanelOptions[];
+  hiddenPanelOptions?: FilterPanelOption[];
   timeRangeForSuggestionsOverride?: boolean;
   readonly?: boolean;
 }
@@ -248,7 +247,7 @@ export function FilterItem(props: FilterItemProps) {
 
     if (hiddenPanelOptions && hiddenPanelOptions.length > 0) {
       mainPanelItems = mainPanelItems.filter(
-        (pItem) => !hiddenPanelOptions.includes(pItem['data-test-subj'] as PanelOptions)
+        (pItem) => !hiddenPanelOptions.includes(pItem['data-test-subj'] as FilterPanelOption)
       );
     }
     return [

--- a/src/plugins/unified_search/public/filter_bar/filter_item/filter_items.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_item/filter_items.tsx
@@ -15,7 +15,7 @@ import { IDataPluginServices } from '@kbn/data-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { FilterItem } from './filter_item';
+import { FilterItem, FilterItemProps } from './filter_item';
 
 export interface Props {
   filters: Filter[];
@@ -23,6 +23,7 @@ export interface Props {
   indexPatterns: DataView[];
   intl: InjectedIntl;
   timeRangeForSuggestionsOverride?: boolean;
+  hiddenPanelOptions?: FilterItemProps['hiddenPanelOptions'];
 }
 
 const FilterItemsUI = React.memo(function FilterItemsUI(props: Props) {
@@ -56,6 +57,7 @@ const FilterItemsUI = React.memo(function FilterItemsUI(props: Props) {
           onRemove={() => onRemove(i)}
           indexPatterns={props.indexPatterns}
           uiSettings={uiSettings!}
+          hiddenPanelOptions={props.hiddenPanelOptions}
           timeRangeForSuggestionsOverride={props.timeRangeForSuggestionsOverride}
         />
       </EuiFlexItem>

--- a/src/plugins/unified_search/public/query_string_input/query_bar_menu.test.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_menu.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { act } from 'react-dom/test-utils';
+import { waitFor } from '@testing-library/react';
 import { mountWithIntl as mount } from '@kbn/test-jest-helpers';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { coreMock } from '@kbn/core/public/mocks';
@@ -39,6 +40,30 @@ describe('Querybar Menu component', () => {
     storage.get.mockReturnValue(v);
     return storage;
   };
+
+  const filtersMock = [
+    {
+      meta: {
+        index: 'ff959d40-b880-11e8-a6d9-e546fe2bba5f',
+        alias: null,
+        negate: false,
+        disabled: false,
+        type: 'phrase',
+        key: 'category.keyword',
+        params: {
+          query: "Men's Accessories",
+        },
+      },
+      query: {
+        match_phrase: {
+          'category.keyword': "Men's Accessories",
+        },
+      },
+      $state: {
+        store: 'appState',
+      },
+    },
+  ] as Filter[];
 
   const startMock = coreMock.createStart();
   let dataMock = dataPluginMock.createStartContract();
@@ -181,29 +206,7 @@ describe('Querybar Menu component', () => {
       ...props,
       openQueryBarMenu: true,
       showFilterBar: true,
-      filters: [
-        {
-          meta: {
-            index: 'ff959d40-b880-11e8-a6d9-e546fe2bba5f',
-            alias: null,
-            negate: false,
-            disabled: false,
-            type: 'phrase',
-            key: 'category.keyword',
-            params: {
-              query: "Men's Accessories",
-            },
-          },
-          query: {
-            match_phrase: {
-              'category.keyword': "Men's Accessories",
-            },
-          },
-          $state: {
-            store: 'appState',
-          },
-        },
-      ] as Filter[],
+      filters: filtersMock,
     };
     const component = mount(wrapQueryBarMenuComponentInContext(newProps, 'kuery'));
     const applyToAllFiltersButton = component.find(
@@ -229,29 +232,7 @@ describe('Querybar Menu component', () => {
       ...props,
       openQueryBarMenu: true,
       showSaveQuery: true,
-      filters: [
-        {
-          meta: {
-            index: 'ff959d40-b880-11e8-a6d9-e546fe2bba5f',
-            alias: null,
-            negate: false,
-            disabled: false,
-            type: 'phrase',
-            key: 'category.keyword',
-            params: {
-              query: "Men's Accessories",
-            },
-          },
-          query: {
-            match_phrase: {
-              'category.keyword': "Men's Accessories",
-            },
-          },
-          $state: {
-            store: 'appState',
-          },
-        },
-      ] as Filter[],
+      filters: filtersMock,
       savedQuery: {
         id: '8a0b7cd0-b0c4-11ec-92b2-73d62e0d28a9',
         attributes: {
@@ -274,5 +255,92 @@ describe('Querybar Menu component', () => {
       '[data-test-subj="saved-query-management-save-as-new-button"]'
     );
     expect(saveChangesAsNewButton.length).toBeTruthy();
+  });
+
+  it('should render all filter panel options by default', async () => {
+    const newProps: QueryBarMenuProps = {
+      ...props,
+      openQueryBarMenu: true,
+      showFilterBar: true,
+      filters: filtersMock,
+      hiddenPanelOptions: undefined,
+    };
+    const component = mount(wrapQueryBarMenuComponentInContext(newProps, 'kuery'));
+
+    expect(component.find('[data-test-subj="filter-sets-removeAllFilters"]').length).toBeTruthy();
+    component.find('[data-test-subj="filter-sets-applyToAllFilters"]').first().simulate('click');
+
+    await waitFor(() => {
+      component.update();
+      expect(component.find('[data-test-subj="contextMenuPanelTitleButton"]').length).toBeTruthy();
+    });
+
+    expect(component.find('[data-test-subj="filter-sets-pinAllFilters"]').length).toBeTruthy();
+    expect(component.find('[data-test-subj="filter-sets-unpinAllFilters"]').length).toBeTruthy();
+    expect(component.find('[data-test-subj="filter-sets-invertAllFilters"]').length).toBeTruthy();
+    expect(component.find('[data-test-subj="filter-sets-disableAllFilters"]').length).toBeTruthy();
+    expect(component.find('[data-test-subj="filter-sets-enableAllFilters"]').length).toBeTruthy();
+  });
+
+  it('should hide pinning filter panel options', async () => {
+    const newProps: QueryBarMenuProps = {
+      ...props,
+      openQueryBarMenu: true,
+      showFilterBar: true,
+      filters: filtersMock,
+      hiddenPanelOptions: ['pinFilter'],
+    };
+    const component = mount(wrapQueryBarMenuComponentInContext(newProps, 'kuery'));
+
+    component.find('[data-test-subj="filter-sets-applyToAllFilters"]').first().simulate('click');
+
+    await waitFor(() => {
+      component.update();
+      expect(component.find('[data-test-subj="contextMenuPanelTitleButton"]').length).toBeTruthy();
+    });
+
+    expect(component.find('[data-test-subj="filter-sets-pinAllFilters"]').length).toBeFalsy();
+    expect(component.find('[data-test-subj="filter-sets-unpinAllFilters"]').length).toBeFalsy();
+
+    expect(component.find('[data-test-subj="filter-sets-invertAllFilters"]').length).toBeTruthy();
+    expect(component.find('[data-test-subj="filter-sets-disableAllFilters"]').length).toBeTruthy();
+    expect(component.find('[data-test-subj="filter-sets-enableAllFilters"]').length).toBeTruthy();
+  });
+
+  it('should hide negating and enabling filter panel options', async () => {
+    const newProps: QueryBarMenuProps = {
+      ...props,
+      openQueryBarMenu: true,
+      showFilterBar: true,
+      filters: filtersMock,
+      hiddenPanelOptions: ['negateFilter', 'disableFilter'],
+    };
+    const component = mount(wrapQueryBarMenuComponentInContext(newProps, 'kuery'));
+
+    component.find('[data-test-subj="filter-sets-applyToAllFilters"]').first().simulate('click');
+
+    await waitFor(() => {
+      component.update();
+      expect(component.find('[data-test-subj="contextMenuPanelTitleButton"]').length).toBeTruthy();
+    });
+
+    expect(component.find('[data-test-subj="filter-sets-pinAllFilters"]').length).toBeTruthy();
+    expect(component.find('[data-test-subj="filter-sets-unpinAllFilters"]').length).toBeTruthy();
+    expect(component.find('[data-test-subj="filter-sets-invertAllFilters"]').length).toBeFalsy();
+    expect(component.find('[data-test-subj="filter-sets-disableAllFilters"]').length).toBeFalsy();
+    expect(component.find('[data-test-subj="filter-sets-enableAllFilters"]').length).toBeFalsy();
+  });
+
+  it('should hide deleting filter panel options', async () => {
+    const newProps: QueryBarMenuProps = {
+      ...props,
+      openQueryBarMenu: true,
+      showFilterBar: true,
+      filters: filtersMock,
+      hiddenPanelOptions: ['deleteFilter'],
+    };
+    const component = mount(wrapQueryBarMenuComponentInContext(newProps, 'kuery'));
+
+    expect(component.find('[data-test-subj="filter-sets-removeAllFilters"]').length).toBeFalsy();
   });
 });

--- a/src/plugins/unified_search/public/query_string_input/query_bar_menu.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_menu.tsx
@@ -20,7 +20,7 @@ import { i18n } from '@kbn/i18n';
 import type { Filter, Query } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { TimeRange, SavedQueryService, SavedQuery } from '@kbn/data-plugin/public';
-import { QueryBarMenuPanels } from './query_bar_menu_panels';
+import { QueryBarMenuPanels, QueryBarMenuPanelsProps } from './query_bar_menu_panels';
 import { FilterEditorWrapper } from './filter_editor_wrapper';
 
 export interface QueryBarMenuProps {
@@ -36,6 +36,7 @@ export interface QueryBarMenuProps {
   saveAsNewQueryFormComponent?: JSX.Element;
   saveFormComponent?: JSX.Element;
   manageFilterSetComponent?: JSX.Element;
+  hiddenPanelOptions?: QueryBarMenuPanelsProps['hiddenPanelOptions'];
   onFiltersUpdated?: (filters: Filter[]) => void;
   filters?: Filter[];
   query?: Query;
@@ -60,6 +61,7 @@ export function QueryBarMenu({
   saveAsNewQueryFormComponent,
   saveFormComponent,
   manageFilterSetComponent,
+  hiddenPanelOptions,
   openQueryBarMenu,
   toggleFilterBarMenuPopover,
   onFiltersUpdated,
@@ -124,6 +126,7 @@ export function QueryBarMenu({
     savedQueryService,
     saveAsNewQueryFormComponent,
     manageFilterSetComponent,
+    hiddenPanelOptions,
     nonKqlMode,
     closePopover,
     onQueryBarSubmit,

--- a/src/plugins/unified_search/public/query_string_input/query_bar_menu_panels.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_menu_panels.tsx
@@ -44,6 +44,7 @@ const MAP_ITEMS_TO_FILTER_OPTION: Record<string, FilterPanelOption> = {
   'filter-sets-enableAllFilters': 'disableFilter',
   'filter-sets-disableAllFilters': 'disableFilter',
   'filter-sets-invertAllFilters': 'negateFilter',
+  'filter-sets-removeAllFilters': 'deleteFilter',
 };
 
 export interface QueryBarMenuPanelsProps {

--- a/src/plugins/unified_search/public/search_bar/search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/search_bar.tsx
@@ -25,7 +25,7 @@ import { DataView } from '@kbn/data-views-plugin/public';
 
 import { SavedQueryMeta, SaveQueryForm } from '../saved_query_form';
 import { SavedQueryManagementList } from '../saved_query_management';
-import { QueryBarMenu } from '../query_string_input/query_bar_menu';
+import { QueryBarMenu, QueryBarMenuProps } from '../query_string_input/query_bar_menu';
 import type { DataViewPickerProps } from '../dataview_picker';
 import QueryBarTopRow from '../query_string_input/query_bar_top_row';
 import { FilterBar, FilterItems } from '../filter_bar';
@@ -54,6 +54,7 @@ export interface SearchBarOwnProps {
   showDatePicker?: boolean;
   showAutoRefreshOnly?: boolean;
   filters?: Filter[];
+  hiddenFilterPanelOptions?: QueryBarMenuProps['hiddenPanelOptions'];
   // Date picker
   isRefreshPaused?: boolean;
   refreshInterval?: number;
@@ -393,6 +394,7 @@ class SearchBarUI extends Component<SearchBarProps & WithEuiThemeProps, State> {
         openQueryBarMenu={this.state.openQueryBarMenu}
         onFiltersUpdated={this.props.onFiltersUpdated}
         filters={this.props.filters}
+        hiddenPanelOptions={this.props.hiddenFilterPanelOptions}
         query={this.state.query}
         savedQuery={this.props.savedQuery}
         onClearSavedQuery={this.props.onClearSavedQuery}
@@ -422,6 +424,7 @@ class SearchBarUI extends Component<SearchBarProps & WithEuiThemeProps, State> {
           onFiltersUpdated={this.props.onFiltersUpdated}
           indexPatterns={this.props.indexPatterns!}
           timeRangeForSuggestionsOverride={timeRangeForSuggestionsOverride}
+          hiddenPanelOptions={this.props.hiddenFilterPanelOptions}
         />
       ) : (
         <FilterBar
@@ -430,6 +433,7 @@ class SearchBarUI extends Component<SearchBarProps & WithEuiThemeProps, State> {
           onFiltersUpdated={this.props.onFiltersUpdated}
           indexPatterns={this.props.indexPatterns!}
           timeRangeForSuggestionsOverride={timeRangeForSuggestionsOverride}
+          hiddenPanelOptions={this.props.hiddenFilterPanelOptions}
           data-test-subj="unifiedFilterBar"
         />
       );

--- a/src/plugins/unified_search/public/types.ts
+++ b/src/plugins/unified_search/public/types.ts
@@ -56,3 +56,13 @@ export interface UnifiedSearchPublicPluginStart {
    */
   ui: UnifiedSearchPublicPluginStartUi;
 }
+
+/**
+ * Filter options which will be available in menu panels
+ */
+export type FilterPanelOption =
+  | 'pinFilter'
+  | 'editFilter'
+  | 'negateFilter'
+  | 'disableFilter'
+  | 'deleteFilter';

--- a/src/plugins/unified_search/public/types.ts
+++ b/src/plugins/unified_search/public/types.ts
@@ -58,7 +58,7 @@ export interface UnifiedSearchPublicPluginStart {
 }
 
 /**
- * Filter options which will be available in menu panels
+ * Filter options from Unified Search menu panels
  */
 export type FilterPanelOption =
   | 'pinFilter'


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/131813

## Summary

This PR adds an optional `hiddenFilterPanelOptions` prop to `SearchBar` which allows to hide filter options (pinning, negating, enabling, deleting) from menu panels. I added a story to storybook to visualize how these options will be hidden from query panel and filter bar panels.

This change will allow us to hide pinning actions in https://github.com/elastic/kibana/pull/131688

![May-11-2022 17-15-10](https://user-images.githubusercontent.com/1415710/167885613-b256ce6f-ac85-4830-b21d-3ae47b2915fc.gif)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

