### PR TITLE
[Fleet] Fix rolling upgrade CANCEL and UI fixes

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -338,7 +338,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
   }, [flyoutContext]);
 
   // Current upgrades
-  const { abortUpgrade, currentUpgrades, refreshUpgrades } = useCurrentUpgrades();
+  const { abortUpgrade, currentUpgrades, refreshUpgrades } = useCurrentUpgrades(fetchData);
 
   const columns = [
     {
@@ -545,7 +545,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         selectionMode={selectionMode}
         currentQuery={kuery}
         selectedAgents={selectedAgents}
-        refreshAgents={() => fetchData()}
+        refreshAgents={() => Promise.all([fetchData(), refreshUpgrades()])}
       />
       <EuiSpacer size="m" />
       {/* Agent total, bulk actions and status bar */}

--- a/x-pack/plugins/fleet/server/services/agents/upgrade.ts
+++ b/x-pack/plugins/fleet/server/services/agents/upgrade.ts
@@ -267,6 +267,7 @@ async function _getCancelledActionId(
 ) {
   const res = await esClient.search<FleetServerAgentAction>({
     index: AGENT_ACTIONS_INDEX,
+    ignore_unavailable: true,
     query: {
       bool: {
         must: [
@@ -296,6 +297,7 @@ async function _getCancelledActionId(
 async function _getUpgradeActions(esClient: ElasticsearchClient, now = new Date().toISOString()) {
   const res = await esClient.search<FleetServerAgentAction>({
     index: AGENT_ACTIONS_INDEX,
+    ignore_unavailable: true,
     query: {
       bool: {
         must: [


### PR DESCRIPTION
## Summary

Related to #130259 

That PR fix a few things related to the rolling upgrade feature:
* it remove the `upgrade_start_at` field when cancelling an upgrade this allow the agent status to be updated
* it fix the current upgrade query when no fleet actions have been created
* it refresh the agent list when cancelling an upgrade
* change the polling duration for current upgrades to 2 minutes

