### PR TITLE
[8.2] set browser type in case of monitor management (#132299)

### DIFF
--- a/x-pack/plugins/uptime/e2e/journeys/monitor_details.journey.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/monitor_details.journey.ts
@@ -40,12 +40,12 @@ journey('MonitorDetails', async ({ page, params }: { page: Page; params: any }) 
   step('create basic monitor', async () => {
     await uptime.enableMonitorManagement();
     await uptime.clickAddMonitor();
-    await uptime.createBasicMonitorDetails({
+    await uptime.createBasicHTTPMonitorDetails({
       name,
       locations: ['US Central'],
       apmServiceName: 'synthetics',
+      url: 'https://www.google.com',
     });
-    await uptime.fillByTestSubj('syntheticsUrlField', 'https://www.google.com');
     await uptime.confirmAndSave();
   });
 

--- a/x-pack/plugins/uptime/e2e/journeys/monitor_management.journey.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/monitor_management.journey.ts
@@ -68,6 +68,7 @@ const configuration = {
   [DataStream.BROWSER]: {
     monitorConfig: {
       ...basicMonitorDetails,
+      schedule: '10',
       name: browserName,
       inlineScript: 'step("test step", () => {})',
       locations: [basicMonitorDetails.location],
@@ -75,6 +76,7 @@ const configuration = {
     },
     monitorDetails: {
       ...basicMonitorDetails,
+      schedule: '10',
       name: browserName,
     },
   },

--- a/x-pack/plugins/uptime/e2e/journeys/monitor_name.journey.ts
+++ b/x-pack/plugins/uptime/e2e/journeys/monitor_name.journey.ts
@@ -21,12 +21,12 @@ journey(`MonitorName`, async ({ page, params }: { page: Page; params: any }) => 
   const uptime = monitorManagementPageProvider({ page, kibanaUrl: params.kibanaUrl });
 
   const createBasicMonitor = async () => {
-    await uptime.createBasicMonitorDetails({
+    await uptime.createBasicHTTPMonitorDetails({
       name,
       locations: ['US Central'],
       apmServiceName: 'synthetics',
+      url: 'https://www.google.com',
     });
-    await uptime.fillByTestSubj('syntheticsUrlField', 'https://www.google.com');
   };
 
   before(async () => {
@@ -52,12 +52,12 @@ journey(`MonitorName`, async ({ page, params }: { page: Page; params: any }) => 
 
   step(`shows error if name already exists`, async () => {
     await uptime.navigateToAddMonitor();
-    await uptime.createBasicMonitorDetails({
+    await uptime.createBasicHTTPMonitorDetails({
       name,
       locations: ['US Central'],
       apmServiceName: 'synthetics',
+      url: 'https://www.google.com',
     });
-    await uptime.fillByTestSubj('syntheticsUrlField', 'https://www.google.com');
 
     await uptime.assertText({ text: 'Monitor name already exists.' });
 

--- a/x-pack/plugins/uptime/e2e/page_objects/monitor_management.tsx
+++ b/x-pack/plugins/uptime/e2e/page_objects/monitor_management.tsx
@@ -189,6 +189,7 @@ export function monitorManagementPageProvider({
       apmServiceName: string;
       locations: string[];
     }) {
+      await this.selectMonitorType('http');
       await this.createBasicMonitorDetails({ name, apmServiceName, locations });
       await this.fillByTestSubj('syntheticsUrlField', url);
     },

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/index.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/index.ts
@@ -18,7 +18,7 @@ export type { IPolicyConfigContextProvider } from './policy_config_context';
 export {
   PolicyConfigContext,
   PolicyConfigContextProvider,
-  initialValue as defaultPolicyConfig,
+  initialMonitorTypeValue as defaultPolicyConfig,
   defaultContext as defaultPolicyConfigValues,
   usePolicyConfigContext,
 } from './policy_config_context';

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/policy_config_context.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/policy_config_context.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { useRouteMatch } from 'react-router-dom';
+import { MONITOR_ADD_ROUTE } from '../../../../common/constants';
 import { DEFAULT_NAMESPACE_STRING } from '../../../../common/constants';
 import {
   ScheduleUnit,
@@ -56,7 +58,7 @@ export interface IPolicyConfigContextProvider {
   throttling?: ThrottlingOptions;
 }
 
-export const initialValue = DataStream.HTTP;
+export const initialMonitorTypeValue = DataStream.HTTP;
 
 export const defaultContext: IPolicyConfigContext = {
   setMonitorType: (_monitorType: React.SetStateAction<DataStream>) => {
@@ -79,8 +81,8 @@ export const defaultContext: IPolicyConfigContext = {
   setNamespace: (_namespace: React.SetStateAction<string>) => {
     throw new Error('setNamespace was not initialized, set it when you invoke the context');
   },
-  monitorType: initialValue, // mutable
-  defaultMonitorType: initialValue, // immutable,
+  monitorType: initialMonitorTypeValue, // mutable
+  defaultMonitorType: initialMonitorTypeValue, // immutable,
   runsOnService: false,
   defaultIsTLSEnabled: false,
   defaultIsZipUrlTLSEnabled: false,
@@ -98,7 +100,7 @@ export const PolicyConfigContext = createContext(defaultContext);
 export function PolicyConfigContextProvider<ExtraFields = unknown>({
   children,
   throttling = DEFAULT_THROTTLING,
-  defaultMonitorType = initialValue,
+  defaultMonitorType = initialMonitorTypeValue,
   defaultIsTLSEnabled = false,
   defaultIsZipUrlTLSEnabled = false,
   defaultName = '',
@@ -115,6 +117,14 @@ export function PolicyConfigContextProvider<ExtraFields = unknown>({
   const [isTLSEnabled, setIsTLSEnabled] = useState<boolean>(defaultIsTLSEnabled);
   const [isZipUrlTLSEnabled, setIsZipUrlTLSEnabled] = useState<boolean>(defaultIsZipUrlTLSEnabled);
   const [namespace, setNamespace] = useState<string>(defaultNamespace);
+
+  const isAddMonitorRoute = useRouteMatch(MONITOR_ADD_ROUTE);
+
+  useEffect(() => {
+    if (isAddMonitorRoute?.isExact) {
+      setMonitorType(DataStream.BROWSER);
+    }
+  }, [isAddMonitorRoute?.isExact]);
 
   const value = useMemo(() => {
     return {

--- a/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.tsx
@@ -41,9 +41,6 @@ interface Props {
 }
 
 const dataStreamToString = [
-  { value: DataStream.HTTP, text: 'HTTP' },
-  { value: DataStream.TCP, text: 'TCP' },
-  { value: DataStream.ICMP, text: 'ICMP' },
   {
     value: DataStream.BROWSER,
     text: i18n.translate(
@@ -53,6 +50,9 @@ const dataStreamToString = [
       }
     ),
   },
+  { value: DataStream.HTTP, text: 'HTTP' },
+  { value: DataStream.TCP, text: 'TCP' },
+  { value: DataStream.ICMP, text: 'ICMP' },
 ];
 
 export const CustomFields = memo<Props>(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [set browser type in case of monitor management (#132299)](https://github.com/elastic/kibana/pull/132299)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)