### PR TITLE
[Security Solution] Make some data fetching hooks state updates atomic

### DIFF
--- a/x-pack/plugins/security_solution/public/common/containers/source/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/source/index.tsx
@@ -8,6 +8,7 @@
 import { isEmpty, isEqual, isUndefined, keyBy, pick } from 'lodash/fp';
 import memoizeOne from 'memoize-one';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
 import type { DataViewBase } from '@kbn/es-query';
 import { Subscription } from 'rxjs';
 
@@ -23,6 +24,7 @@ import { isCompleteResponse, isErrorResponse } from '@kbn/data-plugin/common';
 import { useKibana } from '../../lib/kibana';
 import * as i18n from './translations';
 import { useAppToasts } from '../../hooks/use_app_toasts';
+import { getDataViewStateFromIndexFields } from './use_data_view';
 
 export type { BrowserField, BrowserFields, DocValueFields };
 
@@ -155,19 +157,27 @@ export const useFetchIndex = (
           .subscribe({
             next: (response) => {
               if (isCompleteResponse(response)) {
-                const stringifyIndices = response.indicesExist.sort().join();
+                Promise.resolve().then(() => {
+                  ReactDOM.unstable_batchedUpdates(() => {
+                    const stringifyIndices = response.indicesExist.sort().join();
 
-                previousIndexesName.current = response.indicesExist;
-                setLoading(false);
-                setState({
-                  browserFields: getBrowserFields(stringifyIndices, response.indexFields),
-                  docValueFields: getDocValueFields(stringifyIndices, response.indexFields),
-                  indexes: response.indicesExist,
-                  indexExists: response.indicesExist.length > 0,
-                  indexPatterns: getIndexFields(stringifyIndices, response.indexFields),
+                    previousIndexesName.current = response.indicesExist;
+                    const { browserFields, docValueFields } = getDataViewStateFromIndexFields(
+                      stringifyIndices,
+                      response.indexFields
+                    );
+                    setLoading(false);
+                    setState({
+                      browserFields,
+                      docValueFields,
+                      indexes: response.indicesExist,
+                      indexExists: response.indicesExist.length > 0,
+                      indexPatterns: getIndexFields(stringifyIndices, response.indexFields),
+                    });
+
+                    searchSubscription$.current.unsubscribe();
+                  });
                 });
-
-                searchSubscription$.current.unsubscribe();
               } else if (isErrorResponse(response)) {
                 setLoading(false);
                 addWarning(i18n.ERROR_BEAT_FIELDS);

--- a/x-pack/plugins/security_solution/public/common/containers/source/use_data_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/source/use_data_view.tsx
@@ -47,7 +47,7 @@ interface DataViewInfo {
  * HOT Code path where the fields can be 16087 in length or larger. This is
  * VERY mutatious on purpose to improve the performance of the transform.
  */
-const getDataViewStateFromIndexFields = memoizeOne(
+export const getDataViewStateFromIndexFields = memoizeOne(
   (_title: string, fields: IndexField[]): DataViewInfo => {
     // Adds two dangerous casts to allow for mutations within this function
     type DangerCastForMutation = Record<string, {}>;

--- a/x-pack/plugins/security_solution/public/timelines/containers/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/details/index.tsx
@@ -7,6 +7,7 @@
 
 import { isEmpty } from 'lodash/fp';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
 import deepEqual from 'fast-deep-equal';
 import { Subscription } from 'rxjs';
 
@@ -90,11 +91,15 @@ export const useTimelineEventsDetails = ({
           .subscribe({
             next: (response) => {
               if (isCompleteResponse(response)) {
-                setLoading(false);
-                setTimelineDetailsResponse(response.data || []);
-                setRawEventData(response.rawResponse.hits.hits[0]);
-                setEcsData(response.ecs || null);
-                searchSubscription$.current.unsubscribe();
+                Promise.resolve().then(() => {
+                  ReactDOM.unstable_batchedUpdates(() => {
+                    setLoading(false);
+                    setTimelineDetailsResponse(response.data || []);
+                    setRawEventData(response.rawResponse.hits.hits[0]);
+                    setEcsData(response.ecs || null);
+                    searchSubscription$.current.unsubscribe();
+                  });
+                });
               } else if (isErrorResponse(response)) {
                 setLoading(false);
                 addWarning(i18n.FAIL_TIMELINE_DETAILS);


### PR DESCRIPTION
## Summary

This pr is part of a series of prs intended to make the performance of the detail flyout more performant when used with a large number of fields, tested in the integration branch here https://github.com/elastic/kibana/pull/131452 . An issue exists in React versions less than 18 where use of the set function from useState is only guaranteed to be batched in scopes that are "known" to react, i.e. in the top level of a useCallback/useEffect etc. When nested inside of an Observable subscribe.next or in various other places like a try/catch block, async/await or other patterns, these updates are not guaranteed to run at the same time, or even at all. And when dealing with a large amount of fields, this is very likely to be the case. React has a little known but built in solution for this, ReactDOM.unstable_batchedUpdates, which will cause multiple set functions from useState to be called together when wrapped in this helper function.

https://blog.logrocket.com/simplifying-state-management-in-react-apps-with-batched-updates/

https://medium.com/swlh/react-state-batch-update-b1b61bd28cd2

"...the React team has previously encouraged (and at the time of writing, still do) the use of this API when appropriate..."

![fix_that_thing](https://user-images.githubusercontent.com/56408403/165401662-fdb183f7-c661-4c03-9b2d-b8aee517b2fe.gif)

In the gif above, you can see only 1 api call made when opening the flyout at all times, whereas without this change it's often multiple api calls of the same thing fired off immediately, which are expensive and degrade performance massively.



