### PR TITLE
[RAM] Use alert name in flyout header

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.test.tsx
@@ -121,7 +121,7 @@ describe('AlertsFlyout', () => {
         await nextTick();
         wrapper.update();
       });
-      expect(wrapper.find('h2').first().text()).toBe('Sample title');
+      expect(wrapper.find('h2').first().text()).toBe('one');
       expect(wrapper.find('h5').first().text()).toBe('Body');
     });
 
@@ -142,7 +142,7 @@ describe('AlertsFlyout', () => {
         await nextTick();
         wrapper.update();
       });
-      expect(wrapper.find('h2').first().text()).toBe('Sample title');
+      expect(wrapper.find('h2').first().text()).toBe('one');
       expect(wrapper.find('h5').first().text()).toBe('Body');
       expect(wrapper.find('h6').first().text()).toBe('Footer');
     });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout_header.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout_header.tsx
@@ -5,22 +5,16 @@
  * 2.0.
  */
 import React from 'react';
-import { i18n } from '@kbn/i18n';
+import { get } from 'lodash';
+import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import { EuiTitle } from '@elastic/eui';
 import { AlertsTableFlyoutBaseProps } from '../../../../types';
-
-const SAMPLE_TITLE_LABEL = i18n.translate(
-  'xpack.triggersActionsUI.sections.alertsTable.alertsFlyout.sampleTitle',
-  {
-    defaultMessage: 'Sample title',
-  }
-);
 
 type Props = AlertsTableFlyoutBaseProps;
 const AlertsFlyoutHeader = ({ alert }: Props) => {
   return (
     <EuiTitle size="m">
-      <h2>{SAMPLE_TITLE_LABEL}</h2>
+      <h2>{get(alert, ALERT_RULE_NAME)}</h2>
     </EuiTitle>
   );
 };


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/133032

This simple change will ensure the flyout header will not show the term `Sample title` but instead it will show the alert name