### PR TITLE
[Fleet] Remove reference to non removable package feature

### DIFF
--- a/x-pack/plugins/fleet/.storybook/context/fixtures/integration.nginx.ts
+++ b/x-pack/plugins/fleet/.storybook/context/fixtures/integration.nginx.ts
@@ -664,6 +664,5 @@ export const item: GetInfoResponse['item'] = {
     github: 'elastic/integrations',
   },
   latestVersion: '0.7.0',
-  removable: true,
   status: 'not_installed',
 };

--- a/x-pack/plugins/fleet/.storybook/context/fixtures/integration.okta.ts
+++ b/x-pack/plugins/fleet/.storybook/context/fixtures/integration.okta.ts
@@ -263,6 +263,5 @@ export const item: GetInfoResponse['item'] = {
     github: 'elastic/security-external-integrations',
   },
   latestVersion: '1.2.0',
-  removable: true,
   status: 'not_installed',
 };

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3573,9 +3573,6 @@
           },
           "path": {
             "type": "string"
-          },
-          "removable": {
-            "type": "boolean"
           }
         },
         "required": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2228,8 +2228,6 @@ components:
           type: string
         path:
           type: string
-        removable:
-          type: boolean
       required:
         - name
         - title

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/package_info.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/package_info.yaml
@@ -102,8 +102,6 @@ properties:
     type: string
   path:
     type: string
-  removable:
-    type: boolean
 required:
   - name
   - title

--- a/x-pack/plugins/fleet/common/services/fixtures/aws_package.ts
+++ b/x-pack/plugins/fleet/common/services/fixtures/aws_package.ts
@@ -1921,7 +1921,6 @@ export const AWS_PACKAGE = {
     },
   ],
   latestVersion: '0.5.3',
-  removable: true,
   status: 'not_installed',
 };
 

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -372,7 +372,6 @@ export interface EpmPackageAdditions {
   title: string;
   latestVersion: string;
   assets: AssetsGroupedByServiceByType;
-  removable?: boolean;
   notice?: string;
   keepPoliciesUpToDate?: boolean;
 }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.test.tsx
@@ -164,7 +164,6 @@ describe('when on the package policy create page', () => {
             },
           ],
           latestVersion: '1.3.0',
-          removable: true,
           keepPoliciesUpToDate: false,
           status: 'not_installed',
         },

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_configure_package.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_configure_package.test.tsx
@@ -96,7 +96,6 @@ describe('StepConfigurePackage', () => {
         },
       ],
       latestVersion: '1.3.0',
-      removable: true,
       keepPoliciesUpToDate: false,
       status: 'not_installed',
     };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
@@ -89,7 +89,6 @@ jest.mock('../../../hooks', () => {
               },
             ],
             latestVersion: version,
-            removable: true,
             keepPoliciesUpToDate: false,
             status: 'not_installed',
           },

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -509,7 +509,6 @@ const mockApiCalls = (
       ],
       owner: { github: 'elastic/integrations-services' },
       latestVersion: '0.3.7',
