### PR TITLE
[Fleet] fixed agent policy selection when selecting fleet server policy

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
@@ -18,7 +18,11 @@ import {
   getConfirmFleetServerConnectionStep,
 } from './steps';
 
-export const AdvancedTab: React.FunctionComponent = () => {
+interface AdvancedTabProps {
+  selectedPolicyId?: string;
+}
+
+export const AdvancedTab: React.FunctionComponent<AdvancedTabProps> = ({ selectedPolicyId }) => {
   const {
     eligibleFleetServerPolicies,
     refreshEligibleFleetServerPolicies,
@@ -35,7 +39,7 @@ export const AdvancedTab: React.FunctionComponent = () => {
 
   const steps = [
     getSelectAgentPolicyStep({
-      policyId: fleetServerPolicyId,
+      policyId: fleetServerPolicyId || selectedPolicyId,
       setPolicyId: setFleetServerPolicyId,
       eligibleFleetServerPolicies,
       refreshEligibleFleetServerPolicies,

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.ts
@@ -28,7 +28,7 @@ export const useSelectFleetServerPolicy = (defaultAgentPolicyId?: string) => {
 
   useEffect(() => {
     // Default to the first policy found with a fleet server integration installed
-    if (eligibleFleetServerPolicies.length && !fleetServerPolicyId) {
+    if (eligibleFleetServerPolicies.length === 1 && !fleetServerPolicyId) {
       setFleetServerPolicyId(eligibleFleetServerPolicies[0].id);
     }
   }, [eligibleFleetServerPolicies, fleetServerPolicyId]);

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/select_agent_policy.tsx
@@ -58,7 +58,7 @@ const SelectAgentPolicyStepContent: React.FunctionComponent<{
 }) => {
   useEffect(() => {
     // Select default value
-    if (eligibleFleetServerPolicies.length && !policyId) {
+    if (eligibleFleetServerPolicies.length === 1 && !policyId) {
       setPolicyId(eligibleFleetServerPolicies[0].id);
     }
   }, [eligibleFleetServerPolicies, policyId, setPolicyId]);

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
@@ -104,7 +104,11 @@ export const Instructions = (props: InstructionProps) => {
               <EuiSpacer size="l" />
             </>
           )}
-          {isFleetServerPolicySelected ? <AdvancedTab /> : <ManagedSteps {...props} />}
+          {isFleetServerPolicySelected ? (
+            <AdvancedTab selectedPolicyId={props.selectedPolicy?.id} />
+          ) : (
+            <ManagedSteps {...props} />
+          )}
         </>
       );
     }


### PR DESCRIPTION
## Summary

Fixing https://github.com/elastic/kibana/issues/132691

The issue was caused by the logic when selecting a fleet server policy, the UI changes from `ManagedSteps` to `AdvancedTab`, and the previously selected policy disappear and the logic selected the first fleet server policy.

<img width="932" alt="image" src="https://user-images.githubusercontent.com/90178898/170070988-e6d5e4ac-c80c-4219-bcaf-83363b26e903.png">
<img width="895" alt="image" src="https://user-images.githubusercontent.com/90178898/170072813-0005d19b-a711-45fe-9313-e4aa65ba83c1.png">
