### PR TITLE
[jest] fix module mapper regex

### DIFF
--- a/packages/kbn-test/jest-preset.js
+++ b/packages/kbn-test/jest-preset.js
@@ -45,7 +45,7 @@ module.exports = {
     '^(!!)?file-loader!': '<rootDir>/node_modules/@kbn/test/target_node/jest/mocks/file_mock.js',
     ...Object.fromEntries(
       Array.from(pkgMap.entries()).map(([pkgId, repoRelativeDir]) => [
-        `^${pkgId}(/?.*)$`,
+        `^${pkgId}(/.*)?$`,
         `<rootDir>/${repoRelativeDir}$1`,
       ])
     ),


### PR DESCRIPTION
We use module mapper entries in the jest config to handle synthetic plugin packages but the regex is a little faulty and matches `@kbn/core-foo` because there is a synthetic `@kbn/core` package. The regex should specifically only select sub-path selectors for packages when the moduleId is followed by a `/`, so that character shouldn't be optional (`?`) it's the whole sub-path selector which should be optional.