### PR TITLE
[Workplace Search] Fix broken add content source flow for Github

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
@@ -30,7 +30,11 @@ export const SourceAdded: React.FC = () => {
   const state = JSON.parse(params.state);
   const isOrganization = state.context !== 'account';
   const { setChromeIsVisible } = useValues(KibanaLogic);
-  const { saveSourceParams } = useActions(AddSourceLogic);
+  const addSourceLogic = AddSourceLogic({
+    serviceType: state.service_type,
+    initialStep: 'configure',
+  });
+  const { saveSourceParams } = useActions(addSourceLogic);
 
   // We don't want the personal dashboard to flash the Kibana chrome, so we hide it.
   setChromeIsVisible(isOrganization);


### PR DESCRIPTION
`AddSourceLogic` was missing props when included on the `AddSource` view because it had already been instantiated, without props, in `SourceAdded`.  