### PR TITLE
[APM] Fix script used to run API tests

### DIFF
--- a/x-pack/plugins/apm/scripts/test/api.js
+++ b/x-pack/plugins/apm/scripts/test/api.js
@@ -82,7 +82,7 @@ if (server) {
 const cmd = [
   'node',
   ...(inspect ? ['--inspect-brk'] : []),
-  `../../../../scripts/${ftrScript}`,
+  `../../../../../scripts/${ftrScript}`,
   ...(grep ? [`--grep "${grep}"`] : []),
   ...(updateSnapshots ? [`--updateSnapshots`] : []),
   `--config ../../../../test/apm_api_integration/${license}/config.ts`,


### PR DESCRIPTION
## Summary
`x-pack/scripts/functional_tests.ts` was removed by https://github.com/elastic/kibana/pull/130983. Change the script to use `scripts/functional_tests.ts` instead.

