### PR TITLE
[Fleet] fixed undefined error in upgrade integration policy page

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/components/package_policy_input_config.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/components/package_policy_input_config.tsx
@@ -124,7 +124,7 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
                         },
                       });
                     }}
-                    errors={inputVarsValidationResults.vars![varName]}
+                    errors={inputVarsValidationResults.vars?.[varName]}
                     forceShowErrors={forceShowErrors}
                   />
                 </EuiFlexItem>
@@ -181,7 +181,7 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
                                 },
                               });
                             }}
-                            errors={inputVarsValidationResults.vars![varName]}
+                            errors={inputVarsValidationResults.vars?.[varName]}
                             forceShowErrors={forceShowErrors}
                           />
                         </EuiFlexItem>


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/130524

To test:
- force install system package 0.8.0
- add integration policy
- upgrade system package to latest
- open upgrade integration policy window
- expected: no undefined error should come even after refreshing the window a few times (the error was not coming every time previously).

<img width="886" alt="image" src="https://user-images.githubusercontent.com/90178898/170994640-44b7ac18-479c-4b57-b6ce-43fffbb5ec69.png">
