### PR TITLE
Fix flaky user activation/deactivation tests

### DIFF
--- a/x-pack/test/functional/apps/security/users.ts
+++ b/x-pack/test/functional/apps/security/users.ts
@@ -202,8 +202,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/118728
-      describe.skip('Deactivate/Activate user', () => {
+      describe('Deactivate/Activate user', () => {
         it('deactivates user when confirming', async () => {
           await PageObjects.security.deactivatesUser(optionalUser);
           const users = keyBy(await PageObjects.security.getElasticsearchUsers(), 'username');

--- a/x-pack/test/functional/page_objects/security_page.ts
+++ b/x-pack/test/functional/page_objects/security_page.ts
@@ -37,6 +37,7 @@ export class SecurityPageObject extends FtrService {
   private readonly common = this.ctx.getPageObject('common');
   private readonly header = this.ctx.getPageObject('header');
   private readonly monacoEditor = this.ctx.getService('monacoEditor');
+  private readonly es = this.ctx.getService('es');
 
   public loginPage = Object.freeze({
     login: async (username?: string, password?: string, options: LoginOptions = {}) => {
@@ -350,13 +351,6 @@ export class SecurityPageObject extends FtrService {
 
     const btn = await this.find.byButtonText(privilege);
     await btn.click();
-
-    // const options = await this.find.byCssSelector(`.euiFilterSelectItem`);
-    // Object.entries(options).forEach(([key, prop]) => {
-    //   console.log({ key, proto: prop.__proto__ });
-    // });
-
-    // await options.click();
   }
 
   async assignRoleToUser(role: string) {
@@ -516,6 +510,13 @@ export class SecurityPageObject extends FtrService {
     await this.clickUserByUserName(user.username ?? '');
     await this.testSubjects.click('editUserDisableUserButton');
     await this.testSubjects.click('confirmModalConfirmButton');
+    await this.testSubjects.missingOrFail('confirmModalConfirmButton');
+    if (user.username) {
+      await this.retry.waitForWithTimeout('ES to acknowledge deactivation', 15000, async () => {
+        const userResponse = await this.es.security.getUser({ username: user.username });
+        return userResponse[user.username!].enabled === false;
+      });
+    }
     await this.submitUpdateUserForm();
   }
 
@@ -523,6 +524,13 @@ export class SecurityPageObject extends FtrService {
     await this.clickUserByUserName(user.username ?? '');
     await this.testSubjects.click('editUserEnableUserButton');
     await this.testSubjects.click('confirmModalConfirmButton');
+    await this.testSubjects.missingOrFail('confirmModalConfirmButton');
+    if (user.username) {
+      await this.retry.waitForWithTimeout('ES to acknowledge activation', 15000, async () => {
+        const userResponse = await this.es.security.getUser({ username: user.username });
+        return userResponse[user.username!].enabled === true;
+      });
+    }
     await this.submitUpdateUserForm();
   }
 


### PR DESCRIPTION
## Summary

Updates the activate/deactivate page object test functions to wait until ES acknowledges the operation before continuing.

Resolves https://github.com/elastic/kibana/issues/118728

### Flaky test runs
1) https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/640
2) https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/641
3) https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/642

300 test runs completed without failures. 