### PR TITLE
[ML] Hide job messages clear notifications tooltip on click

### DIFF
--- a/x-pack/plugins/ml/public/application/components/job_messages/job_messages.tsx
+++ b/x-pack/plugins/ml/public/application/components/job_messages/job_messages.tsx
@@ -22,12 +22,13 @@ import { euiLightVars as theme } from '@kbn/ui-theme';
 import { JobMessage } from '../../../../common/types/audit_message';
 import { JobIcon } from '../job_message_icon';
 import { timeFormatter } from '../../../../common/util/date_utils';
+import { blurButtonOnClick } from '../../util/component_utils';
 
 interface JobMessagesProps {
   messages: JobMessage[];
   loading: boolean;
   error: string;
-  refreshMessage?: React.MouseEventHandler<HTMLButtonElement>;
+  refreshMessage?: () => Promise<void>;
   actionHandler?: (message: JobMessage) => void;
 }
 
@@ -51,7 +52,9 @@ export const JobMessages: FC<JobMessagesProps> = ({
           })}
         >
           <EuiButtonIcon
-            onClick={refreshMessage}
+            onClick={blurButtonOnClick(() => {
+              refreshMessage();
+            })}
             iconType="refresh"
             aria-label={i18n.translate('xpack.ml.jobMessages.refreshAriaLabel', {
               defaultMessage: 'Refresh',

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/job_messages_pane.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/job_messages_pane.tsx
@@ -16,6 +16,7 @@ import { extractErrorMessage } from '../../../../../../common/util/errors';
 import { useToastNotificationService } from '../../../../services/toast_notification_service';
 import { useMlApiContext } from '../../../../contexts/kibana';
 import { checkPermission } from '../../../../capabilities/check_capabilities';
+import { blurButtonOnClick } from '../../../../util/component_utils';
 interface JobMessagesPaneProps {
   jobId: string;
   showClearButton?: boolean;
@@ -94,7 +95,9 @@ export const JobMessagesPane: FC<JobMessagesPaneProps> = React.memo(
         size="s"
         isLoading={isClearing}
         isDisabled={disabled}
-        onClick={clearMessages}
+        onClick={blurButtonOnClick(() => {
+          clearMessages();
+        })}
         data-test-subj="mlJobMessagesClearButton"
       >
         <FormattedMessage

--- a/x-pack/plugins/ml/public/application/util/component_utils.ts
+++ b/x-pack/plugins/ml/public/application/util/component_utils.ts
@@ -12,6 +12,6 @@ import { MouseEvent } from 'react';
  * ensure a wrapping tooltip is hidden on click.
  */
 export const blurButtonOnClick = (callback: Function) => (event: MouseEvent<HTMLButtonElement>) => {
-  (event.target as HTMLButtonElement).blur();
+  (event.currentTarget as HTMLButtonElement).blur();
   callback();
 };


### PR DESCRIPTION
## Summary

Fixes the `onClick` behavior of the 'Clear notificaitons' and Refresh buttons in the Job Messages tab of the Anomaly Detection jobs list, to hide the tooltip when the button is clicked.

The fix switches the `blurButtonOnClick` function to use `event.currentTarget` rather than `event.target` as `currentTarget` always refers to the element to which the event handler has been attached, as opposed to `target` which identifies the element on which the event occurred and which may be its descendant (as was the case for the Clear Notifications button where the event occured on the `<span>` element containing the button text.

Before:

![job_messages_tooltip_before](https://user-images.githubusercontent.com/7405507/170458458-10d8bb35-5708-43f5-ac97-faf5d0e08236.gif)

After:

![job_messages_tooltip](https://user-images.githubusercontent.com/7405507/170458423-89638de9-a1e7-472f-97bf-ffcf51b0bd52.gif)

### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

Fixes #128734
