### PR TITLE
update kibana-buildkite-library

### DIFF
--- a/.buildkite/package-lock.json
+++ b/.buildkite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kibana-buildkite",
       "version": "1.0.0",
       "dependencies": {
-        "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#ae4994aba5f2e72edcc5914e2aa208086e4b7ea3"
+        "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#4ecaba35293fb635cf92ca205ee84fca52f19e2e"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -264,9 +264,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
       "funding": [
         {
           "type": "individual",
@@ -368,8 +368,8 @@
     },
     "node_modules/kibana-buildkite-library": {
       "version": "1.0.0",
-      "resolved": "git+https://git@github.com/elastic/kibana-buildkite-library.git#ae4994aba5f2e72edcc5914e2aa208086e4b7ea3",
-      "integrity": "sha512-zvMwrJZ7kytbV/rFLMrcKlHGLxrR5G9+mzNqBwvCb0+RIfZ3Kp2IbPkPxqimps/2ipjWTqg92UMv0cGsZedbYQ==",
+      "resolved": "git+https://git@github.com/elastic/kibana-buildkite-library.git#4ecaba35293fb635cf92ca205ee84fca52f19e2e",
+      "integrity": "sha512-AjX3YyovsyYQ7MBoXQcHdyuFbnYZIChxr+gGApTFVNvJx4z9FeuKxQLKfDuONlZpNliHHgaenmf5APU/ZUqxVA==",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.10.0",
@@ -400,9 +400,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -777,9 +777,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
     },
     "glob-parent": {
       "version": "5.1.2",
@@ -839,9 +839,9 @@
       }
     },
     "kibana-buildkite-library": {
-      "version": "git+https://git@github.com/elastic/kibana-buildkite-library.git#ae4994aba5f2e72edcc5914e2aa208086e4b7ea3",
-      "integrity": "sha512-zvMwrJZ7kytbV/rFLMrcKlHGLxrR5G9+mzNqBwvCb0+RIfZ3Kp2IbPkPxqimps/2ipjWTqg92UMv0cGsZedbYQ==",
-      "from": "kibana-buildkite-library@git+https://git@github.com/elastic/kibana-buildkite-library#ae4994aba5f2e72edcc5914e2aa208086e4b7ea3",
+      "version": "git+https://git@github.com/elastic/kibana-buildkite-library.git#4ecaba35293fb635cf92ca205ee84fca52f19e2e",
+      "integrity": "sha512-AjX3YyovsyYQ7MBoXQcHdyuFbnYZIChxr+gGApTFVNvJx4z9FeuKxQLKfDuONlZpNliHHgaenmf5APU/ZUqxVA==",
+      "from": "kibana-buildkite-library@git+https://git@github.com/elastic/kibana-buildkite-library#4ecaba35293fb635cf92ca205ee84fca52f19e2e",
       "requires": {
         "@octokit/rest": "^18.10.0",
         "axios": "^0.21.4",
@@ -865,9 +865,9 @@
       }
     },
     "minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "requires": {
         "brace-expansion": "^2.0.1"
       }

--- a/.buildkite/package.json
+++ b/.buildkite/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#ae4994aba5f2e72edcc5914e2aa208086e4b7ea3"
+    "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#4ecaba35293fb635cf92ca205ee84fca52f19e2e"
   }
 }


### PR DESCRIPTION
Bumps to the latest version of the kibana-buildkite-library which enables automatic fallback for branches which have no test-group timing to pull timing data from the main branch directly. https://github.com/elastic/kibana-buildkite-library/commit/4ecaba35293fb635cf92ca205ee84fca52f19e2e