### PR TITLE
[Visualize] Fixes metric label font size

### DIFF
--- a/src/plugins/vis_types/metric/public/__snapshots__/to_ast.test.ts.snap
+++ b/src/plugins/vis_types/metric/public/__snapshots__/to_ast.test.ts.snap
@@ -59,6 +59,25 @@ Object {
             "type": "expression",
           },
         ],
+        "labelFont": Array [
+          Object {
+            "chain": Array [
+              Object {
+                "arguments": Object {
+                  "align": Array [
+                    "center",
+                  ],
+                  "size": Array [
+                    "14",
+                  ],
+                },
+                "function": "font",
+                "type": "function",
+              },
+            ],
+            "type": "expression",
+          },
+        ],
         "percentageMode": Array [
           true,
         ],
@@ -124,6 +143,25 @@ Object {
                   ],
                   "weight": Array [
                     "bold",
+                  ],
+                },
+                "function": "font",
+                "type": "function",
+              },
+            ],
+            "type": "expression",
+          },
+        ],
+        "labelFont": Array [
+          Object {
+            "chain": Array [
+              Object {
+                "arguments": Object {
+                  "align": Array [
+                    "center",
+                  ],
+                  "size": Array [
+                    "14",
                   ],
                 },
                 "function": "font",

--- a/src/plugins/vis_types/metric/public/to_ast.ts
+++ b/src/plugins/vis_types/metric/public/to_ast.ts
@@ -83,6 +83,8 @@ export const toExpressionAst: VisToExpressionAst<VisParams> = (vis, params) => {
     )
   );
 
+  metricVis.addArgument('labelFont', buildExpression(`font size="14" align="center"`));
+
   if (colorsRange && colorsRange.length > 1) {
     const stopsWithColors = getStopsWithColorsFromRanges(colorsRange, colorSchema, invertColors);
     const palette = buildExpressionFunction('palette', {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/132019

Fixes a regression from the unification of the metric renderers. The metric label should be significant smaller that the default size of 24. It used to be 14 so I reverted it to this value.
<img width="550" alt="image" src="https://user-images.githubusercontent.com/17003240/168028765-22b18af2-05dc-49f5-80a8-5a78abdccf76.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios