### PR TITLE
[ci] always supply defaults for parallelism vars

### DIFF
--- a/.buildkite/scripts/steps/code_coverage/jest_parallel.sh
+++ b/.buildkite/scripts/steps/code_coverage/jest_parallel.sh
@@ -2,8 +2,8 @@
 
 set -uo pipefail
 
-JOB=$BUILDKITE_PARALLEL_JOB
-JOB_COUNT=$BUILDKITE_PARALLEL_JOB_COUNT
+JOB=${BUILDKITE_PARALLEL_JOB:-0}
+JOB_COUNT=${BUILDKITE_PARALLEL_JOB_COUNT:-1}
 
 # a jest failure will result in the script returning an exit code of 10
 

--- a/.buildkite/scripts/steps/test/ftr_configs.sh
+++ b/.buildkite/scripts/steps/test/ftr_configs.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 
 source .buildkite/scripts/steps/functional/common.sh
 
-export JOB_NUM=$BUILDKITE_PARALLEL_JOB
+export JOB_NUM=${BUILDKITE_PARALLEL_JOB:-0}
 export JOB=ftr-configs-${JOB_NUM}
 
-FAILED_CONFIGS_KEY="${BUILDKITE_STEP_ID}${BUILDKITE_PARALLEL_JOB:-0}"
+FAILED_CONFIGS_KEY="${BUILDKITE_STEP_ID}${JOB_NUM}"
 
 # a FTR failure will result in the script returning an exit code of 10
 exitCode=0

--- a/.buildkite/scripts/steps/test/jest.sh
+++ b/.buildkite/scripts/steps/test/jest.sh
@@ -8,6 +8,8 @@ is_test_execution_step
 
 .buildkite/scripts/bootstrap.sh
 
+JOB=${BUILDKITE_PARALLEL_JOB:-0}
+
 echo '--- Jest'
-checks-reporter-with-killswitch "Jest Unit Tests $((BUILDKITE_PARALLEL_JOB+1))" \
+checks-reporter-with-killswitch "Jest Unit Tests $((JOB+1))" \
   .buildkite/scripts/steps/test/jest_parallel.sh jest.config.js

--- a/.buildkite/scripts/steps/test/jest_integration.sh
+++ b/.buildkite/scripts/steps/test/jest_integration.sh
@@ -8,6 +8,8 @@ is_test_execution_step
 
 .buildkite/scripts/bootstrap.sh
 
+JOB=${BUILDKITE_PARALLEL_JOB:-0}
+
 echo '--- Jest Integration Tests'
-checks-reporter-with-killswitch "Jest Integration Tests $((BUILDKITE_PARALLEL_JOB+1))" \
+checks-reporter-with-killswitch "Jest Integration Tests $((JOB+1))" \
   .buildkite/scripts/steps/test/jest_parallel.sh jest.integration.config.js

--- a/.buildkite/scripts/steps/test/jest_parallel.sh
+++ b/.buildkite/scripts/steps/test/jest_parallel.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export JOB=$BUILDKITE_PARALLEL_JOB
+export JOB=${BUILDKITE_PARALLEL_JOB:-0}
 
 # a jest failure will result in the script returning an exit code of 10
 exitCode=0


### PR DESCRIPTION
When we run tests in parallel on Buildkite it sets the `BUILDKITE_PARALLEL_JOB` and `BUILDKITE_PARALLEL_JOB_COUNT` env vars, but when the parallelism is set to 1 those vars are not set and bash fails when trying to access them without defaults. This PR updates all our usage of these vars in parallel scripts to include defaults so that we won't see `BUILDKITE_PARALLEL_JOB: unbound variable` anymore.