### PR TITLE
[Cloud Posture] Findings - stop owning focus on flyout

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -84,7 +84,7 @@ export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) =>
   const [tab, setTab] = useState<FindingsTab>(tabs[0]);
 
   return (
-    <EuiFlyout onClose={onClose}>
+    <EuiFlyout ownFocus={false} onClose={onClose}>
       <EuiFlyoutHeader>
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

In the findings page when the flyout is open, allow focusing on other parts of the page (e.g. the global search bar).

Video:


https://user-images.githubusercontent.com/94899776/170001985-63d01290-3649-44e1-8a76-ffe0dfcc6128.mov


