### PR TITLE
[Workplace Search] Fix error loading connector config data on Source Settings view

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
@@ -72,7 +72,6 @@ export const SourceSettings: React.FC = () => {
     setStagedPrivateKey,
     updateContentSourceConfiguration,
   } = useActions(SourceLogic);
-  const { getSourceConfigData } = useActions(AddSourceLogic);
 
   const {
     contentSource: { name, id, serviceType, isOauth1, secret },
@@ -81,8 +80,12 @@ export const SourceSettings: React.FC = () => {
     isConfigurationUpdateButtonLoading,
   } = useValues(SourceLogic);
 
+  const addSourceLogic = AddSourceLogic({ serviceType });
+  const { getSourceConfigData } = useActions(addSourceLogic);
+
   const {
     sourceConfigData: { configuredFields },
+    dataLoading,
   } = useValues(AddSourceLogic);
 
   const { isOrganization } = useValues(AppLogic);
@@ -161,7 +164,11 @@ export const SourceSettings: React.FC = () => {
   );
 
   return (
-    <SourceLayout pageChrome={[NAV.SETTINGS]} pageViewTelemetry="source_settings">
+    <SourceLayout
+      pageChrome={[NAV.SETTINGS]}
+      pageViewTelemetry="source_settings"
+      isLoading={dataLoading}
+    >
       <ViewContentHeader title={SOURCE_SETTINGS_HEADING} />
       <ContentSection title={SOURCE_SETTINGS_TITLE} description={SOURCE_SETTINGS_DESCRIPTION}>
         <form onSubmit={submitNameChange}>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
@@ -80,6 +80,10 @@ export const SourceSettings: React.FC = () => {
     isConfigurationUpdateButtonLoading,
   } = useValues(SourceLogic);
 
+  // Even though SourceLogic.values.contentSource.serviceType is retrieved async
+  // by SourceLogic, it will always be defined by the time this view is rendered
+  // because it is not displayed until SourceLogic has retrieved the content source and
+  // SourceLogic.values.dataLoading === false
   const addSourceLogic = AddSourceLogic({ serviceType });
   const { getSourceConfigData } = useActions(addSourceLogic);
 


### PR DESCRIPTION
## Summary

The view was not setting a `serviceType` prop for `AddSourceLogic` so when `AddSourceLogic.actions.getSourceConfigData()` was being called `serviceType` was undefined.

Introduced in https://github.com/elastic/kibana/pull/131802/

