### PR TITLE
[SecuritySolution] Use correct field in filters and investigate in timeline buttons

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
@@ -136,7 +136,11 @@ function getFieldsByRuleType(ruleType?: string): EventSummaryField[] {
     case 'threshold':
       return [
         { id: THRESHOLD_COUNT, label: ALERTS_HEADERS_THRESHOLD_COUNT },
-        { id: THRESHOLD_TERMS_FIELD, label: ALERTS_HEADERS_THRESHOLD_TERMS },
+        {
+          id: THRESHOLD_TERMS_FIELD,
+          overrideField: THRESHOLD_TERMS_VALUE,
+          label: ALERTS_HEADERS_THRESHOLD_TERMS,
+        },
         {
           id: THRESHOLD_CARDINALITY_FIELD,
           label: ALERTS_HEADERS_THRESHOLD_CARDINALITY,


### PR DESCRIPTION
## Summary

We were using the wrong field for filter- and investigate in timeline-buttons in the highlighted field table. Instead of filtering by `kibana.alert.threshold_result.terms.field: explorer.exe` , the generated filters should be `kibana.alert.threshold_result.terms.value: explorer.exe`. This faulty behaviour was detected in https://github.com/elastic/kibana/issues/132101.

https://user-images.githubusercontent.com/68591/168620621-4e2af17f-dcc7-46f1-97f3-031ee01b3e83.mov

