### PR TITLE
[8.3] [RAM] Allow plugins to configure alerts table flyout (#131401)

### DIFF
--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_alerts.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_alerts.test.tsx
@@ -38,7 +38,7 @@ describe('Case View Page activity tab', () => {
     });
   });
 
-  it('should call the alerts table with correct props', async () => {
+  it('should call the alerts table with correct props for security solution', async () => {
     appMockRender.render(<CaseViewAlerts caseData={caseData} />);
     await waitFor(async () => {
       expect(getAlertsStateTableMock).toHaveBeenCalledWith({
@@ -51,6 +51,30 @@ describe('Case View Page activity tab', () => {
             values: ['alert-id-1'],
           },
         },
+        flyoutState: 'internal',
+        showExpandToDetails: true,
+      });
+    });
+  });
+
+  it('should call the alerts table with correct props for observability', async () => {
+    const getFeatureIdsMock = jest.spyOn(api, 'getFeatureIds');
+    getFeatureIdsMock.mockResolvedValueOnce(['observability']);
+    appMockRender.render(<CaseViewAlerts caseData={caseData} />);
+
+    await waitFor(async () => {
+      expect(getAlertsStateTableMock).toHaveBeenCalledWith({
+        alertsTableConfigurationRegistry: expect.anything(),
+        configurationId: 'securitySolution',
+        featureIds: ['observability'],
+        id: 'case-details-alerts-securitySolution',
+        query: {
+          ids: {
+            values: ['alert-id-1'],
+          },
+        },
+        flyoutState: 'external',
+        showExpandToDetails: false,
       });
     });
   });

--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_alerts.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_alerts.tsx
@@ -7,6 +7,7 @@
 
 import React, { useMemo } from 'react';
 
+import { AlertsTableFlyoutState } from '@kbn/triggers-actions-ui-plugin/public';
 import { EuiFlexItem, EuiFlexGroup, EuiProgress } from '@elastic/eui';
 import { Case } from '../../../../common';
 import { useKibana } from '../../../common/lib/kibana';
@@ -40,8 +41,12 @@ export const CaseViewAlerts = ({ caseData }: CaseViewAlertsProps) => {
     alertsTableConfigurationRegistry: triggersActionsUi.alertsTableConfigurationRegistry,
     configurationId: caseData.owner,
     id: `case-details-alerts-${caseData.owner}`,
+    flyoutState: alertFeatureIds.includes('siem')
+      ? AlertsTableFlyoutState.internal
+      : AlertsTableFlyoutState.external,
     featureIds: alertFeatureIds,
     query: alertIdsQuery,
+    showExpandToDetails: alertFeatureIds.includes('siem'),
   };
 
   if (alertIdsQuery.ids.values.length === 0) {

--- a/x-pack/plugins/observability/public/config/register_alerts_table_configuration.tsx
+++ b/x-pack/plugins/observability/public/config/register_alerts_table_configuration.tsx
@@ -5,10 +5,27 @@
  * 2.0.
  */
 
-import { AlertsTableConfigurationRegistryContract } from '@kbn/triggers-actions-ui-plugin/public';
+import type {
+  AlertsTableConfigurationRegistryContract,
+  AlertTableFlyoutComponent,
+  GetRenderCellValue,
+} from '@kbn/triggers-actions-ui-plugin/public';
+import { lazy } from 'react';
 
 import { observabilityFeatureId } from '../../common';
+import { getRenderCellValue } from '../pages/alerts/components/render_cell_value';
+import { addDisplayNames } from '../pages/alerts/containers/alerts_table_t_grid/add_display_names';
 import { columns as alertO11yColumns } from '../pages/alerts/containers/alerts_table_t_grid/alerts_table_t_grid';
+
+const AlertsPageFlyoutHeaderLazy = lazy(
+  () => import('../pages/alerts/components/alerts_flyout/alerts_flyout_header')
+);
+const AlertsPageFlyoutBodyLazy = lazy(
+  () => import('../pages/alerts/components/alerts_flyout/alerts_flyout_body')
+);
+const AlertsFlyoutFooterLazy = lazy(
+  () => import('../pages/alerts/components/alerts_flyout/alerts_flyout_footer')
+);
 
 const registerAlertsTableConfiguration = (registry: AlertsTableConfigurationRegistryContract) => {
   if (registry.has(observabilityFeatureId)) {
@@ -16,7 +33,13 @@ const registerAlertsTableConfiguration = (registry: AlertsTableConfigurationRegi
   }
   registry.register({
     id: observabilityFeatureId,
-    columns: alertO11yColumns,
+    columns: alertO11yColumns.map(addDisplayNames),
+    externalFlyout: {
+      header: AlertsPageFlyoutHeaderLazy as AlertTableFlyoutComponent,
+      body: AlertsPageFlyoutBodyLazy as AlertTableFlyoutComponent,
+      footer: AlertsFlyoutFooterLazy as AlertTableFlyoutComponent,
+    },
+    getRenderCellValue: getRenderCellValue as GetRenderCellValue,
   });
 };
 

--- a/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/alerts_flyout_body.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/alerts_flyout_body.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { get } from 'lodash';
+import {
+  EuiSpacer,
+  EuiTitle,
+  EuiText,
+  EuiLink,
+  EuiHorizontalRule,
+  EuiDescriptionList,
+} from '@elastic/eui';
+import {
+  ALERT_DURATION,
+  ALERT_EVALUATION_THRESHOLD,
+  ALERT_EVALUATION_VALUE,
+  ALERT_RULE_CATEGORY,
+  ALERT_STATUS_ACTIVE,
+  ALERT_STATUS_RECOVERED,
+} from '@kbn/rule-data-utils';
+import moment from 'moment-timezone';
+import { useKibana, useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { asDuration } from '../../../../../common/utils/formatters';
+import { translations, paths } from '../../../../config';
+import { AlertStatusIndicator } from '../../../../components/shared/alert_status_indicator';
+import { usePluginContext } from '../../../../hooks/use_plugin_context';
+import { parseAlert } from '../parse_alert';
+import { FlyoutProps } from './types';
+
+// eslint-disable-next-line import/no-default-export
+export default function AlertsFlyoutBody(props: FlyoutProps) {
+  const { observabilityRuleTypeRegistry } = usePluginContext();
+  const alert = props.alert.start
+    ? props.alert
+    : parseAlert(observabilityRuleTypeRegistry)(props.alert);
+  const { services } = useKibana();
+  const { http } = services;
+  const dateFormat = useUiSetting<string>('dateFormat');
+  const prepend = http?.basePath.prepend;
+  const ruleId = get(props.alert, 'kibana.alert.rule.uuid') ?? null;
+  const linkToRule = ruleId && prepend ? prepend(paths.management.ruleDetails(ruleId)) : null;
+  const overviewListItems = [
+    {
+      title: translations.alertsFlyout.statusLabel,
+      description: (
+        <AlertStatusIndicator
+          alertStatus={alert.active ? ALERT_STATUS_ACTIVE : ALERT_STATUS_RECOVERED}
+        />
+      ),
+    },
+    {
+      title: translations.alertsFlyout.lastUpdatedLabel,
+      description: (
+        <span title={alert.start.toString()}>{moment(alert.start).format(dateFormat)}</span>
+      ),
+    },
+    {
+      title: translations.alertsFlyout.durationLabel,
+      description: asDuration(alert.fields[ALERT_DURATION], { extended: true }),
+    },
+    {
+      title: translations.alertsFlyout.expectedValueLabel,
+      description: alert.fields[ALERT_EVALUATION_THRESHOLD] ?? '-',
+    },
+    {
+      title: translations.alertsFlyout.actualValueLabel,
+      description: alert.fields[ALERT_EVALUATION_VALUE] ?? '-',
+    },
+    {
+      title: translations.alertsFlyout.ruleTypeLabel,
+      description: alert.fields[ALERT_RULE_CATEGORY] ?? '-',
+    },
+  ];
+
+  return (
+    <>
+      <EuiTitle size="xs">
+        <h4>{translations.alertsFlyout.reasonTitle}</h4>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiText size="s">{alert.reason}</EuiText>
+      <EuiSpacer size="s" />
+      {!!linkToRule && (
+        <EuiLink href={linkToRule} data-test-subj="viewRuleDetailsFlyout">
+          {translations.alertsFlyout.viewRulesDetailsLinkText}
+        </EuiLink>
+      )}
+      <EuiHorizontalRule size="full" />
+      <EuiTitle size="xs">
+        <h4>{translations.alertsFlyout.documentSummaryTitle}</h4>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+      <EuiDescriptionList
+        compressed={true}
+        type="responsiveColumn"
+        listItems={overviewListItems}
+        titleProps={{
+          'data-test-subj': 'alertsFlyoutDescriptionListTitle',
+        }}
+        descriptionProps={{
+          'data-test-subj': 'alertsFlyoutDescriptionListDescription',
+        }}
+      />
+    </>
+  );
+}

--- a/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/alerts_flyout_footer.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/alerts_flyout_footer.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiButton } from '@elastic/eui';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { FlyoutProps } from './types';
+import { translations } from '../../../../config';
+
+// eslint-disable-next-line import/no-default-export
+export default function AlertsFlyoutFooter({ alert, isInApp }: FlyoutProps & { isInApp: boolean }) {
+  const { services } = useKibana();
+  const { http } = services;
+  const prepend = http?.basePath.prepend;
+
+  if (!alert.link || isInApp) return <></>;
+  return (
+    <EuiFlexGroup justifyContent="flexEnd">
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          href={prepend && prepend(alert.link)}
+          data-test-subj="alertsFlyoutViewInAppButton"
+          fill
+        >
+          {translations.alertsFlyout.viewInAppButtonText}
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/alerts_flyout_header.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/alerts_flyout_header.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
+import { get } from 'lodash';
+import { EuiSpacer, EuiTitle } from '@elastic/eui';
+import { ExperimentalBadge } from '../../../../components/shared/experimental_badge';
+import { FlyoutProps } from './types';
+
+// eslint-disable-next-line import/no-default-export
+export default function AlertsFlyoutHeader({ alert }: FlyoutProps) {
+  return (
+    <>
+      <ExperimentalBadge />
+      <EuiSpacer size="s" />
+      <EuiTitle size="m" data-test-subj="alertsFlyoutTitle">
+        <h2>{get(alert, ALERT_RULE_NAME)}</h2>
+      </EuiTitle>
+    </>
+  );
+}

--- a/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/types.ts
+++ b/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/types.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { AlertsTableFlyoutBaseProps } from '@kbn/triggers-actions-ui-plugin/public';
+import { ParsedTechnicalFields } from '@kbn/rule-registry-plugin/common/parse_technical_fields';
+import { ParsedExperimentalFields } from '@kbn/rule-registry-plugin/common/parse_experimental_fields';
+import { EcsFieldsResponse } from '@kbn/rule-registry-plugin/common/search_strategy';
+
+export type FlyoutProps = AlertsTableFlyoutBaseProps & {
+  alert: EcsFieldsResponse & {
+    fields: ParsedTechnicalFields & ParsedExperimentalFields;
+    start: number;
+    reason: string;
+    link?: string;
+    active: boolean;
+  };
+};

--- a/x-pack/plugins/observability/public/pages/alerts/components/render_cell_value/render_cell_value.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/components/render_cell_value/render_cell_value.tsx
@@ -50,6 +50,7 @@ export const getRenderCellValue = ({
   setFlyoutAlert: (data: TopAlert) => void;
 }) => {
   return ({ columnId, data }: CellValueElementProps) => {
+    if (!data) return null;
     const { observabilityRuleTypeRegistry } = usePluginContext();
     const value = getMappedNonEcsValue({
       data,

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { mountWithIntl, nextTick } from '@kbn/test-jest-helpers';
 import { act } from 'react-dom/test-utils';
 import { AlertsFlyout } from './alerts_flyout';
-import { AlertsField } from '../../../../types';
+import { AlertsField, AlertsTableFlyoutState } from '../../../../types';
 
 const onClose = jest.fn();
 const onPaginate = jest.fn();
@@ -17,9 +17,35 @@ const props = {
     [AlertsField.name]: ['one'],
     [AlertsField.reason]: ['two'],
   },
+  alertsTableConfiguration: {
+    id: 'test',
+    columns: [
+      {
+        id: AlertsField.name,
+        displayAsText: 'Name',
+        initialWidth: 150,
+      },
+      {
+        id: AlertsField.reason,
+        displayAsText: 'Reason',
+        initialWidth: 250,
+      },
+    ],
+    externalFlyout: {
+      body: () => <h3>External flyout body</h3>,
+    },
+    internalFlyout: {
+      body: () => <h3>Internal flyout body</h3>,
+    },
+    getRenderCellValue: () =>
+      jest.fn().mockImplementation((rcvProps) => {
+        return `${rcvProps.colIndex}:${rcvProps.rowIndex}`;
+      }),
+  },
   flyoutIndex: 0,
   alertsCount: 4,
   isLoading: false,
+  state: AlertsTableFlyoutState.internal,
   onClose,
   onPaginate,
 };
@@ -35,9 +61,92 @@ describe('AlertsFlyout', () => {
       await nextTick();
       wrapper.update();
     });
-    expect(wrapper.find('[data-test-subj="alertsFlyoutName"]').first().text()).toBe('one');
-    expect(wrapper.find('[data-test-subj="alertsFlyoutReason"]').first().text()).toBe('two');
+    expect(wrapper.find('h3').first().text()).toBe('Internal flyout body');
+
+    const externalWrapper = mountWithIntl(
+      <AlertsFlyout
+        {...{
+          ...props,
+          state: AlertsTableFlyoutState.external,
+        }}
+      />
+    );
+    await act(async () => {
+      await nextTick();
+      externalWrapper.update();
+    });
+    expect(externalWrapper.find('h3').first().text()).toBe('External flyout body');
   });
+
+  const configurations = [AlertsTableFlyoutState.external, AlertsTableFlyoutState.internal];
+  for (const configuration of configurations) {
+    const base = {
+      body: () => <h5>Body</h5>,
+    };
+
+    it(`should use ${configuration} header configuration`, async () => {
+      const customProps = {
+        ...props,
+        alertsTableConfiguration: {
+          ...props.alertsTableConfiguration,
+          [`${configuration}Flyout`]: {
+            ...base,
+            header: () => <h4>Header</h4>,
+          },
+        },
+        state: configuration,
+      };
+      const wrapper = mountWithIntl(<AlertsFlyout {...customProps} />);
+      await act(async () => {
+        await nextTick();
+        wrapper.update();
+      });
+      expect(wrapper.find('h4').first().text()).toBe('Header');
+      expect(wrapper.find('h5').first().text()).toBe('Body');
+    });
+
+    it(`should use ${configuration} body configuration`, async () => {
+      const customProps = {
+        ...props,
+        alertsTableConfiguration: {
+          ...props.alertsTableConfiguration,
+          [`${configuration}Flyout`]: {
+            ...base,
+          },
+        },
+        state: configuration,
+      };
+      const wrapper = mountWithIntl(<AlertsFlyout {...customProps} />);
+      await act(async () => {
+        await nextTick();
+        wrapper.update();
+      });
+      expect(wrapper.find('h2').first().text()).toBe('Sample title');
+      expect(wrapper.find('h5').first().text()).toBe('Body');
+    });
+
+    it(`should use ${configuration} body configuration`, async () => {
+      const customProps = {
+        ...props,
+        alertsTableConfiguration: {
+          ...props.alertsTableConfiguration,
+          [`${configuration}Flyout`]: {
+            ...base,
+            footer: () => <h6>Footer</h6>,
+          },
+        },
+        state: configuration,
+      };
+      const wrapper = mountWithIntl(<AlertsFlyout {...customProps} />);
+      await act(async () => {
+        await nextTick();
+        wrapper.update();
+      });
+      expect(wrapper.find('h2').first().text()).toBe('Sample title');
+      expect(wrapper.find('h5').first().text()).toBe('Body');
+      expect(wrapper.find('h6').first().text()).toBe('Footer');
+    });
+  }
 
   it('should allow pagination with next', async () => {
     const wrapper = mountWithIntl(<AlertsFlyout {...props} />);

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.tsx
@@ -4,47 +4,27 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
-import { get } from 'lodash';
+import React, { Suspense, lazy } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiSpacer,
-  EuiTitle,
-  EuiText,
-  EuiHorizontalRule,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPagination,
   EuiProgress,
-  EuiLoadingContent,
+  EuiFlyoutFooter,
 } from '@elastic/eui';
 import type { EcsFieldsResponse } from '@kbn/rule-registry-plugin/common/search_strategy';
-import { AlertsField } from '../../../../types';
+import {
+  AlertsTableConfigurationRegistry,
+  AlertsTableFlyoutState,
+  AlertTableFlyoutComponent,
+} from '../../../../types';
 
-const SAMPLE_TITLE_LABEL = i18n.translate(
-  'xpack.triggersActionsUI.sections.alertsTable.alertsFlyout.sampleTitle',
-  {
-    defaultMessage: 'Sample title',
-  }
-);
-
-const NAME_LABEL = i18n.translate(
-  'xpack.triggersActionsUI.sections.alertsTable.alertsFlyout.name',
-  {
-    defaultMessage: 'Name',
-  }
-);
-
-const REASON_LABEL = i18n.translate(
-  'xpack.triggersActionsUI.sections.alertsTable.alertsFlyout.reason',
-  {
-    defaultMessage: 'Reason',
-  }
-);
-
+const AlertsFlyoutHeader = lazy(() => import('./alerts_flyout_header'));
 const PAGINATION_LABEL = i18n.translate(
   'xpack.triggersActionsUI.sections.alertsTable.alertsFlyout.paginationLabel',
   {
@@ -54,27 +34,53 @@ const PAGINATION_LABEL = i18n.translate(
 
 interface AlertsFlyoutProps {
   alert: EcsFieldsResponse;
+  alertsTableConfiguration: AlertsTableConfigurationRegistry;
   flyoutIndex: number;
   alertsCount: number;
   isLoading: boolean;
+  state: AlertsTableFlyoutState;
   onClose: () => void;
   onPaginate: (pageIndex: number) => void;
 }
 export const AlertsFlyout: React.FunctionComponent<AlertsFlyoutProps> = ({
   alert,
+  alertsTableConfiguration,
   flyoutIndex,
   alertsCount,
   isLoading,
+  state,
   onClose,
   onPaginate,
 }: AlertsFlyoutProps) => {
+  let Header: AlertTableFlyoutComponent;
+  let Body: AlertTableFlyoutComponent;
+  let Footer: AlertTableFlyoutComponent;
+
+  switch (state) {
+    case AlertsTableFlyoutState.external:
+      Header = alertsTableConfiguration?.externalFlyout?.header ?? AlertsFlyoutHeader;
+      Body = alertsTableConfiguration?.externalFlyout?.body ?? null;
+      Footer = alertsTableConfiguration?.externalFlyout?.footer ?? null;
+      break;
+    case AlertsTableFlyoutState.internal:
+      Header = alertsTableConfiguration?.internalFlyout?.header ?? AlertsFlyoutHeader;
+      Body = alertsTableConfiguration?.internalFlyout?.body ?? null;
+      Footer = alertsTableConfiguration?.internalFlyout?.footer ?? null;
+      break;
+  }
+
+  const passedProps = {
+    alert,
+    isLoading,
+  };
+
   return (
     <EuiFlyout onClose={onClose} size="s" data-test-subj="alertsFlyout">
       {isLoading && <EuiProgress size="xs" color="accent" data-test-subj="alertsFlyoutLoading" />}
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="m">
-          <h2>{SAMPLE_TITLE_LABEL}</h2>
-        </EuiTitle>
+        <Suspense fallback={null}>
+          <Header {...passedProps} />
+        </Suspense>
         <EuiSpacer size="m" />
         <EuiFlexGroup gutterSize="none" justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
@@ -90,39 +96,19 @@ export const AlertsFlyout: React.FunctionComponent<AlertsFlyoutProps> = ({
         </EuiFlexGroup>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween" direction="column">
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="xs">
-              <h4>{NAME_LABEL}</h4>
-            </EuiTitle>
-            <EuiSpacer size="s" />
-            {isLoading ? (
-              <EuiLoadingContent lines={1} />
-            ) : (
-              <EuiText size="s" data-test-subj="alertsFlyoutName">
-                {/* any is required here to improve typescript performance */}
-                {get(alert as any, AlertsField.name, [])[0] as string}
-              </EuiText>
-            )}
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="xs">
-              <h4>{REASON_LABEL}</h4>
-            </EuiTitle>
-            <EuiSpacer size="s" />
-            {isLoading ? (
-              <EuiLoadingContent lines={3} />
-            ) : (
-              <EuiText size="s" data-test-subj="alertsFlyoutReason">
-                {/* any is required here to improve typescript performance */}
-                {get(alert as any, AlertsField.reason, [])[0] as string}
-              </EuiText>
-            )}
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer size="s" />
-        <EuiHorizontalRule size="full" />
+        {Body && (
+          <Suspense fallback={null}>
+            <Body {...passedProps} />
+          </Suspense>
+        )}
       </EuiFlyoutBody>
+      {Footer ? (
+        <EuiFlyoutFooter>
+          <Suspense fallback={null}>
+            <Footer {...passedProps} />
+          </Suspense>
+        </EuiFlyoutFooter>
+      ) : null}
     </EuiFlyout>
   );
 };

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout_header.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout_header.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiTitle } from '@elastic/eui';
+import { AlertsTableFlyoutBaseProps } from '../../../../types';
+
+const SAMPLE_TITLE_LABEL = i18n.translate(
+  'xpack.triggersActionsUI.sections.alertsTable.alertsFlyout.sampleTitle',
+  {
+    defaultMessage: 'Sample title',
+  }
+);
+
+type Props = AlertsTableFlyoutBaseProps;
+const AlertsFlyoutHeader = ({ alert }: Props) => {
+  return (
+    <EuiTitle size="m">
+      <h2>{SAMPLE_TITLE_LABEL}</h2>
+    </EuiTitle>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default AlertsFlyoutHeader;

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_page/alerts_page.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_page/alerts_page.tsx
@@ -4,28 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState, useCallback, useEffect } from 'react';
-import { get } from 'lodash';
-import {
-  EuiDataGridControlColumn,
-  EuiDataGridSorting,
-  EuiFlexItem,
-  EuiFlexGroup,
-  EuiSpacer,
-  EuiProgress,
-} from '@elastic/eui';
-import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import React from 'react';
+import { EuiFlexItem, EuiFlexGroup, EuiSpacer } from '@elastic/eui';
 import { AlertConsumers } from '@kbn/rule-data-utils';
-import {
-  RuleRegistrySearchRequest,
-  RuleRegistrySearchResponse,
-  RuleRegistrySearchRequestPagination,
-} from '@kbn/rule-registry-plugin/common';
-import { AbortError } from '@kbn/kibana-utils-plugin/common';
-import type { EcsFieldsResponse } from '@kbn/rule-registry-plugin/common/search_strategy';
+import { getAlertsTableStateLazy } from '../../../../common/get_alerts_table_state';
 import { PLUGIN_ID } from '../../../../common/constants';
-import { AlertsTable } from '../alerts_table';
 import { useKibana } from '../../../../common/lib/kibana';
+import { AlertsTableConfigurationRegistry, AlertsTableFlyoutState } from '../../../../types';
+import { TypeRegistry } from '../../../type_registry';
 
 const consumers = [
   AlertConsumers.APM,
@@ -34,138 +20,18 @@ const consumers = [
   AlertConsumers.INFRASTRUCTURE,
 ];
 
-const defaultPagination = {
-  pageSize: 10,
-  pageIndex: 0,
-};
-
-const emptyConfiguration = {
-  id: '',
-  columns: [],
-};
-
-const defaultSort: estypes.SortCombinations[] = [
-  {
-    'event.action': {
-      order: 'asc',
-    },
-  },
-];
-
 const AlertsPage: React.FunctionComponent = () => {
-  const { data, notifications } = useKibana().services;
-  const [showCheckboxes] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isInitializing, setIsInitializing] = useState(true);
-  const [alertsCount, setAlertsCount] = useState(0);
-  const [alerts, setAlerts] = useState<EcsFieldsResponse[]>([]);
-  const [sort, setSort] = useState<estypes.SortCombinations[]>(defaultSort);
-  const [pagination, setPagination] = useState(defaultPagination);
+  const { alertsTableConfigurationRegistry } = useKibana().services;
 
-  const alertsTableConfigurationRegistry = useKibana().services.alertsTableConfigurationRegistry;
-  const hasAlertsTableConfiguration = alertsTableConfigurationRegistry.has(PLUGIN_ID);
-  const alertsTableConfiguration = hasAlertsTableConfiguration
-    ? alertsTableConfigurationRegistry.get(PLUGIN_ID)
-    : emptyConfiguration;
-
-  const onPageChange = (_pagination: RuleRegistrySearchRequestPagination) => {
-    setPagination(_pagination);
-  };
-  const onSortChange = (_sort: EuiDataGridSorting['columns']) => {
-    setSort(
-      _sort.map((sortItem) => {
-        return {
-          [sortItem.id]: {
-            order: sortItem.direction,
-          },
-        };
-      })
-    );
-  };
-
-  const asyncSearch = useCallback(() => {
-    setIsLoading(true);
-    const abortController = new AbortController();
-    const request: RuleRegistrySearchRequest = {
-      featureIds: consumers,
-      sort,
-      pagination,
-    };
-    data.search
-      .search<RuleRegistrySearchRequest, RuleRegistrySearchResponse>(request, {
-        strategy: 'privateRuleRegistryAlertsSearchStrategy',
-        abortSignal: abortController.signal,
-      })
-      .subscribe({
-        next: (res) => {
-          const alertsResponse = res.rawResponse.hits.hits.map<EcsFieldsResponse>(
-            (hit) => hit.fields as EcsFieldsResponse
-          );
-          setAlerts(alertsResponse);
-          const total = !isNaN(res.rawResponse.hits.total as number)
-            ? (res.rawResponse.hits.total as number)
-            : (res.rawResponse.hits.total as estypes.SearchTotalHits).value ?? 0;
-          setAlertsCount(total);
-          setIsLoading(false);
-        },
-        error: (e) => {
-          if (e instanceof AbortError) {
-            notifications.toasts.addWarning({
-              title: e.message,
-            });
-          } else {
-            notifications.toasts.addDanger({
-              title: 'Failed to run search',
-              text: e.message,
-            });
-          }
-          setIsLoading(false);
-        },
-      });
-    setIsInitializing(false);
-  }, [data.search, notifications.toasts, sort, pagination]);
-
-  useEffect(() => {
-    asyncSearch();
-  }, [asyncSearch]);
-
-  const useFetchAlertsData = () => {
-    return {
-      activePage: pagination.pageIndex,
-      alerts,
-      alertsCount,
-      isInitializing,
-      isLoading,
-      getInspectQuery: () => ({ request: {}, response: {} }),
-      onColumnsChange: (columns: EuiDataGridControlColumn[]) => {},
-      onPageChange,
-      onSortChange,
-      refresh: () => {
-        asyncSearch();
-      },
-      sort,
-    };
-  };
-
-  const tableProps = {
-    columns: alertsTableConfiguration.columns,
-    consumers,
-    bulkActions: [],
-    deletedEventIds: [],
-    disabledCellActions: [],
-    pageSize: defaultPagination.pageSize,
-    pageSizeOptions: [1, 2, 5, 10, 20, 50, 100],
-    leadingControlColumns: [],
-    renderCellValue: ({ alert, field }: { alert: EcsFieldsResponse; field: string }) => {
-      // any is required here to improve typescript performance
-      const value = get(alert as any, field, [])[0] as string;
-      return value ?? 'N/A';
-    },
-    showCheckboxes,
-    trailingControlColumns: [],
-    useFetchAlertsData,
-    alerts,
-    'data-test-subj': 'internalAlertsPage',
+  const alertStateProps = {
+    alertsTableConfigurationRegistry:
+      alertsTableConfigurationRegistry as TypeRegistry<AlertsTableConfigurationRegistry>,
+    configurationId: PLUGIN_ID,
+    id: `internal-alerts-page`,
+    flyoutState: AlertsTableFlyoutState.internal,
+    featureIds: consumers,
+    query: { bool: { must: [] } },
+    showExpandToDetails: true,
   };
 
   return (
@@ -173,12 +39,7 @@ const AlertsPage: React.FunctionComponent = () => {
       <h1>THIS IS AN INTERNAL TEST PAGE</h1>
       <EuiSpacer />
       <EuiFlexGroup>
-        <EuiFlexItem grow={true}>
-          {isLoading && (
-            <EuiProgress size="xs" color="accent" data-test-subj="internalAlertsPageLoading" />
-          )}
-          <AlertsTable {...tableProps} />
-        </EuiFlexItem>
+        <EuiFlexItem grow={true}>{getAlertsTableStateLazy(alertStateProps)}</EuiFlexItem>
       </EuiFlexGroup>
     </section>
   );

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_page/alerts_page_flyout_body.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_page/alerts_page_flyout_body.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { get } from 'lodash';
+import {
+  EuiFlexGroup,
+  EuiTitle,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiLoadingContent,
+  EuiText,
+} from '@elastic/eui';
+import { AlertsField, AlertsTableFlyoutBaseProps } from '../../../../types';
+
+const NAME_LABEL = i18n.translate(
+  'xpack.triggersActionsUI.sections.alertsTable.alertsFlyout.name',
+  {
+    defaultMessage: 'Name',
+  }
+);
+
+const REASON_LABEL = i18n.translate(
+  'xpack.triggersActionsUI.sections.alertsTable.alertsFlyout.reason',
+  {
+    defaultMessage: 'Reason',
+  }
+);
+
+type Props = AlertsTableFlyoutBaseProps;
+const AlertsFlyoutBody = ({ alert, isLoading }: Props) => {
+  return (
+    <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween" direction="column">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h4>{NAME_LABEL}</h4>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        {isLoading ? (
+          <EuiLoadingContent lines={1} />
+        ) : (
+          <EuiText size="s" data-test-subj="alertsFlyoutName">
+            {get(alert as any, AlertsField.name, [])[0]}
+          </EuiText>
+        )}
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h4>{REASON_LABEL}</h4>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        {isLoading ? (
+          <EuiLoadingContent lines={3} />
+        ) : (
+          <EuiText size="s" data-test-subj="alertsFlyoutReason">
+            {get(alert as any, AlertsField.reason, [])[0]}
+          </EuiText>
+        )}
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default AlertsFlyoutBody;

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_page/alerts_page_flyout_header.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_page/alerts_page_flyout_header.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { AlertsTableFlyoutBaseProps } from '../../../../types';
+
+type FlyoutHeaderProps = AlertsTableFlyoutBaseProps;
+const FlyoutHeader = (props: FlyoutHeaderProps) => {
+  return <h2>Alerts page</h2>;
+};
+
+// eslint-disable-next-line import/no-default-export
+export default FlyoutHeader;

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_page/register_alerts_table_configuration.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_page/register_alerts_table_configuration.tsx
@@ -5,9 +5,13 @@
  * 2.0.
  */
 
+import React, { lazy } from 'react';
 import { PLUGIN_ID } from '../../../../common/constants';
 import { AlertsTableConfigurationRegistry } from '../../../../types';
 import { TypeRegistry } from '../../../type_registry';
+
+const AlertsPageFlyoutHeader = lazy(() => import('./alerts_page_flyout_header'));
+const AlertsPageFlyoutBody = lazy(() => import('./alerts_page_flyout_body'));
 
 export function registerAlertsTableConfiguration({
   alertsTableConfigurationRegistry,
@@ -35,6 +39,26 @@ export function registerAlertsTableConfiguration({
       {
         id: 'kibana.alert.reason',
         displayAsText: 'Reason',
+      },
+    ],
+    internalFlyout: {
+      header: AlertsPageFlyoutHeader,
+      body: AlertsPageFlyoutBody,
+    },
+    externalFlyout: {
+      header: AlertsPageFlyoutHeader,
+      body: AlertsPageFlyoutBody,
+    },
+    getRenderCellValue: () => (props) => {
+      const myProps = props as any;
+      const value = myProps.data.find((d: any) => d.field === myProps.columnId)?.value ?? [];
+      return <>{value.length ? value.join() : '--'}</>;
+    },
+    sort: [
+      {
+        'event.action': {
+          order: 'asc',
+        },
       },
     ],
   });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_fetch_alerts.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_fetch_alerts.test.tsx
@@ -152,7 +152,7 @@ describe('useFetchAlerts', () => {
     expect(dataSearchMock).toHaveBeenCalledWith(
       {
         featureIds: args.featureIds,
-        fields: args.fields,
+        fields: undefined,
         pagination: args.pagination,
         query: {
           ids: {
@@ -315,7 +315,7 @@ describe('useFetchAlerts', () => {
     expect(dataSearchMock).toHaveBeenCalledWith(
       {
         featureIds: args.featureIds,
-        fields: args.fields,
+        fields: undefined,
         pagination: {
           pageIndex: 5,
           pageSize: 10,
@@ -337,7 +337,7 @@ describe('useFetchAlerts', () => {
     expect(dataSearchMock).toHaveBeenCalledWith(
       {
         featureIds: args.featureIds,
-        fields: args.fields,
+        fields: undefined,
         pagination: {
           pageIndex: 0,
           pageSize: 10,

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_fetch_alerts.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_fetch_alerts.tsx
@@ -176,7 +176,7 @@ const useFetchAlerts = ({
         if (data && data.search) {
           searchSubscription$.current = data.search
             .search<RuleRegistrySearchRequest, RuleRegistrySearchResponse>(
-              { ...request, featureIds, fields, query },
+              { ...request, featureIds, fields: undefined, query },
               {
                 strategy: 'privateRuleRegistryAlertsSearchStrategy',
                 abortSignal: abortCtrl.current.signal,
@@ -227,7 +227,7 @@ const useFetchAlerts = ({
       asyncSearch();
       refetch.current = asyncSearch;
     },
-    [skip, data, featureIds, fields, query]
+    [skip, data, featureIds, query]
   );
 
   useEffect(() => {

--- a/x-pack/plugins/triggers_actions_ui/public/common/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/common/index.ts
@@ -6,10 +6,22 @@
  */
 
 // TODO: https://github.com/elastic/kibana/issues/110895
-/* eslint-disable @kbn/eslint/no_export_all */
 
-export * from './expression_items';
-export * from './constants';
-export * from './index_controls';
-export * from './lib';
-export * from './types';
+export {
+  GroupByExpression,
+  ForLastExpression,
+  ValueExpression,
+  WhenExpression,
+  OfExpression,
+  ThresholdExpression,
+} from './expression_items';
+export {
+  COMPARATORS,
+  builtInComparators,
+  builtInAggregationTypes,
+  builtInGroupByTypes,
+} from './constants';
+export type { IOption } from './index_controls';
+export { getFields, getIndexOptions, firstFieldOption } from './index_controls';
+export { getTimeFieldOptions } from './lib';
+export type { Comparator, AggregationType, GroupByType, RuleStatus } from './types';

--- a/x-pack/plugins/triggers_actions_ui/public/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/index.ts
@@ -6,7 +6,6 @@
  */
 
 // TODO: https://github.com/elastic/kibana/issues/110895
-/* eslint-disable @kbn/eslint/no_export_all */
 
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { PluginInitializerContext } from '@kbn/core/server';
@@ -36,8 +35,13 @@ export type {
   RuleSummary,
   AlertStatus,
   AlertsTableConfigurationRegistryContract,
+  AlertsTableFlyoutBaseProps,
   RuleEventLogListProps,
+  AlertTableFlyoutComponent,
+  GetRenderCellValue,
 } from './types';
+
+export { AlertsTableFlyoutState } from './types';
 
 export {
   ActionForm,
@@ -65,15 +69,18 @@ export {
   builtInGroupByTypes,
   builtInAggregationTypes,
   getFields,
-  firstFieldOption,
   getIndexOptions,
+  firstFieldOption,
   getTimeFieldOptions,
   GroupByExpression,
   COMPARATORS,
 } from './common';
 
-export { Plugin };
-export * from './plugin';
+export type {
+  TriggersAndActionsUIPublicPluginSetup,
+  TriggersAndActionsUIPublicPluginStart,
+} from './plugin';
+export { Plugin } from './plugin';
 // TODO remove this import when we expose the Rules tables as a component
 export { loadRules } from './application/lib/rule_api/rules';
 export { loadExecutionLogAggregations } from './application/lib/rule_api/load_execution_log_aggregations';
@@ -92,7 +99,11 @@ export { loadRule } from './application/lib/rule_api/get_rule';
 export { loadAllActions } from './application/lib/action_connector_api';
 export { suspendedComponentWithProps } from './application/lib/suspended_component_with_props';
 export { loadActionTypes } from './application/lib/action_connector_api/connector_types';
-export { NOTIFY_WHEN_OPTIONS } from './application/sections/rule_form/rule_notify_when';
 export type { TIME_UNITS } from './application/constants';
 export { getTimeUnitLabel } from './common/lib/get_time_unit_label';
 export type { TriggersAndActionsUiServices } from './application/app';
+
+export const getNotifyWhenOptions = async () => {
+  const { NOTIFY_WHEN_OPTIONS } = await import('./application/sections/rule_form/rule_notify_when');
+  return NOTIFY_WHEN_OPTIONS;
+};

--- a/x-pack/plugins/triggers_actions_ui/public/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/types.ts
@@ -13,12 +13,7 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { IconType } from '@elastic/eui';
-import {
-  EuiDataGridColumn,
-  EuiDataGridControlColumn,
-  EuiDataGridCellValueElementProps,
-  EuiDataGridSorting,
-} from '@elastic/eui';
+import { EuiDataGridColumn, EuiDataGridControlColumn, EuiDataGridSorting } from '@elastic/eui';
 import {
   ActionType,
   AlertHistoryEsIndexConnectorId,
@@ -47,8 +42,8 @@ import {
 } from '@kbn/alerting-plugin/common';
 import { RuleRegistrySearchRequestPagination } from '@kbn/rule-registry-plugin/common';
 import { EcsFieldsResponse } from '@kbn/rule-registry-plugin/common/search_strategy';
-
 import { SortCombinations } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import React from 'react';
 import { TypeRegistry } from './application/type_registry';
 import type { ComponentOpts as RuleStatusDropdownProps } from './application/sections/rules_list/components/rule_status_dropdown';
 import type { RuleTagFilterProps } from './application/sections/rules_list/components/rule_tag_filter';
@@ -398,7 +393,7 @@ export interface FetchAlertData {
   isInitializing: boolean;
   isLoading: boolean;
   getInspectQuery: () => { request: {}; response: {} };
-  onColumnsChange: (columns: EuiDataGridControlColumn[]) => void;
+  onColumnsChange: (columns: EuiDataGridColumn[], visibleColumns: string[]) => void;
   onPageChange: (pagination: RuleRegistrySearchRequestPagination) => void;
   onSortChange: (sort: EuiDataGridSorting['columns']) => void;
   refresh: () => void;
@@ -412,30 +407,60 @@ export interface BulkActionsObjectProp {
 }
 
 export interface AlertsTableProps {
+  alertsTableConfiguration: AlertsTableConfigurationRegistry;
   columns: EuiDataGridColumn[];
   bulkActions: BulkActionsObjectProp;
   // defaultCellActions: TGridCellAction[];
   deletedEventIds: string[];
   disabledCellActions: string[];
+  flyoutState: AlertsTableFlyoutState;
   pageSize: number;
   pageSizeOptions: number[];
   leadingControlColumns: EuiDataGridControlColumn[];
-  renderCellValue: (props: RenderCellValueProps) => React.ReactNode;
   showCheckboxes: boolean;
+  showExpandToDetails: boolean;
   trailingControlColumns: EuiDataGridControlColumn[];
   useFetchAlertsData: () => FetchAlertData;
+  visibleColumns: string[];
   'data-test-subj': string;
 }
 
-export type RenderCellValueProps = EuiDataGridCellValueElementProps & {
-  alert: EcsFieldsResponse;
-  field: string;
-};
+// TODO We need to create generic type between our plugin, right now we have different one because of the old alerts table
+export type GetRenderCellValue = ({
+  setFlyoutAlert,
+}: {
+  setFlyoutAlert?: (data: unknown) => void;
+}) => (props: unknown) => React.ReactNode;
 
+export type AlertTableFlyoutComponent =
+  | React.FunctionComponent<AlertsTableFlyoutBaseProps>
+  | React.LazyExoticComponent<ComponentType<AlertsTableFlyoutBaseProps>>
+  | null;
 export interface AlertsTableConfigurationRegistry {
   id: string;
   columns: EuiDataGridColumn[];
+  externalFlyout?: {
+    header?: AlertTableFlyoutComponent;
+    body?: AlertTableFlyoutComponent;
+    footer?: AlertTableFlyoutComponent;
+  };
+  internalFlyout?: {
+    header?: AlertTableFlyoutComponent;
+    body?: AlertTableFlyoutComponent;
+    footer?: AlertTableFlyoutComponent;
+  };
   sort?: SortCombinations[];
+  getRenderCellValue?: GetRenderCellValue;
+}
+
+export interface AlertsTableFlyoutBaseProps {
+  alert: EcsFieldsResponse;
+  isLoading: boolean;
+}
+
+export enum AlertsTableFlyoutState {
+  internal = 'internal',
+  external = 'external',
 }
 
 export type RuleStatus = 'enabled' | 'disabled' | 'snoozed';

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alerts_table.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alerts_table.ts
@@ -10,6 +10,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
+  const browser = getService('browser');
   const PageObjects = getPageObjects(['common', 'triggersActionsUI', 'header']);
   const retry = getService('retry');
   const esArchiver = getService('esArchiver');
@@ -21,6 +22,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     });
     after(async () => {
       await esArchiver.unload('x-pack/test/functional/es_archives/observability/alerts');
+    });
+
+    afterEach(async () => {
+      await browser.clearLocalStorage();
     });
 
     it('should load the table', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[RAM] Allow plugins to configure alerts table flyout (#131401)](https://github.com/elastic/kibana/pull/131401)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)