### PR TITLE
[jest/ci-stats] when jest fails to execute a test file, report it as a failure

### DIFF
--- a/packages/kbn-test/src/jest/ci_stats_jest_reporter.ts
+++ b/packages/kbn-test/src/jest/ci_stats_jest_reporter.ts
@@ -41,6 +41,7 @@ export default class CiStatsJestReporter extends BaseReporter {
   private startTime: number | undefined;
   private passCount = 0;
   private failCount = 0;
+  private testExecErrorCount = 0;
 
   private group: CiStatsReportTestsOptions['group'] | undefined;
   private readonly testRuns: CiStatsReportTestsOptions['testRuns'] = [];
@@ -90,6 +91,10 @@ export default class CiStatsJestReporter extends BaseReporter {
       return;
     }
 
+    if (testResult.testExecError) {
+      this.testExecErrorCount += 1;
+    }
+
     let elapsedTime = 0;
     for (const t of testResult.testResults) {
       const result = t.status === 'failed' ? 'fail' : t.status === 'passed' ? 'pass' : 'skip';
@@ -123,7 +128,8 @@ export default class CiStatsJestReporter extends BaseReporter {
     }
 
     this.group.durationMs = Date.now() - this.startTime;
-    this.group.result = this.failCount ? 'fail' : this.passCount ? 'pass' : 'skip';
+    this.group.result =
+      this.failCount || this.testExecErrorCount ? 'fail' : this.passCount ? 'pass' : 'skip';
 
     await this.reporter.reportTests({
       group: this.group,


### PR DESCRIPTION
Currently, the ci-stats jest reporter only looks for test failures, which works most of the time but when Jest encouters a failure executing a test file (because of a syntax error, bad import, or something) there are not test failures reported, instead the result object for the test file has a `testExecError` attached which we should check for. When any number of `testExecError`'s are found the test group should be reported as a failure regardless of the number of tests we are able to report.