### PR TITLE
[Cloud Posture] add resource findings page flyout

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_table.tsx
@@ -4,20 +4,26 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
-import { EuiEmptyPrompt, EuiBasicTable, CriteriaWithPagination, Pagination } from '@elastic/eui';
+import React, { useMemo, useState } from 'react';
+import {
+  EuiEmptyPrompt,
+  EuiBasicTable,
+  CriteriaWithPagination,
+  Pagination,
+  EuiBasicTableColumn,
+  EuiTableActionsColumnType,
+} from '@elastic/eui';
 import { extractErrorMessage } from '../../../../../common/utils/helpers';
 import * as TEXT from '../../translations';
 import type { ResourceFindingsResult } from './use_resource_findings';
-import { getFindingsColumns } from '../../layout/findings_layout';
+import { getExpandColumn, getFindingsColumns } from '../../layout/findings_layout';
 import type { CspFinding } from '../../types';
+import { FindingsRuleFlyout } from '../../findings_flyout/findings_flyout';
 
 interface Props extends ResourceFindingsResult {
   pagination: Pagination;
   setTableOptions(options: CriteriaWithPagination<CspFinding>): void;
 }
-
-const columns = getFindingsColumns();
 
 const ResourceFindingsTableComponent = ({
   error,
@@ -26,18 +32,36 @@ const ResourceFindingsTableComponent = ({
   pagination,
   setTableOptions,
 }: Props) => {
+  const [selectedFinding, setSelectedFinding] = useState<CspFinding>();
+
+  const columns: [
+    EuiTableActionsColumnType<CspFinding>,
+    ...Array<EuiBasicTableColumn<CspFinding>>
+  ] = useMemo(
+    () => [getExpandColumn<CspFinding>({ onClick: setSelectedFinding }), ...getFindingsColumns()],
+    []
+  );
+
   if (!loading && !data?.page.length)
     return <EuiEmptyPrompt iconType="logoKibana" title={<h2>{TEXT.NO_FINDINGS}</h2>} />;
 
   return (
-    <EuiBasicTable
-      loading={loading}
-      error={error ? extractErrorMessage(error) : undefined}
-      items={data?.page || []}
-      columns={columns}
-      onChange={setTableOptions}
-      pagination={pagination}
-    />
+    <>
+      <EuiBasicTable
+        loading={loading}
+        error={error ? extractErrorMessage(error) : undefined}
+        items={data?.page || []}
+        columns={columns}
+        onChange={setTableOptions}
+        pagination={pagination}
+      />
+      {selectedFinding && (
+        <FindingsRuleFlyout
+          findings={selectedFinding}
+          onClose={() => setSelectedFinding(undefined)}
+        />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

this PR adds the `Findings` flyout to the `resource-findings` table.

the flyout is the same one as we use for the `group-by-none` page. 


