### PR TITLE
[Cases] refactor configuration page hooks to usereact-query

### DIFF
--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -72,6 +72,7 @@ export interface AppMockRenderer {
   render: UiRender;
   coreStart: StartServices;
   queryClient: QueryClient;
+  AppWrapper: React.FC<{ children: React.ReactElement }>;
 }
 export const testQueryClient = new QueryClient({
   defaultOptions: {
@@ -120,6 +121,7 @@ export const createAppMockRenderer = ({
     coreStart: services,
     queryClient,
     render,
+    AppWrapper,
   };
 };
 

--- a/x-pack/plugins/cases/public/components/configure_cases/__mock__/index.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/__mock__/index.tsx
@@ -9,7 +9,6 @@ import { ActionTypeConnector, ConnectorTypes } from '../../../../common/api';
 import { ActionConnector } from '../../../containers/configure/types';
 import { UseConnectorsResponse } from '../../../containers/configure/use_connectors';
 import { ReturnUseCaseConfigure } from '../../../containers/configure/use_configure';
-import { UseActionTypesResponse } from '../../../containers/configure/use_action_types';
 import { connectorsMock, actionTypesMock } from '../../../common/mock/connectors';
 export { mappings } from '../../../containers/configure/mock';
 
@@ -56,8 +55,8 @@ export const useConnectorsResponse: UseConnectorsResponse = {
   refetchConnectors: jest.fn(),
 };
 
-export const useActionTypesResponse: UseActionTypesResponse = {
-  loading: false,
-  actionTypes: actionTypesMock,
-  refetchActionTypes: jest.fn(),
+export const useActionTypesResponse = {
+  isLoading: false,
+  data: actionTypesMock,
+  refetch: jest.fn(),
 };

--- a/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
@@ -17,7 +17,6 @@ import { ClosureOptions } from './closure_options';
 import { useKibana } from '../../common/lib/kibana';
 import { useConnectors } from '../../containers/configure/use_connectors';
 import { useCaseConfigure } from '../../containers/configure/use_configure';
-import { useActionTypes } from '../../containers/configure/use_action_types';
 
 import {
   connectors,
@@ -28,6 +27,7 @@ import {
 } from './__mock__';
 import { ConnectorTypes } from '../../../common/api';
 import { actionTypeRegistryMock } from '@kbn/triggers-actions-ui-plugin/public/application/action_type_registry.mock';
+import { useGetActionTypes } from '../../containers/configure/use_action_types';
 
 jest.mock('../../common/lib/kibana');
 jest.mock('../../containers/configure/use_connectors');
@@ -38,7 +38,7 @@ const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 const useConnectorsMock = useConnectors as jest.Mock;
 const useCaseConfigureMock = useCaseConfigure as jest.Mock;
 const useGetUrlSearchMock = jest.fn();
-const useActionTypesMock = useActionTypes as jest.Mock;
+const useGetActionTypesMock = useGetActionTypes as jest.Mock;
 const getAddConnectorFlyoutMock = jest.fn();
 const getEditConnectorFlyoutMock = jest.fn();
 
@@ -57,7 +57,7 @@ describe('ConfigureCases', () => {
   });
 
   beforeEach(() => {
-    useActionTypesMock.mockImplementation(() => useActionTypesResponse);
+    useGetActionTypesMock.mockImplementation(() => useActionTypesResponse);
   });
 
   describe('rendering', () => {
@@ -285,7 +285,10 @@ describe('ConfigureCases', () => {
         loading: false,
       }));
 
-      useActionTypesMock.mockImplementation(() => ({ ...useActionTypesResponse, loading: true }));
+      useGetActionTypesMock.mockImplementation(() => ({
+        ...useActionTypesResponse,
+        isLoading: true,
+      }));
 
       wrapper = mount(<ConfigureCases />, {
         wrappingComponent: TestProviders,

--- a/x-pack/plugins/cases/public/components/configure_cases/index.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/index.tsx
@@ -16,7 +16,7 @@ import { ActionConnectorTableItem } from '@kbn/triggers-actions-ui-plugin/public
 import { SUPPORTED_CONNECTORS } from '../../../common/constants';
 import { useKibana } from '../../common/lib/kibana';
 import { useConnectors } from '../../containers/configure/use_connectors';
-import { useActionTypes } from '../../containers/configure/use_action_types';
+import { useGetActionTypes } from '../../containers/configure/use_action_types';
 import { useCaseConfigure } from '../../containers/configure/use_configure';
 
 import { ClosureType } from '../../containers/configure/types';
@@ -75,7 +75,12 @@ export const ConfigureCases: React.FC = React.memo(() => {
   } = useCaseConfigure();
 
   const { loading: isLoadingConnectors, connectors, refetchConnectors } = useConnectors();
-  const { loading: isLoadingActionTypes, actionTypes, refetchActionTypes } = useActionTypes();
+  const {
+    isLoading: isLoadingActionTypes,
+    data: actionTypes = [],
+    refetch: refetchActionTypes,
+  } = useGetActionTypes();
+
   const supportedActionTypes = useMemo(
     () => actionTypes.filter((actionType) => SUPPORTED_CONNECTORS.includes(actionType.id)),
     [actionTypes]

--- a/x-pack/plugins/cases/public/containers/configure/use_action_types.test.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_action_types.test.tsx
@@ -5,99 +5,44 @@
  * 2.0.
  */
 
-import { renderHook, act } from '@testing-library/react-hooks';
-import { useActionTypes, UseActionTypesResponse } from './use_action_types';
+import { renderHook } from '@testing-library/react-hooks';
 import * as api from './api';
-import { actionTypesMock } from '../../common/mock/connectors';
+import { AppMockRenderer, createAppMockRenderer } from '../../common/mock';
+import { useGetActionTypes } from './use_action_types';
+import { useToasts } from '../../common/lib/kibana';
 
 jest.mock('./api');
 jest.mock('../../common/lib/kibana');
 
 describe('useActionTypes', () => {
+  let appMockRenderer: AppMockRenderer;
   beforeEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
+    appMockRenderer = createAppMockRenderer();
   });
 
-  test('init', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseActionTypesResponse>(() =>
-        useActionTypes()
-      );
-      await waitForNextUpdate();
-      expect(result.current).toEqual({
-        loading: true,
-        actionTypes: [],
-        refetchActionTypes: result.current.refetchActionTypes,
-      });
+  it('should fetch action types', async () => {
+    const spy = jest.spyOn(api, 'fetchActionTypes');
+    const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
+      wrapper: appMockRenderer.AppWrapper,
     });
+
+    await waitForNextUpdate();
+    expect(spy).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
   });
 
-  test('fetch action types', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseActionTypesResponse>(() =>
-        useActionTypes()
-      );
-
-      await waitForNextUpdate();
-      await waitForNextUpdate();
-
-      expect(result.current).toEqual({
-        loading: false,
-        actionTypes: actionTypesMock,
-        refetchActionTypes: result.current.refetchActionTypes,
-      });
-    });
-  });
-
-  test('refetch actionTypes', async () => {
-    const spyOnfetchActionTypes = jest.spyOn(api, 'fetchActionTypes');
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseActionTypesResponse>(() =>
-        useActionTypes()
-      );
-
-      await waitForNextUpdate();
-      await waitForNextUpdate();
-
-      result.current.refetchActionTypes();
-      expect(spyOnfetchActionTypes).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  test('set isLoading to true when refetching actionTypes', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseActionTypesResponse>(() =>
-        useActionTypes()
-      );
-
-      await waitForNextUpdate();
-      await waitForNextUpdate();
-
-      result.current.refetchActionTypes();
-
-      expect(result.current.loading).toBe(true);
-    });
-  });
-
-  test('unhappy path', async () => {
-    const spyOnfetchActionTypes = jest.spyOn(api, 'fetchActionTypes');
-    spyOnfetchActionTypes.mockImplementation(() => {
+  it('should show a toast eror message if failed to fetch', async () => {
+    const spy = jest.spyOn(api, 'fetchActionTypes');
+    spy.mockImplementation(() => {
       throw new Error('Something went wrong');
     });
-
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, UseActionTypesResponse>(() =>
-        useActionTypes()
-      );
-      await waitForNextUpdate();
-      await waitForNextUpdate();
-
-      expect(result.current).toEqual({
-        loading: false,
-        actionTypes: [],
-        refetchActionTypes: result.current.refetchActionTypes,
-      });
+    const addErrorMock = jest.fn();
+    (useToasts as jest.Mock).mockReturnValue({ addError: addErrorMock });
+    const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
+      wrapper: appMockRenderer.AppWrapper,
     });
+    await waitForNextUpdate();
+    expect(addErrorMock).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/cases/public/containers/configure/use_action_types.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_action_types.tsx
@@ -5,67 +5,28 @@
  * 2.0.
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react';
-
+import { useQuery } from 'react-query';
 import * as i18n from '../translations';
 import { fetchActionTypes } from './api';
-import { ActionTypeConnector } from './types';
 import { useToasts } from '../../common/lib/kibana';
+import { CASE_CONFIGURATION_CACHE_KEY } from '../constants';
+import { ServerError } from '../../types';
 
-export interface UseActionTypesResponse {
-  loading: boolean;
-  actionTypes: ActionTypeConnector[];
-  refetchActionTypes: () => void;
-}
-
-export const useActionTypes = (): UseActionTypesResponse => {
+export const useGetActionTypes = () => {
   const toasts = useToasts();
-  const [loading, setLoading] = useState(true);
-  const [actionTypes, setActionTypes] = useState<ActionTypeConnector[]>([]);
-  const isCancelledRef = useRef(false);
-  const abortCtrlRef = useRef(new AbortController());
-  const queryFirstTime = useRef(true);
-
-  const refetchActionTypes = useCallback(async () => {
-    try {
-      setLoading(true);
-      isCancelledRef.current = false;
-      abortCtrlRef.current.abort();
-      abortCtrlRef.current = new AbortController();
-
-      const res = await fetchActionTypes({ signal: abortCtrlRef.current.signal });
-
-      if (!isCancelledRef.current) {
-        setLoading(false);
-        setActionTypes(res);
-      }
-    } catch (error) {
-      if (!isCancelledRef.current) {
-        setLoading(false);
-        setActionTypes([]);
+  return useQuery(
+    [CASE_CONFIGURATION_CACHE_KEY, 'actionTypes'],
+    () => {
+      const abortController = new AbortController();
+      return fetchActionTypes({ signal: abortController.signal });
+    },
+    {
+      initialData: [],
+      onError: (error: ServerError) => {
         toasts.addError(error.body && error.body.message ? new Error(error.body.message) : error, {
           title: i18n.ERROR_TITLE,
         });
-      }
+      },
     }
-  }, [toasts]);
-
-  useEffect(() => {
-    if (queryFirstTime.current) {
-      refetchActionTypes();
-      queryFirstTime.current = false;
-    }
-
-    return () => {
-      isCancelledRef.current = true;
-      abortCtrlRef.current.abort();
-      queryFirstTime.current = true;
-    };
-  }, [refetchActionTypes]);
-
-  return {
-    loading,
-    actionTypes,
-    refetchActionTypes,
-  };
+  );
 };

--- a/x-pack/plugins/cases/public/containers/constants.ts
+++ b/x-pack/plugins/cases/public/containers/constants.ts
@@ -11,3 +11,4 @@ export const DEFAULT_TABLE_LIMIT = 5;
 export const CASE_VIEW_CACHE_KEY = 'case';
 export const CASE_VIEW_ACTIONS_CACHE_KEY = 'user-actions';
 export const CASE_VIEW_METRICS_CACHE_KEY = 'metrics';
+export const CASE_CONFIGURATION_CACHE_KEY = 'case-configuration';


### PR DESCRIPTION
## Summary

This is a partial refactor of the configuration page hooks to use react-query.


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
