### PR TITLE
[Security Solution][Admin][Kql bar] Align kql bar with buttons on same row in endpoint list

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
@@ -726,7 +726,7 @@ export const EndpointList = () => {
           </>
         )}
         {transformFailedCallout}
-        <EuiFlexGroup gutterSize="s">
+        <EuiFlexGroup gutterSize="s" alignItems="center">
           {shouldShowKQLBar && (
             <EuiFlexItem>
               <AdminSearchBar />


### PR DESCRIPTION
## Summary

- [x] Fixes a bug where the kql bar was not aligned with the other buttons on the same row in the admin > endpoint list

# Screenshots
BEFORE
<img width="1665" alt="image" src="https://user-images.githubusercontent.com/56409205/169144010-15581c47-477a-40b7-8123-fcbe37b9cb13.png">


AFTER
<img width="1663" alt="image" src="https://user-images.githubusercontent.com/56409205/169143808-1145e75b-4f27-4f89-9745-a44a041021e0.png">
