### PR TITLE
[Workplace Search] Add documentation links for v8.3.0 connectors

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -152,6 +152,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       synch: `${WORKPLACE_SEARCH_DOCS}workplace-search-customizing-indexing-rules.html`,
       teams: `${WORKPLACE_SEARCH_DOCS}microsoft-teams.html`,
       zendesk: `${WORKPLACE_SEARCH_DOCS}workplace-search-zendesk-connector.html`,
+      zoom: `${WORKPLACE_SEARCH_DOCS}zoom.html`,
     },
     metricbeat: {
       base: `${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}`,

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -150,6 +150,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       sharePointServer: `${WORKPLACE_SEARCH_DOCS}sharepoint-server.html`,
       slack: `${WORKPLACE_SEARCH_DOCS}workplace-search-slack-connector.html`,
       synch: `${WORKPLACE_SEARCH_DOCS}workplace-search-customizing-indexing-rules.html`,
+      teams: `${WORKPLACE_SEARCH_DOCS}microsoft-teams.html`,
       zendesk: `${WORKPLACE_SEARCH_DOCS}workplace-search-zendesk-connector.html`,
     },
     metricbeat: {

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -139,6 +139,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       indexingSchedule: `${WORKPLACE_SEARCH_DOCS}workplace-search-customizing-indexing-rules.html#_indexing_schedule`,
       jiraCloud: `${WORKPLACE_SEARCH_DOCS}workplace-search-jira-cloud-connector.html`,
       jiraServer: `${WORKPLACE_SEARCH_DOCS}workplace-search-jira-server-connector.html`,
+      networkDrive: `${WORKPLACE_SEARCH_DOCS}network-drives.html`,
       oneDrive: `${WORKPLACE_SEARCH_DOCS}workplace-search-onedrive-connector.html`,
       permissions: `${WORKPLACE_SEARCH_DOCS}workplace-search-permissions.html#organizational-sources-private-sources`,
       salesforce: `${WORKPLACE_SEARCH_DOCS}workplace-search-salesforce-connector.html`,

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -126,6 +126,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       box: `${WORKPLACE_SEARCH_DOCS}workplace-search-box-connector.html`,
       confluenceCloud: `${WORKPLACE_SEARCH_DOCS}workplace-search-confluence-cloud-connector.html`,
       confluenceServer: `${WORKPLACE_SEARCH_DOCS}workplace-search-confluence-server-connector.html`,
+      customConnectorPackage: `${WORKPLACE_SEARCH_DOCS}custom-connector-package.html`,
       customSources: `${WORKPLACE_SEARCH_DOCS}workplace-search-custom-api-sources.html`,
       customSourcePermissions: `${WORKPLACE_SEARCH_DOCS}workplace-search-custom-api-sources.html#custom-api-source-document-level-access-control`,
       documentPermissions: `${WORKPLACE_SEARCH_DOCS}workplace-search-sources-document-permissions.html`,

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -141,6 +141,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       jiraServer: `${WORKPLACE_SEARCH_DOCS}workplace-search-jira-server-connector.html`,
       networkDrive: `${WORKPLACE_SEARCH_DOCS}network-drives.html`,
       oneDrive: `${WORKPLACE_SEARCH_DOCS}workplace-search-onedrive-connector.html`,
+      outlook: `${WORKPLACE_SEARCH_DOCS}microsoft-outlook.html`,
       permissions: `${WORKPLACE_SEARCH_DOCS}workplace-search-permissions.html#organizational-sources-private-sources`,
       salesforce: `${WORKPLACE_SEARCH_DOCS}workplace-search-salesforce-connector.html`,
       security: `${WORKPLACE_SEARCH_DOCS}workplace-search-security.html`,

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -125,6 +125,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       apiKeys: `${WORKPLACE_SEARCH_DOCS}workplace-search-api-authentication.html`,
       box: `${WORKPLACE_SEARCH_DOCS}workplace-search-box-connector.html`,
       confluenceCloud: `${WORKPLACE_SEARCH_DOCS}workplace-search-confluence-cloud-connector.html`,
+      confluenceCloudConnectorPackage: `${WORKPLACE_SEARCH_DOCS}confluence-cloud.html`,
       confluenceServer: `${WORKPLACE_SEARCH_DOCS}workplace-search-confluence-server-connector.html`,
       customConnectorPackage: `${WORKPLACE_SEARCH_DOCS}custom-connector-package.html`,
       customSources: `${WORKPLACE_SEARCH_DOCS}workplace-search-custom-api-sources.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -136,6 +136,7 @@ export interface DocLinks {
     readonly sharePointServer: string;
     readonly slack: string;
     readonly synch: string;
+    readonly teams: string;
     readonly zendesk: string;
   };
   readonly heartbeat: {

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -138,6 +138,7 @@ export interface DocLinks {
     readonly synch: string;
     readonly teams: string;
     readonly zendesk: string;
+    readonly zoom: string;
   };
   readonly heartbeat: {
     readonly base: string;

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -111,6 +111,7 @@ export interface DocLinks {
     readonly apiKeys: string;
     readonly box: string;
     readonly confluenceCloud: string;
+    readonly confluenceCloudConnectorPackage: string;
     readonly confluenceServer: string;
     readonly customConnectorPackage: string;
     readonly customSources: string;

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -112,6 +112,7 @@ export interface DocLinks {
     readonly box: string;
     readonly confluenceCloud: string;
     readonly confluenceServer: string;
+    readonly customConnectorPackage: string;
     readonly customSources: string;
     readonly customSourcePermissions: string;
     readonly documentPermissions: string;

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -127,6 +127,7 @@ export interface DocLinks {
     readonly jiraServer: string;
     readonly networkDrive: string;
     readonly oneDrive: string;
+    readonly outlook: string;
     readonly permissions: string;
     readonly salesforce: string;
     readonly security: string;

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -125,6 +125,7 @@ export interface DocLinks {
     readonly indexingSchedule: string;
     readonly jiraCloud: string;
     readonly jiraServer: string;
+    readonly networkDrive: string;
     readonly oneDrive: string;
     readonly permissions: string;
     readonly salesforce: string;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -89,6 +89,7 @@ class DocLinks {
   public workplaceSearchSharePointServer: string;
   public workplaceSearchSlack: string;
   public workplaceSearchSynch: string;
+  public workplaceSearchTeams: string;
   public workplaceSearchZendesk: string;
 
   constructor() {
@@ -173,6 +174,7 @@ class DocLinks {
     this.workplaceSearchSharePointServer = '';
     this.workplaceSearchSlack = '';
     this.workplaceSearchSynch = '';
+    this.workplaceSearchTeams = '';
     this.workplaceSearchZendesk = '';
   }
 
@@ -261,6 +263,7 @@ class DocLinks {
     this.workplaceSearchSharePointServer = docLinks.links.workplaceSearch.sharePointServer;
     this.workplaceSearchSlack = docLinks.links.workplaceSearch.slack;
     this.workplaceSearchSynch = docLinks.links.workplaceSearch.synch;
+    this.workplaceSearchTeams = docLinks.links.workplaceSearch.teams;
     this.workplaceSearchZendesk = docLinks.links.workplaceSearch.zendesk;
   }
 }

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -65,6 +65,7 @@ class DocLinks {
   public workplaceSearchBox: string;
   public workplaceSearchConfluenceCloud: string;
   public workplaceSearchConfluenceServer: string;
+  public workplaceSearchCustomConnectorPackage: string;
   public workplaceSearchCustomSources: string;
   public workplaceSearchCustomSourcePermissions: string;
   public workplaceSearchDocumentPermissions: string;
@@ -151,6 +152,7 @@ class DocLinks {
     this.workplaceSearchBox = '';
     this.workplaceSearchConfluenceCloud = '';
     this.workplaceSearchConfluenceServer = '';
+    this.workplaceSearchCustomConnectorPackage = '';
     this.workplaceSearchCustomSources = '';
     this.workplaceSearchCustomSourcePermissions = '';
     this.workplaceSearchDocumentPermissions = '';
@@ -239,6 +241,8 @@ class DocLinks {
     this.workplaceSearchBox = docLinks.links.workplaceSearch.box;
     this.workplaceSearchConfluenceCloud = docLinks.links.workplaceSearch.confluenceCloud;
     this.workplaceSearchConfluenceServer = docLinks.links.workplaceSearch.confluenceServer;
+    this.workplaceSearchCustomConnectorPackage =
+      docLinks.links.workplaceSearch.customConnectorPackage;
     this.workplaceSearchCustomSources = docLinks.links.workplaceSearch.customSources;
     this.workplaceSearchCustomSourcePermissions =
       docLinks.links.workplaceSearch.customSourcePermissions;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -91,6 +91,7 @@ class DocLinks {
   public workplaceSearchSynch: string;
   public workplaceSearchTeams: string;
   public workplaceSearchZendesk: string;
+  public workplaceSearchZoom: string;
 
   constructor() {
     this.appSearchApis = '';
@@ -176,6 +177,7 @@ class DocLinks {
     this.workplaceSearchSynch = '';
     this.workplaceSearchTeams = '';
     this.workplaceSearchZendesk = '';
+    this.workplaceSearchZoom = '';
   }
 
   public setDocLinks(docLinks: DocLinksStart): void {
@@ -265,6 +267,7 @@ class DocLinks {
     this.workplaceSearchSynch = docLinks.links.workplaceSearch.synch;
     this.workplaceSearchTeams = docLinks.links.workplaceSearch.teams;
     this.workplaceSearchZendesk = docLinks.links.workplaceSearch.zendesk;
+    this.workplaceSearchZoom = docLinks.links.workplaceSearch.zoom;
   }
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -64,6 +64,7 @@ class DocLinks {
   public workplaceSearchApiKeys: string;
   public workplaceSearchBox: string;
   public workplaceSearchConfluenceCloud: string;
+  public workplaceSearchConfluenceCloudConnectorPackage: string;
   public workplaceSearchConfluenceServer: string;
   public workplaceSearchCustomConnectorPackage: string;
   public workplaceSearchCustomSources: string;
@@ -151,6 +152,7 @@ class DocLinks {
     this.workplaceSearchApiKeys = '';
     this.workplaceSearchBox = '';
     this.workplaceSearchConfluenceCloud = '';
+    this.workplaceSearchConfluenceCloudConnectorPackage = '';
     this.workplaceSearchConfluenceServer = '';
     this.workplaceSearchCustomConnectorPackage = '';
     this.workplaceSearchCustomSources = '';
@@ -240,6 +242,8 @@ class DocLinks {
     this.workplaceSearchApiKeys = docLinks.links.workplaceSearch.apiKeys;
     this.workplaceSearchBox = docLinks.links.workplaceSearch.box;
     this.workplaceSearchConfluenceCloud = docLinks.links.workplaceSearch.confluenceCloud;
+    this.workplaceSearchConfluenceCloudConnectorPackage =
+      docLinks.links.workplaceSearch.confluenceCloudConnectorPackage;
     this.workplaceSearchConfluenceServer = docLinks.links.workplaceSearch.confluenceServer;
     this.workplaceSearchCustomConnectorPackage =
       docLinks.links.workplaceSearch.customConnectorPackage;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -78,6 +78,7 @@ class DocLinks {
   public workplaceSearchIndexingSchedule: string;
   public workplaceSearchJiraCloud: string;
   public workplaceSearchJiraServer: string;
+  public workplaceSearchNetworkDrive: string;
   public workplaceSearchOneDrive: string;
   public workplaceSearchPermissions: string;
   public workplaceSearchSalesforce: string;
@@ -160,6 +161,7 @@ class DocLinks {
     this.workplaceSearchIndexingSchedule = '';
     this.workplaceSearchJiraCloud = '';
     this.workplaceSearchJiraServer = '';
+    this.workplaceSearchNetworkDrive = '';
     this.workplaceSearchOneDrive = '';
     this.workplaceSearchPermissions = '';
     this.workplaceSearchSalesforce = '';
@@ -246,6 +248,7 @@ class DocLinks {
     this.workplaceSearchIndexingSchedule = docLinks.links.workplaceSearch.indexingSchedule;
     this.workplaceSearchJiraCloud = docLinks.links.workplaceSearch.jiraCloud;
     this.workplaceSearchJiraServer = docLinks.links.workplaceSearch.jiraServer;
+    this.workplaceSearchNetworkDrive = docLinks.links.workplaceSearch.networkDrive;
     this.workplaceSearchOneDrive = docLinks.links.workplaceSearch.oneDrive;
     this.workplaceSearchPermissions = docLinks.links.workplaceSearch.permissions;
     this.workplaceSearchSalesforce = docLinks.links.workplaceSearch.salesforce;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -80,6 +80,7 @@ class DocLinks {
   public workplaceSearchJiraServer: string;
   public workplaceSearchNetworkDrive: string;
   public workplaceSearchOneDrive: string;
+  public workplaceSearchOutlook: string;
   public workplaceSearchPermissions: string;
   public workplaceSearchSalesforce: string;
   public workplaceSearchSecurity: string;
@@ -163,6 +164,7 @@ class DocLinks {
     this.workplaceSearchJiraServer = '';
     this.workplaceSearchNetworkDrive = '';
     this.workplaceSearchOneDrive = '';
+    this.workplaceSearchOutlook = '';
     this.workplaceSearchPermissions = '';
     this.workplaceSearchSalesforce = '';
     this.workplaceSearchSecurity = '';
@@ -250,6 +252,7 @@ class DocLinks {
     this.workplaceSearchJiraServer = docLinks.links.workplaceSearch.jiraServer;
     this.workplaceSearchNetworkDrive = docLinks.links.workplaceSearch.networkDrive;
     this.workplaceSearchOneDrive = docLinks.links.workplaceSearch.oneDrive;
+    this.workplaceSearchOutlook = docLinks.links.workplaceSearch.outlook;
     this.workplaceSearchPermissions = docLinks.links.workplaceSearch.permissions;
     this.workplaceSearchSalesforce = docLinks.links.workplaceSearch.salesforce;
     this.workplaceSearchSecurity = docLinks.links.workplaceSearch.security;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -25,7 +25,7 @@ export const staticGenericExternalSourceData: SourceDataItem = {
     isPublicKey: false,
     hasOauthRedirect: false,
     needsBaseUrl: false,
-    documentationUrl: docLinks.workplaceSearchCustomSources, // TODO Update this when we have a doclink
+    documentationUrl: docLinks.workplaceSearchCustomConnectorPackage,
     applicationPortalUrl: '',
   },
   objTypes: [],

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -107,7 +107,7 @@ export const staticSourceData: SourceDataItem[] = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: true,
-      documentationUrl: docLinks.workplaceSearchConfluenceCloud, // TODO Update this when we have a doclink
+      documentationUrl: docLinks.workplaceSearchConfluenceCloud,
       applicationPortalUrl: 'https://developer.atlassian.com/console/myapps/',
     },
     objTypes: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -649,7 +649,7 @@ export const staticSourceData: SourceDataItem[] = [
       isPublicKey: false,
       hasOauthRedirect: false,
       needsBaseUrl: false,
-      documentationUrl: docLinks.workplaceSearchCustomSources, // TODO Update this when we have a doclink
+      documentationUrl: docLinks.workplaceSearchTeams,
       applicationPortalUrl: '',
       githubRepository: 'elastic/enterprise-search-teams-connector',
     },

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -387,7 +387,7 @@ export const staticSourceData: SourceDataItem[] = [
       isPublicKey: false,
       hasOauthRedirect: false,
       needsBaseUrl: false,
-      documentationUrl: docLinks.workplaceSearchCustomSources, // TODO Update this when we have a doclink
+      documentationUrl: docLinks.workplaceSearchNetworkDrive,
       applicationPortalUrl: '',
       githubRepository: 'elastic/enterprise-search-network-drive-connector',
     },

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -433,7 +433,7 @@ export const staticSourceData: SourceDataItem[] = [
       isPublicKey: false,
       hasOauthRedirect: false,
       needsBaseUrl: false,
-      documentationUrl: docLinks.workplaceSearchCustomSources, // TODO Update this when we have a doclink
+      documentationUrl: docLinks.workplaceSearchOutlook,
       applicationPortalUrl: '',
       githubRepository: 'elastic/enterprise-search-outlook-connector',
     },

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -691,7 +691,7 @@ export const staticSourceData: SourceDataItem[] = [
       isPublicKey: false,
       hasOauthRedirect: false,
       needsBaseUrl: false,
-      documentationUrl: docLinks.workplaceSearchCustomSources, // TODO Update this when we have a doclink
+      documentationUrl: docLinks.workplaceSearchZoom,
       applicationPortalUrl: '',
       githubRepository: 'elastic/enterprise-search-zoom-connector',
     },

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -107,7 +107,7 @@ export const staticSourceData: SourceDataItem[] = [
       isPublicKey: false,
       hasOauthRedirect: true,
       needsBaseUrl: true,
-      documentationUrl: docLinks.workplaceSearchConfluenceCloud,
+      documentationUrl: docLinks.workplaceSearchConfluenceCloudConnectorPackage,
       applicationPortalUrl: 'https://developer.atlassian.com/console/myapps/',
     },
     objTypes: [


### PR DESCRIPTION
## Summary

Links provided by @chriscressman 

| Connector | Documentation link |
| ------------- | ------------- |
| Confluence Cloud (Connector package)  | https://www.elastic.co/guide/en/workplace-search/master/confluence-cloud.html |
| Network Drive (Custom API source)  | https://www.elastic.co/guide/en/workplace-search/master/network-drives.html  |
| Outlook (Custom API source) | https://www.elastic.co/guide/en/workplace-search/master/microsoft-outlook.html |
| Teams (Custom API source) | https://www.elastic.co/guide/en/workplace-search/master/microsoft-teams.html |
| Zoom (Custom API source) | https://www.elastic.co/guide/en/workplace-search/master/zoom.html |
| Custom connector package | https://www.elastic.co/guide/en/workplace-search/master/custom-connector-package.html |


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials