### PR TITLE
[scalability testing] extend FTR config with optional scalability configuration

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/lib/config/schema.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/config/schema.ts
@@ -14,6 +14,7 @@ import type { CustomHelpers } from 'joi';
 // valid pattern for ID
 // enforced camel-case identifiers for consistency
 const ID_PATTERN = /^[a-zA-Z0-9_]+$/;
+const SCALABILITY_DURATION_PATTERN = /^[1-9]\d{0,}[m|s]$/;
 // it will search both --inspect and --inspect-brk
 const INSPECTING = !!process.execArgv.find((arg) => arg.includes('--inspect'));
 
@@ -263,6 +264,67 @@ export const schema = Joi.object()
         directory: Joi.string().default(defaultRelativeToConfigPath('fixtures/kbn_archiver')),
       })
       .default(),
+
+    /**
+     * Optional settings to list test data archives, that will be loaded during the 'beforeTests'
+     * lifecycle phase and unloaded during the 'cleanup' lifecycle phase.
+     */
+    testData: Joi.object()
+      .keys({
+        kbnArchives: Joi.array().items(Joi.string()).optional(),
+        esArchives: Joi.array().items(Joi.string()).optional(),
+      })
+      .optional(),
+
+    /**
+     * Optional settings to enable scalability testing for single user performance journey.
+     * If defined, 'scalabilitySetup' must include 'warmup' and 'test' stages,
+     * 'maxDuration', e.g. '10m' to limit execution time to 10 minutes.
+     * Each stage must include 'action', 'duration' and 'maxUsersCount'.
+     * In addition, 'rampConcurrentUsers' requires 'minUsersCount' to ramp users from
+     * min to max within provided time duration.
+     */
+    scalabilitySetup: Joi.object()
+      .keys({
+        warmup: Joi.object()
+          .keys({
+            stages: Joi.array().items(
+              Joi.object().keys({
+                action: Joi.string()
+                  .valid('constantConcurrentUsers', 'rampConcurrentUsers')
+                  .required(),
+                duration: Joi.string().pattern(SCALABILITY_DURATION_PATTERN).required(),
+                minUsersCount: Joi.number().when('action', {
+                  is: 'rampConcurrentUsers',
+                  then: Joi.number().required().less(Joi.ref('maxUsersCount')),
+                  otherwise: Joi.forbidden(),
+                }),
+                maxUsersCount: Joi.number().required().greater(0),
+              })
+            ),
+          })
+          .required(),
+        test: Joi.object()
+          .keys({
+            stages: Joi.array().items(
+              Joi.object().keys({
+                action: Joi.string()
+                  .valid('constantConcurrentUsers', 'rampConcurrentUsers')
+                  .required(),
+                duration: Joi.string().pattern(SCALABILITY_DURATION_PATTERN).required(),
+                minUsersCount: Joi.number().when('action', {
+                  is: 'rampConcurrentUsers',
+                  then: Joi.number().required().less(Joi.ref('maxUsersCount')),
+                  otherwise: Joi.forbidden(),
+                }),
+                maxUsersCount: Joi.number().required().greater(0),
+              })
+            ),
+          })
+          .required(),
+        maxDuration: Joi.string().pattern(SCALABILITY_DURATION_PATTERN).required(),
+      })
+      .optional(),
 
     // settings for the kibanaServer.uiSettings module
     uiSettings: Joi.object()

--- a/packages/kbn-test/src/functional_test_runner/lib/config/schema.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/config/schema.ts
@@ -271,10 +271,10 @@ export const schema = Joi.object()
      */
     testData: Joi.object()
       .keys({
-        kbnArchives: Joi.array().items(Joi.string()).optional(),
-        esArchives: Joi.array().items(Joi.string()).optional(),
+        kbnArchives: Joi.array().items(Joi.string()).default([]),
+        esArchives: Joi.array().items(Joi.string()).default([]),
       })
