### PR TITLE
[Fleet] Use search limit constant to fetch policies instead of an hardcoded 1000 perPage

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/step_select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/step_select_agent_policy.tsx
@@ -35,7 +35,7 @@ import {
   sendGetOneAgentPolicy,
   useFleetStatus,
 } from '../../../../hooks';
-import { FLEET_APM_PACKAGE, outputType } from '../../../../../../../common';
+import { FLEET_APM_PACKAGE, SO_SEARCH_LIMIT, outputType } from '../../../../../../../common';
 
 const AgentPolicyFormRow = styled(EuiFormRow)`
   .euiFormRow__label {
@@ -51,7 +51,7 @@ function useAgentPoliciesOptions(packageInfo?: PackageInfo) {
     isLoading: isAgentPoliciesLoading,
   } = useGetAgentPolicies({
     page: 1,
-    perPage: 1000,
+    perPage: SO_SEARCH_LIMIT,
     sortField: 'name',
     sortOrder: 'asc',
     full: true,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/step_select_hosts.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/step_select_hosts.tsx
@@ -14,7 +14,7 @@ import { useGetAgentPolicies } from '../../../../hooks';
 import type { AgentPolicy, NewAgentPolicy, PackageInfo } from '../../../../types';
 import { AgentPolicyIntegrationForm } from '../../components';
 import type { ValidationResults } from '../../components/agent_policy_validation';
-
+import { SO_SEARCH_LIMIT } from '../../../../constants';
 import { incrementPolicyName } from '../../../../services';
 
 import { StepSelectAgentPolicy } from './step_select_agent_policy';
@@ -60,7 +60,7 @@ export const StepSelectHosts: React.FunctionComponent<Props> = ({
   let agentPolicies: AgentPolicy[] = [];
   const { data: agentPoliciesData, error: err } = useGetAgentPolicies({
     page: 1,
-    perPage: 1000,
+    perPage: SO_SEARCH_LIMIT,
     sortField: 'name',
     sortOrder: 'asc',
     full: true,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -35,7 +35,7 @@ import {
 } from '../../../hooks';
 import { AgentEnrollmentFlyout, AgentPolicySummaryLine } from '../../../components';
 import { AgentStatusKueryHelper, isAgentUpgradeable } from '../../../services';
-import { AGENTS_PREFIX, FLEET_SERVER_PACKAGE } from '../../../constants';
+import { AGENTS_PREFIX, FLEET_SERVER_PACKAGE, SO_SEARCH_LIMIT } from '../../../constants';
 import {
   AgentReassignAgentPolicyModal,
   AgentHealth,
@@ -291,7 +291,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
 
   const agentPoliciesRequest = useGetAgentPolicies({
     page: 1,
-    perPage: 1000,
+    perPage: SO_SEARCH_LIMIT,
     full: true,
   });
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_reassign_policy_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_reassign_policy_modal/index.tsx
@@ -25,6 +25,7 @@ import {
   useGetAgentPolicies,
 } from '../../../../hooks';
 import { AgentPolicyPackageBadges } from '../../../../components';
+import { SO_SEARCH_LIMIT } from '../../../../constants';
 
 interface Props {
   onClose: () => void;
@@ -43,7 +44,7 @@ export const AgentReassignAgentPolicyModal: React.FunctionComponent<Props> = ({
   );
   const agentPoliciesRequest = useGetAgentPolicies({
     page: 1,
-    perPage: 1000,
+    perPage: SO_SEARCH_LIMIT,
   });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const agentPolicies = agentPoliciesRequest.data ? agentPoliciesRequest.data.items : [];

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
@@ -21,7 +21,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage, FormattedDate } from '@kbn/i18n-react';
 
-import { ENROLLMENT_API_KEYS_INDEX } from '../../../constants';
+import { ENROLLMENT_API_KEYS_INDEX, SO_SEARCH_LIMIT } from '../../../constants';
 import { NewEnrollmentTokenModal } from '../../../components';
 import {
   useBreadcrumbs,
@@ -167,7 +167,7 @@ export const EnrollmentTokenListPage: React.FunctionComponent<{}> = () => {
   });
   const agentPoliciesRequest = useGetAgentPolicies({
     page: 1,
-    perPage: 1000,
+    perPage: SO_SEARCH_LIMIT,
   });
 
   const agentPolicies = agentPoliciesRequest.data ? agentPoliciesRequest.data.items : [];

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/hooks/use_fleet_server_unhealthy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/hooks/use_fleet_server_unhealthy.tsx
@@ -8,7 +8,11 @@
 import { i18n } from '@kbn/i18n';
 import { useEffect, useCallback, useState } from 'react';
 
-import { FLEET_SERVER_PACKAGE, PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../../constants';
+import {
+  FLEET_SERVER_PACKAGE,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  SO_SEARCH_LIMIT,
+} from '../../../constants';
 import { sendGetAgentStatus, sendGetPackagePolicies, useStartServices } from '../../../hooks';
 
 export function useFleetServerUnhealthy() {
@@ -19,7 +23,7 @@ export function useFleetServerUnhealthy() {
     try {
       const packagePoliciesRes = await sendGetPackagePolicies({
         page: 1,
-        perPage: 10000,
+        perPage: SO_SEARCH_LIMIT,
         kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${FLEET_SERVER_PACKAGE}`,
       });
 

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -39,6 +39,7 @@ import {
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
   KEEP_POLICIES_UP_TO_DATE_PACKAGES,
   AUTO_UPGRADE_POLICIES_PACKAGES,
+  SO_SEARCH_LIMIT,
 } from '../../../../../constants';
 
 import { KeepPoliciesUpToDateSwitch } from '../components';
