### PR TITLE
[Unified Search] Add refresh button text back in when window is very large

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -8,7 +8,7 @@
 
 import dateMath from '@kbn/datemath';
 import classNames from 'classnames';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import deepEqual from 'fast-deep-equal';
 import useObservable from 'react-use/lib/useObservable';
 import type { Filter } from '@kbn/es-query';
@@ -126,6 +126,20 @@ const SharingMetaFields = React.memo(function SharingMetaFields({
 export const QueryBarTopRow = React.memo(
   function QueryBarTopRow(props: QueryBarTopRowProps) {
     const isMobile = useIsWithinBreakpoints(['xs', 's']);
+    const [isXXLarge, setIsXXLarge] = useState<boolean>(false);
+
+    useEffect(() => {
+      function handleResize() {
+        setIsXXLarge(window.innerWidth >= 1440);
+      }
+
+      window.removeEventListener('resize', handleResize);
+      window.addEventListener('resize', handleResize);
+      handleResize();
+
+      return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
     const {
       showQueryInput = true,
       showDatePicker = true,
@@ -367,7 +381,7 @@ export const QueryBarTopRow = React.memo(
         <EuiFlexItem grow={false}>
           <EuiSuperUpdateButton
             iconType={props.isDirty ? 'kqlFunction' : 'refresh'}
-            iconOnly
+            iconOnly={!isXXLarge}
             aria-label={props.isLoading ? buttonLabelUpdate : buttonLabelRefresh}
             isDisabled={isDateRangeInvalid}
             isLoading={props.isLoading}


### PR DESCRIPTION
## Closes #131641

On screens 1440px and larger, the text of the refresh button will be visible.

<img width="1493" alt="Screen Shot 2022-05-17 at 17 43 59 PM" src="https://user-images.githubusercontent.com/549577/168915373-48e3573f-e472-4d92-94d2-f6be18cf5559.png">

Otherwise it's only the icon that will show 

<img width="1511" alt="Screen Shot 2022-05-17 at 17 44 07 PM" src="https://user-images.githubusercontent.com/549577/168915383-9a5ceed4-f411-4fb6-95dd-f44eff017f33.png">
