### PR TITLE
[CI] Add check for possible new FTR configs

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/index.ts
+++ b/packages/kbn-test/src/functional_test_runner/index.ts
@@ -14,6 +14,7 @@ export {
   EsVersion,
   Lifecycle,
   LifecyclePhase,
+  FTR_CONFIGS_MANIFEST_PATHS,
 } from './lib';
 export { runFtrCli } from './cli';
 export * from './lib/docker_servers';

--- a/packages/kbn-test/src/functional_test_runner/lib/config/index.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/config/index.ts
@@ -8,3 +8,4 @@
 
 export { Config } from './config';
 export { readConfigFile } from './read_config_file';
+export { FTR_CONFIGS_MANIFEST_PATHS } from './ftr_configs_manifest';

--- a/packages/kbn-test/src/functional_test_runner/lib/index.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/index.ts
@@ -8,7 +8,7 @@
 
 export { Lifecycle } from './lifecycle';
 export { LifecyclePhase } from './lifecycle_phase';
-export { readConfigFile, Config } from './config';
+export { readConfigFile, Config, FTR_CONFIGS_MANIFEST_PATHS } from './config';
 export * from './providers';
 // @internal
 export { runTests, setupMocha } from './mocha';

--- a/src/dev/precommit_hook/check_possible_new_ftr_config.js
+++ b/src/dev/precommit_hook/check_possible_new_ftr_config.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { FTR_CONFIGS_MANIFEST_PATHS } from '@kbn/test';
+import { readFileSync } from 'fs';
+
+// This isn't meant to be 100% accurate at identifying new config files
+// But it should catch /most/ of them with no false positives
+// As of writing, when run against every file in the repo, it identifies about 90% of FTR configs with 0 false positives.
+export function checkPossibleNewFtrConfig(newFiles, ftrConfigs = FTR_CONFIGS_MANIFEST_PATHS) {
+  const possibleConfigs = newFiles
+    .filter(({ path }) => {
+      if (!path.match(/(test|e2e).*config[^\/]*\.(t|j)s$/)) {
+        return false;
+      }
+
+      if (path.match(/\/__(fixtures|tests)__\//)) {
+        return false;
+      }
+
+      if (path.match(/\.test\.(t|j)s$/)) {
+        return false;
+      }
+
+      if (path.match(/\/common\/config.(t|j)s$/)) {
+        return false;
+      }
+
+      return readFileSync(path)
+        .toString()
+        .match(/(testRunner)|(testFiles)/);
+    })
+    .map(({ relativePath }) => relativePath);
+
+  for (const config of possibleConfigs) {
+    if (!ftrConfigs.includes(config)) {
+      throw new Error(
+        `${config} looks like a new FTR config. Please add it to .buildkite/ftr_configs.yml. If it's not a new FTR config, please contact #kibana-operations`
+      );
+    }
+  }
+}

--- a/src/dev/precommit_hook/index.js
+++ b/src/dev/precommit_hook/index.js
@@ -8,3 +8,4 @@
 
 export { checkFileCasing } from './check_file_casing';
 export { getFilesForCommit } from './get_files_for_commit';
+export { checkPossibleNewFtrConfig } from './check_possible_new_ftr_config';

--- a/src/dev/run_precommit_hook.js
+++ b/src/dev/run_precommit_hook.js
@@ -8,13 +8,12 @@
 
 import SimpleGit from 'simple-git/promise';
 
-import { combineErrors } from '@kbn/dev-utils';
 import { run } from '@kbn/dev-cli-runner';
-import { createFlagError } from '@kbn/dev-cli-errors';
+import { createFlagError, combineErrors } from '@kbn/dev-cli-errors';
 import { REPO_ROOT } from '@kbn/utils';
 import * as Eslint from './eslint';
 import * as Stylelint from './stylelint';
-import { getFilesForCommit, checkFileCasing } from './precommit_hook';
+import { getFilesForCommit, checkFileCasing, checkPossibleNewFtrConfig } from './precommit_hook';
 
 run(
   async ({ log, flags }) => {
@@ -35,6 +34,12 @@ run(
         `--max-files is set to ${maxFilesCount} and ${files.length} were discovered. The current script execution will be skipped.`
       );
       return;
+    }
+
+    try {
+      checkPossibleNewFtrConfig(files);
+    } catch (error) {
+      errors.push(error);
     }
 
     try {


### PR DESCRIPTION
This check will catch *most* (but not all) new FTR configs that are added to the repo without being added to `.buildkite/ftr_configs.yml`. Several users have added new configs without adding them there, and I've done it a few times myself.

As of writing, when run against every file in the repo, it identifies about 90% of FTR configs with 0 false positives.

Also, the precommit hook is currently broken, because `combineErrors` was moved out of `@kbn/dev-utils`, so this fixes that as well.