### PR TITLE
[8.3] Adapt `incompatible_cluster_routing_allocation.test.ts` to work on any branch (#133129)

### DIFF
--- a/src/core/server/saved_objects/migrations/integration_tests/incompatible_cluster_routing_allocation.test.ts
+++ b/src/core/server/saved_objects/migrations/integration_tests/incompatible_cluster_routing_allocation.test.ts
@@ -95,8 +95,7 @@ async function updateRoutingAllocations(
   });
 }
 
-// Failing ES snapshot verification: https://github.com/elastic/kibana/issues/133014
-describe.skip('incompatible_cluster_routing_allocation', () => {
+describe('incompatible_cluster_routing_allocation', () => {
   let client: ElasticsearchClient;
   let root: Root;
 

--- a/src/core/server/saved_objects/migrations/integration_tests/incompatible_cluster_routing_allocation.test.ts
+++ b/src/core/server/saved_objects/migrations/integration_tests/incompatible_cluster_routing_allocation.test.ts
@@ -9,6 +9,10 @@
 import Path from 'path';
 import fs from 'fs/promises';
 import JSON5 from 'json5';
+import { REPO_ROOT } from '@kbn/utils';
+import { Env } from '@kbn/config';
+import { getDocLinksMeta } from '@kbn/doc-links';
+import { getEnvOptions } from '../../../config/mocks';
 import * as kbnTestServer from '../../../../test_helpers/kbn_server';
 import { Root } from '../../../root';
 import { ElasticsearchClient } from '../../../elasticsearch';
@@ -16,6 +20,8 @@ import { LogRecord } from '@kbn/logging';
 import { retryAsync } from '../test_helpers/retry_async';
 
 const logFilePath = Path.join(__dirname, 'incompatible_cluster_routing_allocation.log');
+const env = Env.createDefault(REPO_ROOT, getEnvOptions());
+const docVersion = getDocLinksMeta({ kibanaBranch: env.packageInfo.branch }).version;
 
 async function removeLogFile() {
   // ignore errors if it doesn't exist
@@ -66,6 +72,7 @@ function createKbnRoot() {
     }
   );
 }
+
 const getClusterRoutingAllocations = (settings: Record<string, any>) => {
   const routingAllocations =
     settings?.transient?.['cluster.routing.allocation.enable'] ??
@@ -132,7 +139,7 @@ describe.skip('incompatible_cluster_routing_allocation', () => {
         expect(
           records.find((rec) =>
             rec.message.includes(
-              `Action failed with '[incompatible_cluster_routing_allocation] Incompatible Elasticsearch cluster settings detected. Remove the persistent and transient Elasticsearch cluster setting 'cluster.routing.allocation.enable' or set it to a value of 'all' to allow migrations to proceed. Refer to https://www.elastic.co/guide/en/kibana/master/resolve-migrations-failures.html#routing-allocation-disabled for more information on how to resolve the issue.'. Retrying attempt 2 in 4 seconds.`
+              `Action failed with '[incompatible_cluster_routing_allocation] Incompatible Elasticsearch cluster settings detected. Remove the persistent and transient Elasticsearch cluster setting 'cluster.routing.allocation.enable' or set it to a value of 'all' to allow migrations to proceed. Refer to https://www.elastic.co/guide/en/kibana/${docVersion}/resolve-migrations-failures.html#routing-allocation-disabled for more information on how to resolve the issue.'. Retrying attempt 2 in 4 seconds.`
             )
           )
         ).toBeDefined();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Adapt `incompatible_cluster_routing_allocation.test.ts` to work on any branch (#133129)](https://github.com/elastic/kibana/pull/133129)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)