### PR TITLE
[Security Solution][Investigations] - Fix no data found on bulk update

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.test.tsx
@@ -15,7 +15,7 @@ import { mockTimelineData } from '../../../../../common/mock';
 import { defaultHeaders } from '../column_headers/default_headers';
 import { getDefaultControlColumn } from '../control_columns';
 
-import { DataDrivenColumns } from '.';
+import { DataDrivenColumns, getMappedNonEcsValue } from '.';
 
 describe('Columns', () => {
   const headersSansTimestamp = defaultHeaders.filter((h) => h.id !== '@timestamp');
@@ -55,5 +55,40 @@ describe('Columns', () => {
     );
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('getMappedNonEcsValue', () => {
+    const existingField = 'Descarte';
+    const existingValue = ['IThinkThereforeIAm'];
+
+    test('should return the value if the fieldName is found', () => {
+      const result = getMappedNonEcsValue({
+        data: [{ field: existingField, value: existingValue }],
+        fieldName: existingField,
+      });
+
+      expect(result).toBe(existingValue);
+    });
+
+    test('should return undefined if the value cannot be found in the array', () => {
+      const result = getMappedNonEcsValue({
+        data: [{ field: existingField, value: existingValue }],
+        fieldName: 'nonExistent',
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    test('should return undefined when data is an empty array', () => {
+      const result = getMappedNonEcsValue({ data: [], fieldName: existingField });
+
+      expect(result).toBeUndefined();
+    });
+
+    test('should return undefined when data is undefined', () => {
+      const result = getMappedNonEcsValue({ data: undefined, fieldName: existingField });
+
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.tsx
@@ -444,6 +444,12 @@ export const getMappedNonEcsValue = ({
   data: TimelineNonEcsData[];
   fieldName: string;
 }): string[] | undefined => {
+  /*
+   While data _should_ always be defined
+   There is the potential for race conditions where a component using this function
+   is still visible in the UI, while the data has since been removed.
+   To cover all scenarios where this happens we'll check for the presence of data here
+  */
   if (!data || data.length === 0) return undefined;
   const item = data.find((d) => d.field === fieldName);
   if (item != null && item.value != null) {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.tsx
@@ -441,7 +441,7 @@ export const getMappedNonEcsValue = ({
   data,
   fieldName,
 }: {
-  data: TimelineNonEcsData[];
+  data?: TimelineNonEcsData[];
   fieldName: string;
 }): string[] | undefined => {
   /*
@@ -462,7 +462,7 @@ export const useGetMappedNonEcsValue = ({
   data,
   fieldName,
 }: {
-  data: TimelineNonEcsData[];
+  data?: TimelineNonEcsData[];
   fieldName: string;
 }): string[] | undefined => {
   return useMemo(() => getMappedNonEcsValue({ data, fieldName }), [data, fieldName]);

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.tsx
@@ -444,6 +444,7 @@ export const getMappedNonEcsValue = ({
   data: TimelineNonEcsData[];
   fieldName: string;
 }): string[] | undefined => {
+  if (!data || data.length === 0) return undefined;
   const item = data.find((d) => d.field === fieldName);
   if (item != null && item.value != null) {
     return item.value;


### PR DESCRIPTION
## Summary

This PR addresses https://github.com/elastic/kibana/issues/131794

The underlying issue we're facing here is a race condition between the rendering of the row and the updating of the data that is used to render the row. The default cell actions which are rendered in the table make use of the `useGetMappedNonEcsValue`, which is based on `rowData`, which is based on `data` here: https://github.com/elastic/kibana/blob/ec7f3d703d302574e96ef8ad50724616abd03559/x-pack/plugins/security_solution/public/common/lib/cell_actions/default_cell_actions.tsx#L124-L131

Since `data` is not in the scope of React as props since data is passed in via an external function which returns a React function component, changes in it aren't caught by the `useMemo`. Even if this is added by caching `data` within the scope of the React component, data will still become an empty array for the given view, and `rowData` will be `undefined`. This is okay, if the table isn't trying to render the cell actions, but if you hover over the row (which will attempt to render the cell actions) while that process is taking place, the error will occur. This can be seen in the below video:

This fix is a low surface area fix, but a more "involved" fix and cleanup of the files can be found here: https://github.com/elastic/kibana/pull/133232


https://user-images.githubusercontent.com/17211684/171210258-c13e783b-ff34-4c15-9959-850452c02550.mov
