### PR TITLE
[Security Solution] Telemetry for Event Filters counts on both user and global entries

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
@@ -256,6 +256,7 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
             malicious_behavior_rules: maliciousBehaviorRules,
             system_impact: systemImpact,
             threads,
+            event_filter: eventFilter,
           } = endpoint.endpoint_metrics.Endpoint.metrics;
           const endpointPolicyDetail = extractEndpointPolicyConfig(policyConfig);
 
@@ -275,6 +276,7 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
               maliciousBehaviorRules,
               systemImpact,
               threads,
+              eventFilter,
             },
             endpoint_meta: {
               os: endpoint.endpoint_metrics.host.os,

--- a/x-pack/plugins/security_solution/server/lib/telemetry/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/types.ts
@@ -233,6 +233,10 @@ export interface EndpointMetrics {
     library_load_events?: SystemImpactEventsMetrics;
   }>;
   threads: Array<{ name: string; cpu: { mean: number } }>;
+  event_filter: {
+    active_global_count: number;
+    active_user_count: number;
+  };
 }
 
 interface EndpointMetricOS {


### PR DESCRIPTION
## Summary

This PR adds new telemetry fields to the Endpoint metrics document which reports Event Filter counts for both user and global entries.  This can be used to see if there is a correlation between overall document volume and the usages of each types of Event Filter.

Fields:
  - `Endpoint.metrics.event_filter.active_global_count`
  - `Endpoint.metrics.event_filter.active_user_count`
