### PR TITLE
[es-snapshots] Trigger packer cache job using API instead of pipeline

### DIFF
--- a/.buildkite/package-lock.json
+++ b/.buildkite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kibana-buildkite",
       "version": "1.0.0",
       "dependencies": {
-        "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#4ecaba35293fb635cf92ca205ee84fca52f19e2e"
+        "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#6a73a417decc52f309ede3644577c9dca7b411a2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -368,8 +368,8 @@
     },
     "node_modules/kibana-buildkite-library": {
       "version": "1.0.0",
-      "resolved": "git+https://git@github.com/elastic/kibana-buildkite-library.git#4ecaba35293fb635cf92ca205ee84fca52f19e2e",
-      "integrity": "sha512-AjX3YyovsyYQ7MBoXQcHdyuFbnYZIChxr+gGApTFVNvJx4z9FeuKxQLKfDuONlZpNliHHgaenmf5APU/ZUqxVA==",
+      "resolved": "git+https://git@github.com/elastic/kibana-buildkite-library.git#6a73a417decc52f309ede3644577c9dca7b411a2",
+      "integrity": "sha512-SMW4Eoc/Tkg2lW63iB34obeiqCMhW4a7n3wWa7Ps63eI7+74QlIJha6K5Fa4fO/08ABZ6nEqsWeAOYAFnVLF7g==",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.10.0",
@@ -839,9 +839,9 @@
       }
     },
     "kibana-buildkite-library": {
-      "version": "git+https://git@github.com/elastic/kibana-buildkite-library.git#4ecaba35293fb635cf92ca205ee84fca52f19e2e",
-      "integrity": "sha512-AjX3YyovsyYQ7MBoXQcHdyuFbnYZIChxr+gGApTFVNvJx4z9FeuKxQLKfDuONlZpNliHHgaenmf5APU/ZUqxVA==",
-      "from": "kibana-buildkite-library@git+https://git@github.com/elastic/kibana-buildkite-library#4ecaba35293fb635cf92ca205ee84fca52f19e2e",
+      "version": "git+https://git@github.com/elastic/kibana-buildkite-library.git#6a73a417decc52f309ede3644577c9dca7b411a2",
+      "integrity": "sha512-SMW4Eoc/Tkg2lW63iB34obeiqCMhW4a7n3wWa7Ps63eI7+74QlIJha6K5Fa4fO/08ABZ6nEqsWeAOYAFnVLF7g==",
+      "from": "kibana-buildkite-library@git+https://git@github.com/elastic/kibana-buildkite-library#6a73a417decc52f309ede3644577c9dca7b411a2",
       "requires": {
         "@octokit/rest": "^18.10.0",
         "axios": "^0.21.4",

--- a/.buildkite/package.json
+++ b/.buildkite/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#4ecaba35293fb635cf92ca205ee84fca52f19e2e"
+    "kibana-buildkite-library": "git+https://git@github.com/elastic/kibana-buildkite-library#6a73a417decc52f309ede3644577c9dca7b411a2"
   }
 }

--- a/.buildkite/pipelines/es_snapshots/promote.yml
+++ b/.buildkite/pipelines/es_snapshots/promote.yml
@@ -13,6 +13,6 @@ steps:
     agents:
       queue: kibana-default
   - wait
-  - trigger: kibana-agent-packer-cache
-    async: true
+  - label: Trigger packer agent cache pipeline
+    command: node .buildkite/scripts/steps/trigger_packer_cache.js
     branches: main

--- a/.buildkite/pipelines/es_snapshots/promote.yml
+++ b/.buildkite/pipelines/es_snapshots/promote.yml
@@ -12,7 +12,3 @@ steps:
     command: .buildkite/scripts/steps/es_snapshots/promote.sh
     agents:
       queue: kibana-default
-  - wait
-  - label: Trigger packer agent cache pipeline
-    command: node .buildkite/scripts/steps/trigger_packer_cache.js
-    branches: main

--- a/.buildkite/scripts/steps/es_snapshots/promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/promote.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+echo "--- Promote snapshot"
 export ES_SNAPSHOT_MANIFEST="${ES_SNAPSHOT_MANIFEST:-"$(buildkite-agent meta-data get ES_SNAPSHOT_MANIFEST)"}"
 
 cat << EOF | buildkite-agent annotate --style "info"
@@ -11,3 +12,6 @@ cat << EOF | buildkite-agent annotate --style "info"
 EOF
 
 node "$(dirname "${0}")/promote_manifest.js" "$ES_SNAPSHOT_MANIFEST"
+
+echo "--- Trigger agent packer cache pipeline"
+node .buildkite/scripts/steps/trigger_packer_cache.js

--- a/.buildkite/scripts/steps/es_snapshots/promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/promote.sh
@@ -13,5 +13,7 @@ EOF
 
 node "$(dirname "${0}")/promote_manifest.js" "$ES_SNAPSHOT_MANIFEST"
 
-echo "--- Trigger agent packer cache pipeline"
-node .buildkite/scripts/steps/trigger_packer_cache.js
+if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
+  echo "--- Trigger agent packer cache pipeline"
+  node .buildkite/scripts/steps/trigger_packer_cache.js
+fi

--- a/.buildkite/scripts/steps/trigger_packer_cache.js
+++ b/.buildkite/scripts/steps/trigger_packer_cache.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
 const { BuildkiteClient } = require('kibana-buildkite-library');
 
 (async () => {

--- a/.buildkite/scripts/steps/trigger_packer_cache.js
+++ b/.buildkite/scripts/steps/trigger_packer_cache.js
@@ -1,0 +1,20 @@
+const { BuildkiteClient } = require('kibana-buildkite-library');
+
+(async () => {
+  try {
+    const client = new BuildkiteClient();
+    const build = await client.triggerBuild('kibana-agent-packer-cache', {
+      commit: 'HEAD',
+      branch: 'main',
+    });
+    console.log(`Triggered build: ${build.web_url}`);
+    process.exit(0);
+  } catch (ex) {
+    console.error('Buildkite API Error', ex.toString());
+    if (ex.response) {
+      console.error('HTTP Error Response Status', ex.response.status);
+      console.error('HTTP Error Response Body', ex.response.data);
+    }
+    process.exit(1);
+  }
+})();

--- a/.buildkite/scripts/steps/trigger_packer_cache.js
+++ b/.buildkite/scripts/steps/trigger_packer_cache.js
@@ -6,6 +6,7 @@ const { BuildkiteClient } = require('kibana-buildkite-library');
     const build = await client.triggerBuild('kibana-agent-packer-cache', {
       commit: 'HEAD',
       branch: 'main',
+      ignore_pipeline_branch_filters: true, // Required because of a Buildkite bug
     });
     console.log(`Triggered build: ${build.web_url}`);
     process.exit(0);


### PR DESCRIPTION
Tested here: https://buildkite.com/elastic/kibana-elasticsearch-snapshot-promote/builds/1041#01811b08-4c99-4d4f-8653-883a5d250542/163

The packer cache pipeline can't be triggered from the ES snapshot promotion pipeline using a regular `trigger` step, because the promotion pipeline is public. Public pipelines can't trigger private pipelines in Buildkite, and I'd rather keep the packer pipeline private. So, we'll trigger it with the API instead.