### PR TITLE
[Security Solution][Endpoint][Activity Log] Remove redux from activity log

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/action.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/action.ts
@@ -147,10 +147,6 @@ export type EndpointIsolationRequestStateChange = Action<'endpointIsolationReque
   payload: EndpointState['isolationRequestState'];
 };
 
-export type EndpointDetailsActivityLogChanged = Action<'endpointDetailsActivityLogChanged'> & {
-  payload: EndpointState['endpointDetails']['activityLog']['logData'];
-};
-
 export type EndpointPendingActionsStateChanged = Action<'endpointPendingActionsStateChanged'> & {
   payload: EndpointState['endpointPendingActions'];
 };
@@ -158,10 +154,6 @@ export type EndpointPendingActionsStateChanged = Action<'endpointPendingActionsS
 export interface EndpointDetailsActivityLogUpdatePaging {
   type: 'endpointDetailsActivityLogUpdatePaging';
   payload: {
-    // disable paging when no more data after paging
-    disabled?: boolean;
-    page: number;
-    pageSize: number;
     startDate: string;
     endDate: string;
   };
@@ -186,13 +178,6 @@ export interface EndpointDetailsLoad {
   };
 }
 
-export interface EndpointDetailsActivityLogUpdateIsInvalidDateRange {
-  type: 'endpointDetailsActivityLogUpdateIsInvalidDateRange';
-  payload: {
-    isInvalidDateRange?: boolean;
-  };
-}
-
 export type LoadMetadataTransformStats = Action<'loadMetadataTransformStats'>;
 
 export type MetadataTransformStatsChanged = Action<'metadataTransformStatsChanged'> & {
@@ -205,8 +190,6 @@ export type EndpointAction =
   | ServerReturnedEndpointDetails
   | ServerFailedToReturnEndpointDetails
   | EndpointDetailsActivityLogUpdatePaging
-  | EndpointDetailsActivityLogUpdateIsInvalidDateRange
-  | EndpointDetailsActivityLogChanged
   | UserUpdatedActivityLogRefreshOptions
   | UserUpdatedActivityLogRecentlyUsedDateRanges
   | EndpointDetailsLoad

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/builders.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/builders.ts
@@ -21,19 +21,14 @@ export const initialEndpointPageState = (): Immutable<EndpointState> => {
     endpointDetails: {
       activityLog: {
         paging: {
-          disabled: false,
-          page: 1,
-          pageSize: 50,
           startDate: 'now-1d',
           endDate: 'now',
-          isInvalidDateRange: false,
           autoRefreshOptions: {
             enabled: false,
             duration: DEFAULT_POLL_INTERVAL,
           },
           recentlyUsedDateRanges: [],
         },
-        logData: createUninitialisedResourceState(),
       },
       hostDetails: {
         details: undefined,

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/index.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/index.test.ts
@@ -45,19 +45,14 @@ describe('EndpointList store concerns', () => {
         endpointDetails: {
           activityLog: {
             paging: {
-              disabled: false,
-              page: 1,
-              pageSize: 50,
               startDate: 'now-1d',
               endDate: 'now',
-              isInvalidDateRange: false,
               autoRefreshOptions: {
                 enabled: false,
                 duration: DEFAULT_POLL_INTERVAL,
               },
               recentlyUsedDateRanges: [],
             },
-            logData: { type: 'UninitialisedResourceState' },
           },
           hostDetails: {
             details: undefined,

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
@@ -18,7 +18,6 @@ import {
   Immutable,
   HostIsolationResponse,
   ISOLATION_ACTIONS,
-  ActivityLog,
   MetadataListResponse,
 } from '../../../../../common/endpoint/types';
 import { AppAction } from '../../../../common/store/actions';
@@ -30,7 +29,6 @@ import { endpointMiddlewareFactory } from './middleware';
 import { getEndpointListPath, getEndpointDetailsPath } from '../../../common/routing';
 import { resolvePathVariables } from '../../../../common/utils/resolve_path_variables';
 import {
-  createLoadingResourceState,
   FailedResourceState,
   isFailedResourceState,
   isLoadedResourceState,
@@ -233,175 +231,6 @@ describe('endpoint list middleware', () => {
       const failedAction = (await failedDispatched)
         .payload as FailedResourceState<HostIsolationResponse>;
       expect(failedAction.error).toBe(apiError);
-    });
-  });
-
-  describe('handle ActivityLog State Change actions', () => {
-    let mockedApis: ReturnType<typeof endpointPageHttpMock>;
-
-    beforeEach(() => {
-      mockedApis = endpointPageHttpMock(fakeHttpServices);
-    });
-
-    const endpointList = getEndpointListApiResponse();
-    const agentId = endpointList.data[0].metadata.agent.id;
-    const search = getEndpointDetailsPath({
-      name: 'endpointActivityLog',
-      selected_endpoint: agentId,
-    });
-    const dispatchUserChangedUrl = () => {
-      dispatchUserChangedUrlToEndpointList({ search: `?${search.split('?').pop()}` });
-    };
-
-    const dispatchGetActivityLogLoading = () => {
-      dispatch({
-        type: 'endpointDetailsActivityLogChanged',
-        payload: createLoadingResourceState(),
-      });
-    };
-
-    const dispatchGetActivityLogPaging = ({ page = 1 }: { page: number }) => {
-      dispatch({
-        type: 'endpointDetailsActivityLogUpdatePaging',
-        payload: {
-          page,
-          pageSize: 50,
-          startDate: 'now-1d',
-          endDate: 'now',
-        },
-      });
-    };
-
-    const dispatchGetActivityLogUpdateInvalidDateRange = ({
-      isInvalidDateRange = false,
-    }: {
-      isInvalidDateRange: boolean;
-    }) => {
-      dispatch({
-        type: 'endpointDetailsActivityLogUpdateIsInvalidDateRange',
-        payload: {
-          isInvalidDateRange,
-        },
-      });
-    };
-
-    it('should set ActivityLog state to loading', async () => {
-      dispatchUserChangedUrl();
-
-      const loadingDispatched = waitForAction('endpointDetailsActivityLogChanged', {
-        validate(action) {
-          return isLoadingResourceState(action.payload);
-        },
-      });
-      dispatchGetActivityLogLoading();
-
-      const loadingDispatchedResponse = await loadingDispatched;
-      expect(loadingDispatchedResponse.payload.type).toEqual('LoadingResourceState');
-    });
-
-    it('should set ActivityLog state to loaded when fetching activity log is successful', async () => {
-      dispatchUserChangedUrl();
-
-      const loadedDispatched = waitForAction('endpointDetailsActivityLogChanged', {
-        validate(action) {
-          return isLoadedResourceState(action.payload);
-        },
-      });
-
-      const activityLogResponse = await loadedDispatched;
-      expect(mockedApis.responseProvider.activityLogResponse).toHaveBeenCalledWith({
-        path: expect.any(String),
-        query: {
-          end_date: 'now',
-          start_date: 'now-1d',
-          page: 1,
-          page_size: 50,
-        },
-      });
-      expect(activityLogResponse.payload.type).toEqual('LoadedResourceState');
-    });
-
-    it('should set ActivityLog to Failed if API call fails', async () => {
-      dispatchUserChangedUrl();
-
-      const apiError = new Error('oh oh');
-      const failedDispatched = waitForAction('endpointDetailsActivityLogChanged', {
-        validate(action) {
-          return isFailedResourceState(action.payload);
-        },
-      });
-
-      mockedApis.responseProvider.activityLogResponse.mockImplementation(() => {
-        throw apiError;
-      });
-
-      const failedAction = (await failedDispatched).payload as FailedResourceState<ActivityLog>;
-      expect(failedAction.error).toBe(apiError);
-    });
-
-    it('should not call API again if it fails', async () => {
-      dispatchUserChangedUrl();
-
-      const apiError = new Error('oh oh');
-      const failedDispatched = waitForAction('endpointDetailsActivityLogChanged', {
-        validate(action) {
-          return isFailedResourceState(action.payload);
-        },
-      });
-
-      mockedApis.responseProvider.activityLogResponse.mockImplementation(() => {
-        throw apiError;
-      });
-
-      await failedDispatched;
-
-      expect(mockedApis.responseProvider.activityLogResponse).toHaveBeenCalledTimes(1);
-    });
-
-    it('should not fetch Activity Log with invalid date ranges', async () => {
-      dispatchUserChangedUrl();
-
-      const updateInvalidDateRangeDispatched = waitForAction(
-        'endpointDetailsActivityLogUpdateIsInvalidDateRange'
-      );
-      dispatchGetActivityLogUpdateInvalidDateRange({ isInvalidDateRange: true });
-      await updateInvalidDateRangeDispatched;
-
-      expect(mockedApis.responseProvider.activityLogResponse).not.toHaveBeenCalled();
-    });
-
-    it('should call get Activity Log API with valid date ranges', async () => {
-      dispatchUserChangedUrl();
-
-      const updatePagingDispatched = waitForAction('endpointDetailsActivityLogUpdatePaging');
-      dispatchGetActivityLogPaging({ page: 1 });
-
-      const updateInvalidDateRangeDispatched = waitForAction(
-        'endpointDetailsActivityLogUpdateIsInvalidDateRange'
-      );
-      dispatchGetActivityLogUpdateInvalidDateRange({ isInvalidDateRange: false });
-      await updateInvalidDateRangeDispatched;
-      await updatePagingDispatched;
-
-      expect(mockedApis.responseProvider.activityLogResponse).toHaveBeenCalled();
-    });
-
-    it('should call get Activity Log API with correct paging options', async () => {
-      dispatchUserChangedUrl();
-      const updatePagingDispatched = waitForAction('endpointDetailsActivityLogUpdatePaging');
-      dispatchGetActivityLogPaging({ page: 3 });
-
-      await updatePagingDispatched;
-
-      expect(mockedApis.responseProvider.activityLogResponse).toHaveBeenCalledWith({
-        path: expect.any(String),
-        query: {
-          page: 3,
-          page_size: 50,
-          start_date: 'now-1d',
-          end_date: 'now',
-        },
-      });
     });
   });
 

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.ts
@@ -12,7 +12,6 @@ import semverGte from 'semver/functions/gte';
 import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
 import {
   BASE_POLICY_RESPONSE_ROUTE,
-  ENDPOINT_ACTION_LOG_ROUTE,
   HOST_METADATA_GET_ROUTE,
   HOST_METADATA_LIST_ROUTE,
   metadataCurrentIndexPattern,
@@ -20,7 +19,6 @@ import {
   METADATA_TRANSFORMS_STATUS_ROUTE,
 } from '../../../../../common/endpoint/constants';
 import {
-  ActivityLog,
   GetHostPolicyResponse,
   HostInfo,
   HostIsolationRequestBody,
@@ -55,21 +53,14 @@ import {
   TransformStats,
   TransformStatsResponse,
 } from '../types';
-import { getIsInvalidDateRange } from '../utils';
 import { EndpointPackageInfoStateChanged } from './action';
 import {
   detailsData,
   endpointPackageInfo,
   endpointPackageVersion,
-  getActivityLogData,
-  getActivityLogDataPaging,
-  getActivityLogError,
-  getActivityLogIsUninitializedOrHasSubsequentAPIError,
   getCurrentIsolationRequestState,
   getIsEndpointPackageInfoUninitialized,
   getIsIsolationRequestPending,
-  getIsOnEndpointDetailsActivityLog,
-  getLastLoadedActivityLogData,
   getMetadataTransformStats,
   hasSelectedEndpoint,
   isMetadataTransformStatsLoading,
@@ -78,7 +69,6 @@ import {
   nonExistingPolicies,
   patterns,
   searchBarQuery,
-  selectedAgent,
   uiQueryParams,
 } from './selectors';
 
@@ -139,25 +129,6 @@ export const endpointMiddlewareFactory: ImmutableMiddlewareFactory<EndpointState
 
     if (action.type === 'endpointDetailsLoad') {
       await loadEndpointDetails({ store, coreStart, selectedEndpoint: action.payload.endpointId });
-    }
-
-    // get activity log API
-    if (
-      action.type === 'userChangedUrl' &&
-      hasSelectedEndpoint(getState()) === true &&
-      getIsOnEndpointDetailsActivityLog(getState()) &&
-      getActivityLogIsUninitializedOrHasSubsequentAPIError(getState())
-    ) {
-      await endpointDetailsActivityLogChangedMiddleware({ store, coreStart });
-    }
-
-    // page activity log API
-    if (
-      action.type === 'endpointDetailsActivityLogUpdatePaging' &&
-      !getActivityLogError(getState()) &&
-      hasSelectedEndpoint(getState())
-    ) {
-      await endpointDetailsActivityLogPagingMiddleware({ store, coreStart });
     }
 
     // Isolate Host
@@ -640,130 +611,6 @@ async function endpointDetailsMiddleware({
     return;
   }
   await loadEndpointDetails({ store, coreStart, selectedEndpoint });
-}
-
-async function endpointDetailsActivityLogChangedMiddleware({
-  store,
-  coreStart,
-}: {
-  store: ImmutableMiddlewareAPI<EndpointState, AppAction>;
-  coreStart: CoreStart;
-}) {
-  const { getState, dispatch } = store;
-  dispatch({
-    type: 'endpointDetailsActivityLogChanged',
-    payload: createLoadingResourceState(asStaleResourceState(getActivityLogData(getState()))),
-  });
-
-  try {
-    const { page, pageSize, startDate, endDate } = getActivityLogDataPaging(getState());
-    const route = resolvePathVariables(ENDPOINT_ACTION_LOG_ROUTE, {
-      agent_id: selectedAgent(getState()),
-    });
-    const activityLog = await coreStart.http.get<ActivityLog>(route, {
-      query: { page, page_size: pageSize, start_date: startDate, end_date: endDate },
-    });
-    dispatch({
-      type: 'endpointDetailsActivityLogChanged',
-      payload: createLoadedResourceState<ActivityLog>(activityLog),
-    });
-  } catch (error) {
-    dispatch({
-      type: 'endpointDetailsActivityLogChanged',
-      payload: createFailedResourceState<ActivityLog>(error.body ?? error),
-    });
-  }
-}
-
-async function endpointDetailsActivityLogPagingMiddleware({
-  store,
-  coreStart,
-}: {
-  store: ImmutableMiddlewareAPI<EndpointState, AppAction>;
-  coreStart: CoreStart;
-}) {
-  const { getState, dispatch } = store;
-  try {
-    const { disabled, page, pageSize, startDate, endDate } = getActivityLogDataPaging(getState());
-    // don't page when paging is disabled or when date ranges are invalid
-    if (disabled) {
-      return;
-    }
-    if (getIsInvalidDateRange({ startDate, endDate })) {
-      dispatch({
-        type: 'endpointDetailsActivityLogUpdateIsInvalidDateRange',
-        payload: {
-          isInvalidDateRange: true,
-        },
-      });
-      return;
-    }
-
-    dispatch({
-      type: 'endpointDetailsActivityLogUpdateIsInvalidDateRange',
-      payload: {
-        isInvalidDateRange: false,
-      },
-    });
-    dispatch({
-      type: 'endpointDetailsActivityLogChanged',
-      payload: createLoadingResourceState(asStaleResourceState(getActivityLogData(getState()))),
-    });
-    const route = resolvePathVariables(ENDPOINT_ACTION_LOG_ROUTE, {
-      agent_id: selectedAgent(getState()),
-    });
-    const activityLog = await coreStart.http.get<ActivityLog>(route, {
-      query: {
-        page,
-        page_size: pageSize,
-        start_date: startDate,
-        end_date: endDate,
-      },
-    });
-
-    const lastLoadedLogData = getLastLoadedActivityLogData(getState());
-    if (lastLoadedLogData !== undefined) {
-      const updatedLogDataItems = (
-        [...new Set([...lastLoadedLogData.data, ...activityLog.data])] as ActivityLog['data']
-      ).sort((a, b) =>
-        new Date(b.item.data['@timestamp']) > new Date(a.item.data['@timestamp']) ? 1 : -1
-      );
-
-      const updatedLogData = {
-        page: activityLog.page,
-        pageSize: activityLog.pageSize,
-        startDate: activityLog.startDate,
-        endDate: activityLog.endDate,
-        data: activityLog.page === 1 ? activityLog.data : updatedLogDataItems,
-      };
-      dispatch({
-        type: 'endpointDetailsActivityLogChanged',
-        payload: createLoadedResourceState<ActivityLog>(updatedLogData),
-      });
-      if (!activityLog.data.length) {
-        dispatch({
-          type: 'endpointDetailsActivityLogUpdatePaging',
-          payload: {
-            disabled: true,
-            page: activityLog.page > 1 ? activityLog.page - 1 : 1,
-            pageSize: activityLog.pageSize,
-            startDate: activityLog.startDate,
-            endDate: activityLog.endDate,
-          },
-        });
-      }
-    } else {
-      dispatch({
-        type: 'endpointDetailsActivityLogChanged',
-        payload: createLoadedResourceState<ActivityLog>(activityLog),
-      });
-    }
-  } catch (error) {
-    dispatch({
-      type: 'endpointDetailsActivityLogChanged',
-      payload: createFailedResourceState<ActivityLog>(error.body ?? error),
-    });
-  }
 }
 
 export async function handleLoadMetadataTransformStats(http: HttpStart, store: EndpointPageStore) {

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/reducer.ts
@@ -6,7 +6,6 @@
  */
 
 import {
-  EndpointDetailsActivityLogChanged,
   EndpointPackageInfoStateChanged,
   EndpointPendingActionsStateChanged,
   MetadataTransformStatsChanged,
@@ -31,35 +30,6 @@ type CaseReducer<T extends AppAction> = (
   state: Immutable<EndpointState>,
   action: Immutable<T>
 ) => Immutable<EndpointState>;
-
-const handleEndpointDetailsActivityLogChanged: CaseReducer<EndpointDetailsActivityLogChanged> = (
-  state,
-  action
-) => {
-  const updatedActivityLog =
-    action.payload.type === 'LoadedResourceState'
-      ? {
-          ...state.endpointDetails.activityLog,
-          paging: {
-            ...state.endpointDetails.activityLog.paging,
-            page: action.payload.data.page,
-            pageSize: action.payload.data.pageSize,
-            startDate: action.payload.data.startDate,
-            endDate: action.payload.data.endDate,
-          },
-        }
-      : { ...state.endpointDetails.activityLog };
-  return {
-    ...state,
-    endpointDetails: {
-      ...state.endpointDetails,
-      activityLog: {
-        ...updatedActivityLog,
-        logData: action.payload,
-      },
-    },
-  };
-};
 
 const handleEndpointPendingActionsStateChanged: CaseReducer<EndpointPendingActionsStateChanged> = (
   state,
@@ -168,7 +138,6 @@ export const endpointListReducer: StateReducer = (state = initialEndpointPageSta
     };
   } else if (
     action.type === 'endpointDetailsActivityLogUpdatePaging' ||
-    action.type === 'endpointDetailsActivityLogUpdateIsInvalidDateRange' ||
     action.type === 'userUpdatedActivityLogRefreshOptions'
   ) {
     return {
@@ -176,7 +145,6 @@ export const endpointListReducer: StateReducer = (state = initialEndpointPageSta
       endpointDetails: {
         ...state.endpointDetails,
         activityLog: {
-          ...state.endpointDetails.activityLog,
           paging: {
             ...state.endpointDetails.activityLog.paging,
             ...action.payload,
@@ -198,8 +166,6 @@ export const endpointListReducer: StateReducer = (state = initialEndpointPageSta
         },
       },
     };
-  } else if (action.type === 'endpointDetailsActivityLogChanged') {
-    return handleEndpointDetailsActivityLogChanged(state, action);
   } else if (action.type === 'endpointPendingActionsStateChanged') {
     return handleEndpointPendingActionsStateChanged(state, action);
   } else if (action.type === 'serverReturnedPoliciesForOnboarding') {
@@ -312,10 +278,6 @@ export const endpointListReducer: StateReducer = (state = initialEndpointPageSta
     const activityLog = {
       logData: createUninitialisedResourceState(),
       paging: {
-        disabled: false,
-        isInvalidDateRange: false,
-        page: 1,
-        pageSize: 50,
         startDate: 'now-1d',
         endDate: 'now',
         autoRefreshOptions: {

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/selectors.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/selectors.ts
@@ -17,7 +17,6 @@ import {
   HostPolicyResponseConfiguration,
   HostPolicyResponseActionStatus,
   HostStatus,
-  ActivityLog,
   HostMetadata,
 } from '../../../../../common/endpoint/types';
 import { EndpointState, EndpointIndexUIQueryParams } from '../types';
@@ -28,7 +27,6 @@ import {
   MANAGEMENT_ROUTING_ENDPOINTS_PATH,
 } from '../../../common/constants';
 import {
-  getLastLoadedResourceState,
   isFailedResourceState,
   isLoadedResourceState,
   isLoadingResourceState,
@@ -368,53 +366,6 @@ export const getActivityLogDataPaging = (
 ): Immutable<EndpointState['endpointDetails']['activityLog']['paging']> => {
   return state.endpointDetails.activityLog.paging;
 };
-
-export const getActivityLogData = (
-  state: Immutable<EndpointState>
-): Immutable<EndpointState['endpointDetails']['activityLog']['logData']> =>
-  state.endpointDetails.activityLog.logData;
-
-export const getLastLoadedActivityLogData: (
-  state: Immutable<EndpointState>
-) => Immutable<ActivityLog> | undefined = createSelector(getActivityLogData, (activityLog) => {
-  return getLastLoadedResourceState(activityLog)?.data;
-});
-
-export const getActivityLogUninitialized: (state: Immutable<EndpointState>) => boolean =
-  createSelector(getActivityLogData, (activityLog) => isUninitialisedResourceState(activityLog));
-
-export const getActivityLogRequestLoading: (state: Immutable<EndpointState>) => boolean =
-  createSelector(getActivityLogData, (activityLog) => isLoadingResourceState(activityLog));
-
-export const getActivityLogRequestLoaded: (state: Immutable<EndpointState>) => boolean =
-  createSelector(getActivityLogData, (activityLog) => isLoadedResourceState(activityLog));
-
-export const getActivityLogIterableData: (
-  state: Immutable<EndpointState>
-) => Immutable<ActivityLog['data']> = createSelector(getActivityLogData, (activityLog) => {
-  const emptyArray: ActivityLog['data'] = [];
-  return isLoadedResourceState(activityLog) ? activityLog.data.data : emptyArray;
-});
-
-export const getActivityLogError: (state: Immutable<EndpointState>) => ServerApiError | undefined =
-  createSelector(getActivityLogData, (activityLog) => {
-    if (isFailedResourceState(activityLog)) {
-      return activityLog.error;
-    }
-  });
-
-// returns a true if either lgo is uninitialised
-// or if it has failed an api call after having fetched a non empty log list earlier
-export const getActivityLogIsUninitializedOrHasSubsequentAPIError: (
-  state: Immutable<EndpointState>
-) => boolean = createSelector(
-  getActivityLogUninitialized,
-  getLastLoadedActivityLogData,
-  getActivityLogError,
-  (isUninitialized, lastLoadedLogData, isAPIError) => {
-    return isUninitialized || (!isAPIError && !!lastLoadedLogData?.data.length);
-  }
-);
 
 export const getIsEndpointHostIsolated = createSelector(detailsData, (details) => {
   return (details && isEndpointHostIsolated(details)) || false;

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/types.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/types.ts
@@ -9,7 +9,6 @@ import { EuiSuperDatePickerRecentRange } from '@elastic/eui';
 import type { DataViewBase } from '@kbn/es-query';
 import { GetPackagesResponse } from '@kbn/fleet-plugin/common';
 import {
-  ActivityLog,
   HostInfo,
   Immutable,
   HostMetadata,
@@ -40,19 +39,14 @@ export interface EndpointState {
   endpointDetails: {
     activityLog: {
       paging: {
-        disabled?: boolean;
-        page: number;
-        pageSize: number;
         startDate: string;
         endDate: string;
-        isInvalidDateRange: boolean;
         autoRefreshOptions: {
           enabled: boolean;
           duration: number;
         };
         recentlyUsedDateRanges: EuiSuperDatePickerRecentRange[];
       };
-      logData: AsyncResourceState<ActivityLog>;
     };
     hostDetails: {
       /** details data for a specific host */

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/activity_log_date_range_picker/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/activity_log_date_range_picker/index.tsx
@@ -17,10 +17,7 @@ import {
 } from '@elastic/eui';
 
 import { useEndpointSelector } from '../../../hooks';
-import {
-  getActivityLogDataPaging,
-  getActivityLogRequestLoading,
-} from '../../../../store/selectors';
+import { getActivityLogDataPaging } from '../../../../store/selectors';
 import { DEFAULT_TIMEPICKER_QUICK_RANGES } from '../../../../../../../../common/constants';
 import { useUiSetting$ } from '../../../../../../../common/lib/kibana';
 
@@ -41,27 +38,22 @@ const StickyFlexItem = styled(EuiFlexItem)`
   padding: ${(props) => `${props.theme.eui.paddingSizes.m}`};
 `;
 
-export const DateRangePicker = memo(() => {
+export const DateRangePicker = memo(({ isLoading }: { isLoading: boolean }) => {
   const dispatch = useDispatch();
-  const { page, pageSize, startDate, endDate, autoRefreshOptions, recentlyUsedDateRanges } =
+  const { startDate, endDate, autoRefreshOptions, recentlyUsedDateRanges } =
     useEndpointSelector(getActivityLogDataPaging);
-
-  const activityLogLoading = useEndpointSelector(getActivityLogRequestLoading);
 
   const dispatchActionUpdateActivityLogPaging = useCallback(
     async ({ start, end }) => {
       dispatch({
         type: 'endpointDetailsActivityLogUpdatePaging',
         payload: {
-          disabled: false,
-          page,
-          pageSize,
           startDate: dateMath.parse(start)?.toISOString(),
           endDate: dateMath.parse(end)?.toISOString(),
         },
       });
     },
-    [dispatch, page, pageSize]
+    [dispatch]
   );
 
   const onRefreshChange = useCallback(
@@ -80,14 +72,11 @@ export const DateRangePicker = memo(() => {
     dispatch({
       type: 'endpointDetailsActivityLogUpdatePaging',
       payload: {
-        disabled: false,
-        page,
-        pageSize,
         startDate,
         endDate,
       },
     });
-  }, [dispatch, page, pageSize, startDate, endDate]);
+  }, [dispatch, startDate, endDate]);
 
   const onTimeChange = useCallback(
     ({ start: newStart, end: newEnd }) => {
@@ -125,7 +114,7 @@ export const DateRangePicker = memo(() => {
         <DatePickerWrapper data-test-subj="activityLogSuperDatePicker">
           <EuiFlexItem>
             <EuiSuperDatePicker
-              isLoading={activityLogLoading}
+              isLoading={isLoading}
               commonlyUsedRanges={commonlyUsedRanges}
               end={dateMath.parse(endDate)?.toISOString()}
               isPaused={!autoRefreshOptions.enabled}

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoint_details.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoint_details.tsx
@@ -15,14 +15,12 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { memo, useCallback, useEffect, useMemo } from 'react';
-import { HostMetadata } from '../../../../../../common/endpoint/types';
 import { PreferenceFormattedDateFromPrimitive } from '../../../../../common/components/formatted_date';
 import { useToasts } from '../../../../../common/lib/kibana';
 import { getEndpointDetailsPath } from '../../../../common/routing';
 import {
   detailsData,
   detailsError,
-  getActivityLogData,
   hostStatusInfo,
   policyResponseActions,
   policyResponseAppliedRevision,
@@ -52,7 +50,6 @@ export const EndpointDetails = memo(() => {
   const toasts = useToasts();
   const queryParams = useEndpointSelector(uiQueryParams);
 
-  const activityLog = useEndpointSelector(getActivityLogData);
   const hostDetails = useEndpointSelector(detailsData);
   const hostDetailsError = useEndpointSelector(detailsError);
 
@@ -100,10 +97,15 @@ export const EndpointDetails = memo(() => {
           name: 'endpointActivityLog',
           selected_endpoint: id,
         }),
-        content: <EndpointActivityLog activityLog={activityLog} />,
+        content:
+          hostDetails === undefined ? (
+            ContentLoadingMarkup
+          ) : (
+            <EndpointActivityLog agentId={hostDetails.agent.id} />
+          ),
       },
     ],
-    [ContentLoadingMarkup, hostDetails, policyInfo, hostStatus, activityLog, queryParams]
+    [ContentLoadingMarkup, hostDetails, policyInfo, hostStatus, queryParams]
   );
 
   const showFlyoutFooter =
@@ -144,7 +146,7 @@ export const EndpointDetails = memo(() => {
             />
           )}
 
-          {show === 'policy_response' && <PolicyResponseFlyoutPanel hostMeta={hostDetails} />}
+          {show === 'policy_response' && <PolicyResponseFlyoutPanel />}
 
           {(show === 'isolate' || show === 'unisolate') && (
             <EndpointIsolationFlyoutPanel hostMeta={hostDetails} />
@@ -163,9 +165,7 @@ export const EndpointDetails = memo(() => {
 
 EndpointDetails.displayName = 'EndpointDetails';
 
-const PolicyResponseFlyoutPanel = memo<{
-  hostMeta: HostMetadata;
-}>(({ hostMeta }) => {
+const PolicyResponseFlyoutPanel = () => {
   const responseConfig = useEndpointSelector(policyResponseConfigurations);
   const responseActions = useEndpointSelector(policyResponseActions);
   const responseAttentionCount = useEndpointSelector(policyResponseFailedOrWarningActionCount);
@@ -221,6 +221,6 @@ const PolicyResponseFlyoutPanel = memo<{
       </EuiFlyoutBody>
     </>
   );
-});
+};
 
 PolicyResponseFlyoutPanel.displayName = 'PolicyResponseFlyoutPanel';

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoints.stories.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoints.stories.tsx
@@ -6,110 +6,12 @@
  */
 
 import React, { ComponentType } from 'react';
-import moment from 'moment';
 
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
-import {
-  ActivityLog,
-  Immutable,
-  ActivityLogItemTypes,
-} from '../../../../../../common/endpoint/types';
+
 import { EndpointDetailsFlyoutTabs } from './components/endpoint_details_tabs';
 import { EndpointActivityLog } from './endpoint_activity_log';
 import { EndpointDetailsFlyout } from '.';
-import { AsyncResourceState } from '../../../../state';
-
-export const dummyEndpointActivityLog = (
-  selectedEndpoint: string = ''
-): AsyncResourceState<Immutable<ActivityLog>> => ({
-  type: 'LoadedResourceState',
-  data: {
-    page: 1,
-    pageSize: 50,
-    startDate: moment().subtract(5, 'day').fromNow().toString(),
-    endDate: moment().toString(),
-    data: [
-      {
-        type: ActivityLogItemTypes.FLEET_ACTION,
-        item: {
-          id: '',
-          data: {
-            action_id: '1',
-            '@timestamp': moment().subtract(1, 'hours').fromNow().toString(),
-            expiration: moment().add(3, 'day').fromNow().toString(),
-            type: 'INPUT_ACTION',
-            input_type: 'endpoint',
-            agents: [`${selectedEndpoint}`],
-            user_id: 'sys',
-            data: {
-              command: 'isolate',
-            },
-          },
-        },
-      },
-      {
-        type: ActivityLogItemTypes.FLEET_ACTION,
-        item: {
-          id: '',
-          data: {
-            action_id: '2',
-            '@timestamp': moment().subtract(2, 'hours').fromNow().toString(),
-            expiration: moment().add(1, 'day').fromNow().toString(),
-            type: 'INPUT_ACTION',
-            input_type: 'endpoint',
-            agents: [`${selectedEndpoint}`],
-            user_id: 'ash',
-            data: {
-              command: 'isolate',
-              comment: 'Sem et tortor consequat id porta nibh venenatis cras sed.',
-            },
-          },
-        },
-      },
-      {
-        type: ActivityLogItemTypes.FLEET_ACTION,
-        item: {
-          id: '',
-          data: {
-            action_id: '3',
-            '@timestamp': moment().subtract(4, 'hours').fromNow().toString(),
-            expiration: moment().add(1, 'day').fromNow().toString(),
-            type: 'INPUT_ACTION',
-            input_type: 'endpoint',
-            agents: [`${selectedEndpoint}`],
-            user_id: 'someone',
-            data: {
-              command: 'unisolate',
-              comment: 'Turpis egestas pretium aenean pharetra.',
-            },
-          },
-        },
-      },
-      {
-        type: ActivityLogItemTypes.FLEET_ACTION,
-        item: {
-          id: '',
-          data: {
-            action_id: '4',
-            '@timestamp': moment().subtract(1, 'day').fromNow().toString(),
-            expiration: moment().add(3, 'day').fromNow().toString(),
-            type: 'INPUT_ACTION',
-            input_type: 'endpoint',
-            agents: [`${selectedEndpoint}`],
-            user_id: 'ash',
-            data: {
-              command: 'isolate',
-              comment:
-                'Lorem \
-                  ipsum dolor sit amet, consectetur adipiscing elit, \
-                  sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-            },
-          },
-        },
-      },
-    ],
-  },
-});
 
 export default {
   title: 'Endpoints/Endpoint Details',
@@ -146,6 +48,4 @@ export const Tabs = () => (
   />
 );
 
-export const ActivityLogMarkup = () => (
-  <EndpointActivityLog activityLog={dummyEndpointActivityLog()} />
-);
+export const ActivityLogMarkup = () => <EndpointActivityLog agentId={'some-agent-id'} />;

--- a/x-pack/plugins/security_solution/public/management/services/activity_log/index.ts
+++ b/x-pack/plugins/security_solution/public/management/services/activity_log/index.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { UseQueryResult, useQuery } from 'react-query';
+import { HttpFetchError } from '@kbn/core/public';
+import { useHttp } from '../../../common/lib/kibana';
+import { ActivityLog } from '../../../../common/endpoint/types';
+import { MANAGEMENT_DEFAULT_PAGE, MANAGEMENT_DEFAULT_PAGE_SIZE } from '../../common/constants';
+
+const ACTIVITY_LOG_API_PATH = `/api/endpoint/action_log/`;
+
+export const useGetActivityLog = ({
+  agentId,
+  options,
+}: {
+  agentId: string;
+  options: Partial<ActivityLog>;
+}): UseQueryResult<ActivityLog, HttpFetchError> => {
+  const {
+    page = MANAGEMENT_DEFAULT_PAGE + 1,
+    pageSize = MANAGEMENT_DEFAULT_PAGE_SIZE,
+    startDate = 'now-1d',
+    endDate = 'now',
+  } = options;
+
+  const http = useHttp();
+
+  return useQuery<ActivityLog, HttpFetchError>(
+    ['activityLog', { page, pageSize, startDate, endDate }],
+    async () => {
+      const response = await http.get<ActivityLog>(`${ACTIVITY_LOG_API_PATH}${agentId}`, {
+        query: {
+          page,
+          page_size: pageSize,
+          start_date: startDate,
+          end_date: endDate,
+        },
+      });
+      return response;
+    },
+    {
+      keepPreviousData: true,
+    }
+  );
+};


### PR DESCRIPTION
## Summary

- [x] Removes a lot of redux and middleware dependencies for fetching activity log data on endpoint details flyout.
- [ ] Should work as before, refetch, on scroll fetching etc

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
