### PR TITLE
[docs] document yarn.lock backport rules

### DIFF
--- a/dev_docs/contributing/how_we_use_github.mdx
+++ b/dev_docs/contributing/how_we_use_github.mdx
@@ -27,7 +27,9 @@ Pull requests are made into the main branch and only backported when it is safe 
 - Bug fixes can be backported to a `<major>.<minor>` branch if the changes are safe and appropriate. Safety is a judgment call you make based on factors like the bug’s severity, test coverage, confidence in the changes, etc. Your reasoning should be included in the pull request description.
 - Documentation changes can be backported to any branch at any time.
 
-**Note:** We want to keep updates to dependencies (both transitive dependencies and direct dependencies) in sync across both `main` and `<previous major>.<last minor>` (ex: `7.17`) as much as possible.
+### Managing updates to `yarn.lock` across branches
+
+We want to keep updates to dependencies (both transitive dependencies and direct dependencies) in sync across both `main` and `<previous major>.<last minor>` (ex: `7.17`) as much as possible.
 A good rule of thumb is that most package upgrades should be backported to the `<previous major>.<last minor>` branch, though as always, exceptions may apply – if an upgrade requires significant code changes, then it might make sense to skip a backport for it.
 
 ## Commits and Merging

--- a/dev_docs/contributing/how_we_use_github.mdx
+++ b/dev_docs/contributing/how_we_use_github.mdx
@@ -27,6 +27,9 @@ Pull requests are made into the main branch and only backported when it is safe 
 - Bug fixes can be backported to a `<major>.<minor>` branch if the changes are safe and appropriate. Safety is a judgment call you make based on factors like the bug’s severity, test coverage, confidence in the changes, etc. Your reasoning should be included in the pull request description.
 - Documentation changes can be backported to any branch at any time.
 
+**Note:** We want to keep updates to dependencies (both transitive dependencies and direct dependencies) in sync across both `main` and `7.17` as much as possible.
+A good rule of thumb is that most package upgrades should be backported to the `7.17` branch, though as always, exceptions may apply – if an upgrade requires significant code changes, then it might make sense to skip a backport for it.
+
 ## Commits and Merging
 
 - Feel free to make as many commits as you want, while working on a branch.

--- a/dev_docs/contributing/how_we_use_github.mdx
+++ b/dev_docs/contributing/how_we_use_github.mdx
@@ -27,8 +27,8 @@ Pull requests are made into the main branch and only backported when it is safe 
 - Bug fixes can be backported to a `<major>.<minor>` branch if the changes are safe and appropriate. Safety is a judgment call you make based on factors like the bug’s severity, test coverage, confidence in the changes, etc. Your reasoning should be included in the pull request description.
 - Documentation changes can be backported to any branch at any time.
 
-**Note:** We want to keep updates to dependencies (both transitive dependencies and direct dependencies) in sync across both `main` and `7.17` as much as possible.
-A good rule of thumb is that most package upgrades should be backported to the `7.17` branch, though as always, exceptions may apply – if an upgrade requires significant code changes, then it might make sense to skip a backport for it.
+**Note:** We want to keep updates to dependencies (both transitive dependencies and direct dependencies) in sync across both `main` and `<previous major>.<last minor>` (ex: `7.17`) as much as possible.
+A good rule of thumb is that most package upgrades should be backported to the `<previous major>.<last minor>` branch, though as always, exceptions may apply – if an upgrade requires significant code changes, then it might make sense to skip a backport for it.
 
 ## Commits and Merging
 


### PR DESCRIPTION
Related PR: https://github.com/elastic/dev/pull/2025

## Todo

- [x] Decide if we need to backport this to older branches. The `dev_docs/contributing/how_we_use_github.mdx` page exists as far back as `7.16` as far as I can see. With normal doc changes we do want to backport, but I'm not sure if this applies for docs published under `docs.elastic.dev` as well? ping @elastic/docs 