### PR TITLE
[maps] update vector tile search API integration tests for fixed polygon orientation

### DIFF
--- a/x-pack/test/api_integration/apis/maps/get_grid_tile.js
+++ b/x-pack/test/api_integration/apis/maps/get_grid_tile.js
@@ -12,8 +12,7 @@ import expect from '@kbn/expect';
 export default function ({ getService }) {
   const supertest = getService('supertest');
 
-  // Failing: See https://github.com/elastic/kibana/issues/132372
-  describe.skip('getGridTile', () => {
+  describe('getGridTile', () => {
     const URL = `/api/maps/mvt/getGridTile/3/2/3.pbf\
 ?geometryFieldName=geo.coordinates\
 &index=logstash-*\
@@ -110,9 +109,9 @@ export default function ({ getService }) {
       expect(gridFeature.loadGeometry()).to.eql([
         [
           { x: 80, y: 672 },
-          { x: 96, y: 672 },
-          { x: 96, y: 656 },
           { x: 80, y: 656 },
+          { x: 96, y: 656 },
+          { x: 96, y: 672 },
           { x: 80, y: 672 },
         ],
       ]);
@@ -143,11 +142,11 @@ export default function ({ getService }) {
       expect(gridFeature.loadGeometry()).to.eql([
         [
           { x: 102, y: 669 },
-          { x: 99, y: 659 },
-          { x: 89, y: 657 },
-          { x: 83, y: 664 },
-          { x: 86, y: 674 },
           { x: 96, y: 676 },
+          { x: 86, y: 674 },
+          { x: 83, y: 664 },
+          { x: 89, y: 657 },
+          { x: 99, y: 659 },
           { x: 102, y: 669 },
         ],
       ]);
@@ -186,9 +185,9 @@ export default function ({ getService }) {
       expect(metadataFeature.loadGeometry()).to.eql([
         [
           { x: 0, y: 4096 },
-          { x: 4096, y: 4096 },
-          { x: 4096, y: 0 },
           { x: 0, y: 0 },
+          { x: 4096, y: 0 },
+          { x: 4096, y: 4096 },
           { x: 0, y: 4096 },
         ],
       ]);

--- a/x-pack/test/api_integration/apis/maps/get_tile.js
+++ b/x-pack/test/api_integration/apis/maps/get_tile.js
@@ -21,8 +21,7 @@ function findFeature(layer, callbackFn) {
 export default function ({ getService }) {
   const supertest = getService('supertest');
 
-  // Failing: See https://github.com/elastic/kibana/issues/132368
-  describe.skip('getTile', () => {
+  describe('getTile', () => {
     it('should return ES vector tile containing documents and metadata', async () => {
       const resp = await supertest
         .get(
@@ -78,9 +77,9 @@ export default function ({ getService }) {
       expect(metadataFeature.loadGeometry()).to.eql([
         [
           { x: 44, y: 2382 },
-          { x: 550, y: 2382 },
-          { x: 550, y: 1913 },
           { x: 44, y: 1913 },
+          { x: 550, y: 1913 },
+          { x: 550, y: 2382 },
           { x: 44, y: 2382 },
         ],
       ]);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/132368 and https://github.com/elastic/kibana/issues/132372

https://github.com/elastic/elasticsearch/pull/86555 changed order to coordinates in vector tile search API response. This PR updates maps integration tests to reflect those changes.

Verified new polygon orientation renders as expected.