### PR TITLE
[Infrastructure UI][Rules] Add logging to Metric Threshold Rule

### DIFF
--- a/x-pack/plugins/infra/server/lib/alerting/inventory_metric_threshold/evaluate_condition.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/inventory_metric_threshold/evaluate_condition.ts
@@ -7,7 +7,7 @@
 
 import { ElasticsearchClient } from '@kbn/core/server';
 import { mapValues } from 'lodash';
-import { Logger } from '@kbn/logging';
+import type { Logger } from '@kbn/logging';
 import { InventoryMetricConditions } from '../../../../common/alerting/metrics';
 import { InfraTimerangeInput } from '../../../../common/http_api';
 import { InventoryItemType } from '../../../../common/inventory_models/types';

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_rule.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_rule.ts
@@ -7,6 +7,7 @@
 
 import { ElasticsearchClient } from '@kbn/core/server';
 import moment from 'moment';
+import type { Logger } from '@kbn/logging';
 import { MetricExpressionParams } from '../../../../../common/alerting/metrics';
 import { InfraSource } from '../../../../../common/source_configuration/source_configuration';
 import { getIntervalInSeconds } from '../../../../utils/get_interval_in_seconds';
@@ -36,6 +37,7 @@ export const evaluateRule = async <Params extends EvaluatedRuleParams = Evaluate
   config: InfraSource['configuration'],
   compositeSize: number,
   alertOnGroupDisappear: boolean,
+  logger: Logger,
   lastPeriodEnd?: number,
   timeframe?: { start?: number; end: number },
   missingGroups: string[] = []
@@ -63,6 +65,7 @@ export const evaluateRule = async <Params extends EvaluatedRuleParams = Evaluate
         compositeSize,
         alertOnGroupDisappear,
         calculatedTimerange,
