### PR TITLE
Rename host risk field in alert flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/host_risk_summary.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/host_risk_summary.tsx
@@ -54,7 +54,7 @@ const HostRiskSummaryComponent: React.FC<{
       {hostRisk.isModuleEnabled && hostRisk.result && hostRisk.result.length > 0 && (
         <>
           <EnrichedDataRow
-            field={'host.risk.keyword'}
+            field={i18n.HOST_RISK_CLASSIFICATION}
             value={
               <RiskScore severity={hostRisk.result[0].risk as RiskSeverity} hideBackgroundColor />
             }

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/translations.ts
@@ -145,3 +145,10 @@ export const ENRICHED_DATA = i18n.translate(
     defaultMessage: 'Enriched data',
   }
 );
+
+export const HOST_RISK_CLASSIFICATION = i18n.translate(
+  'xpack.securitySolution.alertDetails.hostRiskClassification',
+  {
+    defaultMessage: 'Host risk classification',
+  }
+);


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/129153

## Summary

Rename host risk field in the alert flyout

<img width="907" alt="Screenshot 2022-06-01 at 10 03 12" src="https://user-images.githubusercontent.com/1490444/171357556-6fd7dba9-f216-4011-985f-1b24888c1ffb.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
