### PR TITLE
[ML] Optimize resize behaviour for the Anomaly Explorer page

### DIFF
--- a/x-pack/plugins/ml/public/application/services/anomaly_timeline_service.ts
+++ b/x-pack/plugins/ml/public/application/services/anomaly_timeline_service.ts
@@ -258,7 +258,7 @@ export class AnomalyTimelineService {
     swimlaneLimit: number,
     perPage: number,
     fromPage: number,
-    swimlaneContainerWidth: number,
+    bucketInterval: TimeBucketsInterval,
     selectionInfluencers: EntityField[],
     influencersFilterQuery: InfluencersFilterQuery
   ) {
@@ -296,7 +296,7 @@ export class AnomalyTimelineService {
         selectedJobIds,
         earliestMs,
         latestMs,
-        this.getSwimlaneBucketInterval(selectedJobs, swimlaneContainerWidth).asMilliseconds(),
+        bucketInterval.asMilliseconds(),
         perPage,
         fromPage,
         swimlaneLimit


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/124696

Refetches swim lanes data only on the actual bucket interval change instead of every (insignificant) window resize.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


