### PR TITLE
[Cloud Posture] Findings - reset page index when query changes

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
@@ -61,7 +61,9 @@ export const LatestFindingsContainer = ({ dataView }: { dataView: DataView }) =>
     <div data-test-subj={TEST_SUBJECTS.FINDINGS_CONTAINER}>
       <FindingsSearchBar
         dataView={dataView}
-        setQuery={setUrlQuery}
+        setQuery={(query) => {
+          setUrlQuery({ ...query, pageIndex: 0 });
+        }}
         query={urlQuery.query}
         filters={urlQuery.filters}
         loading={findingsCount.isFetching}

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
@@ -54,7 +54,9 @@ const LatestFindingsByResource = ({ dataView }: { dataView: DataView }) => {
     <div data-test-subj={TEST_SUBJECTS.FINDINGS_CONTAINER}>
       <FindingsSearchBar
         dataView={dataView}
-        setQuery={setUrlQuery}
+        setQuery={(query) => {
+          setUrlQuery({ ...query, pageIndex: 0 });
+        }}
         query={urlQuery.query}
         filters={urlQuery.filters}
         loading={findingsGroupByResource.isLoading}

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -63,7 +63,9 @@ export const ResourceFindings = ({ dataView }: { dataView: DataView }) => {
     <div data-test-subj={TEST_SUBJECTS.FINDINGS_CONTAINER}>
       <FindingsSearchBar
         dataView={dataView}
-        setQuery={setUrlQuery}
+        setQuery={(query) => {
+          setUrlQuery({ ...query, pageIndex: 0 });
+        }}
         query={urlQuery.query}
         filters={urlQuery.filters}
         loading={resourceFindings.isFetching}


### PR DESCRIPTION
## Summary

When updating the findings page query the user will be directed to the 1st page of the table.




