### PR TITLE
Update user risk dashboard title

### DIFF
--- a/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_tab_body.tsx
@@ -27,7 +27,7 @@ const StyledEuiFlexGroup = styled(EuiFlexGroup)`
   margin-top: ${({ theme }) => theme.eui.paddingSizes.l};
 `;
 
-const RISKY_USERS_DASHBOARD_TITLE = 'User Risk Score (Start Here)';
+const RISKY_USERS_DASHBOARD_TITLE = 'Current Risk Score For Users';
 
 const UserRiskTabBodyComponent: React.FC<
   Pick<UsersComponentsQueryProps, 'startDate' | 'endDate' | 'setQuery' | 'deleteQuery'> & {


### PR DESCRIPTION
## Summary

Update user risk dashboard title.

** The button is enabled when it finds a saved object with the right title.


<img width="1772" alt="Screenshot 2022-05-18 at 16 39 37" src="https://user-images.githubusercontent.com/1490444/169068630-99eb6620-cb1c-421b-a9a3-e0d8a30407b3.png">
