### PR TITLE
[Fleet] Swap Fleet Server tabs to `EuiButtonGroup`

### DIFF
--- a/x-pack/plugins/fleet/cypress/integration/fleet_startup.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/fleet_startup.spec.ts
@@ -80,6 +80,11 @@ describe('Fleet startup', () => {
       cy.getBySel('fleetServerFlyoutTab-advanced').click();
       cy.getBySel('createFleetServerPolicyBtn').click();
 
+      // Wait until the success callout is shown before navigating away
+      cy.getBySel('agentPolicyCreateStatusCallOut')
+        .should('exist')
+        .and('have.class', 'euiCallOut--success');
+
       // verify policy is created and has fleet server and system package
       verifyPolicy('Fleet Server policy 1', ['Fleet Server', 'System']);
 
@@ -90,7 +95,10 @@ describe('Fleet startup', () => {
       cy.getBySel('agentPolicyDropdown');
 
       // verify fleet server enroll command contains created policy id
-      cy.getBySel('fleetServerHostInput').type('https://localhost:8220');
+      cy.getBySel('fleetServerHostInput')
+        .getBySel('comboBoxSearchInput')
+        .type('https://localhost:8220');
+
       cy.getBySel('fleetServerAddHostBtn').click();
       cy.getBySel('fleetServerGenerateServiceTokenBtn').click();
       cy.get('.euiCodeBlock__code').contains('--fleet-server-policy=fleet-server-policy');

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/index.tsx
@@ -108,9 +108,7 @@ const Header: React.FunctionComponent<{
         options={tabs}
         idSelected={currentTabId}
         onChange={(id) => onTabClick(id)}
-        css={`
-          max-width: 500px;
-        `}
+        style={{ maxWidth: '500px' }}
       />
     </>
   );

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/index.tsx
@@ -49,7 +49,7 @@ const useFleetServerTabs = () => {
     id: 'advanced',
     label: 'Advanced',
     content: <AdvancedTab />,
-    'data-test-subj': 'fleetServerFlyoutTab-advancedStart',
+    'data-test-subj': 'fleetServerFlyoutTab-advanced',
   };
 
   const currentTabContent =

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/index.tsx
@@ -7,14 +7,13 @@
 
 import React, { useState } from 'react';
 import {
+  EuiButtonGroup,
   EuiFlexGroup,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiLink,
   EuiSpacer,
-  EuiTab,
-  EuiTabs,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
@@ -41,14 +40,16 @@ const useFleetServerTabs = () => {
 
   const quickStartTab = {
     id: 'quickStart',
-    name: 'Quick Start',
+    label: 'Quick Start',
     content: <QuickStartTab />,
+    'data-test-subj': 'fleetServerFlyoutTab-quickStart',
   };
 
   const advancedTab = {
     id: 'advanced',
-    name: 'Advanced',
+    label: 'Advanced',
     content: <AdvancedTab />,
+    'data-test-subj': 'fleetServerFlyoutTab-advancedStart',
   };
 
   const currentTabContent =
@@ -60,7 +61,7 @@ const useFleetServerTabs = () => {
 const Header: React.FunctionComponent<{
   isFlyout?: boolean;
   currentTab: string;
-  tabs: Array<{ id: string; name: string; content: React.ReactNode }>;
+  tabs: Array<{ id: string; label: string; content: React.ReactNode }>;
   onTabClick: (id: string) => void;
 }> = ({ isFlyout = false, currentTab: currentTabId, tabs, onTabClick }) => {
   const { docLinks } = useStartServices();
@@ -99,21 +100,18 @@ const Header: React.FunctionComponent<{
         />
       </EuiText>
 
-      <EuiSpacer size="m" />
+      <EuiSpacer size="xl" />
 
-      <EuiTabs style={{ marginBottom: isFlyout ? '-25px' : '' }}>
-        {tabs.map((tab) => (
-          <EuiTab
-            key={`fleetServerFlyoutTab-${tab.id}`}
-            data-test-subj={`fleetServerFlyoutTab-${tab.id}`}
-            id={tab.id}
-            isSelected={tab.id === currentTabId}
-            onClick={() => onTabClick(tab.id)}
-          >
-            {tab.name}
-          </EuiTab>
-        ))}
-      </EuiTabs>
+      <EuiButtonGroup
+        legend="Fleet Server instructions"
+        isFullWidth
+        options={tabs}
+        idSelected={currentTabId}
+        onChange={(id) => onTabClick(id)}
+        css={`
+          max-width: 500px;
+        `}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Summary

Fixes #130888

Convert `EuiTabs` UI in Fleet Server instructions/flyout to `EuiButtonGroup` to avoid "double tab" layout issue.

![image](https://user-images.githubusercontent.com/6766512/168659638-9b08252c-9dbb-4f52-b995-6c3ed760d9d0.png)

