### PR TITLE
[Cloud Posture] Trend query size fix

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_trends.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_trends.ts
@@ -27,6 +27,7 @@ export interface ScoreTrendDoc {
 
 export const getTrendsQuery = () => ({
   index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
+  // large number that should be sufficient for 24 hours considering we write to the score index every 5 minutes
   size: 999,
   sort: '@timestamp:desc',
   query: {

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_trends.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_trends.ts
@@ -27,7 +27,7 @@ export interface ScoreTrendDoc {
 
 export const getTrendsQuery = () => ({
   index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
-  size: 99,
+  size: 999,
   sort: '@timestamp:desc',
   query: {
     bool: {


### PR DESCRIPTION
## Summary

We now write to the score index every 5 minutes instead of 30. I've increased the query `size` to fetch enough results in 24 hours