### PR TITLE
[Fleet] Fix sorting by size on data streams table

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/data_stream/list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/data_stream/list_page/index.tsx
@@ -105,11 +105,14 @@ export const DataStreamListPage: React.FunctionComponent<{}> = () => {
         },
       },
       {
-        field: 'size_in_bytes_formatted',
+        field: 'size_in_bytes',
         sortable: true,
         name: i18n.translate('xpack.fleet.dataStreamList.sizeColumnTitle', {
           defaultMessage: 'Size',
         }),
+        render: (_, datastream: DataStream) => {
+          return <>{datastream.size_in_bytes_formatted}</>;
+        },
       },
       {
         name: i18n.translate('xpack.fleet.dataStreamList.actionsColumnTitle', {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/132825

Use non-formatted size field to sort, but render formatted size group in column.

## Screenshots

Ascending sort:

![image](https://user-images.githubusercontent.com/6766512/170091262-d676f36c-cdf6-4b9a-ad00-269b9281324f.png)

Descending sort:

![image](https://user-images.githubusercontent.com/6766512/170091292-5624b5f8-cb32-42c8-88c4-3a16da738183.png)