### PR TITLE
[8.3] [FTR analytics] Unskip flaky tests (#132925)

### DIFF
--- a/test/analytics/__fixtures__/plugins/analytics_ftr_helpers/public/plugin.ts
+++ b/test/analytics/__fixtures__/plugins/analytics_ftr_helpers/public/plugin.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { ReplaySubject, firstValueFrom, filter, take, toArray } from 'rxjs';
+import { ReplaySubject, firstValueFrom, filter, take, toArray, map } from 'rxjs';
 import type { Plugin, CoreSetup, Event } from '@kbn/core/public';
 import { CustomShipper } from './custom_shipper';
 import './types';
@@ -31,7 +31,13 @@ export class AnalyticsFTRHelpers implements Plugin {
               return true;
             }),
             take(takeNumberOfEvents),
-            toArray()
+            toArray(),
+            // Sorting the events by timestamp... on CI it's happening an event may occur while the client is still forwarding the early ones...
+            map((_events) =>
+              _events.sort(
+                (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+              )
+            )
           )
         ),
     };

--- a/test/analytics/__fixtures__/plugins/analytics_ftr_helpers/server/plugin.ts
+++ b/test/analytics/__fixtures__/plugins/analytics_ftr_helpers/server/plugin.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { firstValueFrom, ReplaySubject, filter, take, toArray } from 'rxjs';
+import { firstValueFrom, ReplaySubject, filter, take, toArray, map } from 'rxjs';
 import { schema } from '@kbn/config-schema';
 import type { Plugin, CoreSetup, Event } from '@kbn/core/server';
 import { CustomShipper } from './custom_shipper';
@@ -60,7 +60,13 @@ export class AnalyticsFTRHelpers implements Plugin {
               return true;
             }),
             take(takeNumberOfEvents),
-            toArray()
+            toArray(),
+            // Sorting the events by timestamp... on CI it's happening an event may occur while the client is still forwarding the early ones...
+            map((_events) =>
+              _events.sort(
+                (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+              )
+            )
           )
         );
 

--- a/test/analytics/__fixtures__/plugins/analytics_plugin_a/server/plugin.ts
+++ b/test/analytics/__fixtures__/plugins/analytics_plugin_a/server/plugin.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { BehaviorSubject, firstValueFrom, ReplaySubject } from 'rxjs';
+import { BehaviorSubject, filter, firstValueFrom, ReplaySubject } from 'rxjs';
 import { takeWhile, tap, toArray } from 'rxjs/operators';
 import { schema } from '@kbn/config-schema';
 import type { Plugin, CoreSetup, CoreStart, TelemetryCounter, Event } from '@kbn/core/server';
@@ -90,11 +90,15 @@ export class AnalyticsPluginAPlugin implements Plugin {
         const actions = await firstValueFrom(
           actions$.pipe(
             takeWhile(() => !found),
-            tap(({ action, meta }) => {
-              found =
-                action === 'reportEvents' &&
-                meta.find((event: Event) => event.event_type === 'test-plugin-lifecycle');
+            tap((action) => {
+              found = isTestPluginLifecycleReportEventAction(action);
             }),
+            // Filter only the actions that are relevant to this plugin
+            filter(
+              ({ action, meta }) =>
+                ['optIn', 'extendContext'].includes(action) ||
+                isTestPluginLifecycleReportEventAction({ action, meta })
+            ),
             toArray()
           )
         );
@@ -124,4 +128,11 @@ export class AnalyticsPluginAPlugin implements Plugin {
   }
 
   public stop() {}
+}
+
+function isTestPluginLifecycleReportEventAction({ action, meta }: Action): boolean {
+  return (
+    action === 'reportEvents' &&
+    meta.find((event: Event) => event.event_type === 'test-plugin-lifecycle')
+  );
 }

--- a/test/analytics/tests/analytics_from_the_browser.ts
+++ b/test/analytics/tests/analytics_from_the_browser.ts
@@ -87,28 +87,17 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('after setting opt-in', () => {
       let actions: Action[];
-      let context: Action['meta'];
 
       before(async () => {
         actions = await getActions();
-        context = actions[1].meta;
-      });
-
-      it('it should extend the contexts with pid injected by "analytics_plugin_a"', () => {
-        // Validating the remote user_agent because that's the only field that it's added by the FTR plugin.
-        expect(context).to.have.property('user_agent');
-        expect(context.user_agent).to.be.a('string');
       });
 
       it('it calls optIn first, then extendContext, followed by reportEvents', async () => {
         const [optInAction, extendContextAction, ...reportEventsAction] = actions;
         expect(optInAction).to.eql({ action: 'optIn', meta: true });
-        expect(extendContextAction).to.eql({ action: 'extendContext', meta: context });
-        while (reportEventsAction[0].action === 'extendContext') {
-          // it could happen that a context provider emits a bit delayed
-          reportEventsAction.shift();
-        }
-        reportEventsAction.forEach((entry) => expect(entry.action).to.eql('reportEvents'));
+        expect(extendContextAction).to.have.property('action', 'extendContext');
+        // Checking `some` because there could be more `extendContext` actions for late context providers
+        expect(reportEventsAction.some((entry) => entry.action === 'reportEvents')).to.be(true);
       });
 
       it('Initial calls to reportEvents from cached events group the requests by event_type', async () => {
@@ -172,6 +161,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             properties: { plugin: 'analyticsPluginA', step: 'start' },
           },
         ]);
+      });
+
+      it('it should extend the contexts with pid injected by "analytics_plugin_a"', async () => {
+        const [event] = await ebtUIHelper.getLastEvents(1, ['test-plugin-lifecycle']);
+        // Validating the remote user_agent because that's the only field that it's added by the FTR plugin.
+        expect(event.context).to.have.property('user_agent');
+        expect(event.context.user_agent).to.be.a('string');
       });
     });
   });

