### PR TITLE
[EBT] Elastic V3: `fetch` cannot be deconstructed

### DIFF
--- a/packages/analytics/shippers/elastic_v3/browser/src/browser_shipper.test.ts
+++ b/packages/analytics/shippers/elastic_v3/browser/src/browser_shipper.test.ts
@@ -130,7 +130,7 @@ describe('ElasticV3BrowserShipper', () => {
         {
           body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
           headers: {
-            'content-type': 'application/x-njson',
+            'content-type': 'application/x-ndjson',
             'x-elastic-cluster-id': 'UNKNOWN',
             'x-elastic-stack-version': '1.2.3',
           },
@@ -171,7 +171,7 @@ describe('ElasticV3BrowserShipper', () => {
       {
         body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
         headers: {
-          'content-type': 'application/x-njson',
+          'content-type': 'application/x-ndjson',
           'x-elastic-cluster-id': 'UNKNOWN',
           'x-elastic-stack-version': '1.2.3',
         },
@@ -206,7 +206,7 @@ describe('ElasticV3BrowserShipper', () => {
         {
           body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
           headers: {
-            'content-type': 'application/x-njson',
+            'content-type': 'application/x-ndjson',
             'x-elastic-cluster-id': 'UNKNOWN',
             'x-elastic-stack-version': '1.2.3',
           },
@@ -230,7 +230,7 @@ describe('ElasticV3BrowserShipper', () => {
         {
           body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
           headers: {
-            'content-type': 'application/x-njson',
+            'content-type': 'application/x-ndjson',
             'x-elastic-cluster-id': 'UNKNOWN',
             'x-elastic-stack-version': '1.2.3',
           },
@@ -268,7 +268,7 @@ describe('ElasticV3BrowserShipper', () => {
         {
           body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
           headers: {
-            'content-type': 'application/x-njson',
+            'content-type': 'application/x-ndjson',
             'x-elastic-cluster-id': 'UNKNOWN',
             'x-elastic-stack-version': '1.2.3',
           },

--- a/packages/analytics/shippers/elastic_v3/browser/src/browser_shipper.ts
+++ b/packages/analytics/shippers/elastic_v3/browser/src/browser_shipper.ts
@@ -97,7 +97,7 @@ export class ElasticV3BrowserShipper implements IShipper {
   }
 
   private async makeRequest(events: Event[]): Promise<string> {
-    const { status, text, ok } = await fetch(this.url, {
+    const response = await fetch(this.url, {
       method: 'POST',
       body: eventsToNDJSON(events),
       headers: buildHeaders(this.clusterUuid, this.options.version, this.licenseId),
@@ -108,14 +108,17 @@ export class ElasticV3BrowserShipper implements IShipper {
 
     if (this.options.debug) {
       this.initContext.logger.debug(
-        `[${ElasticV3BrowserShipper.shipperName}]: ${status} - ${await text()}`
+        `[${ElasticV3BrowserShipper.shipperName}]: ${response.status} - ${await response.text()}`
       );
     }
 
-    if (!ok) {
-      throw new ErrorWithCode(`${status} - ${await text()}`, `${status}`);
+    if (!response.ok) {
+      throw new ErrorWithCode(
+        `${response.status} - ${await response.text()}`,
+        `${response.status}`
+      );
     }
 
-    return `${status}`;
+    return `${response.status}`;
   }
 }

--- a/packages/analytics/shippers/elastic_v3/common/src/build_headers.test.ts
+++ b/packages/analytics/shippers/elastic_v3/common/src/build_headers.test.ts
@@ -12,7 +12,7 @@ describe('buildHeaders', () => {
   test('builds the headers as expected in the V3 endpoints', () => {
     expect(buildHeaders('test-cluster', '1.2.3', 'test-license')).toMatchInlineSnapshot(`
       Object {
-        "content-type": "application/x-njson",
+        "content-type": "application/x-ndjson",
         "x-elastic-cluster-id": "test-cluster",
         "x-elastic-license-id": "test-license",
         "x-elastic-stack-version": "1.2.3",
@@ -23,7 +23,7 @@ describe('buildHeaders', () => {
   test('if license is not provided, it skips the license header', () => {
     expect(buildHeaders('test-cluster', '1.2.3')).toMatchInlineSnapshot(`
       Object {
-        "content-type": "application/x-njson",
+        "content-type": "application/x-ndjson",
         "x-elastic-cluster-id": "test-cluster",
         "x-elastic-stack-version": "1.2.3",
       }

--- a/packages/analytics/shippers/elastic_v3/common/src/build_headers.ts
+++ b/packages/analytics/shippers/elastic_v3/common/src/build_headers.ts
@@ -8,7 +8,7 @@
 
 export function buildHeaders(clusterUuid: string, version: string, licenseId?: string) {
   return {
-    'content-type': 'application/x-njson',
+    'content-type': 'application/x-ndjson',
     'x-elastic-cluster-id': clusterUuid,
     'x-elastic-stack-version': version,
     ...(licenseId && { 'x-elastic-license-id': licenseId }),

--- a/packages/analytics/shippers/elastic_v3/server/src/server_shipper.test.ts
+++ b/packages/analytics/shippers/elastic_v3/server/src/server_shipper.test.ts
@@ -129,7 +129,7 @@ describe('ElasticV3ServerShipper', () => {
         {
           body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
           headers: {
-            'content-type': 'application/x-njson',
+            'content-type': 'application/x-ndjson',
             'x-elastic-cluster-id': 'UNKNOWN',
             'x-elastic-stack-version': '1.2.3',
           },
@@ -171,7 +171,7 @@ describe('ElasticV3ServerShipper', () => {
       {
         body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
         headers: {
-          'content-type': 'application/x-njson',
+          'content-type': 'application/x-ndjson',
           'x-elastic-cluster-id': 'UNKNOWN',
           'x-elastic-stack-version': '1.2.3',
         },
@@ -208,7 +208,7 @@ describe('ElasticV3ServerShipper', () => {
         {
           body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
           headers: {
-            'content-type': 'application/x-njson',
+            'content-type': 'application/x-ndjson',
             'x-elastic-cluster-id': 'UNKNOWN',
             'x-elastic-stack-version': '1.2.3',
           },
@@ -241,7 +241,7 @@ describe('ElasticV3ServerShipper', () => {
               )
               .join(''),
             headers: {
-              'content-type': 'application/x-njson',
+              'content-type': 'application/x-ndjson',
               'x-elastic-cluster-id': 'UNKNOWN',
               'x-elastic-stack-version': '1.2.3',
             },
@@ -284,7 +284,7 @@ describe('ElasticV3ServerShipper', () => {
         {
           body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
           headers: {
-            'content-type': 'application/x-njson',
+            'content-type': 'application/x-ndjson',
             'x-elastic-cluster-id': 'UNKNOWN',
             'x-elastic-stack-version': '1.2.3',
           },
@@ -322,7 +322,7 @@ describe('ElasticV3ServerShipper', () => {
         {
           body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
           headers: {
-            'content-type': 'application/x-njson',
+            'content-type': 'application/x-ndjson',
             'x-elastic-cluster-id': 'UNKNOWN',
             'x-elastic-stack-version': '1.2.3',
           },
@@ -357,7 +357,7 @@ describe('ElasticV3ServerShipper', () => {
         {
           body: '{"timestamp":"2020-01-01T00:00:00.000Z","event_type":"test-event-type","context":{},"properties":{}}\n',
           headers: {
-            'content-type': 'application/x-njson',
+            'content-type': 'application/x-ndjson',
             'x-elastic-cluster-id': 'UNKNOWN',
             'x-elastic-stack-version': '1.2.3',
           },

--- a/packages/analytics/shippers/elastic_v3/server/src/server_shipper.ts
+++ b/packages/analytics/shippers/elastic_v3/server/src/server_shipper.ts
@@ -258,17 +258,21 @@ export class ElasticV3ServerShipper implements IShipper {
   }
 
   private async sendEvents(events: Event[]) {
+    this.initContext.logger.debug(`Reporting ${events.length} events...`);
     try {
       const code = await this.makeRequest(events);
       this.reportTelemetryCounters(events, { code });
+      this.initContext.logger.debug(`Reported ${events.length} events...`);
     } catch (error) {
+      this.initContext.logger.debug(`Failed to report ${events.length} events...`);
+      this.initContext.logger.debug(error);
       this.reportTelemetryCounters(events, { code: error.code, error });
       this.firstTimeOffline = undefined;
     }
   }
 
   private async makeRequest(events: Event[]): Promise<string> {
-    const { status, text, ok } = await fetch(this.url, {
+    const response = await fetch(this.url, {
       method: 'POST',
       body: eventsToNDJSON(events),
       headers: buildHeaders(this.clusterUuid, this.options.version, this.licenseId),
@@ -276,15 +280,16 @@ export class ElasticV3ServerShipper implements IShipper {
     });
 
     if (this.options.debug) {
-      this.initContext.logger.debug(
-        `[${ElasticV3ServerShipper.shipperName}]: ${status} - ${await text()}`
+      this.initContext.logger.debug(`${response.status} - ${await response.text()}`);
+    }
+
+    if (!response.ok) {
+      throw new ErrorWithCode(
+        `${response.status} - ${await response.text()}`,
+        `${response.status}`
       );
     }
 
-    if (!ok) {
-      throw new ErrorWithCode(`${status} - ${await text()}`, `${status}`);
-    }
-
-    return `${status}`;
+    return `${response.status}`;
   }
 }

--- a/src/plugins/telemetry/public/plugin.test.ts
+++ b/src/plugins/telemetry/public/plugin.test.ts
@@ -66,7 +66,19 @@ describe('TelemetryPlugin', () => {
 
         expect(coreSetupMock.analytics.registerShipper).toHaveBeenCalledWith(
           ElasticV3BrowserShipper,
-          { channelName: 'kibana-browser', version: 'version' }
+          { channelName: 'kibana-browser', version: 'version', sendTo: 'staging' }
+        );
+      });
+
+      it('registers the UI telemetry shipper (pointing to prod)', () => {
+        const initializerContext = coreMock.createPluginInitializerContext({ sendUsageTo: 'prod' });
+        const coreSetupMock = coreMock.createSetup();
+
+        new TelemetryPlugin(initializerContext).setup(coreSetupMock, { screenshotMode, home });
+
+        expect(coreSetupMock.analytics.registerShipper).toHaveBeenCalledWith(
+          ElasticV3BrowserShipper,
+          { channelName: 'kibana-browser', version: 'version', sendTo: 'production' }
         );
       });
     });

--- a/src/plugins/telemetry/public/plugin.ts
+++ b/src/plugins/telemetry/public/plugin.ts
@@ -158,6 +158,7 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
     analytics.registerShipper(ElasticV3BrowserShipper, {
       channelName: 'kibana-browser',
       version: currentKibanaVersion,
+      sendTo: config.sendUsageTo === 'prod' ? 'production' : 'staging',
     });
 
     this.telemetrySender = new TelemetrySender(this.telemetryService, async () => {

--- a/src/plugins/telemetry/server/plugin.test.ts
+++ b/src/plugins/telemetry/server/plugin.test.ts
@@ -26,7 +26,22 @@ describe('TelemetryPlugin', () => {
 
         expect(coreSetupMock.analytics.registerShipper).toHaveBeenCalledWith(
           ElasticV3ServerShipper,
-          { channelName: 'kibana-server', version: 'version' }
+          { channelName: 'kibana-server', version: 'version', sendTo: 'staging' }
+        );
+      });
+
+      it('registers the Server telemetry shipper (sendTo: production)', () => {
+        const initializerContext = coreMock.createPluginInitializerContext({ sendUsageTo: 'prod' });
+        const coreSetupMock = coreMock.createSetup();
+
+        new TelemetryPlugin(initializerContext).setup(coreSetupMock, {
+          usageCollection: usageCollectionPluginMock.createSetupContract(),
+          telemetryCollectionManager: telemetryCollectionManagerPluginMock.createSetupContract(),
+        });
+
+        expect(coreSetupMock.analytics.registerShipper).toHaveBeenCalledWith(
+          ElasticV3ServerShipper,
+          { channelName: 'kibana-server', version: 'version', sendTo: 'production' }
         );
       });
     });


### PR DESCRIPTION
## Summary

When setting up the indexers on the receiving end, I wondered if we were actually sending the data to the remote end. TL;DR, we are. However, I noticed 2 gotchas in the implementation:

1. When running with `debug: true` it fails because `fetch` cannot be deconstructed and call `text()`
2. We are not explicitly setting the `sendTo` option, so we risked sending to production from CI.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
