### PR TITLE
[Observability] Use Observability rule type registry for list of rule types

### DIFF
--- a/x-pack/plugins/observability/public/hooks/use_fetch_rules.ts
+++ b/x-pack/plugins/observability/public/hooks/use_fetch_rules.ts
@@ -10,8 +10,8 @@ import { isEmpty } from 'lodash';
 import { loadRules, loadRuleTags } from '@kbn/triggers-actions-ui-plugin/public';
 import { RULES_LOAD_ERROR, RULE_TAGS_LOAD_ERROR } from '../pages/rules/translations';
 import { FetchRulesProps, RuleState, TagsState } from '../pages/rules/types';
-import { OBSERVABILITY_RULE_TYPES } from '../pages/rules/config';
 import { useKibana } from '../utils/kibana_react';
+import { usePluginContext } from './use_plugin_context';
 
 export function useFetchRules({
   searchText,
@@ -24,6 +24,7 @@ export function useFetchRules({
   sort,
 }: FetchRulesProps) {
   const { http } = useKibana().services;
+  const { observabilityRuleTypeRegistry } = usePluginContext();
 
   const [rulesState, setRulesState] = useState<RuleState>({
     isLoading: false,
@@ -60,7 +61,7 @@ export function useFetchRules({
         http,
         page,
         searchText,
-        typesFilter: typesFilter.length > 0 ? typesFilter : OBSERVABILITY_RULE_TYPES,
+        typesFilter: typesFilter.length > 0 ? typesFilter : observabilityRuleTypeRegistry.list(),
         tagsFilter,
         ruleExecutionStatusesFilter: ruleLastResponseFilter,
         ruleStatusesFilter,
@@ -93,14 +94,15 @@ export function useFetchRules({
   }, [
     http,
     page,
-    setPage,
     searchText,
-    ruleLastResponseFilter,
-    tagsFilter,
-    loadRuleTagsAggs,
-    ruleStatusesFilter,
     typesFilter,
+    observabilityRuleTypeRegistry,
+    tagsFilter,
+    ruleLastResponseFilter,
+    ruleStatusesFilter,
     sort,
+    loadRuleTagsAggs,
+    setPage,
   ]);
   useEffect(() => {
     fetchRules();

--- a/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
@@ -38,7 +38,6 @@ import './styles.scss';
 import { AlertsStatusFilter, AlertsDisclaimer, AlertsSearchBar } from '../../components';
 import { renderRuleStats } from '../../components/rule_stats';
 import { ObservabilityAppServices } from '../../../../application/types';
-import { OBSERVABILITY_RULE_TYPES } from '../../../rules/config';
 
 interface RuleStatsState {
   total: number;
@@ -69,7 +68,7 @@ const ALERT_STATUS_REGEX = new RegExp(
 const ALERT_TABLE_STATE_STORAGE_KEY = 'xpack.observability.alert.tableState';
 
 function AlertsPage() {
-  const { ObservabilityPageTemplate, config } = usePluginContext();
+  const { ObservabilityPageTemplate, config, observabilityRuleTypeRegistry } = usePluginContext();
   const [alertFilterStatus, setAlertFilterStatus] = useState('' as AlertStatusFilterButton);
   const refetch = useRef<() => void>();
   const timefilterService = useTimefilterService();
@@ -110,7 +109,7 @@ function AlertsPage() {
     try {
       const response = await loadRuleAggregations({
         http,
-        typesFilter: OBSERVABILITY_RULE_TYPES,
+        typesFilter: observabilityRuleTypeRegistry.list(),
       });
       const { ruleExecutionStatus, ruleMutedStatus, ruleEnabledStatus, ruleSnoozedStatus } =
         response;

--- a/x-pack/plugins/observability/public/pages/rules/config.ts
+++ b/x-pack/plugins/observability/public/pages/rules/config.ts
@@ -42,20 +42,6 @@ export const rulesStatusesTranslationsMapping = {
   warning: RULE_STATUS_WARNING,
 };
 
-export const OBSERVABILITY_RULE_TYPES = [
-  'xpack.uptime.alerts.monitorStatus',
-  'xpack.uptime.alerts.tls',
-  'xpack.uptime.alerts.tlsCertificate',
-  'xpack.uptime.alerts.durationAnomaly',
-  'apm.error_rate',
-  'apm.transaction_error_rate',
-  'apm.anomaly',
-  'apm.transaction_duration',
-  'metrics.alert.inventory.threshold',
-  'metrics.alert.threshold',
-  'logs.alert.document.count',
-];
-
 export const OBSERVABILITY_SOLUTIONS = ['logs', 'uptime', 'infrastructure', 'apm'];
 
 export type InitialRule = Partial<Rule> &

--- a/x-pack/plugins/observability/public/rules/create_observability_rule_type_registry.ts
+++ b/x-pack/plugins/observability/public/rules/create_observability_rule_type_registry.ts
@@ -35,6 +35,7 @@ export function createObservabilityRuleTypeRegistry(ruleTypeRegistry: RuleTypeRe
     getFormatter: (typeId: string) => {
       return formatters.find((formatter) => formatter.typeId === typeId)?.fn;
     },
+    list: () => formatters.map((formatter) => formatter.typeId),
   };
 }
 


### PR DESCRIPTION
## Summary

This PR removes the static list of rule types, `OBSERVABILITY_RULE_TYPES`, by adding a `list()` method to the `observabilityRuleTypeRegistry` which returns a dynamic list of rules that are registered with Observability. This will prevent situations where solutions add new rules but they don't show up in the Observability rules manager because the author didn't realize they also needed to update `OBSERVABILITY_RULE_TYPES`.