### PR TITLE
[8.2] unskipping the grok debugger a11y  test - works as expected (#131564)

### DIFF
--- a/x-pack/test/accessibility/apps/grok_debugger.ts
+++ b/x-pack/test/accessibility/apps/grok_debugger.ts
@@ -12,8 +12,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const a11y = getService('a11y');
   const grokDebugger = getService('grokDebugger');
 
-  // this test is failing as there is a violation https://github.com/elastic/kibana/issues/62102
-  describe.skip('Dev tools grok debugger', () => {
+  // Fixes:https://github.com/elastic/kibana/issues/62102
+  describe('Dev tools grok debugger', () => {
     before(async () => {
       await PageObjects.common.navigateToApp('grokDebugger');
       await grokDebugger.assertExists();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [unskipping the grok debugger a11y  test - works as expected (#131564)](https://github.com/elastic/kibana/pull/131564)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)