### PR TITLE
Don't load connectors and connector types when there isn't an encryptionKey

### DIFF
--- a/src/plugins/discover/public/application/main/components/top_nav/open_alerts_popover.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/open_alerts_popover.tsx
@@ -108,12 +108,7 @@ export function AlertsPopover({
       name: 'Alerting',
       items: [
         {
-          name: (
-            <>
-              {SearchThresholdAlertFlyout}
-              {createSearchThresholdRuleLink}
-            </>
-          ),
+          name: <>{createSearchThresholdRuleLink}</>,
           icon: 'bell',
           disabled: !hasTimeFieldName,
         },

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_add.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_add.test.tsx
@@ -13,7 +13,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiFormLabel } from '@elastic/eui';
 import { coreMock } from '@kbn/core/public/mocks';
 import RuleAdd from './rule_add';
-import { createRule } from '../../lib/rule_api';
+import { createRule, alertingFrameworkHealth } from '../../lib/rule_api';
 import { actionTypeRegistryMock } from '../../action_type_registry.mock';
 import {
   Rule,
@@ -28,6 +28,8 @@ import { ReactWrapper } from 'enzyme';
 import { ALERTS_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { useKibana } from '../../../common/lib/kibana';
 import { triggersActionsUiConfig } from '../../../common/lib/config_api';
+import { triggersActionsUiHealth } from '../../../common/lib/health_api';
+import { loadActionTypes, loadAllActions } from '../../lib/action_connector_api';
 
 jest.mock('../../../common/lib/kibana');
 
@@ -48,9 +50,13 @@ jest.mock('../../../common/lib/health_api', () => ({
   triggersActionsUiHealth: jest.fn(() => ({ isRulesAvailable: true })),
 }));
 
+jest.mock('../../lib/action_connector_api', () => ({
+  loadActionTypes: jest.fn(),
+  loadAllActions: jest.fn(),
+}));
+
 const actionTypeRegistry = actionTypeRegistryMock.create();
 const ruleTypeRegistry = ruleTypeRegistryMock.create();
-const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
 export const TestExpression: FunctionComponent<any> = () => {
   return (
@@ -65,13 +71,23 @@ export const TestExpression: FunctionComponent<any> = () => {
 };
 
 describe('rule_add', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
   let wrapper: ReactWrapper<any>;
 
   async function setup(
     initialValues?: Partial<Rule>,
     onClose: RuleAddProps['onClose'] = jest.fn(),
-    defaultScheduleInterval?: string
+    defaultScheduleInterval?: string,
+    ruleTypeId?: string,
+    actionsShow: boolean = false
   ) {
+    const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
     const mocks = coreMock.createSetup();
     const { loadRuleTypes } = jest.requireMock('../../lib/rule_api');
     const ruleTypes = [
@@ -113,6 +129,9 @@ describe('rule_add', () => {
         show: true,
         save: true,
         delete: true,
+      },
+      actions: {
+        show: actionsShow,
       },
     };
 
@@ -165,6 +184,7 @@ describe('rule_add', () => {
         actionTypeRegistry={actionTypeRegistry}
         ruleTypeRegistry={ruleTypeRegistry}
         metadata={{ test: 'some value', fields: ['test'] }}
+        ruleTypeId={ruleTypeId}
       />
     );
 
@@ -181,6 +201,11 @@ describe('rule_add', () => {
     });
     const onClose = jest.fn();
     await setup({}, onClose);
+
+    await act(async () => {
+      await nextTick();
+      wrapper.update();
+    });
 
     expect(wrapper.find('[data-test-subj="addRuleFlyoutTitle"]').exists()).toBeTruthy();
     expect(wrapper.find('[data-test-subj="saveRuleButton"]').exists()).toBeTruthy();
@@ -273,7 +298,7 @@ describe('rule_add', () => {
     (triggersActionsUiConfig as jest.Mock).mockResolvedValue({
       minimumScheduleInterval: { value: '1m', enforce: false },
     });
-    await setup({ ruleTypeId: 'my-rule-type' }, jest.fn(), '3h');
+    await setup({ ruleTypeId: 'my-rule-type' }, jest.fn(), '3h', 'my-rule-type', true);
 
     // Wait for handlers to fire
     await act(async () => {
@@ -289,6 +314,39 @@ describe('rule_add', () => {
       .props.value;
     expect(intervalInputUnit).toBe('h');
     expect(intervalInput).toBe(3);
+  });
+
+  it('should load connectors and connector types when there is a pre-selected rule type', async () => {
+    (triggersActionsUiConfig as jest.Mock).mockResolvedValue({
+      minimumScheduleInterval: { value: '1m', enforce: false },
+    });
+
+    await setup({}, jest.fn(), undefined, 'my-rule-type', true);
+
+    expect(triggersActionsUiHealth).toHaveBeenCalledTimes(1);
+    expect(alertingFrameworkHealth).toHaveBeenCalledTimes(1);
+    expect(loadActionTypes).toHaveBeenCalledTimes(1);
+    expect(loadAllActions).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not load connectors and connector types when there is not an encryptionKey', async () => {
+    (triggersActionsUiConfig as jest.Mock).mockResolvedValue({
+      minimumScheduleInterval: { value: '1m', enforce: false },
+    });
+    (alertingFrameworkHealth as jest.Mock).mockResolvedValue({
+      isSufficientlySecure: true,
+      hasPermanentEncryptionKey: false,
+    });
+
+    await setup({}, jest.fn(), undefined, 'my-rule-type', true);
+
+    expect(triggersActionsUiHealth).toHaveBeenCalledTimes(1);
+    expect(alertingFrameworkHealth).toHaveBeenCalledTimes(1);
+    expect(loadActionTypes).not.toHaveBeenCalled();
+    expect(loadAllActions).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-test-subj="actionNeededEmptyPrompt"]').first().text()).toContain(
+      'You must configure an encryption key to use Alerting'
+    );
   });
 });
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_add.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_add.tsx
@@ -245,7 +245,7 @@ const RuleAdd = ({
           </EuiTitle>
         </EuiFlyoutHeader>
         <HealthContextProvider>
-          <HealthCheck inFlyout={true} waitForCheck={false}>
+          <HealthCheck inFlyout={true} waitForCheck={true}>
             <EuiFlyoutBody>
               <RuleForm
                 rule={rule}


### PR DESCRIPTION
fixes:#131986

Http requests to connectors and connector-types endpoints return error when there isn't a permanent encryptionKey.
This PR intends to stop making those redundant http requests triggered by RuleAdd flyout.

I also found out that RuleAdd flyout was added to the Discover page twice. This PR removes one of them too. 