### PR TITLE
[Security Solution] Renames Close button to Cancel for bulk actions

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/bulk_edit_form_wrapper.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/bulk_edit_form_wrapper.tsx
@@ -59,12 +59,11 @@ const BulkEditFormWrapperComponent: FC<BulkEditFormWrapperProps> = ({
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty
-              iconType="cross"
               onClick={onClose}
               flush="left"
               data-test-subj="rulesBulkEditFormCancelBtn"
             >
-              {i18n.BULK_EDIT_FLYOUT_FORM_CLOSE}
+              {i18n.BULK_EDIT_FLYOUT_FORM_CANCEL}
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -261,10 +261,10 @@ export const BULK_EDIT_FLYOUT_FORM_SAVE = i18n.translate(
   }
 );
 
-export const BULK_EDIT_FLYOUT_FORM_CLOSE = i18n.translate(
-  'xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.closeButtonLabel',
+export const BULK_EDIT_FLYOUT_FORM_CANCEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.cancelButtonLabel',
   {
-    defaultMessage: 'Close',
+    defaultMessage: 'Cancel',
   }
 );
 

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -23838,7 +23838,6 @@
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.addTagsComboboxLabel": "Ajouter des balises pour les règles sélectionnées",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.addTagsOverwriteCheckboxLabel": "Écraser toutes les balises pour les règles sélectionnées",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.addTagsTitle": "Ajouter des balises",
-    "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.closeButtonLabel": "Fermer",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.deleteIndexPatternsComboboxHelpText": "Supprimez de la liste déroulante les modèles d'indexation par défaut des index Elasticsearch. Vous pouvez ajouter des modèles d'indexation personnalisés, puis appuyer sur Entrée pour en ajouter un nouveau.",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.deleteIndexPatternsComboboxLabel": "Supprimer les modèles d'indexation pour les règles sélectionnées",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.deleteIndexPatternsTitle": "Supprimer les modèles d'indexation",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -23976,7 +23976,6 @@
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.addTagsComboboxLabel": "選択したルールのタグを追加",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.addTagsOverwriteCheckboxLabel": "すべての選択したルールタグを上書き",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.addTagsTitle": "タグを追加",
-    "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.closeButtonLabel": "閉じる",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.deleteIndexPatternsComboboxHelpText": "Elasticsearchインデックスのデフォルトインデックスパターンをドロップダウンから削除します。カスタムインデックスパターンを追加し、Enterを押すと、新しいインデックスパターンを開始できます。",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.deleteIndexPatternsComboboxLabel": "選択したルールのインデックスパターンを削除",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.deleteIndexPatternsTitle": "インデックスパターンを削除",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -24008,7 +24008,6 @@
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.addTagsComboboxLabel": "为选定规则添加标签",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.addTagsOverwriteCheckboxLabel": "覆盖所有选定规则标签",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.addTagsTitle": "添加标签",
-    "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.closeButtonLabel": "关闭",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.deleteIndexPatternsComboboxHelpText": "从下拉列表中删除 Elasticsearch 索引的默认索引模式。您可以添加定制索引模式，然后按 Enter 键以开始新索引。",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.deleteIndexPatternsComboboxLabel": "删除选定规则的索引模式",
     "xpack.securitySolution.detectionEngine.components.allRules.bulkActions.bulkEditFlyoutForm.deleteIndexPatternsTitle": "删除索引模式",


### PR DESCRIPTION
## Summary

In this PR we are fixing the following issue: https://github.com/elastic/kibana/issues/131135

BEFORE for Add/Delete index patterns, Add/Delete tags and Apply Timeline Template:

<img width="420" alt="Screenshot 2022-05-30 at 17 18 53" src="https://user-images.githubusercontent.com/17427073/171021980-dcfbba98-4ed3-4dbb-b230-93b9a123f7eb.png">

AFTER for Add/Delete index patterns, Add/Delete tags and Apply Timeline Template:

<img width="421" alt="Screenshot 2022-05-30 at 17 16 36" src="https://user-images.githubusercontent.com/17427073/171021521-7056bd3e-760a-4a1a-b3ea-b292e2660c0e.png">

