### PR TITLE
[8.2] [ML] Fix JVM heap size position on the ML memory overview chart (#132888)

### DIFF
--- a/x-pack/plugins/ml/public/application/trained_models/nodes_overview/memory_preview_chart.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/nodes_overview/memory_preview_chart.tsx
@@ -72,11 +72,6 @@ export const MemoryPreviewChart: FC<MemoryPreviewChartProps> = ({ memoryOverview
   const chartData = [
     {
       x: 0,
-      y: memoryOverview.machine_memory.jvm,
-      g: groups.jvm.name,
-    },
-    {
-      x: 0,
       y: memoryOverview.trained_models.total,
       g: groups.trained_models.name,
     },
@@ -99,6 +94,11 @@ export const MemoryPreviewChart: FC<MemoryPreviewChartProps> = ({ memoryOverview
         memoryOverview.dfa_training.total -
         memoryOverview.anomaly_detection.total,
       g: groups.available.name,
+    },
+    {
+      x: 0,
+      y: memoryOverview.machine_memory.jvm,
+      g: groups.jvm.name,
     },
   ];
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[ML] Fix JVM heap size position on the ML memory overview chart (#132888)](https://github.com/elastic/kibana/pull/132888)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)