### PR TITLE
[Cloud Posture] Rules page changes and clickable breadcrumbs

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
@@ -9,7 +9,6 @@ import type { ChromeBreadcrumb, CoreStart } from '@kbn/core/public';
 import { useEffect } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { type RouteProps, useRouteMatch, useHistory } from 'react-router-dom';
-import { PLUGIN_ID } from '../../../common';
 import type { CspNavigationItem } from './types';
 import { CLOUD_POSTURE } from './translations';
 
@@ -36,7 +35,6 @@ export const useCspBreadcrumbs = (breadcrumbs: CspNavigationItem[]) => {
   const history = useHistory();
 
   useEffect(() => {
-    const cspPath = getUrlForApp(PLUGIN_ID);
     const additionalBreadCrumbs: ChromeBreadcrumb[] = breadcrumbs.map((breadcrumb) => {
       const clickableLink = getClickableBreadcrumb(match.path, breadcrumb.path);
 
@@ -54,7 +52,10 @@ export const useCspBreadcrumbs = (breadcrumbs: CspNavigationItem[]) => {
     setBreadcrumbs([
       {
         text: CLOUD_POSTURE,
-        href: cspPath,
+        onClick: (e) => {
+          e.preventDefault();
+          history.push(`/`);
+        },
       },
       ...additionalBreadCrumbs,
     ]);

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
@@ -59,5 +59,5 @@ export const useCspBreadcrumbs = (breadcrumbs: CspNavigationItem[]) => {
       },
       ...additionalBreadCrumbs,
     ]);
-  }, [match.path, getUrlForApp, setBreadcrumbs, breadcrumbs]);
+  }, [match.path, getUrlForApp, setBreadcrumbs, breadcrumbs, history]);
 };

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
@@ -8,9 +8,18 @@
 import type { ChromeBreadcrumb, CoreStart } from '@kbn/core/public';
 import { useEffect } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import { PLUGIN_ID } from '../../../common';
 import type { CspNavigationItem } from './types';
 import { CLOUD_POSTURE } from './translations';
