### PR TITLE
[7.17] [Security Solution] Fixes sorting and tooltips on columns for non-ECS fields that are only one level deep (#132570)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/helpers.test.ts
@@ -25,7 +25,7 @@ describe('helpers', () => {
   });
 
   describe('getRootCategory', () => {
-    const baseFields = ['@timestamp', '_id', 'message'];
+    const baseFields = ['@timestamp'];
 
     baseFields.forEach((field) => {
       test(`it returns the 'base' category for the ${field} field`, () => {
@@ -107,29 +107,31 @@ describe('helpers', () => {
       expect(getColumnHeaders(mockHeader, mockBrowserFields)).toEqual(expectedData);
     });
 
-    test('it should return the expected metadata for the `_id` field, which is one level deep, and belongs to the `base` category', () => {
+    test('it should return the expected metadata for the `@timestamp` field, which is one level deep, and belongs to the `base` category', () => {
       const headers: ColumnHeaderOptions[] = [
         {
           columnHeaderType: 'not-filtered',
-          id: '_id',
+          id: '@timestamp',
           initialWidth: 180,
         },
       ];
 
       expect(getColumnHeaders(headers, mockBrowserFields)).toEqual([
         {
-          aggregatable: false,
+          aggregatable: true,
           category: 'base',
           columnHeaderType: 'not-filtered',
-          description: 'Each document has an _id that uniquely identifies it',
-          esTypes: [],
-          example: 'Y-6TfmcB0WOhS6qyMv3s',
-          id: '_id',
+          description:
+            'Date/time when the event originated. For log events this is the date/time when the event was generated, and not when it was read. Required field for all events.',
+          esTypes: ['date'],
+          example: '2016-05-23T08:05:34.853Z',
+          format: '',
+          id: '@timestamp',
           indexes: ['auditbeat', 'filebeat', 'packetbeat'],
           initialWidth: 180,
-          name: '_id',
+          name: '@timestamp',
           searchable: true,
-          type: 'string',
+          type: 'date',
         },
       ]);
     });
@@ -164,7 +166,6 @@ describe('helpers', () => {
                 'winlogbeat-*',
               ],
               name: 'test_field_1',
-              readFromDocValues: true,
               searchable: true,
               type: 'string',
             },
@@ -194,7 +195,6 @@ describe('helpers', () => {
           ],
           initialWidth: 180,
           name: 'test_field_1',
-          readFromDocValues: true,
           searchable: true,
           type: 'string',
         },
@@ -231,7 +231,6 @@ describe('helpers', () => {
                 'winlogbeat-*',
               ],
               name: 'foo.bar',
-              readFromDocValues: true,
               searchable: true,
               type: 'string',
             },
@@ -261,7 +260,6 @@ describe('helpers', () => {
           ],
           initialWidth: 180,
           name: 'foo.bar',
-          readFromDocValues: true,
           searchable: true,
           type: 'string',
         },

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/helpers.test.ts
@@ -6,11 +6,12 @@
  */
 
 import { mockBrowserFields } from '../../../../../common/containers/source/mock';
-
-import { defaultHeaders } from './default_headers';
-import { getColumnWidthFromType, getColumnHeaders } from './helpers';
-import { DEFAULT_COLUMN_MIN_WIDTH, DEFAULT_DATE_COLUMN_MIN_WIDTH } from '../constants';
 import '../../../../../common/mock/match_media';
+import { BrowserFields } from '../../../../../../common/search_strategy';
+import { ColumnHeaderOptions } from '../../../../../../common/types';
+import { DEFAULT_COLUMN_MIN_WIDTH, DEFAULT_DATE_COLUMN_MIN_WIDTH } from '../constants';
+import { defaultHeaders } from './default_headers';
+import { getColumnWidthFromType, getColumnHeaders, getRootCategory } from './helpers';
 
 describe('helpers', () => {
   describe('getColumnWidthFromType', () => {
@@ -20,6 +21,32 @@ describe('helpers', () => {
 
     test('it returns the expected width for a date column', () => {
       expect(getColumnWidthFromType('date')).toEqual(DEFAULT_DATE_COLUMN_MIN_WIDTH);
+    });
+  });
+
+  describe('getRootCategory', () => {
+    const baseFields = ['@timestamp', '_id', 'message'];
+
+    baseFields.forEach((field) => {
+      test(`it returns the 'base' category for the ${field} field`, () => {
+        expect(
+          getRootCategory({
+            field,
+            browserFields: mockBrowserFields,
+          })
+        ).toEqual('base');
+      });
+    });
+
+    test(`it echos the field name for a field that's NOT in the base category`, () => {
+      const field = 'test_field_1';
+
+      expect(
+        getRootCategory({
+          field,
+          browserFields: mockBrowserFields,
+        })
+      ).toEqual(field);
     });
   });
 
@@ -78,6 +105,203 @@ describe('helpers', () => {
         ['@timestamp', 'source.ip', 'destination.ip'].includes(h.id)
       );
       expect(getColumnHeaders(mockHeader, mockBrowserFields)).toEqual(expectedData);
+    });
+
+    test('it should return the expected metadata for the `_id` field, which is one level deep, and belongs to the `base` category', () => {
+      const headers: ColumnHeaderOptions[] = [
+        {
+          columnHeaderType: 'not-filtered',
+          id: '_id',
+          initialWidth: 180,
+        },
+      ];
+
+      expect(getColumnHeaders(headers, mockBrowserFields)).toEqual([
+        {
+          aggregatable: false,
+          category: 'base',
+          columnHeaderType: 'not-filtered',
+          description: 'Each document has an _id that uniquely identifies it',
+          esTypes: [],
+          example: 'Y-6TfmcB0WOhS6qyMv3s',
+          id: '_id',
+          indexes: ['auditbeat', 'filebeat', 'packetbeat'],
+          initialWidth: 180,
+          name: '_id',
+          searchable: true,
+          type: 'string',
+        },
+      ]);
+    });
+
+    test('it should return the expected metadata for a field one level deep that does NOT belong to the `base` category', () => {
+      const headers: ColumnHeaderOptions[] = [
+        {
+          columnHeaderType: 'not-filtered',
+          id: 'test_field_1', // one level deep, but does NOT belong to the `base` category
+          initialWidth: 180,
+        },
+      ];
+
+      const oneLevelDeep: BrowserFields = {
+        test_field_1: {
+          fields: {
+            test_field_1: {
+              aggregatable: true,
+              category: 'test_field_1',
+              esTypes: ['keyword'],
+              format: 'string',
+              indexes: [
+                '-*elastic-cloud-logs-*',
+                '.alerts-security.alerts-default',
+                'apm-*-transaction*',
+                'auditbeat-*',
+                'endgame-*',
+                'filebeat-*',
+                'logs-*',
+                'packetbeat-*',
+                'traces-apm*',
+                'winlogbeat-*',
+              ],
+              name: 'test_field_1',
+              readFromDocValues: true,
+              searchable: true,
+              type: 'string',
+            },
+          },
+        },
+      };
+
+      expect(getColumnHeaders(headers, oneLevelDeep)).toEqual([
+        {
+          aggregatable: true,
+          category: 'test_field_1',
+          columnHeaderType: 'not-filtered',
+          esTypes: ['keyword'],
+          format: 'string',
+          id: 'test_field_1',
+          indexes: [
+            '-*elastic-cloud-logs-*',
+            '.alerts-security.alerts-default',
+            'apm-*-transaction*',
+            'auditbeat-*',
+            'endgame-*',
+            'filebeat-*',
+            'logs-*',
+            'packetbeat-*',
+            'traces-apm*',
+            'winlogbeat-*',
+          ],
+          initialWidth: 180,
+          name: 'test_field_1',
+          readFromDocValues: true,
+          searchable: true,
+          type: 'string',
+        },
+      ]);
+    });
+
+    test('it should return the expected metadata for a field that is more than one level deep', () => {
+      const headers: ColumnHeaderOptions[] = [
+        {
+          columnHeaderType: 'not-filtered',
+          id: 'foo.bar', // two levels deep
+          initialWidth: 180,
+        },
+      ];
+
+      const twoLevelsDeep: BrowserFields = {
+        foo: {
+          fields: {
+            'foo.bar': {
+              aggregatable: true,
+              category: 'foo',
+              esTypes: ['keyword'],
+              format: 'string',
+              indexes: [
+                '-*elastic-cloud-logs-*',
+                '.alerts-security.alerts-default',
+                'apm-*-transaction*',
+                'auditbeat-*',
+                'endgame-*',
+                'filebeat-*',
+                'logs-*',
+                'packetbeat-*',
+                'traces-apm*',
+                'winlogbeat-*',
+              ],
+              name: 'foo.bar',
+              readFromDocValues: true,
+              searchable: true,
+              type: 'string',
+            },
+          },
+        },
+      };
+
+      expect(getColumnHeaders(headers, twoLevelsDeep)).toEqual([
+        {
+          aggregatable: true,
+          category: 'foo',
+          columnHeaderType: 'not-filtered',
+          esTypes: ['keyword'],
+          format: 'string',
+          id: 'foo.bar',
+          indexes: [
+            '-*elastic-cloud-logs-*',
+            '.alerts-security.alerts-default',
+            'apm-*-transaction*',
+            'auditbeat-*',
+            'endgame-*',
+            'filebeat-*',
+            'logs-*',
+            'packetbeat-*',
+            'traces-apm*',
+            'winlogbeat-*',
+          ],
+          initialWidth: 180,
+          name: 'foo.bar',
+          readFromDocValues: true,
+          searchable: true,
+          type: 'string',
+        },
+      ]);
+    });
+
+    test('it should return the expected metadata for an UNKNOWN field one level deep', () => {
+      const headers: ColumnHeaderOptions[] = [
+        {
+          columnHeaderType: 'not-filtered',
+          id: 'unknown', // one level deep, but not contained in the `BrowserFields`
+          initialWidth: 180,
+        },
+      ];
+
+      expect(getColumnHeaders(headers, mockBrowserFields)).toEqual([
+        {
+          columnHeaderType: 'not-filtered',
+          id: 'unknown',
+          initialWidth: 180,
+        },
+      ]);
+    });
+
+    test('it should return the expected metadata for an UNKNOWN field that is more than one level deep', () => {
+      const headers: ColumnHeaderOptions[] = [
+        {
+          columnHeaderType: 'not-filtered',
+          id: 'unknown.more.than.one.level', // more than one level deep, and not contained in the `BrowserFields`
+          initialWidth: 180,
+        },
+      ];
+
+      expect(getColumnHeaders(headers, mockBrowserFields)).toEqual([
+        {
+          columnHeaderType: 'not-filtered',
+          id: 'unknown.more.than.one.level',
+          initialWidth: 180,
+        },
+      ]);
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/helpers.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/helpers.ts
@@ -5,11 +5,27 @@
  * 2.0.
  */
 
-import { get } from 'lodash/fp';
+import { has, get } from 'lodash/fp';
 import { ColumnHeaderOptions } from '../../../../../../common';
 
 import { BrowserFields } from '../../../../../common/containers/source';
 import { DEFAULT_COLUMN_MIN_WIDTH, DEFAULT_DATE_COLUMN_MIN_WIDTH } from '../constants';
+
+/**
+ * Returns the root category for fields that are only one level, e.g. `_id` or `test_field_1`
+ *
+ * The `base` category will be returned for fields that are members of `base`,
+ * e.g. the `@timestamp`, `_id`, and `message` fields.
+ *
+ * The field name will be echoed-back for all other fields, e.g. `test_field_1`
+ */
+export const getRootCategory = ({
+  browserFields,
+  field,
+}: {
+  browserFields: BrowserFields;
+  field: string;
+}): string => (has(`base.fields.${field}`, browserFields) ? 'base' : field);
 
 /** Enriches the column headers with field details from the specified browserFields */
 export const getColumnHeaders = (
@@ -19,13 +35,14 @@ export const getColumnHeaders = (
   return headers
     ? headers.map((header) => {
         const splitHeader = header.id.split('.'); // source.geo.city_name -> [source, geo, city_name]
+        const category =
+          splitHeader.length > 1
+            ? splitHeader[0]
+            : getRootCategory({ field: header.id, browserFields });
 
         return {
           ...header,
-          ...get(
-            [splitHeader.length > 1 ? splitHeader[0] : 'base', 'fields', header.id],
-            browserFields
-          ),
+          ...get([category, 'fields', header.id], browserFields),
         };
       })
     : [];

--- a/x-pack/plugins/timelines/public/components/t_grid/body/helpers.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/helpers.test.tsx
@@ -307,7 +307,7 @@ describe('helpers', () => {
       ]);
     });
 
-    test('it defaults to a `columnType` of empty string when a column does NOT has a corresponding entry in `columnHeaders`', () => {
+    test('it defaults to a `columnType` of empty string when a column does NOT have a corresponding entry in `columnHeaders`', () => {
       const withUnknownColumn: Array<{
         id: string;
         direction: 'asc' | 'desc';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Security Solution] Fixes sorting and tooltips on columns for non-ECS fields that are only one level deep (#132570)](https://github.com/elastic/kibana/pull/132570)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)