### PR TITLE
[Cloud Posture] Use security logo in search bar for CSP app

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/public/plugin.ts
@@ -32,6 +32,7 @@ export class CspPlugin
     core.application.register({
       id: PLUGIN_ID,
       title: PLUGIN_NAME,
+      euiIconType: 'logoSecurity',
       category: DEFAULT_APP_CATEGORIES.security,
       async mount(params: AppMountParameters) {
         // Load application bundle


### PR DESCRIPTION
## Summary

Use the security logo for the CSP app when it appears in the global search bar

![Screen Shot 2022-05-24 at 11 44 57](https://user-images.githubusercontent.com/94899776/169990608-81268bb8-783d-44dc-884a-78565ea5f315.png)

