### PR TITLE
[7.10] [docs] Improve Secure saved objects and kibana-encryption-keys docs (#132828)

### DIFF
--- a/docs/user/security/secure-saved-objects.asciidoc
+++ b/docs/user/security/secure-saved-objects.asciidoc
@@ -45,3 +45,17 @@ You might also leverage this functionality if multiple {kib} instances connected
 ============================================================================
 
 At some point, you might want to dispose of old encryption keys completely. Make sure there are no saved objects that {kib} encrypted with these encryption keys. You can use the <<saved-objects-api-rotate-encryption-key, rotate encryption key API>> to determine which existing saved objects require decryption-only keys and re-encrypt them with the primary key.
+
+[[encryption-key-docker-configuration]]
+==== Docker configuration
+
+It's also possible to configure the encryption keys using <<environment-variable-config,Docker environment variables>>.
+
+Docker environment variable examples:
+
+[source,sh]
+--------------------------------------------------------------------------------
+XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY="min-32-byte-long-NEW-encryption-key"
+XPACK_ENCRYPTEDSAVEDOBJECTS_KEYROTATION_DECRYPTIONONLYKEYS[0]="min-32-byte-long-OLD#1-encryption-key"
+XPACK_ENCRYPTEDSAVEDOBJECTS_KEYROTATION_DECRYPTIONONLYKEYS[1]="min-32-byte-long-OLD#2-encryption-key"
+--------------------------------------------------------------------------------


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.10`:
 - [[docs] Improve Secure saved objects and kibana-encryption-keys docs (#132828)](https://github.com/elastic/kibana/pull/132828)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)