### PR TITLE
[ML] Adds placeholder text for testing NLP models

### DIFF
--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/ner/ner_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/ner/ner_inference.ts
@@ -52,7 +52,13 @@ export class NerInference extends InferenceBase<NerResponse> {
   }
 
   public getInputComponent(): JSX.Element {
-    return getGeneralInputComponent(this);
+    const placeholder = i18n.translate(
+      'xpack.ml.trainedModels.testModelsFlyout.ner.inputText',
+      {
+        defaultMessage: 'Enter a phrase to test.',
+      }
+    );
+    return getGeneralInputComponent(this, placeholder);
   }
 
   public getOutputComponent(): JSX.Element {

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/ner/ner_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/ner/ner_inference.ts
@@ -55,7 +55,7 @@ export class NerInference extends InferenceBase<NerResponse> {
     const placeholder = i18n.translate(
       'xpack.ml.trainedModels.testModelsFlyout.ner.inputText',
       {
-        defaultMessage: 'Enter a phrase to test.',
+        defaultMessage: 'Enter a phrase to test',
       }
     );
     return getGeneralInputComponent(this, placeholder);

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/ner/ner_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/ner/ner_inference.ts
@@ -6,7 +6,7 @@
  */
 
 import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-
+import { i18n } from '@kbn/i18n';
 import { InferenceBase, InferResponse } from '../inference_base';
 import { getGeneralInputComponent } from '../text_input';
 import { getNerOutputComponent } from './ner_output';

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/ner/ner_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/ner/ner_inference.ts
@@ -52,12 +52,9 @@ export class NerInference extends InferenceBase<NerResponse> {
   }
 
   public getInputComponent(): JSX.Element {
-    const placeholder = i18n.translate(
-      'xpack.ml.trainedModels.testModelsFlyout.ner.inputText',
-      {
-        defaultMessage: 'Enter a phrase to test',
-      }
-    );
+    const placeholder = i18n.translate('xpack.ml.trainedModels.testModelsFlyout.ner.inputText', {
+      defaultMessage: 'Enter a phrase to test',
+    });
     return getGeneralInputComponent(this, placeholder);
   }
 

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/fill_mask_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/fill_mask_inference.ts
@@ -57,7 +57,8 @@ export class FillMaskInference extends InferenceBase<TextClassificationResponse>
     const placeholder = i18n.translate(
       'xpack.ml.trainedModels.testModelsFlyout.fillMask.inputText',
       {
-        defaultMessage: 'Enter a phrase to test. Use [MASK] as a placeholder for the missing words.',
+        defaultMessage:
+          'Enter a phrase to test. Use [MASK] as a placeholder for the missing words.',
       }
     );
 

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/fill_mask_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/fill_mask_inference.ts
@@ -55,9 +55,9 @@ export class FillMaskInference extends InferenceBase<TextClassificationResponse>
 
   public getInputComponent(): JSX.Element {
     const placeholder = i18n.translate(
-      'xpack.ml.trainedModels.testModelsFlyout.langIdent.inputText',
+      'xpack.ml.trainedModels.testModelsFlyout.fillMask.inputText',
       {
-        defaultMessage: 'Mask token: [MASK]. e.g. Paris is the [MASK] of France.',
+        defaultMessage: 'Enter a phrase to test. Use [MASK] as a placeholder for the missing words.',
       }
     );
 

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/lang_ident_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/lang_ident_inference.ts
@@ -44,7 +44,13 @@ export class LangIdentInference extends InferenceBase<TextClassificationResponse
   }
 
   public getInputComponent(): JSX.Element {
-    return getGeneralInputComponent(this);
+    const placeholder = i18n.translate(
+      'xpack.ml.trainedModels.testModelsFlyout.langIdent.inputText',
+      {
+        defaultMessage: 'Enter a phrase to test',
+      }
+    );
+    return getGeneralInputComponent(this, placeholder);
   }
 
   public getOutputComponent(): JSX.Element {

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/lang_ident_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/lang_ident_inference.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
 import { InferenceBase, InferenceType } from '../inference_base';
 import { processResponse } from './common';
 import { getGeneralInputComponent } from '../text_input';

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/text_classification_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/text_classification_inference.ts
@@ -45,7 +45,13 @@ export class TextClassificationInference extends InferenceBase<TextClassificatio
   }
 
   public getInputComponent(): JSX.Element {
-    return getGeneralInputComponent(this);
+    const placeholder = i18n.translate(
+      'xpack.ml.trainedModels.testModelsFlyout.textClassification.inputText',
+      {
+        defaultMessage: 'Enter a phrase to test',
+      }
+    );
+    return getGeneralInputComponent(this, placeholder);
   }
 
   public getOutputComponent(): JSX.Element {

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/text_classification_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/text_classification_inference.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
 import { InferenceBase } from '../inference_base';
 import { processResponse } from './common';
 import type { TextClassificationResponse, RawTextClassificationResponse } from './common';

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_embedding/text_embedding_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_embedding/text_embedding_inference.ts
@@ -7,6 +7,7 @@
 
 import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
+import { i18n } from '@kbn/i18n';
 import { InferenceBase, InferResponse } from '../inference_base';
 import { getGeneralInputComponent } from '../text_input';
 import { getTextEmbeddingOutputComponent } from './text_embedding_output';

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_embedding/text_embedding_inference.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_embedding/text_embedding_inference.ts
@@ -53,7 +53,13 @@ export class TextEmbeddingInference extends InferenceBase<TextEmbeddingResponse>
   }
 
   public getInputComponent(): JSX.Element {
-    return getGeneralInputComponent(this);
+    const placeholder = i18n.translate(
+      'xpack.ml.trainedModels.testModelsFlyout.textEmbedding.inputText',
+      {
+        defaultMessage: 'Enter a phrase to test',
+      }
+    );
+    return getGeneralInputComponent(this, placeholder);
   }
 
   public getOutputComponent(): JSX.Element {


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/129209 

This PR adds simple placeholder text to the "Test trained model" UI for NER, fill mask, language identification, text classification, and text embedding NLP tasks

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

### Screenshot

![image](https://user-images.githubusercontent.com/26471269/169438328-25a8b4d7-c92f-4680-abc6-882183315c6c.png)

