### PR TITLE
[Fleet] changing fleet server query to include more than first 1000

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
@@ -13,7 +13,7 @@ import { useFleetStatus, useGetAgents } from '../../hooks';
 
 import { FleetServerRequirementPage } from '../../applications/fleet/sections/agents/agent_requirements_page';
 
-import { FLEET_SERVER_PACKAGE } from '../../constants';
+import { AGENTS_PREFIX, FLEET_SERVER_PACKAGE, SO_SEARCH_LIMIT } from '../../constants';
 
 import { useFleetServerUnhealthy } from '../../applications/fleet/sections/agents/hooks/use_fleet_server_unhealthy';
 
@@ -43,20 +43,23 @@ export const Instructions = (props: InstructionProps) => {
   const fleetStatus = useFleetStatus();
   const { isUnhealthy: isFleetServerUnhealthy } = useFleetServerUnhealthy();
 
+  const fleetServerAgentPolicies: string[] = useMemo(
+    () => agentPolicies.filter((pol) => policyHasFleetServer(pol)).map((pol) => pol.id),
+    [agentPolicies]
+  );
+
   const { data: agents, isLoading: isLoadingAgents } = useGetAgents({
-    page: 1,
-    perPage: 1000,
+    perPage: SO_SEARCH_LIMIT,
     showInactive: false,
+    kuery:
+      fleetServerAgentPolicies.length === 0
+        ? ''
+        : `${AGENTS_PREFIX}.policy_id:${fleetServerAgentPolicies
+            .map((id) => `"${id}"`)
+            .join(' or ')}`,
   });
 
-  const fleetServers = useMemo(() => {
-    const fleetServerAgentPolicies: string[] = agentPolicies
-      .filter((pol) => policyHasFleetServer(pol))
-      .map((pol) => pol.id);
-    return (agents?.items ?? []).filter((agent) =>
-      fleetServerAgentPolicies.includes(agent.policy_id ?? '')
-    );
-  }, [agents, agentPolicies]);
+  const fleetServers = agents?.items || [];
 
   const fleetServerHosts = useMemo(() => {
     return settings?.fleet_server_hosts || [];


### PR DESCRIPTION
## Summary

Fixing https://github.com/elastic/kibana/issues/132803

Changed agents query so that only agents with fleet server policy are included, and increased limit to SO_SEARCH_LIMIT, this ensures that all fleet servers will be queried.

Verified by enrolling a fleet server and agent, and verifying that the query returns only the agent running fleet server.

<img width="1800" alt="image" src="https://user-images.githubusercontent.com/90178898/170242517-3efd2103-1322-4c6e-9329-ae212f3b34a3.png">
<img width="891" alt="image" src="https://user-images.githubusercontent.com/90178898/170242612-47fa0e7f-dd69-408c-8e64-aec9d4d028cd.png">
