### PR TITLE
[Actionable Observability]130374 use shared execution history table

### DIFF
--- a/x-pack/plugins/observability/public/pages/rule_details/index.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/index.tsx
@@ -23,6 +23,7 @@ import {
   EuiHorizontalRule,
   EuiTabbedContent,
   EuiEmptyPrompt,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 
 import {
@@ -33,9 +34,11 @@ import {
   deleteRules,
   useLoadRuleTypes,
   RuleType,
+  RuleEventLogListProps,
 } from '@kbn/triggers-actions-ui-plugin/public';
 // TODO: use a Delete modal from triggersActionUI when it's sharable
 import { ALERTS_FEATURE_ID } from '@kbn/alerting-plugin/common';
+
 import { DeleteModalConfirmation } from '../rules/components/delete_modal_confirmation';
 import { CenterJustifiedSpinner } from '../rules/components/center_justified_spinner';
 import { getHealthColor, OBSERVABILITY_SOLUTIONS } from '../rules/config';
@@ -63,7 +66,12 @@ import {
 export function RuleDetailsPage() {
   const {
     http,
-    triggersActionsUi: { ruleTypeRegistry, getRuleStatusDropdown, getEditAlertFlyout },
+    triggersActionsUi: {
+      ruleTypeRegistry,
+      getRuleStatusDropdown,
+      getEditAlertFlyout,
+      getRuleEventLogList,
+    },
     application: { capabilities, navigateToUrl },
     notifications: { toasts },
   } = useKibana().services;
@@ -163,7 +171,13 @@ export function RuleDetailsPage() {
         defaultMessage: 'Execution history',
       }),
       'data-test-subj': 'eventLogListTab',
-      content: <EuiText>Execution history</EuiText>,
+      content: rule ? (
+        getRuleEventLogList({
+          rule,
+        } as RuleEventLogListProps)
+      ) : (
+        <EuiLoadingSpinner size="m" />
+      ),
     },
     {
       id: ALERT_LIST_TAB,

--- a/x-pack/plugins/triggers_actions_ui/public/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/index.ts
@@ -37,6 +37,7 @@ export type {
   RuleSummary,
   AlertStatus,
   AlertsTableConfigurationRegistryContract,
+  RuleEventLogListProps,
 } from './types';
 
 export {


### PR DESCRIPTION
## Summary

Depends on #130330 
Fixes #130374

From triggresActionsUi use the execution history table on the rule details page.


