### PR TITLE
[DOCS] Removes coming tag from 8.2.1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -29,8 +29,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.2.1]]
 == {kib} 8.2.1
 
-coming::[8.2.1]
-
 Review the following information about the {kib} 8.2.1 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes `coming` tag from 8.2.1 release notes.