### PR TITLE
Fix bug in which polling options for 'Data streams' option weren't appearing in Console Settings modal

### DIFF
--- a/src/plugins/console/public/application/components/settings_modal.tsx
+++ b/src/plugins/console/public/application/components/settings_modal.tsx
@@ -169,7 +169,7 @@ export function DevToolsSettingsModal(props: Props) {
 
   // It only makes sense to show polling options if the user needs to fetch any data.
   const pollingFields =
-    fields || indices || templates ? (
+    fields || indices || templates || dataStreams ? (
       <Fragment>
         <EuiFormRow
           label={


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1238659/168662612-7618e88e-3a53-4d7a-adca-cd4e41d76d4c.png)

After:

![image](https://user-images.githubusercontent.com/1238659/168662626-3eeaafd1-e429-43b1-9eee-6e0b79339046.png)
