### PR TITLE
[artifacts] Soft fail when Cloud dependencies are unavailable

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -53,6 +53,7 @@ steps:
 
   - command: KIBANA_DOCKER_CONTEXT=cloud .buildkite/scripts/steps/artifacts/docker_context.sh
     label: 'Docker Context Verification'
+    soft_fail: true
     agents:
       queue: n2-2
     timeout_in_minutes: 30
@@ -74,6 +75,7 @@ steps:
 
   - command: .buildkite/scripts/steps/artifacts/cloud.sh
     label: 'Cloud Deployment'
+    soft_fail: true
     agents:
       queue: n2-2
     timeout_in_minutes: 30

--- a/.buildkite/scripts/steps/artifacts/env.sh
+++ b/.buildkite/scripts/steps/artifacts/env.sh
@@ -22,7 +22,7 @@ if [[ "$RELEASE_BUILD" == "true" ]]; then
   WORKFLOW="staging"
 else
   FULL_VERSION="$QUALIFIER_VERSION-SNAPSHOT"
-  BUILD_ARGS="--version-qualifier=$VERSION_QUALIFIER"
+  BUILD_ARGS="--skip-docker-cloud --version-qualifier=$VERSION_QUALIFIER"
   WORKFLOW="snapshot"
 fi
 


### PR DESCRIPTION
There's currently a circular dependency between testing against Cloud and publishing our first set of artifacts.  When versions are bumped, we need to get our core packages published before testing can be made available.

This adds a soft failure mode for our Cloud tests when we build artifacts.