+        logger,
         lastPeriodEnd
       );
 

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/get_data.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/get_data.ts
@@ -6,6 +6,7 @@
  */
 
 import { ElasticsearchClient } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
 import {
   Aggregators,
   Comparator,
@@ -80,6 +81,7 @@ export const getData = async (
   compositeSize: number,
   alertOnGroupDisappear: boolean,
   timeframe: { start: number; end: number },
+  logger: Logger,
   lastPeriodEnd?: number,
   previousResults: GetDataResponse = {},
   afterKey?: Record<string, string>
@@ -137,6 +139,7 @@ export const getData = async (
           compositeSize,
           alertOnGroupDisappear,
           timeframe,
+          logger,
           lastPeriodEnd,
           previous,
           nextAfterKey
@@ -203,7 +206,10 @@ export const getData = async (
       afterKey
     ),
   };
-  const { aggregations, _shards } = await esClient.search<undefined, ResponseAggregations>(request);
+  logger.trace(`Request: ${JSON.stringify(request)}`);
+  const body = await esClient.search<undefined, ResponseAggregations>(request);
+  const { aggregations, _shards } = body;
+  logger.trace(`Response: ${JSON.stringify(body)}`);
   if (aggregations) {
     return handleResponse(aggregations, previousResults, _shards.successful);
   } else if (_shards.successful) {

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
@@ -31,6 +31,7 @@ import {
   NO_DATA_ACTIONS,
 } from './metric_threshold_executor';
 import { Evaluation } from './lib/evaluate_rule';
+import type { LogMeta, Logger } from '@kbn/logging';
 
 jest.mock('./lib/evaluate_rule', () => ({ evaluateRule: jest.fn() }));
 
@@ -1520,6 +1521,19 @@ const createMockStaticConfiguration = (sources: any) => ({
   sources,
 });
 
+const fakeLogger = <Meta extends LogMeta = LogMeta>(msg: string, meta?: Meta) => {};
+
+const logger = {
+  trace: fakeLogger,
+  debug: fakeLogger,
+  info: fakeLogger,
+  warn: fakeLogger,
+  error: fakeLogger,
+  fatal: fakeLogger,
+  log: () => void 0,
+  get: () => logger,
+} as unknown as Logger;
+
 const mockLibs: any = {
   sources: new InfraSources({
     config: createMockStaticConfiguration({}),
@@ -1532,6 +1546,7 @@ const mockLibs: any = {
     publicBaseUrl: 'http://localhost:5601',
     prepend: (path: string) => path,
   },
+  logger,
 };
 
 const executor = createMetricThresholdExecutor(mockLibs);

--- a/x-pack/test/api_integration/apis/metrics_ui/create_fake_logger.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/create_fake_logger.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LogMeta, Logger } from '@kbn/logging';
+import { ToolingLog } from '@kbn/tooling-log';
+import sinon from 'sinon';
+
+export const createFakeLogger = (log: ToolingLog) => {
+  const fakeLogger = <Meta extends LogMeta = LogMeta>(msg: string, meta?: Meta) =>
+    meta ? log.debug(msg, meta) : log.debug(msg);
+
+  return {
+    trace: fakeLogger,
+    debug: fakeLogger,
+    info: fakeLogger,
+    warn: fakeLogger,
+    error: fakeLogger,
+    fatal: fakeLogger,
+    log: sinon.stub(),
+    get: sinon.stub(),
+  } as Logger;
+};

--- a/x-pack/test/api_integration/apis/metrics_ui/inventory_threshold_alert.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/inventory_threshold_alert.ts
@@ -6,8 +6,6 @@
  */
 
 import expect from '@kbn/expect';
-import type { Logger, LogMeta } from '@kbn/core/server';
-import sinon from 'sinon';
 import { Comparator, InventoryMetricConditions } from '@kbn/infra-plugin/common/alerting/metrics';
 import {
   InventoryItemType,
@@ -17,25 +15,13 @@ import { evaluateCondition } from '@kbn/infra-plugin/server/lib/alerting/invento
 import { InfraSource } from '@kbn/infra-plugin/server/lib/sources';
 import { FtrProviderContext } from '../../ftr_provider_context';
 import { DATES } from './constants';
+import { createFakeLogger } from './create_fake_logger';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const esClient = getService('es');
   const log = getService('log');
-
-  const fakeLogger = <Meta extends LogMeta = LogMeta>(msg: string, meta?: Meta) =>
-    meta ? log.debug(msg, meta) : log.debug(msg);
-
-  const logger = {
-    trace: fakeLogger,
-    debug: fakeLogger,
-    info: fakeLogger,
-    warn: fakeLogger,
-    error: fakeLogger,
-    fatal: fakeLogger,
-    log: sinon.stub(),
-    get: sinon.stub(),
-  } as Logger;
+  const logger = createFakeLogger(log);
 
   const baseCondition: InventoryMetricConditions = {
     metric: 'cpu',

--- a/x-pack/test/api_integration/apis/metrics_ui/metric_threshold_alert.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/metric_threshold_alert.ts
@@ -20,11 +20,14 @@ import {
 } from '@kbn/infra-plugin/server/lib/alerting/metric_threshold/lib/evaluate_rule';
 import { FtrProviderContext } from '../../ftr_provider_context';
 import { DATES } from './constants';
+import { createFakeLogger } from './create_fake_logger';
 
 const { gauge, rate } = DATES['alert-test-data'];
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const esClient = getService('es');
+  const log = getService('log');
+  const logger = createFakeLogger(log);
 
   const baseParams: EvaluatedRuleParams = {
     groupBy: void 0,
@@ -104,6 +107,7 @@ export default function ({ getService }: FtrProviderContext) {
             config,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );
@@ -152,6 +156,7 @@ export default function ({ getService }: FtrProviderContext) {
             config,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );
@@ -198,6 +203,7 @@ export default function ({ getService }: FtrProviderContext) {
             config,
             10000,
             true,
+            logger,
             void 0,
             timeFrame,
             ['middleware']
@@ -257,6 +263,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );
@@ -287,6 +294,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );
@@ -332,6 +340,7 @@ export default function ({ getService }: FtrProviderContext) {
               configuration,
               10000,
               true,
+              logger,
               void 0,
               timeFrame
             );
@@ -376,6 +385,7 @@ export default function ({ getService }: FtrProviderContext) {
               configuration,
               10000,
               true,
+              logger,
               void 0,
               timeFrame,
               ['web', 'prod']
@@ -452,6 +462,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );
@@ -493,6 +504,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );
@@ -523,6 +535,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );
@@ -567,6 +580,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );
@@ -613,6 +627,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );
@@ -647,6 +662,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             void 0,
             timeFrame,
             ['dev']
@@ -692,6 +708,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             moment(gauge.midpoint).subtract(1, 'm').valueOf(),
             timeFrame,
             ['dev']
@@ -711,6 +728,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             gauge.max,
             timeFrame
           );
@@ -772,6 +790,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );
@@ -819,6 +838,7 @@ export default function ({ getService }: FtrProviderContext) {
             configuration,
             10000,
             true,
+            logger,
             void 0,
             timeFrame
           );


