### PR TITLE
[DOCS] Fixes data type for fields in find rules API

### DIFF
--- a/docs/api/alerting/find_rules.asciidoc
+++ b/docs/api/alerting/find_rules.asciidoc
@@ -43,7 +43,7 @@ NOTE: Rule `params` are stored as a {ref}/flattened.html[flattened field type] a
   (Optional, array|string) The fields to perform the `simple_query_string` parsed query against.
 
 `fields`::
-  (Optional, array|string) The fields to return in the `attributes` key of the response.
+  (Optional, array of strings) The fields to return in the `attributes` key of the response.
 
 `sort_field`::
   (Optional, string) Sorts the response. Could be a rule field returned in the `attributes` key of the response.


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/132137
