### PR TITLE
[Uptime] Show experimental locations only when a particular flag is enabled

### DIFF
--- a/x-pack/plugins/synthetics/common/config.ts
+++ b/x-pack/plugins/synthetics/common/config.ts
@@ -18,6 +18,7 @@ const serviceConfig = schema.object({
   syncInterval: schema.maybe(schema.string()),
   tls: schema.maybe(sslSchema),
   devUrl: schema.maybe(schema.string()),
+  showExperimentalLocations: schema.maybe(schema.boolean()),
 });
 
 const uptimeConfig = schema.object({

--- a/x-pack/plugins/synthetics/common/runtime_types/monitor_management/locations.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/monitor_management/locations.ts
@@ -9,6 +9,11 @@ import { isLeft } from 'fp-ts/lib/Either';
 import * as t from 'io-ts';
 import { tEnum } from '../../utils/t_enum';
 
+export enum LocationStatus {
+  GA = 'ga',
+  EXPERIMENTAL = 'experimental',
+}
+
 export enum BandwidthLimitKey {
   DOWNLOAD = 'download',
   UPLOAD = 'upload',
@@ -36,13 +41,16 @@ export const LocationGeoCodec = t.interface({
   lon: t.number,
 });
 
+export const LocationStatusCodec = tEnum<LocationStatus>('LocationStatus', LocationStatus);
+export type LocationStatusType = t.TypeOf<typeof LocationStatusCodec>;
+
 export const ManifestLocationCodec = t.interface({
   url: t.string,
   geo: t.interface({
     name: t.string,
     location: LocationGeoCodec,
   }),
-  status: t.string,
+  status: LocationStatusCodec,
 });
 
 export const ServiceLocationCodec = t.interface({
@@ -51,6 +59,7 @@ export const ServiceLocationCodec = t.interface({
   geo: LocationGeoCodec,
   url: t.string,
   isServiceManaged: t.boolean,
+  status: LocationStatusCodec,
 });
 
 export const MonitorServiceLocationCodec = t.intersection([

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_config/locations.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_config/locations.tsx
@@ -8,9 +8,9 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { i18n } from '@kbn/i18n';
-import { EuiCheckboxGroup, EuiFormRow } from '@elastic/eui';
+import { EuiCheckboxGroup, EuiFormRow, EuiText, EuiBadge } from '@elastic/eui';
 import { monitorManagementListSelector } from '../../../state/selectors';
-import { MonitorServiceLocations } from '../../../../../common/runtime_types';
+import { MonitorServiceLocations, LocationStatus } from '../../../../../common/runtime_types';
 
 interface Props {
   selectedLocations: MonitorServiceLocations;
@@ -57,10 +57,22 @@ export const ServiceLocations = ({ selectedLocations, setLocations, isInvalid, o
   return (
     <EuiFormRow label={LOCATIONS_LABEL} error={errorMessage} isInvalid={errorMessage !== null}>
       <EuiCheckboxGroup
-        options={locations.map((location) => ({
-          ...location,
-          'data-test-subj': `syntheticsServiceLocation--${location.id}`,
-        }))}
+        options={locations.map((location) => {
+          const badge =
+            location.status !== LocationStatus.GA ? (
+              <EuiBadge color="warning">Tech Preview</EuiBadge>
+            ) : null;
+          const label = (
+            <EuiText size="s" data-test-subj={`syntheticsServiceLocationText--${location.id}`}>
+              {location.label} {badge}
+            </EuiText>
+          );
+          return {
+            ...location,
+            label,
+            'data-test-subj': `syntheticsServiceLocation--${location.id}`,
+          };
+        })}
         idToSelectedMap={checkboxIdToSelectedMap}
         onChange={(id) => onLocationChange(id)}
         onBlur={() => onBlur?.()}

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/monitor_async_error.test.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/monitor_async_error.test.tsx
@@ -7,7 +7,7 @@
 
 import { screen } from '@testing-library/react';
 import React from 'react';
-import { DEFAULT_THROTTLING } from '../../../../../common/runtime_types';
+import { DEFAULT_THROTTLING, LocationStatus } from '../../../../../common/runtime_types';
 import { render } from '../../../lib/helper/rtl_helpers';
 import { MonitorManagementList as MonitorManagementListState } from '../../../state/reducers/monitor_management';
 import { MonitorAsyncError } from './monitor_async_error';
@@ -55,6 +55,7 @@ describe('<MonitorAsyncError />', () => {
           },
           url: '',
           isServiceManaged: true,
+          status: LocationStatus.GA,
         },
         {
           id: 'us_north',
@@ -65,6 +66,7 @@ describe('<MonitorAsyncError />', () => {
           },
           url: '',
           isServiceManaged: true,
+          status: LocationStatus.GA,
         },
       ],
       error: {

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/test_now_mode/test_now_mode.test.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/test_now_mode/test_now_mode.test.tsx
@@ -10,7 +10,7 @@ import { screen } from '@testing-library/react';
 import { render } from '../../../lib/helper/rtl_helpers';
 import { TestNowMode } from './test_now_mode';
 import { kibanaService } from '../../../state/kibana_service';
-import { Locations, MonitorFields } from '../../../../../common/runtime_types';
+import { Locations, MonitorFields, LocationStatus } from '../../../../../common/runtime_types';
 import * as runOnceErrorHooks from '../hooks/use_run_once_errors';
 
 describe('TestNowMode', function () {
@@ -21,6 +21,7 @@ describe('TestNowMode', function () {
       geo: { lat: 33.333, lon: 73.333 },
       url: 'test-url',
       isServiceManaged: true,
+      status: LocationStatus.GA,
     },
   ];
   const testMonitor = {

--- a/x-pack/plugins/synthetics/server/synthetics_service/get_service_locations.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/get_service_locations.test.ts
@@ -6,7 +6,8 @@
  */
 import axios from 'axios';
 import { getServiceLocations } from './get_service_locations';
-import { BandwidthLimitKey } from '../../common/runtime_types';
+
+import { BandwidthLimitKey, LocationStatus } from '../../common/runtime_types';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -26,13 +27,21 @@ describe('getServiceLocations', function () {
             name: 'US Central',
             location: { lat: 41.25, lon: -95.86 },
           },
-          status: 'beta',
+          status: LocationStatus.GA,
+        },
+        us_east: {
+          url: 'https://local.dev',
+          geo: {
+            name: 'US East',
+            location: { lat: 41.25, lon: -95.86 },
+          },
+          status: LocationStatus.EXPERIMENTAL,
         },
       },
     },
   });
 
-  it('should return parsed locations and throttling', async () => {
+  it('should return parsed GA locations and throttling', async () => {
     const locations = await getServiceLocations({
       config: {
         service: {
@@ -60,6 +69,53 @@ describe('getServiceLocations', function () {
           label: 'US Central',
           url: 'https://local.dev',
           isServiceManaged: true,
+          status: LocationStatus.GA,
+        },
+      ],
+    });
+  });
+
+  it('should return parsed experimental locations and throttling with `showExperimentalLocations` flag', async () => {
+    const locations = await getServiceLocations({
+      config: {
+        service: {
+          manifestUrl: 'http://local.dev',
+          showExperimentalLocations: true,
+        },
+      },
+      // @ts-ignore
+      logger: {
+        error: jest.fn(),
+      },
+    });
+
+    expect(locations).toEqual({
+      throttling: {
+        [BandwidthLimitKey.DOWNLOAD]: 100,
+        [BandwidthLimitKey.UPLOAD]: 50,
+      },
+      locations: [
+        {
+          geo: {
+            lat: 41.25,
+            lon: -95.86,
+          },
+          id: 'us_central',
+          label: 'US Central',
+          url: 'https://local.dev',
+          isServiceManaged: true,
+          status: LocationStatus.GA,
+        },
+        {
+          geo: {
+            lat: 41.25,
+            lon: -95.86,
+          },
+          id: 'us_east',
+          label: 'US East',
+          url: 'https://local.dev',
+          isServiceManaged: true,
+          status: LocationStatus.EXPERIMENTAL,
         },
       ],
     });

--- a/x-pack/plugins/synthetics/server/synthetics_service/get_service_locations.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/get_service_locations.test.ts
@@ -41,83 +41,137 @@ describe('getServiceLocations', function () {
     },
   });
 
-  it('should return parsed GA locations and throttling', async () => {
-    const locations = await getServiceLocations({
-      config: {
-        service: {
-          manifestUrl: 'http://local.dev',
-        },
-      },
-      // @ts-ignore
-      logger: {
-        error: jest.fn(),
-      },
-    });
-
-    expect(locations).toEqual({
-      throttling: {
-        [BandwidthLimitKey.DOWNLOAD]: 100,
-        [BandwidthLimitKey.UPLOAD]: 50,
-      },
-      locations: [
-        {
-          geo: {
-            lat: 41.25,
-            lon: -95.86,
+  describe('when out of production', () => {
+    it('should return all locations regardless of the `showExperimentalLocations` key', async () => {
+      const locations = await getServiceLocations({
+        isDev: true,
+        config: {
+          service: {
+            manifestUrl: 'http://local.dev',
+            showExperimentalLocations: false,
           },
-          id: 'us_central',
-          label: 'US Central',
-          url: 'https://local.dev',
-          isServiceManaged: true,
-          status: LocationStatus.GA,
         },
-      ],
+        // @ts-ignore
+        logger: {
+          error: jest.fn(),
+        },
+      });
+
+      expect(locations).toEqual({
+        throttling: {
+          [BandwidthLimitKey.DOWNLOAD]: 100,
+          [BandwidthLimitKey.UPLOAD]: 50,
+        },
+        locations: [
+          {
+            geo: {
+              lat: 41.25,
+              lon: -95.86,
+            },
+            id: 'us_central',
+            label: 'US Central',
+            url: 'https://local.dev',
+            isServiceManaged: true,
+            status: LocationStatus.GA,
+          },
+          {
+            geo: {
+              lat: 41.25,
+              lon: -95.86,
+            },
+            id: 'us_east',
+            label: 'US East',
+            url: 'https://local.dev',
+            isServiceManaged: true,
+            status: LocationStatus.EXPERIMENTAL,
+          },
+        ],
+      });
     });
   });
 
-  it('should return parsed experimental locations and throttling with `showExperimentalLocations` flag', async () => {
-    const locations = await getServiceLocations({
-      config: {
-        service: {
-          manifestUrl: 'http://local.dev',
-          showExperimentalLocations: true,
+  describe('when in production', () => {
+    it('should return only GA locations and throttling when `showExperimentalLocations` is set to false', async () => {
+      const locations = await getServiceLocations({
+        isDev: false,
+        config: {
+          service: {
+            manifestUrl: 'http://local.dev',
+            showExperimentalLocations: false,
+          },
         },
-      },
-      // @ts-ignore
-      logger: {
-        error: jest.fn(),
-      },
+        // @ts-ignore
+        logger: {
+          error: jest.fn(),
+        },
+      });
+
+      expect(locations).toEqual({
+        throttling: {
+          [BandwidthLimitKey.DOWNLOAD]: 100,
+          [BandwidthLimitKey.UPLOAD]: 50,
+        },
+        locations: [
+          {
+            geo: {
+              lat: 41.25,
+              lon: -95.86,
+            },
+            id: 'us_central',
+            label: 'US Central',
+            url: 'https://local.dev',
+            isServiceManaged: true,
+            status: LocationStatus.GA,
+          },
+        ],
+      });
     });
 
-    expect(locations).toEqual({
-      throttling: {
-        [BandwidthLimitKey.DOWNLOAD]: 100,
-        [BandwidthLimitKey.UPLOAD]: 50,
-      },
-      locations: [
-        {
-          geo: {
-            lat: 41.25,
-            lon: -95.86,
+    it('should return all locations and throttling when `showExperimentalLocations` flag is set to true', async () => {
+      const locations = await getServiceLocations({
+        isDev: false,
+        config: {
+          service: {
+            manifestUrl: 'http://local.dev',
+            showExperimentalLocations: true,
           },
-          id: 'us_central',
-          label: 'US Central',
-          url: 'https://local.dev',
-          isServiceManaged: true,
-          status: LocationStatus.GA,
         },
-        {
-          geo: {
-            lat: 41.25,
-            lon: -95.86,
+        // @ts-ignore
+        logger: {
+          error: jest.fn(),
+        },
+      });
+
+      expect(locations).toEqual({
+        throttling: {
+          [BandwidthLimitKey.DOWNLOAD]: 100,
+          [BandwidthLimitKey.UPLOAD]: 50,
+        },
+        locations: [
+          {
+            geo: {
+              lat: 41.25,
+              lon: -95.86,
+            },
+            id: 'us_central',
+            label: 'US Central',
+            url: 'https://local.dev',
+            isServiceManaged: true,
+            status: LocationStatus.GA,
           },
-          id: 'us_east',
-          label: 'US East',
-          url: 'https://local.dev',
-          isServiceManaged: true,
-          status: LocationStatus.EXPERIMENTAL,
-        },
-      ],
+          {
+            geo: {
+              lat: 41.25,
+              lon: -95.86,
+            },
+            id: 'us_east',
+            label: 'US East',
+            url: 'https://local.dev',
+            isServiceManaged: true,
+            status: LocationStatus.EXPERIMENTAL,
+          },
+        ],
+      });
     });
   });
 });

--- a/x-pack/plugins/synthetics/server/synthetics_service/get_service_locations.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/get_service_locations.ts
@@ -43,11 +43,12 @@ export async function getServiceLocations(server: UptimeServerSetup) {
       locations: Record<string, ManifestLocation>;
     }>(server.config.service!.manifestUrl!);
 
-    const availableLocations = server.config.service?.showExperimentalLocations
-      ? Object.entries(data.locations)
-      : Object.entries(data.locations).filter(([_, location]) => {
-          return location.status === LocationStatus.GA;
-        });
+    const availableLocations =
+      server.isDev || server.config.service?.showExperimentalLocations
+        ? Object.entries(data.locations)
+        : Object.entries(data.locations).filter(([_, location]) => {
+            return location.status === LocationStatus.GA;
+          });
 
     availableLocations.forEach(([locationId, location]) => {
       locations.push({

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
@@ -13,6 +13,7 @@ import { loggerMock } from '@kbn/core/server/logging/logger.mock';
 import { UptimeServerSetup } from '../legacy_uptime/lib/adapters';
 import axios, { AxiosResponse } from 'axios';
 import times from 'lodash/times';
+import { LocationStatus } from '../../common/runtime_types';
 
 describe('SyntheticsService', () => {
   const mockEsClient = {
@@ -45,6 +46,7 @@ describe('SyntheticsService', () => {
           lon: 0,
         },
         isServiceManaged: true,
+        status: LocationStatus.GA,
       };
     });
 
@@ -122,6 +124,7 @@ describe('SyntheticsService', () => {
         label: 'Local Synthetics Service',
         url: 'http://localhost',
         isServiceManaged: true,
+        status: LocationStatus.EXPERIMENTAL,
       },
     ]);
   });


### PR DESCRIPTION
> As a note for people doing post-FF testing in the future: please ensure you test this on different cloud regions so that we ensure staging and QA do show experimental locations but `production` doesn't.
> For that, you can simply serve a `manifest.json` locally and point the cloud Kibana to it by editing Kibana settings (you'll have to expose it with something like `ngrok`).

## Summary

This PR closes https://github.com/elastic/kibana/issues/131585. It allows the UI to hide `experimental` locations unless the `xpack.uptime.service.showExperimentalLocations` flag is set to `true`.

> ⚠️ Please notice that in order for us to show all locations by default on `staging` we should set this configuration flag to true on clusters provisioned there.

> ⚠️ The cloud team will have to update the manifest to set existing locations to GA once this gets merged.

![Screenshot 2022-05-11 at 15 35 57](https://user-images.githubusercontent.com/6868147/167889067-04b03159-41ff-4f89-a832-6670df7a7438.png)

## How to test this PR

You must test this PR using a Kibana distributable and running from source so that you can test the `NODE_ENV` as a developer and as if you were in production, respectively.

### Testing in dev mode

1. Create a `manifest.json` file with the following contents and place it under a `manifests` folder:
    ```json
    {
      "throttling": {
        "download": 20,
        "upload": 10
      },
      "locations": {
        "Local Synth Node (GA) [MANIFEST]": {
          "url": "https://localhost:10001",
          "geo": {
            "name": "US East [GA]",
            "location": {"lat": 41.25, "lon": -95.86}
          },
          "status": "ga"
        },
        "Local Synth Node (Experimental) [MANIFEST]": {
          "url": "https://localhost:10001",
          "geo": {
            "name": "US West [EXP]",
            "location": {"lat": 41.25, "lon": -95.86}
          },
          "status": "experimental"
        }
      }
    }
    ```
2. Use the `http-server` package to serve your manifest file.
    ```
    $ npx http-server service_manifest --port 8081
    ```
3. Update your Kibana configs so that it fetches the manifest from your local server.
    ```yaml
    # Make sure to comment the `devUrl` key
    # xpack.uptime.service.devUrl: https://localhost:10001
    xpack.uptime.service.manifestUrl: http://localhost:8081/manifest.json
    xpack.uptime.service.showExperimentalLocations: false
    ```
3. Try to create a new monitor and you should see that all locations appear regardless of `showExperimentalLocations` being `false`.


### Testing as if it was in `production`

> ⚠️ This is the most important test to do. It requires you to build a Kibana distributable so that you set `process.env.NODE_ENV` to `production`, and thus can properly test Kibana.
> For that, you will have to:
> 1. Build `dist` bundles
> 2. Run the `non-dev` version of kibana `NODE_ENV=production node --nolazy --inspect scripts/kibana`.

1. Create a `manifest.json` file with the following contents and place it under a `manifests` folder:
    ```json
    {
      "throttling": {
        "download": 20,
        "upload": 10
      },
      "locations": {
        "Local Synth Node (GA) [MANIFEST]": {
          "url": "https://localhost:10001",
          "geo": {
            "name": "US East [GA]",
            "location": {"lat": 41.25, "lon": -95.86}
          },
          "status": "ga"
        },
        "Local Synth Node (Experimental) [MANIFEST]": {
          "url": "https://localhost:10001",
          "geo": {
            "name": "US West [EXP]",
            "location": {"lat": 41.25, "lon": -95.86}
          },
          "status": "experimental"
        }
      }
    }
    ```
2. Use the `http-server` package to serve your manifest file.
    ```
    $ npx http-server service_manifest --port 8081
    ```
3. Update your Kibana configs so that it fetches the manifest from your local server.
    ```yaml
    # Make sure to comment the `devUrl` key
    # xpack.uptime.service.devUrl: https://localhost:10001
    xpack.uptime.service.manifestUrl: http://localhost:8081/manifest.json
    xpack.uptime.service.showExperimentalLocations: false
    ```
5. Try to create a new monitor and you should see that only the `US East [GA]` location appears.
6. Update the `xpack.uptime.service.showExperimentalLocations` key to `true` and ensure that both locations appear and that the `experimental` location has a `Tech Preview` badge.

> ⚠️ The same should happen when editing a monitor.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
    > ⚠️  I don't believe this is necessary, but I'd appreciate it if reviewers could confirm.
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


## Release note

Kibana will only show experimental Synthetic node locations when the `xpack.uptime.service.showExperimentalLocations` flag is set to true.