### PR TITLE
[docs] Improve Secure saved objects and kibana-encryption-keys docs

### DIFF
--- a/docs/user/commands/encryption-keys/index.asciidoc
+++ b/docs/user/commands/encryption-keys/index.asciidoc
@@ -28,7 +28,7 @@ From here, you should manually copy the keys into either `kibana.yml` or where e
 +
 `-i, --interactive`::: Prompts you for which encryption keys to set and optionally where to save a sample configuration file.
 `-q, --quiet`::: Outputs the config options/encryption keys only (without helper information).
-`-f, --force`::: Generate new keys for all settings. By default, only un-configured encryption keys will be generated.
+`-f, --force`::: Generates new keys for all settings. By default, only un-configured encryption keys will be generated.
 `-h, --help`::: Shows help information.
 
 [discrete]

--- a/docs/user/commands/encryption-keys/index.asciidoc
+++ b/docs/user/commands/encryption-keys/index.asciidoc
@@ -1,21 +1,8 @@
 [[kibana-encryption-keys]]
 === kibana-encryption-keys
 
-The `kibana-encryption-keys` command helps you set up encryption keys that {kib} uses
+The `kibana-encryption-keys` command helps you generate encryption keys that {kib} uses
 to protect sensitive information.
-
-[discrete]
-=== Synopsis
-
-[source,shell]
---------------------------------------------------
-bin/kibana-encryption-keys generate
-[-i, --interactive] [-q, --quiet]
-[-f, --force] [-h, --help]
---------------------------------------------------
-
-[discrete]
-=== Description
 
 {kib} uses encryption keys in several areas, ranging from encrypting data
 in {kib} associated indices to storing session information. By defining these
@@ -23,17 +10,26 @@ encryption keys in your configuration, you'll ensure consistent operations
 across restarts.
 
 [discrete]
+=== Usage
+
+[source,shell]
+--------------------------------------------------
+bin/kibana-encryption-keys [command] [options]
+--------------------------------------------------
+
+[discrete]
 [[encryption-key-parameters]]
-=== Parameters
+=== Commands
 
-`generate`::  Randomly generates passwords to the console.
-
-`-i, --interactive`:: Prompts you for which encryption keys to set and optionally
-where to save a sample configuration file.
-
-`-q, --quiet`:: Outputs the encryption keys without helper information.
-
-`-f, --force`:: Shows help information.
+`generate`:: Generate encryption keys.
++
+Unless interactive mode (`-i`) is used, the generated encryption keys will be output to your console only.
+From here, you should manually copy the keys into either `kibana.yml` or where else you're configurating {kib}.
++
+`-i, --interactive`::: Prompts you for which encryption keys to set and optionally where to save a sample configuration file.
+`-q, --quiet`::: Outputs the config options/encryption keys only (without helper information).
+`-f, --force`::: Generate new keys for all settings. By default, only un-configured encryption keys will be generated.
+`-h, --help`::: Shows help information.
 
 [discrete]
 === Examples

--- a/docs/user/security/secure-saved-objects.asciidoc
+++ b/docs/user/security/secure-saved-objects.asciidoc
@@ -21,7 +21,7 @@ If you don't specify an encryption key, {kib} might disable features that rely o
 
 [TIP]
 ============================================================================
-For help generating the encryption key, see the <<kibana-encryption-keys, `kibana-encryption-keys`>> script.
+For help generating the encryption key, refer to the <<kibana-encryption-keys, `kibana-encryption-keys`>> script.
 ============================================================================
 
 [[encryption-key-rotation]]
@@ -54,9 +54,9 @@ At some point, you might want to dispose of old encryption keys completely. Make
 [[encryption-key-docker-configuration]]
 ==== Docker configuration
 
-It's also possible to configure the encryption keys using <<environment-variable-config,Docker Environment Variables>>.
+It's also possible to configure the encryption keys using <<environment-variable-config,Docker environment variables>>.
 
-Docker Environment Variable Examples:
+Docker environment variable examples:
 
 [source,sh]
 --------------------------------------------------------------------------------

--- a/docs/user/security/secure-saved-objects.asciidoc
+++ b/docs/user/security/secure-saved-objects.asciidoc
@@ -19,6 +19,11 @@ xpack.encryptedSavedObjects:
 If you don't specify an encryption key, {kib} might disable features that rely on encrypted saved objects.
 ============================================================================
 
+[TIP]
+============================================================================
+For help generating the encryption key, see the <<kibana-encryption-keys, `kibana-encryption-keys`>> script.
+============================================================================
+
 [[encryption-key-rotation]]
 ==== Encryption key rotation
 
@@ -45,3 +50,17 @@ You might also leverage this functionality if multiple {kib} instances connected
 ============================================================================
 
 At some point, you might want to dispose of old encryption keys completely. Make sure there are no saved objects that {kib} encrypted with these encryption keys. You can use the <<saved-objects-api-rotate-encryption-key, rotate encryption key API>> to determine which existing saved objects require decryption-only keys and re-encrypt them with the primary key.
+
+[[encryption-key-docker-configuration]]
+==== Docker configuration
+
+It's also possible to configure the encryption keys using <<environment-variable-config,Docker Environment Variables>>.
+
+Docker Environment Variable Examples:
+
+[source,sh]
+--------------------------------------------------------------------------------
+XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY="min-32-byte-long-NEW-encryption-key"
+XPACK_ENCRYPTEDSAVEDOBJECTS_KEYROTATION_DECRYPTIONONLYKEYS[0]="min-32-byte-long-OLD#1-encryption-key"
+XPACK_ENCRYPTEDSAVEDOBJECTS_KEYROTATION_DECRYPTIONONLYKEYS[1]="min-32-byte-long-OLD#2-encryption-key"
+--------------------------------------------------------------------------------


### PR DESCRIPTION
Started this PR to improve the "[Secure saved objects](https://www.elastic.co/guide/en/kibana/current/xpack-security-secure-saved-objects.html)" docs, but found that the "[kibana-encryption-keys](https://www.elastic.co/guide/en/kibana/current/kibana-encryption-keys.html)" docs was lacking as well. Since they are connected, this PR updates them both.

Screenshot of updated "[Secure saved objects](https://www.elastic.co/guide/en/kibana/current/xpack-security-secure-saved-objects.html)" page:

![screencapture-localhost-8000-guide-xpack-security-secure-saved-objects-html-2022-05-24-18_03_23](https://user-images.githubusercontent.com/10602/170081316-2b0830a7-1ce5-41b9-bca9-3ebcc9945866.png)

Screenshot of updated "[kibana-encryption-keys](https://www.elastic.co/guide/en/kibana/current/kibana-encryption-keys.html)" page:

![screencapture-localhost-8000-guide-kibana-encryption-keys-html-2022-05-24-18_04_27](https://user-images.githubusercontent.com/10602/170081497-0d029e74-ab84-4739-b309-21d1702acfca.png)

Closes #129671