### PR TITLE
[TSVB] Adds formattedLabel only for date fields

### DIFF
--- a/src/plugins/vis_types/timeseries/server/lib/vis_data/helpers/get_splits.test.ts
+++ b/src/plugins/vis_types/timeseries/server/lib/vis_data/helpers/get_splits.test.ts
@@ -232,6 +232,72 @@ describe('getSplits(resp, panel, series)', () => {
     ]);
   });
 
+  test('should return a splits for terms group without labelFormatted for multi fields terms aggregation', async () => {
+    const resp = {
+      aggregations: {
+        SERIES: {
+          buckets: [
+            {
+              key: [12, '4107'],
+              key_as_string: '12|4107',
+              timeseries: { buckets: [] },
+              SIBAGG: { value: 1 },
+            },
+            {
+              key: [12, '4108'],
+              key_as_string: '12|4108',
+              timeseries: { buckets: [] },
+              SIBAGG: { value: 2 },
+            },
+          ],
+          meta: { bucketSize: 10 },
+        },
+      },
+    };
+    const series = {
+      id: 'SERIES',
+      label: '--{{key}}--',
+      color: '#F00',
+      split_mode: 'terms',
+      terms_field: ['my_text', 'my_number'],
+      terms_size: 10,
+      metrics: [
+        { id: 'AVG', type: 'avg', field: 'cpu' },
+        { id: 'SIBAGG', type: 'avg_bucket', field: 'AVG' },
+      ],
+    } as unknown as Series;
+    const panel = { type: 'top_n' } as Panel;
+
+    expect(await getSplits(resp, panel, series, undefined, () => [])).toEqual([
+      {
+        id: 'SERIES╰┄►12,4107',
+        key: [12, '4107'],
+        key_as_string: '12|4107',
+        label: '--12,4107--',
+        labelFormatted: '',
+        meta: { bucketSize: 10 },
+        color: 'rgb(255, 0, 0)',
+        splitByLabel: 'Overall Average of Average of cpu',
+        termsSplitKey: [12, '4107'],
+        timeseries: { buckets: [] },
+        SIBAGG: { value: 1 },
+      },
+      {
+        id: 'SERIES╰┄►12,4108',
+        key: [12, '4108'],
+        key_as_string: '12|4108',
+        label: '--12,4108--',
+        labelFormatted: '',
+        meta: { bucketSize: 10 },
+        color: 'rgb(255, 0, 0)',
+        splitByLabel: 'Overall Average of Average of cpu',
+        termsSplitKey: [12, '4108'],
+        timeseries: { buckets: [] },
+        SIBAGG: { value: 2 },
+      },
+    ]);
+  });
+
   test('should return a splits for filters group bys', async () => {
     const resp = {
       aggregations: {

--- a/src/plugins/vis_types/timeseries/server/lib/vis_data/helpers/get_splits.ts
+++ b/src/plugins/vis_types/timeseries/server/lib/vis_data/helpers/get_splits.ts
@@ -7,7 +7,7 @@
  */
 
 import Color from 'color';
-import { get, isPlainObject } from 'lodash';
+import { get, isArray, isPlainObject } from 'lodash';
 import { overwrite } from '.';
 
 import { calculateLabel } from '../../../../common/calculate_label';
@@ -68,11 +68,15 @@ export async function getSplits<TRawResponse = unknown, TMeta extends BaseMeta =
             ...bucket.column_filter,
           };
         }
+        const isMultiFieldsTerms = isArray(bucket.key);
 
         bucket.id = `${series.id}${SERIES_SEPARATOR}${bucket.key}`;
         bucket.splitByLabel = splitByLabel;
         bucket.label = formatKey(bucket.key, series);
-        bucket.labelFormatted = bucket.key_as_string ? formatKey(bucket.key_as_string, series) : '';
+        bucket.labelFormatted =
+          !isMultiFieldsTerms && bucket.key_as_string
+            ? formatKey(bucket.key_as_string, series)
+            : '';
         bucket.color = color.string();
         bucket.meta = meta;
         bucket.termsSplitKey = bucket.key;

--- a/src/plugins/vis_types/timeseries/server/lib/vis_data/response_processors/series/format_label.ts
+++ b/src/plugins/vis_types/timeseries/server/lib/vis_data/response_processors/series/format_label.ts
@@ -7,6 +7,7 @@
  */
 
 import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
+import { KBN_FIELD_TYPES } from '@kbn/field-types';
 import { BUCKET_TYPES, PANEL_TYPES, TSVB_METRIC_TYPES } from '../../../../../common/enums';
 import {
   createCachedFieldValueFormatter,
@@ -57,6 +58,10 @@ export function formatLabel(
         fieldFormatService
       );
 
+      const termsFieldType = fetchedIndex?.indexPattern?.fields.find(
+        ({ name }) => name === termsField
+      )?.type;
+
       results
         .filter(({ seriesId }) => series.id === seriesId)
         .forEach((item) => {
@@ -66,6 +71,9 @@ export function formatLabel(
 
           if (formatted) {
             item.label = formatted;
+          }
+
+          if (formatted && termsFieldType === KBN_FIELD_TYPES.DATE) {
             item.labelFormatted = formatted;
           }
         });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/132208

It fixes the problem with keyword fields (that they are numeric) appear with an invalid date.

You can replicate the problem with the instructions given on the issue.

Now the same chart is rendered correctly.

<img width="1272" alt="image" src="https://user-images.githubusercontent.com/17003240/168561954-a387c79f-7720-47e1-929e-9e86f78e2e3f.png">


### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios