### PR TITLE
[8.2] [Security Solution] Remove `fields` from sourcerer response (#130917)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/sourcerer/routes/index.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/sourcerer/routes/index.test.ts
@@ -26,6 +26,13 @@ jest.mock('./helpers', () => {
 });
 const mockPattern = {
   id: 'security-solution',
+  fields: [
+    { name: '@timestamp', searchable: true, type: 'date', aggregatable: true },
+    { name: '@version', searchable: true, type: 'string', aggregatable: true },
+    { name: 'agent.ephemeral_id', searchable: true, type: 'string', aggregatable: true },
+    { name: 'agent.hostname', searchable: true, type: 'string', aggregatable: true },
+    { name: 'agent.id', searchable: true, type: 'string', aggregatable: true },
+  ],
   title:
     'apm-*-transaction*,traces-apm*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,winlogbeat-*,ml_host_risk_score_*,.siem-signals-default',
 };
@@ -144,7 +151,6 @@ describe('sourcerer route', () => {
 
       test('returns sourcerer formatted Data Views when SIEM Data View does NOT exist but has been created in the mean time', async () => {
         const getMock = jest.fn();
-        getMock.mockResolvedValueOnce(null);
         getMock.mockResolvedValueOnce(mockPattern);
         const getStartServicesSpecial = jest.fn().mockResolvedValue([
           null,

--- a/x-pack/plugins/security_solution/server/lib/sourcerer/routes/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/sourcerer/routes/index.ts
@@ -56,16 +56,8 @@ export const createSourcererDataViewRoute = (
         );
 
         let allDataViews: DataViewListItem[] = await dataViewService.getIdsWithTitle();
-        let siemDataView = null;
-        try {
-          siemDataView = await dataViewService.get(dataViewId);
-        } catch (err) {
-          const error = transformError(err);
-          // Do nothing if statusCode === 404 because we expect that the security dataview does not exist
-          if (error.statusCode !== 404) {
-            throw err;
-          }
-        }
+        let siemDataView: DataView | DataViewListItem | null =
+          allDataViews.find((dv) => dv.id === dataViewId) ?? null;
 
         const { patternList } = request.body;
         const patternListAsTitle = patternList.sort().join();
@@ -92,6 +84,7 @@ export const createSourcererDataViewRoute = (
             }
           }
         } else if (patternListAsTitle !== siemDataViewTitle) {
+          siemDataView = await dataViewService.get(dataViewId);
           siemDataView.title = patternListAsTitle;
           await dataViewService.updateSavedObject(siemDataView);
         }
@@ -161,8 +154,9 @@ export const getSourcererDataViewRoute = (
           request,
           true
         );
-
-        const siemDataView = await dataViewService.get(dataViewId);
+        const allDataViews: DataViewListItem[] = await dataViewService.getIdsWithTitle();
+        const siemDataView: DataViewListItem | null =
+          allDataViews.find((dv) => dv.id === dataViewId) ?? null;
         const kibanaDataView = siemDataView
           ? await buildSourcererDataView(
               siemDataView,
@@ -187,14 +181,27 @@ export const getSourcererDataViewRoute = (
   );
 };
 
+interface KibanaDataView {
+  /** Uniquely identifies a Kibana Data View */
+  id: string;
+  /**  list of active patterns that return data  */
+  patternList: string[];
+  /**
+   * title of Kibana Data View
+   * title also serves as "all pattern list", including inactive
+   * comma separated string
+   */
+  title: string;
+}
+
 const buildSourcererDataView = async (
-  dataView: DataView,
+  dataView: DataView | DataViewListItem,
   clientAsCurrentUser: ElasticsearchClient
-) => {
+): Promise<KibanaDataView> => {
   const patternList = dataView.title.split(',');
   const activePatternBools: boolean[] = await findExistingIndices(patternList, clientAsCurrentUser);
   const activePatternLists: string[] = patternList.filter(
     (pattern, j, self) => self.indexOf(pattern) === j && activePatternBools[j]
   );
-  return { ...dataView, patternList: activePatternLists };
+  return { id: dataView.id ?? '', title: dataView.title, patternList: activePatternLists };
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Security Solution] Remove `fields` from sourcerer response (#130917)](https://github.com/elastic/kibana/pull/130917)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)