### PR TITLE
[DOCS] Removes 8.2.2 release notes tag

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -30,8 +30,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.2.2]]
 == {kib} 8.2.2
 
-coming::[8.2.2]
-
 Review the following information about the {kib} 8.2.2 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes coming tag from 8.2.2 release notes.