### PR TITLE
[8.2] [ResponseOps] Fix broken search strategy test (#130393)

### DIFF
--- a/x-pack/test/common/services/bsearch_secure.ts
+++ b/x-pack/test/common/services/bsearch_secure.ts
@@ -79,12 +79,11 @@ export const BSecureSearchFactory = (retry: RetryService) => ({
           .set('kbn-xsrf', 'true')
           .send(options);
       }
-      if (result.status === 500 || result.status === 200) {
+      if ((result.status === 500 || result.status === 200) && result.body) {
         return result;
       }
       throw new Error('try again');
     });
-
     if (body.isRunning) {
       const result = await retry.try(async () => {
         const resp = await supertestWithoutAuth

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/search_strategy.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/search_strategy.ts
@@ -43,7 +43,7 @@ export default ({ getService }: FtrProviderContext) => {
   const SPACE1 = 'space1';
 
   // Failing: See https://github.com/elastic/kibana/issues/129219
-  describe.skip('ruleRegistryAlertsSearchStrategy', () => {
+  describe('ruleRegistryAlertsSearchStrategy', () => {
     let kibanaVersion: string;
     before(async () => {
       kibanaVersion = await kbnClient.version.get();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[ResponseOps] Fix broken search strategy test (#130393)](https://github.com/elastic/kibana/pull/130393)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)