### PR TITLE
Fix error handling on precommit hook

### DIFF
--- a/src/dev/run_precommit_hook.js
+++ b/src/dev/run_precommit_hook.js
@@ -8,9 +8,8 @@
 
 import SimpleGit from 'simple-git/promise';
 
-import { combineErrors } from '@kbn/dev-utils';
 import { run } from '@kbn/dev-cli-runner';
-import { createFlagError } from '@kbn/dev-cli-errors';
+import { createFlagError, combineErrors } from '@kbn/dev-cli-errors';
 import { REPO_ROOT } from '@kbn/utils';
 import * as Eslint from './eslint';
 import * as Stylelint from './stylelint';


### PR DESCRIPTION
## Summary

Today I had a filename case issue that made the precommit hook fail, but given the following error I could find out what was about:

```
git commit -m'blah blah'
 succ [eslint] 9 files linted successfully
ERROR UNHANDLED ERROR
ERROR TypeError: (0 , _devUtils.combineErrors) is not a function
          at description (./kibana/src/dev/run_precommit_hook.js:65:13)
          at processTicksAndRejections (node:internal/process/task_queues:96:5)
          at ./kibana/node_modules/@kbn/dev-cli-runner/target_node/run.js:62:7
          at withProcRunner (./kibana/node_modules/@kbn/dev-proc-runner/target_node/with_proc_runner.js:31:5)
          at run (./kibana/node_modules/@kbn/dev-cli-runner/target_node/run.js:61:5)
Pre-commit hook failed (add --no-verify to bypass)
  For eslint failures you can try running `node scripts/precommit_hook --fix`
```

The problem was due to the `combineErrors` function that has moved from the `@kbn/dev-utils` to the `@kbn/dev-cli-errors`.
With this fix the same execution reports:

```
succ [eslint] 9 files linted successfully
ERROR Filenames MUST use snake_case.
       - x-pack/plugins/lens/common/expressions/rename_columns/renameColumns_fn.ts
```

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
