### PR TITLE
[SharedUX] NoDataPage: open docs link in a new tab

### DIFF
--- a/packages/kbn-shared-ux-components/src/empty_state/kibana_no_data_page.stories.tsx
+++ b/packages/kbn-shared-ux-components/src/empty_state/kibana_no_data_page.stories.tsx
@@ -32,7 +32,7 @@ const noDataConfig = {
       title: 'Add Integrations',
     },
   },
-  docsLink: 'http://www.docs.com',
+  docsLink: 'http://docs.elastic.dev',
 };
 
 type Params = Pick<NoDataPageProps, 'solution' | 'logo'> & DataServiceFactoryConfig;

--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/__snapshots__/no_data_page.test.tsx.snap
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/__snapshots__/no_data_page.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`NoDataPage render 1`] = `
             Object {
               "link": <EuiLink
                 href="test"
+                target="_blank"
               >
                 <FormattedMessage
                   defaultMessage="learn more"

--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_page.tsx
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_page.tsx
@@ -58,7 +58,7 @@ export const NoDataPage: FunctionComponent<NoDataPageProps> = ({
               values={{
                 solution,
                 link: (
-                  <EuiLink href={docsLink}>
+                  <EuiLink href={docsLink} target="_blank">
                     <FormattedMessage
                       id="sharedUXComponents.noDataPage.intro.link"
                       defaultMessage="learn more"


### PR DESCRIPTION
## Summary

It was pointed [here](https://github.com/elastic/kibana/pull/131965#pullrequestreview-975275231) that we should be opening a docs link in a new tab, and I agree with that. 
This PR adds a change to open docs link in a new tab to `NoDataPage` component.


### Checklist

Delete any items that are not applicable to this PR.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
