### PR TITLE
[Actionable Observability] fix broken rule details page for users with read only permissions

### DIFF
--- a/x-pack/plugins/observability/public/pages/rule_details/components/actions.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/components/actions.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   EuiText,
   EuiSpacer,
@@ -38,6 +38,11 @@ export function Actions({ ruleActions }: ActionsProps) {
     notifications: { toasts },
   } = useKibana().services;
   const { isLoadingActions, allActions, errorActions } = useFetchRuleActions({ http });
+  useEffect(() => {
+    if (errorActions) {
+      toasts.addDanger({ title: errorActions });
+    }
+  }, [errorActions, toasts]);
   if (ruleActions && ruleActions.length <= 0)
     return (
       <EuiFlexItem>
@@ -65,7 +70,6 @@ export function Actions({ ruleActions }: ActionsProps) {
           <EuiSpacer size="s" />
         </>
       ))}
-      {errorActions && toasts.addDanger({ title: errorActions })}
     </EuiFlexGroup>
   );
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/132485

### Before fix
<img src="https://user-images.githubusercontent.com/2852703/169164899-1f1d04bc-85bb-4081-b327-b15b0c26f17f.png"/>

### After fix
<img width="1418" alt="Screenshot 2022-05-19 at 10 21 27" src="https://user-images.githubusercontent.com/2852703/169247519-dc858fe7-7350-4731-a508-c794c726cb9d.png">
