### PR TITLE
[Cloud Posture] fix findings distribution display

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
@@ -8,6 +8,7 @@ import React, { useMemo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import type { DataView } from '@kbn/data-plugin/common';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { number } from 'io-ts';
 import { FindingsTable } from './latest_findings_table';
 import { FindingsSearchBar } from '../layout/findings_search_bar';
 import * as TEST_SUBJECTS from '../test_subjects';
@@ -108,7 +109,8 @@ const getFindingsDistribution = ({
   pageSize,
 }: Record<'currentPageSize' | 'total' | 'passed' | 'failed', number | undefined> &
   Record<'pageIndex' | 'pageSize', number>) => {
-  if (!total || !passed || !failed || !currentPageSize) return;
+  if (!number.is(total) || !number.is(passed) || !number.is(failed) || !number.is(currentPageSize))
+    return;
 
   return {
     total,

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
@@ -47,6 +47,15 @@ export const LatestFindingsContainer = ({ dataView }: { dataView: DataView }) =>
     sort: urlQuery.sort,
   });
 
+  const findingsDistribution = getFindingsDistribution({
+    total: findingsGroupByNone.data?.total,
+    passed: findingsCount.data?.passed,
+    failed: findingsCount.data?.failed,
+    pageIndex: urlQuery.pageIndex,
+    pageSize: urlQuery.pageSize,
+    currentPageSize: findingsGroupByNone.data?.page.length,
+  });
+
   return (
     <div data-test-subj={TEST_SUBJECTS.FINDINGS_CONTAINER}>
       <FindingsSearchBar
@@ -54,18 +63,12 @@ export const LatestFindingsContainer = ({ dataView }: { dataView: DataView }) =>
         setQuery={setUrlQuery}
         query={urlQuery.query}
         filters={urlQuery.filters}
-        loading={findingsGroupByNone.isFetching}
+        loading={findingsCount.isFetching}
       />
       <PageWrapper>
         <LatestFindingsPageTitle />
         <FindingsGroupBySelector type="default" />
-        <FindingsDistributionBar
-          total={findingsGroupByNone.data?.total || 0}
-          passed={findingsCount.data?.passed || 0}
-          failed={findingsCount.data?.failed || 0}
-          pageStart={urlQuery.pageIndex * urlQuery.pageSize + 1} // API index is 0, but UI is 1
-          pageEnd={urlQuery.pageIndex * urlQuery.pageSize + urlQuery.pageSize}
-        />
+        {findingsDistribution && <FindingsDistributionBar {...findingsDistribution} />}
         <EuiSpacer />
         <FindingsTable
           data={findingsGroupByNone.data}
@@ -95,3 +98,23 @@ const LatestFindingsPageTitle = () => (
     />
   </PageTitle>
 );
+
+const getFindingsDistribution = ({
+  total,
+  passed,
+  failed,
+  currentPageSize,
+  pageIndex,
+  pageSize,
+}: Record<'currentPageSize' | 'total' | 'passed' | 'failed', number | undefined> &
+  Record<'pageIndex' | 'pageSize', number>) => {
+  if (!total || !passed || !failed || !currentPageSize) return;
+
+  return {
+    total,
+    passed,
+    failed,
+    pageStart: pageIndex * pageSize + 1,
+    pageEnd: pageIndex * pageSize + currentPageSize,
+  };
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/use_latest_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/use_latest_findings.ts
@@ -75,6 +75,8 @@ export const useLatestFindings = ({ index, query, sort, from, size }: UseFinding
         })
       ),
     {
+      keepPreviousData: true,
+      refetchOnWindowFocus: false,
       select: ({ rawResponse: { hits } }) => ({
         page: hits.hits.map((hit) => hit._source!),
         total: number.is(hits.total) ? hits.total : 0,

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/use_latest_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/use_latest_findings.ts
@@ -76,7 +76,6 @@ export const useLatestFindings = ({ index, query, sort, from, size }: UseFinding
       ),
     {
       keepPreviousData: true,
-      refetchOnWindowFocus: false,
       select: ({ rawResponse: { hits } }) => ({
         page: hits.hits.map((hit) => hit._source!),
         total: number.is(hits.total) ? hits.total : 0,

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_distribution_bar.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_distribution_bar.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useMemo } from 'react';
+import React from 'react';
 import { css } from '@emotion/react';
 import {
   EuiHealth,
@@ -29,35 +29,25 @@ interface Props {
 
 const formatNumber = (value: number) => (value < 1000 ? value : numeral(value).format('0.0a'));
 
-export const FindingsDistributionBar = ({ failed, passed, total, pageEnd, pageStart }: Props) => {
-  const count = useMemo(
-    () =>
-      total
-        ? { total, passed: passed / total, failed: failed / total }
-        : { total: 0, passed: 0, failed: 0 },
-    [total, failed, passed]
-  );
-
-  return (
-    <div>
-      <Counters {...{ failed, passed, total, pageEnd, pageStart }} />
-      <EuiSpacer size="s" />
-      <DistributionBar {...count} />
-    </div>
-  );
-};
+export const FindingsDistributionBar = (props: Props) => (
+  <div>
+    <Counters {...props} />
+    <EuiSpacer size="s" />
+    <DistributionBar {...props} />
+  </div>
+);
 
 const Counters = ({ pageStart, pageEnd, total, failed, passed }: Props) => (
   <EuiFlexGroup justifyContent="spaceBetween">
     <EuiFlexItem>
-      {!!total && <CurrentPageOfTotal pageStart={pageStart} pageEnd={pageEnd} total={total} />}
+      <CurrentPageOfTotal pageStart={pageStart} pageEnd={pageEnd} total={total} />
     </EuiFlexItem>
     <EuiFlexItem
       css={css`
         align-items: flex-end;
       `}
     >
-      {!!total && <PassedFailedCounters passed={passed} failed={failed} />}
+      <PassedFailedCounters passed={passed} failed={failed} />
     </EuiFlexItem>
   </EuiFlexGroup>
 );

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_count.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_count.ts
@@ -48,6 +48,8 @@ export const useFindingsCounter = ({ index, query }: FindingsBaseEsQuery) => {
         })
       ),
     {
+      keepPreviousData: true,
+      refetchOnWindowFocus: false,
       onError: (err) => showErrorToast(toasts, err),
       select: (response) =>
         Object.fromEntries(

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_count.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings_count.ts
@@ -49,7 +49,6 @@ export const useFindingsCounter = ({ index, query }: FindingsBaseEsQuery) => {
       ),
     {
       keepPreviousData: true,
-      refetchOnWindowFocus: false,
       onError: (err) => showErrorToast(toasts, err),
       select: (response) =>
         Object.fromEntries(


### PR DESCRIPTION
## Summary

the `Showing X of Y` text was off for the case where the last page has less items than `rows-per-page` 

this PR fixes it by taking into account the actual page size when doing the calculation. 

