### PR TITLE
[APM] Add fields to apm syntrace package

### DIFF
--- a/packages/elastic-apm-synthtrace/src/lib/apm/apm_fields.ts
+++ b/packages/elastic-apm-synthtrace/src/lib/apm/apm_fields.ts
@@ -50,7 +50,9 @@ export type ApmFields = Fields &
     'error.grouping_name': string;
     'error.grouping_key': string;
     'host.name': string;
+    'host.hostname': string;
     'kubernetes.pod.uid': string;
+    'kubernetes.pod.name': string;
     'metricset.name': string;
     observer: Observer;
     'parent.id': string;


### PR DESCRIPTION
We add fields that will be needed to generate data with synthtrace to test the APM infrastructure endpoints.