### PR TITLE
[Security Solution] Unskips cypress exceptions test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/exceptions/add_exception.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/exceptions/add_exception.spec.ts
@@ -58,7 +58,7 @@ describe('Adds rule exception', () => {
     esArchiverUnload('exceptions');
   });
 
-  it.skip('Creates an exception from an alert and deletes it', () => {
+  it('Creates an exception from an alert and deletes it', () => {
     cy.get(ALERTS_COUNT).should('exist');
     cy.get(NUMBER_OF_ALERTS).should('have.text', NUMBER_OF_AUDITBEAT_EXCEPTIONS_ALERTS);
     // Create an exception from the alerts actions menu that matches


### PR DESCRIPTION
## Summary

In this PR we are unskipping an exceptions Cypress test since the following issue: https://github.com/elastic/kibana/issues/127711 has been fixed :) 