### PR TITLE
Skip CI when `dev_docs` or `.mdx` files are changed

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -18,6 +18,7 @@
       "skip_ci_labels": ["skip-ci", "jenkins-ci"],
       "skip_target_branches": ["6.8", "7.11", "7.12"],
       "skip_ci_on_only_changed": [
+        "^dev_docs/",
         "^docs/",
         "^rfcs/",
         "^.ci/.+\\.yml$",
@@ -26,6 +27,7 @@
         "^.ci/Jenkinsfile_[^/]+$",
         "^\\.github/",
         "\\.md$",
+        "\\.mdx$",
         "^\\.backportrc\\.json$",
         "^nav-kibana-dev\\.docnav\\.json$",
         "^src/dev/prs/kibana_qa_pr_list\\.json$",


### PR DESCRIPTION
I noticed that CI appears to be broken on the 8.0 branch which is preventing #132944 from merging.
However, that PR contains only docs changes and it shouldn't be triggering the `kibana-ci` actions anyway.

I updated the Buildkite config to skip CI when dev docs and/or MDX files are changed.

Note that this config was changed recently (in #132461), so backports for this PR will run into merge conflicts and will need to be manually fixed.