### PR TITLE
[8.2] [kbn/es] capture es debug files (#132355)

### DIFF
--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -26,6 +26,7 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
   buildkite-agent artifact upload 'x-pack/test/functional/apps/reporting/reports/session/*.pdf'
   buildkite-agent artifact upload 'x-pack/test/functional/failure_debug/html/*.html'
   buildkite-agent artifact upload '.es/**/*.hprof'
+  buildkite-agent artifact upload 'data/es_debug_*.tar.gz'
 
   echo "--- Run Failed Test Reporter"
   node scripts/report_failed_tests --build-url="${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}" 'target/junit/**/*.xml'

--- a/packages/kbn-test/BUILD.bazel
+++ b/packages/kbn-test/BUILD.bazel
@@ -94,12 +94,14 @@ TYPES_DEPS = [
   "@npm//form-data",
   "@npm//get-port",
   "@npm//getopts",
+  "@npm//globby",
   "@npm//jest",
   "@npm//jest-cli",
   "@npm//jest-snapshot",
   "@npm//redux",
   "@npm//rxjs",
   "@npm//xmlbuilder",
+  "@npm//@types/archiver",
   "@npm//@types/chance",
   "@npm//@types/dedent",
   "@npm//@types/enzyme",
@@ -117,6 +119,7 @@ TYPES_DEPS = [
   "@npm//@types/react-redux",
   "@npm//@types/react-router-dom",
   "@npm//@types/semver",
+  "@npm//@types/uuid",
   "@npm//@types/xml2js",
 ]
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[kbn/es] capture es debug files (#132355)](https://github.com/elastic/kibana/pull/132355)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)