### PR TITLE
[os packages] Mark all files in /etc/kibana as config files

### DIFF
--- a/src/dev/build/tasks/os_packages/run_fpm.ts
+++ b/src/dev/build/tasks/os_packages/run_fpm.ts
@@ -85,7 +85,7 @@ export async function runFpm(
 
     // tell fpm about the config file so that it is called out in the package definition
     '--config-files',
-    `/etc/kibana/kibana.yml`,
+    `/etc/kibana`,
 
     // define template values that will be injected into the install/uninstall
     // scripts, also causes scripts to be processed with erb


### PR DESCRIPTION
This marks all files in `/etc/kibana` as config files.  Currently this folder contains `kibana.yml` and `node.options`, files with user provided settings.  Config files are not automatically updated between version upgrades.

Closes https://github.com/elastic/kibana/issues/133057

Release note:
Fixes an issue where `node.options` was reset between upgrades in deb and rpm packages.