### PR TITLE
[Files] File service CRUD functionality and audit logging

### DIFF
--- a/x-pack/plugins/files/common/index.ts
+++ b/x-pack/plugins/files/common/index.ts
@@ -7,4 +7,10 @@
 
 export { FILE_SO_TYPE, PLUGIN_ID, PLUGIN_NAME } from './constants';
 
-export type { FileSavedObjectAttributes, FileStatus, File, FileSavedObject } from './types';
+export type {
+  FileSavedObjectAttributes,
+  FileStatus,
+  File,
+  FileSavedObject,
+  UpdateableFileAttributes,
+} from './types';

--- a/x-pack/plugins/files/common/index.ts
+++ b/x-pack/plugins/files/common/index.ts
@@ -7,4 +7,4 @@
 
 export { FILE_SO_TYPE, PLUGIN_ID, PLUGIN_NAME } from './constants';
 
-export type { FileSavedObjectAttributes, FileStatus } from './types';
+export type { FileSavedObjectAttributes, FileStatus, File, FileSavedObject } from './types';

--- a/x-pack/plugins/files/common/index.ts
+++ b/x-pack/plugins/files/common/index.ts
@@ -12,5 +12,5 @@ export type {
   FileStatus,
   File,
   FileSavedObject,
-  UpdateableFileAttributes,
+  UpdatableFileAttributes,
 } from './types';

