### PR TITLE
[Fleet] Add "clear all" button to tag filter dropdown

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -13,12 +13,15 @@ import {
   EuiFilterSelectItem,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
   EuiPopover,
   EuiPortal,
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import styled from 'styled-components';
 
 import type { Agent, AgentPolicy } from '../../../../types';
 import { AgentEnrollmentFlyout, SearchBar } from '../../../../components';
@@ -61,6 +64,10 @@ const statusFilters = [
     }),
   },
 ];
+
+const ClearAllTagsFilterItem = styled(EuiFilterSelectItem)`
+  padding: ${(props) => props.theme.eui.paddingSizes.s};
+`;
 
 export const SearchAndFilterBar: React.FunctionComponent<{
   agentPolicies: AgentPolicy[];
@@ -222,27 +229,45 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                   panelPaddingSize="none"
                 >
                   <div className="euiFilterSelect__items">
-                    {tags.map((tag, index) => (
-                      <EuiFilterSelectItem
-                        checked={selectedTags.includes(tag) ? 'on' : undefined}
-                        key={index}
+                    <>
+                      {tags.map((tag, index) => (
+                        <EuiFilterSelectItem
+                          checked={selectedTags.includes(tag) ? 'on' : undefined}
+                          key={index}
+                          onClick={() => {
+                            if (selectedTags.includes(tag)) {
+                              removeTagsFilter(tag);
+                            } else {
+                              addTagsFilter(tag);
+                            }
+                          }}
+                        >
+                          {tag.length > MAX_TAG_DISPLAY_LENGTH ? (
+                            <EuiToolTip content={tag}>
+                              <span>{truncateTag(tag)}</span>
+                            </EuiToolTip>
+                          ) : (
+                            tag
+                          )}
+                        </EuiFilterSelectItem>
+                      ))}
+
+                      <EuiHorizontalRule margin="none" />
+
+                      <ClearAllTagsFilterItem
+                        showIcons={false}
                         onClick={() => {
-                          if (selectedTags.includes(tag)) {
-                            removeTagsFilter(tag);
-                          } else {
-                            addTagsFilter(tag);
-                          }
+                          onSelectedTagsChange([]);
                         }}
                       >
-                        {tag.length > MAX_TAG_DISPLAY_LENGTH ? (
-                          <EuiToolTip content={tag}>
-                            <span>{truncateTag(tag)}</span>
-                          </EuiToolTip>
-                        ) : (
-                          tag
-                        )}
-                      </EuiFilterSelectItem>
-                    ))}
+                        <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="s">
+                          <EuiFlexItem grow={false}>
+                            <EuiIcon type="crossInACircleFilled" color="danger" size="s" />
+                          </EuiFlexItem>
+                          <EuiFlexItem grow={false}>Clear all</EuiFlexItem>
+                        </EuiFlexGroup>
+                      </ClearAllTagsFilterItem>
+                    </>
                   </div>
                 </EuiPopover>
                 <EuiPopover


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/132426

Adds a "clear all" button per designs to the tag filter dropdown. 

## Screenshot

![image](https://user-images.githubusercontent.com/6766512/169062524-f7874f42-73f3-47f6-a1a1-06bfa1fee495.png)

## Screen Recording

https://user-images.githubusercontent.com/6766512/169062402-4662e2b4-f749-4148-a855-2e708384cf46.mov