### PR DESCRIPTION
## Summary

This PR adds logging for the execution time (debug) along with the Elasticsearch request/responses (trace) to the Metric  Threshold Rule.

To enable the logging for the Metric Threshold rule, add the following snippet to your `config/kibana.dev.yml`:
```YAML
logging.loggers:
  - name: plugins.infra.metricThresholdRule
    level: trace
```

### Example Log Format
```
[2022-05-17T09:58:20.209-06:00][TRACE][plugins.infra.metricThresholdRule] [AlertId: cbf86ed0-d5f6-11ec-8e5e-efda79ee6822][ExecutionId: 33745d86-4f21-4cf2-805a-4ca2b9528805] Request: {"index":"metrics-*,metricbeat-*","allow_no_indices":true,"ignore_unavailable":true,"body":{"track_total_hits":true,"query":{"bool":{"filter":[{"range":{"@timestamp":{"gte":"2022-05-17T15:56:17.079Z","lte":"2022-05-17T15:58:20.084Z"}}},{"exists":{"field":"system.cpu.total.norm.pct"}}]}},"size":0,"aggs":{"groupings":{"composite":{"size":10000,"sources":[{"groupBy0":{"terms":{"field":"host.name"}}}],"after":{"groupBy0":"host-4"}},"aggs":{"currentPeriod":{"filter":{"range":{"@timestamp":{"gte":"2022-05-17T15:57:20.084Z","lte":"2022-05-17T15:58:20.084Z"}}},"aggs":{"aggregatedValue":{"avg":{"field":"system.cpu.total.norm.pct"}}}},"shouldWarn":{"bucket_script":{"buckets_path":{},"script":"0"}},"shouldTrigger":{"bucket_script":{"buckets_path":{"value":"currentPeriod>aggregatedValue"},"script":"params.value > 0.01 ? 1 : 0"}},"lastPeriod":{"filter":{"range":{"@timestamp":{"gte":"2022-05-17T15:56:17.079Z","lte":"2022-05-17T15:57:17.079Z"}}}},"missingGroup":{"bucket_script":{"buckets_path":{"lastPeriod":"lastPeriod>_count","currentPeriod":"currentPeriod>_count"},"script":"params.lastPeriod > 0 && params.currentPeriod < 1 ? 1 : 0"}},"newOrRecoveredGroup":{"bucket_script":{"buckets_path":{"lastPeriod":"lastPeriod>_count","currentPeriod":"currentPeriod>_count"},"script":"params.lastPeriod < 1 && params.currentPeriod > 0 ? 1 : 0"}},"evaluation":{"bucket_selector":{"buckets_path":{"shouldWarn":"shouldWarn","shouldTrigger":"shouldTrigger","missingGroup":"missingGroup","newOrRecoveredGroup":"newOrRecoveredGroup"},"script":"(params.missingGroup != null && params.missingGroup > 0) || (params.shouldWarn != null && params.shouldWarn > 0) || (params.shouldTrigger != null && params.shouldTrigger > 0) || (params.newOrRecoveredGroup != null && params.newOrRecoveredGroup > 0)"}}}}}}}
[2022-05-17T09:58:20.211-06:00][TRACE][plugins.infra.metricThresholdRule] [AlertId: cbf86ed0-d5f6-11ec-8e5e-efda79ee6822][ExecutionId: 33745d86-4f21-4cf2-805a-4ca2b9528805] Response: {"took":0,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":60,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"groupings":{"buckets":[]}}}
[2022-05-17T09:58:20.213-06:00][DEBUG][plugins.infra.metricThresholdRule] [AlertId: cbf86ed0-d5f6-11ec-8e5e-efda79ee6822][ExecutionId: 33745d86-4f21-4cf2-805a-4ca2b9528805] Scheduled 5 actions in 12ms
```

### Checklist


- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
