### PR TITLE
[Cloud Posture] Fix findings search bar example

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
@@ -239,5 +239,5 @@ export const NO_FINDINGS = i18n.translate('xpack.csp.findings.nonFindingsLabel',
 
 export const FINDINGS_SEARCH_PLACEHOLDER = i18n.translate(
   'xpack.csp.findings.searchBar.searchPlaceholder',
-  { defaultMessage: 'Search findings (eg. resource.section : "API Server")' }
+  { defaultMessage: 'Search findings (eg. rule.section.keyword : "API Server" )' }
 );


### PR DESCRIPTION
## Summary
Fixed lousy example in the findings search bar

### Now
![image](https://user-images.githubusercontent.com/51442161/168477065-57b6e2f5-e487-4c56-9d3f-0e8c2221d82d.png)

### Before
![image](https://user-images.githubusercontent.com/51442161/168477088-4648c591-3cf3-477e-9870-ff8619799fa2.png)


