### PR TITLE
[Workplace Search] Add categories to source data for internal connectors

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -366,6 +366,12 @@ export const SOURCE_OBJ_TYPES = {
 };
 
 export const SOURCE_CATEGORIES = {
+  ACCOUNT_MANAGEMENT: i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sources.categories.accountManagement',
+    {
+      defaultMessage: 'Account management',
+    }
+  ),
   ATLASSIAN: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.atlassian', {
     defaultMessage: 'Atlassian',
   }),
@@ -388,6 +394,15 @@ export const SOURCE_CATEGORIES = {
     'xpack.enterpriseSearch.workplaceSearch.sources.categories.communication',
     {
       defaultMessage: 'Communication',
+    }
+  ),
+  CRM: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.crm', {
+    defaultMessage: 'CRM',
+  }),
+  CUSTOMER_RELATIONSHIP_MANAGEMENT: i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sources.categories.customerRelationshipManagement',
+    {
+      defaultMessage: 'Customer relationship management',
     }
   ),
   EMAIL: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.email', {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -369,6 +369,12 @@ export const SOURCE_CATEGORIES = {
   ATLASSIAN: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.atlassian', {
     defaultMessage: 'Atlassian',
   }),
+  BUG_TRACKING: i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sources.categories.bugTracking',
+    {
+      defaultMessage: 'Bug Tracking',
+    }
+  ),
   CLOUD: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.cloud', {
     defaultMessage: 'Cloud',
   }),
@@ -412,6 +418,12 @@ export const SOURCE_CATEGORIES = {
     'xpack.enterpriseSearch.workplaceSearch.sources.categories.productivity',
     {
       defaultMessage: 'Productivity',
+    }
+  ),
+  PROJECT_MANAGEMENT: i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sources.categories.projectManagement',
+    {
+      defaultMessage: 'Project management',
     }
   ),
   SOFTWARE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.software', {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -378,18 +378,24 @@ export const SOURCE_CATEGORIES = {
       defaultMessage: 'Code repository',
     }
   ),
-  COMMUNICATIONS: i18n.translate(
-    'xpack.enterpriseSearch.workplaceSearch.sources.categories.communications',
+  COMMUNICATION: i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sources.categories.communication',
     {
-      defaultMessage: 'Communications',
+      defaultMessage: 'Communication',
     }
   ),
+  EMAIL: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.email', {
+    defaultMessage: 'Email',
+  }),
   FILE_SHARING: i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.sources.categories.fileSharing',
     {
       defaultMessage: 'File Sharing',
     }
   ),
+  GOOGLE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.google', {
+    defaultMessage: 'Google',
+  }),
   INTRANET: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.intranet', {
     defaultMessage: 'Intranet',
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -378,7 +378,7 @@ export const SOURCE_CATEGORIES = {
   BUG_TRACKING: i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.sources.categories.bugTracking',
     {
-      defaultMessage: 'Bug Tracking',
+      defaultMessage: 'Bug tracking',
     }
   ),
   CHAT: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.chat', {
@@ -426,7 +426,7 @@ export const SOURCE_CATEGORIES = {
   FILE_SHARING: i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.sources.categories.fileSharing',
     {
-      defaultMessage: 'File Sharing',
+      defaultMessage: 'File sharing',
     }
   ),
   GOOGLE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.google', {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -456,6 +456,9 @@ export const SOURCE_CATEGORIES = {
   WIKI: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.wiki', {
     defaultMessage: 'Wiki',
   }),
+  WORKFLOW: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.workflow', {
+    defaultMessage: 'Workflow',
+  }),
 };
 
 export const API_KEYS_TITLE = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -396,6 +396,9 @@ export const SOURCE_CATEGORIES = {
   GOOGLE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.google', {
     defaultMessage: 'Google',
   }),
+  GSUITE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.gsuite', {
+    defaultMessage: 'GSuite',
+  }),
   INTRANET: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.intranet', {
     defaultMessage: 'Intranet',
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -381,6 +381,9 @@ export const SOURCE_CATEGORIES = {
       defaultMessage: 'Bug Tracking',
     }
   ),
