### PR TITLE
[8.2] remove human-readable automatic slug generation (#132593)

### DIFF
--- a/src/plugins/share/README.mdx
+++ b/src/plugins/share/README.mdx
@@ -215,19 +215,6 @@ const url = await shortUrls.create({
 });
 ```
 
-You can make the short URL slug human-readable by specifying the
-`humanReadableSlug` flag:
-
-```ts
-const url = await shortUrls.create({
-  locator,
-  params: {
-    dashboardId: '123',
-  },
-  humanReadableSlug: true,
-});
-```
-
 Or you can manually specify the slug for the short URL using the `slug` option:
 
 ```ts

--- a/src/plugins/share/common/url_service/short_urls/types.ts
+++ b/src/plugins/share/common/url_service/short_urls/types.ts
@@ -79,12 +79,6 @@ export interface ShortUrlCreateParams<P extends SerializableRecord> {
    * URL. This part will be visible to the user, it can have user-friendly text.
    */
   slug?: string;
-
-  /**
-   * Whether to generate a slug automatically. If `true`, the slug will be
-   * a human-readable text consisting of three worlds: "<adjective>-<adjective>-<noun>".
-   */
-  humanReadableSlug?: boolean;
 }
 
 /**

--- a/src/plugins/share/public/url_service/short_urls/short_url_client.test.ts
+++ b/src/plugins/share/public/url_service/short_urls/short_url_client.test.ts
@@ -88,7 +88,6 @@ describe('create()', () => {
       body: expect.any(String),
     });
     expect(JSON.parse(fetchSpy.mock.calls[0][1].body)).toStrictEqual({
-      humanReadableSlug: false,
       locatorId: LEGACY_SHORT_URL_LOCATOR_ID,
       params: {
         url: 'https://example.com/foo/bar',
@@ -173,7 +172,6 @@ describe('createFromLongUrl()', () => {
       body: expect.any(String),
     });
     expect(JSON.parse(fetchSpy.mock.calls[0][1].body)).toStrictEqual({
-      humanReadableSlug: true,
       locatorId: LEGACY_SHORT_URL_LOCATOR_ID,
       params: {
         url: '/a/b/c',

--- a/src/plugins/share/public/url_service/short_urls/short_url_client.ts
+++ b/src/plugins/share/public/url_service/short_urls/short_url_client.ts
@@ -59,7 +59,6 @@ export class BrowserShortUrlClient implements IShortUrlClient {
     locator,
     params,
     slug = undefined,
-    humanReadableSlug = false,
   }: ShortUrlCreateParams<P>): Promise<ShortUrl<P>> {
     const { http } = this.dependencies;
     const data = await http.fetch<ShortUrlData<P>>('/api/short_url', {
@@ -67,7 +66,6 @@ export class BrowserShortUrlClient implements IShortUrlClient {
       body: JSON.stringify({
         locatorId: locator.id,
         slug,
-        humanReadableSlug,
         params,
       }),
     });
@@ -113,7 +111,6 @@ export class BrowserShortUrlClient implements IShortUrlClient {
 
     const result = await this.createWithLocator({
       locator,
-      humanReadableSlug: true,
       params: {
         url: relativeUrl,
       },

--- a/src/plugins/share/server/url_service/http/short_urls/register_create_route.ts
+++ b/src/plugins/share/server/url_service/http/short_urls/register_create_route.ts
@@ -26,6 +26,15 @@ export const registerCreateRoute = (router: IRouter, url: ServerUrlService) => {
             minLength: 3,
             maxLength: 255,
           }),
+          /**
+           * @deprecated
+           *
+           * This field is deprecated as the API does not support automatic
+           * human-readable slug generation.
+           *
+           * @todo This field will be removed in a future version. It is left
+           * here for backwards compatibility.
+           */
           humanReadableSlug: schema.boolean({
             defaultValue: false,
           }),
@@ -36,7 +45,7 @@ export const registerCreateRoute = (router: IRouter, url: ServerUrlService) => {
     router.handleLegacyErrors(async (ctx, req, res) => {
       const savedObjects = ctx.core.savedObjects.client;
       const shortUrls = url.shortUrls.get({ savedObjects });
-      const { locatorId, params, slug, humanReadableSlug } = req.body;
+      const { locatorId, params, slug } = req.body;
       const locator = url.locators.get(locatorId);
 
       if (!locator) {
@@ -51,7 +60,6 @@ export const registerCreateRoute = (router: IRouter, url: ServerUrlService) => {
           locator,
           params,
           slug,
-          humanReadableSlug,
         });
 
         return res.ok({

--- a/src/plugins/share/server/url_service/short_urls/short_url_client.test.ts
+++ b/src/plugins/share/server/url_service/short_urls/short_url_client.test.ts
@@ -128,19 +128,6 @@ describe('ServerShortUrlClient', () => {
         })
       ).rejects.toThrowError(new UrlServiceError(`Slug "lala" already exists.`, 'SLUG_EXISTS'));
     });
-
-    test('can automatically generate human-readable slug', async () => {
-      const { client, locator } = setup();
-      const shortUrl = await client.create({
-        locator,
-        humanReadableSlug: true,
-        params: {
-          url: '/app/test#foo/bar/baz',
-        },
-      });
-
-      expect(shortUrl.data.slug.split('-').length).toBe(3);
-    });
   });
 
   describe('.get()', () => {

--- a/src/plugins/share/server/url_service/short_urls/short_url_client.ts
+++ b/src/plugins/share/server/url_service/short_urls/short_url_client.ts
@@ -8,7 +8,6 @@
 
 import type { SerializableRecord } from '@kbn/utility-types';
 import { SavedObjectReference } from 'kibana/server';
-import { generateSlug } from 'random-word-slugs';
 import { ShortUrlRecord } from '.';
 import type {
   IShortUrlClient,
@@ -60,14 +59,13 @@ export class ServerShortUrlClient implements IShortUrlClient {
     locator,
     params,
     slug = '',
-    humanReadableSlug = false,
   }: ShortUrlCreateParams<P>): Promise<ShortUrl<P>> {
     if (slug) {
       validateSlug(slug);
     }
 
     if (!slug) {
-      slug = humanReadableSlug ? generateSlug() : randomStr(4);
+      slug = randomStr(5);
     }
 
     const { storage, currentVersion } = this.dependencies;

--- a/test/api_integration/apis/short_url/create_short_url/main.ts
+++ b/test/api_integration/apis/short_url/create_short_url/main.ts
@@ -70,22 +70,6 @@ export default function ({ getService }: FtrProviderContext) {
         expect(response.body.url).to.be('');
       });
 
-      it('can generate a human-readable slug, composed of three words', async () => {
-        const response = await supertest.post('/api/short_url').send({
-          locatorId: 'LEGACY_SHORT_URL_LOCATOR',
-          params: {},
-          humanReadableSlug: true,
-        });
-
-        expect(response.status).to.be(200);
-        expect(typeof response.body.slug).to.be('string');
-        const words = response.body.slug.split('-');
-        expect(words.length).to.be(3);
-        for (const word of words) {
-          expect(word.length > 0).to.be(true);
-        }
-      });
-
       it('can create a short URL with custom slug', async () => {
         const rnd = Math.round(Math.random() * 1e6) + 1;
         const slug = 'test-slug-' + Date.now() + '-' + rnd;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [remove human-readable automatic slug generation (#132593)](https://github.com/elastic/kibana/pull/132593)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)