### PR TITLE
[ML] Fix JVM heap size position on the ML memory overview chart

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/anomaly_timeline_state_service.ts
+++ b/x-pack/plugins/ml/public/application/explorer/anomaly_timeline_state_service.ts
@@ -14,6 +14,7 @@ import {
   startWith,
   tap,
   debounceTime,
+  filter,
 } from 'rxjs/operators';
 import { isEqual, sortBy, uniq } from 'lodash';
 import type { TimefilterContract } from '@kbn/data-plugin/public';
@@ -731,8 +732,7 @@ export class AnomalyTimelineStateService extends StateService {
 
   public getSwimLaneBucketInterval$(): Observable<TimeBucketsInterval> {
     return this._swimLaneBucketInterval$.pipe(
-      // @ts-ignore
-      skipWhile((v) => !v),
+      filter((v): v is TimeBucketsInterval => !v),
       distinctUntilChanged((prev, curr) => {
         return prev.asSeconds() === curr.asSeconds();
       })

--- a/x-pack/plugins/ml/public/application/trained_models/nodes_overview/memory_preview_chart.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/nodes_overview/memory_preview_chart.tsx
@@ -72,11 +72,6 @@ export const MemoryPreviewChart: FC<MemoryPreviewChartProps> = ({ memoryOverview
   const chartData = [
     {
       x: 0,
-      y: memoryOverview.machine_memory.jvm,
-      g: groups.jvm.name,
-    },
-    {
-      x: 0,
       y: memoryOverview.trained_models.total,
       g: groups.trained_models.name,
     },
@@ -99,6 +94,11 @@ export const MemoryPreviewChart: FC<MemoryPreviewChartProps> = ({ memoryOverview
         memoryOverview.dfa_training.total -
         memoryOverview.anomaly_detection.total,
       g: groups.available.name,
+    },
+    {
+      x: 0,
+      y: memoryOverview.machine_memory.jvm,
+      g: groups.jvm.name,
     },
   ];
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/132135

When we introduced the marker that indicated the maximum memory permitted for the ML native processes, the position of the JVM heap size on the ML memory overview chart started causing confusion because of being stacked with memory indicators of the ML native processes. 

This PR fixes this by moving the JVM heap size to the right side of the chart, which makes the max memory marker behaviour consistent, having only ML native processes on the left side of the marker.

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/5236598/170228861-539d84de-5960-4656-a923-fb1a0be71937.png">
