### PR TITLE
[Dashboard] [ftr] Add dashboard group 6 to ftr_configs.yml

### DIFF
--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -68,6 +68,7 @@ enabled:
   - test/functional/apps/dashboard/group3/config.ts
   - test/functional/apps/dashboard/group4/config.ts
   - test/functional/apps/dashboard/group5/config.ts
+  - test/functional/apps/dashboard/group6/config.ts
   - test/functional/apps/discover/config.ts
   - test/functional/apps/getting_started/config.ts
   - test/functional/apps/home/config.ts


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/132193, group 6 was added to rebalance group 1 but it wasn't added to the `ftr_configs.yml` so all tests in group 6 are currently being skipped. This PR simply adds it back.