### PR TITLE
Synthtrace: make streamprocessors optional

### DIFF
--- a/packages/elastic-apm-synthtrace/README.md
+++ b/packages/elastic-apm-synthtrace/README.md
@@ -137,11 +137,12 @@ Note:
 
 
 ### Setup options
-| Option                 | Type      | Default    | Description                                                                                             |
-|------------------------|-----------|:-----------|---------------------------------------------------------------------------------------------------------|
-| `--numShards`          | [number]  |            | Updates the component templates to update the number of primary shards, requires cloudId to be provided |
-| `--clean`              | [boolean] | `false`    | Clean APM data before indexing new data                                                                 |
-| `--workers`            | [number]  |            | Amount of Node.js worker threads                                                                        |
-| `--logLevel`           | [enum]    | `info`     | Log level                                                                                               |
-| `--gcpRepository`      | [string]  |            | Allows you to register a GCP repository in <client_name>:<bucket>[:base_path] format                    |
+| Option            | Type      | Default    | Description                                                                                             |
+|-------------------|-----------|:-----------|---------------------------------------------------------------------------------------------------------|
+| `--numShards`     | [number]  |            | Updates the component templates to update the number of primary shards, requires cloudId to be provided |
+| `--clean`         | [boolean] | `false`    | Clean APM data before indexing new data                                                                 |
+| `--workers`       | [number]  |            | Amount of Node.js worker threads                                                                        |
+| `--logLevel`      | [enum]    | `info`     | Log level                                                                                               |
+| `--gcpRepository` | [string]  |            | Allows you to register a GCP repository in <client_name>:<bucket>[:base_path] format                    |
+| `-p`              | [string]  |            | Specify multiple sets of streamaggregators to be included in the StreamProcessor                        |
 

--- a/packages/elastic-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client.ts
+++ b/packages/elastic-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client.ts
@@ -258,7 +258,19 @@ export class ApmSynthtraceEsClient {
     });
     this.logger.info(`Created index template for ${datastreamName}-*`);
 
-    await this.client.indices.createDataStream({ name: datastreamName + '-default' });
+    const dataStreamWithNamespace = datastreamName + '-default';
+    const getDataStreamResponse = await this.client.indices.getDataStream(
+      {
+        name: dataStreamWithNamespace,
+      },
+      { ignore: [404] }
+    );
+    if (getDataStreamResponse.data_streams && getDataStreamResponse.data_streams.length === 0) {
+      await this.client.indices.createDataStream({ name: dataStreamWithNamespace });
+      this.logger.info(`Created data stream: ${dataStreamWithNamespace}.`);
+    } else {
+      this.logger.info(`Data stream: ${dataStreamWithNamespace} already exists.`);
+    }
 
     await aggregator.bootstrapElasticsearch(this.client);
   }

--- a/packages/elastic-apm-synthtrace/src/scripts/utils/parse_run_cli_flags.ts
+++ b/packages/elastic-apm-synthtrace/src/scripts/utils/parse_run_cli_flags.ts
@@ -50,7 +50,8 @@ export function parseRunCliFlags(flags: RunCliFlags) {
       'scenarioOpts',
       'forceLegacyIndices',
       'dryRun',
-      'gcpRepository'
+      'gcpRepository',
+      'streamProcessors'
     ),
     logLevel: parsedLogLevel,
     file: parsedFile,


### PR DESCRIPTION
The tool always included the `ServiceLatencyAggregator`. 
Including stream aggregators is now opt in through the `-p` flag which selects from a known
map of stream aggregators.

```bash
node src/scripts/run src/scripts/scenarios/01_low_throughput.ts --local --maxDocs 1 -p service
```


When a stream aggregator is selected it now only creates its target datastream if the datastream does not exist already.

This was failing the ability the run the tool in succession.

