### PR TITLE
Comment out SERVICE_NAME for django/flask onboarding

### DIFF
--- a/x-pack/plugins/apm/public/tutorial/config_agent/commands/django.ts
+++ b/x-pack/plugins/apm/public/tutorial/config_agent/commands/django.ts
@@ -31,7 +31,7 @@ ELASTIC_APM = {
     defaultMessage: 'a-z, A-Z, 0-9, -, _, and space',
   }
 )}
-'SERVICE_NAME': 'my_python_service',
+#'SERVICE_NAME': 'unknown-python-service',
 
 # ${i18n.translate(
   'xpack.apm.tutorial.djangoClient.configure.commands.useIfApmServerRequiresTokenComment',

--- a/x-pack/plugins/apm/public/tutorial/config_agent/commands/flask.ts
+++ b/x-pack/plugins/apm/public/tutorial/config_agent/commands/flask.ts
@@ -38,7 +38,7 @@ app.config['ELASTIC_APM'] = {
     defaultMessage: 'a-z, A-Z, 0-9, -, _, and space',
   }
 )}
-'SERVICE_NAME': 'my_python_service',
+#'SERVICE_NAME': 'unknown-python-service',
 
 # ${i18n.translate(
   'xpack.apm.tutorial.flaskClient.configure.commands.useIfApmServerRequiresTokenComment',

--- a/x-pack/plugins/apm/public/tutorial/config_agent/commands/get_commands.test.ts
+++ b/x-pack/plugins/apm/public/tutorial/config_agent/commands/get_commands.test.ts
@@ -181,7 +181,7 @@ describe('getCommands', () => {
         ELASTIC_APM = {
         # Set the required service name. Allowed characters:
         # a-z, A-Z, 0-9, -, _, and space
-        'SERVICE_NAME': 'my_python_service',
+        #'SERVICE_NAME': 'unknown-python-service',
 
         # Use if APM Server requires a secret token
         'SECRET_TOKEN': '',
@@ -219,7 +219,7 @@ describe('getCommands', () => {
         ELASTIC_APM = {
         # Set the required service name. Allowed characters:
         # a-z, A-Z, 0-9, -, _, and space
-        'SERVICE_NAME': 'my_python_service',
+        #'SERVICE_NAME': 'unknown-python-service',
 
         # Use if APM Server requires a secret token
         'SECRET_TOKEN': 'foobar',
@@ -257,7 +257,7 @@ describe('getCommands', () => {
         app.config['ELASTIC_APM'] = {
         # Set the required service name. Allowed characters:
         # a-z, A-Z, 0-9, -, _, and space
-        'SERVICE_NAME': 'my_python_service',
+        #'SERVICE_NAME': 'unknown-python-service',
 
         # Use if APM Server requires a secret token
         'SECRET_TOKEN': '',
@@ -292,7 +292,7 @@ describe('getCommands', () => {
         app.config['ELASTIC_APM'] = {
         # Set the required service name. Allowed characters:
         # a-z, A-Z, 0-9, -, _, and space
-        'SERVICE_NAME': 'my_python_service',
+        #'SERVICE_NAME': 'unknown-python-service',
 
         # Use if APM Server requires a secret token
         'SECRET_TOKEN': 'foobar',


### PR DESCRIPTION
## Summary

After some discussion, we realized that #131959 would probably be better if we just commented out the service_name, which would use the configured default and encourage better behavior (setting a useful SERVICE_NAME) from the user.

### Checklist

No items were applicable to this change.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
