### PR TITLE
[ML] Support IP split fields in lens visualizations

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/create_job.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/create_job.ts
@@ -39,7 +39,7 @@ import {
   hasIncompatibleProperties,
   hasSourceField,
   isTermsField,
-  isStringField,
+  isSupportedSplitFieldType,
   getMlFunction,
   getJobsItemsFromEmbeddable,
 } from './utils';
@@ -288,7 +288,7 @@ async function extractFields(
     );
   }
 
-  if (splitField !== null && isStringField(splitField) === false) {
+  if (splitField !== null && isSupportedSplitFieldType(splitField) === false) {
     throw Error(
       i18n.translate('xpack.ml.newJob.fromLens.createJob.error.splitFieldMustBeString', {
         defaultMessage: 'Selected split field type must be string.',

--- a/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/create_job.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/create_job.ts
@@ -39,7 +39,7 @@ import {
   hasIncompatibleProperties,
   hasSourceField,
   isTermsField,
-  isSupportedSplitFieldType,
+  isCompatibleSplitFieldType,
   getMlFunction,
   getJobsItemsFromEmbeddable,
 } from './utils';
@@ -288,7 +288,7 @@ async function extractFields(
     );
   }
 
-  if (splitField !== null && isSupportedSplitFieldType(splitField) === false) {
+  if (splitField !== null && isCompatibleSplitFieldType(splitField) === false) {
     throw Error(
       i18n.translate('xpack.ml.newJob.fromLens.createJob.error.splitFieldMustBeString', {
         defaultMessage: 'Selected split field type must be string.',

--- a/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/utils.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/utils.ts
@@ -19,6 +19,9 @@ import type {
   DataType,
 } from '@kbn/lens-plugin/public';
 import { layerTypes } from '@kbn/lens-plugin/public';
+import { KBN_FIELD_TYPES } from '@kbn/data-plugin/public';
+
+import { ML_JOB_AGGREGATION } from '../../../../../common/constants/aggregation_types';
 
 export const COMPATIBLE_SERIES_TYPES: SeriesType[] = [
   'line',
@@ -36,7 +39,10 @@ export const COMPATIBLE_LAYER_TYPE: XYDataLayerConfig['layerType'] = layerTypes.
 
 export const COMPATIBLE_VISUALIZATION = 'lnsXY';
 
-export const COMPATIBLE_SPLIT_FIELD_TYPES: DataType[] = ['string', 'ip'];
+export const COMPATIBLE_SPLIT_FIELD_TYPES: DataType[] = [
+  KBN_FIELD_TYPES.STRING,
+  KBN_FIELD_TYPES.IP,
+];
 
 export function getJobsItemsFromEmbeddable(embeddable: Embeddable) {
   const { query, filters, timeRange } = embeddable.getInput();
@@ -71,19 +77,19 @@ export function getJobsItemsFromEmbeddable(embeddable: Embeddable) {
 export function lensOperationToMlFunction(operationType: string) {
   switch (operationType) {
     case 'average':
-      return 'mean';
+      return ML_JOB_AGGREGATION.MEAN;
     case 'count':
-      return 'count';
+      return ML_JOB_AGGREGATION.COUNT;
     case 'max':
-      return 'max';
+      return ML_JOB_AGGREGATION.MAX;
     case 'median':
-      return 'median';
+      return ML_JOB_AGGREGATION.MEDIAN;
     case 'min':
-      return 'min';
+      return ML_JOB_AGGREGATION.MIN;
     case 'sum':
-      return 'sum';
+      return ML_JOB_AGGREGATION.SUM;
     case 'unique_count':
-      return 'distinct_count';
+      return ML_JOB_AGGREGATION.DISTINCT_COUNT;
 
     default:
       return null;

--- a/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/utils.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/utils.ts
@@ -16,6 +16,7 @@ import type {
   TermsIndexPatternColumn,
   SeriesType,
   XYLayerConfig,
+  DataType,
 } from '@kbn/lens-plugin/public';
 import { layerTypes } from '@kbn/lens-plugin/public';
 
@@ -34,6 +35,8 @@ export const COMPATIBLE_SERIES_TYPES: SeriesType[] = [
 export const COMPATIBLE_LAYER_TYPE: XYDataLayerConfig['layerType'] = layerTypes.DATA;
 
 export const COMPATIBLE_VISUALIZATION = 'lnsXY';
+
+export const SUPPORTED_SPLIT_FIELD_TYPES: DataType[] = ['string', 'ip'];
 
 export function getJobsItemsFromEmbeddable(embeddable: Embeddable) {
   const { query, filters, timeRange } = embeddable.getInput();
@@ -167,8 +170,8 @@ export function isTermsField(column: GenericIndexPatternColumn): column is Terms
   return column.operationType === 'terms' && 'params' in column;
 }
 
-export function isStringField(column: GenericIndexPatternColumn) {
-  return column.dataType === 'string';
+export function isSupportedSplitFieldType(column: GenericIndexPatternColumn) {
+  return SUPPORTED_SPLIT_FIELD_TYPES.includes(column.dataType);
 }
 
 export function hasIncompatibleProperties(column: GenericIndexPatternColumn) {

--- a/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/utils.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/utils.ts
@@ -36,7 +36,7 @@ export const COMPATIBLE_LAYER_TYPE: XYDataLayerConfig['layerType'] = layerTypes.
 
 export const COMPATIBLE_VISUALIZATION = 'lnsXY';
 
-export const SUPPORTED_SPLIT_FIELD_TYPES: DataType[] = ['string', 'ip'];
+export const COMPATIBLE_SPLIT_FIELD_TYPES: DataType[] = ['string', 'ip'];
 
 export function getJobsItemsFromEmbeddable(embeddable: Embeddable) {
   const { query, filters, timeRange } = embeddable.getInput();
@@ -170,8 +170,8 @@ export function isTermsField(column: GenericIndexPatternColumn): column is Terms
   return column.operationType === 'terms' && 'params' in column;
 }
 
-export function isSupportedSplitFieldType(column: GenericIndexPatternColumn) {
-  return SUPPORTED_SPLIT_FIELD_TYPES.includes(column.dataType);
+export function isCompatibleSplitFieldType(column: GenericIndexPatternColumn) {
+  return COMPATIBLE_SPLIT_FIELD_TYPES.includes(column.dataType);
 }
 
 export function hasIncompatibleProperties(column: GenericIndexPatternColumn) {


### PR DESCRIPTION
IP fields can be supported as a split field when creating a multi-metric job from a lens visualization

