### PR TITLE
[ci] support skip:auto-commit label on CI

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 export KBN_NP_PLUGINS_BUILT=true
 
 echo "--- Build Kibana Distribution"
-if [[ "${GITHUB_PR_LABELS:-}" == *"ci:build-all-platforms"* ]]; then
+if is_pr_with_label "ci:build-all-platforms"; then
   node scripts/build --all-platforms --skip-os-packages
-elif [[ "${GITHUB_PR_LABELS:-}" == *"ci:build-os-packages"* ]]; then
+elif is_pr_with_label "ci:build-os-packages"; then
   node scripts/build --all-platforms --docker-cross-compile
 else
   node scripts/build

--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -41,7 +41,7 @@ export ELASTIC_APM_SERVER_URL=https://kibana-ci-apm.apm.us-central1.gcp.cloud.es
 export ELASTIC_APM_SECRET_TOKEN=7YKhoXsO4MzjhXjx2c
 
 if is_pr; then
-  if [[ "${GITHUB_PR_LABELS:-}" == *"ci:collect-apm"* ]]; then
+  if is_pr_with_label "ci:collect-apm"; then
     export ELASTIC_APM_ACTIVE=true
     export ELASTIC_APM_CONTEXT_PROPAGATION_ONLY=false
   else

--- a/.buildkite/scripts/steps/lint.sh
+++ b/.buildkite/scripts/steps/lint.sh
@@ -11,20 +11,26 @@ checks-reporter-with-killswitch "Lint: stylelint" \
   node scripts/stylelint
 echo "stylelint ✅"
 
+echo '--- Lint: eslint'
 # disable "Exit immediately" mode so that we can run eslint, capture it's exit code, and respond appropriately
 # after possibly commiting fixed files to the repo
 set +e;
-
-echo '--- Lint: eslint'
-checks-reporter-with-killswitch "Lint: eslint" \
+if is_pr && ! is_auto_commit_disabled; then
   node scripts/eslint --no-cache --fix
+else
+  node scripts/eslint --no-cache
+fi
 
 eslint_exit=$?
-
 # re-enable "Exit immediately" mode
 set -e;
 
-check_for_changed_files 'node scripts/eslint --no-cache --fix' true
+desc="node scripts/eslint --no-cache"
+if is_pr && ! is_auto_commit_disabled; then
+  desc="$desc --fix"
+fi
+
+check_for_changed_files "$desc" true
 
 if [[ "${eslint_exit}" != "0" ]]; then
   exit 1

--- a/src/cli_plugin/cli.js
+++ b/src/cli_plugin/cli.js
@@ -23,7 +23,7 @@ program
   );
 
 listCommand(program);
-installCommand(program);
+  installCommand(program);
 removeCommand(program);
 
 program

--- a/src/cli_plugin/cli.js
+++ b/src/cli_plugin/cli.js
@@ -23,7 +23,7 @@ program
   );
 
 listCommand(program);
-  installCommand(program);
+installCommand(program);
 removeCommand(program);
 
 program


### PR DESCRIPTION
We've received some feedback from contributors that the auto-committing coming from CI is annoying and just causes delays in their desired workflows. To assist with that we should support a label for disabling auto-commit features on CI and instead just report the errors like we would on non-PR jobs.

This PR makes checking PR labels a little easier with a `is_pr_with_label` helper, which actually parses the comma separated list of labels in the environment variable, and defines the `ci:no-auto-commit` label as the flag users can use to opt-out of auto-committing on a PR.

Validated that with the label the precommit hook complains about the changes caused by the precommit_hook: https://buildkite.com/elastic/kibana-pull-request/builds/44559#8036e8ae-1f16-47ac-9ae7-d099c1fb326f

Then with the label it auto-fixed: https://buildkite.com/elastic/kibana-pull-request/builds/44565#2dced966-6288-4749-94e1-d5fbbc7f2870/590-603
