### PR TITLE
Add message about search.check_ccs_compatibility error to troubleshooting guide.

### DIFF
--- a/dev_docs/getting_started/troubleshooting.mdx
+++ b/dev_docs/getting_started/troubleshooting.mdx
@@ -26,3 +26,17 @@ git clean -fdxn -e /config -e /.vscode
 # review the files which will be deleted, consider adding some more excludes (-e)
 # re-run without the dry-run (-n) flag to actually delete the files
 ```
+
+### search.check_ccs_compatibility error
+
+If you run into an error that says something like:
+
+```
+[class org.elasticsearch.action.search.SearchRequest] is not compatible version 8.1.0 and the 'search.check_ccs_compatibility' setting is enabled.
+```
+
+it means you are using a new Elasticsearch feature that will not work in a CCS environment because the feature does not exist in older versions. If you are working on an experimental feature and are okay with this limitation, you will have to move the failing test into a special test suite that does not use this setting to get ci to pass. Take this path cautiously. If you do not remember to move the test back into the default test suite when the feature is GA'ed, it will not have proper CCS test coverage.
+
+We added this test coverage in version `8.1` because we accidentally broke core Kibana features (for example, when Discover started using the new fields parameter) for our CCS users. CCS is not a corner case and (excluding certain experimental features) Kibana should always work for our CCS users. This setting is our way of ensuring test coverage.
+
+Please reach out to the [Kibana Operations team](https://github.com/orgs/elastic/teams/kibana-operations) if you have further questions.


### PR DESCRIPTION
Inform Kibana contributors about what this error message means, how to work around it, and why we added it in the first place.