+  CHAT: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.chat', {
+    defaultMessage: 'Chat',
+  }),
   CLOUD: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.cloud', {
     defaultMessage: 'Cloud',
   }),
@@ -388,6 +391,12 @@ export const SOURCE_CATEGORIES = {
     'xpack.enterpriseSearch.workplaceSearch.sources.categories.codeRepository',
     {
       defaultMessage: 'Code repository',
+    }
+  ),
+  COLLABORATION: i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sources.categories.collaboration',
+    {
+      defaultMessage: 'Collaboration',
     }
   ),
   COMMUNICATION: i18n.translate(
@@ -420,6 +429,12 @@ export const SOURCE_CATEGORIES = {
   GSUITE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.gsuite', {
     defaultMessage: 'GSuite',
   }),
+  INSTANT_MESSAGING: i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sources.categories.instantMessaging',
+    {
+      defaultMessage: 'Instant messaging',
+    }
+  ),
   INTRANET: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.intranet', {
     defaultMessage: 'Intranet',
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -372,6 +372,12 @@ export const SOURCE_CATEGORIES = {
   CLOUD: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.cloud', {
     defaultMessage: 'Cloud',
   }),
+  CODE_REPOSITORY: i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sources.categories.codeRepository',
+    {
+      defaultMessage: 'Code repository',
+    }
+  ),
   COMMUNICATIONS: i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.sources.categories.communications',
     {
@@ -399,9 +405,18 @@ export const SOURCE_CATEGORIES = {
       defaultMessage: 'Productivity',
     }
   ),
+  SOFTWARE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.software', {
+    defaultMessage: 'Software',
+  }),
   STORAGE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.storage', {
     defaultMessage: 'Storage',
   }),
+  VERSION_CONTROL: i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sources.categories.versionControl',
+    {
+      defaultMessage: 'Version control',
+    }
+  ),
   WIKI: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.wiki', {
     defaultMessage: 'Wiki',
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -414,6 +414,12 @@ export const SOURCE_CATEGORIES = {
       defaultMessage: 'Customer relationship management',
     }
   ),
+  CUSTOMER_SERVICE: i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sources.categories.customerService',
+    {
+      defaultMessage: 'Customer service',
+    }
+  ),
   EMAIL: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.email', {
     defaultMessage: 'Email',
   }),
@@ -428,6 +434,12 @@ export const SOURCE_CATEGORIES = {
   }),
   GSUITE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.gsuite', {
     defaultMessage: 'GSuite',
+  }),
+  HELP: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.help', {
+    defaultMessage: 'Help',
+  }),
+  HELPDESK: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.helpdesk', {
+    defaultMessage: 'Helpdesk',
   }),
   INSTANT_MESSAGING: i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.sources.categories.instantMessaging',
@@ -461,6 +473,9 @@ export const SOURCE_CATEGORIES = {
   }),
   STORAGE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.storage', {
     defaultMessage: 'Storage',
+  }),
+  TICKETING: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.ticketing', {
+    defaultMessage: 'Ticketing',
   }),
   VERSION_CONTROL: i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.sources.categories.versionControl',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -366,6 +366,9 @@ export const SOURCE_OBJ_TYPES = {
 };
 
 export const SOURCE_CATEGORIES = {
+  ATLASSIAN: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.atlassian', {
+    defaultMessage: 'Atlassian',
+  }),
   CLOUD: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.cloud', {
     defaultMessage: 'Cloud',
   }),
@@ -381,6 +384,9 @@ export const SOURCE_CATEGORIES = {
       defaultMessage: 'File Sharing',
     }
   ),
+  INTRANET: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.intranet', {
+    defaultMessage: 'Intranet',
+  }),
   MICROSOFT: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.microsoft', {
     defaultMessage: 'Microsoft',
   }),
@@ -395,6 +401,9 @@ export const SOURCE_CATEGORIES = {
   ),
   STORAGE: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.storage', {
     defaultMessage: 'Storage',
+  }),
+  WIKI: i18n.translate('xpack.enterpriseSearch.workplaceSearch.sources.categories.wiki', {
+    defaultMessage: 'Wiki',
   }),
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -311,6 +311,13 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.GOOGLE_DRIVE,
     serviceType: 'google_drive',
