### PR TITLE
[APM] Fix cypress `—open`

### DIFF
--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -32,6 +32,7 @@ disabled:
   - x-pack/test/security_solution_cypress/upgrade_config.ts
   - x-pack/test/security_solution_cypress/visual_config.ts
   - x-pack/test/functional_enterprise_search/with_host_configured.config.ts
+  - x-pack/plugins/apm/ftr_e2e/ftr_config_open.ts
   - x-pack/plugins/apm/ftr_e2e/ftr_config_run.ts
   - x-pack/plugins/apm/ftr_e2e/ftr_config.ts
 


### PR DESCRIPTION
Running:

```
node x-pack/plugins/apm/scripts/test/e2e.js --open
```

Gives the error:
```
Running "node ../../../../scripts/functional_test_runner --config ./ftr_config_open.ts   --kibana-install-dir ''"
 debg KIBANA_CI_STATS_CONFIG environment variable not found, disabling CiStatsReporter
ERROR Refusing to load FTR Config at [x-pack/plugins/apm/ftr_e2e/ftr_config_open.ts] which is not listed in [.buildkite/ftr_configs.yml]. All FTR Config files must be listed there, use the "enabled" key if the FTR Config should be run on automatically on PR CI, or the "disabled" key if it is run manually or by a special job.
```

Adding "ftr_config_open.ts" to buildkite config fixes it.

cc @qn895 