### PR TITLE
[8.0] [plugin-helpers] Skip build.test.ts log matching on ci-stats service (#127560)

### DIFF
--- a/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
@@ -43,8 +43,14 @@ it('builds a generated plugin into a viable archive', async () => {
       all: true,
     }
   );
+  const filterLogs = (logs: string | undefined) => {
+    return logs
+      ?.split('\n')
+      .filter((l) => !l.includes('failed to reach ci-stats service'))
+      .join('\n');
+  };
 
-  expect(generateProc.all).toMatchInlineSnapshot(`
+  expect(filterLogs(generateProc.all)).toMatchInlineSnapshot(`
     " succ 🎉
 
           Your plugin has been created in plugins/foo_test_plugin
@@ -60,12 +66,7 @@ it('builds a generated plugin into a viable archive', async () => {
     }
   );
 
-  expect(
-    buildProc.all
-      ?.split('\n')
-      .filter((l) => !l.includes('failed to reach ci-stats service'))
-      .join('\n')
-  ).toMatchInlineSnapshot(`
+  expect(filterLogs(buildProc.all)).toMatchInlineSnapshot(`
     " info deleting the build and target directories
      info running @kbn/optimizer
      │ info initialized, 0 bundles cached


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[plugin-helpers] Skip build.test.ts log matching on ci-stats service (#127560)](https://github.com/elastic/kibana/pull/127560)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)