### PR TITLE
[Osquery] Fix pagination issue on Alert's Osquery Flyout

### DIFF
--- a/x-pack/plugins/osquery/public/results/results_table.tsx
+++ b/x-pack/plugins/osquery/public/results/results_table.tsx
@@ -315,8 +315,11 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
           id: 'timeline',
           width: 38,
           headerCellRender: () => null,
-          rowCellRender: (actionProps: EuiDataGridCellValueElementProps) => {
-            const eventId = data[actionProps.rowIndex]._id;
+          rowCellRender: (actionProps) => {
+            const { visibleRowIndex } = actionProps as EuiDataGridCellValueElementProps & {
+              visibleRowIndex: number;
+            };
+            const eventId = data[visibleRowIndex]._id;
 
             return addToTimeline({ query: ['_id', eventId], isIcon: true });
           },


### PR DESCRIPTION
Fix the issue where table has 50 relative elements per page, and we used `rowIndex` which is absolute number. 