+    categories: [
+      SOURCE_CATEGORIES.FILE_SHARING,
+      SOURCE_CATEGORIES.STORAGE,
+      SOURCE_CATEGORIES.CLOUD,
+      SOURCE_CATEGORIES.PRODUCTIVITY,
+      SOURCE_CATEGORIES.GSUITE,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -74,6 +74,7 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.CONFLUENCE,
     serviceType: 'confluence_cloud',
+    categories: [SOURCE_CATEGORIES.WIKI, SOURCE_CATEGORIES.ATLASSIAN, SOURCE_CATEGORIES.INTRANET],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -698,6 +698,12 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.SLACK,
     serviceType: 'slack',
+    categories: [
+      SOURCE_CATEGORIES.COLLABORATION,
+      SOURCE_CATEGORIES.COMMUNICATION,
+      SOURCE_CATEGORIES.INSTANT_MESSAGING,
+      SOURCE_CATEGORIES.CHAT,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -290,6 +290,11 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.GMAIL,
     serviceType: 'gmail',
+    categories: [
+      SOURCE_CATEGORIES.COMMUNICATION,
+      SOURCE_CATEGORIES.EMAIL,
+      SOURCE_CATEGORIES.GOOGLE,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,
@@ -446,7 +451,7 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.OUTLOOK,
     categories: [
-      SOURCE_CATEGORIES.COMMUNICATIONS,
+      SOURCE_CATEGORIES.COMMUNICATION,
       SOURCE_CATEGORIES.PRODUCTIVITY,
       SOURCE_CATEGORIES.MICROSOFT,
     ],
@@ -662,7 +667,7 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.TEAMS,
     categories: [
-      SOURCE_CATEGORIES.COMMUNICATIONS,
+      SOURCE_CATEGORIES.COMMUNICATION,
       SOURCE_CATEGORIES.PRODUCTIVITY,
       SOURCE_CATEGORIES.MICROSOFT,
     ],
@@ -707,7 +712,7 @@ export const staticSourceData: SourceDataItem[] = [
   },
   {
     name: SOURCE_NAMES.ZOOM,
-    categories: [SOURCE_CATEGORIES.COMMUNICATIONS, SOURCE_CATEGORIES.PRODUCTIVITY],
+    categories: [SOURCE_CATEGORIES.COMMUNICATION, SOURCE_CATEGORIES.PRODUCTIVITY],
     serviceType: 'custom',
     baseServiceType: 'zoom',
     configuration: {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -496,6 +496,11 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.SALESFORCE,
     serviceType: 'salesforce',
+    categories: [
+      SOURCE_CATEGORIES.CRM,
+      SOURCE_CATEGORIES.CUSTOMER_RELATIONSHIP_MANAGEMENT,
+      SOURCE_CATEGORIES.ACCOUNT_MANAGEMENT,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -607,6 +607,13 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.SHAREPOINT,
     serviceType: 'share_point',
+    categories: [
+      SOURCE_CATEGORIES.FILE_SHARING,
+      SOURCE_CATEGORIES.STORAGE,
+      SOURCE_CATEGORIES.CLOUD,
+      SOURCE_CATEGORIES.MICROSOFT,
+      SOURCE_CATEGORIES.OFFICE_365,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -143,6 +143,7 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.CONFLUENCE_SERVER,
     serviceType: 'confluence_server',
+    categories: [SOURCE_CATEGORIES.WIKI, SOURCE_CATEGORIES.ATLASSIAN, SOURCE_CATEGORIES.INTRANET],
     configuration: {
       isPublicKey: true,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -174,6 +174,11 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.DROPBOX,
     serviceType: 'dropbox',
+    categories: [
+      SOURCE_CATEGORIES.FILE_SHARING,
+      SOURCE_CATEGORIES.STORAGE,
+      SOURCE_CATEGORIES.CLOUD,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -743,6 +743,13 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.ZENDESK,
     serviceType: 'zendesk',
+    categories: [
+      SOURCE_CATEGORIES.HELP,
+      SOURCE_CATEGORIES.CUSTOMER_SERVICE,
+      SOURCE_CATEGORIES.CUSTOMER_RELATIONSHIP_MANAGEMENT,
+      SOURCE_CATEGORIES.TICKETING,
+      SOURCE_CATEGORIES.HELPDESK,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -574,6 +574,7 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.SERVICENOW,
     serviceType: 'service_now',
+    categories: [SOURCE_CATEGORIES.WORKFLOW],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: false,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -642,6 +642,13 @@ export const staticSourceData: SourceDataItem[] = [
     name: SOURCE_NAMES.SHAREPOINT_CONNECTOR_PACKAGE,
     serviceType: 'external',
     baseServiceType: 'share_point',
+    categories: [
+      SOURCE_CATEGORIES.FILE_SHARING,
+      SOURCE_CATEGORIES.STORAGE,
+      SOURCE_CATEGORIES.CLOUD,
+      SOURCE_CATEGORIES.MICROSOFT,
+      SOURCE_CATEGORIES.OFFICE_365,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -389,6 +389,12 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.JIRA_SERVER,
     serviceType: 'jira_server',
+    categories: [
+      SOURCE_CATEGORIES.SOFTWARE,
+      SOURCE_CATEGORIES.BUG_TRACKING,
+      SOURCE_CATEGORIES.ATLASSIAN,
+      SOURCE_CATEGORIES.PROJECT_MANAGEMENT,
+    ],
     configuration: {
       isPublicKey: true,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -245,6 +245,11 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.GITHUB_ENTERPRISE,
     serviceType: 'github_enterprise_server',
+    categories: [
+      SOURCE_CATEGORIES.SOFTWARE,
+      SOURCE_CATEGORIES.VERSION_CONTROL,
+      SOURCE_CATEGORIES.CODE_REPOSITORY,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -206,6 +206,11 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.GITHUB,
     serviceType: 'github',
+    categories: [
+      SOURCE_CATEGORIES.SOFTWARE,
+      SOURCE_CATEGORIES.VERSION_CONTROL,
+      SOURCE_CATEGORIES.CODE_REPOSITORY,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -535,6 +535,11 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.SALESFORCE_SANDBOX,
     serviceType: 'salesforce_sandbox',
+    categories: [
+      SOURCE_CATEGORIES.CRM,
+      SOURCE_CATEGORIES.CUSTOMER_RELATIONSHIP_MANAGEMENT,
+      SOURCE_CATEGORIES.ACCOUNT_MANAGEMENT,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -443,6 +443,13 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.ONEDRIVE,
     serviceType: 'one_drive',
+    categories: [
+      SOURCE_CATEGORIES.FILE_SHARING,
+      SOURCE_CATEGORIES.CLOUD,
+      SOURCE_CATEGORIES.STORAGE,
+      SOURCE_CATEGORIES.MICROSOFT,
+      SOURCE_CATEGORIES.OFFICE_365,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -109,6 +109,7 @@ export const staticSourceData: SourceDataItem[] = [
     name: SOURCE_NAMES.CONFLUENCE_CONNECTOR_PACKAGE,
     serviceType: 'external',
     baseServiceType: 'confluence_cloud',
+    categories: [SOURCE_CATEGORIES.WIKI, SOURCE_CATEGORIES.ATLASSIAN, SOURCE_CATEGORIES.INTRANET],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -349,6 +349,12 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.JIRA,
     serviceType: 'jira_cloud',
+    categories: [
+      SOURCE_CATEGORIES.SOFTWARE,
+      SOURCE_CATEGORIES.BUG_TRACKING,
+      SOURCE_CATEGORIES.ATLASSIAN,
+      SOURCE_CATEGORIES.PROJECT_MANAGEMENT,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -42,6 +42,11 @@ export const staticSourceData: SourceDataItem[] = [
   {
     name: SOURCE_NAMES.BOX,
     serviceType: 'box',
+    categories: [
+      SOURCE_CATEGORIES.FILE_SHARING,
+      SOURCE_CATEGORIES.STORAGE,
+      SOURCE_CATEGORIES.CLOUD,
+    ],
     configuration: {
       isPublicKey: false,
       hasOauthRedirect: true,


### PR DESCRIPTION
## Summary

These were previously coming from the Enterprise Search app but for the onboarding flow we're not loading connector data from the BE anymore.


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
