### PR TITLE
Fix All Users and All Hosts page should reset the current page when sorting

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/pagination/pagination.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/pagination/pagination.spec.ts
@@ -11,98 +11,141 @@ import {
 } from '../../screens/hosts/uncommon_processes';
 import { FIRST_PAGE_SELECTOR, SECOND_PAGE_SELECTOR } from '../../screens/pagination';
 import { esArchiverLoad, esArchiverUnload } from '../../tasks/es_archiver';
-
 import { waitsForEventsToBeLoaded } from '../../tasks/hosts/events';
 import { openEvents, openUncommonProcesses } from '../../tasks/hosts/main';
 import { waitForUncommonProcessesToBeLoaded } from '../../tasks/hosts/uncommon_processes';
 import { login, visit } from '../../tasks/login';
-import { goToFirstPage, goToSecondPage } from '../../tasks/pagination';
+import { goToFirstPage, goToSecondPage, sortFirstColumn } from '../../tasks/pagination';
 import { refreshPage } from '../../tasks/security_header';
-
-import { HOSTS_PAGE_TAB_URLS } from '../../urls/navigation';
+import { HOSTS_URL, USERS_URL, HOSTS_PAGE_TAB_URLS } from '../../urls/navigation';
+import { ALL_HOSTS_TABLE } from '../../screens/hosts/all_hosts';
+import { ALL_USERS_TABLE } from '../../screens/users/all_users';
 
 describe('Pagination', () => {
   before(() => {
-    esArchiverLoad('host_uncommon_processes');
     login();
-    visit(HOSTS_PAGE_TAB_URLS.uncommonProcesses);
-    waitForUncommonProcessesToBeLoaded();
-  });
-  after(() => {
-    esArchiverUnload('host_uncommon_processes');
   });
 
-  afterEach(() => {
-    goToFirstPage();
+  describe('Host uncommon processes table)', () => {
+    before(() => {
+      esArchiverLoad('host_uncommon_processes');
+      visit(HOSTS_PAGE_TAB_URLS.uncommonProcesses);
+      waitForUncommonProcessesToBeLoaded();
+    });
+    after(() => {
+      esArchiverUnload('host_uncommon_processes');
+    });
+
+    afterEach(() => {
+      goToFirstPage();
+    });
+
+    it('pagination updates results and page number', () => {
+      cy.get(UNCOMMON_PROCESSES_TABLE)
+        .find(FIRST_PAGE_SELECTOR)
+        .should('have.class', 'euiPaginationButton-isActive');
+
+      cy.get(UNCOMMON_PROCESSES_TABLE)
+        .find(PROCESS_NAME_FIELD)
+        .first()
+        .invoke('text')
+        .then((processNameFirstPage) => {
+          goToSecondPage();
+          waitForUncommonProcessesToBeLoaded();
+          cy.get(UNCOMMON_PROCESSES_TABLE)
+            .find(PROCESS_NAME_FIELD)
+            .first()
+            .invoke('text')
+            .should((processNameSecondPage) => {
+              expect(processNameFirstPage).not.to.eq(processNameSecondPage);
+            });
+        });
+      cy.get(UNCOMMON_PROCESSES_TABLE)
+        .find(FIRST_PAGE_SELECTOR)
+        .should('not.have.class', 'euiPaginationButton-isActive');
+      cy.get(UNCOMMON_PROCESSES_TABLE)
+        .find(SECOND_PAGE_SELECTOR)
+        .should('have.class', 'euiPaginationButton-isActive');
+    });
+
+    it('pagination keeps track of page results when tabs change', () => {
+      cy.get(UNCOMMON_PROCESSES_TABLE)
+        .find(FIRST_PAGE_SELECTOR)
+        .should('have.class', 'euiPaginationButton-isActive');
+      goToSecondPage();
+      waitForUncommonProcessesToBeLoaded();
+
+      cy.get(PROCESS_NAME_FIELD)
+        .first()
+        .invoke('text')
+        .then((expectedThirdPageResult) => {
+          openEvents();
+          waitsForEventsToBeLoaded();
+          cy.get(FIRST_PAGE_SELECTOR).should('have.class', 'euiPaginationButton-isActive');
+          openUncommonProcesses();
+          waitForUncommonProcessesToBeLoaded();
+          cy.get(SECOND_PAGE_SELECTOR).should('have.class', 'euiPaginationButton-isActive');
+          cy.get(PROCESS_NAME_FIELD)
+            .first()
+            .invoke('text')
+            .should((actualThirdPageResult) => {
+              expect(expectedThirdPageResult).to.eq(actualThirdPageResult);
+            });
+        });
+    });
+
+    it('pagination resets results and page number to first page when refresh is clicked', () => {
+      cy.get(UNCOMMON_PROCESSES_TABLE)
+        .find(FIRST_PAGE_SELECTOR)
+        .should('have.class', 'euiPaginationButton-isActive');
+      goToSecondPage();
+      waitForUncommonProcessesToBeLoaded();
+      cy.get(UNCOMMON_PROCESSES_TABLE)
+        .find(FIRST_PAGE_SELECTOR)
+        .should('not.have.class', 'euiPaginationButton-isActive');
+      refreshPage();
+      waitForUncommonProcessesToBeLoaded();
+      cy.get(UNCOMMON_PROCESSES_TABLE)
+        .find(FIRST_PAGE_SELECTOR)
+        .should('have.class', 'euiPaginationButton-isActive');
+    });
   });
 
-  it('pagination updates results and page number', () => {
-    cy.get(UNCOMMON_PROCESSES_TABLE)
-      .find(FIRST_PAGE_SELECTOR)
-      .should('have.class', 'euiPaginationButton-isActive');
+  describe('All users and all Hosts tables', () => {
+    before(() => {
+      esArchiverLoad('all_users');
+    });
 
-    cy.get(UNCOMMON_PROCESSES_TABLE)
-      .find(PROCESS_NAME_FIELD)
-      .first()
-      .invoke('text')
-      .then((processNameFirstPage) => {
-        goToSecondPage();
-        waitForUncommonProcessesToBeLoaded();
-        cy.get(UNCOMMON_PROCESSES_TABLE)
-          .find(PROCESS_NAME_FIELD)
-          .first()
-          .invoke('text')
-          .should((processNameSecondPage) => {
-            expect(processNameFirstPage).not.to.eq(processNameSecondPage);
-          });
-      });
-    cy.get(UNCOMMON_PROCESSES_TABLE)
-      .find(FIRST_PAGE_SELECTOR)
-      .should('not.have.class', 'euiPaginationButton-isActive');
-    cy.get(UNCOMMON_PROCESSES_TABLE)
-      .find(SECOND_PAGE_SELECTOR)
-      .should('have.class', 'euiPaginationButton-isActive');
-  });
+    after(() => {
+      esArchiverUnload('all_users');
+    });
 
-  it('pagination keeps track of page results when tabs change', () => {
-    cy.get(UNCOMMON_PROCESSES_TABLE)
-      .find(FIRST_PAGE_SELECTOR)
-      .should('have.class', 'euiPaginationButton-isActive');
-    goToSecondPage();
-    waitForUncommonProcessesToBeLoaded();
+    it(`reset all Hosts pagination when sorting column`, () => {
+      visit(HOSTS_URL);
+      goToSecondPage();
+      cy.get(ALL_HOSTS_TABLE)
+        .find(FIRST_PAGE_SELECTOR)
+        .should('not.have.class', 'euiPaginationButton-isActive');
 
-    cy.get(PROCESS_NAME_FIELD)
-      .first()
-      .invoke('text')
-      .then((expectedThirdPageResult) => {
-        openEvents();
-        waitsForEventsToBeLoaded();
-        cy.get(FIRST_PAGE_SELECTOR).should('have.class', 'euiPaginationButton-isActive');
-        openUncommonProcesses();
-        waitForUncommonProcessesToBeLoaded();
-        cy.get(SECOND_PAGE_SELECTOR).should('have.class', 'euiPaginationButton-isActive');
-        cy.get(PROCESS_NAME_FIELD)
-          .first()
-          .invoke('text')
-          .should((actualThirdPageResult) => {
-            expect(expectedThirdPageResult).to.eq(actualThirdPageResult);
-          });
-      });
-  });
+      sortFirstColumn();
 
-  it('pagination resets results and page number to first page when refresh is clicked', () => {
-    cy.get(UNCOMMON_PROCESSES_TABLE)
-      .find(FIRST_PAGE_SELECTOR)
-      .should('have.class', 'euiPaginationButton-isActive');
-    goToSecondPage();
-    waitForUncommonProcessesToBeLoaded();
-    cy.get(UNCOMMON_PROCESSES_TABLE)
-      .find(FIRST_PAGE_SELECTOR)
-      .should('not.have.class', 'euiPaginationButton-isActive');
-    refreshPage();
-    waitForUncommonProcessesToBeLoaded();
-    cy.get(UNCOMMON_PROCESSES_TABLE)
-      .find(FIRST_PAGE_SELECTOR)
-      .should('have.class', 'euiPaginationButton-isActive');
+      cy.get(ALL_HOSTS_TABLE)
+        .find(FIRST_PAGE_SELECTOR)
+        .should('have.class', 'euiPaginationButton-isActive');
+    });
+
+    it(`reset all users pagination when sorting column`, () => {
+      visit(USERS_URL);
+      goToSecondPage();
+      cy.get(ALL_USERS_TABLE)
+        .find(FIRST_PAGE_SELECTOR)
+        .should('not.have.class', 'euiPaginationButton-isActive');
+
+      sortFirstColumn();
+
+      cy.get(ALL_USERS_TABLE)
+        .find(FIRST_PAGE_SELECTOR)
+        .should('have.class', 'euiPaginationButton-isActive');
+    });
   });
 });

--- a/x-pack/plugins/security_solution/cypress/screens/pagination.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/pagination.ts
@@ -7,3 +7,4 @@
 
 export const FIRST_PAGE_SELECTOR = '[data-test-subj="pagination-button-0"]';
 export const SECOND_PAGE_SELECTOR = '[data-test-subj="pagination-button-1"]';
+export const SORT_BTN = '[data-test-subj="tableHeaderSortButton"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/pagination.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/pagination.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FIRST_PAGE_SELECTOR, SECOND_PAGE_SELECTOR } from '../screens/pagination';
+import { FIRST_PAGE_SELECTOR, SECOND_PAGE_SELECTOR, SORT_BTN } from '../screens/pagination';
 
 export const goToFirstPage = () => {
   cy.get(FIRST_PAGE_SELECTOR).last().click({ force: true });
@@ -13,4 +13,8 @@ export const goToFirstPage = () => {
 
 export const goToSecondPage = () => {
   cy.get(SECOND_PAGE_SELECTOR).last().click({ force: true });
+};
+
+export const sortFirstColumn = () => {
+  cy.get(SORT_BTN).first().click();
 };

--- a/x-pack/plugins/security_solution/public/hosts/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/hosts/store/reducer.ts
@@ -165,6 +165,7 @@ export const hostsReducer = reducerWithInitialState(initialHostsState)
           ...state[hostsType].queries[HostsTableType.hosts],
           direction: sort.direction,
           sortField: sort.field,
+          activePage: DEFAULT_TABLE_ACTIVE_PAGE,
         },
       },
     },

--- a/x-pack/plugins/security_solution/public/users/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/users/store/reducer.ts
@@ -114,6 +114,7 @@ export const usersReducer = reducerWithInitialState(initialUsersState)
         [tableType]: {
           ...state.page.queries[tableType],
           sort,
+          activePage: DEFAULT_TABLE_ACTIVE_PAGE,
         },
       },
     },

--- a/x-pack/test/security_solution_cypress/es_archives/all_users/data.json
+++ b/x-pack/test/security_solution_cypress/es_archives/all_users/data.json
@@ -1,0 +1,265 @@
+{
+  "type": "doc",
+  "value": {
+    "id": "_aZE5nwBOpWiDweSth_1",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "505",
+        "name" : "test1"
+      },
+      "host": {
+        "name": "test-host1"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "_aZE5nwBOpWiDweSth_2",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "505",
+        "name" : "test2"
+      },
+      "host": {
+        "name": "test-host2"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "_aZE5nwBOpWiDweSth_3",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "505",
+        "name" : "test3"
+      },
+      "host": {
+        "name": "test-host3"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "_aZE5nwBOpWiDweSth_4",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "505",
+        "name" : "test4"
+      },
+      "host": {
+        "name": "test-host4"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "_aZE5nwBOpWiDweSth_5",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "505",
+        "name" : "test5"
+      },
+      "host": {
+        "name": "test-host5"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "_aZE5nwBOpWiDweSth_6",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "505",
+        "name" : "test6"
+      },
+      "host": {
+        "name": "test-host6"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "_aZE5nwBOpWiDweSth_7",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "505",
+        "name" : "test7"
+      },
+      "host": {
+        "name": "test-host7"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "_aZE5nwBOpWiDweSth_8",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "505",
+        "name" : "test8"
+      },
+      "host": {
+        "name": "test-host8"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}
+
+
+{
+  "type": "doc",
+  "value": {
+    "id": "AsHnFIEB0n46H1MqOpz1",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "108",
+        "name" : "elasticsearch"
+      },
+      "host": {
+        "name": "test-host9"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}
+
+
+{
+  "type": "doc",
+  "value": {
+    "id": "AsHnFIEB0n46H1MqOpz2",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "0",
+        "name" : "root"
+      },
+      "host": {
+        "name": "test-host10"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "AsHnFIEB0n46H1MqOpz3",
+    "index": "auditbeat-users-2022",
+    "source": {
+      "@timestamp" : "2022-02-04T19:41:33.045Z",      
+      "user" : {
+        "id" : "107",
+        "name" : "redis"
+      },
+      "host": {
+        "name": "test-host11"
+      },
+      "service" : {
+        "type" : "system"
+      },
+      "ecs" : {
+        "version" : "8.0.0"
+      }
+    }
+  }
+}

--- a/x-pack/test/security_solution_cypress/es_archives/all_users/mappings.json
+++ b/x-pack/test/security_solution_cypress/es_archives/all_users/mappings.json
@@ -1,0 +1,7854 @@
+{
+  "type": "index",
+  "value": {
+    "aliases": {
+      "auditbeat": {
+        "is_write_index": false
+      }
+    },
+    "settings": {
+      "index": {
+        "refresh_interval": "5s"
+      },
+      "index.mapping.total_fields.limit": 2000
+    },
+    "index": "auditbeat-users-2022",
+    "mappings": {
+      "date_detection": false,
+      "dynamic_templates" : [
+        {
+          "labels" : {
+            "path_match" : "labels.*",
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        {
+          "container.labels" : {
+            "path_match" : "container.labels.*",
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        {
+          "fields" : {
+            "path_match" : "fields.*",
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        {
+          "docker.container.labels" : {
+            "path_match" : "docker.container.labels.*",
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        {
+          "kubernetes.labels.*" : {
+            "path_match" : "kubernetes.labels.*",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        {
+          "kubernetes.annotations.*" : {
+            "path_match" : "kubernetes.annotations.*",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        {
+          "kubernetes.selectors.*" : {
+            "path_match" : "kubernetes.selectors.*",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        {
+          "strings_as_keyword" : {
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "ignore_above" : 1024,
+              "type" : "keyword"
+            }
+          }
+        }
+      ],
+      "properties" : {
+        "@timestamp" : {
+          "type" : "date"
+        },
+        "agent" : {
+          "properties" : {
+            "build" : {
+              "properties" : {
+                "original" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "ephemeral_id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "hostname" : {
+              "type" : "alias",
+              "path" : "agent.name"
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "as" : {
+          "properties" : {
+            "number" : {
+              "type" : "long"
+            },
+            "organization" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "auditd" : {
+          "properties" : {
+            "data" : {
+              "properties" : {
+                "a0" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "a1" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "a2" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "a3" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "a[0-3]" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "acct" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "acl" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "action" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "added" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "addr" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "apparmor" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "arch" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "argc" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "audit_backlog_limit" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "audit_backlog_wait_time" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "audit_enabled" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "audit_failure" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "banners" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "bool" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "bus" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cap_fe" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cap_fi" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cap_fp" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cap_fver" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cap_pe" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cap_pi" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cap_pp" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "capability" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cgroup" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "changed" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cipher" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "class" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cmd" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "compat" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "daddr" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "data" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "default-context" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "device" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "dir" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "direction" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "dmac" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "dport" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "enforcing" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "entries" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "exit" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "fam" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "family" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "fd" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "fe" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "feature" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "fi" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "file" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "flags" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "format" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "fp" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "fver" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "grantors" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "grp" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "hook" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "hostname" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "icmp_type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "igid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "img-ctx" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "inif" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ino" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "inode_gid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "inode_uid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "invalid_context" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ioctlcmd" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ip" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ipid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ipx-net" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "items" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "iuid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "kernel" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "kind" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ksize" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "laddr" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "len" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "list" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "lport" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "mac" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "macproto" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "maj" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "major" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "minor" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "model" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "msg" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "nargs" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "net" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-chardev" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-disk" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-enabled" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-fs" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-level" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-log_passwd" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-mem" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-net" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-range" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-rng" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-role" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-seuser" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new-vcpu" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new_gid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new_lock" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new_pe" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new_pi" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "new_pp" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "nlnk-fam" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "nlnk-grp" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "nlnk-pid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "oauid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "obj" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "obj_gid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "obj_uid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ocomm" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "oflag" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-auid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-chardev" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-disk" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-enabled" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-fs" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-level" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-log_passwd" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-mem" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-net" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-range" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-rng" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-role" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-ses" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-seuser" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old-vcpu" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old_enforcing" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old_lock" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old_pe" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old_pi" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old_pp" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old_prom" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "old_val" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "op" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "opid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "oses" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "outif" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "parent" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "per" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "perm" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "perm_mask" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "permissive" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "pfs" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "printer" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "prom" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "proto" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "qbytes" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "range" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "reason" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "removed" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "res" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "resrc" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "rport" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sauid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "scontext" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "selected-context" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "seperm" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "seperms" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "seqno" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "seresult" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ses" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "seuser" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sig" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sigev_signo" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "smac" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "socket" : {
+                  "properties" : {
+                    "addr" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "family" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "path" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "port" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "saddr" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "spid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sport" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "state" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "subj" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "success" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "syscall" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "table" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "tclass" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "tcontext" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "terminal" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "tty" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "unit" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "uri" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "uuid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "val" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ver" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "virt" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "vm" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "vm-ctx" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "vm-pid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "watch" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "message_type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "paths" : {
+              "properties" : {
+                "dev" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "inode" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "item" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "mode" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "nametype" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "obj_domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "obj_level" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "obj_role" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "obj_user" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "objtype" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ogid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ouid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "rdev" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "result" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sequence" : {
+              "type" : "long"
+            },
+            "session" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "summary" : {
+              "properties" : {
+                "actor" : {
+                  "properties" : {
+                    "primary" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "secondary" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "how" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "object" : {
+                  "properties" : {
+                    "primary" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "secondary" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "client" : {
+          "properties" : {
+            "address" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "as" : {
+              "properties" : {
+                "number" : {
+                  "type" : "long"
+                },
+                "organization" : {
+                  "properties" : {
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "bytes" : {
+              "type" : "long"
+            },
+            "domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "geo" : {
+              "properties" : {
+                "city_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "location" : {
+                  "type" : "geo_point"
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "postal_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "timezone" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "ip" : {
+              "type" : "ip"
+            },
+            "mac" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "nat" : {
+              "properties" : {
+                "ip" : {
+                  "type" : "ip"
+                },
+                "port" : {
+                  "type" : "long"
+                }
+              }
+            },
+            "packets" : {
+              "type" : "long"
+            },
+            "port" : {
+              "type" : "long"
+            },
+            "registered_domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "subdomain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "top_level_domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "user" : {
+              "properties" : {
+                "domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "email" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "full_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "group" : {
+                  "properties" : {
+                    "domain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "hash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "roles" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            }
+          }
+        },
+        "cloud" : {
+          "properties" : {
+            "account" : {
+              "properties" : {
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "availability_zone" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "image" : {
+              "properties" : {
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "instance" : {
+              "properties" : {
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "machine" : {
+              "properties" : {
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "origin" : {
+              "properties" : {
+                "account" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "availability_zone" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "instance" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "machine" : {
+                  "properties" : {
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "project" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "provider" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "service" : {
+                  "properties" : {
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            },
+            "project" : {
+              "properties" : {
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "provider" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "region" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "service" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "target" : {
+              "properties" : {
+                "account" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "availability_zone" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "instance" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "machine" : {
+                  "properties" : {
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "project" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "provider" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "service" : {
+                  "properties" : {
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "code_signature" : {
+          "properties" : {
+            "digest_algorithm" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "exists" : {
+              "type" : "boolean"
+            },
+            "signing_id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "status" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "subject_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "team_id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "timestamp" : {
+              "type" : "date"
+            },
+            "trusted" : {
+              "type" : "boolean"
+            },
+            "valid" : {
+              "type" : "boolean"
+            }
+          }
+        },
+        "container" : {
+          "properties" : {
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "image" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "tag" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "labels" : {
+              "type" : "object"
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "runtime" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "data_stream" : {
+          "properties" : {
+            "dataset" : {
+              "type" : "constant_keyword"
+            },
+            "namespace" : {
+              "type" : "constant_keyword"
+            },
+            "type" : {
+              "type" : "constant_keyword"
+            }
+          }
+        },
+        "destination" : {
+          "properties" : {
+            "address" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "as" : {
+              "properties" : {
+                "number" : {
+                  "type" : "long"
+                },
+                "organization" : {
+                  "properties" : {
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "bytes" : {
+              "type" : "long"
+            },
+            "domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "geo" : {
+              "properties" : {
+                "city_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "location" : {
+                  "type" : "geo_point"
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "postal_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "timezone" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "ip" : {
+              "type" : "ip"
+            },
+            "mac" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "nat" : {
+              "properties" : {
+                "ip" : {
+                  "type" : "ip"
+                },
+                "port" : {
+                  "type" : "long"
+                }
+              }
+            },
+            "packets" : {
+              "type" : "long"
+            },
+            "path" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "port" : {
+              "type" : "long"
+            },
+            "registered_domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "subdomain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "top_level_domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "user" : {
+              "properties" : {
+                "domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "email" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "full_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "group" : {
+                  "properties" : {
+                    "domain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "hash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "roles" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            }
+          }
+        },
+        "dll" : {
+          "properties" : {
+            "code_signature" : {
+              "properties" : {
+                "digest_algorithm" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "exists" : {
+                  "type" : "boolean"
+                },
+                "signing_id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "status" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "subject_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "team_id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "timestamp" : {
+                  "type" : "date"
+                },
+                "trusted" : {
+                  "type" : "boolean"
+                },
+                "valid" : {
+                  "type" : "boolean"
+                }
+              }
+            },
+            "hash" : {
+              "properties" : {
+                "md5" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha1" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha256" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha512" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ssdeep" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "path" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "pe" : {
+              "properties" : {
+                "architecture" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "company" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "description" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "file_version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "imphash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "original_file_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "product" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            }
+          }
+        },
+        "dns" : {
+          "properties" : {
+            "answers" : {
+              "properties" : {
+                "class" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "data" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ttl" : {
+                  "type" : "long"
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "header_flags" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "op_code" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "question" : {
+              "properties" : {
+                "class" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "registered_domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "subdomain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "top_level_domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "resolved_ip" : {
+              "type" : "ip"
+            },
+            "response_code" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "docker" : {
+          "properties" : {
+            "container" : {
+              "properties" : {
+                "labels" : {
+                  "type" : "object"
+                }
+              }
+            }
+          }
+        },
+        "ecs" : {
+          "properties" : {
+            "version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "elf" : {
+          "properties" : {
+            "architecture" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "byte_order" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "cpu_type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "creation_date" : {
+              "type" : "date"
+            },
+            "exports" : {
+              "type" : "flattened"
+            },
+            "header" : {
+              "properties" : {
+                "abi_version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "class" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "data" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "entrypoint" : {
+                  "type" : "long"
+                },
+                "object_version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "os_abi" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "imports" : {
+              "type" : "flattened"
+            },
+            "sections" : {
+              "type" : "nested",
+              "properties" : {
+                "chi2" : {
+                  "type" : "long"
+                },
+                "entropy" : {
+                  "type" : "long"
+                },
+                "flags" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "physical_offset" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "physical_size" : {
+                  "type" : "long"
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "virtual_address" : {
+                  "type" : "long"
+                },
+                "virtual_size" : {
+                  "type" : "long"
+                }
+              }
+            },
+            "segments" : {
+              "type" : "nested",
+              "properties" : {
+                "sections" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "shared_libraries" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "telfhash" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "error" : {
+          "properties" : {
+            "code" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "message" : {
+              "type" : "match_only_text"
+            },
+            "stack_trace" : {
+              "type" : "wildcard",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "event" : {
+          "properties" : {
+            "action" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "agent_id_status" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "category" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "code" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "created" : {
+              "type" : "date"
+            },
+            "dataset" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "duration" : {
+              "type" : "long"
+            },
+            "end" : {
+              "type" : "date"
+            },
+            "hash" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "ingested" : {
+              "type" : "date"
+            },
+            "kind" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "module" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "origin" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "original" : {
+              "type" : "keyword",
+              "index" : false,
+              "doc_values" : false,
+              "ignore_above" : 1024
+            },
+            "outcome" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "provider" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "reason" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "reference" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "risk_score" : {
+              "type" : "float"
+            },
+            "risk_score_norm" : {
+              "type" : "float"
+            },
+            "sequence" : {
+              "type" : "long"
+            },
+            "severity" : {
+              "type" : "long"
+            },
+            "start" : {
+              "type" : "date"
+            },
+            "timezone" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "url" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "faas" : {
+          "properties" : {
+            "coldstart" : {
+              "type" : "boolean"
+            },
+            "execution" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "trigger" : {
+              "type" : "nested",
+              "properties" : {
+                "request_id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            }
+          }
+        },
+        "fields" : {
+          "type" : "object"
+        },
+        "file" : {
+          "properties" : {
+            "accessed" : {
+              "type" : "date"
+            },
+            "attributes" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "code_signature" : {
+              "properties" : {
+                "digest_algorithm" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "exists" : {
+                  "type" : "boolean"
+                },
+                "signing_id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "status" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "subject_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "team_id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "timestamp" : {
+                  "type" : "date"
+                },
+                "trusted" : {
+                  "type" : "boolean"
+                },
+                "valid" : {
+                  "type" : "boolean"
+                }
+              }
+            },
+            "created" : {
+              "type" : "date"
+            },
+            "ctime" : {
+              "type" : "date"
+            },
+            "device" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "directory" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "drive_letter" : {
+              "type" : "keyword",
+              "ignore_above" : 1
+            },
+            "elf" : {
+              "properties" : {
+                "architecture" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "byte_order" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cpu_type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "creation_date" : {
+                  "type" : "date"
+                },
+                "exports" : {
+                  "type" : "flattened"
+                },
+                "header" : {
+                  "properties" : {
+                    "abi_version" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "class" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "data" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "entrypoint" : {
+                      "type" : "long"
+                    },
+                    "object_version" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "os_abi" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "version" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "imports" : {
+                  "type" : "flattened"
+                },
+                "sections" : {
+                  "type" : "nested",
+                  "properties" : {
+                    "chi2" : {
+                      "type" : "long"
+                    },
+                    "entropy" : {
+                      "type" : "long"
+                    },
+                    "flags" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "physical_offset" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "physical_size" : {
+                      "type" : "long"
+                    },
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "virtual_address" : {
+                      "type" : "long"
+                    },
+                    "virtual_size" : {
+                      "type" : "long"
+                    }
+                  }
+                },
+                "segments" : {
+                  "type" : "nested",
+                  "properties" : {
+                    "sections" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "shared_libraries" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "telfhash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "extension" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "fork_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "gid" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "group" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "hash" : {
+              "properties" : {
+                "md5" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha1" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha256" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha512" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ssdeep" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "inode" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "mime_type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "mode" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "mtime" : {
+              "type" : "date"
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "origin" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "text",
+                  "norms" : false
+                }
+              }
+            },
+            "owner" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "path" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "pe" : {
+              "properties" : {
+                "architecture" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "company" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "description" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "file_version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "imphash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "original_file_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "product" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "selinux" : {
+              "properties" : {
+                "domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "level" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "role" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "user" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "setgid" : {
+              "type" : "boolean"
+            },
+            "setuid" : {
+              "type" : "boolean"
+            },
+            "size" : {
+              "type" : "long"
+            },
+            "target_path" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "uid" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "x509" : {
+              "properties" : {
+                "alternative_names" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "issuer" : {
+                  "properties" : {
+                    "common_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "country" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "distinguished_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "locality" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "organization" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "organizational_unit" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "state_or_province" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "not_after" : {
+                  "type" : "date"
+                },
+                "not_before" : {
+                  "type" : "date"
+                },
+                "public_key_algorithm" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "public_key_curve" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "public_key_exponent" : {
+                  "type" : "long",
+                  "index" : false,
+                  "doc_values" : false
+                },
+                "public_key_size" : {
+                  "type" : "long"
+                },
+                "serial_number" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "signature_algorithm" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "subject" : {
+                  "properties" : {
+                    "common_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "country" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "distinguished_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "locality" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "organization" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "organizational_unit" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "state_or_province" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "version_number" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            }
+          }
+        },
+        "geo" : {
+          "properties" : {
+            "city_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "continent_code" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "continent_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "country_iso_code" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "country_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "location" : {
+              "type" : "geo_point"
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "postal_code" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "region_iso_code" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "region_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "timezone" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "geoip" : {
+          "properties" : {
+            "city_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "continent_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "country_iso_code" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "location" : {
+              "type" : "geo_point"
+            },
+            "region_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "group" : {
+          "properties" : {
+            "domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "hash" : {
+          "properties" : {
+            "blake2b_256" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "blake2b_384" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "blake2b_512" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "md5" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha1" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha224" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha256" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha384" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha3_224" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha3_256" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha3_384" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha3_512" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha512" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha512_224" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "sha512_256" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "ssdeep" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "xxh64" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "host" : {
+          "properties" : {
+            "architecture" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "containerized" : {
+              "type" : "boolean"
+            },
+            "cpu" : {
+              "properties" : {
+                "usage" : {
+                  "type" : "scaled_float",
+                  "scaling_factor" : 1000.0
+                }
+              }
+            },
+            "disk" : {
+              "properties" : {
+                "read" : {
+                  "properties" : {
+                    "bytes" : {
+                      "type" : "long"
+                    }
+                  }
+                },
+                "write" : {
+                  "properties" : {
+                    "bytes" : {
+                      "type" : "long"
+                    }
+                  }
+                }
+              }
+            },
+            "domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "geo" : {
+              "properties" : {
+                "city_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "location" : {
+                  "type" : "geo_point"
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "postal_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "timezone" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "hostname" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "ip" : {
+              "type" : "ip"
+            },
+            "mac" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "network" : {
+              "properties" : {
+                "egress" : {
+                  "properties" : {
+                    "bytes" : {
+                      "type" : "long"
+                    },
+                    "packets" : {
+                      "type" : "long"
+                    }
+                  }
+                },
+                "ingress" : {
+                  "properties" : {
+                    "bytes" : {
+                      "type" : "long"
+                    },
+                    "packets" : {
+                      "type" : "long"
+                    }
+                  }
+                }
+              }
+            },
+            "os" : {
+              "properties" : {
+                "build" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "codename" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "family" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "full" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "kernel" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "platform" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "uptime" : {
+              "type" : "long"
+            }
+          }
+        },
+        "http" : {
+          "properties" : {
+            "request" : {
+              "properties" : {
+                "body" : {
+                  "properties" : {
+                    "bytes" : {
+                      "type" : "long"
+                    },
+                    "content" : {
+                      "type" : "wildcard",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    }
+                  }
+                },
+                "bytes" : {
+                  "type" : "long"
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "method" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "mime_type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "referrer" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "response" : {
+              "properties" : {
+                "body" : {
+                  "properties" : {
+                    "bytes" : {
+                      "type" : "long"
+                    },
+                    "content" : {
+                      "type" : "wildcard",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    }
+                  }
+                },
+                "bytes" : {
+                  "type" : "long"
+                },
+                "mime_type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "status_code" : {
+                  "type" : "long"
+                }
+              }
+            },
+            "version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "interface" : {
+          "properties" : {
+            "alias" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "jolokia" : {
+          "properties" : {
+            "agent" : {
+              "properties" : {
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "secured" : {
+              "type" : "boolean"
+            },
+            "server" : {
+              "properties" : {
+                "product" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "vendor" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "url" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "kubernetes" : {
+          "properties" : {
+            "annotations" : {
+              "properties" : {
+                "*" : {
+                  "type" : "object"
+                }
+              }
+            },
+            "container" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "deployment" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "labels" : {
+              "properties" : {
+                "*" : {
+                  "type" : "object"
+                }
+              }
+            },
+            "namespace" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "node" : {
+              "properties" : {
+                "hostname" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "pod" : {
+              "properties" : {
+                "ip" : {
+                  "type" : "ip"
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "uid" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "replicaset" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "selectors" : {
+              "properties" : {
+                "*" : {
+                  "type" : "object"
+                }
+              }
+            },
+            "statefulset" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            }
+          }
+        },
+        "labels" : {
+          "type" : "object"
+        },
+        "log" : {
+          "properties" : {
+            "file" : {
+              "properties" : {
+                "path" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "level" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "logger" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "origin" : {
+              "properties" : {
+                "file" : {
+                  "properties" : {
+                    "line" : {
+                      "type" : "long"
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "function" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "syslog" : {
+              "properties" : {
+                "facility" : {
+                  "properties" : {
+                    "code" : {
+                      "type" : "long"
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "priority" : {
+                  "type" : "long"
+                },
+                "severity" : {
+                  "properties" : {
+                    "code" : {
+                      "type" : "long"
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "message" : {
+          "type" : "match_only_text"
+        },
+        "network" : {
+          "properties" : {
+            "application" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "bytes" : {
+              "type" : "long"
+            },
+            "community_id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "direction" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "forwarded_ip" : {
+              "type" : "ip"
+            },
+            "iana_number" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "inner" : {
+              "properties" : {
+                "vlan" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "packets" : {
+              "type" : "long"
+            },
+            "protocol" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "transport" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "vlan" : {
+              "properties" : {
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            }
+          }
+        },
+        "observer" : {
+          "properties" : {
+            "egress" : {
+              "properties" : {
+                "interface" : {
+                  "properties" : {
+                    "alias" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "vlan" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "zone" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "geo" : {
+              "properties" : {
+                "city_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "location" : {
+                  "type" : "geo_point"
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "postal_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "timezone" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "hostname" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "ingress" : {
+              "properties" : {
+                "interface" : {
+                  "properties" : {
+                    "alias" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "vlan" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "zone" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "ip" : {
+              "type" : "ip"
+            },
+            "mac" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "os" : {
+              "properties" : {
+                "family" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "full" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "kernel" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "platform" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "product" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "serial_number" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "vendor" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "orchestrator" : {
+          "properties" : {
+            "api_version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "cluster" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "url" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "namespace" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "organization" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "resource" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "organization" : {
+          "properties" : {
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            }
+          }
+        },
+        "os" : {
+          "properties" : {
+            "family" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "full" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "kernel" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "platform" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "package" : {
+          "properties" : {
+            "architecture" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "build_version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "checksum" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "description" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "install_scope" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "installed" : {
+              "type" : "date"
+            },
+            "license" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "path" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "reference" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "size" : {
+              "type" : "long"
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "pe" : {
+          "properties" : {
+            "architecture" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "company" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "description" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "file_version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "imphash" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "original_file_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "product" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "process" : {
+          "properties" : {
+            "args" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "args_count" : {
+              "type" : "long"
+            },
+            "code_signature" : {
+              "properties" : {
+                "digest_algorithm" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "exists" : {
+                  "type" : "boolean"
+                },
+                "signing_id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "status" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "subject_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "team_id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "timestamp" : {
+                  "type" : "date"
+                },
+                "trusted" : {
+                  "type" : "boolean"
+                },
+                "valid" : {
+                  "type" : "boolean"
+                }
+              }
+            },
+            "command_line" : {
+              "type" : "wildcard",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "elf" : {
+              "properties" : {
+                "architecture" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "byte_order" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "cpu_type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "creation_date" : {
+                  "type" : "date"
+                },
+                "exports" : {
+                  "type" : "flattened"
+                },
+                "header" : {
+                  "properties" : {
+                    "abi_version" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "class" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "data" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "entrypoint" : {
+                      "type" : "long"
+                    },
+                    "object_version" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "os_abi" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "version" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "imports" : {
+                  "type" : "flattened"
+                },
+                "sections" : {
+                  "type" : "nested",
+                  "properties" : {
+                    "chi2" : {
+                      "type" : "long"
+                    },
+                    "entropy" : {
+                      "type" : "long"
+                    },
+                    "flags" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "physical_offset" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "physical_size" : {
+                      "type" : "long"
+                    },
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "virtual_address" : {
+                      "type" : "long"
+                    },
+                    "virtual_size" : {
+                      "type" : "long"
+                    }
+                  }
+                },
+                "segments" : {
+                  "type" : "nested",
+                  "properties" : {
+                    "sections" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "shared_libraries" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "telfhash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "end" : {
+              "type" : "date"
+            },
+            "entity_id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "executable" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "exit_code" : {
+              "type" : "long"
+            },
+            "hash" : {
+              "properties" : {
+                "blake2b_256" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "blake2b_384" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "blake2b_512" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "md5" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha1" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha224" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha256" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha384" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha3_224" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha3_256" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha3_384" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha3_512" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha512" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha512_224" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "sha512_256" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ssdeep" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "xxh64" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "owner" : {
+              "properties" : {
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "text",
+                      "norms" : false
+                    }
+                  }
+                }
+              }
+            },
+            "parent" : {
+              "properties" : {
+                "args" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "args_count" : {
+                  "type" : "long"
+                },
+                "code_signature" : {
+                  "properties" : {
+                    "digest_algorithm" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "exists" : {
+                      "type" : "boolean"
+                    },
+                    "signing_id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "status" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "subject_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "team_id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "timestamp" : {
+                      "type" : "date"
+                    },
+                    "trusted" : {
+                      "type" : "boolean"
+                    },
+                    "valid" : {
+                      "type" : "boolean"
+                    }
+                  }
+                },
+                "command_line" : {
+                  "type" : "wildcard",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "elf" : {
+                  "properties" : {
+                    "architecture" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "byte_order" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "cpu_type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "creation_date" : {
+                      "type" : "date"
+                    },
+                    "exports" : {
+                      "type" : "flattened"
+                    },
+                    "header" : {
+                      "properties" : {
+                        "abi_version" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "class" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "data" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "entrypoint" : {
+                          "type" : "long"
+                        },
+                        "object_version" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "os_abi" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "type" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "version" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "imports" : {
+                      "type" : "flattened"
+                    },
+                    "sections" : {
+                      "type" : "nested",
+                      "properties" : {
+                        "chi2" : {
+                          "type" : "long"
+                        },
+                        "entropy" : {
+                          "type" : "long"
+                        },
+                        "flags" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "physical_offset" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "physical_size" : {
+                          "type" : "long"
+                        },
+                        "type" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "virtual_address" : {
+                          "type" : "long"
+                        },
+                        "virtual_size" : {
+                          "type" : "long"
+                        }
+                      }
+                    },
+                    "segments" : {
+                      "type" : "nested",
+                      "properties" : {
+                        "sections" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "type" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "shared_libraries" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "telfhash" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "end" : {
+                  "type" : "date"
+                },
+                "entity_id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "executable" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "exit_code" : {
+                  "type" : "long"
+                },
+                "hash" : {
+                  "properties" : {
+                    "md5" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "sha1" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "sha256" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "sha512" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "ssdeep" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "pe" : {
+                  "properties" : {
+                    "architecture" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "company" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "description" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "file_version" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "imphash" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "original_file_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "product" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "pgid" : {
+                  "type" : "long"
+                },
+                "pid" : {
+                  "type" : "long"
+                },
+                "start" : {
+                  "type" : "date"
+                },
+                "thread" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "long"
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "title" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "uptime" : {
+                  "type" : "long"
+                },
+                "working_directory" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                }
+              }
+            },
+            "pe" : {
+              "properties" : {
+                "architecture" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "company" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "description" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "file_version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "imphash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "original_file_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "product" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "pgid" : {
+              "type" : "long"
+            },
+            "pid" : {
+              "type" : "long"
+            },
+            "start" : {
+              "type" : "date"
+            },
+            "thread" : {
+              "properties" : {
+                "id" : {
+                  "type" : "long"
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "title" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "uptime" : {
+              "type" : "long"
+            },
+            "working_directory" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            }
+          }
+        },
+        "registry" : {
+          "properties" : {
+            "data" : {
+              "properties" : {
+                "bytes" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "strings" : {
+                  "type" : "wildcard",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "hive" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "key" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "path" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "value" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "related" : {
+          "properties" : {
+            "hash" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "hosts" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "ip" : {
+              "type" : "ip"
+            },
+            "user" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "rule" : {
+          "properties" : {
+            "author" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "category" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "description" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "license" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "reference" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "ruleset" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "uuid" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "server" : {
+          "properties" : {
+            "address" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "as" : {
+              "properties" : {
+                "number" : {
+                  "type" : "long"
+                },
+                "organization" : {
+                  "properties" : {
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "bytes" : {
+              "type" : "long"
+            },
+            "domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "geo" : {
+              "properties" : {
+                "city_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "location" : {
+                  "type" : "geo_point"
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "postal_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "timezone" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "ip" : {
+              "type" : "ip"
+            },
+            "mac" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "nat" : {
+              "properties" : {
+                "ip" : {
+                  "type" : "ip"
+                },
+                "port" : {
+                  "type" : "long"
+                }
+              }
+            },
+            "packets" : {
+              "type" : "long"
+            },
+            "port" : {
+              "type" : "long"
+            },
+            "registered_domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "subdomain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "top_level_domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "user" : {
+              "properties" : {
+                "domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "email" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "full_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "group" : {
+                  "properties" : {
+                    "domain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "hash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "roles" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            }
+          }
+        },
+        "service" : {
+          "properties" : {
+            "address" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "environment" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "ephemeral_id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "node" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "origin" : {
+              "properties" : {
+                "address" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "environment" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ephemeral_id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "node" : {
+                  "properties" : {
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "state" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "state" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "target" : {
+              "properties" : {
+                "address" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "environment" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ephemeral_id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "node" : {
+                  "properties" : {
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "state" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "type" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "socket" : {
+          "properties" : {
+            "entity_id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "source" : {
+          "properties" : {
+            "address" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "as" : {
+              "properties" : {
+                "number" : {
+                  "type" : "long"
+                },
+                "organization" : {
+                  "properties" : {
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "bytes" : {
+              "type" : "long"
+            },
+            "domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "geo" : {
+              "properties" : {
+                "city_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "continent_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "location" : {
+                  "type" : "geo_point"
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "postal_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_iso_code" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "region_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "timezone" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "ip" : {
+              "type" : "ip"
+            },
+            "mac" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "nat" : {
+              "properties" : {
+                "ip" : {
+                  "type" : "ip"
+                },
+                "port" : {
+                  "type" : "long"
+                }
+              }
+            },
+            "packets" : {
+              "type" : "long"
+            },
+            "path" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "port" : {
+              "type" : "long"
+            },
+            "registered_domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "subdomain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "top_level_domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "user" : {
+              "properties" : {
+                "domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "email" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "full_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "group" : {
+                  "properties" : {
+                    "domain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "hash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "roles" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            }
+          }
+        },
+        "span" : {
+          "properties" : {
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "system" : {
+          "properties" : {
+            "audit" : {
+              "properties" : {
+                "host" : {
+                  "properties" : {
+                    "architecture" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "boottime" : {
+                      "type" : "date"
+                    },
+                    "containerized" : {
+                      "type" : "boolean"
+                    },
+                    "hostname" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "ip" : {
+                      "type" : "ip"
+                    },
+                    "mac" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "os" : {
+                      "properties" : {
+                        "codename" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "family" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "kernel" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "platform" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "type" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "version" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "timezone" : {
+                      "properties" : {
+                        "name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "offset" : {
+                          "properties" : {
+                            "sec" : {
+                              "type" : "long"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "uptime" : {
+                      "type" : "long"
+                    }
+                  }
+                },
+                "package" : {
+                  "properties" : {
+                    "arch" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "entity_id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "installtime" : {
+                      "type" : "date"
+                    },
+                    "license" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "release" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "size" : {
+                      "type" : "long"
+                    },
+                    "summary" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "url" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "version" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "user" : {
+                  "properties" : {
+                    "dir" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "gid" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "group" : {
+                      "type" : "object"
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "password" : {
+                      "properties" : {
+                        "last_changed" : {
+                          "type" : "date"
+                        },
+                        "type" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "shell" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "uid" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "user_information" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : {
+          "type" : "keyword",
+          "ignore_above" : 1024
+        },
+        "threat" : {
+          "properties" : {
+            "enrichments" : {
+              "type" : "nested",
+              "properties" : {
+                "indicator" : {
+                  "properties" : {
+                    "as" : {
+                      "properties" : {
+                        "number" : {
+                          "type" : "long"
+                        },
+                        "organization" : {
+                          "properties" : {
+                            "name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024,
+                              "fields" : {
+                                "text" : {
+                                  "type" : "match_only_text"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "confidence" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "description" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "email" : {
+                      "properties" : {
+                        "address" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "file" : {
+                      "properties" : {
+                        "accessed" : {
+                          "type" : "date"
+                        },
+                        "attributes" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "code_signature" : {
+                          "properties" : {
+                            "digest_algorithm" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "exists" : {
+                              "type" : "boolean"
+                            },
+                            "signing_id" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "status" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "subject_name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "team_id" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "timestamp" : {
+                              "type" : "date"
+                            },
+                            "trusted" : {
+                              "type" : "boolean"
+                            },
+                            "valid" : {
+                              "type" : "boolean"
+                            }
+                          }
+                        },
+                        "created" : {
+                          "type" : "date"
+                        },
+                        "ctime" : {
+                          "type" : "date"
+                        },
+                        "device" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "directory" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "drive_letter" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1
+                        },
+                        "elf" : {
+                          "properties" : {
+                            "architecture" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "byte_order" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "cpu_type" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "creation_date" : {
+                              "type" : "date"
+                            },
+                            "exports" : {
+                              "type" : "flattened"
+                            },
+                            "header" : {
+                              "properties" : {
+                                "abi_version" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "class" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "data" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "entrypoint" : {
+                                  "type" : "long"
+                                },
+                                "object_version" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "os_abi" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "type" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "version" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                }
+                              }
+                            },
+                            "imports" : {
+                              "type" : "flattened"
+                            },
+                            "sections" : {
+                              "type" : "nested",
+                              "properties" : {
+                                "chi2" : {
+                                  "type" : "long"
+                                },
+                                "entropy" : {
+                                  "type" : "long"
+                                },
+                                "flags" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "name" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "physical_offset" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "physical_size" : {
+                                  "type" : "long"
+                                },
+                                "type" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "virtual_address" : {
+                                  "type" : "long"
+                                },
+                                "virtual_size" : {
+                                  "type" : "long"
+                                }
+                              }
+                            },
+                            "segments" : {
+                              "type" : "nested",
+                              "properties" : {
+                                "sections" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "type" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                }
+                              }
+                            },
+                            "shared_libraries" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "telfhash" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        },
+                        "extension" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "fork_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "gid" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "group" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "hash" : {
+                          "properties" : {
+                            "md5" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "sha1" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "sha256" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "sha512" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "ssdeep" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        },
+                        "inode" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "mime_type" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "mode" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "mtime" : {
+                          "type" : "date"
+                        },
+                        "name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "owner" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "path" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024,
+                          "fields" : {
+                            "text" : {
+                              "type" : "match_only_text"
+                            }
+                          }
+                        },
+                        "pe" : {
+                          "properties" : {
+                            "architecture" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "company" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "description" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "file_version" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "imphash" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "original_file_name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "product" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        },
+                        "size" : {
+                          "type" : "long"
+                        },
+                        "target_path" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024,
+                          "fields" : {
+                            "text" : {
+                              "type" : "match_only_text"
+                            }
+                          }
+                        },
+                        "type" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "uid" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "x509" : {
+                          "properties" : {
+                            "alternative_names" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "issuer" : {
+                              "properties" : {
+                                "common_name" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "country" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "distinguished_name" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "locality" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "organization" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "organizational_unit" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "state_or_province" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                }
+                              }
+                            },
+                            "not_after" : {
+                              "type" : "date"
+                            },
+                            "not_before" : {
+                              "type" : "date"
+                            },
+                            "public_key_algorithm" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "public_key_curve" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "public_key_exponent" : {
+                              "type" : "long",
+                              "index" : false,
+                              "doc_values" : false
+                            },
+                            "public_key_size" : {
+                              "type" : "long"
+                            },
+                            "serial_number" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "signature_algorithm" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "subject" : {
+                              "properties" : {
+                                "common_name" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "country" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "distinguished_name" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "locality" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "organization" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "organizational_unit" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                },
+                                "state_or_province" : {
+                                  "type" : "keyword",
+                                  "ignore_above" : 1024
+                                }
+                              }
+                            },
+                            "version_number" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "first_seen" : {
+                      "type" : "date"
+                    },
+                    "geo" : {
+                      "properties" : {
+                        "city_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "continent_code" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "continent_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "country_iso_code" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "country_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "location" : {
+                          "type" : "geo_point"
+                        },
+                        "name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "postal_code" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "region_iso_code" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "region_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "timezone" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "ip" : {
+                      "type" : "ip"
+                    },
+                    "last_seen" : {
+                      "type" : "date"
+                    },
+                    "marking" : {
+                      "properties" : {
+                        "tlp" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "modified_at" : {
+                      "type" : "date"
+                    },
+                    "port" : {
+                      "type" : "long"
+                    },
+                    "provider" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "reference" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "registry" : {
+                      "properties" : {
+                        "data" : {
+                          "properties" : {
+                            "bytes" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "strings" : {
+                              "type" : "wildcard",
+                              "ignore_above" : 1024
+                            },
+                            "type" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        },
+                        "hive" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "key" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "path" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "value" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "scanner_stats" : {
+                      "type" : "long"
+                    },
+                    "sightings" : {
+                      "type" : "long"
+                    },
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "url" : {
+                      "properties" : {
+                        "domain" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "extension" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "fragment" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "full" : {
+                          "type" : "wildcard",
+                          "ignore_above" : 1024,
+                          "fields" : {
+                            "text" : {
+                              "type" : "match_only_text"
+                            }
+                          }
+                        },
+                        "original" : {
+                          "type" : "wildcard",
+                          "ignore_above" : 1024,
+                          "fields" : {
+                            "text" : {
+                              "type" : "match_only_text"
+                            }
+                          }
+                        },
+                        "password" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "path" : {
+                          "type" : "wildcard",
+                          "ignore_above" : 1024
+                        },
+                        "port" : {
+                          "type" : "long"
+                        },
+                        "query" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "registered_domain" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "scheme" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "subdomain" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "top_level_domain" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "username" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "x509" : {
+                      "properties" : {
+                        "alternative_names" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "issuer" : {
+                          "properties" : {
+                            "common_name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "country" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "distinguished_name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "locality" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "organization" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "organizational_unit" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "state_or_province" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        },
+                        "not_after" : {
+                          "type" : "date"
+                        },
+                        "not_before" : {
+                          "type" : "date"
+                        },
+                        "public_key_algorithm" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "public_key_curve" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "public_key_exponent" : {
+                          "type" : "long",
+                          "index" : false,
+                          "doc_values" : false
+                        },
+                        "public_key_size" : {
+                          "type" : "long"
+                        },
+                        "serial_number" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "signature_algorithm" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "subject" : {
+                          "properties" : {
+                            "common_name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "country" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "distinguished_name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "locality" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "organization" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "organizational_unit" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "state_or_province" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        },
+                        "version_number" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    }
+                  }
+                },
+                "matched" : {
+                  "properties" : {
+                    "atomic" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "field" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "index" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            },
+            "framework" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "group" : {
+              "properties" : {
+                "alias" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "reference" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "indicator" : {
+              "properties" : {
+                "as" : {
+                  "properties" : {
+                    "number" : {
+                      "type" : "long"
+                    },
+                    "organization" : {
+                      "properties" : {
+                        "name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024,
+                          "fields" : {
+                            "text" : {
+                              "type" : "match_only_text"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "confidence" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "description" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "email" : {
+                  "properties" : {
+                    "address" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "file" : {
+                  "properties" : {
+                    "accessed" : {
+                      "type" : "date"
+                    },
+                    "attributes" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "code_signature" : {
+                      "properties" : {
+                        "digest_algorithm" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "exists" : {
+                          "type" : "boolean"
+                        },
+                        "signing_id" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "status" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "subject_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "team_id" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "timestamp" : {
+                          "type" : "date"
+                        },
+                        "trusted" : {
+                          "type" : "boolean"
+                        },
+                        "valid" : {
+                          "type" : "boolean"
+                        }
+                      }
+                    },
+                    "created" : {
+                      "type" : "date"
+                    },
+                    "ctime" : {
+                      "type" : "date"
+                    },
+                    "device" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "directory" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "drive_letter" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1
+                    },
+                    "elf" : {
+                      "properties" : {
+                        "architecture" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "byte_order" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "cpu_type" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "creation_date" : {
+                          "type" : "date"
+                        },
+                        "exports" : {
+                          "type" : "flattened"
+                        },
+                        "header" : {
+                          "properties" : {
+                            "abi_version" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "class" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "data" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "entrypoint" : {
+                              "type" : "long"
+                            },
+                            "object_version" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "os_abi" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "type" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "version" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        },
+                        "imports" : {
+                          "type" : "flattened"
+                        },
+                        "sections" : {
+                          "type" : "nested",
+                          "properties" : {
+                            "chi2" : {
+                              "type" : "long"
+                            },
+                            "entropy" : {
+                              "type" : "long"
+                            },
+                            "flags" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "physical_offset" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "physical_size" : {
+                              "type" : "long"
+                            },
+                            "type" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "virtual_address" : {
+                              "type" : "long"
+                            },
+                            "virtual_size" : {
+                              "type" : "long"
+                            }
+                          }
+                        },
+                        "segments" : {
+                          "type" : "nested",
+                          "properties" : {
+                            "sections" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "type" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        },
+                        "shared_libraries" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "telfhash" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "extension" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "fork_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "gid" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "group" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "hash" : {
+                      "properties" : {
+                        "md5" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "sha1" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "sha256" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "sha512" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "ssdeep" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "inode" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "mime_type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "mode" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "mtime" : {
+                      "type" : "date"
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "owner" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "path" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    },
+                    "pe" : {
+                      "properties" : {
+                        "architecture" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "company" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "description" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "file_version" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "imphash" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "original_file_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "product" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "size" : {
+                      "type" : "long"
+                    },
+                    "target_path" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    },
+                    "type" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "uid" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "x509" : {
+                      "properties" : {
+                        "alternative_names" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "issuer" : {
+                          "properties" : {
+                            "common_name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "country" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "distinguished_name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "locality" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "organization" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "organizational_unit" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "state_or_province" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        },
+                        "not_after" : {
+                          "type" : "date"
+                        },
+                        "not_before" : {
+                          "type" : "date"
+                        },
+                        "public_key_algorithm" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "public_key_curve" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "public_key_exponent" : {
+                          "type" : "long",
+                          "index" : false,
+                          "doc_values" : false
+                        },
+                        "public_key_size" : {
+                          "type" : "long"
+                        },
+                        "serial_number" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "signature_algorithm" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "subject" : {
+                          "properties" : {
+                            "common_name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "country" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "distinguished_name" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "locality" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "organization" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "organizational_unit" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            },
+                            "state_or_province" : {
+                              "type" : "keyword",
+                              "ignore_above" : 1024
+                            }
+                          }
+                        },
+                        "version_number" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    }
+                  }
+                },
+                "first_seen" : {
+                  "type" : "date"
+                },
+                "geo" : {
+                  "properties" : {
+                    "city_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "continent_code" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "continent_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "country_iso_code" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "country_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "location" : {
+                      "type" : "geo_point"
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "postal_code" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "region_iso_code" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "region_name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "timezone" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "ip" : {
+                  "type" : "ip"
+                },
+                "last_seen" : {
+                  "type" : "date"
+                },
+                "marking" : {
+                  "properties" : {
+                    "tlp" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "modified_at" : {
+                  "type" : "date"
+                },
+                "port" : {
+                  "type" : "long"
+                },
+                "provider" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "reference" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "registry" : {
+                  "properties" : {
+                    "data" : {
+                      "properties" : {
+                        "bytes" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "strings" : {
+                          "type" : "wildcard",
+                          "ignore_above" : 1024
+                        },
+                        "type" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "hive" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "key" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "path" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "value" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "scanner_stats" : {
+                  "type" : "long"
+                },
+                "sightings" : {
+                  "type" : "long"
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "url" : {
+                  "properties" : {
+                    "domain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "extension" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "fragment" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "full" : {
+                      "type" : "wildcard",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    },
+                    "original" : {
+                      "type" : "wildcard",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    },
+                    "password" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "path" : {
+                      "type" : "wildcard",
+                      "ignore_above" : 1024
+                    },
+                    "port" : {
+                      "type" : "long"
+                    },
+                    "query" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "registered_domain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "scheme" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "subdomain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "top_level_domain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "username" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "x509" : {
+                  "properties" : {
+                    "alternative_names" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "issuer" : {
+                      "properties" : {
+                        "common_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "country" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "distinguished_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "locality" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organization" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organizational_unit" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "state_or_province" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "not_after" : {
+                      "type" : "date"
+                    },
+                    "not_before" : {
+                      "type" : "date"
+                    },
+                    "public_key_algorithm" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "public_key_curve" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "public_key_exponent" : {
+                      "type" : "long",
+                      "index" : false,
+                      "doc_values" : false
+                    },
+                    "public_key_size" : {
+                      "type" : "long"
+                    },
+                    "serial_number" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "signature_algorithm" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "subject" : {
+                      "properties" : {
+                        "common_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "country" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "distinguished_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "locality" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organization" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organizational_unit" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "state_or_province" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "version_number" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            },
+            "software" : {
+              "properties" : {
+                "alias" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "platforms" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "reference" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "tactic" : {
+              "properties" : {
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "reference" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "technique" : {
+              "properties" : {
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "reference" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "subtechnique" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024,
+                      "fields" : {
+                        "text" : {
+                          "type" : "match_only_text"
+                        }
+                      }
+                    },
+                    "reference" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "timeseries" : {
+          "properties" : {
+            "instance" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "tls" : {
+          "properties" : {
+            "cipher" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "client" : {
+              "properties" : {
+                "certificate" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "certificate_chain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "hash" : {
+                  "properties" : {
+                    "md5" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "sha1" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "sha256" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "issuer" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ja3" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "not_after" : {
+                  "type" : "date"
+                },
+                "not_before" : {
+                  "type" : "date"
+                },
+                "server_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "subject" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "supported_ciphers" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "x509" : {
+                  "properties" : {
+                    "alternative_names" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "issuer" : {
+                      "properties" : {
+                        "common_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "country" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "distinguished_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "locality" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organization" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organizational_unit" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "state_or_province" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "not_after" : {
+                      "type" : "date"
+                    },
+                    "not_before" : {
+                      "type" : "date"
+                    },
+                    "public_key_algorithm" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "public_key_curve" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "public_key_exponent" : {
+                      "type" : "long",
+                      "index" : false,
+                      "doc_values" : false
+                    },
+                    "public_key_size" : {
+                      "type" : "long"
+                    },
+                    "serial_number" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "signature_algorithm" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "subject" : {
+                      "properties" : {
+                        "common_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "country" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "distinguished_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "locality" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organization" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organizational_unit" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "state_or_province" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "version_number" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            },
+            "curve" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "established" : {
+              "type" : "boolean"
+            },
+            "next_protocol" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "resumed" : {
+              "type" : "boolean"
+            },
+            "server" : {
+              "properties" : {
+                "certificate" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "certificate_chain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "hash" : {
+                  "properties" : {
+                    "md5" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "sha1" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "sha256" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "issuer" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "ja3s" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "not_after" : {
+                  "type" : "date"
+                },
+                "not_before" : {
+                  "type" : "date"
+                },
+                "subject" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "x509" : {
+                  "properties" : {
+                    "alternative_names" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "issuer" : {
+                      "properties" : {
+                        "common_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "country" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "distinguished_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "locality" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organization" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organizational_unit" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "state_or_province" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "not_after" : {
+                      "type" : "date"
+                    },
+                    "not_before" : {
+                      "type" : "date"
+                    },
+                    "public_key_algorithm" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "public_key_curve" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "public_key_exponent" : {
+                      "type" : "long",
+                      "index" : false,
+                      "doc_values" : false
+                    },
+                    "public_key_size" : {
+                      "type" : "long"
+                    },
+                    "serial_number" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "signature_algorithm" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "subject" : {
+                      "properties" : {
+                        "common_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "country" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "distinguished_name" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "locality" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organization" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "organizational_unit" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        },
+                        "state_or_province" : {
+                          "type" : "keyword",
+                          "ignore_above" : 1024
+                        }
+                      }
+                    },
+                    "version_number" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                }
+              }
+            },
+            "version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "version_protocol" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "trace" : {
+          "properties" : {
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "transaction" : {
+          "properties" : {
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "url" : {
+          "properties" : {
+            "domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "extension" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "fragment" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "full" : {
+              "type" : "wildcard",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "original" : {
+              "type" : "wildcard",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "password" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "path" : {
+              "type" : "wildcard",
+              "ignore_above" : 1024
+            },
+            "port" : {
+              "type" : "long"
+            },
+            "query" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "registered_domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "scheme" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "subdomain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "top_level_domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "username" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "user" : {
+          "properties" : {
+            "audit" : {
+              "properties" : {
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "changes" : {
+              "properties" : {
+                "domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "email" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "full_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "group" : {
+                  "properties" : {
+                    "domain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "hash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "roles" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "domain" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "effective" : {
+              "properties" : {
+                "domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "email" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "full_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "group" : {
+                  "properties" : {
+                    "domain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "hash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "roles" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "email" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "entity_id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "filesystem" : {
+              "properties" : {
+                "group" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "full_name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "group" : {
+              "properties" : {
+                "domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "hash" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "roles" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "saved" : {
+              "properties" : {
+                "group" : {
+                  "properties" : {
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "selinux" : {
+              "properties" : {
+                "category" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "level" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "role" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "user" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "target" : {
+              "properties" : {
+                "domain" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "email" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "full_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "group" : {
+                  "properties" : {
+                    "domain" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "id" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    },
+                    "name" : {
+                      "type" : "keyword",
+                      "ignore_above" : 1024
+                    }
+                  }
+                },
+                "hash" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "id" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "roles" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "terminal" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "user_agent" : {
+          "properties" : {
+            "device" : {
+              "properties" : {
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "original" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "os" : {
+              "properties" : {
+                "family" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "full" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "kernel" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024,
+                  "fields" : {
+                    "text" : {
+                      "type" : "match_only_text"
+                    }
+                  }
+                },
+                "platform" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "type" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "version" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "vlan" : {
+          "properties" : {
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "name" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "vulnerability" : {
+          "properties" : {
+            "category" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "classification" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "description" : {
+              "type" : "keyword",
+              "ignore_above" : 1024,
+              "fields" : {
+                "text" : {
+                  "type" : "match_only_text"
+                }
+              }
+            },
+            "enumeration" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "reference" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "report_id" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "scanner" : {
+              "properties" : {
+                "vendor" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "score" : {
+              "properties" : {
+                "base" : {
+                  "type" : "float"
+                },
+                "environmental" : {
+                  "type" : "float"
+                },
+                "temporal" : {
+                  "type" : "float"
+                },
+                "version" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "severity" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        },
+        "x509" : {
+          "properties" : {
+            "alternative_names" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "issuer" : {
+              "properties" : {
+                "common_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "distinguished_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "locality" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "organization" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "organizational_unit" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "state_or_province" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "not_after" : {
+              "type" : "date"
+            },
+            "not_before" : {
+              "type" : "date"
+            },
+            "public_key_algorithm" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "public_key_curve" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "public_key_exponent" : {
+              "type" : "long",
+              "index" : false,
+              "doc_values" : false
+            },
+            "public_key_size" : {
+              "type" : "long"
+            },
+            "serial_number" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "signature_algorithm" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            },
+            "subject" : {
+              "properties" : {
+                "common_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "country" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "distinguished_name" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "locality" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "organization" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "organizational_unit" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                },
+                "state_or_province" : {
+                  "type" : "keyword",
+                  "ignore_above" : 1024
+                }
+              }
+            },
+            "version_number" : {
+              "type" : "keyword",
+              "ignore_above" : 1024
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/132316

## Summary
Fix All Users and All Hosts page should reset the current page when sorting.

** This bug was also happening on all hosts table.

<img width="1446" alt="Screenshot 2022-05-30 at 13 25 14" src="https://user-images.githubusercontent.com/1490444/170982737-3db38350-c874-41f8-889f-b0a577487c3c.png">

### Impact
* Host page / all hosts table
* User page / all users table

### Steps to reproduce
* Navigate to Users->All users tab of Security.
* Navigate to page number greater than 1.
* Applied sorting on any column i.e User name OR Last seen
* Observe that All users page is navigating to starting page

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

