### PR TITLE
[Security Solution] CODEOWNERS: assign ml_popover to the Rules Area

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -499,6 +499,7 @@
 /x-pack/plugins/security_solution/public/common/components/health_truncate_text @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/common/components/links_to_docs @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/common/components/callouts @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/common/components/ml_popover @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/detections/components/callouts @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/detections/mitre @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules @elastic/security-detections-response-rules


### PR DESCRIPTION
## Summary

This PR assigns the `<MlPopover />` component and all the related code in the `x-pack/plugins/security_solution/public/common/components/ml_popover` folder to the @elastic/security-detections-response-rules area team.

This component renders the **"ML job settings"** popover we have on the Rule Management page:

<img width="1578" alt="ML job settings popover screenshot" src="https://user-images.githubusercontent.com/7359339/167900123-cf501ce2-8abe-4e01-9af5-9c1c97141d83.png">

