### PR TITLE
Solution nav add flex column styles

### DIFF
--- a/packages/kbn-shared-ux-components/src/page_template/solution_nav/solution_nav.scss
+++ b/packages/kbn-shared-ux-components/src/page_template/solution_nav/solution_nav.scss
@@ -18,7 +18,7 @@ $euiSideNavEmphasizedBackgroundColor: transparentize($euiColorLightShade, .7);
   .kbnPageTemplateSolutionNav__avatar {
     margin-right: $euiSize;
   }
-  
+
   display: flex;
   flex-direction: column;
 }

--- a/packages/kbn-shared-ux-components/src/page_template/solution_nav/solution_nav.scss
+++ b/packages/kbn-shared-ux-components/src/page_template/solution_nav/solution_nav.scss
@@ -18,6 +18,9 @@ $euiSideNavEmphasizedBackgroundColor: transparentize($euiColorLightShade, .7);
   .kbnPageTemplateSolutionNav__avatar {
     margin-right: $euiSize;
   }
+  
+  display: flex;
+  flex-direction: column;
 }
 
 .kbnPageTemplateSolutionNav--hidden {

--- a/packages/kbn-shared-ux-components/src/page_template/solution_nav/solution_nav.scss
+++ b/packages/kbn-shared-ux-components/src/page_template/solution_nav/solution_nav.scss
@@ -10,6 +10,9 @@ $euiSideNavEmphasizedBackgroundColor: transparentize($euiColorLightShade, .7);
   @include euiSideNavEmbellish;
   @include euiYScroll;
 
+  display: flex;
+  flex-direction: column;
+
   @include euiBreakpoint('m' ,'l', 'xl') {
     width: 248px;
     padding: $euiSizeL;
@@ -18,9 +21,6 @@ $euiSideNavEmphasizedBackgroundColor: transparentize($euiColorLightShade, .7);
   .kbnPageTemplateSolutionNav__avatar {
     margin-right: $euiSize;
   }
-
-  display: flex;
-  flex-direction: column;
 }
 
 .kbnPageTemplateSolutionNav--hidden {


### PR DESCRIPTION
## Summary

This change is needed by https://github.com/elastic/kibana/issues/130023

It will be used in this PR https://github.com/elastic/kibana/pull/132210

The new Security Solution side nav needs to place some items at the bottom of the container, this change is needed to position them correctly. This style change is unnoticeable for the rest of the integrations.