@@ -102,7 +103,7 @@ export const SettingsPage: React.FC<Props> = memo(({ packageInfo, theme$ }: Prop
   const [isUpgradingPackagePolicies, setIsUpgradingPackagePolicies] = useState<boolean>(false);
   const getPackageInstallStatus = useGetPackageInstallStatus();
   const { data: packagePoliciesData } = useGetPackagePolicies({
-    perPage: 1000,
+    perPage: SO_SEARCH_LIMIT,
     page: 1,
     kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${name}`,
   });

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -30,7 +30,7 @@ import type {
   PackagePolicy,
 } from '../../../../../types';
 import { InstallStatus } from '../../../../../types';
-import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '../../../../../constants';
+import { AGENT_POLICY_SAVED_OBJECT_TYPE, SO_SEARCH_LIMIT } from '../../../../../constants';
 import {
   sendGetAgentPolicies,
   useInstallPackage,
@@ -98,7 +98,7 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
     const fetchAgentPolicyData = async () => {
       if (packagePolicyIds && packagePolicyIds.length > 0) {
         const { data } = await sendGetAgentPolicies({
-          perPage: 1000,
+          perPage: SO_SEARCH_LIMIT,
           page: 1,
           // Fetch all agent policies that include one of the eligible package policies
           kuery: `${AGENT_POLICY_SAVED_OBJECT_TYPE}.package_policies:${packagePolicyIds

--- a/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
@@ -8,6 +8,7 @@
 import { useMemo } from 'react';
 
 import type { AgentPolicy } from '../types';
+import { SO_SEARCH_LIMIT } from '../constants';
 
 import { useGetAgentPolicies } from './use_request';
 
@@ -26,7 +27,7 @@ export function useAgentEnrollmentFlyoutData(): AgentEnrollmentFlyoutData {
     resendRequest: refreshAgentPolicies,
   } = useGetAgentPolicies({
     page: 1,
-    perPage: 1000,
+    perPage: SO_SEARCH_LIMIT,
     full: true,
   });
 


### PR DESCRIPTION
## Description

In a lot of place in the Fleet UI we use an hardcoded value of 1000 items per page causing the UI to break when a user has more than 1000 policies

That PR should address that by mitigating that problem up to 10k policies, we will have to think to a more robust solution after.


I tested with 1200 policies and policies are well displayed