+
+const getClickableHref = (routeMatch, breadcrumbPath, basePath) => {
+  if (routeMatch !== breadcrumbPath) {
+    return breadcrumbPath.startsWith('/')
+      ? `${basePath}${breadcrumbPath}`
+      : `${basePath}/${breadcrumbPath}`;
+  }
+};
 
 export const useCspBreadcrumbs = (breadcrumbs: CspNavigationItem[]) => {
   const {
@@ -19,14 +28,18 @@ export const useCspBreadcrumbs = (breadcrumbs: CspNavigationItem[]) => {
       application: { getUrlForApp },
     },
   } = useKibana<CoreStart>();
+  const location = useLocation();
+  const history = useHistory();
+  const match = useRouteMatch();
+  console.log(location);
+  console.log(history);
+  console.log(match);
 
   useEffect(() => {
     const cspPath = getUrlForApp(PLUGIN_ID);
     const additionalBreadCrumbs: ChromeBreadcrumb[] = breadcrumbs.map((breadcrumb) => ({
       text: breadcrumb.name,
-      path: breadcrumb.path.startsWith('/')
-        ? `${cspPath}${breadcrumb.path}`
-        : `${cspPath}/${breadcrumb.path}`,
+      href: getClickableHref(match.path, breadcrumb.path, cspPath),
     }));
 
     setBreadcrumbs([

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
@@ -8,12 +8,19 @@
 import type { ChromeBreadcrumb, CoreStart } from '@kbn/core/public';
 import { useEffect } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
+import { type RouteProps, useRouteMatch } from 'react-router-dom';
 import { PLUGIN_ID } from '../../../common';
 import type { CspNavigationItem } from './types';
 import { CLOUD_POSTURE } from './translations';
 
-const getClickableHref = (routeMatch, breadcrumbPath, basePath) => {
+const getClickableHref = (
+  routeMatch: RouteProps['path'],
+  breadcrumbPath: CspNavigationItem['path'],
+  basePath: string
+) => {
+  const hasParams = breadcrumbPath.includes(':');
+  if (hasParams) return;
+
   if (routeMatch !== breadcrumbPath) {
     return breadcrumbPath.startsWith('/')
       ? `${basePath}${breadcrumbPath}`
@@ -28,12 +35,7 @@ export const useCspBreadcrumbs = (breadcrumbs: CspNavigationItem[]) => {
       application: { getUrlForApp },
     },
   } = useKibana<CoreStart>();
-  const location = useLocation();
-  const history = useHistory();
   const match = useRouteMatch();
-  console.log(location);
-  console.log(history);
-  console.log(match);
 
   useEffect(() => {
     const cspPath = getUrlForApp(PLUGIN_ID);
@@ -49,5 +51,5 @@ export const useCspBreadcrumbs = (breadcrumbs: CspNavigationItem[]) => {
       },
       ...additionalBreadCrumbs,
     ]);
-  }, [getUrlForApp, setBreadcrumbs, breadcrumbs]);
+  }, [match.path, getUrlForApp, setBreadcrumbs, breadcrumbs]);
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -18,7 +18,6 @@ import { CspNavigationItem } from '../../common/navigation/types';
 import { extractErrorMessage } from '../../../common/utils/helpers';
 import { useCspIntegration } from './use_csp_integration';
 import { CspPageTemplate } from '../../components/csp_page_template';
-import * as TEXT from './translations';
 
 const getRulesBreadcrumbs = (name?: string): CspNavigationItem[] =>
   [allNavigationItems.benchmarks, { ...allNavigationItems.rules, name }].filter(
@@ -48,13 +47,26 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
                 />
               </EuiButtonEmpty>
             </Link>
-            {TEXT.RULES}
+            <FormattedMessage
+              id="xpack.csp.rules.rulePageHeader.pageHeaderTitle"
+              defaultMessage="Rules - {integrationName}"
+              values={{
+                integrationName: integrationInfo.data?.name,
+              }}
+            />
           </EuiFlexGroup>
         ),
         description: integrationInfo.data && integrationInfo.data.package && (
-          <PageDescription
-            text={`${integrationInfo.data.package.title}, ${integrationInfo.data.name}`}
-          />
+          <EuiTextColor color="subdued">
+            <FormattedMessage
+              id="xpack.csp.rules.rulePageHeader.pageDescriptionTitle"
+              defaultMessage="{integrationType}, {agentPolicyName}"
+              values={{
+                integrationType: integrationInfo.data.package.title,
+                agentPolicyName: integrationInfo.data.name,
+              }}
+            />
+          </EuiTextColor>
         ),
       },
     }),
@@ -85,10 +97,6 @@ const extractErrorBodyMessage = (err: unknown) => {
   if (bodyError.is(err)) return err.body.message;
   return extractErrorMessage(err);
 };
