### PR TITLE
TSVB] Chart is failing when the user tries to add a percentile_rank

### DIFF
--- a/src/plugins/vis_types/timeseries/public/application/components/aggs/percentile_rank/percentile_rank.tsx
+++ b/src/plugins/vis_types/timeseries/public/application/components/aggs/percentile_rank/percentile_rank.tsx
@@ -112,7 +112,7 @@ export const PercentileRankAgg = (props: PercentileRankAggProps) => {
             indexPattern={indexPattern}
             value={model.field ?? ''}
             onChange={(value) =>
-              props.onChange({
+              handleChange({
                 field: value?.[0],
               })
             }


### PR DESCRIPTION
Closes: #131999

**Describe the bug:**

1. Open a new TSVB viz, there is always a default first layer (count(
2. Change the first layer aggregation to **percentile rank**
5. Try to add a field
6. Field is not added and I can see an incorrect warning
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/17003240/167792870-2e5c3464-9194-48cb-aae8-9a2450e388ee.png">
8.  Even if I remove the warning I can't make my TSVB chart to work

**Errors in browser console (if relevant):**

<img width="498" alt="image" src="https://user-images.githubusercontent.com/17003240/167792781-e9b32c00-081c-43f4-b305-956fae5c2d3b.png">

**Screens:**

