### PR TITLE
Rename 'Threat hunting' menu group to 'Explore'

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -89,7 +89,6 @@ export enum SecurityPageName {
   endpoints = 'endpoints',
   eventFilters = 'event_filters',
   exceptions = 'exceptions',
-  explore = 'explore',
   hostIsolationExceptions = 'host_isolation_exceptions',
   hosts = 'hosts',
   hostsAnomalies = 'hosts-anomalies',
@@ -120,11 +119,11 @@ export enum SecurityPageName {
   sessions = 'sessions',
   usersEvents = 'users-events',
   usersExternalAlerts = 'users-external_alerts',
-  threatHuntingLanding = 'threat_hunting',
+  exploreLanding = 'explore',
   dashboardsLanding = 'dashboards',
 }
 
-export const THREAT_HUNTING_PATH = '/threat_hunting' as const;
+export const EXPLORE_PATH = '/explore' as const;
 export const DASHBOARDS_PATH = '/dashboards' as const;
 export const MANAGE_PATH = '/manage' as const;
 export const TIMELINES_PATH = '/timelines' as const;
@@ -153,7 +152,7 @@ export const APP_OVERVIEW_PATH = `${APP_PATH}${OVERVIEW_PATH}` as const;
 export const APP_LANDING_PATH = `${APP_PATH}${LANDING_PATH}` as const;
 export const APP_DETECTION_RESPONSE_PATH = `${APP_PATH}${DETECTION_RESPONSE_PATH}` as const;
 export const APP_MANAGEMENT_PATH = `${APP_PATH}${MANAGEMENT_PATH}` as const;
-export const APP_THREAT_HUNTING_PATH = `${APP_PATH}${THREAT_HUNTING_PATH}` as const;
+export const APP_EXPLORE_PATH = `${APP_PATH}${EXPLORE_PATH}` as const;
 export const APP_DASHBOARDS_PATH = `${APP_PATH}${DASHBOARDS_PATH}` as const;
 
 export const APP_ALERTS_PATH = `${APP_PATH}${ALERTS_PATH}` as const;

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -34,7 +34,6 @@ import {
   POLICIES,
   ENDPOINTS,
   GETTING_STARTED,
-  THREAT_HUNTING,
   DASHBOARDS,
   CREATE_NEW_RULE,
 } from '../translations';
@@ -58,7 +57,7 @@ import {
   HOST_ISOLATION_EXCEPTIONS_PATH,
   SERVER_APP_ID,
   USERS_PATH,
-  THREAT_HUNTING_PATH,
+  EXPLORE_PATH,
   DASHBOARDS_PATH,
   MANAGE_PATH,
   RULES_CREATE_PATH,
@@ -112,18 +111,6 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
     keywords: [
       i18n.translate('xpack.securitySolution.search.getStarted', {
         defaultMessage: 'Getting started',
-      }),
-    ],
-  },
-  {
-    id: SecurityPageName.threatHuntingLanding,
-    title: THREAT_HUNTING,
-    path: THREAT_HUNTING_PATH,
-    navLinkStatus: AppNavLinkStatus.hidden,
-    features: [FEATURE.general],
-    keywords: [
-      i18n.translate('xpack.securitySolution.search.threatHunting', {
-        defaultMessage: 'Threat Hunting',
       }),
     ],
   },
@@ -213,8 +200,9 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
     ],
   },
   {
-    id: SecurityPageName.explore,
+    id: SecurityPageName.exploreLanding,
     title: EXPLORE,
+    path: EXPLORE_PATH,
     navLinkStatus: AppNavLinkStatus.hidden,
     features: [FEATURE.general],
     keywords: [

--- a/x-pack/plugins/security_solution/public/app/translations.ts
+++ b/x-pack/plugins/security_solution/public/app/translations.ts
@@ -26,10 +26,6 @@ export const GETTING_STARTED = i18n.translate('xpack.securitySolution.navigation
   defaultMessage: 'Get started',
 });
 
-export const THREAT_HUNTING = i18n.translate('xpack.securitySolution.navigation.threatHunting', {
-  defaultMessage: 'Threat Hunting',
-});
-
 export const DASHBOARDS = i18n.translate('xpack.securitySolution.navigation.dashboards', {
   defaultMessage: 'Dashboards',
 });

--- a/x-pack/plugins/security_solution/public/common/components/link_to/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/link_to/index.ts
@@ -90,7 +90,7 @@ function formatPath(path: string, search: string, skipSearch?: boolean) {
 function needsUrlState(pageId: SecurityPageName) {
   return (
     pageId !== SecurityPageName.dashboardsLanding &&
-    pageId !== SecurityPageName.threatHuntingLanding &&
+    pageId !== SecurityPageName.exploreLanding &&
     pageId !== SecurityPageName.administration &&
     pageId !== SecurityPageName.rules &&
     pageId !== SecurityPageName.exceptions &&

--- a/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
@@ -132,6 +132,36 @@ jest.mock('../../../lib/kibana/kibana_react', () => {
   };
 });
 
+const securityBreadCrumb = {
+  href: 'securitySolutionUI/get_started',
+  text: 'Security',
+};
+
+const hostsBreadcrumbs = {
+  href: 'securitySolutionUI/hosts',
+  text: 'Hosts',
+};
+
+const networkBreadcrumb = {
+  text: 'Network',
+  href: 'securitySolutionUI/network',
+};
+
+const exploreBreadcrumbs = {
+  href: 'securitySolutionUI/explore',
+  text: 'Explore',
+};
+
+const rulesBReadcrumb = {
+  text: 'Rules',
+  href: 'securitySolutionUI/rules',
+};
+
+const manageBreadcrumbs = {
+  text: 'Manage',
+  href: 'securitySolutionUI/administration',
+};
+
 describe('Navigation Breadcrumbs', () => {
   beforeAll(async () => {
     const appLinks = await getAppLinks(coreMock.createStart(), {} as StartPlugins);
@@ -169,10 +199,7 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          {
-            href: 'securitySolutionUI/get_started',
-            text: 'Security',
-          },
+          securityBreadCrumb,
           {
             href: '',
             text: 'Overview',
@@ -187,14 +214,8 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          {
-            href: 'securitySolutionUI/get_started',
-            text: 'Security',
-          },
-          {
-            href: 'securitySolutionUI/hosts',
-            text: 'Hosts',
-          },
+          securityBreadCrumb,
+          hostsBreadcrumbs,
           {
             href: '',
             text: 'Authentications',
@@ -209,11 +230,8 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Network',
-            href: 'securitySolutionUI/network',
-          },
+          securityBreadCrumb,
+          networkBreadcrumb,
           {
             text: 'Flows',
             href: '',
@@ -228,7 +246,7 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
+          securityBreadCrumb,
           {
             text: 'Timelines',
             href: '',
@@ -243,11 +261,8 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Hosts',
-            href: 'securitySolutionUI/hosts',
-          },
+          securityBreadCrumb,
+          hostsBreadcrumbs,
           {
             text: 'siem-kibana',
             href: 'securitySolutionUI/hosts/siem-kibana',
@@ -263,11 +278,8 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Network',
-            href: 'securitySolutionUI/network',
-          },
+          securityBreadCrumb,
+          networkBreadcrumb,
           {
             text: ipv4,
             href: `securitySolutionUI/network/ip/${ipv4}/source`,
@@ -283,11 +295,8 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Network',
-            href: 'securitySolutionUI/network',
-          },
+          securityBreadCrumb,
+          networkBreadcrumb,
           {
             text: ipv6,
             href: `securitySolutionUI/network/ip/${ipv6Encoded}/source`,
@@ -303,7 +312,7 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
+          securityBreadCrumb,
           {
             text: 'Alerts',
             href: '',
@@ -318,7 +327,7 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
+          securityBreadCrumb,
           {
             text: 'Exception lists',
             href: '',
@@ -333,7 +342,7 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
+          securityBreadCrumb,
           {
             text: 'Rules',
             href: '',
@@ -348,11 +357,8 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Rules',
-            href: 'securitySolutionUI/rules',
-          },
+          securityBreadCrumb,
+          rulesBReadcrumb,
           {
             text: 'Create',
             href: '',
@@ -375,11 +381,8 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Rules',
-            href: 'securitySolutionUI/rules',
-          },
+          securityBreadCrumb,
+          rulesBReadcrumb,
           {
             text: mockRuleName,
             href: ``,
@@ -402,11 +405,8 @@ describe('Navigation Breadcrumbs', () => {
           false
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Rules',
-            href: 'securitySolutionUI/rules',
-          },
+          securityBreadCrumb,
+          rulesBReadcrumb,
           {
             text: 'ALERT_RULE_NAME',
             href: `securitySolutionUI/rules/id/${mockDetailName}`,
@@ -451,7 +451,7 @@ describe('Navigation Breadcrumbs', () => {
         );
 
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
+          securityBreadCrumb,
           {
             text: 'Endpoints',
             href: '',
@@ -504,10 +504,7 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          {
-            href: 'securitySolutionUI/get_started',
-            text: 'Security',
-          },
+          securityBreadCrumb,
           {
             href: 'securitySolutionUI/dashboards',
             text: 'Dashboards',
@@ -526,18 +523,9 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          {
-            href: 'securitySolutionUI/get_started',
-            text: 'Security',
-          },
-          {
-            href: 'securitySolutionUI/threat_hunting',
-            text: 'Threat Hunting',
-          },
-          {
-            href: 'securitySolutionUI/hosts',
-            text: 'Hosts',
-          },
+          securityBreadCrumb,
+          exploreBreadcrumbs,
+          hostsBreadcrumbs,
           {
             href: '',
             text: 'Authentications',
@@ -552,15 +540,9 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            href: 'securitySolutionUI/threat_hunting',
-            text: 'Threat Hunting',
-          },
-          {
-            text: 'Network',
-            href: 'securitySolutionUI/network',
-          },
+          securityBreadCrumb,
+          exploreBreadcrumbs,
+          networkBreadcrumb,
           {
             text: 'Flows',
             href: '',
@@ -575,7 +557,7 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
+          securityBreadCrumb,
           {
             text: 'Timelines',
             href: '',
@@ -590,15 +572,9 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            href: 'securitySolutionUI/threat_hunting',
-            text: 'Threat Hunting',
-          },
-          {
-            text: 'Hosts',
-            href: 'securitySolutionUI/hosts',
-          },
+          securityBreadCrumb,
+          exploreBreadcrumbs,
+          hostsBreadcrumbs,
           {
             text: 'siem-kibana',
             href: 'securitySolutionUI/hosts/siem-kibana',
@@ -614,15 +590,9 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            href: 'securitySolutionUI/threat_hunting',
-            text: 'Threat Hunting',
-          },
-          {
-            text: 'Network',
-            href: 'securitySolutionUI/network',
-          },
+          securityBreadCrumb,
+          exploreBreadcrumbs,
+          networkBreadcrumb,
           {
             text: ipv4,
             href: `securitySolutionUI/network/ip/${ipv4}/source`,
@@ -638,15 +608,9 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            href: 'securitySolutionUI/threat_hunting',
-            text: 'Threat Hunting',
-          },
-          {
-            text: 'Network',
-            href: 'securitySolutionUI/network',
-          },
+          securityBreadCrumb,
+          exploreBreadcrumbs,
+          networkBreadcrumb,
           {
             text: ipv6,
             href: `securitySolutionUI/network/ip/${ipv6Encoded}/source`,
@@ -662,7 +626,7 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
+          securityBreadCrumb,
           {
             text: 'Alerts',
             href: '',
@@ -677,11 +641,8 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Manage',
-            href: 'securitySolutionUI/administration',
-          },
+          securityBreadCrumb,
+          manageBreadcrumbs,
           {
             text: 'Exception lists',
             href: '',
@@ -696,11 +657,8 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Manage',
-            href: 'securitySolutionUI/administration',
-          },
+          securityBreadCrumb,
+          manageBreadcrumbs,
           {
             text: 'Rules',
             href: '',
@@ -715,15 +673,9 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Manage',
-            href: 'securitySolutionUI/administration',
-          },
-          {
-            text: 'Rules',
-            href: 'securitySolutionUI/rules',
-          },
+          securityBreadCrumb,
+          manageBreadcrumbs,
+          rulesBReadcrumb,
           {
             text: 'Create',
             href: '',
@@ -746,15 +698,9 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Manage',
-            href: 'securitySolutionUI/administration',
-          },
-          {
-            text: 'Rules',
-            href: 'securitySolutionUI/rules',
-          },
+          securityBreadCrumb,
+          manageBreadcrumbs,
+          rulesBReadcrumb,
           {
             text: mockRuleName,
             href: ``,
@@ -777,15 +723,9 @@ describe('Navigation Breadcrumbs', () => {
           true
         );
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Manage',
-            href: 'securitySolutionUI/administration',
-          },
-          {
-            text: 'Rules',
-            href: 'securitySolutionUI/rules',
-          },
+          securityBreadCrumb,
+          manageBreadcrumbs,
+          rulesBReadcrumb,
           {
             text: 'ALERT_RULE_NAME',
             href: `securitySolutionUI/rules/id/${mockDetailName}`,
@@ -830,11 +770,8 @@ describe('Navigation Breadcrumbs', () => {
         );
 
         expect(breadcrumbs).toEqual([
-          { text: 'Security', href: 'securitySolutionUI/get_started' },
-          {
-            text: 'Manage',
-            href: 'securitySolutionUI/administration',
-          },
+          securityBreadCrumb,
+          manageBreadcrumbs,
           {
             text: 'Endpoints',
             href: '',
@@ -858,8 +795,8 @@ describe('Navigation Breadcrumbs', () => {
             onClick: expect.any(Function),
           }),
           expect.objectContaining({
-            text: 'Threat Hunting',
-            href: `securitySolutionUI/threat_hunting`,
+            text: 'Explore',
+            href: `securitySolutionUI/explore`,
             onClick: expect.any(Function),
           }),
           expect.objectContaining({

--- a/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav.test.tsx
@@ -74,14 +74,14 @@ describe('SolutionGroupedNav', () => {
       const items = [
         ...mockItems,
         {
-          id: SecurityPageName.threatHuntingLanding,
-          label: 'Threat Hunting',
-          href: '/threat_hunting',
+          id: SecurityPageName.exploreLanding,
+          label: 'Explore',
+          href: '/explore',
           onClick: mockOnClick,
         },
       ];
       const result = renderNav({ items });
-      result.getByTestId(`groupedNavItemLink-${SecurityPageName.threatHuntingLanding}`).click();
+      result.getByTestId(`groupedNavItemLink-${SecurityPageName.exploreLanding}`).click();
       expect(mockOnClick).toHaveBeenCalled();
     });
   });
@@ -122,9 +122,9 @@ describe('SolutionGroupedNav', () => {
       const items = [
         ...mockItems,
         {
-          id: SecurityPageName.threatHuntingLanding,
-          label: 'Threat Hunting',
-          href: '/threat_hunting',
+          id: SecurityPageName.exploreLanding,
+          label: 'Explore',
+          href: '/explore',
           items: [
             {
               id: SecurityPageName.users,
@@ -141,7 +141,7 @@ describe('SolutionGroupedNav', () => {
       expect(result.getByTestId('groupedNavPanel')).toBeInTheDocument();
       expect(result.getByText('Overview')).toBeInTheDocument();
 
-      result.getByTestId(`groupedNavItemButton-${SecurityPageName.threatHuntingLanding}`).click();
+      result.getByTestId(`groupedNavItemButton-${SecurityPageName.exploreLanding}`).click();
       expect(result.queryByTestId('groupedNavPanel')).toBeInTheDocument();
       expect(result.getByText('Users')).toBeInTheDocument();
     });

--- a/x-pack/plugins/security_solution/public/common/components/url_state/constants.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/constants.ts
@@ -38,5 +38,5 @@ export type UrlStateType =
   | 'overview'
   | 'rules'
   | 'timeline'
-  | 'threat_hunting'
+  | 'explore'
   | 'dashboards';

--- a/x-pack/plugins/security_solution/public/common/utils/timeline/use_show_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/timeline/use_show_timeline.tsx
@@ -16,7 +16,7 @@ const DEPRECATED_HIDDEN_TIMELINE_ROUTES: readonly string[] = [
   '/administration',
   '/rules/create',
   '/get_started',
-  '/threat_hunting',
+  '/explore',
   '/dashboards',
   '/manage',
 ];

--- a/x-pack/plugins/security_solution/public/landing_pages/links.ts
+++ b/x-pack/plugins/security_solution/public/landing_pages/links.ts
@@ -8,11 +8,11 @@
 import { i18n } from '@kbn/i18n';
 import {
   DASHBOARDS_PATH,
+  EXPLORE_PATH,
   SecurityPageName,
   SERVER_APP_ID,
-  THREAT_HUNTING_PATH,
 } from '../../common/constants';
-import { DASHBOARDS, THREAT_HUNTING } from '../app/translations';
+import { DASHBOARDS, EXPLORE } from '../app/translations';
 import { LinkItem } from '../common/links/types';
 import { overviewLinks, detectionResponseLinks } from '../overview/links';
 import { links as hostsLinks } from '../hosts/links';
@@ -36,14 +36,14 @@ export const dashboardsLandingLinks: LinkItem = {
 };
 
 export const threatHuntingLandingLinks: LinkItem = {
-  id: SecurityPageName.threatHuntingLanding,
-  title: THREAT_HUNTING,
-  path: THREAT_HUNTING_PATH,
+  id: SecurityPageName.exploreLanding,
+  title: EXPLORE,
+  path: EXPLORE_PATH,
   globalNavEnabled: false,
   capabilities: [`${SERVER_APP_ID}.show`],
   globalSearchKeywords: [
-    i18n.translate('xpack.securitySolution.appLinks.threatHunting', {
-      defaultMessage: 'Threat hunting',
+    i18n.translate('xpack.securitySolution.appLinks.explore', {
+      defaultMessage: 'Explore',
     }),
   ],
   links: [hostsLinks, networkLinks, usersLinks],

--- a/x-pack/plugins/security_solution/public/landing_pages/pages/explore.tsx
+++ b/x-pack/plugins/security_solution/public/landing_pages/pages/explore.tsx
@@ -11,16 +11,16 @@ import { useAppRootNavLink } from '../../common/components/navigation/nav_links'
 import { SecuritySolutionPageWrapper } from '../../common/components/page_wrapper';
 import { SpyRoute } from '../../common/utils/route/spy_routes';
 import { LandingLinksImages } from '../components/landing_links_images';
-import { THREAT_HUNTING_PAGE_TITLE } from './translations';
+import { EXPLORE_PAGE_TITLE } from './translations';
 
-export const ThreatHuntingLandingPage = () => {
-  const threatHuntinglinks = useAppRootNavLink(SecurityPageName.threatHuntingLanding)?.links ?? [];
+export const ExploreLandingPage = () => {
+  const exploreLinks = useAppRootNavLink(SecurityPageName.exploreLanding)?.links ?? [];
 
   return (
     <SecuritySolutionPageWrapper>
-      <HeaderPage title={THREAT_HUNTING_PAGE_TITLE} />
-      <LandingLinksImages items={threatHuntinglinks} />
-      <SpyRoute pageName={SecurityPageName.threatHuntingLanding} />
+      <HeaderPage title={EXPLORE_PAGE_TITLE} />
+      <LandingLinksImages items={exploreLinks} />
+      <SpyRoute pageName={SecurityPageName.exploreLanding} />
     </SecuritySolutionPageWrapper>
   );
 };

--- a/x-pack/plugins/security_solution/public/landing_pages/pages/translations.ts
+++ b/x-pack/plugins/security_solution/public/landing_pages/pages/translations.ts
@@ -7,10 +7,10 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const THREAT_HUNTING_PAGE_TITLE = i18n.translate(
+export const EXPLORE_PAGE_TITLE = i18n.translate(
   'xpack.securitySolution.landing.threatHunting.pageTitle',
   {
-    defaultMessage: 'Threat hunting',
+    defaultMessage: 'Explore',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/landing_pages/routes.tsx
+++ b/x-pack/plugins/security_solution/public/landing_pages/routes.tsx
@@ -9,14 +9,14 @@ import React from 'react';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 
 import { SecurityPageName, SecuritySubPluginRoutes } from '../app/types';
-import { DASHBOARDS_PATH, MANAGE_PATH, THREAT_HUNTING_PATH } from '../../common/constants';
-import { ThreatHuntingLandingPage } from './pages/threat_hunting';
+import { DASHBOARDS_PATH, MANAGE_PATH, EXPLORE_PATH } from '../../common/constants';
+import { ExploreLandingPage } from './pages/explore';
 import { DashboardsLandingPage } from './pages/dashboards';
 import { ManageLandingPage } from './pages/manage';
 
 export const ThreatHuntingRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.threatHuntingLanding}>
-    <ThreatHuntingLandingPage />
+  <TrackApplicationView viewId={SecurityPageName.exploreLanding}>
+    <ExploreLandingPage />
   </TrackApplicationView>
 );
 
@@ -34,7 +34,7 @@ export const ManageRoutes = () => (
 
 export const routes: SecuritySubPluginRoutes = [
   {
-    path: THREAT_HUNTING_PATH,
+    path: EXPLORE_PATH,
     render: ThreatHuntingRoutes,
   },
   {


### PR DESCRIPTION
## Summary

It renames the menu group title, every file and variable.

![Screenshot 2022-05-23 at 09 41 04](https://user-images.githubusercontent.com/1490444/169768675-6a8e5c8d-21a8-4c3c-bdb6-0d3b8083060e.png)

How to test:

* Enable the FF 'groupedNavigation'
* Enable the advanced setting flag: "grouped navigation"
* Opens security solutions


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
