### PR TITLE
[Monitor Management] Don't show required error on Script Field before field is touched.

### DIFF
--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/source_field.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/source_field.tsx
@@ -78,10 +78,27 @@ export const SourceField = ({ onChange, onFieldBlur, defaultConfig = defaultValu
     getDefaultTab(defaultConfig, isZipUrlSourceEnabled)
   );
   const [config, setConfig] = useState<SourceConfig>(defaultConfig);
+  const [touchedFields, setTouchedFields] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     onChange(config);
   }, [config, onChange]);
+
+  const onFieldTouched = (field: ConfigKey) => {
+    if (!touchedFields[field]) {
+      setTouchedFields((existing) => ({ ...existing, [field]: true }));
+    }
+
+    onFieldBlur(field);
+  };
+
+  const isWithInUptime = window.location.pathname.includes('/app/uptime');
+  const isZipUrlInvalid = isWithInUptime
+    ? touchedFields[ConfigKey.SOURCE_ZIP_URL] && !config.zipUrl
+    : !config.zipUrl;
+  const isScriptInvalid = isWithInUptime
+    ? touchedFields[ConfigKey.SOURCE_INLINE] && !config.inlineScript
+    : !config.inlineScript;
 
   const zipUrlLabel = (
     <FormattedMessage
@@ -101,7 +118,7 @@ export const SourceField = ({ onChange, onFieldBlur, defaultConfig = defaultValu
           <EuiSpacer size="m" />
           <EuiFormRow
             label={zipUrlLabel}
-            isInvalid={!config.zipUrl}
+            isInvalid={isZipUrlInvalid}
             error={
               <FormattedMessage
                 id="xpack.synthetics.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.browser.zipUrl.error"
@@ -119,7 +136,7 @@ export const SourceField = ({ onChange, onFieldBlur, defaultConfig = defaultValu
               onChange={({ target: { value } }) =>
                 setConfig((prevConfig) => ({ ...prevConfig, zipUrl: value }))
               }
-              onBlur={() => onFieldBlur(ConfigKey.SOURCE_ZIP_URL)}
+              onBlur={() => onFieldTouched(ConfigKey.SOURCE_ZIP_URL)}
               value={config.zipUrl}
               data-test-subj="syntheticsBrowserZipUrl"
             />
@@ -267,7 +284,7 @@ export const SourceField = ({ onChange, onFieldBlur, defaultConfig = defaultValu
       'data-test-subj': `syntheticsSourceTab__inline`,
       content: (
         <EuiFormRow
-          isInvalid={!config.inlineScript}
+          isInvalid={isScriptInvalid}
           error={
             <FormattedMessage
               id="xpack.synthetics.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.browser.inlineScript.error"
@@ -292,7 +309,7 @@ export const SourceField = ({ onChange, onFieldBlur, defaultConfig = defaultValu
             languageId={MonacoEditorLangId.JAVASCRIPT}
             onChange={(code) => {
               setConfig((prevConfig) => ({ ...prevConfig, inlineScript: code }));
-              onFieldBlur(ConfigKey.SOURCE_INLINE);
+              onFieldTouched(ConfigKey.SOURCE_INLINE);
             }}
             value={config.inlineScript}
           />


### PR DESCRIPTION
Now that the Browser type will be the default monitor type for Synthetics, Script field should not show a _required_ validation error until it is touched/changed.

The CodeEditor component doesn't expose onBlur so the PR makes use of onChange to show _required_ validation error only after code is changed.

Also, with Zip Url field as well, only shows validation error if it was touched (onBlur).

The above two changes will only be effective under uptime. Under fleet, the form fields aren't changed.