### PR TITLE
[TSVB] Error messages not centered

### DIFF
--- a/src/plugins/visualizations/public/vis.scss
+++ b/src/plugins/visualizations/public/vis.scss
@@ -8,7 +8,6 @@
 // SASSTODO: Too risky to change to BEM naming
 .visualization {
   display: flex;
-  flex-direction: column;
   width: 100%;
   height: 100%;
   overflow: auto;


### PR DESCRIPTION
## Summary

The new version of `Eui` wraps the content of `EuiEmptyPrompt` in an additional Panel, which was not the case before


<img width="1240" alt="image" src="https://user-images.githubusercontent.com/20072247/171406625-c7222288-8cc4-4f8a-82fe-548db5bfb897.png">

In `TSVB`, after that, the error message is no longer centered vertically

Removing `flex-direction: column;` solves this problem. I tested other visualizations, everything seems to work correctly

## After: 
<img width="505" alt="image" src="https://user-images.githubusercontent.com/20072247/171407914-91fd3e96-4e0a-46e6-ab26-5588e87c7c51.png">
