### PR TITLE
[7.17] remove human-readable automatic slug generation (#132593)

### DIFF
--- a/src/plugins/share/common/url_service/short_urls/types.ts
+++ b/src/plugins/share/common/url_service/short_urls/types.ts
@@ -78,12 +78,6 @@ export interface ShortUrlCreateParams<P extends SerializableRecord> {
    * URL. This part will be visible to the user, it can have user-friendly text.
    */
   slug?: string;
-
-  /**
-   * Whether to generate a slug automatically. If `true`, the slug will be
-   * a human-readable text consisting of three worlds: "<adjective>-<adjective>-<noun>".
-   */
-  humanReadableSlug?: boolean;
 }
 
 /**

--- a/src/plugins/share/server/url_service/http/short_urls/register_create_route.ts
+++ b/src/plugins/share/server/url_service/http/short_urls/register_create_route.ts
@@ -25,6 +25,15 @@ export const registerCreateRoute = (router: IRouter, url: ServerUrlService) => {
             minLength: 3,
             maxLength: 255,
           }),
+          /**
+           * @deprecated
+           *
+           * This field is deprecated as the API does not support automatic
+           * human-readable slug generation.
+           *
+           * @todo This field will be removed in a future version. It is left
+           * here for backwards compatibility.
+           */
           humanReadableSlug: schema.boolean({
             defaultValue: false,
           }),
@@ -35,7 +44,7 @@ export const registerCreateRoute = (router: IRouter, url: ServerUrlService) => {
     router.handleLegacyErrors(async (ctx, req, res) => {
       const savedObjects = ctx.core.savedObjects.client;
       const shortUrls = url.shortUrls.get({ savedObjects });
-      const { locatorId, params, slug, humanReadableSlug } = req.body;
+      const { locatorId, params, slug } = req.body;
       const locator = url.locators.get(locatorId);
 
       if (!locator) {
@@ -52,7 +61,6 @@ export const registerCreateRoute = (router: IRouter, url: ServerUrlService) => {
         locator,
         params,
         slug,
-        humanReadableSlug,
       });
 
       return res.ok({

--- a/src/plugins/share/server/url_service/short_urls/short_url_client.test.ts
+++ b/src/plugins/share/server/url_service/short_urls/short_url_client.test.ts
@@ -127,19 +127,6 @@ describe('ServerShortUrlClient', () => {
         })
       ).rejects.toThrowError(new Error(`Slug "lala" already exists.`));
     });
-
-    test('can automatically generate human-readable slug', async () => {
-      const { client, locator } = setup();
-      const shortUrl = await client.create({
-        locator,
-        humanReadableSlug: true,
-        params: {
-          url: '/app/test#foo/bar/baz',
-        },
-      });
-
-      expect(shortUrl.data.slug.split('-').length).toBe(3);
-    });
   });
 
   describe('.get()', () => {

--- a/src/plugins/share/server/url_service/short_urls/short_url_client.ts
+++ b/src/plugins/share/server/url_service/short_urls/short_url_client.ts
@@ -8,7 +8,6 @@
 
 import type { SerializableRecord } from '@kbn/utility-types';
 import { SavedObjectReference } from 'kibana/server';
-import { generateSlug } from 'random-word-slugs';
 import { ShortUrlRecord } from '.';
 import type {
   IShortUrlClient,
@@ -59,14 +58,13 @@ export class ServerShortUrlClient implements IShortUrlClient {
     locator,
     params,
     slug = '',
-    humanReadableSlug = false,
   }: ShortUrlCreateParams<P>): Promise<ShortUrl<P>> {
     if (slug) {
       validateSlug(slug);
     }
 
     if (!slug) {
-      slug = humanReadableSlug ? generateSlug() : randomStr(4);
+      slug = randomStr(5);
     }
 
     const { storage, currentVersion } = this.dependencies;

--- a/test/api_integration/apis/short_url/create_short_url/main.ts
+++ b/test/api_integration/apis/short_url/create_short_url/main.ts
@@ -70,22 +70,6 @@ export default function ({ getService }: FtrProviderContext) {
         expect(response.body.url).to.be('');
       });
 
-      it('can generate a human-readable slug, composed of three words', async () => {
-        const response = await supertest.post('/api/short_url').send({
-          locatorId: 'LEGACY_SHORT_URL_LOCATOR',
-          params: {},
-          humanReadableSlug: true,
-        });
-
-        expect(response.status).to.be(200);
-        expect(typeof response.body.slug).to.be('string');
-        const words = response.body.slug.split('-');
-        expect(words.length).to.be(3);
-        for (const word of words) {
-          expect(word.length > 0).to.be(true);
-        }
-      });
-
       it('can create a short URL with custom slug', async () => {
         const rnd = Math.round(Math.random() * 1e6) + 1;
         const slug = 'test-slug-' + Date.now() + '-' + rnd;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [remove human-readable automatic slug generation (#132593)](https://github.com/elastic/kibana/pull/132593)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)