### PR TITLE
[Fleet] Fix static versions for upgrade modal

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/constants.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/constants.tsx
@@ -6,10 +6,9 @@
  */
 
 // Available versions for the upgrade of the Elastic Agent
-// These versions are only intended to be used as a fallback
-// in the event that the updated versions cannot be retrieved from the endpoint
 
 export const FALLBACK_VERSIONS = [
+  '8.2.1',
   '8.2.0',
   '8.1.3',
   '8.1.2',
@@ -17,12 +16,7 @@ export const FALLBACK_VERSIONS = [
   '8.1.0',
   '8.0.1',
   '8.0.0',
-  '7.9.3',
-  '7.9.2',
-  '7.9.1',
-  '7.9.0',
-  '7.8.1',
-  '7.8.0',
+  '7.17.4',
   '7.17.3',
   '7.17.2',
   '7.17.1',


### PR DESCRIPTION
## Summary

Bug fix for https://github.com/elastic/kibana/issues/132781

When creating the static list of versions I didn't notice that there were some more versions than intended and they were not ordered correctly. Any version < 7.17 shouldn't be present since it's the lowest compatible version with 8.3.0.

![Screenshot 2022-05-24 at 17 46 26](https://user-images.githubusercontent.com/16084106/170077804-68b3b512-222e-4407-8c1d-c0dcd17d1cfa.png)

![Screenshot 2022-05-24 at 17 46 34](https://user-images.githubusercontent.com/16084106/170077788-2269dbd1-d7a1-4e3b-8bf0-93e79e638394.png)

Note: 8.3.0 is not in the static list since is dynamically added to the list.