### PR TITLE
[APM] Remove fixed height from service groups card and move EuiTourStep within the card

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_groups/service_groups_list/service_group_card.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_groups/service_groups_list/service_group_card.tsx
@@ -106,7 +106,7 @@ export function ServiceGroupsCard({
                 }
               )}
             >
-              {cardProps.description as JSX.Element}
+              <>{cardProps.description}</>
             </ServiceGroupsTour>
           }
         />

--- a/x-pack/plugins/apm/public/components/app/service_groups/service_groups_list/service_group_card.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_groups/service_groups_list/service_group_card.tsx
@@ -39,7 +39,7 @@ export function ServiceGroupsCard({
   const { tourEnabled, dismissTour } = useServiceGroupsTour('serviceGroupCard');
 
   const cardProps: EuiCardProps = {
-    style: { width: 286, height: 186 },
+    style: { width: 286 },
     icon: (
       <EuiAvatar
         name={serviceGroup.groupName}
@@ -87,23 +87,29 @@ export function ServiceGroupsCard({
   if (withTour) {
     return (
       <EuiFlexItem key={serviceGroup.groupName}>
-        <ServiceGroupsTour
-          tourEnabled={tourEnabled}
-          dismissTour={dismissTour}
-          title={i18n.translate(
-            'xpack.apm.serviceGroups.tour.serviceGroups.title',
-            { defaultMessage: 'All services group' }
-          )}
-          content={i18n.translate(
-            'xpack.apm.serviceGroups.tour.serviceGroups.content',
-            {
-              defaultMessage:
-                "Now that you've created a service group, your All services inventory has moved here. This group cannot be edited or removed.",
-            }
-          )}
-        >
-          <EuiCard layout="vertical" {...cardProps} />
-        </ServiceGroupsTour>
+        <EuiCard
+          layout="vertical"
+          {...cardProps}
+          description={
+            <ServiceGroupsTour
+              tourEnabled={tourEnabled}
+              dismissTour={dismissTour}
+              title={i18n.translate(
+                'xpack.apm.serviceGroups.tour.serviceGroups.title',
+                { defaultMessage: 'All services group' }
+              )}
+              content={i18n.translate(
+                'xpack.apm.serviceGroups.tour.serviceGroups.content',
+                {
+                  defaultMessage:
+                    "Now that you've created a service group, your All services inventory has moved here. This group cannot be edited or removed.",
+                }
+              )}
+            >
+              {cardProps.description as JSX.Element}
+            </ServiceGroupsTour>
+          }
+        />
       </EuiFlexItem>
     );
   }


### PR DESCRIPTION
## Summary
Remove fixed height from service groups card and move EuiTourStep within the card.

<img width="845" alt="image" src="https://user-images.githubusercontent.com/5831975/168837873-a48a6dfc-e5a2-42a6-bfdc-fe7b72372aed.png">

Closes https://github.com/elastic/kibana/issues/127728