### PR TITLE
[Cloud Posture] findings flyout changes

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
@@ -29,16 +29,16 @@ type Accordion = Pick<EuiAccordionProps, 'title' | 'id' | 'initialIsOpen'> &
 
 const getDetailsList = (data: CspFinding) => [
   {
+    title: TEXT.RULE_NAME,
+    description: data.rule.name,
+  },
+  {
     title: TEXT.EVALUATED_AT,
     description: moment(data['@timestamp']).format('MMMM D, YYYY @ HH:mm:ss.SSS'),
   },
   {
     title: TEXT.RESOURCE_NAME,
     description: data.resource.name,
-  },
-  {
-    title: TEXT.RULE_NAME,
-    description: data.rule.name,
   },
   {
     title: TEXT.FRAMEWORK_SOURCES,
@@ -127,7 +127,7 @@ export const OverviewTab = ({ data }: { data: CspFinding }) => {
                   <strong>{accordion.title}</strong>
                 </EuiText>
               }
-              arrowDisplay="right"
+              arrowDisplay="left"
               initialIsOpen={accordion.initialIsOpen}
             >
               <EuiSpacer size="m" />

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/resource_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/resource_tab.tsx
@@ -80,7 +80,7 @@ export const ResourceTab = ({ data }: { data: CspFinding }) => {
                   <strong>{accordion.title}</strong>
                 </EuiText>
               }
-              arrowDisplay="right"
+              arrowDisplay="left"
               initialIsOpen
             >
               <EuiDescriptionList


### PR DESCRIPTION
## Summary

- Rule name is now displayed first
- Arrows for collapsable sections were moved to the left

![image](https://user-images.githubusercontent.com/51442161/168580929-fbf713e9-6fe1-4c90-a3be-6aa8c927f593.png)