### PR TITLE
[8.3] [RAM] Use alert name in flyout header (#133038)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.test.tsx
@@ -121,7 +121,7 @@ describe('AlertsFlyout', () => {
         await nextTick();
         wrapper.update();
       });
-      expect(wrapper.find('h2').first().text()).toBe('Sample title');
+      expect(wrapper.find('h2').first().text()).toBe('one');
       expect(wrapper.find('h5').first().text()).toBe('Body');
     });
 
@@ -142,7 +142,7 @@ describe('AlertsFlyout', () => {
         await nextTick();
         wrapper.update();
       });
-      expect(wrapper.find('h2').first().text()).toBe('Sample title');
+      expect(wrapper.find('h2').first().text()).toBe('one');
       expect(wrapper.find('h5').first().text()).toBe('Body');
       expect(wrapper.find('h6').first().text()).toBe('Footer');
     });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout_header.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout_header.tsx
@@ -5,22 +5,16 @@
  * 2.0.
  */
 import React from 'react';
-import { i18n } from '@kbn/i18n';
+import { get } from 'lodash';
+import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import { EuiTitle } from '@elastic/eui';
 import { AlertsTableFlyoutBaseProps } from '../../../../types';
-
-const SAMPLE_TITLE_LABEL = i18n.translate(
-  'xpack.triggersActionsUI.sections.alertsTable.alertsFlyout.sampleTitle',
-  {
-    defaultMessage: 'Sample title',
-  }
-);
 
 type Props = AlertsTableFlyoutBaseProps;
 const AlertsFlyoutHeader = ({ alert }: Props) => {
   return (
     <EuiTitle size="m">
-      <h2>{SAMPLE_TITLE_LABEL}</h2>
+      <h2>{get(alert, ALERT_RULE_NAME)}</h2>
     </EuiTitle>
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[RAM] Use alert name in flyout header (#133038)](https://github.com/elastic/kibana/pull/133038)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)