### PR TITLE
[ML] Explain log rate spikes: Disable UI/APIs.

### DIFF
--- a/x-pack/plugins/aiops/common/index.ts
+++ b/x-pack/plugins/aiops/common/index.ts
@@ -19,4 +19,4 @@ export const PLUGIN_NAME = 'AIOps';
  * This is an internal hard coded feature flag so we can easily turn on/off the
  * "Explain log rate spikes UI" during development until the first release.
  */
-export const AIOPS_ENABLED = true;
+export const AIOPS_ENABLED = false;

--- a/x-pack/test/api_integration/apis/aiops/index.ts
+++ b/x-pack/test/api_integration/apis/aiops/index.ts
@@ -5,13 +5,17 @@
  * 2.0.
  */
 
+import { AIOPS_ENABLED } from '@kbn/aiops-plugin/common';
+
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('AIOps', function () {
     this.tags(['ml']);
 
-    loadTestFile(require.resolve('./example_stream'));
-    loadTestFile(require.resolve('./explain_log_rate_spikes'));
+    if (AIOPS_ENABLED) {
+      loadTestFile(require.resolve('./example_stream'));
+      loadTestFile(require.resolve('./explain_log_rate_spikes'));
+    }
   });
 }


### PR DESCRIPTION
## Summary

Part of #136265.

This disables the UI and APIs for Explain log rate spikes in the ML plugin since it will not be part of `8.3`. Once `8.3` has been branched off, we can reenable it in `main`. This also adds a check to the API integration tests to run the tests only when the hard coded feature flag is set to `true`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
