### PR TITLE
[Cloud Posture] Findings table new columns

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/use_latest_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/use_latest_findings.ts
@@ -38,7 +38,12 @@ interface CspFindingsData {
 
 export type CspFindingsResult = FindingsQueryResult<CspFindingsData | undefined, unknown>;
 
-const FIELDS_WITHOUT_KEYWORD_MAPPING = new Set(['@timestamp']);
+const FIELDS_WITHOUT_KEYWORD_MAPPING = new Set([
+  '@timestamp',
+  'resource.sub_type',
+  'resource.name',
+  'rule.name',
+]);
 
 // NOTE: .keyword comes from the mapping we defined for the Findings index
 const getSortKey = (key: string): string =>

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
@@ -106,8 +106,8 @@ const columns: Array<EuiTableFieldDataColumnType<CspFindingsByResource>> = [
     truncateText: true,
     name: (
       <FormattedMessage
-        id="xpack.csp.findings.groupByResourceTable.cisSectionColumnLabel"
-        defaultMessage="CIS Section"
+        id="xpack.csp.findings.groupByResourceTable.cisSectionsColumnLabel"
+        defaultMessage="CIS Sections"
       />
     ),
     render: (sections: string[]) => sections.join(', '),

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
@@ -87,14 +87,19 @@ export const getFindingsColumns = (): Array<EuiBasicTableColumn<CspFinding>> => 
     ),
   },
   {
-    field: 'rule.name',
-    name: TEXT.RULE,
+    field: 'resource.sub_type',
+    name: TEXT.RESOURCE_TYPE,
+    sortable: true,
+    width: '150px',
+  },
+  {
+    field: 'resource.name',
+    name: TEXT.RESOURCE_NAME,
     sortable: true,
   },
   {
-    field: 'cluster_id',
-    name: TEXT.CLUSTER_ID,
-    truncateText: true,
+    field: 'rule.name',
+    name: TEXT.RULE,
     sortable: true,
   },
   {
@@ -102,6 +107,12 @@ export const getFindingsColumns = (): Array<EuiBasicTableColumn<CspFinding>> => 
     name: TEXT.CIS_SECTION,
     sortable: true,
     truncateText: true,
+  },
+  {
+    field: 'cluster_id',
+    name: TEXT.CLUSTER_ID,
+    truncateText: true,
+    sortable: true,
   },
   {
     field: '@timestamp',

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
@@ -72,6 +72,13 @@ export const RESULT = i18n.translate(
   }
 );
 
+export const RESOURCE_TYPE = i18n.translate(
+  'xpack.csp.findings.findingsTable.findingsTableColumn.resourceTypeColumnLabel',
+  {
+    defaultMessage: 'Resource Type',
+  }
+);
+
 export const CLUSTER_ID = i18n.translate(
   'xpack.csp.findings.findingsTable.findingsTableColumn.clusterIdColumnLabel',
   {


### PR DESCRIPTION
## Summary

- Added new sortable columns to the findings table, `Resource Type` `Resource Name`
- In the Resource Table changed `CIS Section` to `CIS Sections`
- Changed columns order

![image](https://user-images.githubusercontent.com/51442161/170086859-0fedc449-5dc9-4569-96ea-e36189a9d9b9.png)