### PR TITLE
[Fleet] Add link to installation docs in Fleet Server instructions

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/install_fleet_server.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/install_fleet_server.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 
 import type { EuiStepProps } from '@elastic/eui';
-import { EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
@@ -84,7 +84,21 @@ const InstallFleetServerStepContent: React.FunctionComponent<{
       <EuiText>
         <FormattedMessage
           id="xpack.fleet.fleetServerFlyout.installFleetServerInstructions"
-          defaultMessage="Install Fleet Server agent on a centralized host so that other hosts you wish to monitor can connect to it. In production, we recommend using one or more dedicated hosts. "
+          defaultMessage="Install Fleet Server agent on a centralized host so that other hosts you wish to monitor can connect to it. In production, we recommend using one or more dedicated hosts. For additional guidance, see our {installationLink}."
+          values={{
+            installationLink: (
+              <EuiLink
+                target="_blank"
+                external
+                href="https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html"
+              >
+                <FormattedMessage
+                  id="xpack.fleet.enrollmentInstructions.installationMessage.link"
+                  defaultMessage="installation docs"
+                />
+              </EuiLink>
+            ),
+          }}
         />
       </EuiText>
 

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/install_fleet_server.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/install_fleet_server.tsx
@@ -13,7 +13,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import type { PLATFORM_TYPE } from '../../../hooks';
-import { useDefaultOutput, useKibanaVersion } from '../../../hooks';
+import { useStartServices, useDefaultOutput, useKibanaVersion } from '../../../hooks';
 
 import { PlatformSelector } from '../..';
 
@@ -58,6 +58,7 @@ const InstallFleetServerStepContent: React.FunctionComponent<{
   fleetServerPolicyId?: string;
   deploymentMode: DeploymentMode;
 }> = ({ serviceToken, fleetServerHost, fleetServerPolicyId, deploymentMode }) => {
+  const { docLinks } = useStartServices();
   const kibanaVersion = useKibanaVersion();
   const { output } = useDefaultOutput();
 
@@ -87,11 +88,7 @@ const InstallFleetServerStepContent: React.FunctionComponent<{
           defaultMessage="Install Fleet Server agent on a centralized host so that other hosts you wish to monitor can connect to it. In production, we recommend using one or more dedicated hosts. For additional guidance, see our {installationLink}."
           values={{
             installationLink: (
-              <EuiLink
-                target="_blank"
-                external
-                href="https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html"
-              >
+              <EuiLink target="_blank" external href={docLinks.links.fleet.installElasticAgent}>
                 <FormattedMessage
                   id="xpack.fleet.enrollmentInstructions.installationMessage.link"
                   defaultMessage="installation docs"

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/installation_message.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/installation_message.tsx
@@ -12,7 +12,7 @@ import semverMajor from 'semver/functions/major';
 import semverMinor from 'semver/functions/minor';
 import semverPatch from 'semver/functions/patch';
 
-import { useKibanaVersion } from '../../hooks';
+import { useKibanaVersion, useStartServices } from '../../hooks';
 
 import type { K8sMode } from './types';
 
@@ -21,6 +21,7 @@ interface Props {
 }
 
 export const InstallationMessage: React.FunctionComponent<Props> = ({ isK8s }) => {
+  const { docLinks } = useStartServices();
   const kibanaVersion = useKibanaVersion();
   const kibanaVersionURLString = useMemo(
     () =>
@@ -54,11 +55,7 @@ export const InstallationMessage: React.FunctionComponent<Props> = ({ isK8s }) =
                 </EuiLink>
               ),
               installationLink: (
-                <EuiLink
-                  target="_blank"
-                  external
-                  href="https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html"
-                >
+                <EuiLink target="_blank" external href={docLinks.links.fleet.installElasticAgent}>
                   <FormattedMessage
                     id="xpack.fleet.enrollmentInstructions.installationMessage.link"
                     defaultMessage="installation docs"


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/130729

Adds a link to the Elastic Agent [installation docs](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html) to the Fleet Server instructions UI. 

The motivation here comes from exposing the new options around tagging agents to users both when they add plain agents as well as Fleet Server agents.

![image](https://user-images.githubusercontent.com/6766512/168652108-16ac9315-c696-4b31-a6bf-b29572334ffa.png)
