### PR TITLE
[DOCS] Remove "ESS" indicator for `server.publicBaseUrl` user setting

### DIFF
--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -440,7 +440,7 @@ running behind a proxy. Use the <<server-rewriteBasePath, `server.rewriteBasePat
 if it should remove the basePath from requests it receives, and to prevent a
 deprecation warning at startup. This setting cannot end in a slash (`/`).
 
-|[[server-publicBaseUrl]] `server.publicBaseUrl:` {ess-icon}
+|[[server-publicBaseUrl]] `server.publicBaseUrl:`
  | The publicly available URL that end-users access Kibana at. Must include the protocol, hostname, port
  (if different than the defaults for `http` and `https`, 80 and 443 respectively), and the
  <<server-basePath, `server.basePath`>> (if configured). This setting cannot end in a slash (`/`).


### PR DESCRIPTION
This removes indication that the `server.publicBaseUrl` setting is supported on Elasticsearch Service. While the setting is technically available in ESS it's not configurable and it's best not documented.
