### PR TITLE
[Uptime] Add ability to rerun edited monitor

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
@@ -92,16 +92,19 @@ export const editSyntheticsMonitorRoute: UMRestApiRouteFactory = () => ({
           monitor.type === 'browser' ? { ...formattedMonitor, urls: '' } : formattedMonitor
         );
 
-      const errors = await syntheticsService.pushConfigs([
-        {
-          ...editedMonitor,
-          id: updatedMonitor.id,
-          fields: {
-            config_id: updatedMonitor.id,
+      const errors = await syntheticsService.pushConfigs(
+        [
+          {
+            ...editedMonitor,
+            id: updatedMonitor.id,
+            fields: {
+              config_id: updatedMonitor.id,
+            },
+            fields_under_root: true,
           },
-          fields_under_root: true,
-        },
-      ]);
+        ],
+        true
+      );
 
       sendTelemetryEvents(
         logger,

--- a/x-pack/plugins/synthetics/server/synthetics_service/service_api_client.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/service_api_client.ts
@@ -24,6 +24,7 @@ export interface ServiceData {
     api_key: string;
   };
   runOnce?: boolean;
+  isEdit?: boolean;
 }
 
 export class ServiceAPIClient {
@@ -118,7 +119,7 @@ export class ServiceAPIClient {
 
   async callAPI(
     method: 'POST' | 'PUT' | 'DELETE',
-    { monitors: allMonitors, output, runOnce }: ServiceData
+    { monitors: allMonitors, output, runOnce, isEdit }: ServiceData
   ) {
     if (this.username === TEST_SERVICE_USERNAME) {
       // we don't want to call service while local integration tests are running
@@ -134,7 +135,12 @@ export class ServiceAPIClient {
       return axios({
         method,
         url: url + (runOnce ? '/run' : '/monitors'),
-        data: { monitors: monitorsStreams, output, stack_version: this.kibanaVersion },
+        data: {
+          monitors: monitorsStreams,
+          output,
+          stack_version: this.kibanaVersion,
+          is_edit: isEdit,
+        },
         headers:
           process.env.NODE_ENV !== 'production' && this.authorization
             ? {

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
@@ -12,6 +12,7 @@ import { SyntheticsService, SyntheticsConfig } from './synthetics_service';
 import { loggerMock } from '@kbn/core/server/logging/logger.mock';
 import { UptimeServerSetup } from '../legacy_uptime/lib/adapters';
 import axios, { AxiosResponse } from 'axios';
+import times from 'lodash/times';
 
 describe('SyntheticsService', () => {
   const mockEsClient = {
@@ -26,6 +27,60 @@ describe('SyntheticsService', () => {
   } as unknown as UptimeServerSetup;
 
   const logger = loggerMock.create();
+
+  const getMockedService = (locationsNum: number = 1) => {
+    serverMock.config = { service: { devUrl: 'http://localhost' } };
+    const service = new SyntheticsService(logger, serverMock, {
+      username: 'dev',
+      password: '12345',
+    });
+
+    const locations = times(locationsNum).map((n) => {
+      return {
+        id: `loc-${n}`,
+        label: `Location ${n}`,
+        url: `example.com/${n}`,
+        geo: {
+          lat: 0,
+          lon: 0,
+        },
+        isServiceManaged: true,
+      };
+    });
+
+    service.apiClient.locations = locations;
+
+    jest.spyOn(service, 'getApiKey').mockResolvedValue({ name: 'example', id: 'i', apiKey: 'k' });
+    jest.spyOn(service, 'getOutput').mockResolvedValue({ hosts: ['es'], api_key: 'i:k' });
+
+    return { service, locations };
+  };
+
+  const getFakePayload = (locations: SyntheticsConfig['locations']) => {
+    return {
+      type: 'http',
+      enabled: true,
+      schedule: {
+        number: '3',
+        unit: 'm',
+      },
+      name: 'my mon',
+      locations,
+      urls: 'http://google.com',
+      max_redirects: '0',
+      password: '',
+      proxy_url: '',
+      id: '7af7e2f0-d5dc-11ec-87ac-bdfdb894c53d',
+      fields: { config_id: '7af7e2f0-d5dc-11ec-87ac-bdfdb894c53d' },
+      fields_under_root: true,
+    };
+  };
+
+  beforeEach(() => {
+    (axios as jest.MockedFunction<typeof axios>).mockReset();
+  });
+
+  afterEach(() => jest.restoreAllMocks());
 
   it('inits properly', async () => {
     const service = new SyntheticsService(logger, serverMock, {});
@@ -72,58 +127,10 @@ describe('SyntheticsService', () => {
   });
 
   describe('addConfig', () => {
-    afterEach(() => jest.restoreAllMocks());
-
     it('saves configs only to the selected locations', async () => {
-      serverMock.config = { service: { devUrl: 'http://localhost' } };
-      const service = new SyntheticsService(logger, serverMock, {
-        username: 'dev',
-        password: '12345',
-      });
+      const { service, locations } = getMockedService(3);
 
-      service.apiClient.locations = [
-        {
-          id: 'selected',
-          label: 'Selected Location',
-          url: 'example.com/1',
-          geo: {
-            lat: 0,
-            lon: 0,
-          },
-          isServiceManaged: true,
-        },
-        {
-          id: 'not selected',
-          label: 'Not Selected Location',
-          url: 'example.com/2',
-          geo: {
-            lat: 0,
-            lon: 0,
-          },
-          isServiceManaged: true,
-        },
-      ];
-
-      jest.spyOn(service, 'getApiKey').mockResolvedValue({ name: 'example', id: 'i', apiKey: 'k' });
-      jest.spyOn(service, 'getOutput').mockResolvedValue({ hosts: ['es'], api_key: 'i:k' });
-
-      const payload = {
-        type: 'http',
-        enabled: true,
-        schedule: {
-          number: '3',
-          unit: 'm',
-        },
-        name: 'my mon',
-        locations: [{ id: 'selected', isServiceManaged: true }],
-        urls: 'http://google.com',
-        max_redirects: '0',
-        password: '',
-        proxy_url: '',
-        id: '7af7e2f0-d5dc-11ec-87ac-bdfdb894c53d',
-        fields: { config_id: '7af7e2f0-d5dc-11ec-87ac-bdfdb894c53d' },
-        fields_under_root: true,
-      };
+      const payload = getFakePayload([locations[0]]);
 
       (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
@@ -132,7 +139,43 @@ describe('SyntheticsService', () => {
       expect(axios).toHaveBeenCalledTimes(1);
       expect(axios).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: 'example.com/1/monitors',
+          url: locations[0].url + '/monitors',
+        })
+      );
+    });
+  });
+
+  describe('pushConfigs', () => {
+    it('does not include the isEdit flag on normal push requests', async () => {
+      const { service, locations } = getMockedService();
+
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
+
+      const payload = getFakePayload([locations[0]]);
+
+      await service.pushConfigs([payload] as SyntheticsConfig[]);
+
+      expect(axios).toHaveBeenCalledTimes(1);
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ is_edit: false }),
+        })
+      );
+    });
+
+    it('includes the isEdit flag on edit requests', async () => {
+      const { service, locations } = getMockedService();
+
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
+
+      const payload = getFakePayload([locations[0]]);
+
+      await service.pushConfigs([payload] as SyntheticsConfig[], true);
+
+      expect(axios).toHaveBeenCalledTimes(1);
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ is_edit: true }),
         })
       );
     });

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -251,7 +251,7 @@ export class SyntheticsService {
     }
   }
 
-  async pushConfigs(configs?: SyntheticsConfig[]) {
+  async pushConfigs(configs?: SyntheticsConfig[], isEdit?: boolean) {
     const monitors = this.formatConfigs(configs || (await this.getMonitorConfigs()));
     if (monitors.length === 0) {
       this.logger.debug('No monitor found which can be pushed to service.');
@@ -267,6 +267,7 @@ export class SyntheticsService {
     const data = {
       monitors,
       output: await this.getOutput(this.apiKey),
+      isEdit: !!isEdit,
     };
 
     this.logger.debug(`${monitors.length} monitors will be pushed to synthetics service.`);


### PR DESCRIPTION
> ⚠️ Given there were testing overlaps, this PR builds on top of https://github.com/elastic/kibana/pull/132325

## Summary

This PR will cause edited monitors to be rerun immediately.

As discussed on Slack, we decided that simply kicking-off another job was enough to re-run a monitor rather than having a more complex flow to reinstate cronJobs at the right time.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


## Release Note

Immediately re-run monitors in the synthetics service when they're edited.


# How to test this PR

1. Checkout the appropriate Kibana version and start it pointing to the service (this branch)
    ```yaml
    # Use the URL of the service here
    xpack.uptime.service.devUrl: https://localhost:10001
    ```
2. Checkout the appropriate version of the service, build it, and start it 
3. Create a monitor in Kibana
    ```js
    step("visit google", async () => {
        await page.goto("https://google.com");
    });
    ```
4. Go to Uptime and check the time this monitor has last run
5. Edit the monitor's code
    ```js
    step("visit HackerNews", async () => {
        await page.goto("https://news.ycombinator.com");
    });
    ```
6. Once you've saved it, give it a few seconds to re-run and check the `Uptime` page. You should soon get results for the edited monitor with the new URL.