### PR TITLE
[Discover] Improve and unskip functional test of hiding the histogram

### DIFF
--- a/test/functional/apps/discover/_chart_hidden.ts
+++ b/test/functional/apps/discover/_chart_hidden.ts
@@ -19,8 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     defaultIndex: 'logstash-*',
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/132288
-  describe.skip('discover show/hide chart test', function () {
+  describe('discover show/hide chart test', function () {
     before(async function () {
       log.debug('load kibana index with default index pattern');
 

--- a/test/functional/page_objects/discover_page.ts
+++ b/test/functional/page_objects/discover_page.ts
@@ -199,6 +199,7 @@ export class DiscoverPageObject extends FtrService {
   }
 
   public async toggleChartVisibility() {
+    await this.testSubjects.moveMouseTo('discoverChartOptionsToggle');
     await this.testSubjects.click('discoverChartOptionsToggle');
     await this.testSubjects.exists('discoverChartToggle');
     await this.testSubjects.click('discoverChartToggle');


### PR DESCRIPTION
## Summary

Fixing the test of hiding the histogram by adding a little mouse movement. It failed because the button to click was hidden by an overlapping popover but the button starting the search.

Flaky test runner, 100 runs: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/662

Fixes #132288


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