-      removable: true,
       status: 'installed',
     },
   } as GetInfoResponse;

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -97,7 +97,7 @@ interface Props {
 }
 
 export const SettingsPage: React.FC<Props> = memo(({ packageInfo, theme$ }: Props) => {
-  const { name, title, removable, latestVersion, version, keepPoliciesUpToDate } = packageInfo;
+  const { name, title, latestVersion, version, keepPoliciesUpToDate } = packageInfo;
   const [dryRunData, setDryRunData] = useState<UpgradePackagePolicyDryRunResponse | null>();
   const [isUpgradingPackagePolicies, setIsUpgradingPackagePolicies] = useState<boolean>(false);
   const getPackageInstallStatus = useGetPackageInstallStatus();
@@ -342,60 +342,44 @@ export const SettingsPage: React.FC<Props> = memo(({ packageInfo, theme$ }: Prop
                   </EuiFlexGroup>
                 </div>
               ) : (
-                removable && (
-                  <>
-                    <div>
-                      <EuiTitle>
-                        <h4>
-                          <FormattedMessage
-                            id="xpack.fleet.integrations.settings.packageUninstallTitle"
-                            defaultMessage="Uninstall"
-                          />
-                        </h4>
-                      </EuiTitle>
-                      <EuiSpacer size="s" />
-                      <p>
+                <>
+                  <div>
+                    <EuiTitle>
+                      <h4>
                         <FormattedMessage
-                          id="xpack.fleet.integrations.settings.packageUninstallDescription"
-                          defaultMessage="Remove Kibana and Elasticsearch assets that were installed by this integration."
+                          id="xpack.fleet.integrations.settings.packageUninstallTitle"
+                          defaultMessage="Uninstall"
+                        />
+                      </h4>
+                    </EuiTitle>
+                    <EuiSpacer size="s" />
+                    <p>
+                      <FormattedMessage
+                        id="xpack.fleet.integrations.settings.packageUninstallDescription"
+                        defaultMessage="Remove Kibana and Elasticsearch assets that were installed by this integration."
+                      />
+                    </p>
+                  </div>
+                  <EuiFlexGroup>
+                    <EuiFlexItem grow={false}>
+                      <p>
+                        <UninstallButton
+                          {...packageInfo}
+                          numOfAssets={numOfAssets}
+                          latestVersion={latestVersion}
+                          disabled={!packagePoliciesData || packageHasUsages}
                         />
                       </p>
-                    </div>
-                    <EuiFlexGroup>
-                      <EuiFlexItem grow={false}>
-                        <p>
-                          <UninstallButton
-                            {...packageInfo}
-                            numOfAssets={numOfAssets}
-                            latestVersion={latestVersion}
-                            disabled={!packagePoliciesData || packageHasUsages}
-                          />
-                        </p>
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  </>
-                )
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </>
               )}
-              {packageHasUsages && removable === true && (
+              {packageHasUsages && (
                 <p>
                   <EuiText color="subdued">
                     <FormattedMessage
                       id="xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteDetail"
                       defaultMessage="{strongNote} {title} cannot be uninstalled because there are active agents that use this integration. To uninstall, remove all {title} integrations from your agent policies."
-                      values={{
-                        title,
-                        strongNote: <NoteLabel />,
-                      }}
-                    />
-                  </EuiText>
-                </p>
-              )}
-              {removable === false && (
-                <p>
-                  <EuiText color="subdued">
-                    <FormattedMessage
-                      id="xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallUninstallableNoteDetail"
-                      defaultMessage="{strongNote} The {title} integration is a system integration and cannot be removed."
                       values={{
                         title,
                         strongNote: <NoteLabel />,

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -38,6 +38,7 @@ import { migratePackagePolicyToV7150 } from './migrations/to_v7_15_0';
 import { migrateInstallationToV7160, migratePackagePolicyToV7160 } from './migrations/to_v7_16_0';
 import { migrateInstallationToV800, migrateOutputToV800 } from './migrations/to_v8_0_0';
 import { migratePackagePolicyToV820 } from './migrations/to_v8_2_0';
+import { migrateInstallationToV830 } from './migrations/to_v8_3_0';
 
 /*
  * Saved object types and mappings
@@ -223,7 +224,6 @@ const getSavedObjectTypes = (
         name: { type: 'keyword' },
         version: { type: 'keyword' },
         internal: { type: 'boolean' },
-        removable: { type: 'boolean' },
         keep_policies_up_to_date: { type: 'boolean', index: false },
         es_index_patterns: {
           enabled: false,
@@ -262,6 +262,7 @@ const getSavedObjectTypes = (
       '7.14.1': migrateInstallationToV7140,
       '7.16.0': migrateInstallationToV7160,
       '8.0.0': migrateInstallationToV800,
+      '8.3.0': migrateInstallationToV830,
     },
   },
   [ASSETS_SAVED_OBJECT_TYPE]: {

--- a/x-pack/plugins/fleet/server/saved_objects/migrations/to_v8_3_0.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/migrations/to_v8_3_0.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectMigrationFn } from '@kbn/core/server';
+
+import type { Installation } from '../../../common';
+
+export const migrateInstallationToV830: SavedObjectMigrationFn<Installation, Installation> = (
+  installationDoc,
+  migrationContext
+) => {
+  delete installationDoc.attributes.removable;
+
+  return installationDoc;
+};

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -176,7 +176,6 @@ export async function getPackageInfo({
         : resolvedPkgVersion,
     title: packageInfo.title || nameAsTitle(packageInfo.name),
     assets: Registry.groupPathsByService(paths || []),
-    removable: true,
     notice: Registry.getNoticePath(paths || []),
     keepPoliciesUpToDate: savedObject?.attributes.keep_policies_up_to_date ?? false,
   };

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -598,7 +598,6 @@ export async function createInstallation(options: {
     ? true
     : undefined;
 
-  // TODO cleanup removable flag and isUnremovablePackage function
   const created = await savedObjectsClient.create<Installation>(
     PACKAGES_SAVED_OBJECT_TYPE,
     {
@@ -609,7 +608,6 @@ export async function createInstallation(options: {
       es_index_patterns: toSaveESIndexPatterns,
       name: pkgName,
       version: pkgVersion,
-      removable: true,
       install_version: pkgVersion,
       install_status: 'installing',
       install_started_at: new Date().toISOString(),

--- a/x-pack/plugins/fleet/server/services/epm/packages/remove.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/remove.ts
@@ -44,11 +44,9 @@ export async function removeInstallation(options: {
   esClient: ElasticsearchClient;
   force?: boolean;
 }): Promise<AssetReference[]> {
-  const { savedObjectsClient, pkgName, pkgVersion, esClient, force } = options;
+  const { savedObjectsClient, pkgName, pkgVersion, esClient } = options;
   const installation = await getInstallation({ savedObjectsClient, pkgName });
   if (!installation) throw Boom.badRequest(`${pkgName} is not installed`);
-  if (installation.removable === false && !force)
-    throw Boom.badRequest(`${pkgName} is installed by default and cannot be removed`);
 
   const { total } = await packagePolicyService.list(savedObjectsClient, {
     kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${pkgName}`,

--- a/x-pack/plugins/fleet/server/services/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/plugins/fleet/server/services/package_policies_to_agent_permissions.test.ts
@@ -391,7 +391,6 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
         },
       ],
       latestVersion: '0.3.0',
-      removable: true,
       notice: undefined,
       status: 'not_installed',
       assets: {

--- a/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
@@ -1764,7 +1764,6 @@ export class EndpointDocGenerator extends BaseDataGenerator {
           name: 'endpoint',
           version: '0.5.0',
           internal: false,
-          removable: false,
           install_version: '0.5.0',
           install_status: 'installed',
           install_started_at: '2020-06-24T14:41:23.098Z',

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -12839,7 +12839,6 @@
     "xpack.fleet.integrations.settings.packageUninstallDescription": "Supprimez les ressources Kibana et Elasticsearch installées par cette intégration.",
     "xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteDetail": "{strongNote} Impossible d'installer {title}, car des agents actifs utilisent cette intégration. Pour procéder à la désinstallation, supprimez toutes les intégrations {title} de vos stratégies d'agent.",
     "xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteLabel": "Remarque :",
-    "xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallUninstallableNoteDetail": "{strongNote} L'intégration de {title} est une intégration système. Vous ne pouvez pas la supprimer.",
     "xpack.fleet.integrations.settings.packageUninstallTitle": "Désinstaller",
     "xpack.fleet.integrations.settings.packageVersionTitle": "Version de {title}",
     "xpack.fleet.integrations.settings.versionInfo.installedVersion": "Version installée",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -12946,7 +12946,6 @@
     "xpack.fleet.integrations.settings.packageUninstallDescription": "この統合によってインストールされたKibanaおよびElasticsearchアセットを削除します。",
     "xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteDetail": "{strongNote} {title}をアンインストールできません。この統合を使用しているアクティブなエージェントがあります。アンインストールするには、エージェントポリシーからすべての{title}統合を削除します。",
     "xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteLabel": "注：",
-    "xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallUninstallableNoteDetail": "{strongNote} {title}統合はシステム統合であるため、削除できません。",
     "xpack.fleet.integrations.settings.packageUninstallTitle": "アンインストール",
     "xpack.fleet.integrations.settings.packageVersionTitle": "{title}バージョン",
     "xpack.fleet.integrations.settings.versionInfo.installedVersion": "インストールされているバージョン",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -12970,7 +12970,6 @@
     "xpack.fleet.integrations.settings.packageUninstallDescription": "移除此集成安装的 Kibana 和 Elasticsearch 资产。",
     "xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteDetail": "{strongNote}{title} 无法卸载，因为存在使用此集成的活动代理。要卸载，请从您的代理策略中移除所有 {title} 集成。",
     "xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteLabel": "注意：",
-    "xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallUninstallableNoteDetail": "{strongNote}{title} 集成是系统集成，无法移除。",
     "xpack.fleet.integrations.settings.packageUninstallTitle": "卸载",
     "xpack.fleet.integrations.settings.packageVersionTitle": "{title} 版本",
     "xpack.fleet.integrations.settings.versionInfo.installedVersion": "已安装版本",

--- a/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
@@ -738,7 +738,6 @@ const expectAssetsInstalled = ({
       },
       name: 'all_assets',
       version: '0.1.0',
-      removable: true,
       install_version: '0.1.0',
       install_status: 'installed',
       install_started_at: res.attributes.install_started_at,

--- a/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
@@ -498,7 +498,6 @@ export default function (providerContext: FtrProviderContext) {
         ],
         name: 'all_assets',
         version: '0.2.0',
-        removable: true,
         install_version: '0.2.0',
         install_status: 'installed',
         install_started_at: res.attributes.install_started_at,

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/filetest/0.1.0/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/filetest/0.1.0/manifest.yml
@@ -10,8 +10,6 @@ release: beta
 # The default type is integration and will be set if empty.
 type: integration
 license: basic
-# This package can be removed
-removable: true
 
 requirement:
   elasticsearch:

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/with_required_variables/0.1.0/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/with_required_variables/0.1.0/manifest.yml
@@ -10,8 +10,6 @@ release: beta
 # The default type is integration and will be set if empty.
 type: integration
 license: basic
-# This package can be removed
-removable: true
 
 requirement:
   elasticsearch:


### PR DESCRIPTION
## Summary

Resolve #125806 

We used to allow to have non removable package, that feature do not exists anymore, so that PR remove all the reference to `removable` package.

There is one breaking change in the API: I removed the `removable: true` from the get package info, I checked it is not used by any internal fleet API consumer.