--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -6,12 +6,13 @@
  */
 
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import type { SavedObjectAttributes } from '@kbn/core/server';
+import type { SavedObject } from '@kbn/core/server';
+import { Readable } from 'stream';
 
 export type FileStatus = 'AWAITING_UPLOAD' | 'UPLOADING' | 'READY' | 'ERROR';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type FileSavedObjectAttributes = {
+export type FileSavedObjectAttributes<Meta = {}> = {
   created_at: string;
 
   updated_at: string;
@@ -62,5 +63,16 @@ export type FileSavedObjectAttributes = {
   /**
    * User-defined metadata
    */
-  meta?: SavedObjectAttributes;
+  meta?: Meta;
 };
+
+export type FileSavedObject<Meta = {}> = SavedObject<FileSavedObjectAttributes<Meta>>;
+
+export interface File<Meta = {}> {
+  status: FileStatus;
+  id: string;
+
+  uploadContent(content: Readable): Promise<void>;
+  getMetadata(): Omit<FileSavedObjectAttributes<Meta>, 'status' | 'content_ref'>;
+  delete(): Promise<void>;
+}

--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -68,11 +68,15 @@ export type FileSavedObjectAttributes<Meta = {}> = {
 
 export type FileSavedObject<Meta = {}> = SavedObject<FileSavedObjectAttributes<Meta>>;
 
+export type UpdateableFileAttributes = Pick<FileSavedObjectAttributes, 'meta' | 'alt' | 'name'>;
+
 export interface File<Meta = {}> {
   status: FileStatus;
   id: string;
 
+  update(attr: Partial<UpdateableFileAttributes>): Promise<File>;
   uploadContent(content: Readable): Promise<void>;
+  downloadContent(): Promise<Readable>;
   getMetadata(): Omit<FileSavedObjectAttributes<Meta>, 'status' | 'content_ref'>;
   delete(): Promise<void>;
 }

--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -9,10 +9,10 @@
 import type { SavedObject } from '@kbn/core/server';
 import { Readable } from 'stream';
 
-export type FileStatus = 'AWAITING_UPLOAD' | 'UPLOADING' | 'READY' | 'ERROR';
+export type FileStatus = 'AWAITING_UPLOAD' | 'UPLOADING' | 'READY' | 'UPLOAD_ERROR';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type FileSavedObjectAttributes<Meta = {}> = {
+export type FileSavedObjectAttributes<Meta = unknown> = {
   created_at: string;
 
   updated_at: string;
@@ -66,17 +66,23 @@ export type FileSavedObjectAttributes<Meta = {}> = {
   meta?: Meta;
 };
 
-export type FileSavedObject<Meta = {}> = SavedObject<FileSavedObjectAttributes<Meta>>;
+export type FileSavedObject<Meta = unknown> = SavedObject<FileSavedObjectAttributes<Meta>>;
 
-export type UpdateableFileAttributes = Pick<FileSavedObjectAttributes, 'meta' | 'alt' | 'name'>;
+export type UpdatableFileAttributes = Pick<FileSavedObjectAttributes, 'meta' | 'alt' | 'name'>;
 
-export interface File<Meta = {}> {
-  status: FileStatus;
+export interface File<Meta = unknown> {
   id: string;
+  fileKind: string;
+  name: string;
+  status: FileStatus;
+  /**
+   * User provided metadata
+   */
+  meta: Meta;
+  alt: undefined | string;
 
-  update(attr: Partial<UpdateableFileAttributes>): Promise<File>;
+  update(attr: Partial<UpdatableFileAttributes>): Promise<File>;
   uploadContent(content: Readable): Promise<void>;
   downloadContent(): Promise<Readable>;
-  getMetadata(): Omit<FileSavedObjectAttributes<Meta>, 'status' | 'content_ref'>;
   delete(): Promise<void>;
 }

--- a/x-pack/plugins/files/kibana.json
+++ b/x-pack/plugins/files/kibana.json
@@ -10,5 +10,5 @@
   "server": true,
   "ui": false,
   "requiredPlugins": [],
-  "optionalPlugins": []
+  "optionalPlugins": ["security"]
 }

--- a/x-pack/plugins/files/server/audit_events.ts
+++ b/x-pack/plugins/files/server/audit_events.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EcsEventOutcome } from '@kbn/logging';
+import { AuditEvent } from '@kbn/security-plugin/server';
+
+export type AuditAction = 'create' | 'delete';
+
+interface CreateAuditEventArgs {
+  message: string;
+  action: AuditAction;
+  error?: Error;
+  outcome?: EcsEventOutcome;
+}
+
+export function createAuditEvent({
+  message,
+  action,
+  error,
+  outcome,
+}: CreateAuditEventArgs): AuditEvent {
+  return {
+    message,
+    event: {
+      action,
+      outcome: outcome ?? error ? 'failure' : 'success',
+    },
+    error: error && {
+      message: error?.message,
+    },
+  };
+}

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
@@ -39,6 +39,7 @@ describe('Elasticsearch blob storage', () => {
   beforeEach(() => {
     esBlobStorage = new ElasticsearchBlobStorage(
       esClient,
+      undefined,
       manageKbn.root.logger.get('es-blob-test')
     );
     sandbox.spy(esClient, 'get');

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
@@ -24,7 +24,7 @@ describe('Elasticsearch blob storage', () => {
   const sandbox = sinon.createSandbox();
 
   beforeAll(async () => {
-    const { startES, startKibana } = createTestServers({ adjustTimeout: () => 30000 });
+    const { startES, startKibana } = createTestServers({ adjustTimeout: jest.setTimeout });
     manageES = await startES();
     manageKbn = await startKibana();
     esClient = manageKbn.coreStart.elasticsearch.client.asInternalUser;

--- a/x-pack/plugins/files/server/blob_storage_service/blob_storage_service.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/blob_storage_service.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
+import { Readable } from 'stream';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { BlobStorage } from './types';
 import { ElasticsearchBlobStorage } from './adapters';
 
 export class BlobStorageService {
-  // @ts-ignore FIXME:
   private readonly adapters: { es: BlobStorage };
 
   constructor(private readonly esClient: ElasticsearchClient, private readonly logger: Logger) {
@@ -20,5 +20,16 @@ export class BlobStorageService {
         this.logger.get('elasticsearch-blob-storage')
       ),
     };
+  }
+  public async upload(content: Readable): Promise<{ id: string; size: number }> {
+    return this.adapters.es.upload(content);
+  }
+
+  public async delete(id: string): Promise<void> {
+    return this.adapters.es.delete(id);
+  }
+
+  public async download(id: string, size?: number): Promise<Readable> {
+    return this.adapters.es.download({ id, size });
   }
 }

--- a/x-pack/plugins/files/server/blob_storage_service/types.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/types.ts
@@ -26,7 +26,7 @@ export interface BlobStorage {
    * Generates a random file ID and returns it upon successfully uploading a
    * file.
    */
-  upload(content: Readable): Promise<{ id: string }>;
+  upload(content: Readable): Promise<{ id: string; size: number }>;
 
   /**
    * Download a file.

--- a/x-pack/plugins/files/server/file.ts
+++ b/x-pack/plugins/files/server/file.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Logger } from '@kbn/core/server';
+import { omit } from 'lodash';
+import { Readable } from 'stream';
+import { File as IFile, FileSavedObject, FileSavedObjectAttributes, FileStatus } from '../common';
+import { BlobStorageService } from './blob_storage_service';
+import { InternalFileService } from './file_service';
+
+type Action =
+  | { action: 'create'; payload: FileSavedObjectAttributes }
+  | {
+      action: 'uploading';
+      payload?: undefined;
+    }
+  | { action: 'uploaded'; payload: { content_ref: string; size: number } }
+  | { action: 'uploadError'; payload?: undefined };
+
+export function createDefaultFileAttributes(): Pick<
+  FileSavedObjectAttributes,
+  'created_at' | 'updated_at' | 'status'
+> {
+  const dateString = new Date().toISOString();
+  return {
+    created_at: dateString,
+    updated_at: dateString,
+    status: 'AWAITING_UPLOAD',
+  };
+}
+
+function fileAttributesReducer(
+  state: FileSavedObjectAttributes,
+  { action, payload }: Action
+): FileSavedObjectAttributes {
+  switch (action) {
+    case 'uploading':
+      return { ...state, content_ref: undefined, status: 'UPLOADING' };
+    case 'uploaded':
+      return { ...state, ...payload, status: 'READY' };
+    case 'uploadError':
+      return { ...state, status: 'ERROR', content_ref: undefined };
+    default:
+      return state;
+  }
+}
+
+/**
+ * Public file class that wraps all functionality consumers will need at the
+ * individual file level
+ */
+export class File implements IFile {
+  constructor(
+    private readonly fileService: InternalFileService,
+    private readonly blobStorageService: BlobStorageService,
+    private fileSO: FileSavedObject,
+    private readonly logger: Logger
+  ) {}
+
+  private async updateFileState(action: Action) {
+    const nextAttr = fileAttributesReducer(this.attributes, action);
+    const nextFileSO = await this.fileService.updateFileSO(this.id, nextAttr);
+    this.fileSO = {
+      ...nextFileSO,
+      references: nextFileSO.references ?? [],
+      attributes: {
+        ...this.fileSO,
+        ...nextAttr,
+      },
+    };
+  }
+
+  private hasContent(): boolean {
+    return Boolean(this.fileSO.attributes.status === 'READY' && this.fileSO.attributes.content_ref);
+  }
+
+  async uploadContent(content: Readable): Promise<void> {
+    if (this.hasContent()) {
+      this.logger.error('File content already uploaded.');
+      throw new Error('File content already uploaded');
+    }
+    this.logger.debug('Uploading file contents...');
+    await this.updateFileState({
+      action: 'uploading',
+    });
+
+    try {
+      const { id: contentRef, size } = await this.blobStorageService.upload(content);
+      await this.updateFileState({
+        action: 'uploaded',
+        payload: { content_ref: contentRef, size },
+      });
+    } catch (e) {
+      await this.updateFileState({ action: 'uploadError' });
+      throw e;
+    }
+  }
+
+  async delete(): Promise<void> {
+    const { attributes, id } = this.fileSO;
+    if (attributes.content_ref) {
+      await this.blobStorageService.delete(attributes.content_ref);
+    }
+    await this.fileService.deleteFileSO(id);
+  }
+
+  public getMetadata(): Omit<FileSavedObjectAttributes<{}>, 'status' | 'content_ref'> {
+    return omit({ ...this.fileSO.attributes }, ['status', 'content_ref']);
+  }
+
+  public get id(): string {
+    return this.fileSO.id;
+  }
+
+  public get attributes(): FileSavedObjectAttributes {
+    return this.fileSO.attributes;
+  }
+
+  public get status(): FileStatus {
+    return this.fileSO.attributes.status;
+  }
+}

--- a/x-pack/plugins/files/server/file/file.ts
+++ b/x-pack/plugins/files/server/file/file.ts
@@ -63,10 +63,9 @@ export class File<M = unknown> implements IFile {
 
   public async uploadContent(content: Readable): Promise<void> {
     if (!this.canUpload()) {
-      this.logger.error('File content already uploaded.');
-      throw new Error('File content already uploaded');
+      throw new Error(`Already uploaded file [id = ${this.id}][name = ${this.name}].`);
     }
-    this.logger.debug('Uploading file contents...');
+    this.logger.debug(`Uploading file [id = ${this.id}][name = ${this.name}].`);
     await this.updateFileState({
       action: 'uploading',
     });

--- a/x-pack/plugins/files/server/file/file.ts
+++ b/x-pack/plugins/files/server/file/file.ts
@@ -24,7 +24,7 @@ import { createAuditEvent } from '../audit_events';
 import { InternalFileService } from '../file_service/internal_file_service';
 
 /**
- * Public file class that wraps all functionality consumers will need at the
+ * Public class that provides all data and functionality consumers will need at the
  * individual file level
  */
 export class File<M = unknown> implements IFile {

--- a/x-pack/plugins/files/server/file/file.ts
+++ b/x-pack/plugins/files/server/file/file.ts
@@ -53,7 +53,7 @@ export class File<M = unknown> implements IFile {
     );
   }
 
-  async update(attrs: UpdatableFileAttributes): Promise<IFile> {
+  public async update(attrs: UpdatableFileAttributes): Promise<IFile> {
     await this.updateFileState({
       action: 'updateFile',
       payload: attrs,
@@ -61,7 +61,7 @@ export class File<M = unknown> implements IFile {
     return this;
   }
 
-  async uploadContent(content: Readable): Promise<void> {
+  public async uploadContent(content: Readable): Promise<void> {
     if (!this.canUpload()) {
       this.logger.error('File content already uploaded.');
       throw new Error('File content already uploaded');
@@ -83,7 +83,7 @@ export class File<M = unknown> implements IFile {
     }
   }
 
-  downloadContent(): Promise<Readable> {
+  public downloadContent(): Promise<Readable> {
     const { content_ref: id, size } = this.attributes;
     if (!id) {
       throw new Error('No content to download');
@@ -91,7 +91,7 @@ export class File<M = unknown> implements IFile {
     return this.blobStorageService.download(id, size);
   }
 
-  async delete(): Promise<void> {
+  public async delete(): Promise<void> {
     const { attributes, id } = this.fileSO;
     if (attributes.content_ref) {
       await this.blobStorageService.delete(attributes.content_ref);

--- a/x-pack/plugins/files/server/file/file.ts
+++ b/x-pack/plugins/files/server/file/file.ts
@@ -61,7 +61,6 @@ export class File<M = unknown> implements IFile {
     return this;
   }
 
-  // TODO: Use security audit logger to log file content upload
   async uploadContent(content: Readable): Promise<void> {
     if (!this.canUpload()) {
       this.logger.error('File content already uploaded.');
@@ -92,7 +91,6 @@ export class File<M = unknown> implements IFile {
     return this.blobStorageService.download(id, size);
   }
 
-  // TODO: Use security audit logger to log file deletion
   async delete(): Promise<void> {
     const { attributes, id } = this.fileSO;
     if (attributes.content_ref) {

--- a/x-pack/plugins/files/server/file/file_attributes_reducer.ts
+++ b/x-pack/plugins/files/server/file/file_attributes_reducer.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
-import { FileSavedObjectAttributes } from '../../common';
+import { FileSavedObjectAttributes, UpdateableFileAttributes } from '../../common';
 
 export type Action =
-  | { action: 'create'; payload: FileSavedObjectAttributes }
   | {
       action: 'uploading';
       payload?: undefined;
     }
   | { action: 'uploaded'; payload: { content_ref: string; size: number } }
-  | { action: 'uploadError'; payload?: undefined };
+  | { action: 'uploadError'; payload?: undefined }
+  | { action: 'updateFile'; payload: UpdateableFileAttributes };
 
 export function createDefaultFileAttributes(): Pick<
   FileSavedObjectAttributes,
@@ -39,6 +39,13 @@ export function fileAttributesReducer(
       return { ...state, ...payload, status: 'READY' };
     case 'uploadError':
       return { ...state, status: 'ERROR', content_ref: undefined };
+    case 'updateFile':
+      const d = new Date();
+      return {
+        ...state,
+        ...payload,
+        updated_at: d.toISOString(),
+      };
     default:
       return state;
   }

--- a/x-pack/plugins/files/server/file/file_attributes_reducer.ts
+++ b/x-pack/plugins/files/server/file/file_attributes_reducer.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FileSavedObjectAttributes, UpdateableFileAttributes } from '../../common';
+import { FileSavedObjectAttributes, UpdatableFileAttributes } from '../../common';
 
 export type Action =
   | {
@@ -14,7 +14,7 @@ export type Action =
     }
   | { action: 'uploaded'; payload: { content_ref: string; size: number } }
   | { action: 'uploadError'; payload?: undefined }
-  | { action: 'updateFile'; payload: UpdateableFileAttributes };
+  | { action: 'updateFile'; payload: UpdatableFileAttributes };
 
 export function createDefaultFileAttributes(): Pick<
   FileSavedObjectAttributes,
@@ -38,7 +38,7 @@ export function fileAttributesReducer(
     case 'uploaded':
       return { ...state, ...payload, status: 'READY' };
     case 'uploadError':
-      return { ...state, status: 'ERROR', content_ref: undefined };
+      return { ...state, status: 'UPLOAD_ERROR', content_ref: undefined };
     case 'updateFile':
       const d = new Date();
       return {

--- a/x-pack/plugins/files/server/file/file_attributes_reducer.ts
+++ b/x-pack/plugins/files/server/file/file_attributes_reducer.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FileSavedObjectAttributes } from '../../common';
+
+export type Action =
+  | { action: 'create'; payload: FileSavedObjectAttributes }
+  | {
+      action: 'uploading';
+      payload?: undefined;
+    }
+  | { action: 'uploaded'; payload: { content_ref: string; size: number } }
+  | { action: 'uploadError'; payload?: undefined };
+
+export function createDefaultFileAttributes(): Pick<
+  FileSavedObjectAttributes,
+  'created_at' | 'updated_at' | 'status'
+> {
+  const dateString = new Date().toISOString();
+  return {
+    created_at: dateString,
+    updated_at: dateString,
+    status: 'AWAITING_UPLOAD',
+  };
+}
+
+export function fileAttributesReducer(
+  state: FileSavedObjectAttributes,
+  { action, payload }: Action
+): FileSavedObjectAttributes {
+  switch (action) {
+    case 'uploading':
+      return { ...state, content_ref: undefined, status: 'UPLOADING' };
+    case 'uploaded':
+      return { ...state, ...payload, status: 'READY' };
+    case 'uploadError':
+      return { ...state, status: 'ERROR', content_ref: undefined };
+    default:
+      return state;
+  }
+}

--- a/x-pack/plugins/files/server/file/index.ts
+++ b/x-pack/plugins/files/server/file/index.ts
@@ -6,8 +6,6 @@
  */
 
 export { File } from './file';
-export {
-  Action,
-  createDefaultFileAttributes,
-  fileAttributesReducer,
-} from './file_attributes_reducer';
+
+export { createDefaultFileAttributes, fileAttributesReducer } from './file_attributes_reducer';
+export type { Action } from './file_attributes_reducer';

--- a/x-pack/plugins/files/server/file/index.ts
+++ b/x-pack/plugins/files/server/file/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { File } from './file';
+export {
+  Action,
+  createDefaultFileAttributes,
+  fileAttributesReducer,
+} from './file_attributes_reducer';

--- a/x-pack/plugins/files/server/file_service.ts
+++ b/x-pack/plugins/files/server/file_service.ts
@@ -5,24 +5,98 @@
  * 2.0.
  */
 
-import type { Logger, SavedObjectsServiceSetup, SavedObjectsServiceStart } from '@kbn/core/server';
+import type {
+  Logger,
+  SavedObjectsServiceSetup,
+  SavedObjectsServiceStart,
+  SavedObject,
+} from '@kbn/core/server';
 import { BlobStorageService } from './blob_storage_service';
 import { fileObjectType } from './saved_objects';
+import { FileSavedObjectAttributes, File as IFile } from '../common';
+import { File, createDefaultFileAttributes } from './file';
+
+interface CreateFileArgs<Meta = {}> {
+  name: string;
+  fileKind: string;
+  alt?: string;
+  meta?: Meta;
+}
+
+interface ListFilesArgs {
+  fileKind: string;
+}
+
+interface FindFileArgs {
+  id: string;
+  fileKind: string;
+}
 
 /**
  * @internal
  */
 export class InternalFileService {
   constructor(
-    // @ts-ignore FIXME:
-    private readonly savedObjectsStart: SavedObjectsServiceStart,
-    // @ts-ignore FIXME:
+    private readonly savedObjectsService: SavedObjectsServiceStart,
     private readonly blobStorageService: BlobStorageService,
-    // @ts-ignore FIXME:
     private readonly logger: Logger
   ) {}
 
-  static setup(savedObjectsSetup: SavedObjectsServiceSetup): void {
+  private readonly savedObjectType = fileObjectType.name;
+
+  // TODO: Enforce that file kind exists based on registry
+  public async createFile(args: CreateFileArgs): Promise<IFile> {
+    const fileSO = await this.savedObjectsService
+      .createInternalRepository()
+      .create<FileSavedObjectAttributes>(this.savedObjectType, {
+        ...createDefaultFileAttributes(),
+        ...args,
+        file_kind: args.fileKind,
+      });
+
+    return this.from(fileSO);
+  }
+
+  public async find({ fileKind, id }: FindFileArgs): Promise<undefined | IFile> {
+    const result = await this.savedObjectsService
+      .createInternalRepository()
+      .find<FileSavedObjectAttributes>({
+        type: this.savedObjectType,
+        search: `_id=${id} AND file_kind=${fileKind}`,
+        searchFields: ['_id', 'attributes.file_kind'],
+      });
+
+    const so = result.saved_objects[0];
+    return so ? this.from(so) : undefined;
+  }
+
+  public async list({ fileKind }: ListFilesArgs): Promise<IFile[]> {
+    const result = await this.savedObjectsService
+      .createInternalRepository()
+      .find<FileSavedObjectAttributes>({
+        type: this.savedObjectType,
+        search: `file_kind=${fileKind}`,
+        searchFields: ['attributes.file_kind'],
+      });
+
+    return result.saved_objects.map(this.from.bind(this));
+  }
+
+  public async deleteFileSO(id: string): Promise<void> {
+    await this.savedObjectsService.createInternalRepository().delete(this.savedObjectType, id);
+  }
+
+  public async updateFileSO(id: string, attributes: FileSavedObjectAttributes) {
+    return await this.savedObjectsService
+      .createInternalRepository()
+      .update(this.savedObjectType, id, attributes);
+  }
+
+  public from<M>(fileSO: SavedObject<FileSavedObjectAttributes<M>>): IFile {
+    return new File(this, this.blobStorageService, fileSO, this.logger.get(`file-${fileSO.id}`));
+  }
+
+  public static setup(savedObjectsSetup: SavedObjectsServiceSetup): void {
     savedObjectsSetup.registerType(fileObjectType);
   }
 }

--- a/x-pack/plugins/files/server/file_service.ts
+++ b/x-pack/plugins/files/server/file_service.ts
@@ -45,6 +45,7 @@ export class InternalFileService {
   private readonly savedObjectType = fileObjectType.name;
 
   // TODO: Enforce that file kind exists based on registry
+  // TODO: Use security audit logger to log file creation
   public async createFile(args: CreateFileArgs): Promise<IFile> {
     const fileSO = await this.savedObjectsService
       .createInternalRepository()

--- a/x-pack/plugins/files/server/file_service/file_service_factory.ts
+++ b/x-pack/plugins/files/server/file_service/file_service_factory.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  SavedObjectsServiceSetup,
+  SavedObjectsServiceStart,
+  Logger,
+  KibanaRequest,
+} from '@kbn/core/server';
+import { SecurityPluginSetup } from '@kbn/security-plugin/server';
+
+import type { FileSavedObjectAttributes } from '../../common';
+import { fileObjectType } from '../saved_objects';
+import { BlobStorageService } from '../blob_storage_service';
+import { InternalFileService } from './internal_file_service';
+
+export class FileServiceFactory {
+  constructor(
+    private readonly savedObjectsService: SavedObjectsServiceStart,
+    private readonly blobStorageService: BlobStorageService,
+    private readonly security: undefined | SecurityPluginSetup,
+    private readonly logger: Logger
+  ) {}
+
+  private readonly savedObjectType = fileObjectType.name;
+
+  // TODO: This should probably not returnt he InternalFileService directly rather a FileService designed for public
+  private createFileService(req?: KibanaRequest): InternalFileService {
+    const soClient = req
+      ? this.savedObjectsService.getScopedClient(req, {
+          includedHiddenTypes: [this.savedObjectType],
+        })
+      : this.savedObjectsService.createInternalRepository([this.savedObjectType]);
+
+    const auditLogger = req
+      ? this.security?.audit.asScoped(req)
+      : this.security?.audit.withoutRequest;
+
+    return new InternalFileService(
+      this.savedObjectType,
+      soClient,
+      this.blobStorageService,
+      auditLogger,
+      this.logger
+    );
+  }
+
+  asScoped(req: KibanaRequest): InternalFileService {
+    return this.createFileService(req);
+  }
+
+  asInternal(): InternalFileService {
+    return this.createFileService();
+  }
+
+  public static setup(savedObjectsSetup: SavedObjectsServiceSetup): void {
+    savedObjectsSetup.registerType<FileSavedObjectAttributes<{}>>(fileObjectType);
+  }
+}

--- a/x-pack/plugins/files/server/file_service/file_service_factory.ts
+++ b/x-pack/plugins/files/server/file_service/file_service_factory.ts
@@ -49,14 +49,27 @@ export class FileServiceFactory {
     );
   }
 
-  asScoped(req: KibanaRequest): InternalFileService {
+  /**
+   * Get a file service instance that is scoped to the current user request.
+   */
+  public asScoped(req: KibanaRequest): InternalFileService {
     return this.createFileService(req);
   }
 
-  asInternal(): InternalFileService {
+  /**
+   * Get a file service instance that is scoped to the internal user.
+   *
+   * @note
+   * Do not use this to drive interactions with files that are initiated by a
+   * user.
+   */
+  public asInternal(): InternalFileService {
     return this.createFileService();
   }
 
+  /**
+   * This function can only called during Kibana's setup phase
+   */
   public static setup(savedObjectsSetup: SavedObjectsServiceSetup): void {
     savedObjectsSetup.registerType<FileSavedObjectAttributes<{}>>(fileObjectType);
   }

--- a/x-pack/plugins/files/server/file_service/index.ts
+++ b/x-pack/plugins/files/server/file_service/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { FileServiceFactory } from './file_service_factory';

--- a/x-pack/plugins/files/server/file_service/integration_tests/file_service.test.ts
+++ b/x-pack/plugins/files/server/file_service/integration_tests/file_service.test.ts
@@ -120,11 +120,11 @@ describe('FileService', () => {
     const file = await createDisposableFile({ fileKind, name: 'test' });
     const updatableFields = { name: 'new name', alt: 'my alt text', meta: { some: 'data' } };
     const updatedFile1 = await file.update(updatableFields);
-    // Fetch the file anew to be doubly sure
     expect(updatedFile1.meta).toEqual(expect.objectContaining(updatableFields.meta));
     expect(updatedFile1.name).toBe(updatableFields.name);
     expect(updatedFile1.alt).toBe(updatableFields.alt);
 
+    // Fetch the file anew to be doubly sure
     const updatedFile2 = await fileService.find({ fileKind, id: file.id });
     expect(updatedFile2.meta).toEqual(expect.objectContaining(updatableFields.meta));
     expect(updatedFile2.name).toBe(updatableFields.name);

--- a/x-pack/plugins/files/server/file_service/integration_tests/file_service.test.ts
+++ b/x-pack/plugins/files/server/file_service/integration_tests/file_service.test.ts
@@ -110,7 +110,10 @@ describe('FileService', () => {
 
   it('deletes files', async () => {
     const file = await fileService.createFile({ fileKind, name: 'test' });
+    const files = await fileService.list({ fileKind });
+    expect(files.length).toBe(1);
     await file.delete();
+    expect(await fileService.list({ fileKind })).toEqual([]);
   });
 
   it('updates files', async () => {

--- a/x-pack/plugins/files/server/file_service/internal_file_service.ts
+++ b/x-pack/plugins/files/server/file_service/internal_file_service.ts
@@ -45,8 +45,9 @@ interface FindFileArgs {
 }
 
 /**
- * Service containing methods for working with classes. All business logic for files
- * is encapsulated in {@link File} class.
+ * Service containing methods for working with files.
+ *
+ * All file business logic is encapsulated in the {@link File} class.
  *
  * @internal
  */

--- a/x-pack/plugins/files/server/file_services.test.ts
+++ b/x-pack/plugins/files/server/file_services.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Readable } from 'stream';
+import { InternalFileService } from './file_service';
+
+describe('FileService', () => {
+  let fileService: InternalFileService;
+  const fileKind: string = 'test';
+
+  it('creates file metadata', async () => {
+    const file = await fileService.createFile({ fileKind, name: 'test' });
+    expect(file.getMetadata()).toEqual(expect.objectContaining({}));
+  });
+
+  it('uploads file content', async () => {
+    const file = await fileService.createFile({ fileKind, name: 'test' });
+    await file.uploadContent(Readable.from(['upload this']));
+  });
+
+  it('retrieves a file', async () => {
+    const file = await fileService.createFile({ fileKind, name: 'test' });
+    const file2 = await fileService.find({ id: file.id, fileKind });
+  });
+
+  it('lists files', async () => {
+    const file = await fileService.createFile({ fileKind, name: 'test' });
+  });
+
+  it('deletes files', async () => {
+    const file = await fileService.createFile({ fileKind, name: 'test' });
+    await file.delete();
+  });
+});

--- a/x-pack/plugins/files/server/integration_tests/file_service.test.ts
+++ b/x-pack/plugins/files/server/integration_tests/file_service.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { Readable } from 'stream';
-import { InternalFileService } from './file_service';
+import { InternalFileService } from '../file_service';
 
 describe('FileService', () => {
   let fileService: InternalFileService;

--- a/x-pack/plugins/files/server/integration_tests/file_service.test.ts
+++ b/x-pack/plugins/files/server/integration_tests/file_service.test.ts
@@ -5,30 +5,108 @@
  * 2.0.
  */
 
+import { CoreStart, ElasticsearchClient } from '@kbn/core/server';
+import {
+  createTestServers,
+  createRootWithCorePlugins,
+  TestElasticsearchUtils,
+} from '@kbn/core/test_helpers/kbn_server';
 import { Readable } from 'stream';
+
+import type { FileStatus, File } from '../../common';
+
+import { BlobStorageService } from '../blob_storage_service';
 import { InternalFileService } from '../file_service';
 
 describe('FileService', () => {
-  let fileService: InternalFileService;
   const fileKind: string = 'test';
 
+  let manageES: TestElasticsearchUtils;
+  let kbnRoot: ReturnType<typeof createRootWithCorePlugins>;
+  let fileService: InternalFileService;
+  let blobStorageService: BlobStorageService;
+  let esClient: ElasticsearchClient;
+  let coreSetup: Awaited<ReturnType<typeof kbnRoot.setup>>;
+  let coreStart: CoreStart;
+
+  let disposables: File[] = [];
+  const createFile: typeof fileService.createFile = async (args) => {
+    const file = await fileService.createFile(args);
+    disposables.push(file);
+    return file;
+  };
+
+  beforeAll(async () => {
+    const { startES } = createTestServers({ adjustTimeout: jest.setTimeout });
+    manageES = await startES();
+    kbnRoot = createRootWithCorePlugins();
+    await kbnRoot.preboot();
+    coreSetup = await kbnRoot.setup();
+    InternalFileService.setup(coreSetup.savedObjects);
+    coreStart = await kbnRoot.start();
+    esClient = coreStart.elasticsearch.client.asInternalUser;
+  });
+
+  afterAll(async () => {
+    await kbnRoot.shutdown();
+    await manageES.stop();
+  });
+
+  beforeEach(() => {
+    blobStorageService = new BlobStorageService(esClient, kbnRoot.logger.get('test-blob-service'));
+    fileService = new InternalFileService(
+      coreStart.savedObjects,
+      blobStorageService,
+      kbnRoot.logger.get('test-file-service')
+    );
+  });
+
+  afterEach(async () => {
+    await Promise.all(disposables.map((file) => file.delete()));
+    const results = await fileService.list({ fileKind });
+    expect(results.length).toBe(0);
+    disposables = [];
+  });
+
   it('creates file metadata', async () => {
-    const file = await fileService.createFile({ fileKind, name: 'test' });
-    expect(file.getMetadata()).toEqual(expect.objectContaining({}));
+    const file = await createFile({ fileKind, name: 'test' });
+    expect(file.getMetadata()).toEqual(
+      expect.objectContaining({
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+        name: 'test',
+        file_kind: 'test',
+      })
+    );
+    expect(file.status).toBe('AWAITING_UPLOAD' as FileStatus);
   });
 
   it('uploads file content', async () => {
-    const file = await fileService.createFile({ fileKind, name: 'test' });
+    const file = await createFile({ fileKind, name: 'test' });
     await file.uploadContent(Readable.from(['upload this']));
+    const rs = await file.downloadContent();
+    const chunks: string[] = [];
+    for await (const chunk of rs) {
+      chunks.push(chunk);
+    }
+    expect(chunks.join('')).toBe('upload this');
   });
 
   it('retrieves a file', async () => {
-    const file = await fileService.createFile({ fileKind, name: 'test' });
-    const file2 = await fileService.find({ id: file.id, fileKind });
+    const { id } = await createFile({ fileKind, name: 'test' });
+    const myFile = await fileService.find({ id, fileKind });
+    expect(myFile?.id).toMatch(id);
   });
 
   it('lists files', async () => {
-    const file = await fileService.createFile({ fileKind, name: 'test' });
+    await Promise.all([
+      createFile({ fileKind, name: 'test-1' }),
+      createFile({ fileKind, name: 'test-2' }),
+      createFile({ fileKind, name: 'test-3' }),
+      createFile({ fileKind, name: 'test-3' /* Also test file with same name */ }),
+    ]);
+    const result = await fileService.list({ fileKind });
+    expect(result.length).toBe(4);
   });
 
   it('deletes files', async () => {

--- a/x-pack/plugins/files/server/types.ts
+++ b/x-pack/plugins/files/server/types.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { SecurityPluginSetup } from '@kbn/security-plugin/server';
+
+export interface FilePluginSetup {
+  security?: SecurityPluginSetup;
+}

--- a/x-pack/plugins/files/tsconfig.json
+++ b/x-pack/plugins/files/tsconfig.json
@@ -9,5 +9,6 @@
   "include": ["common/**/*", "public/**/*", "server/**/*"],
   "references": [
     { "path": "../../../src/core/tsconfig.json" },
+    { "path": "../security/tsconfig.json" },
   ]
 }


### PR DESCRIPTION
## Summary

Addresses KS-2318

## To reviewers

* `InternalFileService` functions as a service class to `File` which contains all of the business logic of working with files. See the `integration_tests` for an example of how this works from a consumer perspective. The `InternalFileService` does contain functionality for working with files without the `File` class directly (like when you only have an ID and file kind), but these still use `File` under the hood.
* Added `asScoped` and `asInternal` functions to the new `FileServiceFactory` that instantiate a scoped or unscoped version of the `InternalFileService` and any subsequent `File` classes.

## How to test

Easiest is to view the `integration_test` files

## Follow up

* Add unit tests for the `File` class
* Add some more test coverage to the ES-backed blob storage implementation