### PR TITLE
[ML] Transforms: Fix width of icon column in Messages table

### DIFF
--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_messages_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_messages_pane.tsx
@@ -81,7 +81,7 @@ export const ExpandedRowMessagesPane: React.FC<Props> = ({ transformId }) => {
     {
       name: '',
       render: (message: TransformMessage) => <JobIcon message={message} />,
-      width: `${theme.euiSizeXL}px`,
+      width: theme.euiSizeXL,
     },
     {
       name: i18n.translate(


### PR DESCRIPTION
## Summary

Fixes the style of the column used to display the info / warning / error level icon in the Messages table in the expanded row of the Transforms table, so that it fits the width of the icon.

Before:

![image](https://user-images.githubusercontent.com/7405507/169083350-839eb465-104d-4a30-b665-ea105f9c607d.png)


After:

![image](https://user-images.githubusercontent.com/7405507/169083239-37dba2ba-0d6c-4e5f-bc89-ccba1fd422a1.png)



### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)





