### PR TITLE
[Security Solution] Hide empty state for timeline when graph overlay is rendered

### DIFF
--- a/x-pack/plugins/timelines/public/components/t_grid/integrated/index.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/integrated/index.test.tsx
@@ -78,4 +78,13 @@ describe('integrated t_grid', () => {
       euiDarkVars.paddingSizes.xl
     );
   });
+  it(`does not render the empty state when the graph overlay is open`, () => {
+    render(
+      <TestProviders>
+        <TGridIntegrated {...defaultProps} graphOverlay={<div />} />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId('tGridEmptyState')).toBeNull();
+  });
 });

--- a/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
@@ -353,8 +353,8 @@ const TGridIntegratedComponent: React.FC<TGridIntegratedProps> = ({
                   )}
               </UpdatedFlexGroup>
               <>
-              {!hasAlerts && !loading && !graphOverlay && <TGridEmpty height="short" />}
-              {hasAlerts && (
+                {!hasAlerts && !loading && !graphOverlay && <TGridEmpty height="short" />}
+                {hasAlerts && (
                   <FullWidthFlexGroup
                     $visible={!graphEventId && graphOverlay == null}
                     gutterSize="none"

--- a/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
@@ -353,8 +353,8 @@ const TGridIntegratedComponent: React.FC<TGridIntegratedProps> = ({
                   )}
               </UpdatedFlexGroup>
               <>
-                {!hasAlerts && !loading && <TGridEmpty height="short" />}
-                {hasAlerts && (
+              {!hasAlerts && !loading && !graphOverlay && <TGridEmpty height="short" />}
+              {hasAlerts && (
                   <FullWidthFlexGroup
                     $visible={!graphEventId && graphOverlay == null}
                     gutterSize="none"


### PR DESCRIPTION
## Summary

Resolves #[132794](https://github.com/elastic/kibana/issues/132794) by not rendering the empty state of the alerts table when the graph overlay component is open.

Before:

![empty_state_broken](https://user-images.githubusercontent.com/56408403/170098338-e4f7372f-24db-489c-bc4a-db67e9d62f53.jpg)

After:

![empty_state_fixed](https://user-images.githubusercontent.com/56408403/170098367-567fafcd-41ec-4829-b7f3-7abb9303aec5.jpg)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



