### PR TITLE
[Cloud Posture] fix CIS integration link

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_navigate_to_cis_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_navigate_to_cis_integration.ts
@@ -5,12 +5,24 @@
  * 2.0.
  */
 
-import { pagePathGetters } from '@kbn/fleet-plugin/public';
+import { pagePathGetters, pkgKeyFromPackageInfo } from '@kbn/fleet-plugin/public';
+import { useCisKubernetesIntegration } from '../api/use_cis_kubernetes_integration';
 import { useKibana } from '../hooks/use_kibana';
 
-const CIS_INTEGRATION_PATH = pagePathGetters.integrations_all({ searchTerm: 'CIS' }).join('');
-
-export const useCISIntegrationLink = () => {
+export const useCISIntegrationLink = (): string | undefined => {
   const { http } = useKibana().services;
-  return http.basePath.prepend(CIS_INTEGRATION_PATH);
+  const cisIntegration = useCisKubernetesIntegration();
+
+  if (!cisIntegration.isSuccess) return;
+
+  const path = pagePathGetters
+    .integration_details_overview({
+      pkgkey: pkgKeyFromPackageInfo({
+        name: cisIntegration.data.item.name,
+        version: cisIntegration.data.item.version,
+      }),
+    })
+    .join('/');
+
+  return http.basePath.prepend(path);
 };

--- a/x-pack/plugins/cloud_security_posture/public/components/csp_page_template.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_page_template.tsx
@@ -81,7 +81,7 @@ export const LOADING_STATE_TEST_SUBJECT = 'csp_page_template_loading';
 export const ERROR_STATE_TEST_SUBJECT = 'csp_page_template_error';
 
 const getPackageNotInstalledNoDataConfig = (
-  cisIntegrationLink: string
+  cisIntegrationLink?: string
 ): KibanaPageTemplateProps['noDataConfig'] => ({
   pageTitle: PACKAGE_NOT_INSTALLED_TEXT.PAGE_TITLE,
   solution: PACKAGE_NOT_INSTALLED_TEXT.SOLUTION,
@@ -91,6 +91,7 @@ const getPackageNotInstalledNoDataConfig = (
   actions: {
     elasticAgent: {
       href: cisIntegrationLink,
+      isDisabled: !cisIntegrationLink,
       title: PACKAGE_NOT_INSTALLED_TEXT.BUTTON_TITLE,
       description: PACKAGE_NOT_INSTALLED_TEXT.DESCRIPTION,
     },

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -46,6 +46,7 @@ const AddCisIntegrationButton = () => {
       fill
       iconType="plusInCircle"
       href={cisIntegrationLink}
+      isDisabled={!cisIntegrationLink}
     >
       <FormattedMessage
         id="xpack.csp.benchmarks.addCisIntegrationButtonLabel"


### PR DESCRIPTION
this PR replaces the link we use to guide users how to install the CIS integration 

it used to be a link to integrations screen filtered on CIS, now it goes directly to the CIS integration 

