### PR TITLE
[Cases] refactor: remove updateCase prop from other child components.

### DIFF
--- a/x-pack/plugins/cases/common/ui/types.ts
+++ b/x-pack/plugins/cases/common/ui/types.ts
@@ -155,8 +155,6 @@ export type UpdateKey = keyof Pick<
 export interface UpdateByKey {
   updateKey: UpdateKey;
   updateValue: CasePatchRequest[UpdateKey];
-  fetchCaseUserActions?: (caseId: string, caseConnectorId: string) => void;
-  updateCase?: (newCase: Case) => void;
   caseData: Case;
   onSuccess?: () => void;
   onError?: () => void;

--- a/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
@@ -11,12 +11,12 @@ import { render } from '@testing-library/react';
 
 import { basicCase, caseUserActions, getAlertUserAction } from '../../containers/mock';
 import { CaseActionBar, CaseActionBarProps } from '.';
-import { createAppMockRenderer, TestProviders } from '../../common/mock';
+import { TestProviders } from '../../common/mock';
 import { useGetCaseUserActions } from '../../containers/use_get_case_user_actions';
-import userEvent from '@testing-library/user-event';
-import { CASE_VIEW_CACHE_KEY } from '../../containers/constants';
+import { useRefreshCaseViewPage } from '../case_view/use_on_refresh_case_view_page';
 
 jest.mock('../../containers/use_get_case_user_actions');
+jest.mock('../case_view/use_on_refresh_case_view_page');
 
 const useGetCaseUserActionsMock = useGetCaseUserActions as jest.Mock;
 const defaultUseGetCaseUserActions = {
@@ -106,13 +106,15 @@ describe('CaseActionBar', () => {
   });
 
   it('invalidates the queryClient cache onRefresh', () => {
-    const app = createAppMockRenderer();
-    const spy = jest.spyOn(app.queryClient, 'invalidateQueries');
-    const result = app.render(<CaseActionBar {...defaultProps} />);
+    const wrapper = mount(
+      <TestProviders>
+        <CaseActionBar {...defaultProps} />
+      </TestProviders>
+    );
 
-    userEvent.click(result.getByTestId('case-refresh'));
+    wrapper.find(`[data-test-subj="case-refresh"]`).first().simulate('click');
 
-    expect(spy).toHaveBeenCalledWith(CASE_VIEW_CACHE_KEY);
+    expect(useRefreshCaseViewPage()).toHaveBeenCalled();
   });
 
   it('should call onUpdateField when changing status', () => {

--- a/x-pack/plugins/cases/public/components/case_action_bar/index.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.tsx
@@ -28,6 +28,7 @@ import type { OnUpdateFields } from '../case_view/types';
 import { useCasesFeatures } from '../cases_context/use_cases_features';
 import { FormattedRelativePreferenceDate } from '../formatted_date';
 import { getStatusDate, getStatusTitle } from './helpers';
+import { useRefreshCaseViewPage } from '../case_view/case_view_page';
 
 const MyDescriptionList = styled(EuiDescriptionList)`
   ${({ theme }) => css`
@@ -46,19 +47,18 @@ export interface CaseActionBarProps {
   caseData: Case;
   userCanCrud: boolean;
   isLoading: boolean;
-  onRefresh: () => void;
   onUpdateField: (args: OnUpdateFields) => void;
 }
 const CaseActionBarComponent: React.FC<CaseActionBarProps> = ({
   caseData,
   userCanCrud,
   isLoading,
-  onRefresh,
   onUpdateField,
 }) => {
   const { isSyncAlertsEnabled, metricsFeatures } = useCasesFeatures();
   const date = useMemo(() => getStatusDate(caseData), [caseData]);
   const title = useMemo(() => getStatusTitle(caseData.status), [caseData.status]);
+  const refreshCaseViewPage = useRefreshCaseViewPage();
   const onStatusChanged = useCallback(
     (status: CaseStatuses) =>
       onUpdateField({
@@ -166,7 +166,7 @@ const CaseActionBarComponent: React.FC<CaseActionBarProps> = ({
                       data-test-subj="case-refresh"
                       flush="left"
                       iconType="refresh"
-                      onClick={onRefresh}
+                      onClick={refreshCaseViewPage}
                     >
                       {i18n.CASE_REFRESH}
                     </EuiButtonEmpty>

--- a/x-pack/plugins/cases/public/components/case_action_bar/index.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.tsx
@@ -28,7 +28,7 @@ import type { OnUpdateFields } from '../case_view/types';
 import { useCasesFeatures } from '../cases_context/use_cases_features';
 import { FormattedRelativePreferenceDate } from '../formatted_date';
 import { getStatusDate, getStatusTitle } from './helpers';
-import { useRefreshCaseViewPage } from '../case_view/case_view_page';
+import { useRefreshCaseViewPage } from '../case_view/use_on_refresh_case_view_page';
 
 const MyDescriptionList = styled(EuiDescriptionList)`
   ${({ theme }) => css`

--- a/x-pack/plugins/cases/public/components/case_view/__mocks__/use_on_refresh_case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/__mocks__/use_on_refresh_case_view_page.tsx
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const refreshFunction = jest.fn();
+export const useRefreshCaseViewPage = () => refreshFunction;

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
@@ -7,10 +7,8 @@
 
 import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTab, EuiTabs } from '@elastic/eui';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useQueryClient } from 'react-query';
 import styled from 'styled-components';
 import { useCaseViewNavigation, useUrlParams } from '../../common/navigation';
-import { CASE_VIEW_CACHE_KEY } from '../../containers/constants';
 import { useCasesContext } from '../cases_context/use_cases_context';
 import { CaseActionBar } from '../case_action_bar';
 import { HeaderPage } from '../header_page';
@@ -24,18 +22,12 @@ import { CaseViewAlerts } from './components/case_view_alerts';
 import { CaseViewMetrics } from './metrics';
 import { ACTIVITY_TAB, ALERTS_TAB } from './translations';
 import { CaseViewPageProps, CASE_VIEW_PAGE_TABS } from './types';
+import { useRefreshCaseViewPage } from './use_on_refresh_case_view_page';
 import { useOnUpdateField } from './use_on_update_field';
 
 const ExperimentalBadge = styled(EuiBetaBadge)`
   margin-left: 5px;
 `;
-
-export const useRefreshCaseViewPage = () => {
-  const queryClient = useQueryClient();
-  return useCallback(() => {
-    queryClient.invalidateQueries(CASE_VIEW_CACHE_KEY);
-  }, [queryClient]);
-};
 
 export const CaseViewPage = React.memo<CaseViewPageProps>(
   ({

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
@@ -192,7 +192,6 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
             caseData={caseData}
             userCanCrud={userCanCrud}
             isLoading={isLoading && (loadingKey === 'status' || loadingKey === 'settings')}
-            onRefresh={refreshCaseViewPage}
             onUpdateField={onUpdateField}
           />
         </HeaderPage>

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
@@ -60,7 +60,6 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
     const { onUpdateField, isLoading, loadingKey } = useOnUpdateField({
       caseId,
       caseData,
-      handleUpdateField: refreshCaseViewPage,
     });
 
     // Set `refreshRef` if needed

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
@@ -34,7 +34,6 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
   ({
     caseData,
     caseId,
-    fetchCase,
     onComponentInitialized,
     refreshRef,
     ruleDetailsNavigation,
@@ -87,7 +86,7 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
           refreshRef.current = null;
         };
       }
-    }, [fetchCase, isLoading, refreshRef, handleRefresh]);
+    }, [isLoading, refreshRef, handleRefresh]);
 
     const onSubmitTitle = useCallback(
       (newTitle) =>
@@ -119,7 +118,6 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
               caseData={caseData}
               actionsNavigation={actionsNavigation}
               showAlertDetails={showAlertDetails}
-              updateCase={fetchCase}
               useFetchAlertData={useFetchAlertData}
             />
           ),
@@ -149,7 +147,6 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
         actionsNavigation,
         caseData,
         features.alerts.enabled,
-        fetchCase,
         ruleDetailsNavigation,
         showAlertDetails,
         useFetchAlertData,

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
@@ -30,6 +30,13 @@ const ExperimentalBadge = styled(EuiBetaBadge)`
   margin-left: 5px;
 `;
 
+export const useRefreshCaseViewPage = () => {
+  const queryClient = useQueryClient();
+  return useCallback(() => {
+    queryClient.invalidateQueries(CASE_VIEW_CACHE_KEY);
+  }, [queryClient]);
+};
+
 export const CaseViewPage = React.memo<CaseViewPageProps>(
   ({
     caseData,
@@ -44,7 +51,7 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
     const { userCanCrud, features } = useCasesContext();
     const { navigateToCaseView } = useCaseViewNavigation();
     const { urlParams } = useUrlParams();
-    const queryClient = useQueryClient();
+    const refreshCaseViewPage = useRefreshCaseViewPage();
 
     useCasesTitleBreadcrumbs(caseData.title);
 
@@ -58,14 +65,10 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
     const init = useRef(true);
     const timelineUi = useTimelineContext()?.ui;
 
-    const handleRefresh = useCallback(() => {
-      queryClient.invalidateQueries(CASE_VIEW_CACHE_KEY);
-    }, [queryClient]);
-
     const { onUpdateField, isLoading, loadingKey } = useOnUpdateField({
       caseId,
       caseData,
-      handleUpdateField: handleRefresh,
+      handleUpdateField: refreshCaseViewPage,
     });
 
     // Set `refreshRef` if needed
@@ -78,7 +81,7 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
             if (isStale || isLoading) {
               return;
             }
-            handleRefresh();
+            refreshCaseViewPage();
           },
         };
         return () => {
@@ -86,7 +89,7 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
           refreshRef.current = null;
         };
       }
-    }, [isLoading, refreshRef, handleRefresh]);
+    }, [isLoading, refreshRef, refreshCaseViewPage]);
 
     const onSubmitTitle = useCallback(
       (newTitle) =>
@@ -189,7 +192,7 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
             caseData={caseData}
             userCanCrud={userCanCrud}
             isLoading={isLoading && (loadingKey === 'status' || loadingKey === 'settings')}
-            onRefresh={handleRefresh}
+            onRefresh={refreshCaseViewPage}
             onUpdateField={onUpdateField}
           />
         </HeaderPage>

--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.test.tsx
@@ -86,7 +86,6 @@ const defaultUseGetCaseUserActions = {
 export const caseProps = {
   ...caseViewProps,
   caseData,
-  updateCase: jest.fn(),
   fetchCaseMetrics: jest.fn(),
 };
 

--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
@@ -25,7 +25,7 @@ import { getNoneConnector, normalizeActionConnector } from '../../configure_case
 import { getConnectorById } from '../../utils';
 import { SeveritySidebarSelector } from '../../severity/sidebar_selector';
 import { useGetCaseUserActions } from '../../../containers/use_get_case_user_actions';
-import { useRefreshCaseViewPage } from '../case_view_page';
+import { useRefreshCaseViewPage } from '../use_on_refresh_case_view_page';
 
 export const CaseViewActivity = ({
   ruleDetailsNavigation,
@@ -43,11 +43,10 @@ export const CaseViewActivity = ({
   const { userCanCrud } = useCasesContext();
   const { getCaseViewUrl } = useCaseViewNavigation();
 
-  const {
-    data: userActionsData,
-    refetch: fetchCaseUserActions,
-    isLoading: isLoadingUserActions,
-  } = useGetCaseUserActions(caseData.id, caseData.connector.id);
+  const { data: userActionsData, isLoading: isLoadingUserActions } = useGetCaseUserActions(
+    caseData.id,
+    caseData.connector.id
+  );
 
   const onShowAlertDetails = useCallback(
     (alertId: string, index: string) => {
@@ -133,7 +132,6 @@ export const CaseViewActivity = ({
                 caseUserActions={userActionsData.caseUserActions}
                 data={caseData}
                 actionsNavigation={actionsNavigation}
-                fetchUserActions={fetchCaseUserActions}
                 isLoadingDescription={isLoading && loadingKey === 'description'}
                 isLoadingUserActions={isLoadingUserActions}
                 onShowAlertDetails={onShowAlertDetails}
@@ -147,7 +145,6 @@ export const CaseViewActivity = ({
                     />
                   ) : null
                 }
-                updateCase={refreshCaseViewPage}
                 useFetchAlertData={useFetchAlertData}
                 userCanCrud={userCanCrud}
               />

--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
@@ -194,7 +194,6 @@ export const CaseViewActivity = ({
             isLoading={isLoadingConnectors || (isLoading && loadingKey === 'connector')}
             isValidConnector={isLoadingConnectors ? true : isValidConnector}
             onSubmit={onSubmitConnector}
-            updateCase={refreshCaseViewPage}
             userActions={userActionsData.caseUserActions}
             userCanCrud={userCanCrud}
           />

--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
@@ -33,14 +33,12 @@ export const CaseViewActivity = ({
   caseData,
   actionsNavigation,
   showAlertDetails,
-  updateCase,
   useFetchAlertData,
 }: {
   ruleDetailsNavigation?: CasesNavigation<string | null | undefined, 'configurable'>;
   caseData: Case;
   actionsNavigation?: CasesNavigation<string, 'configurable'>;
   showAlertDetails?: (alertId: string, index: string) => void;
-  updateCase: () => void;
   useFetchAlertData: UseFetchAlertData;
 }) => {
   const { userCanCrud } = useCasesContext();
@@ -111,10 +109,9 @@ export const CaseViewActivity = ({
 
   const handleUpdateCase = useCallback(
     (_newCase: Case) => {
-      updateCase();
-      fetchCaseUserActions();
+      queryClient.invalidateQueries(CASE_VIEW_CACHE_KEY);
     },
-    [updateCase, fetchCaseUserActions]
+    [queryClient]
   );
 
   const onSubmitConnector = useCallback(
@@ -164,7 +161,7 @@ export const CaseViewActivity = ({
                     />
                   ) : null
                 }
-                updateCase={updateCase}
+                updateCase={handleUpdateCase}
                 useFetchAlertData={useFetchAlertData}
                 userCanCrud={userCanCrud}
               />

--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
@@ -25,7 +25,6 @@ import { getNoneConnector, normalizeActionConnector } from '../../configure_case
 import { getConnectorById } from '../../utils';
 import { SeveritySidebarSelector } from '../../severity/sidebar_selector';
 import { useGetCaseUserActions } from '../../../containers/use_get_case_user_actions';
-import { useRefreshCaseViewPage } from '../use_on_refresh_case_view_page';
 
 export const CaseViewActivity = ({
   ruleDetailsNavigation,
@@ -57,12 +56,9 @@ export const CaseViewActivity = ({
     [showAlertDetails]
   );
 
-  const refreshCaseViewPage = useRefreshCaseViewPage();
-
   const { onUpdateField, isLoading, loadingKey } = useOnUpdateField({
     caseId: caseData.id,
     caseData,
-    handleUpdateField: refreshCaseViewPage,
   });
 
   const changeStatus = useCallback(

--- a/x-pack/plugins/cases/public/components/case_view/use_on_refresh_case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/use_on_refresh_case_view_page.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+import { useQueryClient } from 'react-query';
+import { CASE_VIEW_CACHE_KEY } from '../../containers/constants';
+
+export const useRefreshCaseViewPage = () => {
+  const queryClient = useQueryClient();
+  return useCallback(() => {
+    queryClient.invalidateQueries(CASE_VIEW_CACHE_KEY);
+  }, [queryClient]);
+};

--- a/x-pack/plugins/cases/public/components/case_view/use_on_refresh_case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/use_on_refresh_case_view_page.tsx
@@ -9,6 +9,14 @@ import { useCallback } from 'react';
 import { useQueryClient } from 'react-query';
 import { CASE_VIEW_CACHE_KEY } from '../../containers/constants';
 
+/**
+ * Using react-query queryClient to invalidate all the
+ * case view page cache namespace.
+ *
+ * This effectively clears the cache for all the case view pages and
+ * forces the page to fetch all the data again. Including
+ * metrics, actions, comments, etc.
+ */
 export const useRefreshCaseViewPage = () => {
   const queryClient = useQueryClient();
   return useCallback(() => {

--- a/x-pack/plugins/cases/public/components/case_view/use_on_update_field.ts
+++ b/x-pack/plugins/cases/public/components/case_view/use_on_update_field.ts
@@ -14,15 +14,7 @@ import { useUpdateCase } from '../../containers/use_update_case';
 import { getTypedPayload } from '../../containers/utils';
 import { OnUpdateFields } from './types';
 
-export const useOnUpdateField = ({
-  caseData,
-  caseId,
-  handleUpdateField,
-}: {
-  caseData: Case;
-  caseId: string;
-  handleUpdateField: (newCase: Case, updateKey: UpdateKey) => void;
-}) => {
+export const useOnUpdateField = ({ caseData, caseId }: { caseData: Case; caseId: string }) => {
   const { isLoading, updateKey: loadingKey, updateCaseProperty } = useUpdateCase({ caseId });
 
   const onUpdateField = useCallback(

--- a/x-pack/plugins/cases/public/components/case_view/use_on_update_field.ts
+++ b/x-pack/plugins/cases/public/components/case_view/use_on_update_field.ts
@@ -31,7 +31,6 @@ export const useOnUpdateField = ({
         updateCaseProperty({
           updateKey,
           updateValue,
-          updateCase: (newCase) => handleUpdateField(newCase, updateKey),
           caseData,
           onSuccess,
           onError,
@@ -81,7 +80,7 @@ export const useOnUpdateField = ({
           return null;
       }
     },
-    [updateCaseProperty, handleUpdateField, caseData]
+    [updateCaseProperty, caseData]
   );
   return { onUpdateField, isLoading, loadingKey };
 };

--- a/x-pack/plugins/cases/public/components/edit_connector/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/edit_connector/index.test.tsx
@@ -16,7 +16,6 @@ import { basicCase, basicPush, caseUserActions, connectorsMock } from '../../con
 import { CaseConnector } from '../../containers/configure/types';
 
 const onSubmit = jest.fn();
-const updateCase = jest.fn();
 const caseServices = {
   '123': {
     ...basicPush,
@@ -36,7 +35,6 @@ const getDefaultProps = (): EditConnectorProps => {
     isLoading: false,
     isValidConnector: true,
     onSubmit,
-    updateCase,
     userActions: caseUserActions,
     userCanCrud: true,
   };

--- a/x-pack/plugins/cases/public/components/edit_connector/index.tsx
+++ b/x-pack/plugins/cases/public/components/edit_connector/index.tsx
@@ -47,7 +47,6 @@ export interface EditConnectorProps {
     onError: () => void,
     onSuccess: () => void
   ) => void;
-  updateCase: (newCase: Case) => void;
   userActions: CaseUserActions[];
   userCanCrud?: boolean;
 }
@@ -119,7 +118,6 @@ export const EditConnector = React.memo(
     isLoading,
     isValidConnector,
     onSubmit,
-    updateCase,
     userActions,
     userCanCrud = true,
   }: EditConnectorProps) => {
@@ -275,7 +273,6 @@ export const EditConnector = React.memo(
       connectors,
       hasDataToPush,
       onEditClick,
-      updateCase,
       userCanCrud,
       isValidConnector,
     });

--- a/x-pack/plugins/cases/public/components/use_push_to_service/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/use_push_to_service/index.test.tsx
@@ -26,7 +26,6 @@ jest.mock('../../common/navigation/hooks');
 
 describe('usePushToService', () => {
   const caseId = '12345';
-  const updateCase = jest.fn();
   const onEditClick = jest.fn();
   const pushCaseToExternalService = jest.fn();
   const mockPostPush = {
@@ -65,7 +64,6 @@ describe('usePushToService', () => {
     hasDataToPush: true,
     onEditClick,
     isValidConnector: true,
-    updateCase,
     userCanCrud: true,
   };
 

--- a/x-pack/plugins/cases/public/components/use_push_to_service/index.tsx
+++ b/x-pack/plugins/cases/public/components/use_push_to_service/index.tsx
@@ -19,10 +19,10 @@ import {
   getCaseClosedInfo,
 } from './helpers';
 import * as i18n from './translations';
-import { Case } from '../../../common/ui/types';
 import { CaseConnector, ActionConnector, CaseStatuses } from '../../../common/api';
 import { CaseServices } from '../../containers/use_get_case_user_actions';
 import { ErrorMessage } from './callout/types';
+import { useRefreshCaseViewPage } from '../case_view/case_view_page';
 
 export interface UsePushToService {
   caseId: string;
@@ -33,7 +33,6 @@ export interface UsePushToService {
   hasDataToPush: boolean;
   isValidConnector: boolean;
   onEditClick: () => void;
-  updateCase: (newCase: Case) => void;
   userCanCrud: boolean;
 }
 
@@ -51,13 +50,13 @@ export const usePushToService = ({
   hasDataToPush,
   isValidConnector,
   onEditClick,
-  updateCase,
   userCanCrud,
 }: UsePushToService): ReturnUsePushToService => {
   const { isLoading, pushCaseToExternalService } = usePostPushToService();
 
   const { isLoading: loadingLicense, actionLicense } = useGetActionLicense();
   const hasLicenseError = actionLicense != null && !actionLicense.enabledInLicense;
+  const refreshCaseViewPage = useRefreshCaseViewPage();
 
   const handlePushToService = useCallback(async () => {
     if (connector.id != null && connector.id !== 'none') {
@@ -67,10 +66,10 @@ export const usePushToService = ({
       });
 
       if (theCase != null) {
-        updateCase(theCase);
+        refreshCaseViewPage();
       }
     }
-  }, [caseId, connector, pushCaseToExternalService, updateCase]);
+  }, [caseId, connector, pushCaseToExternalService, refreshCaseViewPage]);
 
   const errorsMsg = useMemo(() => {
     const errors: ErrorMessage[] = [];

--- a/x-pack/plugins/cases/public/components/use_push_to_service/index.tsx
+++ b/x-pack/plugins/cases/public/components/use_push_to_service/index.tsx
@@ -22,7 +22,7 @@ import * as i18n from './translations';
 import { CaseConnector, ActionConnector, CaseStatuses } from '../../../common/api';
 import { CaseServices } from '../../containers/use_get_case_user_actions';
 import { ErrorMessage } from './callout/types';
-import { useRefreshCaseViewPage } from '../case_view/case_view_page';
+import { useRefreshCaseViewPage } from '../case_view/use_on_refresh_case_view_page';
 
 export interface UsePushToService {
   caseId: string;

--- a/x-pack/plugins/cases/public/components/user_actions/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/index.test.tsx
@@ -283,8 +283,6 @@ describe(`UserActions`, () => {
         commentUpdate: sampleData.content,
         caseId: 'case-id',
         commentId: props.data.comments[0].id,
-        fetchUserActions,
-        updateCase,
         version: props.data.comments[0].version,
       });
     });

--- a/x-pack/plugins/cases/public/components/user_actions/index.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/index.tsx
@@ -81,7 +81,6 @@ export const UserActions = React.memo(
     caseServices,
     caseUserActions,
     data: caseData,
-    fetchUserActions,
     getRuleDetailsHref,
     actionsNavigation,
     isLoadingDescription,
@@ -90,7 +89,6 @@ export const UserActions = React.memo(
     onShowAlertDetails,
     onUpdateField,
     statusActionButton,
-    updateCase,
     useFetchAlertData,
     userCanCrud,
   }: UserActionTreeProps) => {
@@ -116,7 +114,7 @@ export const UserActions = React.memo(
       handleManageQuote,
       handleDeleteComment,
       handleUpdate,
-    } = useUserActionsHandler({ fetchUserActions, updateCase });
+    } = useUserActionsHandler();
 
     const MarkdownNewComment = useMemo(
       () => (

--- a/x-pack/plugins/cases/public/components/user_actions/types.ts
+++ b/x-pack/plugins/cases/public/components/user_actions/types.ts
@@ -20,7 +20,6 @@ export interface UserActionTreeProps {
   caseServices: CaseServices;
   caseUserActions: CaseUserActions[];
   data: Case;
-  fetchUserActions: () => void;
   getRuleDetailsHref?: RuleDetailsNavigation['href'];
   actionsNavigation?: ActionsNavigation;
   isLoadingDescription: boolean;
@@ -29,7 +28,6 @@ export interface UserActionTreeProps {
   onShowAlertDetails: (alertId: string, index: string) => void;
   onUpdateField: ({ key, value, onSuccess, onError }: OnUpdateFields) => void;
   statusActionButton: JSX.Element | null;
-  updateCase: (newCase: Case) => void;
   useFetchAlertData: UseFetchAlertData;
   userCanCrud: boolean;
 }

--- a/x-pack/plugins/cases/public/components/user_actions/use_user_actions_handler.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/use_user_actions_handler.test.tsx
@@ -27,9 +27,6 @@ const clearDraftComment = jest.fn();
 const openLensModal = jest.fn();
 
 describe('useUserActionsHandler', () => {
-  const fetchUserActions = jest.fn();
-  const updateCase = jest.fn();
-
   beforeAll(() => {
     jest.useFakeTimers();
     jest.spyOn(global, 'setTimeout');

--- a/x-pack/plugins/cases/public/components/user_actions/use_user_actions_handler.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/use_user_actions_handler.test.tsx
@@ -9,16 +9,14 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { basicCase } from '../../containers/mock';
 
 import { useUpdateComment } from '../../containers/use_update_comment';
+import { useRefreshCaseViewPage } from '../case_view/use_on_refresh_case_view_page';
 import { useLensDraftComment } from '../markdown_editor/plugins/lens/use_lens_draft_comment';
 import { NEW_COMMENT_ID } from './constants';
-import {
-  useUserActionsHandler,
-  UseUserActionsHandlerArgs,
-  UseUserActionsHandler,
-} from './use_user_actions_handler';
+import { useUserActionsHandler } from './use_user_actions_handler';
 
 jest.mock('../../common/lib/kibana');
 jest.mock('../../common/navigation/hooks');
+jest.mock('../case_view/use_on_refresh_case_view_page');
 jest.mock('../markdown_editor/plugins/lens/use_lens_draft_comment');
 jest.mock('../../containers/use_update_comment');
 
@@ -56,36 +54,27 @@ describe('useUserActionsHandler', () => {
     });
   });
 
-  it('should saves a comment', async () => {
-    const { result } = renderHook<UseUserActionsHandlerArgs, UseUserActionsHandler>(() =>
-      useUserActionsHandler({ fetchUserActions, updateCase })
-    );
+  it('should save a comment', async () => {
+    const { result } = renderHook(() => useUserActionsHandler());
 
     result.current.handleSaveComment({ id: 'test-id', version: 'test-version' }, 'a comment');
     expect(patchComment).toHaveBeenCalledWith({
       caseId: 'basic-case-id',
       commentId: 'test-id',
       commentUpdate: 'a comment',
-      fetchUserActions,
-      updateCase,
       version: 'test-version',
     });
   });
 
-  it('should update a case', async () => {
-    const { result } = renderHook<UseUserActionsHandlerArgs, UseUserActionsHandler>(() =>
-      useUserActionsHandler({ fetchUserActions, updateCase })
-    );
+  it('should refresh the case case after updating', async () => {
+    const { result } = renderHook(() => useUserActionsHandler());
 
     result.current.handleUpdate(basicCase);
-    expect(fetchUserActions).toHaveBeenCalled();
-    expect(updateCase).toHaveBeenCalledWith(basicCase);
+    expect(useRefreshCaseViewPage()).toHaveBeenCalled();
   });
 
   it('should handle markdown edit', async () => {
-    const { result } = renderHook<UseUserActionsHandlerArgs, UseUserActionsHandler>(() =>
-      useUserActionsHandler({ fetchUserActions, updateCase })
-    );
+    const { result } = renderHook(() => useUserActionsHandler());
 
     act(() => {
       result.current.handleManageMarkdownEditId('test-id');
@@ -96,9 +85,7 @@ describe('useUserActionsHandler', () => {
   });
 
   it('should remove id from the markdown edit ids', async () => {
-    const { result } = renderHook<UseUserActionsHandlerArgs, UseUserActionsHandler>(() =>
-      useUserActionsHandler({ fetchUserActions, updateCase })
-    );
+    const { result } = renderHook(() => useUserActionsHandler());
 
     act(() => {
       result.current.handleManageMarkdownEditId('test-id');
@@ -114,9 +101,7 @@ describe('useUserActionsHandler', () => {
   });
 
   it('should outline a comment', async () => {
-    const { result } = renderHook<UseUserActionsHandlerArgs, UseUserActionsHandler>(() =>
-      useUserActionsHandler({ fetchUserActions, updateCase })
-    );
+    const { result } = renderHook(() => useUserActionsHandler());
 
     act(() => {
       result.current.handleOutlineComment('test-id');
@@ -133,9 +118,7 @@ describe('useUserActionsHandler', () => {
 
   it('should quote', async () => {
     const addQuote = jest.fn();
-    const { result } = renderHook<UseUserActionsHandlerArgs, UseUserActionsHandler>(() =>
-      useUserActionsHandler({ fetchUserActions, updateCase })
-    );
+    const { result } = renderHook(() => useUserActionsHandler());
 
     result.current.commentRefs.current[NEW_COMMENT_ID] = {
       addQuote,

--- a/x-pack/plugins/cases/public/components/user_actions/use_user_actions_handler.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/use_user_actions_handler.tsx
@@ -12,14 +12,10 @@ import { useLensDraftComment } from '../markdown_editor/plugins/lens/use_lens_dr
 import { useUpdateComment } from '../../containers/use_update_comment';
 import { AddCommentRefObject } from '../add_comment';
 import { UserActionMarkdownRefObject } from './markdown_form';
-import { UserActionBuilderArgs, UserActionTreeProps } from './types';
+import { UserActionBuilderArgs } from './types';
 import { NEW_COMMENT_ID } from './constants';
 import { useDeleteComment } from '../../containers/use_delete_comment';
-
-export type UseUserActionsHandlerArgs = Pick<
-  UserActionTreeProps,
-  'fetchUserActions' | 'updateCase'
->;
+import { useRefreshCaseViewPage } from '../case_view/use_on_refresh_case_view_page';
 
 export type UseUserActionsHandler = Pick<
   UserActionBuilderArgs,
@@ -41,10 +37,7 @@ const isAddCommentRef = (
   return commentRef?.addQuote != null;
 };
 
-export const useUserActionsHandler = ({
-  fetchUserActions,
-  updateCase,
-}: UseUserActionsHandlerArgs): UseUserActionsHandler => {
+export const useUserActionsHandler = (): UseUserActionsHandler => {
   const { detailName: caseId } = useCaseViewParams();
   const { clearDraftComment, draftComment, hasIncomingLensState, openLensModal } =
     useLensDraftComment();
@@ -53,6 +46,7 @@ export const useUserActionsHandler = ({
   const { deleteComment } = useDeleteComment();
   const [selectedOutlineCommentId, setSelectedOutlineCommentId] = useState('');
   const [manageMarkdownEditIds, setManageMarkdownEditIds] = useState<string[]>([]);
+  const refreshCaseViewPage = useRefreshCaseViewPage();
   const commentRefs = useRef<
     Record<string, AddCommentRefObject | UserActionMarkdownRefObject | undefined | null>
   >({});
@@ -75,19 +69,17 @@ export const useUserActionsHandler = ({
         caseId,
         commentId: id,
         commentUpdate: content,
-        fetchUserActions,
         version,
-        updateCase,
       });
     },
-    [caseId, fetchUserActions, patchComment, updateCase]
+    [caseId, patchComment]
   );
 
   const handleDeleteComment = useCallback(
     (id: string) => {
-      deleteComment({ caseId, commentId: id, fetchUserActions, updateCase });
+      deleteComment({ caseId, commentId: id });
     },
-    [caseId, deleteComment, fetchUserActions, updateCase]
+    [caseId, deleteComment]
   );
 
   const handleOutlineComment = useCallback(
@@ -129,14 +121,6 @@ export const useUserActionsHandler = ({
     [handleOutlineComment]
   );
 
-  const handleUpdate = useCallback(
-    (newCase: Case) => {
-      updateCase(newCase);
-      fetchUserActions();
-    },
-    [fetchUserActions, updateCase]
-  );
-
   useEffect(() => {
     if (draftComment?.commentId) {
       setManageMarkdownEditIds((prevManageMarkdownEditIds) => {
@@ -172,6 +156,6 @@ export const useUserActionsHandler = ({
     handleSaveComment,
     handleDeleteComment,
     handleManageQuote,
-    handleUpdate,
+    handleUpdate: refreshCaseViewPage,
   };
 };

--- a/x-pack/plugins/cases/public/containers/use_delete_comment.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_delete_comment.test.tsx
@@ -9,13 +9,16 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { useDeleteComment, UseDeleteComment } from './use_delete_comment';
 import * as api from './api';
 import { basicCaseId } from './mock';
+import { useRefreshCaseViewPage } from '../components/case_view/case_view_page';
 
 jest.mock('../common/lib/kibana');
 jest.mock('./api');
+jest.mock('../components/case_view/case_view_page');
 
 const commentId = 'ab124';
-const fetchUserActions = jest.fn();
-const updateCase = jest.fn();
+
+const refreshMock = jest.fn();
+(useRefreshCaseViewPage as jest.Mock).mockReturnValue(refreshMock);
 
 describe('useDeleteComment', () => {
   it('init', async () => {
@@ -43,8 +46,6 @@ describe('useDeleteComment', () => {
       result.current.deleteComment({
         caseId: basicCaseId,
         commentId,
-        fetchUserActions,
-        updateCase,
       });
       await waitForNextUpdate();
       expect(spyOnDeleteComment).toBeCalledWith({
@@ -56,9 +57,7 @@ describe('useDeleteComment', () => {
     });
   });
 
-  it('fetches the case information', async () => {
-    const spyOnGetCase = jest.spyOn(api, 'getCase');
-
+  it('refreshes the case page view after delete', async () => {
     await act(async () => {
       const { result, waitForNextUpdate } = renderHook<string, UseDeleteComment>(() =>
         useDeleteComment()
@@ -68,11 +67,9 @@ describe('useDeleteComment', () => {
       result.current.deleteComment({
         caseId: basicCaseId,
         commentId,
-        fetchUserActions,
-        updateCase,
       });
       await waitForNextUpdate();
-      expect(spyOnGetCase).toBeCalledWith(basicCaseId, true, expect.any(AbortSignal));
+      expect(refreshMock).toBeCalled();
     });
   });
 
@@ -89,8 +86,6 @@ describe('useDeleteComment', () => {
       result.current.deleteComment({
         caseId: basicCaseId,
         commentId,
-        fetchUserActions,
-        updateCase,
       });
       await waitForNextUpdate();
       expect(spyOnDeleteComment).toBeCalledWith({

--- a/x-pack/plugins/cases/public/containers/use_delete_comment.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_delete_comment.test.tsx
@@ -9,16 +9,13 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { useDeleteComment, UseDeleteComment } from './use_delete_comment';
 import * as api from './api';
 import { basicCaseId } from './mock';
-import { useRefreshCaseViewPage } from '../components/case_view/case_view_page';
+import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
 
 jest.mock('../common/lib/kibana');
 jest.mock('./api');
-jest.mock('../components/case_view/case_view_page');
+jest.mock('../components/case_view/use_on_refresh_case_view_page');
 
 const commentId = 'ab124';
-
-const refreshMock = jest.fn();
-(useRefreshCaseViewPage as jest.Mock).mockReturnValue(refreshMock);
 
 describe('useDeleteComment', () => {
   it('init', async () => {
@@ -69,7 +66,7 @@ describe('useDeleteComment', () => {
         commentId,
       });
       await waitForNextUpdate();
-      expect(refreshMock).toBeCalled();
+      expect(useRefreshCaseViewPage()).toBeCalled();
     });
   });
 

--- a/x-pack/plugins/cases/public/containers/use_delete_comment.tsx
+++ b/x-pack/plugins/cases/public/containers/use_delete_comment.tsx
@@ -7,7 +7,7 @@
 
 import { useReducer, useCallback, useRef, useEffect } from 'react';
 import { useToasts } from '../common/lib/kibana';
-import { useRefreshCaseViewPage } from '../components/case_view/case_view_page';
+import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
 import { deleteComment } from './api';
 import * as i18n from './translations';
 

--- a/x-pack/plugins/cases/public/containers/use_delete_comment.tsx
+++ b/x-pack/plugins/cases/public/containers/use_delete_comment.tsx
@@ -7,9 +7,9 @@
 
 import { useReducer, useCallback, useRef, useEffect } from 'react';
 import { useToasts } from '../common/lib/kibana';
-import { deleteComment, getCase } from './api';
+import { useRefreshCaseViewPage } from '../components/case_view/case_view_page';
+import { deleteComment } from './api';
 import * as i18n from './translations';
-import { Case } from './types';
 
 interface CommentDeleteState {
   isError: boolean;
@@ -49,12 +49,10 @@ const dataFetchReducer = (state: CommentDeleteState, action: Action): CommentDel
 interface DeleteComment {
   caseId: string;
   commentId: string;
-  fetchUserActions: () => void;
-  updateCase: (newCase: Case) => void;
 }
 
 export interface UseDeleteComment extends CommentDeleteState {
-  deleteComment: ({ caseId, commentId, fetchUserActions }: DeleteComment) => void;
+  deleteComment: ({ caseId, commentId }: DeleteComment) => void;
 }
 
 export const useDeleteComment = (): UseDeleteComment => {
@@ -64,9 +62,10 @@ export const useDeleteComment = (): UseDeleteComment => {
   const toasts = useToasts();
   const isCancelledRef = useRef(false);
   const abortCtrlRef = useRef(new AbortController());
+  const refreshCaseViewPage = useRefreshCaseViewPage();
 
   const dispatchDeleteComment = useCallback(
-    async ({ caseId, commentId, fetchUserActions, updateCase }: DeleteComment) => {
+    async ({ caseId, commentId }: DeleteComment) => {
       try {
         isCancelledRef.current = false;
         abortCtrlRef.current.abort();
@@ -80,9 +79,7 @@ export const useDeleteComment = (): UseDeleteComment => {
         });
 
         if (!isCancelledRef.current) {
-          const theCase = await getCase(caseId, true, abortCtrlRef.current.signal);
-          updateCase(theCase);
-          fetchUserActions();
+          refreshCaseViewPage();
           dispatch({ type: 'FETCH_SUCCESS', payload: { commentId } });
         }
       } catch (error) {

--- a/x-pack/plugins/cases/public/containers/use_update_case.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_update_case.test.tsx
@@ -10,23 +10,21 @@ import { useUpdateCase, UseUpdateCase } from './use_update_case';
 import { basicCase } from './mock';
 import * as api from './api';
 import { UpdateKey } from './types';
+import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
 
 jest.mock('./api');
 jest.mock('../common/lib/kibana');
+jest.mock('../components/case_view/use_on_refresh_case_view_page');
 
 describe('useUpdateCase', () => {
   const abortCtrl = new AbortController();
-  const fetchCaseUserActions = jest.fn();
-  const updateCase = jest.fn();
   const updateKey: UpdateKey = 'description';
   const onSuccess = jest.fn();
   const onError = jest.fn();
 
   const sampleUpdate = {
-    fetchCaseUserActions,
     updateKey,
     updateValue: 'updated description',
-    updateCase,
     caseData: basicCase,
     onSuccess,
     onError,
@@ -71,7 +69,7 @@ describe('useUpdateCase', () => {
     });
   });
 
-  it('patch case', async () => {
+  it('patch case and refresh the case page', async () => {
     await act(async () => {
       const { result, waitForNextUpdate } = renderHook<string, UseUpdateCase>(() =>
         useUpdateCase({ caseId: basicCase.id })
@@ -85,8 +83,7 @@ describe('useUpdateCase', () => {
         isError: false,
         updateCaseProperty: result.current.updateCaseProperty,
       });
-      expect(fetchCaseUserActions).toBeCalledWith(basicCase.id, 'none');
-      expect(updateCase).toBeCalledWith(basicCase);
+      expect(useRefreshCaseViewPage()).toHaveBeenCalled();
       expect(onSuccess).toHaveBeenCalled();
     });
   });

--- a/x-pack/plugins/cases/public/containers/use_update_case.tsx
+++ b/x-pack/plugins/cases/public/containers/use_update_case.tsx
@@ -12,6 +12,7 @@ import { patchCase } from './api';
 import { UpdateKey, UpdateByKey } from '../../common/ui/types';
 import * as i18n from './translations';
 import { createUpdateSuccessToaster } from './utils';
+import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
 
 interface NewCaseState {
   isLoading: boolean;
@@ -65,17 +66,10 @@ export const useUpdateCase = ({ caseId }: { caseId: string }): UseUpdateCase => 
   const toasts = useToasts();
   const isCancelledRef = useRef(false);
   const abortCtrlRef = useRef(new AbortController());
+  const refreshCaseViewPage = useRefreshCaseViewPage();
 
   const dispatchUpdateCaseProperty = useCallback(
-    async ({
-      fetchCaseUserActions,
-      updateKey,
-      updateValue,
-      updateCase,
-      caseData,
-      onSuccess,
-      onError,
-    }: UpdateByKey) => {
+    async ({ updateKey, updateValue, caseData, onSuccess, onError }: UpdateByKey) => {
       try {
         isCancelledRef.current = false;
         abortCtrlRef.current.abort();
@@ -90,12 +84,7 @@ export const useUpdateCase = ({ caseId }: { caseId: string }): UseUpdateCase => 
         );
 
         if (!isCancelledRef.current) {
-          if (fetchCaseUserActions != null) {
-            fetchCaseUserActions(caseId, response[0].connector.id);
-          }
-          if (updateCase != null) {
-            updateCase(response[0]);
-          }
+          refreshCaseViewPage();
           dispatch({ type: 'FETCH_SUCCESS' });
           toasts.addSuccess(
             createUpdateSuccessToaster(caseData, response[0], updateKey, updateValue)

--- a/x-pack/plugins/cases/public/containers/use_update_comment.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_update_comment.test.tsx
@@ -8,13 +8,15 @@
 import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useUpdateComment, UseUpdateComment } from './use_update_comment';
-import { basicCase, basicCaseCommentPatch } from './mock';
+import { basicCase } from './mock';
 import * as api from './api';
 import { TestProviders } from '../common/mock';
 import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
+import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
 
 jest.mock('./api');
 jest.mock('../common/lib/kibana');
+jest.mock('../components/case_view/use_on_refresh_case_view_page');
 
 describe('useUpdateComment', () => {
   const abortCtrl = new AbortController();
@@ -82,8 +84,7 @@ describe('useUpdateComment', () => {
         isError: false,
         patchComment: result.current.patchComment,
       });
-      expect(fetchUserActions).toBeCalled();
-      expect(updateCase).toBeCalledWith(basicCaseCommentPatch);
+      expect(useRefreshCaseViewPage()).toBeCalled();
     });
   });
 

--- a/x-pack/plugins/cases/public/containers/use_update_comment.tsx
+++ b/x-pack/plugins/cases/public/containers/use_update_comment.tsx
@@ -8,9 +8,9 @@
 import { useReducer, useCallback, useRef, useEffect } from 'react';
 import { useToasts } from '../common/lib/kibana';
 import { useCasesContext } from '../components/cases_context/use_cases_context';
+import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
 import { patchComment } from './api';
 import * as i18n from './translations';
-import { Case } from './types';
 
 interface CommentUpdateState {
   isLoadingIds: string[];
@@ -55,13 +55,11 @@ interface UpdateComment {
   caseId: string;
   commentId: string;
   commentUpdate: string;
-  fetchUserActions: () => void;
-  updateCase: (newCase: Case) => void;
   version: string;
 }
 
 export interface UseUpdateComment extends CommentUpdateState {
-  patchComment: ({ caseId, commentId, commentUpdate, fetchUserActions }: UpdateComment) => void;
+  patchComment: ({ caseId, commentId, commentUpdate }: UpdateComment) => void;
 }
 
 export const useUpdateComment = (): UseUpdateComment => {
@@ -75,23 +73,17 @@ export const useUpdateComment = (): UseUpdateComment => {
   // this hook guarantees that there will be at least one value in the owner array, we'll
   // just use the first entry just in case there are more than one entry
   const owner = useCasesContext().owner[0];
+  const refreshCaseViewPage = useRefreshCaseViewPage();
 
   const dispatchUpdateComment = useCallback(
-    async ({
-      caseId,
-      commentId,
-      commentUpdate,
-      fetchUserActions,
-      updateCase,
-      version,
-    }: UpdateComment) => {
+    async ({ caseId, commentId, commentUpdate, version }: UpdateComment) => {
       try {
         isCancelledRef.current = false;
         abortCtrlRef.current.abort();
         abortCtrlRef.current = new AbortController();
         dispatch({ type: 'FETCH_INIT', payload: commentId });
 
-        const response = await patchComment({
+        await patchComment({
           caseId,
           commentId,
           commentUpdate,
@@ -101,8 +93,7 @@ export const useUpdateComment = (): UseUpdateComment => {
         });
 
         if (!isCancelledRef.current) {
-          updateCase(response);
-          fetchUserActions();
+          refreshCaseViewPage();
           dispatch({ type: 'FETCH_SUCCESS', payload: { commentId } });
         }
       } catch (error) {
@@ -117,8 +108,7 @@ export const useUpdateComment = (): UseUpdateComment => {
         }
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [owner, refreshCaseViewPage, toasts]
   );
 
   useEffect(


### PR DESCRIPTION
## Summary

Removes the left-over updateCase prop that is propagated around many components in the case view page.