### PR TITLE
[8.3] [Uptime] Add missing project fields to fields_under_root (#132954)

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
@@ -17,6 +17,7 @@ import { API_URLS } from '../../../common/constants';
 import { syntheticsMonitorType } from '../../legacy_uptime/lib/saved_objects/synthetics_monitor';
 import { validateMonitor } from './monitor_validation';
 import { sendTelemetryEvents, formatTelemetryEvent } from '../telemetry/monitor_upgrade_sender';
+import { formatHeartbeatRequest } from '../../synthetics_service/formatters/format_configs';
 import { formatSecrets } from '../../synthetics_service/utils/secrets';
 import type { UptimeServerSetup } from '../../legacy_uptime/lib/adapters/framework';
 
@@ -84,14 +85,13 @@ export const syncNewMonitor = async ({
   monitorSavedObject: SavedObject<EncryptedSyntheticsMonitor>;
   server: UptimeServerSetup;
 }) => {
-  const errors = await server.syntheticsService.addConfig({
-    ...monitor,
-    id: (monitor as MonitorFields)[ConfigKey.CUSTOM_HEARTBEAT_ID] || monitorSavedObject.id,
-    fields: {
-      config_id: monitorSavedObject.id,
-    },
-    fields_under_root: true,
-  });
+  const errors = await server.syntheticsService.addConfig(
+    formatHeartbeatRequest({
+      monitor,
+      monitorId: monitorSavedObject.id,
+      customHeartbeatId: (monitor as MonitorFields)[ConfigKey.CUSTOM_HEARTBEAT_ID],
+    })
+  );
 
   sendTelemetryEvents(
     server.logger,

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
@@ -27,6 +27,7 @@ import {
   sendTelemetryEvents,
   formatTelemetryUpdateEvent,
 } from '../telemetry/monitor_upgrade_sender';
+import { formatHeartbeatRequest } from '../../synthetics_service/formatters/format_configs';
 import { formatSecrets, normalizeSecrets } from '../../synthetics_service/utils/secrets';
 import type { UptimeServerSetup } from '../../legacy_uptime/lib/adapters/framework';
 
@@ -127,16 +128,11 @@ export const syncEditedMonitor = async ({
   server: UptimeServerSetup;
 }) => {
   const errors = await server.syntheticsService.pushConfigs([
-    {
-      ...editedMonitor,
-      id:
-        (editedMonitor as MonitorFields)[ConfigKey.CUSTOM_HEARTBEAT_ID] ||
-        editedMonitorSavedObject.id,
-      fields: {
-        config_id: editedMonitorSavedObject.id,
-      },
-      fields_under_root: true,
-    },
+    formatHeartbeatRequest({
+      monitor: editedMonitor,
+      monitorId: editedMonitorSavedObject.id,
+      customHeartbeatId: (editedMonitor as MonitorFields)[ConfigKey.CUSTOM_HEARTBEAT_ID],
+    }),
   ]);
 
   sendTelemetryEvents(

--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/run_once_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/run_once_monitor.ts
@@ -8,6 +8,7 @@ import { schema } from '@kbn/config-schema';
 import { MonitorFields } from '../../../common/runtime_types';
 import { UMRestApiRouteFactory } from '../../legacy_uptime/routes/types';
 import { API_URLS } from '../../../common/constants';
+import { formatHeartbeatRequest } from '../../synthetics_service/formatters/format_configs';
 import { validateMonitor } from '../monitor_cruds/monitor_validation';
 
 export const runOnceSyntheticsMonitorRoute: UMRestApiRouteFactory = () => ({
@@ -33,12 +34,11 @@ export const runOnceSyntheticsMonitorRoute: UMRestApiRouteFactory = () => ({
     const { syntheticsService } = server;
 
     const errors = await syntheticsService.runOnceConfigs([
-      {
-        ...monitor,
-        id: monitorId,
-        fields_under_root: true,
-        fields: { run_once: true, config_id: monitorId },
-      },
+      formatHeartbeatRequest({
+        monitor,
+        monitorId,
+        runOnce: true,
+      }),
     ]);
 
     if (errors) {

--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
@@ -18,6 +18,7 @@ import {
   syntheticsMonitor,
   syntheticsMonitorType,
 } from '../../legacy_uptime/lib/saved_objects/synthetics_monitor';
+import { formatHeartbeatRequest } from '../../synthetics_service/formatters/format_configs';
 import { normalizeSecrets } from '../../synthetics_service/utils/secrets';
 
 export const testNowMonitorRoute: UMRestApiRouteFactory = () => ({
@@ -51,14 +52,14 @@ export const testNowMonitorRoute: UMRestApiRouteFactory = () => ({
     const testRunId = uuidv4();
 
     const errors = await syntheticsService.triggerConfigs(request, [
-      {
-        ...normalizedMonitor.attributes,
-        id:
-          (normalizedMonitor.attributes as MonitorFields)[ConfigKey.CUSTOM_HEARTBEAT_ID] ||
-          monitorId,
-        fields_under_root: true,
-        fields: { config_id: monitorId, test_run_id: testRunId },
-      },
+      formatHeartbeatRequest({
+        monitor: normalizedMonitor.attributes,
+        monitorId,
+        customHeartbeatId: (normalizedMonitor.attributes as MonitorFields)[
+          ConfigKey.CUSTOM_HEARTBEAT_ID
+        ],
+        testRunId,
+      }),
     ]);
 
     if (errors && errors?.length > 0) {

--- a/x-pack/plugins/synthetics/server/synthetics_service/formatters/format_configs.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/formatters/format_configs.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { FormattedValue } from './common';
-import { formatMonitorConfig } from './format_configs';
+import { formatMonitorConfig, formatHeartbeatRequest } from './format_configs';
 import {
   ConfigKey,
   DataStream,
@@ -14,36 +14,72 @@ import {
   MonitorFields,
   ResponseBodyIndexPolicy,
   ScheduleUnit,
+  SyntheticsMonitor,
 } from '../../../common/runtime_types';
+
+const testHTTPConfig: Partial<MonitorFields> = {
+  type: 'http' as DataStream,
+  enabled: true,
+  schedule: { number: '3', unit: 'm' as ScheduleUnit },
+  'service.name': '',
+  tags: [],
+  timeout: '16',
+  name: 'Test',
+  locations: [],
+  __ui: { is_tls_enabled: false, is_zip_url_tls_enabled: false },
+  urls: 'https://www.google.com',
+  max_redirects: '0',
+  password: '3z9SBOQWW5F0UrdqLVFqlF6z',
+  proxy_url: '',
+  'check.response.body.negative': [],
+  'check.response.body.positive': [],
+  'response.include_body': 'on_error' as ResponseBodyIndexPolicy,
+  'check.response.headers': {},
+  'response.include_headers': true,
+  'check.response.status': [],
+  'check.request.body': { type: 'text' as Mode, value: '' },
+  'check.request.headers': {},
+  'check.request.method': 'GET',
+  username: '',
+};
+
+const testBrowserConfig: Partial<MonitorFields> = {
+  type: DataStream.BROWSER,
+  enabled: true,
+  schedule: { number: '3', unit: ScheduleUnit.MINUTES },
+  'service.name': '',
+  tags: [],
+  timeout: '16',
+  name: 'Test',
+  locations: [],
+  __ui: {
+    script_source: { is_generated_script: false, file_name: '' },
+    is_zip_url_tls_enabled: false,
+    is_tls_enabled: false,
+  },
+  'source.zip_url.url': '',
+  'source.zip_url.username': '',
+  'source.zip_url.password': '',
+  'source.zip_url.folder': '',
+  'source.zip_url.proxy_url': '',
+  'source.inline.script':
+    "step('Go to https://www.google.com/', async () => {\n  await page.goto('https://www.google.com/');\n});",
+  params: '',
+  screenshots: 'on',
+  synthetics_args: ['--hasTouch true'],
+  'filter_journeys.match': '',
+  'filter_journeys.tags': ['dev'],
+  ignore_https_errors: false,
+  'throttling.is_enabled': true,
+  'throttling.download_speed': '5',
+  'throttling.upload_speed': '3',
+  'throttling.latency': '20',
+  'throttling.config': '5d/3u/20l',
+  project_id: 'test-project',
+};
 
 describe('formatMonitorConfig', () => {
   describe('http fields', () => {
-    const testHTTPConfig: Partial<MonitorFields> = {
-      type: 'http' as DataStream,
-      enabled: true,
-      schedule: { number: '3', unit: 'm' as ScheduleUnit },
-      'service.name': '',
-      tags: [],
-      timeout: '16',
-      name: 'Test',
-      locations: [],
-      __ui: { is_tls_enabled: false, is_zip_url_tls_enabled: false },
-      urls: 'https://www.google.com',
-      max_redirects: '0',
-      password: '3z9SBOQWW5F0UrdqLVFqlF6z',
-      proxy_url: '',
-      'check.response.body.negative': [],
-      'check.response.body.positive': [],
-      'response.include_body': 'on_error' as ResponseBodyIndexPolicy,
-      'check.response.headers': {},
-      'response.include_headers': true,
-      'check.response.status': [],
-      'check.request.body': { type: 'text' as Mode, value: '' },
-      'check.request.headers': {},
-      'check.request.method': 'GET',
-      username: '',
-    };
-
     it('sets https keys properly', () => {
       const yamlConfig = formatMonitorConfig(
         Object.keys(testHTTPConfig) as ConfigKey[],
@@ -68,44 +104,9 @@ describe('formatMonitorConfig', () => {
   });
 
   describe('browser fields', () => {
-    let testBrowserConfig: Partial<MonitorFields>;
     let formattedBrowserConfig: Record<string, FormattedValue>;
 
     beforeEach(() => {
-      testBrowserConfig = {
-        type: DataStream.BROWSER,
-        enabled: true,
-        schedule: { number: '3', unit: ScheduleUnit.MINUTES },
-        'service.name': '',
-        tags: [],
-        timeout: '16',
-        name: 'Test',
-        locations: [],
-        __ui: {
-          script_source: { is_generated_script: false, file_name: '' },
-          is_zip_url_tls_enabled: false,
-          is_tls_enabled: false,
-        },
-        'source.zip_url.url': '',
-        'source.zip_url.username': '',
-        'source.zip_url.password': '',
-        'source.zip_url.folder': '',
-        'source.zip_url.proxy_url': '',
-        'source.inline.script':
-          "step('Go to https://www.google.com/', async () => {\n  await page.goto('https://www.google.com/');\n});",
-        params: '',
-        screenshots: 'on',
-        synthetics_args: ['--hasTouch true'],
-        'filter_journeys.match': '',
-        'filter_journeys.tags': ['dev'],
-        ignore_https_errors: false,
-        'throttling.is_enabled': true,
-        'throttling.download_speed': '5',
-        'throttling.upload_speed': '3',
-        'throttling.latency': '20',
-        'throttling.config': '5d/3u/20l',
-      };
-
       formattedBrowserConfig = {
         enabled: true,
         'filter_journeys.tags': ['dev'],
@@ -182,6 +183,117 @@ describe('formatMonitorConfig', () => {
       const expected = { ...formattedConfig, enabled: false };
 
       expect(formattedConfig).toEqual(expected);
+    });
+  });
+});
+
+describe('formatHeartbeatRequest', () => {
+  it('uses custom heartbeat id when defined', () => {
+    const monitorId = 'test-monitor-id';
+    const customHeartbeatId = 'test-custom-heartbeat-id';
+    const actual = formatHeartbeatRequest({
+      monitor: testBrowserConfig as SyntheticsMonitor,
+      monitorId,
+      customHeartbeatId,
+    });
+    expect(actual).toEqual({
+      ...testBrowserConfig,
+      id: customHeartbeatId,
+      fields: {
+        config_id: monitorId,
+        'monitor.project.name': testBrowserConfig.project_id,
+        'monitor.project.id': testBrowserConfig.project_id,
+        run_once: undefined,
+        test_run_id: undefined,
+      },
+      fields_under_root: true,
+    });
+  });
+
+  it('uses monitor id when custom heartbeat id is not defined', () => {
+    const monitorId = 'test-monitor-id';
+    const actual = formatHeartbeatRequest({
+      monitor: testBrowserConfig as SyntheticsMonitor,
+      monitorId,
+    });
+    expect(actual).toEqual({
+      ...testBrowserConfig,
+      id: monitorId,
+      fields: {
+        config_id: monitorId,
+        'monitor.project.name': testBrowserConfig.project_id,
+        'monitor.project.id': testBrowserConfig.project_id,
+        run_once: undefined,
+        test_run_id: undefined,
+      },
+      fields_under_root: true,
+    });
+  });
+
+  it('sets project fields as null when project id is not defined', () => {
+    const monitorId = 'test-monitor-id';
+    const monitor = { ...testBrowserConfig, project_id: undefined } as SyntheticsMonitor;
+    const actual = formatHeartbeatRequest({
+      monitor,
+      monitorId,
+    });
+
+    expect(actual).toEqual({
+      ...monitor,
+      id: monitorId,
+      fields: {
+        config_id: monitorId,
+        'monitor.project.name': undefined,
+        'monitor.project.id': undefined,
+        run_once: undefined,
+        test_run_id: undefined,
+      },
+      fields_under_root: true,
+    });
+  });
+
+  it('supports run once', () => {
+    const monitorId = 'test-monitor-id';
+    const actual = formatHeartbeatRequest({
+      monitor: testBrowserConfig as SyntheticsMonitor,
+      monitorId,
+      runOnce: true,
+    });
+
+    expect(actual).toEqual({
+      ...testBrowserConfig,
+      id: monitorId,
+      fields: {
+        config_id: monitorId,
+        'monitor.project.name': testBrowserConfig.project_id,
+        'monitor.project.id': testBrowserConfig.project_id,
+        run_once: true,
+        test_run_id: undefined,
+      },
+      fields_under_root: true,
+    });
+  });
+
+  it('supports test_run_id', () => {
+    const monitorId = 'test-monitor-id';
+    const testRunId = 'beep';
+    const actual = formatHeartbeatRequest({
+      monitor: testBrowserConfig as SyntheticsMonitor,
+      monitorId,
+      testRunId,
+    });
+
+    expect(actual).toEqual({
+      ...testBrowserConfig,
+      id: monitorId,
+      fields: {
+        config_id: monitorId,
+        'monitor.project.name': testBrowserConfig.project_id,
+        'monitor.project.id': testBrowserConfig.project_id,
+        run_once: undefined,
+        test_run_id: testRunId,
+      },
+      fields_under_root: true,
     });
   });
 });

--- a/x-pack/plugins/synthetics/server/synthetics_service/formatters/format_configs.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/formatters/format_configs.ts
@@ -6,8 +6,25 @@
  */
 
 import { isNil, omitBy } from 'lodash';
-import { ConfigKey, MonitorFields } from '../../../common/runtime_types';
+import {
+  BrowserFields,
+  ConfigKey,
+  MonitorFields,
+  SyntheticsMonitor,
+  SyntheticsMonitorWithId,
+} from '../../../common/runtime_types';
 import { formatters } from '.';
+
+export type SyntheticsConfig = SyntheticsMonitorWithId & {
+  fields_under_root: boolean;
+  fields: {
+    config_id: string;
+    run_once?: boolean;
+    test_run_id?: string;
+    'monitor.project.name'?: string;
+    'monitor.project.id'?: string;
+  };
+};
 
 const UI_KEYS_TO_SKIP = [
   ConfigKey.JOURNEY_ID,
@@ -52,3 +69,28 @@ export const formatMonitorConfig = (configKeys: ConfigKey[], config: Partial<Mon
 
   return omitBy(formattedMonitor, isNil) as Partial<MonitorFields>;
 };
+
+export const formatHeartbeatRequest = ({
+  monitor,
+  monitorId,
+  customHeartbeatId,
+  runOnce,
+  testRunId,
+}: {
+  monitor: SyntheticsMonitor;
+  monitorId: string;
+  customHeartbeatId?: string;
+  runOnce?: boolean;
+  testRunId?: string;
+}): SyntheticsConfig => ({
+  ...monitor,
+  id: customHeartbeatId || monitorId,
+  fields: {
+    config_id: monitorId,
+    'monitor.project.name': (monitor as BrowserFields)[ConfigKey.PROJECT_ID],
+    'monitor.project.id': (monitor as BrowserFields)[ConfigKey.PROJECT_ID],
+    run_once: runOnce,
+    test_run_id: testRunId,
+  },
+  fields_under_root: true,
+});

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
@@ -7,13 +7,14 @@
 
 jest.mock('axios', () => jest.fn());
 
-import { SyntheticsService, SyntheticsConfig } from './synthetics_service';
+import { SyntheticsService } from './synthetics_service';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { loggerMock } from '@kbn/core/server/logging/logger.mock';
 import { UptimeServerSetup } from '../legacy_uptime/lib/adapters';
 import axios, { AxiosResponse } from 'axios';
 import times from 'lodash/times';
 import { LocationStatus } from '../../common/runtime_types';
+import { SyntheticsConfig } from './formatters/format_configs';
 
 describe('SyntheticsService', () => {
   const mockEsClient = {

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -29,7 +29,11 @@ import {
 import { getEsHosts } from './get_es_hosts';
 import { ServiceConfig } from '../../common/config';
 import { ServiceAPIClient } from './service_api_client';
-import { formatMonitorConfig } from './formatters/format_configs';
+import {
+  formatMonitorConfig,
+  formatHeartbeatRequest,
+  SyntheticsConfig,
+} from './formatters/format_configs';
 import {
   ConfigKey,
   MonitorFields,
@@ -50,11 +54,6 @@ const SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_TYPE =
   'UPTIME:SyntheticsService:Sync-Saved-Monitor-Objects';
 const SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_ID = 'UPTIME:SyntheticsService:sync-task';
 const SYNTHETICS_SERVICE_SYNC_INTERVAL_DEFAULT = '5m';
-
-export type SyntheticsConfig = SyntheticsMonitorWithId & {
-  fields_under_root?: boolean;
-  fields?: { config_id: string; run_once?: boolean; test_run_id?: string };
-};
 
 export class SyntheticsService {
   private logger: Logger;
@@ -429,13 +428,11 @@ export class SyntheticsService {
 
     return (monitors ?? []).map((monitor) => {
       const attributes = monitor.attributes as unknown as MonitorFields;
-      const id = attributes[ConfigKey.CUSTOM_HEARTBEAT_ID] || monitor.id;
-      return {
-        ...normalizeSecrets(monitor).attributes,
-        id, // heartbeat id
-        fields_under_root: true,
-        fields: { config_id: monitor.id }, // monitor saved object id
-      };
+      return formatHeartbeatRequest({
+        monitor: normalizeSecrets(monitor).attributes,
+        monitorId: monitor.id,
+        customHeartbeatId: attributes[ConfigKey.CUSTOM_HEARTBEAT_ID],
+      });
     });
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[Uptime] Add missing project fields to fields_under_root (#132954)](https://github.com/elastic/kibana/pull/132954)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)