--- a/test/analytics/tests/analytics_from_the_server.ts
+++ b/test/analytics/tests/analytics_from_the_server.ts
@@ -80,28 +80,17 @@ export default function ({ getService }: FtrProviderContext) {
 
     describe('after setting opt-in', () => {
       let actions: Action[];
-      let context: Action['meta'];
 
       before(async () => {
         actions = await getActions();
-        context = actions[1].meta;
-      });
-
-      it('it should extend the contexts with pid injected by "analytics_plugin_a"', async () => {
-        // Validating the remote PID because that's the only field that it's added by the FTR plugin.
-        expect(context).to.have.property('pid');
-        expect(context.pid).to.be.a('number');
       });
 
       it('it calls optIn first, then extendContext, followed by reportEvents', async () => {
         const [optInAction, extendContextAction, ...reportEventsAction] = actions;
         expect(optInAction).to.eql({ action: 'optIn', meta: true });
-        expect(extendContextAction).to.eql({ action: 'extendContext', meta: context });
-        while (reportEventsAction[0].action === 'extendContext') {
-          // it could happen that a context provider emits a bit delayed
-          reportEventsAction.shift();
-        }
-        reportEventsAction.forEach((entry) => expect(entry.action).to.eql('reportEvents'));
+        expect(extendContextAction).to.have.property('action', 'extendContext');
+        // Checking `some` because there could be more `extendContext` actions for late context providers
+        expect(reportEventsAction.some((entry) => entry.action === 'reportEvents')).to.be(true);
       });
 
       it('Initial calls to reportEvents from cached events group the requests by event_type', async () => {
@@ -165,6 +154,13 @@ export default function ({ getService }: FtrProviderContext) {
             properties: { plugin: 'analyticsPluginA', step: 'start' },
           },
         ]);
+      });
+
+      it('it should extend the contexts with pid injected by "analytics_plugin_a"', async () => {
+        const [event] = await ebtServerHelper.getLastEvents(1, ['test-plugin-lifecycle']);
+        // Validating the remote PID because that's the only field that it's added by the FTR plugin.
+        expect(event.context).to.have.property('pid');
+        expect(event.context.pid).to.be.a('number');
       });
     });
   });

--- a/test/analytics/tests/instrumented_events/from_the_server/core_context_providers.ts
+++ b/test/analytics/tests/instrumented_events/from_the_server/core_context_providers.ts
@@ -17,8 +17,13 @@ export default function ({ getService }: FtrProviderContext) {
   describe('Core Context Providers', () => {
     let event: Event;
     before(async () => {
-      // Wait for the 2nd "status_changed" event. At that point all the context providers should be set up.
-      [, event] = await ebtServerHelper.getLastEvents(2, ['core-overall_status_changed']);
+      let i = 2;
+      do {
+        // Wait until we get a GREEN "status_changed" event. At that point all the context providers should be set up.
+        const events = await ebtServerHelper.getLastEvents(i, ['core-overall_status_changed']);
+        event = events[i - 1];
+        i++;
+      } while (event.properties.overall_status_level !== 'available');
     });
 
     it('should have the properties provided by the "kibana info" context provider', () => {

--- a/test/analytics/tests/instrumented_events/from_the_server/core_overall_status_changed.ts
+++ b/test/analytics/tests/instrumented_events/from_the_server/core_overall_status_changed.ts
@@ -31,6 +31,7 @@ export default function ({ getService }: FtrProviderContext) {
         'Kibana is starting up'
       );
       expect(initialEvent.properties).to.have.property('overall_status_level', 'degraded');
+      expect(initialEvent.properties).to.have.property('overall_status_summary');
       expect(initialEvent.properties.overall_status_summary).to.be.a('string');
     });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[FTR analytics] Unskip flaky tests (#132925)](https://github.com/elastic/kibana/pull/132925)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)