### PR TITLE
[Fleet] Update pinned EPR docker image for 8.3.0

### DIFF
--- a/x-pack/plugins/fleet/README.md
+++ b/x-pack/plugins/fleet/README.md
@@ -109,9 +109,9 @@ Once the Fleet Server container is running, you should be able to treat it as if
 2. Click "Add Agent"
 3. Scroll down to the bottom of the flyout that opens to view the enrollment command, copy the contents of the `--enrollment-token` option
 4. Run this docker command:
-    ```
-    docker run -e FLEET_ENROLL=true -e FLEET_INSECURE=true -e FLEET_URL=https://192.168.65.2:8220 -e FLEET_ENROLLMENT_TOKEN=<pasted from step 3> --rm docker.elastic.co/beats/elastic-agent:{VERSION}
-    ```
+   ```
+   docker run -e FLEET_ENROLL=true -e FLEET_INSECURE=true -e FLEET_URL=https://192.168.65.2:8220 -e FLEET_ENROLLMENT_TOKEN=<pasted from step 3> --rm docker.elastic.co/beats/elastic-agent:{VERSION}
+   ```
 
 ### Tests
 
@@ -175,3 +175,14 @@ The set of bundled packages included with Kibana is dictated by a top-level `fle
 
 Until further automation is added, this `fleet_packages.json` file should be updated as part of the release process to ensure the latest compatible version of each bundled package is included with that Kibana version. **This must be done before the final BC for a release is built.**
 Tracking issues should be opened and tracked by the Fleet UI team. See https://github.com/elastic/kibana/issues/129309 as an example.
+
+As part of the bundled package update process, we'll likely also need to update the pinned Docker image that runs in Kibana's test environment. We configure this pinned registry image in
+
+- `x-pack/test/fleet_api_integration/config.ts`
+- `x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts`
+- `x-pack/test/functional/config.base.js`
+- `x-pack/test/functional_synthetics/config.js`
+
+To update this registry image, pull the digest SHA from the package storage Jenkins pipeline at https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/activity and update the files above. The digest value should appear in the "publish Docker image" step as part of the `docker push` command in the logs.
+
+![image](https://user-images.githubusercontent.com/6766512/171409455-64f9ab1d-08fe-4872-9b74-58359ed938dd.png)

--- a/x-pack/plugins/fleet/server/integration_tests/__snapshots__/cloud_preconfiguration.test.ts.snap
+++ b/x-pack/plugins/fleet/server/integration_tests/__snapshots__/cloud_preconfiguration.test.ts.snap
@@ -68,6 +68,7 @@ Object {
         "max_connections": 0,
         "max_event_size": 307200,
         "max_header_size": 1048576,
+        "pprof.enabled": false,
         "read_timeout": "3600s",
         "response_headers": null,
         "rum": Object {

--- a/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
@@ -176,46 +176,49 @@ describe('Fleet preconfiguration reset', () => {
         );
         expect(fleetServerPackagePolicy?.attributes.vars).toMatchInlineSnapshot(`undefined`);
         expect(fleetServerPackagePolicy?.attributes.inputs).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "compiled_input": Object {
-              "server": Object {
-                "host": "0.0.0.0",
-                "port": 8220,
+          Array [
+            Object {
+              "compiled_input": Object {
+                "server": Object {
+                  "host": "0.0.0.0",
+                  "port": 8220,
+                },
+                "server.runtime": Object {
+                  "gc_percent": 20,
+                },
               },
-              "server.runtime": Object {
-                "gc_percent": 20,
+              "enabled": true,
+              "keep_enabled": true,
+              "policy_template": "fleet_server",
+              "streams": Array [],
+              "type": "fleet-server",
+              "vars": Object {
+                "custom": Object {
+                  "type": "yaml",
+                  "value": "server.runtime:
+            gc_percent: 20          # Force the GC to execute more frequently: see https://golang.org/pkg/runtime/debug/#SetGCPercent
+          ",
+                },
+                "host": Object {
+                  "frozen": true,
+                  "type": "text",
+                  "value": "0.0.0.0",
+                },
+                "max_agents": Object {
+                  "type": "integer",
+                },
+                "max_connections": Object {
+                  "type": "integer",
+                },
+                "port": Object {
+                  "frozen": true,
+                  "type": "integer",
+                  "value": 8220,
+                },
               },
             },
-            "enabled": true,
-            "keep_enabled": true,
-            "policy_template": "fleet_server",
-            "streams": Array [],
-            "type": "fleet-server",
-            "vars": Object {
-              "custom": Object {
-                "type": "yaml",
-                "value": "server.runtime:
-          gc_percent: 20          # Force the GC to execute more frequently: see https://golang.org/pkg/runtime/debug/#SetGCPercent
-        ",
-              },
-              "host": Object {
-                "frozen": true,
-                "type": "text",
-                "value": "0.0.0.0",
-              },
-              "max_connections": Object {
-                "type": "integer",
-              },
-              "port": Object {
-                "frozen": true,
-                "type": "integer",
-                "value": 8220,
-              },
-            },
-          },
-        ]
-      `);
+          ]
+        `);
       });
     });
     describe('Adding APM to a preconfigured agent policy after first setup', () => {

--- a/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
@@ -24,7 +24,7 @@ export function useDockerRegistry() {
 
   let dockerProcess: ChildProcess | undefined;
   async function startDockerRegistryServer() {
-    const dockerImage = `docker.elastic.co/package-registry/distribution:e1a3906e0c9944ecade05308022ba35eb0ebd00a`;
+    const dockerImage = `docker.elastic.co/package-registry/distribution:93ffe45d8c4ae11365bc70b1038643121049b9fe`;
 
     const args = ['run', '--rm', '-p', `${packageRegistryPort}:8080`, dockerImage];
 

--- a/x-pack/test/fleet_api_integration/apis/epm/setup.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/setup.ts
@@ -74,7 +74,7 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       it('should upgrade package policy on setup if keep policies up to date set to true', async () => {
-        const oldVersion = '1.9.0';
+        const oldVersion = '1.11.0';
         await supertest
           .post(`/api/fleet/epm/packages/system/${oldVersion}`)
           .set('kbn-xsrf', 'xxxx')

--- a/x-pack/test/fleet_api_integration/config.ts
+++ b/x-pack/test/fleet_api_integration/config.ts
@@ -15,7 +15,7 @@ import { defineDockerServersConfig } from '@kbn/test';
 // example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
 // It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry.
 export const dockerImage =
-  'docker.elastic.co/package-registry/distribution:e1a3906e0c9944ecade05308022ba35eb0ebd00a';
+  'docker.elastic.co/package-registry/distribution:93ffe45d8c4ae11365bc70b1038643121049b9fe';
 
 export const BUNDLED_PACKAGE_DIR = '/tmp/fleet_bundled_packages';
 

--- a/x-pack/test/functional/config.base.js
+++ b/x-pack/test/functional/config.base.js
@@ -15,7 +15,7 @@ import { pageObjects } from './page_objects';
 // example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
 // It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry.
 export const dockerImage =
-  'docker.elastic.co/package-registry/distribution:e1a3906e0c9944ecade05308022ba35eb0ebd00a';
+  'docker.elastic.co/package-registry/distribution:93ffe45d8c4ae11365bc70b1038643121049b9fe';
 
 // the default export of config files must be a config provider
 // that returns an object with the projects config values

--- a/x-pack/test/functional_synthetics/config.js
+++ b/x-pack/test/functional_synthetics/config.js
@@ -17,7 +17,7 @@ import { pageObjects } from './page_objects';
 // example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
 // It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry that updates Synthetics.
 export const dockerImage =
-  'docker.elastic.co/package-registry/distribution:e1a3906e0c9944ecade05308022ba35eb0ebd00a';
+  'docker.elastic.co/package-registry/distribution:93ffe45d8c4ae11365bc70b1038643121049b9fe';
 
 // the default export of config files must be a config provider
 // that returns an object with the projects config values

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_list.ts
@@ -41,7 +41,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await fleetButton.click();
         await testSubjects.existOrFail('createPackagePolicy_pageTitle');
         expect(await testSubjects.getVisibleText('createPackagePolicy_pageTitle')).to.equal(
-          'Add Endpoint Security integration'
+          'Add Endpoint and Cloud Security integration'
         );
       });
       it('navigates back to the policy list page', async () => {


### PR DESCRIPTION
## Summary

Ref https://github.com/elastic/kibana/issues/133255
Ref https://github.com/elastic/kibana/pull/133270

Updates pinned Docker image for EPR service used in Kibana tests to latest version, and adds a note/example to README for repeating this process as part of the bundled package update path.


