### PR TITLE
[Cloud Posture] Findings - set small size for last column in all tables

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
@@ -114,6 +114,7 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
   },
   {
     field: 'failed_findings',
+    width: '150px',
     truncateText: true,
     name: (
       <FormattedMessage
@@ -139,6 +140,7 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
         </>
       </EuiToolTip>
     ),
+    dataType: 'number',
   },
 ];
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
@@ -105,6 +105,7 @@ export const getFindingsColumns = (): Array<EuiBasicTableColumn<CspFinding>> => 
   },
   {
     field: '@timestamp',
+    width: '150px',
     name: TEXT.LAST_CHECKED,
     truncateText: true,
     sortable: true,


### PR DESCRIPTION
## Summary

Cap the size of the last table column in all findings tables - `Last checked` in the findings and per-resource findings table, and `Failed findings` in the grouped-by-resource table.

## Screenshots

<details>
<summary><h3>Findings table - small screen</h3></summary>
<h4>Before:</h4>
<img width="1279" alt="Screen Shot 2022-05-24 at 14 12 35" src="https://user-images.githubusercontent.com/94899776/170022916-1c144c07-691e-426b-9da0-29e8966139e2.png">

<h4>After:</h4>
<img width="1278" alt="Screen Shot 2022-05-24 at 14 14 51" src="https://user-images.githubusercontent.com/94899776/170022964-bdc4b0ea-839a-4fc7-9c3d-8f7b975fbdfc.png">
</details>

<details>
<summary><h3>Grouped-by-resource-id table - small screen</h3></summary>
<h4>Before:</h4>
<img width="1281" alt="Screen Shot 2022-05-24 at 14 12 46" src="https://user-images.githubusercontent.com/94899776/170023004-84f2abf8-3e7c-4503-8478-253f9e5a7e67.png">

<h4>After:</h4>
<img width="1276" alt="Screen Shot 2022-05-24 at 14 15 02" src="https://user-images.githubusercontent.com/94899776/170023028-4175a5fe-f7cd-4e32-a93c-093fc4329885.png">
</details>

<details>
<summary><h3>Findings table - large screen</h3></summary>
<h4>Before:</h4>
<img width="1276" alt="Screen Shot 2022-05-24 at 14 15 02" src="https://user-images.githubusercontent.com/94899776/170023679-da546fd8-fda3-4742-9806-ae5d73399184.png">

<h4>After:</h4>
<img width="1276" alt="Screen Shot 2022-05-24 at 14 15 02" src="https://user-images.githubusercontent.com/94899776/170023802-31752ee0-f54f-48a7-ae83-f730b00a223c.png">
</details>

<details>
<summary><h3>Grouped-by-resource-id table - large screen</h3></summary>
<h4>Before:</h4>
<img width="1276" alt="Screen Shot 2022-05-24 at 14 15 02" src="https://user-images.githubusercontent.com/94899776/170023891-b860c2fc-10b6-4273-9c37-268854f851da.png">

<h4>After:</h4>
<img width="1276" alt="Screen Shot 2022-05-24 at 14 15 02" src="https://user-images.githubusercontent.com/94899776/170023129-cd45691c-e201-4cdd-83a1-c029282756e2.png">
</details>

