### PR TITLE
Supporting branch to display object fields in Enterprise Search

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
@@ -15,7 +15,7 @@ import {
 import { HttpLogic } from '../../../../shared/http';
 import { KibanaLogic } from '../../../../shared/kibana';
 import { ENGINE_CURATIONS_PATH } from '../../../routes';
-import { flattenObject } from '../../../utils/results';
+import { flattenDocument } from '../../../utils/results';
 import { EngineLogic, generateEnginePath } from '../../engine';
 import { DELETE_SUCCESS_MESSAGE } from '../constants';
 
@@ -236,9 +236,12 @@ export const CurationLogic = kea<MakeLogicType<CurationValues, CurationActions, 
           `/internal/app_search/engines/${engineName}/curations/${props.curationId}`,
           { query: { skip_record_analytics: 'true' } }
         );
-        response.hidden = response.hidden.map((x) => flattenObject(x) as CurationResult);
-        response.promoted = response.promoted.map((x) => flattenObject(x) as CurationResult);
-        actions.onCurationLoad(response);
+        const payload = {
+          ...response,
+          hidden: response.hidden.map((x) => flattenDocument(x) as CurationResult),
+          promoted: response.promoted.map((x) => flattenDocument(x) as CurationResult),
+        };
+        actions.onCurationLoad(payload);
       } catch (e) {
         const { navigateToUrl } = KibanaLogic.values;
 
@@ -266,9 +269,12 @@ export const CurationLogic = kea<MakeLogicType<CurationValues, CurationActions, 
             }),
           }
         );
-        response.hidden = response.hidden.map((x) => flattenObject(x) as CurationResult);
-        response.promoted = response.promoted.map((x) => flattenObject(x) as CurationResult);
-        actions.onCurationLoad(response);
+        const payload = {
+          ...response,
+          hidden: response.hidden.map((x) => flattenDocument(x) as CurationResult),
+          promoted: response.promoted.map((x) => flattenDocument(x) as CurationResult),
+        };
+        actions.onCurationLoad(payload);
       } catch (e) {
         flashAPIErrors(e);
         actions.onCurationError();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
@@ -15,10 +15,11 @@ import {
 import { HttpLogic } from '../../../../shared/http';
 import { KibanaLogic } from '../../../../shared/kibana';
 import { ENGINE_CURATIONS_PATH } from '../../../routes';
+import { flattenObject } from '../../../utils/results';
 import { EngineLogic, generateEnginePath } from '../../engine';
 import { DELETE_SUCCESS_MESSAGE } from '../constants';
 
-import { Curation } from '../types';
+import { Curation, CurationResult } from '../types';
 import { addDocument, removeDocument } from '../utils';
 
 type CurationPageTabs = 'promoted' | 'history' | 'hidden';
@@ -235,6 +236,8 @@ export const CurationLogic = kea<MakeLogicType<CurationValues, CurationActions, 
           `/internal/app_search/engines/${engineName}/curations/${props.curationId}`,
           { query: { skip_record_analytics: 'true' } }
         );
+        response.hidden = response.hidden.map((x) => flattenObject(x) as CurationResult);
+        response.promoted = response.promoted.map((x) => flattenObject(x) as CurationResult);
         actions.onCurationLoad(response);
       } catch (e) {
         const { navigateToUrl } = KibanaLogic.values;
@@ -263,6 +266,8 @@ export const CurationLogic = kea<MakeLogicType<CurationValues, CurationActions, 
             }),
           }
         );
