### PR TITLE
Add link to May contributors newsletter

### DIFF
--- a/nav-kibana-dev.docnav.json
+++ b/nav-kibana-dev.docnav.json
@@ -69,6 +69,7 @@
     {
       "label": "Contributors Newsletters",
       "items": [
+        { "id": "kibMay2022ContributorNewsletter" },
         { "id": "kibApril2022ContributorNewsletter" },
         { "id": "kibMarch2022ContributorNewsletter" },
         { "id": "kibFebruary2022ContributorNewsletter" },


### PR DESCRIPTION
Add link to May contributors newsletter.

<img width="911" alt="Screen Shot 2022-05-26 at 12 39 53 PM" src="https://user-images.githubusercontent.com/16563603/170533982-cb1fdd56-01ba-4060-9029-8cdf24966b20.png">

