### PR TITLE
chore(NA): adds backport config for 8.4.0 bump

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,6 +3,7 @@
   "repoName": "kibana",
   "targetBranchChoices": [
     "main",
+    "8.3",
     "8.2",
     "8.1",
     "8.0",
@@ -39,7 +40,7 @@
     "backport"
   ],
   "branchLabelMapping": {
-    "^v8.3.0$": "main",
+    "^v8.4.0$": "main",
     "^v(\\d+).(\\d+).\\d+$": "$1.$2"
   },
   "autoMerge": true,


### PR DESCRIPTION
This PR setups the correct backport config after we bump 8.4.0