-      .optional(),
+      .default(),
 
     /**
      * Optional settings to enable scalability testing for single user performance journey.

--- a/test/common/services/es_archiver.ts
+++ b/test/common/services/es_archiver.ts
@@ -13,10 +13,11 @@ import * as KibanaServer from './kibana_server';
 export function EsArchiverProvider({ getService }: FtrProviderContext): EsArchiver {
   const config = getService('config');
   const client = getService('es');
-
+  const lifecycle = getService('lifecycle');
   const log = getService('log');
   const kibanaServer = getService('kibanaServer');
   const retry = getService('retry');
+  const esArchives = config.get('testData.esArchives');
 
   const esArchiver = new EsArchiver({
     client,
@@ -30,6 +31,20 @@ export function EsArchiverProvider({ getService }: FtrProviderContext): EsArchiv
     retry,
     defaults: config.get('uiSettings.defaults'),
   });
+
+  if (esArchives) {
+    lifecycle.beforeTests.add(async () => {
+      for (const archive of esArchives) {
+        await esArchiver.load(archive);
+      }
+    });
+
+    lifecycle.cleanup.add(async () => {
+      for (const archive of esArchives) {
+        await esArchiver.unload(archive);
+      }
+    });
+  }
 
   return esArchiver;
 }

--- a/test/common/services/kibana_server/kibana_server.ts
+++ b/test/common/services/kibana_server/kibana_server.ts
@@ -17,6 +17,7 @@ export function KibanaServerProvider({ getService }: FtrProviderContext): KbnCli
   const lifecycle = getService('lifecycle');
   const url = Url.format(config.get('servers.kibana'));
   const defaults = config.get('uiSettings.defaults');
+  const kbnArchives = config.get('testData.kbnArchives');
   const kbn = new KbnClient({
     log,
     url,
@@ -27,6 +28,19 @@ export function KibanaServerProvider({ getService }: FtrProviderContext): KbnCli
   if (defaults) {
     lifecycle.beforeTests.add(async () => {
       await kbn.uiSettings.update(defaults);
+    });
+  }
+
+  if (kbnArchives) {
+    lifecycle.beforeTests.add(async () => {
+      for (const archive of kbnArchives) {
+        await kbn.importExport.load(archive);
+      }
+    });
+    lifecycle.cleanup.add(async () => {
+      for (const archive of kbnArchives) {
+        await kbn.importExport.unload(archive);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Closes #131498

This PR changes FTR config schema to support **optional** configuration that includes:
- ES & KBN archives, that will be loaded during `beforeTests` FTR lifecycle phase and unloaded during `cleanup` phase
```
testData: {
  kbnArchives: [
    'test/functional/fixtures/kbn_archiver/many_fields_data_view'
  ],
  esArchives: [
    'test/functional/fixtures/es_archiver/many_fields'
  ]
}
```
- Scalability benchmarking data, that defines the setup for auto-generated Gatling simulation:
  -  both `warmup` and `test` phases and scalability run `maxDuration` are required
  - at least single stage should be defined in each phase
  - 2 [Gatling](https://gatling.io/docs/gatling/reference/current/core/injection/#closed-model) setup actions are supported:  `constantConcurrentUsers` & `rampConcurrentUsers`
  - `constantConcurrentUsers` requires only `maxUsersCount`
  - `rampConcurrentUsers` requires both `minUsersCount` and `maxUsersCount`
  - `duration` / `maxDuration` supports format [number][m|s], e.g. `90s` (90 seconds), `5m` (5 minutes) 
```
    scalabilitySetup: {
      warmup: {
        stages: [
          {
            action: 'constantConcurrentUsers',
            maxUsersCount: 20,
            duration: '90s',
          },
        ],
      },
      test: {
        stages: [
          {
            action: 'rampConcurrentUsers',
            minUsersCount: 20,
            maxUsersCount: 100,
            duration: '2m',
          },
          {
            action: 'constantConcurrentUsers',
            maxUsersCount: 100,
            duration: '5m',
          },
        ],
      },
      maxDuration: '10m',
    },
```
