### PR TITLE
[artifacts] Only upload beats artifacts if they exist

### DIFF
--- a/.buildkite/scripts/steps/artifacts/build.sh
+++ b/.buildkite/scripts/steps/artifacts/build.sh
@@ -25,7 +25,7 @@ buildkite-agent artifact upload "dependencies-$FULL_VERSION.csv.sha512.txt"
 buildkite-agent artifact upload 'i18n/*.json'
 cd -
 
-if [[ -n "$(ls -A .beats 2>/dev/null)"]]; then
+if [ -d .beats ]; then
   cd .beats
   buildkite-agent artifact upload 'metricbeat-*'
   buildkite-agent artifact upload 'filebeat-*'

--- a/.buildkite/scripts/steps/artifacts/build.sh
+++ b/.buildkite/scripts/steps/artifacts/build.sh
@@ -25,7 +25,9 @@ buildkite-agent artifact upload "dependencies-$FULL_VERSION.csv.sha512.txt"
 buildkite-agent artifact upload 'i18n/*.json'
 cd -
 
-cd .beats
-buildkite-agent artifact upload 'metricbeat-*'
-buildkite-agent artifact upload 'filebeat-*'
-cd -
+if [[ -n "$(ls -A .beats 2>/dev/null)"]]; then
+  cd .beats
+  buildkite-agent artifact upload 'metricbeat-*'
+  buildkite-agent artifact upload 'filebeat-*'
+  cd -
+fi


### PR DESCRIPTION
Beats artifacts are downloaded as a side effect  of building the cloud
image.  At times (e.g. a staging build, where we don't have the correct
sha) we may skip the cloud image build and these artifacts will not be
available to upload.