### PR TITLE
Update kibana upgrade assistant doc

### DIFF
--- a/docs/management/upgrade-assistant/index.asciidoc
+++ b/docs/management/upgrade-assistant/index.asciidoc
@@ -10,7 +10,7 @@ The assistant identifies deprecated settings in your configuration,
 enables you to see if you are using deprecated features,
 and guides you through the process of resolving issues.
 
-IMPORTANT: To upgrade to 8.0 or later, **you must first upgrade to {version}**.
+IMPORTANT: To upgrade to 8.0 or later, **you must first upgrade to {prev-major-last}**.
 
 If you have indices that were created prior to 7.0,
 you can use the assistant to reindex them so they can be accessed from 8.0. 


### PR DESCRIPTION
**Description:**
Currently we use major.minor.patch version in kibana upgrade assistant doc:
https://www.elastic.co/guide/en/kibana/7.17/upgrade-assistant.html
> To upgrade to 8.0 or later, you must first upgrade to 7.17.3.

But per the following facts, it's not 100% correct and causing confusion:

- Patch version should not be considered, per Elastic Stack doc [here](https://www.elastic.co/guide/en/elastic-stack/8.2/upgrading-elastic-stack.html#prepare-to-upgrade)
```
To upgrade to 8.2.0 from 7.16 or earlier, you must first upgrade to 7.17.
```

- Upgrade assistant doesn't actually check the patch version if it's already on 7.17.x

We should keep the doc aligned to the real behavior of upgrade assistant, unless it's a bug in kibana upgrade assistant and Elastic Stack side doc.

@JohannesMahne 