### PR TITLE
[8.3] Security form fix (#132834)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
@@ -26,12 +26,12 @@ import {
   SHOWING_RULES_TEXT,
 } from '../../screens/alerts_detection_rules';
 import {
-  // ABOUT_CONTINUE_BTN,
-  // ABOUT_EDIT_BUTTON,
+  ABOUT_CONTINUE_BTN,
+  ABOUT_EDIT_BUTTON,
   ACTIONS_THROTTLE_INPUT,
   CUSTOM_QUERY_INPUT,
-  // DEFINE_CONTINUE_BUTTON,
-  // DEFINE_EDIT_BUTTON,
+  DEFINE_CONTINUE_BUTTON,
+  DEFINE_EDIT_BUTTON,
   DEFINE_INDEX_INPUT,
   DEFAULT_RISK_SCORE_INPUT,
   RULE_DESCRIPTION_INPUT,
@@ -134,7 +134,6 @@ describe('Custom query rules', () => {
       fillAboutRuleAndContinue(this.rule);
       fillScheduleRuleAndContinue(this.rule);
 
-      /* Commenting this piece of code due to the following issue: https://github.com/elastic/kibana/issues/130767
       // expect define step to repopulate
       cy.get(DEFINE_EDIT_BUTTON).click();
       cy.get(CUSTOM_QUERY_INPUT).should('have.value', this.rule.customQuery);
@@ -145,7 +144,7 @@ describe('Custom query rules', () => {
       cy.get(ABOUT_EDIT_BUTTON).click();
       cy.get(RULE_NAME_INPUT).invoke('val').should('eql', this.rule.name);
       cy.get(ABOUT_CONTINUE_BTN).should('exist').click({ force: true });
-      cy.get(ABOUT_CONTINUE_BTN).should('not.exist');  */
+      cy.get(ABOUT_CONTINUE_BTN).should('not.exist');
 
       createAndEnableRule();
 

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
@@ -178,13 +178,11 @@ describe('indicator match', () => {
           selectIndicatorMatchType();
         });
 
-        // Unskip once https://github.com/elastic/kibana/issues/130770 is fixed
-        it.skip('Has a default set of *:*', () => {
+        it('Has a default set of *:*', () => {
           getCustomQueryInput().should('have.text', '*:*');
         });
 
-        // Unskip once https://github.com/elastic/kibana/issues/1307707 is fixed
-        it.skip('Shows invalidation text if text is removed', () => {
+        it('Shows invalidation text if text is removed', () => {
           getCustomQueryInput().type('{selectall}{del}');
           getCustomQueryInvalidationText().should('exist');
         });
@@ -401,8 +399,7 @@ describe('indicator match', () => {
       });
 
       describe('Schedule', () => {
-        // Unskip once https://github.com/elastic/kibana/issues/1307707 is fixed
-        it.skip('IM rule has 1h time interval and lookback by default', () => {
+        it('IM rule has 1h time interval and lookback by default', () => {
           visitWithoutDateRange(RULE_CREATION);
           selectIndicatorMatchType();
           fillDefineIndicatorMatchRuleAndContinue(getNewThreatIndicatorRule());
@@ -421,8 +418,7 @@ describe('indicator match', () => {
         deleteAlertsAndRules();
       });
 
-      // Unskip once https://github.com/elastic/kibana/issues/1307707 is fixed
-      it.skip('Creates and enables a new Indicator Match rule', () => {
+      it('Creates and enables a new Indicator Match rule', () => {
         visitWithoutDateRange(RULE_CREATION);
         selectIndicatorMatchType();
         fillDefineIndicatorMatchRuleAndContinue(getNewThreatIndicatorRule());

--- a/x-pack/plugins/security_solution/public/detections/components/rules/eql_query_bar/eql_query_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/eql_query_bar/eql_query_bar.test.tsx
@@ -48,6 +48,7 @@ describe('EqlQueryBar', () => {
         query: 'newQuery',
         language: 'eql',
       },
+      saved_id: null,
     };
 
     expect(mockField.setValue).toHaveBeenCalledWith(expected);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/eql_query_bar/eql_query_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/eql_query_bar/eql_query_bar.tsx
@@ -96,6 +96,7 @@ export const EqlQueryBar: FC<EqlQueryBarProps> = ({
           query: newQuery,
           language: 'eql',
         },
+        saved_id: null,
       });
     },
     [setValue, onValiditingChange]

--- a/x-pack/plugins/security_solution/public/detections/components/rules/query_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/query_bar/index.tsx
@@ -29,7 +29,7 @@ import * as i18n from './translations';
 export interface FieldValueQueryBar {
   filters: Filter[];
   query: Query;
-  saved_id?: string;
+  saved_id: string | null;
 }
 interface QueryBarDefineRuleProps {
   browserFields: BrowserFields;
@@ -176,7 +176,7 @@ export const QueryBarDefineRule = ({
               query: '',
               language: 'kuery',
             },
-            saved_id: undefined,
+            saved_id: null,
           });
         }
       }
@@ -210,7 +210,7 @@ export const QueryBarDefineRule = ({
             ? [...newFilters, getDataProviderFilter(dataProvidersDsl)]
             : newFilters,
         query: newQuery,
-        saved_id: undefined,
+        saved_id: null,
       });
     },
     [browserFields, indexPattern, setFieldValue]

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/helpers.test.ts
@@ -75,7 +75,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -91,7 +91,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -107,7 +107,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -123,7 +123,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -137,7 +137,7 @@ describe('query_preview/helpers', () => {
         threatIndex: ['threat-*'],
         threatMapping: [],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -151,7 +151,7 @@ describe('query_preview/helpers', () => {
         threatIndex: ['threat-*'],
         threatMapping: [],
         machineLearningJobId: [],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -165,7 +165,7 @@ describe('query_preview/helpers', () => {
         threatIndex: ['threat-*'],
         threatMapping: [],
         machineLearningJobId: [],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(true);
     });
@@ -181,7 +181,7 @@ describe('query_preview/helpers', () => {
           { entries: [{ field: 'test-field', value: 'test-value', type: 'mapping' }] },
         ],
         machineLearningJobId: ['test-ml-job-id'],
-        queryBar: { filters: [], query: { query: '', language: 'testlang' } },
+        queryBar: { filters: [], query: { query: '', language: 'testlang' }, saved_id: null },
       });
       expect(isDisabled).toEqual(false);
     });
@@ -195,7 +195,11 @@ describe('query_preview/helpers', () => {
         threatIndex: ['threat-*'],
         threatMapping: [],
         machineLearningJobId: [],
-        queryBar: { filters: [], query: { query: 'any where true', language: 'testlang' } },
+        queryBar: {
+          filters: [],
+          query: { query: 'any where true', language: 'testlang' },
+          saved_id: null,
+        },
       });
       expect(isDisabled).toEqual(false);
     });
@@ -234,6 +238,7 @@ describe('query_preview/helpers', () => {
         {
           query: { query: 'host.name:*', language: 'kuery' },
           filters: [{ meta: { alias: '', disabled: false, negate: false } }],
+          saved_id: null,
         },
         ['foo-*'],
         'query'
@@ -260,6 +265,7 @@ describe('query_preview/helpers', () => {
         {
           query: { query: 'host.name:*', language: 'kuery' },
           filters: [{ meta: { alias: '', disabled: false, negate: false } }],
+          saved_id: null,
         },
         ['foo-*'],
         'saved_query'
@@ -286,6 +292,7 @@ describe('query_preview/helpers', () => {
         {
           query: { query: 'host.name:*', language: 'kuery' },
           filters: [{ meta: { alias: '', disabled: false, negate: false } }],
+          saved_id: null,
         },
         ['foo-*'],
         'threshold'
@@ -312,6 +319,7 @@ describe('query_preview/helpers', () => {
         {
           query: { query: 'file where true', language: 'eql' },
           filters: [{ meta: { alias: '', disabled: false, negate: false } }],
+          saved_id: null,
         },
         ['foo-*'],
         'eql'
@@ -329,6 +337,7 @@ describe('query_preview/helpers', () => {
         {
           query: { query: 'host.name:', language: 'kuery' },
           filters: [{ meta: { alias: '', disabled: false, negate: false } }],
+          saved_id: null,
         },
         ['foo-*'],
         'threshold'

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.test.tsx
@@ -40,10 +40,12 @@ const defaultProps: RulePreviewProps = {
   query: {
     filters: [],
     query: { query: 'file.hash.md5:*', language: 'kuery' },
+    saved_id: null,
   },
   threatQuery: {
     filters: [],
     query: { query: 'threat.indicator.file.hash.md5:*', language: 'kuery' },
+    saved_id: null,
   },
   threshold: {
     field: ['agent.hostname'],

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.test.ts
@@ -364,6 +364,7 @@ describe('helpers', () => {
         threatQueryBar: {
           query: { language: 'kql', query: 'threat_host: *' },
           filters: threatFilters,
+          saved_id: null,
         },
         threatMapping,
       };

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.ts
@@ -296,7 +296,7 @@ export const formatDefineStepData = (defineStepData: DefineStepRule): DefineStep
         filters: ruleFields.queryBar?.filters,
         language: ruleFields.queryBar?.query?.language,
         query: ruleFields.queryBar?.query?.query as string,
-        saved_id: ruleFields.queryBar?.saved_id,
+        saved_id: ruleFields.queryBar?.saved_id ?? undefined,
         ...(ruleType === 'threshold' && {
           threshold: {
             field: ruleFields.threshold?.field ?? [],
@@ -320,7 +320,7 @@ export const formatDefineStepData = (defineStepData: DefineStepRule): DefineStep
         filters: ruleFields.queryBar?.filters,
         language: ruleFields.queryBar?.query?.language,
         query: ruleFields.queryBar?.query?.query as string,
-        saved_id: ruleFields.queryBar?.saved_id,
+        saved_id: ruleFields.queryBar?.saved_id ?? undefined,
         threat_index: ruleFields.threatIndex,
         threat_query: ruleFields.threatQueryBar?.query?.query as string,
         threat_filters: ruleFields.threatQueryBar?.filters,
@@ -333,7 +333,7 @@ export const formatDefineStepData = (defineStepData: DefineStepRule): DefineStep
         filters: ruleFields.queryBar?.filters,
         language: ruleFields.queryBar?.query?.language,
         query: ruleFields.queryBar?.query?.query as string,
-        saved_id: ruleFields.queryBar?.saved_id,
+        saved_id: ruleFields.queryBar?.saved_id ?? undefined,
         timestamp_field: ruleFields.eqlOptions?.timestampField,
         event_category_override: ruleFields.eqlOptions?.eventCategoryField,
         tiebreaker_field: ruleFields.eqlOptions?.tiebreakerField,
@@ -343,7 +343,7 @@ export const formatDefineStepData = (defineStepData: DefineStepRule): DefineStep
         filters: ruleFields.queryBar?.filters,
         language: ruleFields.queryBar?.query?.language,
         query: ruleFields.queryBar?.query?.query as string,
-        saved_id: ruleFields.queryBar?.saved_id,
+        saved_id: ruleFields.queryBar?.saved_id ?? undefined,
         ...(ruleType === 'query' &&
           ruleFields.queryBar?.saved_id && { type: 'saved_query' as Type }),
       };

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/index.tsx
@@ -77,6 +77,9 @@ const MyEuiPanel = styled(EuiPanel)<{
 
 MyEuiPanel.displayName = 'MyEuiPanel';
 
+const isShouldRerenderStep = (step: RuleStep, activeStep: RuleStep) =>
+  activeStep !== step ? '0' : '1';
+
 const CreateRulePageComponent: React.FC = () => {
   const [
     {
@@ -286,6 +289,7 @@ const CreateRulePageComponent: React.FC = () => {
     });
     return null;
   }
+
   return (
     <>
       <SecuritySolutionPageWrapper>
@@ -330,6 +334,9 @@ const CreateRulePageComponent: React.FC = () => {
                   setForm={setFormHook}
                   onSubmit={submitStepDefineRule}
                   descriptionColumns="singleSplit"
+                  // We need a key to make this component remount when edit/view mode is toggled
+                  // https://github.com/elastic/kibana/pull/132834#discussion_r881705566
+                  key={isShouldRerenderStep(RuleStep.defineRule, activeStep)}
                 />
               </EuiAccordion>
             </MyEuiPanel>
@@ -365,6 +372,9 @@ const CreateRulePageComponent: React.FC = () => {
                   isLoading={isLoading || loading}
                   setForm={setFormHook}
                   onSubmit={() => submitStep(RuleStep.aboutRule)}
+                  // We need a key to make this component remount when edit/view mode is toggled
+                  // https://github.com/elastic/kibana/pull/132834#discussion_r881705566
+                  key={isShouldRerenderStep(RuleStep.aboutRule, activeStep)}
                 />
               </EuiAccordion>
             </MyEuiPanel>
@@ -399,6 +409,9 @@ const CreateRulePageComponent: React.FC = () => {
                   isLoading={isLoading || loading}
                   setForm={setFormHook}
                   onSubmit={() => submitStep(RuleStep.scheduleRule)}
+                  // We need a key to make this component remount when edit/view mode is toggled
+                  // https://github.com/elastic/kibana/pull/132834#discussion_r881705566
+                  key={isShouldRerenderStep(RuleStep.scheduleRule, activeStep)}
                 />
               </EuiAccordion>
             </MyEuiPanel>
@@ -432,6 +445,9 @@ const CreateRulePageComponent: React.FC = () => {
                   setForm={setFormHook}
                   onSubmit={() => submitStep(RuleStep.ruleActions)}
                   actionMessageParams={actionMessageParams}
+                  // We need a key to make this component remount when edit/view mode is toggled
+                  // https://github.com/elastic/kibana/pull/132834#discussion_r881705566
+                  key={isShouldRerenderStep(RuleStep.ruleActions, activeStep)}
                 />
               </EuiAccordion>
             </MyEuiPanel>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.test.tsx
@@ -99,7 +99,7 @@ describe('rule helpers', () => {
             language: '',
           },
           filters: [],
-          saved_id: undefined,
+          saved_id: null,
         },
         timeline: {
           id: '86aa74d0-2136-11ea-9864-ebc8cc1cb8c2',
@@ -236,7 +236,7 @@ describe('rule helpers', () => {
             language: '',
           },
           filters: [],
-          saved_id: undefined,
+          saved_id: null,
         },
         timeline: {
           id: '86aa74d0-2136-11ea-9864-ebc8cc1cb8c2',
@@ -269,7 +269,7 @@ describe('rule helpers', () => {
             language: 'kuery',
           },
           filters: [],
-          saved_id: undefined,
+          saved_id: null,
         },
         relatedIntegrations: [],
         requiredFields: [],
@@ -285,7 +285,7 @@ describe('rule helpers', () => {
             language: '',
           },
           filters: [],
-          saved_id: undefined,
+          saved_id: null,
         },
         timeline: {
           id: '86aa74d0-2136-11ea-9864-ebc8cc1cb8c2',

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.tsx
@@ -87,13 +87,13 @@ export const getDefineStepsData = (rule: Rule): DefineStepRule => ({
   threatQueryBar: {
     query: { query: rule.threat_query ?? '', language: rule.threat_language ?? '' },
     filters: (rule.threat_filters ?? []) as Filter[],
-    saved_id: undefined,
+    saved_id: null,
   },
   threatMapping: rule.threat_mapping ?? [],
   queryBar: {
     query: { query: rule.query ?? '', language: rule.language ?? '' },
     filters: (rule.filters ?? []) as Filter[],
-    saved_id: rule.saved_id,
+    saved_id: rule.saved_id ?? null,
   },
   relatedIntegrations: rule.related_integrations ?? [],
   requiredFields: rule.required_fields ?? [],

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
@@ -37,7 +37,7 @@ const defaultValues = {
   eqlQueryBar: {
     query: { query: '', language: 'eql' },
     filters: [],
-    saved_id: undefined,
+    saved_id: null,
   },
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Security form fix (#132834)](https://github.com/elastic/kibana/pull/132834)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)