### PR TITLE
[App Search] Add instructions for PDF Extraction to Crawler Overview

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -112,6 +112,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       synonyms: `${APP_SEARCH_DOCS}synonyms-guide.html`,
       webCrawler: `${APP_SEARCH_DOCS}web-crawler.html`,
       webCrawlerEventLogs: `${APP_SEARCH_DOCS}view-web-crawler-events-logs.html`,
+      webCrawlerReference: `${APP_SEARCH_DOCS}web-crawler-reference.html`,
     },
     enterpriseSearch: {
       configuration: `${ENTERPRISE_SEARCH_DOCS}configuration.html`,

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -526,6 +526,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       azureRepo: `${ELASTICSEARCH_DOCS}repository-azure.html`,
       gcsRepo: `${ELASTICSEARCH_DOCS}repository-gcs.html`,
       hdfsRepo: `${PLUGIN_DOCS}repository-hdfs.html`,
+      ingestAttachment: `${PLUGIN_DOCS}ingest-attachment.html`,
       s3Repo: `${ELASTICSEARCH_DOCS}repository-s3.html`,
       snapshotRestoreRepos: `${ELASTICSEARCH_DOCS}snapshots-register-repository.html`,
       mapperSize: `${PLUGIN_DOCS}mapper-size-usage.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -337,6 +337,7 @@ export interface DocLinks {
     azureRepo: string;
     gcsRepo: string;
     hdfsRepo: string;
+    ingestAttachment: string;
     s3Repo: string;
     snapshotRestoreRepos: string;
     mapperSize: string;

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -98,6 +98,7 @@ export interface DocLinks {
     readonly synonyms: string;
     readonly webCrawler: string;
     readonly webCrawlerEventLogs: string;
+    readonly webCrawlerReference: string;
   };
   readonly enterpriseSearch: {
     readonly configuration: string;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -49,7 +49,7 @@ export const CrawlerOverview: React.FC = () => {
         description: (
           <FormattedMessage
             id="xpack.enterpriseSearch.appSearch.crawler.pdfExtractionMessage"
-            defaultMessage="Interested in extracting additional content types? Install the {ingestPluginDocumentationLink} and {depoymentSettingsDocumentationLink}."
+            defaultMessage="Interested in extracting additional content types? Install the {ingestPluginDocumentationLink} and {deploymentSettingsDocumentationLink}."
             values={{
               ingestPluginDocumentationLink: (
                 <EuiLink href={docLinks.pluginsIngestAttachment} target="_blank" external>
@@ -59,14 +59,14 @@ export const CrawlerOverview: React.FC = () => {
                   )}
                 </EuiLink>
               ),
-              depoymentSettingsDocumentationLink: (
+              deploymentSettingsDocumentationLink: (
                 <EuiLink
                   href={`${docLinks.appSearchWebCrawlerReference}#web-crawler-reference-binary-content-extraction`}
                   target="_blank"
                   external
                 >
                   {i18n.translate(
-                    'xpack.enterpriseSearch.appSearch.crawler.depoymentSettingsDocumentationLink',
+                    'xpack.enterpriseSearch.appSearch.crawler.deploymentSettingsDocumentationLink',
                     { defaultMessage: 'review your deployment settings' }
                   )}
                 </EuiLink>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -13,6 +13,9 @@ import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from
 
 import { i18n } from '@kbn/i18n';
 
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { docLinks } from '../../../shared/doc_links';
 import { WEB_CRAWLER_DOCS_URL, WEB_CRAWLER_LOG_DOCS_URL } from '../../routes';
 import { getEngineBreadcrumbs } from '../engine';
 import { AppSearchPageTemplate } from '../layout';
@@ -43,6 +46,34 @@ export const CrawlerOverview: React.FC = () => {
       pageHeader={{
         pageTitle: CRAWLER_TITLE,
         rightSideItems: [<ManageCrawlsPopover />, <CrawlerStatusIndicator />],
+        description: (
+          <FormattedMessage
+            id="xpack.enterpriseSearch.appSearch.crawler.pdfExtractionMessage"
+            defaultMessage="Interested in extracting additional content types? Install the {ingestPluginDocumentationLink} and {depoymentSettingsDocumentationLink}."
+            values={{
+              ingestPluginDocumentationLink: (
+                <EuiLink href={docLinks.pluginsIngestAttachment} target="_blank" external>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.appSearch.crawler.ingestionPluginDocumentationLink',
+                    { defaultMessage: 'Elasticsearch ingest attachment plugin' }
+                  )}
+                </EuiLink>
+              ),
+              depoymentSettingsDocumentationLink: (
+                <EuiLink
+                  href={`${docLinks.appSearchWebCrawlerReference}#web-crawler-reference-binary-content-extraction`}
+                  target="_blank"
+                  external
+                >
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.appSearch.crawler.depoymentSettingsDocumentationLink',
+                    { defaultMessage: 'review your deployment settings' }
+                  )}
+                </EuiLink>
+              ),
+            }}
+          />
+        ),
       }}
       isLoading={dataLoading}
     >

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -58,6 +58,7 @@ class DocLinks {
   public enterpriseSearchUsersAccess: string;
   public kibanaSecurity: string;
   public licenseManagement: string;
+  public pluginsIngestAttachment: string;
   public queryDsl: string;
   public workplaceSearchApiKeys: string;
   public workplaceSearchBox: string;
@@ -138,6 +139,7 @@ class DocLinks {
     this.enterpriseSearchUsersAccess = '';
     this.kibanaSecurity = '';
     this.licenseManagement = '';
+    this.pluginsIngestAttachment = '';
     this.queryDsl = '';
     this.workplaceSearchApiKeys = '';
     this.workplaceSearchBox = '';
@@ -220,6 +222,7 @@ class DocLinks {
     this.enterpriseSearchUsersAccess = docLinks.links.enterpriseSearch.usersAccess;
     this.kibanaSecurity = docLinks.links.kibana.xpackSecurity;
     this.licenseManagement = docLinks.links.enterpriseSearch.licenseManagement;
+    this.pluginsIngestAttachment = docLinks.links.plugins.ingestAttachment;
     this.queryDsl = docLinks.links.query.queryDsl;
     this.workplaceSearchApiKeys = docLinks.links.workplaceSearch.apiKeys;
     this.workplaceSearchBox = docLinks.links.workplaceSearch.box;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -30,6 +30,7 @@ class DocLinks {
   public appSearchSynonyms: string;
   public appSearchWebCrawler: string;
   public appSearchWebCrawlerEventLogs: string;
+  public appSearchWebCrawlerReference: string;
   public clientsGoIndex: string;
   public clientsGuide: string;
   public clientsJavaBasicAuthentication: string;
@@ -111,6 +112,7 @@ class DocLinks {
     this.appSearchSynonyms = '';
     this.appSearchWebCrawler = '';
     this.appSearchWebCrawlerEventLogs = '';
+    this.appSearchWebCrawlerReference = '';
     this.clientsGoIndex = '';
     this.clientsGuide = '';
     this.clientsJavaBasicAuthentication = '';
@@ -194,6 +196,7 @@ class DocLinks {
     this.appSearchSynonyms = docLinks.links.appSearch.synonyms;
     this.appSearchWebCrawler = docLinks.links.appSearch.webCrawler;
     this.appSearchWebCrawlerEventLogs = docLinks.links.appSearch.webCrawlerEventLogs;
+    this.appSearchWebCrawlerReference = docLinks.links.appSearch.webCrawlerReference;
     this.clientsGoIndex = docLinks.links.clients.goIndex;
     this.clientsGuide = docLinks.links.clients.guide;
     this.clientsJavaBasicAuthentication = docLinks.links.clients.javaBasicAuthentication;


### PR DESCRIPTION
## Summary

Adds links to documentation for the Ingest Attachment plugin and App Search Web Crawler through which a user could learn about the web crawler's new PDF extraction capabilities.

The new anchor tag `#web-crawler-reference-binary-content-extraction` for `https://www.elastic.co/guide/en/app-search/current/web-crawler-reference.html` will land in https://github.com/elastic/enterprise-search-pubs/pull/2303

### Screenshots

<img width="1643" alt="image" src="https://user-images.githubusercontent.com/2479295/168155211-fcd062a1-3616-40e6-89f7-dffca3e1f305.png">


https://user-images.githubusercontent.com/2479295/168155226-671f046d-779f-4e7f-a503-3a54fd0bc68a.mov

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
