### PR TITLE
[KibanaPageTemplateSolutionNavAvatar] Increase specificity of styles

### DIFF
--- a/src/plugins/kibana_react/public/page_template/solution_nav/solution_nav_avatar.scss
+++ b/src/plugins/kibana_react/public/page_template/solution_nav/solution_nav_avatar.scss
@@ -1,7 +1,7 @@
 .kbnPageTemplateSolutionNavAvatar {
   @include euiBottomShadowSmall;
 
-  &--xxl {
+  &.kbnPageTemplateSolutionNavAvatar--xxl {
     @include euiBottomShadowMedium;
     @include size(100px);
     line-height: 100px;


### PR DESCRIPTION
## Mostly a temporary fix until #132363 is figured out

Since EUI switched to Emotion, we've converted just a few components like EuiAvatar. But there's a slight import of styles ordering issue that causes some custom Kibana styles to not override EUI's styles because of cascade order. This one I just fixed specifically by increasing the specificity for the stylized `xxl` version.

**BEFORE**
<img width="583" alt="Screen Shot 2022-05-18 at 11 52 25 AM" src="https://user-images.githubusercontent.com/549577/169087868-af47139c-80b8-4aef-9bed-b3a7ff5e5f5b.png">


**AFTER**
<img width="774" alt="Screen Shot 2022-05-18 at 11 52 17 AM" src="https://user-images.githubusercontent.com/549577/169087891-521cdfb0-d437-4986-b974-d97f96794f92.png">


### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
