### PR TITLE
Minor UI text edits in Cases

### DIFF
--- a/x-pack/plugins/cases/public/common/translations.ts
+++ b/x-pack/plugins/cases/public/common/translations.ts
@@ -148,7 +148,7 @@ export const TAGS_HELP = i18n.translate('xpack.cases.createCase.fieldTagsHelpTex
 });
 
 export const TAGS_EMPTY_ERROR = i18n.translate('xpack.cases.createCase.fieldTagsEmptyError', {
-  defaultMessage: 'A tag must contain at least one non-space character',
+  defaultMessage: 'A tag must contain at least one non-space character.',
 });
 
 export const NO_TAGS = i18n.translate('xpack.cases.caseView.noTags', {
@@ -229,8 +229,7 @@ export const SYNC_ALERTS_SWITCH_LABEL_OFF = i18n.translate(
 );
 
 export const SYNC_ALERTS_HELP = i18n.translate('xpack.cases.components.create.syncAlertHelpText', {
-  defaultMessage:
-    'Enabling this option will sync the status of alerts in this case with the case status.',
+  defaultMessage: 'Enabling this option will sync the alert statuses with the case status.',
 });
 
 export const ALERT = i18n.translate('xpack.cases.common.alertLabel', {
@@ -268,18 +267,18 @@ export const CASE_SUCCESS_TOAST = (title: string) =>
 export const CASE_ALERT_SUCCESS_TOAST = (title: string) =>
   i18n.translate('xpack.cases.actions.caseAlertSuccessToast', {
     values: { title },
-    defaultMessage: 'An alert has been added to "{title}"',
+    defaultMessage: 'An alert was added to "{title}"',
   });
 
 export const CASE_ALERT_SUCCESS_SYNC_TEXT = i18n.translate(
   'xpack.cases.actions.caseAlertSuccessSyncText',
   {
-    defaultMessage: 'Alerts in this case have their status synched with the case status',
+    defaultMessage: 'The alert statuses are synched with the case status.',
   }
 );
 
 export const VIEW_CASE = i18n.translate('xpack.cases.actions.viewCase', {
-  defaultMessage: 'View Case',
+  defaultMessage: 'View case',
 });
 
 export const APP_TITLE = i18n.translate('xpack.cases.common.appTitle', {

--- a/x-pack/plugins/cases/public/common/use_cases_toast.test.tsx
+++ b/x-pack/plugins/cases/public/common/use_cases_toast.test.tsx
@@ -83,7 +83,7 @@ describe('Use cases toast hook', () => {
         theCase: mockCase,
         attachments: [alertComment as SupportedCaseAttachment],
       });
-      validateTitle('An alert has been added to "Another horrible breach!!');
+      validateTitle('An alert was added to "Another horrible breach!!');
     });
 
     it('should display a generic title when called with a non-alert attachament', () => {
@@ -130,7 +130,7 @@ describe('Use cases toast hook', () => {
         theCase: mockCase,
         attachments: [alertComment as SupportedCaseAttachment],
       });
-      validateContent('Alerts in this case have their status synched with the case status');
+      validateContent('The alert statuses are synched with the case status.');
     });
 
     it('renders empty content when called with an alert attachment and sync off', () => {
@@ -144,7 +144,7 @@ describe('Use cases toast hook', () => {
         theCase: { ...mockCase, settings: { ...mockCase.settings, syncAlerts: false } },
         attachments: [alertComment as SupportedCaseAttachment],
       });
-      validateContent('View Case');
+      validateContent('View case');
     });
 
     it('renders a correct successful message content', () => {
@@ -152,7 +152,7 @@ describe('Use cases toast hook', () => {
         <CaseToastSuccessContent content={'my content'} onViewCaseClick={onViewCaseClick} />
       );
       expect(result.getByTestId('toaster-content-sync-text')).toHaveTextContent('my content');
-      expect(result.getByTestId('toaster-content-case-view-link')).toHaveTextContent('View Case');
+      expect(result.getByTestId('toaster-content-case-view-link')).toHaveTextContent('View case');
       expect(onViewCaseClick).not.toHaveBeenCalled();
     });
 
@@ -161,7 +161,7 @@ describe('Use cases toast hook', () => {
         <CaseToastSuccessContent onViewCaseClick={onViewCaseClick} />
       );
       expect(result.queryByTestId('toaster-content-sync-text')).toBeFalsy();
-      expect(result.getByTestId('toaster-content-case-view-link')).toHaveTextContent('View Case');
+      expect(result.getByTestId('toaster-content-case-view-link')).toHaveTextContent('View case');
       expect(onViewCaseClick).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/130958
This PR improves the text in the toast message that appears when you add alerts to cases, per https://elastic.github.io/eui/#/display/toast/guidelines

### Screenshot

Before:

![image](https://user-images.githubusercontent.com/26471269/167943219-62ce597d-7d9d-4426-8015-1700e1bd261c.png)
