### PR TITLE
[Fleet] Refresh agent policies in flyout to solve sync bug

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { EuiText, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
@@ -39,9 +39,14 @@ export const Instructions = (props: InstructionProps) => {
     mode,
     setMode,
     isIntegrationFlow,
+    refreshAgentPolicies,
   } = props;
   const fleetStatus = useFleetStatus();
   const { isUnhealthy: isFleetServerUnhealthy } = useFleetServerUnhealthy();
+
+  useEffect(() => {
+    refreshAgentPolicies();
+  }, [refreshAgentPolicies]);
 
   const fleetServerAgentPolicies: string[] = useMemo(
     () => agentPolicies.filter((pol) => policyHasFleetServer(pol)).map((pol) => pol.id),


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/131590

Adding the `refreshAgentPolicies` function to fix a sync issue during first setup of fleet server

- On fresh Kibana setup navigate to Fleet tab.
- Go to the agent flyout, it show "Add Fleet Server"
- Install a new agent using Advanced > Quickstart mode.
- Open again the flyout, it should show the "Add agent" layout


