### PR TITLE
Fix link to distributed tracing origins in APM troubleshooting guide

### DIFF
--- a/docs/apm/troubleshooting.asciidoc
+++ b/docs/apm/troubleshooting.asciidoc
@@ -176,7 +176,7 @@ These are dynamic by default, which means they will be indexed and become search
 
 If the service map is not showing an expected connection between the client and server,
 it's likely because you haven't configured
-{apm-agent-rum}/configuration.html#distributed-tracing-origins[`distributedTracingOrigins`].
+{apm-rum-ref}/distributed-tracing-guide.html[`distributedTracingOrigins`].
 
 
 This setting is necessary, for example, for cross-origin requests.


### PR DESCRIPTION
## Summary

The link to the distributed tracing origins for RUM in the [kibana troubleshooting page](https://www.elastic.co/guide/en/kibana/current/troubleshooting.html#service-map-rum-connections) is broken. This PR fixes the broken link


### Checklist

N/A



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