-
-const PageDescription = ({ text }: { text: string }) => (
-  <EuiTextColor color="subdued">{text}</EuiTextColor>
-);
 
 const RulesErrorPrompt = ({ error }: { error: string }) => (
   <EuiEmptyPrompt

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { useMemo } from 'react';
-import { RouteComponentProps } from 'react-router-dom';
-import { EuiTextColor, EuiEmptyPrompt } from '@elastic/eui';
+import { generatePath, Link, RouteComponentProps } from 'react-router-dom';
+import { EuiTextColor, EuiEmptyPrompt, EuiButtonEmpty, EuiFlexGroup } from '@elastic/eui';
 import * as t from 'io-ts';
 import type { KibanaPageTemplateProps } from '@kbn/kibana-react-plugin/public';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { RulesContainer, type PageUrlParams } from './rules_container';
 import { allNavigationItems } from '../../common/navigation/constants';
 import { useCspBreadcrumbs } from '../../common/navigation/use_csp_breadcrumbs';
@@ -17,6 +18,7 @@ import { CspNavigationItem } from '../../common/navigation/types';
 import { extractErrorMessage } from '../../../common/utils/helpers';
 import { useCspIntegration } from './use_csp_integration';
 import { CspPageTemplate } from '../../components/csp_page_template';
+import * as TEXT from './translations';
 
 const getRulesBreadcrumbs = (name?: string): CspNavigationItem[] =>
   [allNavigationItems.benchmarks, { ...allNavigationItems.rules, name }].filter(
@@ -36,8 +38,19 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
   const pageProps: KibanaPageTemplateProps = useMemo(
     () => ({
       pageHeader: {
-        bottomBorder: false, // TODO: border still shows.
-        pageTitle: 'Rules',
+        pageTitle: (
+          <EuiFlexGroup direction="column" gutterSize="none">
+            <Link to={generatePath(allNavigationItems.benchmarks.path)}>
+              <EuiButtonEmpty iconType="arrowLeft" contentProps={{ style: { padding: 0 } }}>
+                <FormattedMessage
+                  id="xpack.csp.rules.rulesPageHeader.benchmarkIntegrationsButtonLabel"
+                  defaultMessage="Benchmark Integrations"
+                />
+              </EuiButtonEmpty>
+            </Link>
+            {TEXT.RULES}
+          </EuiFlexGroup>
+        ),
         description: integrationInfo.data && integrationInfo.data.package && (
           <PageDescription
             text={`${integrationInfo.data.package.title}, ${integrationInfo.data.name}`}
@@ -49,13 +62,15 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
   );
 
   return (
-    <CspPageTemplate
-      {...pageProps}
-      query={integrationInfo}
-      errorRender={(error) => <RulesErrorPrompt error={extractErrorBodyMessage(error)} />}
-    >
-      {integrationInfo.status === 'success' && <RulesContainer />}
-    </CspPageTemplate>
+    <>
+      <CspPageTemplate
+        {...pageProps}
+        query={integrationInfo}
+        errorRender={(error) => <RulesErrorPrompt error={extractErrorBodyMessage(error)} />}
+      >
+        {integrationInfo.status === 'success' && <RulesContainer />}
+      </CspPageTemplate>
+    </>
   );
 };
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -112,7 +112,7 @@ export const RulesContainer = () => {
     filter: `${cspRuleAssetSavedObjectType}.attributes.policy_id: "${params.policyId}" and ${cspRuleAssetSavedObjectType}.attributes.package_policy_id: "${params.packagePolicyId}"`,
     search: '',
     page: 0,
-    perPage: 10,
+    perPage: 25,
   });
 
   const { data, status, error, refetch } = useFindCspRules({

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -112,7 +112,7 @@ export const RulesContainer = () => {
     filter: `${cspRuleAssetSavedObjectType}.attributes.policy_id: "${params.policyId}" and ${cspRuleAssetSavedObjectType}.attributes.package_policy_id: "${params.packagePolicyId}"`,
     search: '',
     page: 0,
-    perPage: 5,
+    perPage: 10,
   });
 
   const { data, status, error, refetch } = useFindCspRules({

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -58,7 +58,7 @@ export const RulesTable = ({
     pageIndex: page,
     pageSize,
     totalItemCount: total,
-    pageSizeOptions: [1, 5, 10, 25],
+    pageSizeOptions: [10, 25, 100],
   };
 
   const selection: EuiBasicTableProps<RuleSavedObject>['selection'] = {

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
@@ -84,3 +84,7 @@ export const OVERVIEW = i18n.translate('xpack.csp.rules.ruleFlyout.tabs.overview
 export const REMEDIATION = i18n.translate('xpack.csp.rules.ruleFlyout.tabs.remediationTabLabel', {
   defaultMessage: 'Remediation',
 });
+
+export const RULES = i18n.translate('xpack.csp.rules.rulesPageHeader.pageTitleLabel', {
+  defaultMessage: 'Rules',
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
@@ -84,7 +84,3 @@ export const OVERVIEW = i18n.translate('xpack.csp.rules.ruleFlyout.tabs.overview
 export const REMEDIATION = i18n.translate('xpack.csp.rules.ruleFlyout.tabs.remediationTabLabel', {
   defaultMessage: 'Remediation',
 });
-
-export const RULES = i18n.translate('xpack.csp.rules.rulesPageHeader.pageTitleLabel', {
-  defaultMessage: 'Rules',
-});


### PR DESCRIPTION
## Summary

- Breadcrumbs are now clickable, you cannot click on a breadcrumb that leads to the same URL you are currently on, this also leads to better UI (the current path is a gray breadcrumb).
For now, URLs with params are not supported and the check for params is very basic.
- Back to benchmark integration button has been added
- Page title now displays the integration name
- Default amount of rows per page was adjusted to 10 from 5
- The amount of rows per page options changed to `10, 25, 100`

https://user-images.githubusercontent.com/51442161/171161087-be89db67-980a-4e11-8503-2c7045b94116.mov


NOTE: after a change suggested by @orouz the page will not completely refresh as we see in the video. we opted to use react-router navigation instead