+        response.hidden = response.hidden.map((x) => flattenObject(x) as CurationResult);
+        response.promoted = response.promoted.map((x) => flattenObject(x) as CurationResult);
         actions.onCurationLoad(response);
       } catch (e) {
         flashAPIErrors(e);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/types.ts
@@ -45,5 +45,5 @@ export interface CurationResult {
   // TODO: Consider updating our internal API to return more standard Result data in the future
   id: string;
   _meta?: ResultMeta;
-  [key: string]: string | string[] | ResultMeta | undefined;
+  [key: string]: string | string[] | ResultMeta | object | undefined;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/types.ts
@@ -45,5 +45,5 @@ export interface CurationResult {
   // TODO: Consider updating our internal API to return more standard Result data in the future
   id: string;
   _meta?: ResultMeta;
-  [key: string]: string | string[] | ResultMeta | object | undefined;
+  [key: string]: string | string[] | ResultMeta | unknown | undefined;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -19,7 +19,7 @@ import { Schema } from '../../../shared/schema/types';
 
 import { ENGINE_DOCUMENT_DETAIL_PATH } from '../../routes';
 import { generateEncodedPath } from '../../utils/encode_path_params';
-import { flattenObject } from '../../utils/results';
+import { flattenDocument } from '../../utils/results';
 
 import { ResultField } from './result_field';
 import { ResultHeader } from './result_header';
@@ -56,7 +56,7 @@ export const Result: React.FC<Props> = ({
   const META = '_meta';
   const resultMeta = result[META];
   const resultFields = useMemo(
-    () => Object.entries(flattenObject(result)).filter(([key]) => key !== META && key !== ID),
+    () => Object.entries(flattenDocument(result)).filter(([key]) => key !== META && key !== ID),
     [result]
   );
   const numResults = resultFields.length;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -19,7 +19,7 @@ import { Schema } from '../../../shared/schema/types';
 
 import { ENGINE_DOCUMENT_DETAIL_PATH } from '../../routes';
 import { generateEncodedPath } from '../../utils/encode_path_params';
-import { flattenSearchResult } from '../../utils/results';
+import { flattenObject } from '../../utils/results';
 
 import { ResultField } from './result_field';
 import { ResultHeader } from './result_header';
@@ -56,7 +56,7 @@ export const Result: React.FC<Props> = ({
   const META = '_meta';
   const resultMeta = result[META];
   const resultFields = useMemo(
-    () => Object.entries(flattenSearchResult(result)).filter(([key]) => key !== META && key !== ID),
+    () => Object.entries(flattenObject(result)).filter(([key]) => key !== META && key !== ID),
     [result]
   );
   const numResults = resultFields.length;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -19,6 +19,7 @@ import { Schema } from '../../../shared/schema/types';
 
 import { ENGINE_DOCUMENT_DETAIL_PATH } from '../../routes';
 import { generateEncodedPath } from '../../utils/encode_path_params';
+import { flattenSearchResult } from '../../utils/results';
 
 import { ResultField } from './result_field';
 import { ResultHeader } from './result_header';
@@ -55,7 +56,7 @@ export const Result: React.FC<Props> = ({
   const META = '_meta';
   const resultMeta = result[META];
   const resultFields = useMemo(
-    () => Object.entries(result).filter(([key]) => key !== META && key !== ID),
+    () => Object.entries(flattenSearchResult(result)).filter(([key]) => key !== META && key !== ID),
     [result]
   );
   const numResults = resultFields.length;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/search/search_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/search/search_logic.ts
@@ -13,6 +13,7 @@ import { HttpLogic } from '../../../shared/http';
 import { EngineLogic } from '../engine';
 
 import { Result } from '../result/types';
+import { flattenSearchResult } from '../../utils/results'
 
 interface SearchValues {
   searchDataLoading: boolean;
@@ -49,7 +50,7 @@ export const SearchLogic = kea<MakeLogicType<SearchValues, SearchActions>>({
     searchResults: [
       [],
       {
-        onSearch: (_, { results }) => results,
+        onSearch: (_, { results }) => results.map((res) => flattenSearchResult(res)),
       },
     ],
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/search/search_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/search/search_logic.ts
@@ -10,10 +10,10 @@ import { kea, MakeLogicType } from 'kea';
 import { flashAPIErrors } from '../../../shared/flash_messages';
 
 import { HttpLogic } from '../../../shared/http';
+import { flattenObject } from '../../utils/results';
 import { EngineLogic } from '../engine';
 
 import { Result } from '../result/types';
-import { flattenSearchResult } from '../../utils/results'
 
 interface SearchValues {
   searchDataLoading: boolean;
@@ -50,7 +50,7 @@ export const SearchLogic = kea<MakeLogicType<SearchValues, SearchActions>>({
     searchResults: [
       [],
       {
-        onSearch: (_, { results }) => results.map((res) => flattenSearchResult(res)),
+        onSearch: (_, { results }) => results.map((res) => flattenObject(res) as Result),
       },
     ],
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/search/search_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/search/search_logic.ts
@@ -10,7 +10,7 @@ import { kea, MakeLogicType } from 'kea';
 import { flashAPIErrors } from '../../../shared/flash_messages';
 
 import { HttpLogic } from '../../../shared/http';
-import { flattenObject } from '../../utils/results';
+import { flattenDocument } from '../../utils/results';
 import { EngineLogic } from '../engine';
 
 import { Result } from '../result/types';
@@ -50,7 +50,7 @@ export const SearchLogic = kea<MakeLogicType<SearchValues, SearchActions>>({
     searchResults: [
       [],
       {
-        onSearch: (_, { results }) => results.map((res) => flattenObject(res) as Result),
+        onSearch: (_, { results }) => results.map((res) => flattenDocument(res) as Result),
       },
     ],
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.test.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 import { Result } from '../../components/result/types';
-import { flattenSearchResult, flattenField } from '.';
+
+import { flattenObject, flattenField } from '.';
 
 describe('flattenField', () => {
   it('flattens field if raw key is absent', () => {
@@ -39,7 +40,7 @@ describe('flattenField', () => {
   });
 });
 
-describe('flattenSearchResult', () => {
+describe('flattenObject', () => {
   it('flattens all fields without raw key', () => {
     const result: Result = {
       id: { raw: '123' },
@@ -54,6 +55,6 @@ describe('flattenSearchResult', () => {
       'address.city': { raw: 'Los Angeles' },
       'address.state': { raw: 'California' },
     };
-    expect(flattenSearchResult(result)).toEqual(expected);
+    expect(flattenObject(result)).toEqual(expected);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.test.ts
@@ -6,16 +6,16 @@
  */
 import { Result } from '../../components/result/types';
 
-import { flattenObject, flattenField } from '.';
+import { flattenDocument, flattenDocumentField } from '.';
 
-describe('flattenField', () => {
+describe('flattenDocumentField', () => {
   it('flattens field if raw key is absent', () => {
-    expect(flattenField('address', { country: { raw: 'United States' } })).toEqual([
+    expect(flattenDocumentField('address', { country: { raw: 'United States' } })).toEqual([
       ['address.country', { raw: 'United States' }],
     ]);
   });
   it('preserves field if raw key is present', () => {
-    expect(flattenField('country', { raw: 'United States' })).toEqual([
+    expect(flattenDocumentField('country', { raw: 'United States' })).toEqual([
       ['country', { raw: 'United States' }],
     ]);
   });
@@ -36,11 +36,11 @@ describe('flattenField', () => {
       ['customer.address.country.code', { raw: 'US' }],
       ['customer.address.country.name', { raw: 'United States' }],
     ];
-    expect(flattenField('customer', data)).toEqual(expected);
+    expect(flattenDocumentField('customer', data)).toEqual(expected);
   });
 });
 
-describe('flattenObject', () => {
+describe('flattenDocument', () => {
   it('flattens all fields without raw key', () => {
     const result: Result = {
       id: { raw: '123' },
@@ -55,6 +55,6 @@ describe('flattenObject', () => {
       'address.city': { raw: 'Los Angeles' },
       'address.state': { raw: 'California' },
     };
-    expect(flattenObject(result)).toEqual(expected);
+    expect(flattenDocument(result)).toEqual(expected);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.test.ts
@@ -18,6 +18,25 @@ describe('flattenField', () => {
       ['country', { raw: 'United States' }],
     ]);
   });
+  it('can flatten multiple levels', () => {
+    const data = {
+      name: { raw: 'Bubba Gump' },
+      address: {
+        street: { raw: 'South St' },
+        country: {
+          code: { raw: 'US' },
+          name: { raw: 'United States' },
+        },
+      },
+    };
+    const expected = [
+      ['customer.name', { raw: 'Bubba Gump' }],
+      ['customer.address.street', { raw: 'South St' }],
+      ['customer.address.country.code', { raw: 'US' }],
+      ['customer.address.country.name', { raw: 'United States' }],
+    ];
+    expect(flattenField('customer', data)).toEqual(expected);
+  });
 });
 
 describe('flattenSearchResult', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { Result } from '../../components/result/types';
+import { flattenSearchResult, flattenField } from '.';
+
+describe('flattenField', () => {
+  it('flattens field if raw key is absent', () => {
+    expect(flattenField('address', { country: { raw: 'United States' } })).toEqual([
+      ['address.country', { raw: 'United States' }],
+    ]);
+  });
+  it('preserves field if raw key is present', () => {
+    expect(flattenField('country', { raw: 'United States' })).toEqual([
+      ['country', { raw: 'United States' }],
+    ]);
+  });
+});
+
+describe('flattenSearchResult', () => {
+  it('flattens all fields without raw key', () => {
+    const result: Result = {
+      id: { raw: '123' },
+      _meta: { engine: 'Test', id: '1' },
+      title: { raw: 'Getty Museum' },
+      address: { city: { raw: 'Los Angeles' }, state: { raw: 'California' } },
+    };
+    const expected: Result = {
+      id: { raw: '123' },
+      _meta: { engine: 'Test', id: '1' },
+      title: { raw: 'Getty Museum' },
+      'address.city': { raw: 'Los Angeles' },
+      'address.state': { raw: 'California' },
+    };
+    expect(flattenSearchResult(result)).toEqual(expected);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.ts
@@ -11,7 +11,9 @@ export const flattenField = (fieldName: string, fieldValue: object): Array<[stri
 
   if (typeof fieldValue === 'object' && !Object.keys(fieldValue).includes('raw')) {
     Object.entries(fieldValue).map(([propName, value]) => {
-      flattened.push([fieldName + '.' + propName, value]);
+      flattenField(fieldName + '.' + propName, value).map(([flatKey, flatVal]) => {
+        flattened.push([flatKey, flatVal]);
+      });
     });
   } else {
     flattened.push([fieldName, fieldValue]);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { Result, ResultMeta } from '../../components/result/types';
+
+export const flattenField = (fieldName: string, fieldValue: object): Array<[string, object]> => {
+  const flattened: Array<[string, object]> = [];
+
+  if (typeof fieldValue === 'object' && !Object.keys(fieldValue).includes('raw')) {
+    Object.entries(fieldValue).map(([propName, value]) => {
+      flattened.push([fieldName + '.' + propName, value]);
+    });
+  } else {
+    flattened.push([fieldName, fieldValue]);
+  }
+
+  return flattened;
+};
+
+export const flattenSearchResult = (result: Result): Result => {
+  const flattened: Result = {
+    id: { raw: '' },
+    _meta: {
+      id: '',
+      engine: '',
+    },
+  };
+
+  Object.entries(result).map(([key, value]) => {
+    if (key === 'id') {
+      flattened[key] = value as { raw: string };
+    } else if (key === '_meta') {
+      flattened[key] = value as ResultMeta;
+    } else {
+      flattenField(key, value).map(([flatName, flatValue]) => {
+        flattened[flatName] = flatValue;
+      });
+    }
+  });
+
+  return flattened;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/results/index.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { Result, ResultMeta } from '../../components/result/types';
 
 export const flattenField = (fieldName: string, fieldValue: object): Array<[string, object]> => {
   const flattened: Array<[string, object]> = [];
@@ -22,20 +21,12 @@ export const flattenField = (fieldName: string, fieldValue: object): Array<[stri
   return flattened;
 };
 
-export const flattenSearchResult = (result: Result): Result => {
-  const flattened: Result = {
-    id: { raw: '' },
-    _meta: {
-      id: '',
-      engine: '',
-    },
-  };
+export const flattenObject = (result: object): object => {
+  const flattened: { [index: string]: object } = {};
 
   Object.entries(result).map(([key, value]) => {
-    if (key === 'id') {
-      flattened[key] = value as { raw: string };
-    } else if (key === '_meta') {
-      flattened[key] = value as ResultMeta;
+    if (key === 'id' || key === '_meta') {
+      flattened[key] = value;
     } else {
       flattenField(key, value).map(([flatName, flatValue]) => {
         flattened[flatName] = flatValue;


### PR DESCRIPTION
Issue: https://github.com/elastic/enterprise-search-team/issues/2021

Related PR in Enterprise Search: https://github.com/elastic/ent-search/pull/6545

## Summary

We're making changes in Enterprise Search to support object fields. This adds support for displaying such fields in the Enterprise Search Kibana plugin. To display the fields, the API response is flattened:

![image](https://user-images.githubusercontent.com/637013/169619790-d7271516-a672-416a-9d7a-21d02741c770.png)

In the API response, a single result now looks like this (`address` is the `object` field):

```json
    {
      "visitors": {
        "raw": 100000.0
      },
      "address": {
        "country": {
          "raw": "United States"
        },
        "country_code": {
          "raw": "US"
        },
        "city": {
          "raw": "Los Angeles"
        },
        "street": {
          "raw": "Getty"
        },
        "postcode": {
          "raw": "90700"
        }
      },
      "title": {
        "raw": "Getty Museum"
      },
      "_meta": {
        "engine": "managed-engine",
        "score": 0.5619608,
        "id": "1"
      },
      "id": {
        "raw": "1"
      }
    }
```

Object fields are still not displayed in Search UI, but to support that, we'll need changes in another repo:

https://github.com/elastic/search-ui

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
