### PR TITLE
Removed the search capabilities tour introduced in 8.2 release

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/feature_tour/README.md
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/feature_tour/README.md
@@ -9,32 +9,24 @@ to demonstrate on the Rule Management Page.
 
 The EUI Tour has evolved and continues to do so.
 
-EUI folks have implemented a new programming model for defining tour steps and binding them to
-UI elements on a page ([ticket][1], [PR][2]). When we revisit the Tour UI, we should build it
-differently - using the new `anchor` property and consolidating all the tour steps and logic
-in a single component. We shouldn't need to wrap the page with the provider anymore. And there's
-[a chance][3] that this implementation based on query selectors will have fewer UI glitches.
-
 New features and fixes to track:
 
-- Support for previous, next and go to step [#4831][4]
-- Built-in 'Next' button [#5715][5]
-- Popover on the EuiTour component doesn't respect the anchorPosition prop [#5731][6]
+- Support for previous, next and go to step [#4831][1]
+- Built-in 'Next' button [#5715][2]
 
 ## How to revive this tour for the next release (if needed)
 
 1. Update Kibana version in `RULES_MANAGEMENT_FEATURE_TOUR_STORAGE_KEY`.
   Set it to a version you're going to implement a feature tour for.
 
-1. Define steps for your tour. See `RulesFeatureTourContextProvider` and `stepsConfig`.
+2. Define the steps for your tour. See `RulesFeatureTour` and `stepsConfig`.
 
-1. Rewrite the implementation using the new `anchor` property and targeting UI elements
-  from steps using query selectors. Consolidate all the steps and their `<EuiTourStep>`
-  components in a single `RuleManagementPageFeatureTour` component. Render this component
-  in the Rule Management page. Get rid of `RulesFeatureTourContextProvider` - we shouldn't
-  need to wrap the page and pass anything down the tree anymore.
+3. Define and set an anchor `id` for every step's target HTML element. 
 
-1. Consider abstracting away persistence in Local Storage and other functionality that
+4. Render `RulesFeatureTour` component somewhere on the Rule Management page.
+   Only one instance of that component should be present on the page.
+
+5. Consider abstracting away persistence in Local Storage and other functionality that
   may be common to tours on different pages.
 
 ## Useful links
@@ -48,9 +40,5 @@ For reference, PRs where this Tour has been introduced or changed:
 
 <!-- Links -->
 
-[1]: https://github.com/elastic/kibana/issues/124052
-[2]: https://github.com/elastic/eui/pull/5696
-[3]: https://github.com/elastic/eui/issues/5731#issuecomment-1075202910
-[4]: https://github.com/elastic/eui/issues/4831
-[5]: https://github.com/elastic/eui/issues/5715
-[6]: https://github.com/elastic/eui/issues/5731
+[1]: https://github.com/elastic/eui/issues/4831
+[2]: https://github.com/elastic/eui/issues/5715

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.tsx
@@ -8,7 +8,6 @@
 import { EuiSpacer } from '@elastic/eui';
 import React, { useState } from 'react';
 import { CreatePreBuiltRules } from '../../../../containers/detection_engine/rules';
-import { RulesFeatureTour } from './feature_tour/rules_feature_tour';
 import { RulesTables } from './rules_tables';
 import { AllRulesTabs, RulesTableToolbar } from './rules_table_toolbar';
 
@@ -46,7 +45,6 @@ export const AllRules = React.memo<AllRulesProps>(
 
     return (
       <>
-        <RulesFeatureTour />
         <RulesTableToolbar activeTab={activeTab} onTabChange={setActiveTab} />
         <EuiSpacer />
         <RulesTables

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_filters/rules_table_filters.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_filters/rules_table_filters.tsx
@@ -16,7 +16,6 @@ import { isEqual } from 'lodash/fp';
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import * as i18n from '../../translations';
-import { SEARCH_CAPABILITIES_TOUR_ANCHOR } from '../feature_tour/rules_feature_tour';
 import { useRulesTableContext } from '../rules_table/rules_table_context';
 import { TagsFilterPopover } from './tags_filter_popover';
 
@@ -81,7 +80,6 @@ const RulesTableFiltersComponent = ({
     <FilterWrapper gutterSize="m" justifyContent="flexEnd">
       <SearchBarWrapper grow>
         <EuiFieldSearch
-          id={SEARCH_CAPABILITIES_TOUR_ANCHOR}
           aria-label={i18n.SEARCH_RULES}
           fullWidth
           incremental={false}


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/133065**

## Summary

- Remove the Tour UI we added to the Rule Management page to highlight the new search capabilities in the rules table, including filtering by index patterns and MITRE Attack fields.
- Updated Readme on how to use the Tour component
- The 8.2 tour steps were kept for future references


