### PR TITLE
[Files] Public API v1

### DIFF
--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -68,7 +68,10 @@ export type FileSavedObjectAttributes<Meta = unknown> = {
 
 export type FileSavedObject<Meta = unknown> = SavedObject<FileSavedObjectAttributes<Meta>>;
 
-export type UpdatableFileAttributes = Pick<FileSavedObjectAttributes, 'meta' | 'alt' | 'name'>;
+export type UpdatableFileAttributes<Meta = unknown> = Pick<
+  FileSavedObjectAttributes<Meta>,
+  'meta' | 'alt' | 'name'
+>;
 
 export interface File<Meta = unknown> {
   id: string;
@@ -81,8 +84,11 @@ export interface File<Meta = unknown> {
   meta: Meta;
   alt: undefined | string;
 
-  update(attr: Partial<UpdatableFileAttributes>): Promise<File>;
+  update(attr: Partial<UpdatableFileAttributes<Meta>>): Promise<File<Meta>>;
+
   uploadContent(content: Readable): Promise<void>;
+
   downloadContent(): Promise<Readable>;
+
   delete(): Promise<void>;
 }

--- a/x-pack/plugins/files/server/file_service/file_service.ts
+++ b/x-pack/plugins/files/server/file_service/file_service.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { File } from '../../common';
+import {
+  CreateFileArgs,
+  UpdateFileArgs,
+  DeleteFileArgs,
+  FindFileArgs,
+  ListFilesArgs,
+} from './internal_file_service';
+
+// TODO: Add file kind registry
+// export interface FileServiceSetup {}
+
+/**
+ * Public file service interface.
+ */
+export interface FileServiceStart {
+  /**
+   * Create a new file.
+   *
+   * Once created, the file content can be uploaded. See {@link File}.
+   */
+  create<M>(args: CreateFileArgs<M>): Promise<File<M>>;
+
+  /**
+   * Update updatable file attributes like name and meta.
+   */
+  update<M>(args: UpdateFileArgs): Promise<File<M>>;
+
+  /**
+   * Delete a file.
+   */
+  delete(args: DeleteFileArgs): Promise<void>;
+
+  /**
+   * Find a file. Will throw if file cannot be found.
+   */
+  find<M>(args: FindFileArgs): Promise<File<M>>;
+
+  /**
+   * List all files of specific file kind.
+   */
+  list<M>(args: ListFilesArgs): Promise<Array<File<M>>>;
+}

--- a/x-pack/plugins/files/server/file_service/internal_file_service.ts
+++ b/x-pack/plugins/files/server/file_service/internal_file_service.ts
@@ -17,29 +17,29 @@ import {
 } from '../../common';
 import { File } from '../file';
 
-interface CreateFileArgs<Meta = unknown> {
+export interface CreateFileArgs<Meta = unknown> {
   name: string;
   fileKind: string;
   alt?: string;
   meta?: Meta;
 }
 
-interface UpdateFileArgs {
+export interface UpdateFileArgs {
   id: string;
   fileKind: string;
   attributes: UpdatableFileAttributes;
 }
 
-interface DeleteFileArgs {
+export interface DeleteFileArgs {
   id: string;
   fileKind: string;
 }
 
-interface ListFilesArgs {
+export interface ListFilesArgs {
   fileKind: string;
 }
 
-interface FindFileArgs {
+export interface FindFileArgs {
   id: string;
   fileKind: string;
 }
@@ -74,9 +74,9 @@ export class InternalFileService {
     }
   }
 
-  public async updateFile({ attributes, fileKind, id }: UpdateFileArgs): Promise<void> {
+  public async updateFile({ attributes, fileKind, id }: UpdateFileArgs): Promise<IFile> {
     const file = await this.find({ fileKind, id });
-    await file.update(attributes);
+    return await file.update(attributes);
   }
 
   public async deleteFile({ id, fileKind }: DeleteFileArgs): Promise<void> {

--- a/x-pack/plugins/files/server/plugin.ts
+++ b/x-pack/plugins/files/server/plugin.ts
@@ -5,46 +5,53 @@
  * 2.0.
  */
 
-import type { PluginInitializerContext, CoreSetup, Plugin, Logger } from '@kbn/core/server';
+import type {
+  PluginInitializerContext,
+  CoreSetup,
+  Plugin,
+  Logger,
+  CoreStart,
+} from '@kbn/core/server';
 
 import { BlobStorageService } from './blob_storage_service';
 import { FileServiceFactory } from './file_service';
-import { FilePluginSetup } from './types';
+import { FilesPluginSetupDependencies, FilesPluginSetup, FilesPluginStart } from './types';
 
-export class FilesPlugin implements Plugin {
+export class FilesPlugin
+  implements Plugin<FilesPluginSetup, FilesPluginStart, FilesPluginSetupDependencies>
+{
   private readonly logger: Logger;
   private fileServiceFactory: undefined | FileServiceFactory;
-  private readyPromise: Promise<void> = Promise.resolve();
+  private securitySetup: FilesPluginSetupDependencies['security'];
 
   constructor(initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get();
   }
 
-  public setup(core: CoreSetup, deps: FilePluginSetup) {
+  public setup(core: CoreSetup, deps: FilesPluginSetupDependencies) {
     FileServiceFactory.setup(core.savedObjects);
-
-    this.readyPromise = core.getStartServices().then(async ([coreStart]) => {
-      const esClient = coreStart.elasticsearch.client.asInternalUser;
-      const blobStorageService = new BlobStorageService(
-        esClient,
-        this.logger.get('blob-storage-service')
-      );
-      this.fileServiceFactory = new FileServiceFactory(
-        coreStart.savedObjects,
-        blobStorageService,
-        deps.security,
-        this.logger.get('files-service')
-      );
-    });
-
-    return {};
+    this.securitySetup = deps.security;
+    return {
+      // TODO: Finish building file kind registry
+      registerFileKind() {},
+    };
   }
 
-  public start() {
-    this.readyPromise.then(() => {
-      this.logger.debug(`Is file servicer ready? ${Boolean(this.fileServiceFactory)}`);
-    });
-    return {};
+  public start(coreStart: CoreStart) {
+    const esClient = coreStart.elasticsearch.client.asInternalUser;
+    const blobStorageService = new BlobStorageService(
+      esClient,
+      this.logger.get('blob-storage-service')
+    );
+    this.fileServiceFactory = new FileServiceFactory(
+      coreStart.savedObjects,
+      blobStorageService,
+      this.securitySetup,
+      this.logger.get('files-service')
+    );
+    return {
+      fileServiceFactory: this.fileServiceFactory,
+    };
   }
 
   public stop() {}

--- a/x-pack/plugins/files/server/types.ts
+++ b/x-pack/plugins/files/server/types.ts
@@ -5,7 +5,16 @@
  * 2.0.
  */
 import { SecurityPluginSetup } from '@kbn/security-plugin/server';
+import { FileServiceFactory } from './file_service';
 
-export interface FilePluginSetup {
+export interface FilesPluginSetup {
+  registerFileKind(arg: unknown): void;
+}
+
+export interface FilesPluginStart {
+  fileServiceFactory: FileServiceFactory;
+}
+
+export interface FilesPluginSetupDependencies {
   security?: SecurityPluginSetup;
 }


### PR DESCRIPTION
## Summary

This is the first iteration of the public CRUD API that will power interactions with files. This will also be used once we start working on HTTP endpoints and integrating files into existing plugins.

Addresses KS-2323

## To reviewers

The current interface is very minimalistic, we can expand with functionality like `createAndUpload` quite easily. Additionally, we do not have support for the file kind registry yet but the `FileServiceFactory` does enable us to scope the SavedObjects client and audit logger to a user request.

Please see `x-pack/plugins/files/server/file_service/file_service.ts`