### PR TITLE
fix(NA): dependencies for @kbn/shared-ux-prompt-no-data-views on Windows

### DIFF
--- a/packages/shared-ux/prompt/no_data_views/BUILD.bazel
+++ b/packages/shared-ux/prompt/no_data_views/BUILD.bazel
@@ -47,6 +47,7 @@ RUNTIME_DEPS = [
   "//packages/kbn-i18n-react",
   "//packages/kbn-i18n",
   "//packages/kbn-shared-ux-utility",
+  "//packages/kbn-test-jest-helpers",
 ]
 
 # In this array place dependencies necessary to build the types, which will include the
@@ -71,6 +72,7 @@ TYPES_DEPS = [
   "//packages/kbn-i18n-react:npm_module_types",
   "//packages/kbn-i18n:npm_module_types",
   "//packages/kbn-shared-ux-utility:npm_module_types",
+  "//packages/kbn-test-jest-helpers:npm_module_types",
 ]
 
 jsts_transpiler(


### PR DESCRIPTION
This PR fixes a dependency missing for `@kbn/shared-ux-prompt-no-data-views` on Windows.
It's a known problem due to the way Bazel sandbox currently works natively on Windows and something we will address in future work. For now we need to also add dependencies used on jest tests on the list of Bazel dependencies to get those work on Windows.