### PR TITLE
[Dashboard] [Controls] Fix new controls causing unsaved changes bug

### DIFF
--- a/src/plugins/controls/public/control_group/editor/control_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_editor.tsx
@@ -235,12 +235,12 @@ export const ControlEditor = ({
               selectedFieldName={selectedField}
               dataView={dataView}
               onSelectField={(field) => {
+                const { parentFieldName, childFieldName } = fieldRegistry?.[field.name] ?? {};
                 onTypeEditorChange({
                   fieldName: field.name,
-                  parentFieldName: fieldRegistry?.[field.name].parentFieldName,
-                  childFieldName: fieldRegistry?.[field.name].childFieldName,
+                  ...(parentFieldName && { parentFieldName }),
+                  ...(childFieldName && { childFieldName }),
                 });
-
                 const newDefaultTitle = field.displayName ?? field.name;
                 setDefaultTitle(newDefaultTitle);
                 setSelectedField(field.name);

--- a/test/functional/apps/dashboard_elements/controls/options_list.ts
+++ b/test/functional/apps/dashboard_elements/controls/options_list.ts
@@ -28,6 +28,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'header',
   ]);
 
+  const DASHBOARD_NAME = 'Test Options List Control';
+
   describe('Dashboard options list integration', () => {
     before(async () => {
       await common.navigateToApp('dashboard');
@@ -35,6 +37,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await dashboard.clickNewDashboard();
       await timePicker.setDefaultDataRange();
       await elasticChart.setNewChartUiDebugFlag();
+      await dashboard.saveDashboard(DASHBOARD_NAME, { exitFromEditMode: false });
     });
 
     describe('Options List Control Editor selects relevant data views', async () => {
@@ -78,6 +81,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           fieldName: 'machine.os.raw',
         });
         expect(await dashboardControls.getControlsCount()).to.be(1);
+        await dashboard.clearUnsavedChanges();
       });
 
       it('can add a second options list control with a non-default data view', async () => {
@@ -90,6 +94,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         // data views should be properly propagated from the control group to the dashboard
         expect(await filterBar.getIndexPatterns()).to.be('logstash-*,animals-*');
+        await dashboard.clearUnsavedChanges();
       });
 
       it('renames an existing control', async () => {
@@ -100,6 +105,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await dashboardControls.controlEditorSetTitle(newTitle);
         await dashboardControls.controlEditorSave();
         expect(await dashboardControls.doesControlTitleExist(newTitle)).to.be(true);
+        await dashboard.clearUnsavedChanges();
       });
 
       it('can change the data view and field of an existing options list', async () => {
@@ -120,6 +126,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await filterBar.ensureFieldEditorModalIsClosed();
           expect(indexPatternSelectExists).to.be(false);
         });
+        await dashboard.clearUnsavedChanges();
       });
 
       it('editing field clears selections', async () => {
@@ -157,6 +164,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await dashboardControls.removeExistingControl(firstId);
         expect(await dashboardControls.getControlsCount()).to.be(1);
+        await dashboard.clearUnsavedChanges();
       });
 
       after(async () => {
@@ -317,7 +325,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         it('Applies options list control options to dashboard by default on open', async () => {
           await dashboard.gotoDashboardLandingPage();
           await header.waitUntilLoadingHasFinished();
-          await dashboard.clickUnsavedChangesContinueEditing('New Dashboard');
+          await dashboard.clickUnsavedChangesContinueEditing(DASHBOARD_NAME);
           await header.waitUntilLoadingHasFinished();
           expect(await pieChart.getPieSliceCount()).to.be(2);
 

--- a/test/functional/apps/dashboard_elements/controls/range_slider.ts
+++ b/test/functional/apps/dashboard_elements/controls/range_slider.ts
@@ -26,6 +26,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'header',
   ]);
 
+  const DASHBOARD_NAME = 'Test Range Slider Control';
+
   const validateRange = async (
     compare: 'value' | 'placeholder', // if 'value', compare actual selections; otherwise, compare the default range
     controlId: string,
@@ -67,6 +69,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'Oct 22, 2018 @ 00:00:00.000',
         'Dec 3, 2018 @ 00:00:00.000'
       );
+      await dashboard.saveDashboard(DASHBOARD_NAME, { exitFromEditMode: false });
     });
 
     after(async () => {
@@ -88,6 +91,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           width: 'small',
         });
         expect(await dashboardControls.getControlsCount()).to.be(1);
