### PR TITLE
[Security Solutions] Remove hover actions from Authentication Successes and Failures column

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/authentication/__snapshots__/authentications_host_table.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/common/components/authentication/__snapshots__/authentications_host_table.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`Authentication Host Table Component rendering it renders the host authe
             </th>
             <th
               class="euiTableHeaderCell"
-              data-test-subj="tableHeaderCell_Successes_1"
+              data-test-subj="tableHeaderCell_node.successes_1"
               role="columnheader"
               scope="col"
               style="width: 8%;"
@@ -224,7 +224,7 @@ exports[`Authentication Host Table Component rendering it renders the host authe
             </th>
             <th
               class="euiTableHeaderCell"
-              data-test-subj="tableHeaderCell_Failures_2"
+              data-test-subj="tableHeaderCell_node.failures_2"
               role="columnheader"
               scope="col"
               style="width: 8%;"

--- a/x-pack/plugins/security_solution/public/common/components/authentication/__snapshots__/authentications_user_table.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/common/components/authentication/__snapshots__/authentications_user_table.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`Authentication User Table Component rendering it renders the user authe
             </th>
             <th
               class="euiTableHeaderCell"
-              data-test-subj="tableHeaderCell_Successes_1"
+              data-test-subj="tableHeaderCell_node.successes_1"
               role="columnheader"
               scope="col"
               style="width: 8%;"
@@ -224,7 +224,7 @@ exports[`Authentication User Table Component rendering it renders the user authe
             </th>
             <th
               class="euiTableHeaderCell"
-              data-test-subj="tableHeaderCell_Failures_2"
+              data-test-subj="tableHeaderCell_node.failures_2"
               role="columnheader"
               scope="col"
               style="width: 8%;"

--- a/x-pack/plugins/security_solution/public/common/components/authentication/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/authentication/helpers.tsx
@@ -8,13 +8,9 @@
 import { has } from 'lodash/fp';
 import React from 'react';
 
-import { DragEffects, DraggableWrapper } from '../drag_and_drop/draggable_wrapper';
-import { escapeDataProviderId } from '../drag_and_drop/helpers';
 import { getEmptyTagValue } from '../empty_value';
 import { FormattedRelativePreferenceDate } from '../formatted_date';
 import { Columns, ItemsPerRow } from '../paginated_table';
-import { IS_OPERATOR } from '../../../timelines/components/timeline/data_providers/data_provider';
-import { Provider } from '../../../timelines/components/timeline/data_providers/provider';
 import { getRowItemDraggables } from '../tables/helpers';
 
 import * as i18n from './translations';
@@ -77,40 +73,9 @@ export const rowItems: ItemsPerRow[] = [
 
 const FAILURES_COLUMN: Columns<AuthenticationsEdges, AuthenticationsEdges> = {
   name: i18n.FAILURES,
+  field: 'node.failures',
   truncateText: false,
   mobileOptions: { show: true },
-  render: ({ node }) => {
-    const id = escapeDataProviderId(`authentications-table-${node._id}-failures-${node.failures}`);
-    return (
-      <DraggableWrapper
-        key={id}
-        dataProvider={{
-          and: [],
-          enabled: true,
-          id,
-          name: 'authentication_failure',
-          excluded: false,
-          kqlQuery: '',
-          queryMatch: {
-            field: 'event.type',
-            value: 'authentication_failure',
-            operator: IS_OPERATOR,
-          },
-        }}
-        isAggregatable={true}
-        fieldType={'keyword'}
-        render={(dataProvider, _, snapshot) =>
-          snapshot.isDragging ? (
-            <DragEffects>
-              <Provider dataProvider={dataProvider} />
-            </DragEffects>
-          ) : (
-            node.failures
-          )
-        }
-      />
-    );
-  },
   width: '8%',
 };
 const LAST_SUCCESSFUL_TIME_COLUMN: Columns<AuthenticationsEdges, AuthenticationsEdges> = {
@@ -226,42 +191,9 @@ const HOST_COLUMN: Columns<AuthenticationsEdges, AuthenticationsEdges> = {
 
 const SUCCESS_COLUMN: Columns<AuthenticationsEdges, AuthenticationsEdges> = {
   name: i18n.SUCCESSES,
+  field: 'node.successes',
   truncateText: false,
   mobileOptions: { show: true },
-  render: ({ node }) => {
-    const id = escapeDataProviderId(
-      `authentications-table-${node._id}-node-successes-${node.successes}`
-    );
-    return (
-      <DraggableWrapper
-        key={id}
-        dataProvider={{
-          and: [],
-          enabled: true,
-          id,
-          name: 'authentication_success',
-          excluded: false,
-          kqlQuery: '',
-          queryMatch: {
-            field: 'event.type',
-            value: 'authentication_success',
-            operator: IS_OPERATOR,
-          },
-        }}
-        isAggregatable={true}
-        fieldType="keyword"
-        render={(dataProvider, _, snapshot) =>
-          snapshot.isDragging ? (
-            <DragEffects>
-              <Provider dataProvider={dataProvider} />
-            </DragEffects>
-          ) : (
-            node.successes
-          )
-        }
-      />
-    );
-  },
   width: '8%',
 };
 


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/132099

## Summary

Remove hover actions from the Authentication Successes and Failures columns. Because this column is an aggregation it isn't clear what the user would filter.



### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
