### PR TITLE
docs(NA): adding @kbn/ambient-ui-types into ops docs

### DIFF
--- a/dev_docs/operations/operations_landing.mdx
+++ b/dev_docs/operations/operations_landing.mdx
@@ -43,5 +43,6 @@ layout: landing
     { pageId: "kibDevDocsToolingLog" },
     { pageId: "kibDevDocsOpsJestSerializers"},
     { pageId: "kibDevDocsOpsExpect" },
+    { pageId: "kibDevDocsOpsAmbientUiTypes"},
   ]}
 />

--- a/nav-kibana-dev.docnav.json
+++ b/nav-kibana-dev.docnav.json
@@ -198,7 +198,8 @@
           "items": [
             { "id": "kibDevDocsToolingLog" },
             { "id": "kibDevDocsOpsJestSerializers"},
-            { "id": "kibDevDocsOpsExpect" }
+            { "id": "kibDevDocsOpsExpect" },
+            { "id": "kibDevDocsOpsAmbientUiTypes" }
           ]
         }
       ]

--- a/packages/kbn-ambient-ui-types/README.mdx
+++ b/packages/kbn-ambient-ui-types/README.mdx
@@ -1,7 +1,15 @@
-# @kbn/ambient-ui-types
+---
+id: kibDevDocsOpsAmbientUiTypes
+slug: /kibana-dev-docs/ops/ambient-ui-types
+title: "@kbn/ambient-ui-types"
+description: A package holding type definitions for ambient file types
+date: 2022-05-18
+tags: ['kibana', 'dev', 'contributor', 'operations', 'ambient', 'ui', 'types']
+---
 
-This is a package of Typescript types for files that might get imported by Webpack and therefore need definitions.
+This package holds typescript definitions for files with extensions like `.html, .png, .svg, .mdx` that might get imported by Webpack and therefore need them.
 
+## Plugins
 These types will automatically be included for plugins.
 
 ## Packages
@@ -9,4 +17,5 @@ These types will automatically be included for plugins.
 To include these types in a package:
 
 - add `"//packages/kbn-ambient-ui-types"` to the `RUNTIME_DEPS` portion of the `BUILD.bazel` file.
+- add `"//packages/kbn-ambient-ui-types:npm_module_types"` to the `TYPES_DEPS` portion of the `BUILD.bazel` file.
 - add `"@kbn/ambient-ui-types"` to the `types` portion of the `tsconfig.json` file.

--- a/packages/kbn-ambient-ui-types/README.mdx
+++ b/packages/kbn-ambient-ui-types/README.mdx
@@ -2,12 +2,12 @@
 id: kibDevDocsOpsAmbientUiTypes
 slug: /kibana-dev-docs/ops/ambient-ui-types
 title: "@kbn/ambient-ui-types"
-description: A package holding type definitions for ambient file types
+description: A package holding ambient type definitions for files
 date: 2022-05-18
 tags: ['kibana', 'dev', 'contributor', 'operations', 'ambient', 'ui', 'types']
 ---
 
-This package holds typescript definitions for files with extensions like `.html, .png, .svg, .mdx` that might get imported by Webpack and therefore need them.
+This package holds ambient typescript definitions for files with extensions like `.html, .png, .svg, .mdx` that might get imported by Webpack and therefore needed.
 
 ## Plugins
 These types will automatically be included for plugins.


### PR DESCRIPTION
This PR adds `@kbn/ambient-ui-types` into the OPS team DevDocs.