### PR TITLE
Fix Manage landing page items title spacing

### DIFF
--- a/x-pack/plugins/security_solution/public/landing_pages/components/landing_links_icons.tsx
+++ b/x-pack/plugins/security_solution/public/landing_pages/components/landing_links_icons.tsx
@@ -48,7 +48,7 @@ export const LandingLinksIcons: React.FC<LandingLinksImagesProps> = ({ items }) 
               <EuiIcon aria-hidden="true" size="xl" type={icon ?? ''} role="presentation" />
             </SecuritySolutionLink>
           </EuiFlexItem>
-          <EuiFlexItem>
+          <EuiFlexItem grow={false}>
             <StyledEuiTitle size="xxs">
               <SecuritySolutionLinkAnchor deepLinkId={id}>
                 <h2>{title}</h2>


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/132797

## Summary

Fix Manage landing page items title spacing.

**Before**
<img width="1429" alt="Screenshot 2022-05-24 at 15 21 28" src="https://user-images.githubusercontent.com/1490444/170045922-a062babe-7698-407c-a187-1c942e3e80ed.png">

**After**
<img width="1457" alt="Screenshot 2022-05-24 at 15 21 02" src="https://user-images.githubusercontent.com/1490444/170045910-1af815cc-f013-447a-ab67-31f459ee01a0.png">