+        await dashboard.clearUnsavedChanges();
       });
 
       it('can add a second range list control with a non-default data view', async () => {
@@ -102,6 +106,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         validateRange('placeholder', secondId, '100', '1200');
         // data views should be properly propagated from the control group to the dashboard
         expect(await filterBar.getIndexPatterns()).to.be('logstash-*,kibana_sample_data_flights');
+        await dashboard.clearUnsavedChanges();
       });
 
       it('renames an existing control', async () => {
@@ -111,6 +116,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await dashboardControls.controlEditorSetTitle(newTitle);
         await dashboardControls.controlEditorSave();
         expect(await dashboardControls.doesControlTitleExist(newTitle)).to.be(true);
+        await dashboard.clearUnsavedChanges();
       });
 
       it('can edit range slider control', async () => {
@@ -133,6 +139,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await filterBar.ensureFieldEditorModalIsClosed();
           expect(indexPatternSelectExists).to.be(false);
         });
+        await dashboard.clearUnsavedChanges();
       });
 
       it('can enter lower bound selection from the number field', async () => {
@@ -196,6 +203,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const firstId = (await dashboardControls.getAllControlIds())[0];
         await dashboardControls.removeExistingControl(firstId);
         expect(await dashboardControls.getControlsCount()).to.be(1);
+        await dashboard.clearUnsavedChanges();
       });
     });
 

--- a/test/functional/apps/dashboard_elements/controls/replace_controls.ts
+++ b/test/functional/apps/dashboard_elements/controls/replace_controls.ts
@@ -26,6 +26,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'header',
   ]);
 
+  const DASHBOARD_NAME = 'Test Replace Controls';
+
   const changeFieldType = async (controlId: string, newField: string, expectedType?: string) => {
     await dashboardControls.editExistingControl(controlId);
     await dashboardControls.controlsEditorSetfield(newField, expectedType);
@@ -60,6 +62,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await dashboard.gotoDashboardLandingPage();
       await dashboard.clickNewDashboard();
       await timePicker.setDefaultDataRange();
+      await dashboard.saveDashboard(DASHBOARD_NAME, { exitFromEditMode: false });
     });
 
     describe('Replace options list', async () => {
@@ -71,6 +74,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           fieldName: 'sound.keyword',
         });
         controlId = (await dashboardControls.getAllControlIds())[0];
+      });
+
+      afterEach(async () => {
+        await dashboard.clearUnsavedChanges();
       });
 
       it('with range slider', async () => {
@@ -96,6 +103,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         controlId = (await dashboardControls.getAllControlIds())[0];
       });
 
+      afterEach(async () => {
+        await dashboard.clearUnsavedChanges();
+      });
+
       it('with options list', async () => {
         await replaceWithOptionsList(controlId);
       });
@@ -115,6 +126,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
         await testSubjects.waitForDeleted('timeSlider-loading-spinner');
         controlId = (await dashboardControls.getAllControlIds())[0];
+      });
+
+      afterEach(async () => {
+        await dashboard.clearUnsavedChanges();
       });
 
       it('with options list', async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/132841

## Summary

Before this change, when a new field was selected via creating a new control, the optional `parentFieldName` and `childFieldName` properties were being injected as `undefined` to the `panels` property of the `controlGroupInput` via the following code in `control_editor.tsx`: 

```typescript
...
onSelectField={(field) => {
  onTypeEditorChange({
    fieldName: field.name,
    parentFieldName: fieldRegistry?.[field.name].parentFieldName,
    childFieldName: fieldRegistry?.[field.name].childFieldName,
  }); 
...
```

However, when the control group panels are saved as JSON, all keys that have `undefined` values are dropped. This means that, when the control group inputs were compared in `diffDashboardState`, the *old* state would **not** have `parent/childFieldName` but they would both be `undefined` in the *new* state.

This PR prevents the initial injection by ensuring that both the `parentFieldName` and `childFieldName` have values before setting them. Therefore, we no longer have the issue of an `undefined` value being different than the key simply not existing in an object, so `deepEqual` works as expected.

### Video

https://user-images.githubusercontent.com/8698078/170139645-f0b41edb-5ad6-49a6-9535-c6deff5503e8.mp4

### Flaky Test Runner

![image](https://user-images.githubusercontent.com/8698078/170300528-988bae50-c0b0-426a-9cf9-8b6280445bcb.png)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
