### PR TITLE
[Security Solution] Update use_url_state to work with new side nav

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/url_state/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/index.test.tsx
@@ -25,6 +25,11 @@ import { UrlStateContainerPropTypes } from './types';
 import { useUrlStateHooks } from './use_url_state';
 import { waitFor } from '@testing-library/react';
 import { useLocation } from 'react-router-dom';
+import { updateAppLinks } from '../../links';
+import { getAppLinks } from '../../links/app_links';
+import { StartPlugins } from '../../../types';
+import { allowedExperimentalValues } from '../../../../common/experimental_features';
+import { coreMock } from '@kbn/core/public/mocks';
 
 let mockProps: UrlStateContainerPropTypes;
 
@@ -78,10 +83,36 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+const mockedUseIsGroupedNavigationEnabled = jest.fn();
+jest.mock('../navigation/helpers', () => ({
+  useIsGroupedNavigationEnabled: () => mockedUseIsGroupedNavigationEnabled(),
+}));
+
 describe('UrlStateContainer', () => {
+  beforeAll(async () => {
+    mockedUseIsGroupedNavigationEnabled.mockReturnValue(false);
+
+    const appLinks = await getAppLinks(coreMock.createStart(), {} as StartPlugins);
+    updateAppLinks(appLinks, {
+      experimentalFeatures: allowedExperimentalValues,
+      capabilities: {
+        navLinks: {},
+        management: {},
+        catalogue: {},
+        actions: { show: true, crud: true },
+        siem: {
+          show: true,
+          crud: true,
+        },
+      },
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
+    mockedUseIsGroupedNavigationEnabled.mockReturnValue(false);
   });
+
   describe('handleInitialize', () => {
     describe('URL state updates redux', () => {
       describe('relative timerange actions are called with correct data on component mount', () => {
@@ -224,6 +255,44 @@ describe('UrlStateContainer', () => {
       mount(<HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />);
 
       expect(mockHistory.replace).not.toHaveBeenCalled();
+    });
+
+    it("it doesn't update URL state when on admin page and grouped nav disabled", () => {
+      mockedUseIsGroupedNavigationEnabled.mockReturnValue(false);
+      mockProps = getMockPropsObj({
+        page: CONSTANTS.unknown,
+        examplePath: '/administration',
+        namespaceLower: 'administration',
+        pageName: SecurityPageName.administration,
+        detailName: undefined,
+      }).noSearch.undefinedQuery;
+
+      (useLocation as jest.Mock).mockReturnValue({
+        pathname: mockProps.pathName,
+      });
+
+      mount(<HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />);
+
+      expect(mockHistory.replace.mock.calls[0][0].search).toBe('?');
+    });
+
+    it("it doesn't update URL state when on admin page and grouped nav enabled", () => {
+      mockedUseIsGroupedNavigationEnabled.mockReturnValue(true);
+      mockProps = getMockPropsObj({
+        page: CONSTANTS.unknown,
+        examplePath: '/dashboards',
+        namespaceLower: 'dashboards',
+        pageName: SecurityPageName.dashboardsLanding,
+        detailName: undefined,
+      }).noSearch.undefinedQuery;
+
+      (useLocation as jest.Mock).mockReturnValue({
+        pathname: mockProps.pathName,
+      });
+
+      mount(<HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />);
+
+      expect(mockHistory.replace.mock.calls[0][0].search).toBe('?');
     });
 
     it('it removes empty AppQuery state from URL', () => {

--- a/x-pack/plugins/security_solution/public/common/components/url_state/use_url_state.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/use_url_state.tsx
@@ -66,8 +66,8 @@ export const useUrlStateHooks = ({
   const { pathname: browserPathName } = useLocation();
   const prevProps = usePrevious({ pathName, pageName, urlState, search });
   const isGroupedNavEnabled = useIsGroupedNavigationEnabled();
-  const linkInfo = pageName ? getLinkInfo(pageName as SecurityPageName) : undefined;
 
+  const linkInfo = pageName ? getLinkInfo(pageName as SecurityPageName) : undefined;
   const { setInitialStateFromUrl, updateTimeline, updateTimelineIsLoading } =
     useSetInitialStateFromUrl();
 

--- a/x-pack/plugins/security_solution/public/common/components/url_state/use_url_state.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/use_url_state.tsx
@@ -40,6 +40,9 @@ import {
 import { TimelineUrl } from '../../../timelines/store/timeline/model';
 import { UrlInputsModel } from '../../store/inputs/model';
 import { queryTimelineByIdOnUrlChange } from './query_timeline_by_id_on_url_change';
+import { useIsGroupedNavigationEnabled } from '../navigation/helpers';
+import { getLinkInfo } from '../../links';
+import { SecurityPageName } from '../../../app/types';
 
 function usePrevious(value: PreviousLocationUrlState) {
   const ref = useRef<PreviousLocationUrlState>(value);
@@ -62,6 +65,7 @@ export const useUrlStateHooks = ({
   const { filterManager, savedQueries } = useKibana().services.data.query;
   const { pathname: browserPathName } = useLocation();
   const prevProps = usePrevious({ pathName, pageName, urlState, search });
+  const isGroupedNavEnabled = useIsGroupedNavigationEnabled();
 
   const { setInitialStateFromUrl, updateTimeline, updateTimelineIsLoading } =
     useSetInitialStateFromUrl();
@@ -189,8 +193,12 @@ export const useUrlStateHooks = ({
   ]);
 
   useEffect(() => {
-    document.title = `${getTitle(pageName, navTabs)} - Kibana`;
-  }, [pageName, navTabs]);
+    if (!isGroupedNavEnabled) {
+      document.title = `${getTitle(pageName, navTabs)} - Kibana`;
+    } else {
+      document.title = `${getLinkInfo(pageName as SecurityPageName)?.title ?? ''} - Kibana`;
+    }
+  }, [pageName, navTabs, isGroupedNavEnabled]);
 
   useEffect(() => {
     queryTimelineByIdOnUrlChange({


### PR DESCRIPTION
## Summary

* Use new navigation config `skipUrlState` to remove URL state from pages
* Get the page title from the new configuration when a new navigation experiment is enabled.

How to test:
* Enable the FF groupedNavigation
* Enable the advanced setting flag: "grouped navigation"
* Navigate between security pages and check if the URL state is removed when it should and if the page title displayed on the browser tab is correct.
<img width="1435" alt="Screenshot 2022-05-19 at 15 57 36" src="https://user-images.githubusercontent.com/1490444/169311425-6e23aaf8-8bd6-4b20-8cfa-3b6b5d9f5d19.png">


