### PR TITLE
[Actionable Observability] Better loading rule details page

### DIFF
--- a/x-pack/plugins/observability/public/hooks/use_fetch_last24h_alerts.ts
+++ b/x-pack/plugins/observability/public/hooks/use_fetch_last24h_alerts.ts
@@ -57,7 +57,7 @@ export function useFetchLast24hAlerts({ http, features, ruleId }: UseFetchLast24
         setLast24hAlerts((oldState: FetchLast24hAlerts) => ({
           ...oldState,
           last24hAlerts: alertsCount,
-          isLoading: false,
+          isLoadingLast24hAlerts: false,
         }));
       }
     } catch (error) {
@@ -65,7 +65,7 @@ export function useFetchLast24hAlerts({ http, features, ruleId }: UseFetchLast24
         if (error.name !== 'AbortError') {
           setLast24hAlerts((oldState: FetchLast24hAlerts) => ({
             ...oldState,
-            isLoading: false,
+            isLoadingLast24hAlerts: false,
             errorLast24hAlerts: RULE_LOAD_ERROR(
               error instanceof Error ? error.message : typeof error === 'string' ? error : ''
             ),

--- a/x-pack/plugins/observability/public/pages/rule_details/index.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/index.tsx
@@ -81,7 +81,7 @@ export function RuleDetailsPage() {
   const [ruleType, setRuleType] = useState<RuleType<string, string>>();
   const [ruleToDelete, setRuleToDelete] = useState<string[]>([]);
   const [isPageLoading, setIsPageLoading] = useState(false);
-  const { last24hAlerts } = useFetchLast24hAlerts({
+  const { isLoadingLast24hAlerts, last24hAlerts } = useFetchLast24hAlerts({
     http,
     features,
     ruleId,
@@ -323,29 +323,37 @@ export function RuleDetailsPage() {
                     defaultMessage: 'Alerts',
                   })}
                 </ItemTitleRuleSummary>
-
-                <ItemValueRuleSummary
-                  extraSpace={false}
-                  itemValue={`
+                {isLoadingLast24hAlerts ? (
+                  <EuiFlexItem>
+                    <EuiLoadingSpinner size="s" />
+                  </EuiFlexItem>
+                ) : (
+                  <ItemValueRuleSummary
+                    extraSpace={false}
+                    itemValue={`
                     ${String(last24hAlerts)} ${i18n.translate(
-                    'xpack.observability.ruleDetails.last24h',
-                    {
-                      defaultMessage: '(last 24 h)',
-                    }
-                  )}`}
-                />
+                      'xpack.observability.ruleDetails.last24h',
+                      {
+                        defaultMessage: '(last 24 h)',
+                      }
+                    )}`}
+                  />
+                )}
               </EuiFlexGroup>
               <EuiSpacer size="s" />
-              {isLoadingExecutionLog ? (
-                <EuiLoadingSpinner size="s" />
-              ) : (
-                <EuiFlexGroup>
-                  <ItemTitleRuleSummary>
-                    {i18n.translate('xpack.observability.ruleDetails.execution', {
-                      defaultMessage: 'Executions',
-                    })}
-                  </ItemTitleRuleSummary>
 
+              <EuiFlexGroup>
+                <ItemTitleRuleSummary>
+                  {i18n.translate('xpack.observability.ruleDetails.execution', {
+                    defaultMessage: 'Executions',
+                  })}
+                </ItemTitleRuleSummary>
+
+                {isLoadingExecutionLog ? (
+                  <EuiFlexItem>
+                    <EuiLoadingSpinner size="s" />
+                  </EuiFlexItem>
+                ) : (
                   <ItemValueRuleSummary
                     extraSpace={false}
                     itemValue={`
@@ -356,8 +364,8 @@ export function RuleDetailsPage() {
                       }
                     )}`}
                   />
-                </EuiFlexGroup>
-              )}
+                )}
+              </EuiFlexGroup>
             </EuiFlexGroup>
           </EuiPanel>
         </EuiFlexItem>


### PR DESCRIPTION
## Summary
Part of #129777

Loader should be on the value of **Executions** and **Alerts** only.
